### PR TITLE
Add cln and ginac recipes

### DIFF
--- a/sci-libs/cln/cln-1.3.4.recipe
+++ b/sci-libs/cln/cln-1.3.4.recipe
@@ -1,0 +1,66 @@
+SUMMARY="A C++ library for efficient computations with arbitrary precision numbers"
+DESCRIPTION="CLN stands for Class Library for Numbers and is a library for \
+high-performance numeric computations with arbitrary precision. It is \
+implemented in C++ for high efficiency, type safety and nice syntax and \
+supports a wide range of types and functions that operate on them. It is \
+highly optimized in terms of both efficiency and speed and provides great \
+interoperability."
+HOMEPAGE="http://www.ginac.de/CLN/"
+COPYRIGHT="
+	1988-2008 Bruno Haible
+	2000-2014 Richard Kreckel
+	2008-2010 Alexei Sheplyakov
+	"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="http://www.ginac.de/CLN/cln-$portVersion.tar.bz2"
+CHECKSUM_SHA256="2d99d7c433fb60db1e28299298a98354339bdc120d31bb9a862cafc5210ab748"
+PATCHES="cln-$portVersion.patch"
+
+ARCHITECTURES="x86 !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	cln$secondaryArchSuffix = $portVersion
+	lib:libcln$secondaryArchSuffix = $portVersion
+	cmd:pi$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	devel:libcln$secondaryArchSuffix = $portVersion
+	"
+REQUIRES_devel="
+	libcln$secondaryArchSuffix == $portVersion
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:make
+	cmd:gcc$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	runConfigure ./configure
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	rm $libDir/*.la
+
+	prepareInstalledDevelLib libcln
+
+	fixPkgconfig
+
+	packageEntries devel \
+		$developDir
+}

--- a/sci-libs/cln/patches/cln-1.3.4.patch
+++ b/sci-libs/cln/patches/cln-1.3.4.patch
@@ -1,0 +1,34 @@
+From 9a214e68d41b72c1515468b9cae413e4985ceec9 Mon Sep 17 00:00:00 2001
+From: Markus Himmel <markus@himmel-villmar.de>
+Date: Mon, 14 Dec 2015 22:10:43 +0100
+Subject: [PATCH] Add Haiku defines
+
+---
+ src/base/random/cl_random_from.cc | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/base/random/cl_random_from.cc b/src/base/random/cl_random_from.cc
+index 22d48b6..7dd243c 100644
+--- a/src/base/random/cl_random_from.cc
++++ b/src/base/random/cl_random_from.cc
+@@ -18,7 +18,7 @@
+ #include "base/cl_low.h"
+ #include <cstdlib>  // declares rand()
+ 
+-#if defined(unix) || defined(__unix) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(_AIX) || defined(sinix) || (defined(__MACH__) && defined(__APPLE__)) || (defined(__CYGWIN__) && defined(__GNUC__)) || defined(__BEOS__)
++#if defined(unix) || defined(__unix) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(_AIX) || defined(sinix) || (defined(__MACH__) && defined(__APPLE__)) || (defined(__CYGWIN__) && defined(__GNUC__)) || defined(__BEOS__) || defined(__HAIKU__)
+ 
+ #include <sys/types.h>
+ #include <unistd.h> // declares getpid()
+@@ -86,7 +86,7 @@ random_state::random_state ()
+ {
+ 	var uint32 seed_hi;
+ 	var uint32 seed_lo;
+-#if defined(unix) || defined(__unix) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(_AIX) || defined(sinix) || (defined(__MACH__) && defined(__APPLE__)) || (defined(__CYGWIN__) && defined(__GNUC__)) || defined(__BEOS__)
++#if defined(unix) || defined(__unix) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(_AIX) || defined(sinix) || (defined(__MACH__) && defined(__APPLE__)) || (defined(__CYGWIN__) && defined(__GNUC__)) || defined(__BEOS__) || defined(__HAIKU__)
+ 	seed_lo = get_seed();
+ 	seed_hi = (rand() // zufällige 31 Bit (bei UNIX_BSD) bzw. 16 Bit (bei UNIX_SYSV)
+                           << 8) ^ (uintL)(getpid()); // ca. 8 Bit von der Process ID
+-- 
+2.2.2
+

--- a/sci-libs/ginac/ginac-1.6.5.recipe
+++ b/sci-libs/ginac/ginac-1.6.5.recipe
@@ -1,0 +1,69 @@
+SUMMARY="A C++ library to combine symbolic manipulation with numeric computations"
+DESCRIPTION="GiNaC (which is a recursive acronym for GiNaC is Not a CAS) was \
+specifically developed to replace the Maple CAS as an engine for xloops. It is \
+a C++ library and attempts to bring the features of a typical CAS to the C++ \
+language itself. By doing that, it enables symbolic manipulation to be used in \
+existing numeric software written in C++."
+HOMEPAGE="http://www.ginac.de/"
+COPYRIGHT="1999-2015 Johannes Gutenberg University Mainz, Germany"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="http://www.ginac.de/ginac-$portVersion.tar.bz2"
+CHECKSUM_SHA256="e8630e186d9846123c58de7e0edcfd11b68d3831a84ae7c039c0606397b01444"
+
+ARCHITECTURES="x86 !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	ginac$secondaryArchSuffix = $portVersion
+	lib:libginac$secondaryArchSuffix = $portVersion
+	cmd:ginac_excompiler$secondaryArchSuffix = $portVersion
+	cmd:ginsh$secondaryArchSuffix = $portVersion
+	cmd:viewgar$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcln$secondaryArchSuffix >= 1.3.4
+	lib:libreadline$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	devel:libginac$secondaryArchSuffix = $portVersion
+	"
+REQUIRES_devel="
+	ginac$secondaryArchSuffix == $portVersion
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libcln$secondaryArchSuffix >= 1.3.4
+	devel:libreadline$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:diff
+	cmd:make
+	cmd:python >= 2.7
+	cmd:gcc$secondaryArchSuffix
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	runConfigure ./configure
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	rm $libDir/*.la
+
+	prepareInstalledDevelLib libginac
+
+	fixPkgconfig
+
+	packageEntries devel \
+		$developDir
+}


### PR DESCRIPTION
GCI task to add a ginac recipe. As ginac depends on cln, I ported that too. I only saw that cln already had a recipe after I was done, but the 1.3.2 recipe looks unusable anyway.