### PR TITLE
Speex 1.2: Fixed compiling problem with aclocal and automake

### DIFF
--- a/media-libs/speex/speex-1.2~rc2.recipe
+++ b/media-libs/speex/speex-1.2~rc2.recipe
@@ -52,9 +52,9 @@ BUILD_REQUIRES="
 	devel:libogg$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:aclocal_1.13
+	cmd:aclocal_1.15
 	cmd:autoconf
-	cmd:automake_1.13
+	cmd:automake_1.15
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
 	cmd:libtoolize
@@ -65,9 +65,9 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	libtoolize --copy --force --install
-	aclocal-1.13
+	aclocal-1.15
 	autoconf
-	automake-1.13
+	automake-1.15 --add-missing
 	runConfigure ./configure
 	make $jobArgs
 }


### PR DESCRIPTION
Libspeex compilation was broken, cause there is no aclocal-1.13 and autotool-1.13, also there was an error with ./compile and it is fixed with add-mising