### PR TITLE
Fix the checksum of bookmarkconverter

### DIFF
--- a/haiku-apps/bookmarkconverter/bookmarkconverter-0.4.3.recipe
+++ b/haiku-apps/bookmarkconverter/bookmarkconverter-0.4.3.recipe
@@ -7,7 +7,7 @@ HOMEPAGE="http://github.com/HaikuArchives/BookmarkConverter"
 
 gitRevision="9f80b05d0afd07fb732f352b92a3e831077d005a"
 SOURCE_URI="https://github.com/HaikuArchives/BookmarkConverter/archive/$gitRevision.zip"
-CHECKSUM_SHA256="fcd74f4f71f9f399b6c5bf824486a898ad99aeef237e674da7c0928d3cafce1e"
+CHECKSUM_SHA256="c87abb461088ff7f959ee1204c93d6632865bca8dfa22d703a2b8c6b52538f4c"
 SOURCE_DIR="BookmarkConverter-$gitRevision"
 
 REVISION="1"


### PR DESCRIPTION
Apparently the checksum for bookmarkconverter was wrong. This commit makes the recipe build again (at least on my machine).