### PR TITLE
add architecture x86_64 for nanosvgtranslator-1.0.1 recipe

### DIFF
--- a/haiku-apps/nanosvgtranslator/nanosvgtranslator-1.0.1.recipe
+++ b/haiku-apps/nanosvgtranslator/nanosvgtranslator-1.0.1.recipe
@@ -1,21 +1,21 @@
 SUMMARY="A translator for SVG files"
-DESCRIPTION="
-This is a translator for SVG files based on nanosvg headers by Mikko Mononen \
-(https://github.com/memononen/nanosvg). Scalable Vector Graphics (SVG) is an \
-XML-based vector image format for two-dimensional graphics with support for \
-interactivity and animation. The SVG specification is an open standard \
-developed by the World Wide Web Consortium (W3C) since 1999.
+DESCRIPTION="This is a translator for SVG files based on nanosvg headers by \
+Mikko Mononen (https://github.com/memononen/nanosvg). Scalable Vector \
+Graphics (SVG) is an XML-based vector image format for two-dimensional \
+graphics with support for interactivity and animation. The SVG specification is \
+an open standard developed by the World Wide Web Consortium (W3C) since \
+1999.
 
 SVG images and their behaviors are defined in XML text files. This means \
 that they can be searched, indexed, scripted, and compressed. As XML files, \
-SVG images can be created and edited with any text editor, but are more often \
-created with drawing software."
+SVG images can be created and edited with any text editor, but are more \
+often created with drawing software."
 LICENSE="MIT"
 COPYRIGHT="2013-2015 3dEyes**"
 HOMEPAGE="https://github.com/threedeyes/NanoSVGTranslator"
 SOURCE_URI="git+https://github.com/threedeyes/NanoSVGTranslator#97666698908722e54d3a1746e03fd1f719438237"
 REVISION="1"
-ARCHITECTURES="x86_gcc2 x86"
+ARCHITECTURES="x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
 PROVIDES="


### PR DESCRIPTION
This adds support for x86_64 as architecture.
I've used the nanosvgtranslator add-on on my x86_64 installation for a few weeks without problems (or let's say: no more than on a gcc2hybrid - there are still some rendering issues), so I assume it should be okay to include x86_64 as supported platform.