### PR TITLE
FPC 2.6.2: Fixed download link

### DIFF
--- a/dev-lang/fpc/fpc-2.6.2.recipe
+++ b/dev-lang/fpc/fpc-2.6.2.recipe
@@ -7,7 +7,7 @@ OS/2, MorphOS, Nintendo GBA, Nintendo DS, and Nintendo Wii. Additionally, JVM, \
 MIPS (big and little endian variants) and Motorola 68k architecture targets \
 are available in the development versions."
 HOMEPAGE="http://www.freepascal.org"
-SOURCE_URI="http://sourceforge.net/projects/freepascal/files/Source/2.6.2/fpc-2.6.2.source.tar.gz/download"
+SOURCE_URI="http://sourceforge.net/projects/freepascal/files/Source/2.6.2/fpc-2.6.2.source.tar.gz"
 CHECKSUM_SHA256="71dd1be93593daf184556377dfde61c7882bc749ad8c0bc342210e542555f9d0"
 LICENSE="
 	GNU LGPL v3

--- a/dev-lang/fpc/fpc_bin-2.6.2.recipe
+++ b/dev-lang/fpc/fpc_bin-2.6.2.recipe
@@ -1,8 +1,8 @@
 SUMMARY="Pre-built binaries for the FPC build"
 DESCRIPTION="Pre-built FPC binaries for Haiku i386."
 HOMEPAGE="http://www.freepascal.org"
-SOURCE_URI="ftp://freepascal.stack.nl/pub/fpc/dist/2.6.0/i386-haiku/fpc-2.6.0.i386-haiku.tar"
-CHECKSUM_SHA256="abec33111d1d88dcce96cf26498b3687d53aa29494c6a8aada16b9b0625eef95"
+SOURCE_URI="http://sourceforge.net/projects/freepascal/files/Haiku/2.6.2/fpc-2.6.2.i386-haiku.tar"
+CHECKSUM_SHA256="9a8b2b37e37c65a467ae909962972e758442b661ddd5f81486274807ad1bd6d2"
 LICENSE="
 	GNU LGPL v3
 	GNU GPL v3
@@ -29,10 +29,11 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	binutils
+	cmd:awk
 	cmd:tar
 	"
 
-SOURCE_DIR="fpc-2.6.0.i386-haiku"
+SOURCE_DIR="fpc-2.6.2.i386-haiku"
 
 BUILD()
 {


### PR DESCRIPTION
The whole compilation was crashing cause of badly inserted link. It seems weird, but still, better when downloaded tarball has right name.