### PR TITLE
Update NetSurf to be gcc4 compatible

### DIFF
--- a/dev-libs/check/check-0.9.14.recipe
+++ b/dev-libs/check/check-0.9.14.recipe
@@ -8,33 +8,42 @@ are reportable in the following: Subunit, TAP, XML, and a generic logging \
 format.
 "
 HOMEPAGE="http://check.sourceforge.net/"
+COPYRIGHT="2001-2014 Arien Malec, Branden Archer, Chris Pickett, Fredrik \
+Hugosson, and Robert Lemmen."
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
+SOURCE_URI="http://sourceforge.net/projects/check/files/check/$portVersion/check-$portVersion.tar.gz"
+CHECKSUM_SHA256="c272624645b1b738cf57fd5d81a3e4d9b722b99d6133ee3f3c4007d4d279840a"
+
 ARCHITECTURES="x86_gcc2 x86 x86_64"
 # NOTE: on x86_64 haikuporter/python 2.7.6 cannot extract correctly the archive
 # because it contains hard links. One has to extract manually, put flag.unpack
 # build, then copy the packages. No source package can be produced.
-SOURCE_URI="http://sourceforge.net/projects/check/files/check/$portVersion/check-$portVersion.tar.gz"
-CHECKSUM_SHA256="c272624645b1b738cf57fd5d81a3e4d9b722b99d6133ee3f3c4007d4d279840a"
-COPYRIGHT="xxx"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	check = $portVersion
-
-	cmd:checkmk
-	lib:libcheck = $portVersion
-"
-
+	check$secondaryArchSuffix = $portVersion
+	cmd:checkmk$secondaryArchSuffix
+	lib:libcheck$secondaryArchSuffix = $portVersion
+	"
 REQUIRES="
-	haiku
-"
+	haiku$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	check${secondaryArchSuffix}_devel = $portVersion
+	devel:libcheck$secondaryArchSuffix = $portVersion
+	"
+REQUIRES_devel="
+	check$secondaryArchSuffix == $portVersion base
+	"
 
 BUILD_PREREQUIRES="
-	haiku_devel
+	haiku${secondaryArchSuffix}_devel
 	cmd:awk
-	cmd:gcc
+	cmd:gcc$secondaryArchSuffix
 	cmd:make
-"
+	"
 
 BUILD()
 {
@@ -55,13 +64,3 @@ TEST()
 {
 	make check
 }
-
-# ----- devel package -------------------------------------------------------
-
-PROVIDES_devel="
-	check_devel = $portVersion
-	devel:libcheck = $portVersion
-	"
-REQUIRES_devel="
-	check == $portVersion base
-	"

--- a/dev-libs/json_c/json_c-0.12.recipe
+++ b/dev-libs/json_c/json_c-0.12.recipe
@@ -5,38 +5,40 @@ construct JSON objects in C, output them as JSON formatted strings and parse \
 JSON formatted strings back into the C representation of JSON objects.
 "
 HOMEPAGE="https://github.com/json-c/json-c/wiki"
-COPYRIGHT="2009-2012 Eric Haszlakiewicz
+COPYRIGHT="
+	2009-2012 Eric Haszlakiewicz
 	2004, 2005 Metaparadigm Pte Ltd"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://s3.amazonaws.com/json-c_releases/releases/json-c-0.12-nodoc.tar.gz"
 CHECKSUM_SHA256="6fd6d2311d610b279e1bcdd5c6d4f699700159d3e0786de8306af7b4bc94fb35"
 SOURCE_DIR="json-c-$portVersion"
 PATCHES="json_c-$portVersion.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	json_c = $portVersion
-	lib:libjson_c = 2.0.1 compat >= 2
+	json_c$secondaryArchSuffix = $portVersion
+	lib:libjson_c$secondaryArchSuffix = 2.0.1 compat >= 2
 	"
 REQUIRES="
-	haiku
+	haiku$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
-	json_c_devel = $portVersion
-	devel:libjson_c = 2.0.1 compat >= 2
+	json_c${secondaryArchSuffix}_devel = $portVersion
+	devel:libjson_c$secondaryArchSuffix = 2.0.1 compat >= 2
 	"
 REQUIRES_devel="
 	json_c$secondaryArchSuffix == $portVersion base
 	"
 
 BUILD_PREREQUIRES="
-	haiku_devel
+	haiku${secondaryArchSuffix}_devel
 	cmd:aclocal
 	cmd:autoreconf
-	cmd:gcc
+	cmd:gcc$secondaryArchSuffix
 	cmd:libtool
 	cmd:make
 	"

--- a/dev-libs/libcss/libcss-0.5.0.recipe
+++ b/dev-libs/libcss/libcss-0.5.0.recipe
@@ -26,7 +26,7 @@ REQUIRES="
 PROVIDES_devel="
 	libcss${secondaryArchSuffix}_devel = $portVersion
 	devel:libcss$secondaryArchSuffix = $portVersion
-"
+	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
@@ -52,8 +52,7 @@ BUILD()
 INSTALL()
 {
 	make install PREFIX=$prefix NSSHARED=/system/data/netsurf-buildsystem \
-		INCLUDEDIR=$relativeIncludeDir
-	mkdir -p $developLibDir
+		INCLUDEDIR=$relativeIncludeDir LIBDIR=$relativeLibDir
 
 	prepareInstalledDevelLib libcss
 	fixPkgconfig

--- a/dev-libs/libnsutils/libnsutils-0.0.1.recipe
+++ b/dev-libs/libnsutils/libnsutils-0.0.1.recipe
@@ -4,31 +4,30 @@ other applications."
 HOMEPAGE="http://git.netsurf-browser.org/libnsutils.git/"
 COPYRIGHT="2014 Vincent Sanders"
 LICENSE="MIT"
-ARCHITECTURES="x86_gcc2 x86_64"
-REVISION="1"
-
+REVISION="2"
 SOURCE_URI="http://download.netsurf-browser.org/libs/releases/libnsutils-$portVersion-src.tar.gz"
 CHECKSUM_SHA256="9ad6b921bceed2c0d44ca6ff36fa76841cc6533f8ed7ccb0a941fd9a78731afd"
 PATCHES="libnsutils-$portVersion.patchset"
 
+ARCHITECTURES="x86_gcc2 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
 PROVIDES="
-	libnsutils = $portVersion
-	lib:libnsutils = 0.0.1 compat >= 0
-"
+	libnsutils$secondaryArchSuffix = $portVersion
+	lib:libnsutils$secondaryArchSuffix = 0.0.1 compat >= 0
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
 
 PROVIDES_devel="
-	libnsutils_devel = $portVersion
-	devel:libnsutils = 0.0.1 compat >= 0
-"
-
-REQUIRES="
-	haiku
-"
+	libnsutils${secondaryArchSuffix}_devel = $portVersion
+	devel:libnsutils$secondaryArchSuffix = 0.0.1 compat >= 0
+	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
-
 BUILD_PREREQUIRES="
 	netsurf_buildsystem >= 1.1
 	cmd:gcc$secondaryArchSuffix

--- a/dev-libs/libutf8proc/libutf8proc-1.1.6.recipe
+++ b/dev-libs/libutf8proc/libutf8proc-1.1.6.recipe
@@ -5,35 +5,36 @@ encoding, supporting Unicode version 7.0."
 HOMEPAGE="http://julialang.org/utf8proc/"
 COPYRIGHT="2006-2013 Public Software Group"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://download.netsurf-browser.org/libs/releases/libutf8proc-1.1.6-src.tar.gz"
 CHECKSUM_SHA256="16e0dacf459bf42098614b714a262633de26ba5a03f05812d6d052c9aeeac384"
 PATCHES="libutf8proc-1.1.6.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	libutf8proc = $portVersion
-	lib:libutf8proc = 1.1.6 compat >= 1
+	libutf8proc$secondaryArchSuffix = $portVersion
+	lib:libutf8proc$secondaryArchSuffix = 1.1.6 compat >= 1
 	"
 REQUIRES="
-	haiku
+	haiku$secondaryArchSuffix
 	"
 
 REQUIRES_devel="
 	libutf8proc$secondaryArchSuffix == $portVersion base
 	"
 PROVIDES_devel="
-	libutf8proc_devel = $portVersion
-	devel:libutf8proc = 1.1.6 compat >= 1
+	libutf8proc${secondaryArchSuffix}_devel = $portVersion
+	devel:libutf8proc$secondaryArchSuffix = 1.1.6 compat >= 1
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
+	haiku${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
 	netsurf_buildsystem
-	cmd:gcc
+	cmd:gcc$secondaryArchSuffix
 	cmd:make
 	"
 

--- a/media-libs/libnsbmp/libnsbmp-0.1.2.recipe
+++ b/media-libs/libnsbmp/libnsbmp-0.1.2.recipe
@@ -3,23 +3,24 @@ DESCRIPTION="Libnsbmp is a decoding library for BMP and ICO image file formats"
 HOMEPAGE="http://www.netsurf-browser.org/projects/libnsbmp/"
 COPYRIGHT="2006 Richard Wilson, 2008 - 2013 Sean Fox"
 LICENSE="MIT"
-REVISION="1"
-SOURCE_URI="http://download.netsurf-browser.org/libs/releases/libnsbmp-$portVersion-src.tar.gz"
+REVISION="2"
 CHECKSUM_SHA256="969ba1c4f778b6ecee5fd834a6206c97b49885673389260fef1043dfca2968b1"
+SOURCE_URI="http://download.netsurf-browser.org/libs/releases/libnsbmp-$portVersion-src.tar.gz"
 PATCHES="libnsbmp-0.1.1.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	libnsbmp = $portVersion
+	libnsbmp$secondaryArchSuffix = $portVersion
 	"
 REQUIRES="
-	haiku
+	haiku$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
-	libnsbmp_devel = $portVersion
-	devel:libnsbmp = $portVersion
+	libnsbmp${secondaryArchSuffix}_devel = $portVersion
+	devel:libnsbmp$secondaryArchSuffix = $portVersion
 	"
 REQUIRES_devel="
 	libnsbmp$secondaryArchSuffix == $portVersion base
@@ -28,9 +29,9 @@ REQUIRES_devel="
 BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
-	haiku_devel
+	haiku${secondaryArchSuffix}_devel
 	netsurf_buildsystem
-	cmd:gcc
+	cmd:gcc$secondaryArchSuffix
 	cmd:make
 	"
 
@@ -42,7 +43,7 @@ BUILD()
 INSTALL()
 {
 	make PREFIX=$prefix NSSHARED=/system/data/netsurf-buildsystem \
-		INCLUDEDIR=$relativeIncludeDir install
+		INCLUDEDIR=$relativeIncludeDir install LIBDIR=$relativeLibDir
 
 	prepareInstalledDevelLib libnsbmp
 	fixPkgconfig

--- a/media-libs/libnsgif/libnsgif-0.1.2.recipe
+++ b/media-libs/libnsgif/libnsgif-0.1.2.recipe
@@ -3,23 +3,24 @@ DESCRIPTION="Libnsgif is a decoding library for GIF image file format"
 HOMEPAGE="http://www.netsurf-browser.org/projects/libnsgif/"
 COPYRIGHT="2006 Richard Wilson, 2008 - 2013 Sean Fox"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://download.netsurf-browser.org/libs/releases/libnsgif-$portVersion-src.tar.gz"
 CHECKSUM_SHA256="dd6948af5c054224489beaa4b4cc13c2c4f695d5bdee7e58ec2370c53cd9faa5"
 PATCHES="libnsgif-0.1.1.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	libnsgif = $portVersion
+	libnsgif$secondaryArchSuffix = $portVersion
 	"
 REQUIRES="
-	haiku
+	haiku$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
-	libnsgif_devel = $portVersion
-	devel:libnsgif = $portVersion
+	libnsgif${secondaryArchSuffix}_devel = $portVersion
+	devel:libnsgif$secondaryArchSuffix = $portVersion
 	"
 REQUIRES_devel="
 	libnsgif$secondaryArchSuffix == $portVersion base
@@ -28,9 +29,9 @@ REQUIRES_devel="
 BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
-	haiku_devel
+	haiku${secondaryArchSuffix}_devel
 	netsurf_buildsystem
-	cmd:gcc
+	cmd:gcc$secondaryArchSuffix
 	cmd:make
 	"
 
@@ -42,7 +43,7 @@ BUILD()
 INSTALL()
 {
 	make PREFIX=$prefix NSSHARED=/system/data/netsurf-buildsystem \
-		INCLUDEDIR=$relativeIncludeDir install
+		INCLUDEDIR=$relativeIncludeDir install LIBDIR=$relativeLibDir
 
 	prepareInstalledDevelLib libnsgif
 	fixPkgconfig

--- a/media-libs/libsvgtiny/libsvgtiny-0.1.3.recipe
+++ b/media-libs/libsvgtiny/libsvgtiny-0.1.3.recipe
@@ -5,41 +5,42 @@ library does not do the actual rendering."
 HOMEPAGE="http://www.netsurf-browser.org/projects/libsvgtiny"
 COPYRIGHT="2003-2014 The NetSurf Developers"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://download.netsurf-browser.org/libs/releases/libsvgtiny-$portVersion-src.tar.gz"
 CHECKSUM_SHA256="cbdc024743a56ccacbfa6d6bbce135ab6d701d38609f4a1ac56c2842457e5dff"
 PATCHES="libsvgtiny-0.1.1.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	libsvgtiny = $portVersion
+	libsvgtiny$secondaryArchSuffix = $portVersion
 	"
 REQUIRES="
-	haiku
+	haiku$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
-	libsvgtiny_devel = $portVersion
-	devel:libsvgtiny = $portVersion
+	libsvgtiny${secondaryArchSuffix}_devel = $portVersion
+	devel:libsvgtiny$secondaryArchSuffix = $portVersion
 	"
 REQUIRES_devel="
 	libsvgtiny$secondaryArchSuffix == $portVersion base
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
-	devel:libwapcaplet
-	devel:libdom
-	devel:libhubbub
-	devel:libparserutils
+	haiku${secondaryArchSuffix}_devel
+	devel:libwapcaplet$secondaryArchSuffix
+	devel:libdom$secondaryArchSuffix
+	devel:libhubbub$secondaryArchSuffix
+	devel:libparserutils$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	netsurf_buildsystem
-	cmd:gcc
+	cmd:gcc$secondaryArchSuffix
 	cmd:gperf
 	cmd:make
-	cmd:pkg_config
+	cmd:pkg_config$secondaryArchSuffix
 	"
 
 BUILD()
@@ -51,7 +52,7 @@ BUILD()
 INSTALL()
 {
 	make PREFIX=$prefix NSSHARED=/system/data/netsurf-buildsystem \
-		INCLUDEDIR=$relativeIncludeDir install
+		INCLUDEDIR=$relativeIncludeDir LIBDIR=$relativeLibDir install
 
 	prepareInstalledDevelLib libsvgtiny
 	fixPkgconfig

--- a/net-libs/hubbub/hubbub-0.3.1.recipe
+++ b/net-libs/hubbub/hubbub-0.3.1.recipe
@@ -10,37 +10,46 @@ If you are looking for an HTML5 parser in Python or Ruby, you may wish to \
 look at html5lib.
 "
 HOMEPAGE="http://www.netsurf-browser.org/projects/hubbub/"
-LICENSE="MIT"
 COPYRIGHT="2007-2014 J-M Bell"
+LICENSE="MIT"
+REVISION="2"
 SOURCE_URI="http://download.netsurf-browser.org/libs/releases/libhubbub-$portVersion-src.tar.gz"
 CHECKSUM_SHA256="1f8b31e86d0d32735f247c071a7ade1a475606b7a3583d2132e567a310b62053"
-REVISION="1"
-ARCHITECTURES="x86_gcc2 x86 x86_64"
-
-PROVIDES="
-	hubbub = $portVersion
-	lib:libhubbub = $portVersion compat >= 0
-	"
-REQUIRES="
-	haiku
-	"
-BUILD_REQUIRES="
-	devel:libparserutils
-	devel:libjson_c
-	devel:libiconv
-	"
-BUILD_PREREQUIRES="
-	haiku_devel
-	netsurf_buildsystem >= 0.3.0
-	cmd:gcc
-	cmd:make
-	cmd:perl
-	cmd:pkg_config
-	"
-
+SOURCE_DIR="libhubbub-$portVersion"
 PATCHES="libhubbub-0.3.0.patchset"
 
-SOURCE_DIR="libhubbub-$portVersion"
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	hubbub$secondaryArchSuffix = $portVersion
+	lib:libhubbub$secondaryArchSuffix = $portVersion compat >= 0
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	hubbub${secondaryArchSuffix}_devel = $portVersion
+	devel:libhubbub$secondaryArchSuffix = $portVersion compat >= 0
+	"
+REQUIRES_devel="
+	hubbub$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	devel:libparserutils$secondaryArchSuffix
+	devel:libjson_c$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	netsurf_buildsystem >= 0.3.0
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:perl
+	cmd:pkg_config$secondaryArchSuffix
+	"
 
 BUILD()
 {
@@ -52,9 +61,10 @@ BUILD()
 INSTALL()
 {
 	make install PREFIX=$prefix NSSHARED=/system/data/netsurf-buildsystem \
-		INCLUDEDIR=$relativeIncludeDir
+		INCLUDEDIR=$relativeIncludeDir LIBDIR=$relativeLibDir
 	make install PREFIX=$prefix NSSHARED=/system/data/netsurf-buildsystem \
-		INCLUDEDIR=$relativeIncludeDir COMPONENT_TYPE=lib-shared
+		INCLUDEDIR=$relativeIncludeDir LIBDIR=$relativeLibDir \
+		COMPONENT_TYPE=lib-shared
 
 	prepareInstalledDevelLib libhubbub
 	fixPkgconfig
@@ -66,13 +76,3 @@ TEST()
 	make PREFIX=$prefix NSSHARED=/system/data/netsurf-buildsystem \
 		LDFLAGS="-liconv -lparserutils" test
 }
-
-# ----- devel package -------------------------------------------------------
-
-PROVIDES_devel="
-	hubbub_devel = $portVersion
-	devel:libhubbub = $portVersion compat >= 0
-"
-REQUIRES_devel="
-	hubbub$secondaryArchSuffix == $portVersion base
-	"

--- a/net-libs/libdom/libdom-0.1.2.recipe
+++ b/net-libs/libdom/libdom-0.1.2.recipe
@@ -3,43 +3,44 @@ DESCRIPTION="An implementation of the W3C DOM for NetSurf, written in C."
 HOMEPAGE="http://www.netsurf-browser.org/projects/libdom/"
 COPYRIGHT="2007-2014 J-M Bell"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://download.netsurf-browser.org/libs/releases/libdom-$portVersion-src.tar.gz"
 CHECKSUM_SHA256="9cd3cf4487735c3cc5d63c5fdee05384eee65318476105646767b34d6e07e9e8"
 PATCHES="libdom-0.1.1.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	libdom = $portVersion
-	lib:libdom = $portVersion
+	libdom$secondaryArchSuffix = $portVersion
+	lib:libdom$secondaryArchSuffix = $portVersion
 	"
 REQUIRES="
-	haiku
+	haiku$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
-	libdom_devel = $portVersion
-	devel:libdom = $portVersion
+	libdom${secondaryArchSuffix}_devel = $portVersion
+	devel:libdom$secondaryArchSuffix = $portVersion
 	"
 REQUIRES_devel="
-	libdom == $portVersion base
+	libdom$secondaryArchSuffix == $portVersion base
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
-	devel:libexpat
-	devel:libhubbub
-	devel:libparserutils
-	devel:libwapcaplet
+	haiku${secondaryArchSuffix}_devel
+	devel:libexpat$secondaryArchSuffix
+	devel:libhubbub$secondaryArchSuffix
+	devel:libparserutils$secondaryArchSuffix
+	devel:libwapcaplet$secondaryArchSuffix
 	netsurf_buildsystem
 	xml_parser
 	"
 BUILD_PREREQUIRES="
-	cmd:gcc
+	cmd:gcc$secondaryArchSuffix
 	cmd:make
 	cmd:perl
-	cmd:pkg_config
+	cmd:pkg_config$secondaryArchSuffix
 	"
 
 BUILD()
@@ -50,7 +51,7 @@ BUILD()
 INSTALL()
 {
 	make PREFIX=$prefix NSSHARED=/system/data/netsurf-buildsystem \
-		INCLUDEDIR=$relativeIncludeDir install
+		INCLUDEDIR=$relativeIncludeDir LIBDIR=$relativeLibDir install
 
 	prepareInstalledDevelLib libdom
 	fixPkgconfig

--- a/www-client/netsurf/netsurf-3.3.recipe
+++ b/www-client/netsurf/netsurf-3.3.recipe
@@ -9,7 +9,7 @@ developed, NetSurf is continually evolving and improving."
 HOMEPAGE="http://www.netsurf-browser.org/"
 COPYRIGHT="2003-2014 The NetSurf Browser project"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 # Do NOT use the netsurf-all package. It contains a bunch of subprojects which
 # we build as separate packages so they can easily be used by other projects.
 SOURCE_URI="http://download.netsurf-browser.org/netsurf/releases/source/netsurf-$portVersion-src.tar.gz"
@@ -17,56 +17,56 @@ CHECKSUM_SHA256="23f92a0940f577b9605f2e54786fea3521680d32d6c00f2a3db1eae3f29e368
 PATCHES="netsurf-$portVersion.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	netsurf$secondaryArchSuffix = $portVersion
+	app:NetSurf = $portVersion
+	"
 REQUIRES="
-	haiku
-	lib:libcurl
-	lib:libexpat
-	lib:libiconv
-	lib:libpng
-	lib:libjpeg
-	lib:libssl
-	lib:libutf8proc
-	lib:libz
-	lib:libhubbub
-"
-
-BUILD_REQUIRES="
-	haiku_devel
-	devel:libcurl
-	devel:libexpat
-	devel:libiconv
-	devel:libjpeg
-	devel:libpng
-	devel:libssl
-	devel:libz
-
-	devel:libcss
-	devel:libdom
-	devel:libhubbub
-	devel:libnsbmp
-	devel:libnsgif
-	devel:libnsutils
-	devel:libparserutils
-	devel:libsvgtiny
-	devel:libutf8proc
-	devel:libwapcaplet
+	haiku$secondaryArchSuffix
+	lib:libcurl$secondaryArchSuffix
+	lib:libexpat$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libpng$secondaryArchSuffix
+	lib:libjpeg$secondaryArchSuffix
+	lib:libssl$secondaryArchSuffix
+	lib:libutf8proc$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	lib:libhubbub$secondaryArchSuffix
 	"
 
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libcurl$secondaryArchSuffix
+	devel:libexpat$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
+	devel:libjpeg$secondaryArchSuffix
+	devel:libpng$secondaryArchSuffix
+	devel:libssl$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+
+	devel:libcss$secondaryArchSuffix
+	devel:libdom$secondaryArchSuffix
+	devel:libhubbub$secondaryArchSuffix
+	devel:libnsbmp$secondaryArchSuffix
+	devel:libnsgif$secondaryArchSuffix
+	devel:libnsutils$secondaryArchSuffix
+	devel:libparserutils$secondaryArchSuffix
+	devel:libsvgtiny$secondaryArchSuffix
+	devel:libutf8proc$secondaryArchSuffix
+	devel:libwapcaplet$secondaryArchSuffix
+	"
 BUILD_PREREQUIRES="
 	html_parser >= 3.70
 	cmd:bison
 	cmd:flex
-	cmd:gcc
+	cmd:gcc$secondaryArchSuffix
 	cmd:git
 	cmd:gperf
 	cmd:make
-	cmd:pkg_config
+	cmd:pkg_config$secondaryArchSuffix
 	"
-
-PROVIDES="
-	netsurf = $portVersion
-	app:NetSurf = $portVersion
-"
 
 BUILD()
 {

--- a/www-client/netsurf/patches/netsurf-3.3.patchset
+++ b/www-client/netsurf/patches/netsurf-3.3.patchset
@@ -5286,3 +5286,39 @@ index 44b65aa..408e94b 100644
 -- 
 1.8.3.4
 
+From bdc9c098a80338e0cca81d363e38b6d6aadd7bd2 Mon Sep 17 00:00:00 2001
+From: DarkmatterVale <valetolpegin@gmail.com>
+Date: Mon, 21 Dec 2015 15:19:34 +0000
+Subject: Fix gcc4 build
+
+
+diff --git a/beos/about.cpp b/beos/about.cpp
+index 7db7145..776cbe9 100644
+--- a/beos/about.cpp
++++ b/beos/about.cpp
+@@ -17,6 +17,11 @@
+  */
+ 
+ #define __STDBOOL_H__	1
++#include <Alert.h>
++#include <Application.h>
++#include <Invoker.h>
++#include <String.h>
++
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+@@ -32,11 +37,6 @@ extern "C" {
+ #include "beos/scaffolding.h"
+ #include "beos/window.h"
+ 
+-#include <Alert.h>
+-#include <Application.h>
+-#include <Invoker.h>
+-#include <String.h>
+-
+ 
+ /**
+  * Creates the about alert
+-- 
+2.2.2


### PR DESCRIPTION
This PR makes all NetSurf dependencies gcc4 compatible.

Please do not merge, this is a WIP PR. I am using this so I can get responses on the changes that I am making (since I have a really difficult time making recipes).