### PR TITLE
Updated freealut recipe.

### DIFF
--- a/media-libs/freealut/freealut-1.1.0.recipe
+++ b/media-libs/freealut/freealut-1.1.0.recipe
@@ -1,24 +1,48 @@
 DESCRIPTION="FreeALUT - a free implementation of OpenAL's ALUT standard."
 HOMEPAGE="http://connect.creativelabs.com/openal"
-SOURCE_URI="http://connect.creativelabs.com/openal/Downloads/ALUT/freealut-1.1.0.tar.gz"
-CHECKSUM_MD5="e089b28a0267faabdb6c079ee173664a"
+SOURCE_URI="http://ftp.de.debian.org/debian/pool/main/f/freealut/freealut_1.1.0.orig.tar.gz"
 REVISION="1"
-STATUS_HAIKU="stable"
-DEPEND="media-libs/openal >= 1.6.372
-		dev-util/cmake >= 2.8.1"
+SUMMARY="Implementation of the OpenAL Utility Toolkit"
+CHECKSUM_SHA256="60d1ea8779471bb851b89b49ce44eecb78e46265be1a6e9320a28b100c8df44f"
+SOURCE_DIR="freealut-1.1.0"
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86_gcc2 x86"
+PROVIDES="
+	freealut$secondaryArchSuffix = $portVersion compat >= 0
+	lib:freealut$secondaryArchSuffix = 1.1.0 compat >= 0
+"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libopenal$secondaryArchSuffix
+"
 
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libopenal$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:automake
+	cmd:doxygen
+	cmd:find
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:libtoolize
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:ranlib
+	"
 BUILD()
 {
-	cd freealut-1.1.0
 	libtoolize --force --copy --install
 	./autogen.sh
-	./configure --prefix=`finddir B_COMMON_DIRECTORY`
-	make
+	runConfigure ./configure
+	make $jobArgs
 }
 
 INSTALL()
 {
-	cd freealut-1.1.0
 	make install
 }
 


### PR DESCRIPTION
This PR updates the freealut recipe with new haikuporter keys and the URL was a dead link, so the mirror from ftp.debian.org was used instead.