### PR TITLE
Add vectoroids recipe

### DIFF
--- a/games-arcade/vectoroids/vectoroids-1.1.0.recipe
+++ b/games-arcade/vectoroids/vectoroids-1.1.0.recipe
@@ -1,0 +1,55 @@
+SUMMARY="A clone of the popular Asteroids game targeting the SDL library"
+DESCRIPTION="Vectoroids is an implementation of the popular Asteroids concept \
+first conceived by Atari in the late 1970s. This version is based off the code \
+of Agendaroids, adapted to use the cross-platform SDL library for audio and \
+video, enabling it to run on numerous platforms. It uses smooth vector graphics \
+and high-quality sound effects."
+HOMEPAGE="http://www.newbreedsoftware.com/vectoroids/"
+COPYRIGHT="2001-2002 Bill Kendrick"
+LICENSE="GNU GPL v2"
+REVISION=1
+SOURCE_URI="ftp://ftp.tuxpaint.org/unix/x/vectoroids/src/vectoroids-1.1.0.tar.gz"
+CHECKSUM_SHA256="8d14dd281767e994108abd77c8e67d5a17718d0ad1e34d37e026911d14697b2e"
+
+ARCHITECTURES="x86_gcc2 ?x86"
+
+PROVIDES="
+	vectoroids = $portVersion
+	cmd:vectoroids = $portVersion
+	"
+REQUIRES="
+	haiku
+	lib:libsdl
+	lib:libSDL_image
+	lib:libSDL_mixer
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	devel:libsdl
+	devel:libSDL_image
+	devel:libSDL_mixer
+	"
+BUILD_PREREQUIRES="
+	cmd:make
+	cmd:gcc
+	"
+
+# The Makefile for Vectoroids is hand-written and only works if you append a
+# slash to DATA_PREFIX, but not the rest of the prefixes. MAN_PREFIX expects
+# the parent directory of the actual man folder.
+makeArgs="PREFIX=$prefix \
+	MAN_PREFIX=${manDir}/.. \
+	BIN_PREFIX=$binDir \
+	DATA_PREFIX=${dataDir}/"
+
+BUILD()
+{
+	make $makeArgs
+}
+
+INSTALL()
+{
+	mkdir -p $binDir
+	make install $makeArgs
+}


### PR DESCRIPTION
This recipe builds the version with sound. On my machine, the game has some performance issues when built with sound. [This branch](http://cgit.haiku-os.org/haiku/tree/src/kits/media/SoundPlayNode.cpp#n641) is triggered a lot, so I am unsure whether this is a bug in Haiku, in SDL_mixer or in Vectoroids. I also do not know whether these problems only occurr on my machine or only happen when using VirtualBox. The game runs smoothly on my machine when building without sound.