### PR TITLE
Update cdrtools to 3.02~a01

### DIFF
--- a/app-cdr/cdrtools/cdrtools-3.02~a01.recipe
+++ b/app-cdr/cdrtools/cdrtools-3.02~a01.recipe
@@ -1,0 +1,155 @@
+SUMMARY="A CD/DVD/Blu-ray premastering and recording software"
+DESCRIPTION="cdrtools is a set of command line programs suitable for creating \
+and recording file system images to CD, DVD and Blu-ray media.
+
+The suite includes the following programs:
+- cdrecord: A CD/DVD/BD recording program
+- readcd: A program to read CD/DVD/BD media with CD-clone features
+- cdda2wav: The most evolved CD-audio extraction program with paranoia support
+- mkisofs: A program to create hybrid ISO9660/JOLIET/HFS filesystems with \
+optional Rock Ridge attributes
+- isodebug: A program to print mkisofs debug information from media
+- isodump: A program to dump ISO-9660 media
+- isoinfo: A program to analyse/verify ISO/9660/Joliet/Rock-Ridge Filesystems
+- isovfy: A program to verify the ISO-9660 structures
+- rscsi: A Remote SCSI enabling daemon"
+HOMEPAGE="http://cdrecord.org/"
+COPYRIGHT="1995-2015 Joerg Schilling (cdrecord, readcd)
+	1993-2004,2015 Heiko Eissfeldt, 2004-2015 Joerg Schilling (cdda2wav)
+	1993-1997 Eric Youngdale, 1997-2002 James Pearson, 1997-2015 Joerg \
+Schilling (mkisofs)"
+LICENSE="GNU GPL v2
+	CDDL v1"
+REVISION="1"
+SOURCE_URI="http://downloads.sourceforge.net/cdrtools/cdrtools-3.02a01.tar.bz2"
+CHECKSUM_SHA256="e5ed2ff44dfb92d1368df2cd648577c8feca6cd8cd52f1f14a0e405a44840e00"
+SOURCE_DIR="cdrtools-3.02"
+PATCHES="cdrtools-3.02-Defaults.haiku.patch cdrtools-3.02-scsi-beos.c.patch"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+GLOBAL_WRITABLE_FILES="
+	settings/cdrecord keep-old
+	settings/rscsi keep-old
+	"
+
+PROVIDES="
+	cdrtools = $portVersion compat >= 3
+	cmd:devdump = $portVersion compat >= 3
+	cmd:rscsi = $portVersion compat >= 3
+	cmd:scgcheck = $portVersion compat >= 3
+	cmd:mkisofs = $portVersion compat >= 3
+	cmd:btcflash = $portVersion compat >= 3
+	cmd:scgskeleton = $portVersion compat >= 3
+	cmd:isovfy = $portVersion compat >= 3
+	cmd:readcd = $portVersion compat >= 3
+	cmd:isodebug = $portVersion compat >= 3
+	cmd:cdda2mp3 = $portVersion compat >= 3
+	cmd:cdda2ogg = $portVersion compat >= 3
+	cmd:cdda2wav = $portVersion compat >= 3
+	cmd:mkhybrid = $portVersion compat >= 3
+	cmd:cdrecord = $portVersion compat >= 3
+	cmd:isodump = $portVersion compat >= 3
+	cmd:isoinfo = $portVersion compat >= 3
+	"
+REQUIRES="
+	haiku
+	"
+
+PROVIDES_devel="
+	cdrtools_devel = $portVersion
+	devel:libcdrdeflt = $portVersion compat >= 3
+	devel:libedc_ecc = $portVersion compat >= 3
+	devel:libedc_ecc_dec = $portVersion compat >= 3
+	devel:libdeflt = $portVersion compat >= 3
+	devel:libfile = $portVersion compat >= 3
+	devel:libfind = $portVersion compat >= 3
+	devel:libhfs = $portVersion compat >= 3
+	devel:libmdigest = $portVersion compat >= 3
+	devel:libparanoia = $portVersion compat >= 3
+	devel:librscg = $portVersion compat >= 3
+	devel:libscg = $portVersion compat >= 3
+	devel:libsiconv = $portVersion compat >= 3
+	devel:libscgcmd = $portVersion compat >= 3
+	devel:libschily = $portVersion compat >= 3
+	"
+REQUIRES_devel="
+	cdrtools == $portVersion
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:find
+	cmd:gcc
+	cmd:grep
+	cmd:ld
+	cmd:make
+	cmd:sed
+	"
+
+patchInsdir()
+{
+	# Usage: patchInsdir <oldDir> <newDir> <file> ...
+	oldDir=$1
+	newDir=$2
+	shift 2
+
+	sed -i "s,^INSDIR=\s*$oldDir,INSDIR= $newDir," $@
+}
+
+PATCH()
+{
+	allMakefiles="$(find . -name Makefile\*) $(find . -name \*.mk)"
+
+	patchInsdir bin $relativeBinDir $allMakefiles
+	patchInsdir sbin $relativeBinDir $allMakefiles
+	patchInsdir share/doc $relativeDocDir $allMakefiles
+	patchInsdir include $relativeIncludeDir $allMakefiles
+	patchInsdir lib $relativeLibDir $allMakefiles
+	patchInsdir etc/default settings $allMakefiles
+
+	sed -i "s,/etc/default,$sysconfDir," \
+		btcflash/btcflash.1 \
+		cdda2wav/cdda2mp3 \
+		cdda2wav/cdda2ogg \
+		cdda2wav/cdda2*.1 \
+		cdrecord/COPYING \
+		cdrecord/README.* \
+		cdrecord/auinfo.c \
+		cdrecord/cdrecord.1 \
+		doc/*.man \
+		doc/*.ps \
+		include/schily/deflts.h \
+		libcdrdeflt/cdrdeflt.c \
+		libcdrdeflt/cdrdeflt.h \
+		mkisofs/diag/isoinfo.8 \
+		readcd/readcd.1 \
+		rscsi/rscsi.1 \
+		rscsi/rscsi.c \
+		scgskeleton/scgskeleton.1
+}
+
+BUILD()
+{
+	# not multi-job safe
+	make GMAKE_NOWARN=true INS_BASE=$prefix INS_RBASE=$prefix LDPATH="" \
+		RUNPATH="" DEFMANBASE=$relativeDocumentationDir
+}
+
+INSTALL()
+{
+	make GMAKE_NOWARN=true INS_BASE=$prefix INS_RBASE=$prefix LDPATH="" \
+		RUNPATH="" DEFMANBASE=$relativeDocumentationDir install
+
+	# The whole lib folder only contains static libraries (even in several
+	# subdirectories).
+	mkdir -p $developLibDir
+	mv $libDir/* $developLibDir/
+	rmdir $libDir
+
+	# devel package
+	packageEntries devel \
+		$developDir
+}

--- a/app-cdr/cdrtools/patches/cdrtools-3.02-Defaults.haiku.patch
+++ b/app-cdr/cdrtools/patches/cdrtools-3.02-Defaults.haiku.patch
@@ -1,0 +1,23 @@
+diff -up cdrtools-3.02/DEFAULTS/Defaults.haiku cdrtools-3.02-haiku/DEFAULTS/Defaults.haiku
+--- cdrtools-3.02/DEFAULTS/Defaults.haiku	2013-11-04 20:58:20.000000000 +0000
++++ cdrtools-3.02-haiku/DEFAULTS/Defaults.haiku
+@@ -30,16 +30,16 @@ CWARNOPTS=
+ 
+ DEFINCDIRS=	$(SRCROOT)/include
+ DEFOSINCDIRS=
+-LDPATH=		-L/opt/schily/lib
++LDPATH=		-L$(shell finddir B_SYSTEM_LIB_DIRECTORY)
+ #RUNPATH=	-R$(INS_BASE)/lib -R/opt/schily/lib -R$(OLIBSDIR)
+-RUNPATH=	-R$(INS_BASE)/lib -R/opt/schily/lib
++RUNPATH=	-R$(INS_BASE)/lib
+ 
+ ###########################################################################
+ #
+ # Installation config stuff
+ #
+ ###########################################################################
+-INS_BASE=	/boot/opt/schily
++#INS_BASE=	/boot/opt/schily
+ INS_KBASE=	/
+ INS_RBASE=	/
+ #

--- a/app-cdr/cdrtools/patches/cdrtools-3.02-scsi-beos.c.patch
+++ b/app-cdr/cdrtools/patches/cdrtools-3.02-scsi-beos.c.patch
@@ -1,0 +1,31 @@
+diff -up cdrtools-3.02/libscg/scsi-beos.c cdrtools-3.02-haiku/libscg/scsi-beos.c
+--- cdrtools-3.02/libscg/scsi-beos.c	2009-06-30 18:34:03.000000000 +0000
++++ cdrtools-3.02-haiku/libscg/scsi-beos.c
+@@ -292,7 +292,11 @@ scgo_havebus(scgp, busno)
+ 	char		buf[128];
+ 
+ 	if (busno < 8)
++#ifdef	__HAIKU__
++		js_snprintf(buf, sizeof (buf), "/dev/disk/scsi/%d", busno);
++#else
+ 		js_snprintf(buf, sizeof (buf), "/dev/bus/scsi/%d", busno);
++#endif
+ 	else
+ #ifdef	__HAIKU__
+ 		js_snprintf(buf, sizeof (buf), "/dev/disk/atapi/%d", busno-8);
+@@ -320,9 +324,15 @@ scgo_fileno(scgp, busno, tgt, tlun)
+ 			return (f->fd);
+ 	}
+ 	if (busno < 8) {
++#ifdef __HAIKU__
++		js_snprintf(buf, sizeof (buf),
++					"/dev/disk/scsi/%d/%d/%d/raw",
++					busno, tgt, tlun);
++#else
+ 		js_snprintf(buf, sizeof (buf),
+ 					"/dev/bus/scsi/%d/%d/%d/raw",
+ 					busno, tgt, tlun);
++#endif
+ 	} else {
+ 		char *tgtstr = (tgt == 0) ? "master" : (tgt == 1) ? "slave" : "dummy";
+ 		js_snprintf(buf, sizeof (buf),


### PR DESCRIPTION
Adding cdrtools-3.02~a01.recipe and 2 patches:
cdrtools-3.02-Defaults.haiku.patch
cdrtools-3.02-scsi-beos.c.patch
Since the patches will probably be valid for all 3.02{,aXX} releases,
I'm getting rid of the "~aXX" string in the names of the patches.
This means future updates for 3.02aXX (as well as for 3.02 stable)
will only require editing a single file: the recipe.