### PR TITLE
Add recipe for the Hack font.

### DIFF
--- a/media-fonts/hack_font/hack_font-2.010.recipe
+++ b/media-fonts/hack_font/hack_font-2.010.recipe
@@ -1,0 +1,32 @@
+SUMMARY="A typeface designed for source code"
+DESCRIPTION="Hack includes monospaced regular, bold, oblique, and bold oblique sets to\
+cover all of your syntax highlighting needs."
+HOMEPAGE="http://sourcefoundry.org/hack/"
+COPYRIGHT="Christopher Simpkins"
+LICENSE="SIL Open Font License v1.1"
+REVISION="1"
+SOURCE_URI="https://github.com/chrissimpkins/Hack/releases/download/v$portVersion/Hack-v2_010-ttf.zip"
+CHECKSUM_SHA256="d28782fc3154fcdda97df66ffc138b087d0f1249f2d9e83d32d209a7935e8493"
+SOURCE_DIR=""
+
+ARCHITECTURES="x86 x86_gcc2 x86_64"
+
+PROVIDES="
+	hack_font = $portVersion
+	"
+BUILD_PREREQUIRES="
+	cmd:cp
+	cmd:mkdir
+	"
+
+BUILD()
+{
+	echo "No building required."
+}
+
+INSTALL()
+{
+	FONTDIR=$fontsDir/ttfonts
+	mkdir -p ${FONTDIR}
+	cp -r *.ttf ${FONTDIR}/
+}


### PR DESCRIPTION
I have created a recipe for a font called Hack.
My only concern is that the font license is `Modified SIL Open Font License & Bitstream Vera License` but haiku porter did not let me use this string as a value.