### PR TITLE
Implement gcc4 support for haikuplot

### DIFF
--- a/haiku-apps/haikuplot/haikuplot-1.0.0.recipe
+++ b/haiku-apps/haikuplot/haikuplot-1.0.0.recipe
@@ -4,12 +4,12 @@ GUI interface to gnuplot, a popular commandline plotting tool."
 HOMEPAGE="https://github.com/HaikuArchives/HaikuPlot"
 COPYRIGHT="2015 Vale Tolpegin"
 LICENSE="MIT"
-SOURCE_URI="git+https://github.com/HaikuArchives/HaikuPlot.git#b7d0d05ad90e30ffee46c90856216b202bef4c97"
+REVISION="2"
 CHECKSUM_SHA256="6a057e52af317d10bd07c4e54643a4c6f61a4b384871a6cabfb3569800879ada"
-REVISION="1"
+SOURCE_URI="git+https://github.com/HaikuArchives/HaikuPlot.git#9ce84f12178641438ff34015c5753905f237fa56"
 
-ARCHITECTURES="x86_gcc2 !x86"
-SECONDARY_ARCHITECTURES="!x86"
+ARCHITECTURES="x86_gcc2 x86"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	haikuplot$secondaryArchSuffix = $portVersion


### PR DESCRIPTION
@humdingerb graciously took some time yesterday to update HaikuPlot to be able to support gcc4.

This PR updates the recipe to implement gcc4 support.