### PR TITLE
bash_completion: fix the recipe and add support for pkgman and finddir

### DIFF
--- a/app-shells/bash/bash-4.3.42.recipe
+++ b/app-shells/bash/bash-4.3.42.recipe
@@ -55,7 +55,7 @@ CHECKSUM_SHA256_042="b75a53141ab3d8fff3fa74b5f3dc76468b01eae299f50bbc2bc71ae395d
 
 PATCHES="bash-kill_by_name.patch"
 SOURCE_DIR="bash-4.3"
-REVISION="1"
+REVISION="2"
 LICENSE="GNU GPL v3"
 COPYRIGHT="1987-2014 Free Software Foundation, Inc."
 ARCHITECTURES="x86_gcc2 x86 x86_64"
@@ -125,6 +125,13 @@ for f in ~/.bash* ~/.profile ; do
 done
 EOF
 	chmod a+x $prefix/boot/post-install/move-bash-files.sh
+
+	# Use bash-completion, if available
+	cat <<'EOF' > $settingsDir/bashrc
+#!/bin/bash
+[[ $PS1 && -f /system/data/bash-completion/bash_completion ]] && \
+    . /system/data/bash-completion/bash_completion
+EOF
 }
 
 POST_INSTALL_SCRIPTS="

--- a/app-shells/bash_completion/bash_completion-2.1.recipe
+++ b/app-shells/bash_completion/bash_completion-2.1.recipe
@@ -11,12 +11,14 @@ programmable completion routines for the most common Linux/UNIX commands, \
 reducing the amount of typing sysadmins and programmers need to do on \
 a daily basis."
 HOMEPAGE="http://bash-completion.alioth.debian.org/"
+COPYRIGHT="2006-2014 Debian Project"
+LICENSE="GNU GPL v2"
+REVISION="2"
 SOURCE_URI="http://bash-completion.alioth.debian.org/files/bash-completion-$portVersion.tar.bz2"
 CHECKSUM_SHA256="2b606804a7d5f823380a882e0f7b6c8a37b0e768e72c3d4107c51fbe8a46ae4f"
 SOURCE_DIR="bash-completion-$portVersion"
-REVISION="1"
-LICENSE="GNU GPL v2"
-COPYRIGHT="2006-2014 Debian Project"
+PATCHES="bash_completion-haiku.patch"
+
 ARCHITECTURES="any"
 
 PROVIDES="
@@ -30,8 +32,11 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	haiku
-	cmd:bash
+	cmd:aclocal
+	cmd:autoconf
+	cmd:automake
 	cmd:awk
+	cmd:bash
 	cmd:make
 	"
 
@@ -42,17 +47,10 @@ USER_SETTINGS_FILES="
 	settings/profile.d/bash_completion.sh
 	"
 
-PATCH()
-{
-	cd completions
-	for file in *
-	do
-    	chmod +x $file
-	done
-}
-
 BUILD()
 {
+	aclocal
+	automake
 	runConfigure ./configure
 	make $jobArgs
 }
@@ -60,6 +58,4 @@ BUILD()
 INSTALL()
 {
 	make install
-	chmod +x $settingsDir/profile.d/bash_completion.sh
-	chmod +x $dataDir/bash-completion/bash_completion
 }

--- a/app-shells/bash_completion/patches/bash_completion-haiku.patch
+++ b/app-shells/bash_completion/patches/bash_completion-haiku.patch
@@ -1,0 +1,102 @@
+From 305b56f2c4e91c8502c253e4cfb2d83f46678dda Mon Sep 17 00:00:00 2001
+From: Kostadin Damyanov <maxmight@gmail.com>
+Date: Wed, 23 Sep 2015 22:55:52 +0300
+Subject: [PATCH] Add pkgman and finddir support.
+
+---
+ completions/Makefile.am |  4 +++-
+ completions/finddir     | 17 +++++++++++++++++
+ completions/pkgman      | 42 ++++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 62 insertions(+), 1 deletion(-)
+ create mode 100644 completions/finddir
+ create mode 100644 completions/pkgman
+
+diff --git a/completions/Makefile.am b/completions/Makefile.am
+index f312b3a..3c43796 100644
+--- a/completions/Makefile.am
++++ b/completions/Makefile.am
+@@ -377,7 +377,9 @@ bashcomp_DATA = a2x \
+ 		xz \
+ 		xzdec \
+ 		ypmatch \
+-		yum-arch
++		yum-arch \
++		pkgman \
++		finddir
+ 
+ EXTRA_DIST = $(bashcomp_DATA) \
+ 	     _mock _modules _subversion _udevadm _yum _yum-utils
+diff --git a/completions/finddir b/completions/finddir
+new file mode 100644
+index 0000000..cf7f6e4
+--- /dev/null
++++ b/completions/finddir
+@@ -0,0 +1,17 @@
++_finddir()
++{
++	local cur words
++	_init_completion || return
++
++	COMPREPLY=()
++	cur=${COMP_WORDS[COMP_CWORD]}
++
++	if [[ "$cur" == -* ]]; then
++		COMPREPLY=( $( compgen -W '-l -v' -- "$cur" ) )
++	else
++		COMPREPLY=( $( compgen -W '$( finddir -l )' -- "$cur" ) )
++	fi
++
++	return 0
++} &&
++complete -F _finddir finddir
+diff --git a/completions/pkgman b/completions/pkgman
+new file mode 100644
+index 0000000..f1f942f
+--- /dev/null
++++ b/completions/pkgman
+@@ -0,0 +1,42 @@
++_pkgman()
++{
++	local cur words
++	_init_completion || return
++
++	COMPREPLY=()
++	cur=${COMP_WORDS[COMP_CWORD]}
++
++	local special i
++	for (( i=0; i < ${#words[@]}-1; i++ )); do
++		if [[ ${words[i]} == @(install|uninstall) ]]; then
++			special=${words[i]}
++		fi
++	done
++
++	if [[ -n $special ]]; then
++		case $special in
++			install)
++				COMPREPLY=( $( compgen -W "$( pkgman search -a -D | awk 'NR>2 { print $2 }' )" -- "$cur" ) )
++				return 0
++				;;
++			uninstall)
++				COMPREPLY=( $( compgen -W "$( pkgman search -a -i | awk 'NR>2 { print $2 }' )" -- "$cur" ) )
++				return 0
++				;;
++			*)
++				return 0
++				;;
++		esac
++	fi
++
++	if [[ "$cur" == -* ]]; then
++		COMPREPLY=( $( compgen -W '-h --help' -- "$cur" ) )
++	else
++		COMPREPLY=( $( compgen -W 'full-sync install search \
++			uninstall update add-repo drop-repo list-repos refresh \
++			resolve-dependencies' -- "$cur" ) )
++	fi
++
++	return 0
++} &&
++complete -F _pkgman pkgman
+-- 
+2.2.2
+


### PR DESCRIPTION
Hello.

I have fixed the recipe and added tab-completion support for pkgman and finddir. The pkgman completion script can even complete package names for the 'install' and 'uninstall' options.

To test it install the package, start a shell and execute `source /system/data/bash-completion/bash_completion`.

To have it automatically enabled you have to put the following code in ~/.bashrc as the README says:

```
# Use bash-completion, if available
[[ $PS1 && -f /system/data/bash-completion/bash_completion ]] && \
    . /system/data/bash-completion/bash_completion
```

I have not tested that last part though.