### PR TITLE
No _devel package needed.

### DIFF
--- a/dev-lang/yab/yab-1.7.5.recipe
+++ b/dev-lang/yab/yab-1.7.5.recipe
@@ -1,4 +1,4 @@
-SUMMARY="Extended version of the yabsic programming language"
+SUMMARY="Extended version of the yabasic programming language"
 DESCRIPTION="
 yab is an extended version of yabasic, a BASIC programming language, with \
 special commands designed for Haiku.
@@ -7,7 +7,7 @@ HOMEPAGE="http://yab.orgfree.com"
 SOURCE_URI="https://github.com/bbjimmy/YAB/archive/1.7.5.tar.gz"
 CHECKSUM_SHA256="45ea5fccd6ec0989e93bdb4dc31c271cf8eb8f39cce9ca9c2f4ab02f3ee8cc10"
 
-REVISION="1"
+REVISION="2"
 LICENSE="Artistic"
 COPYRIGHT="
 	1995-2006 Marc-Oliver Ihm (yabasic)
@@ -18,13 +18,10 @@ COPYRIGHT="
 ARCHITECTURES="x86_gcc2 x86 ?x86_64"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 PROVIDES="
-	yab=$portVersion
-	cmd:yab= $portVersion
-	libyab=$portVersion
-	lib:libyab=$portVersion
-	"
-PROVIDES_devel="
-	devel:libyab=$portVersion
+	yab = $portVersion
+	cmd:yab = $portVersion
+	lib:libyab = $portVersion
+	devel:libyab = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -62,6 +59,4 @@ INSTALL()
 	mkdir -p $documentationDir
 	ln -s $appsDir/yab-IDE/Documentation $documentationDir/yab-1.7.5
 	prepareInstalledDevelLibs libyab
-	
-
 }


### PR DESCRIPTION
Declare devel:libyab to avoid a policy error.
Fixed typo in SUMMARY.