### PR TITLE
Bump HaikuPlot version & update recipe

### DIFF
--- a/haiku-apps/haikuplot/haikuplot-1.0.0.recipe
+++ b/haiku-apps/haikuplot/haikuplot-1.0.0.recipe
@@ -4,9 +4,9 @@ GUI interface to gnuplot, a popular commandline plotting tool."
 HOMEPAGE="https://github.com/HaikuArchives/HaikuPlot"
 COPYRIGHT="2015 Vale Tolpegin"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 CHECKSUM_SHA256="6a057e52af317d10bd07c4e54643a4c6f61a4b384871a6cabfb3569800879ada"
-SOURCE_URI="git+https://github.com/HaikuArchives/HaikuPlot.git#9ce84f12178641438ff34015c5753905f237fa56"
+SOURCE_URI="git+https://github.com/HaikuArchives/HaikuPlot.git#6def19ed31aeed80ab9fbcd0abe70de975598de2"
 
 ARCHITECTURES="x86_gcc2 x86"
 SECONDARY_ARCHITECTURES="x86"
@@ -35,7 +35,8 @@ BUILD()
 
 INSTALL()
 {
-	mkdir -p $appsDir
-	cp -r HaikuPlot $appsDir
+	mkdir -p $appsDir/HaikuPlot
+	cp -r HaikuPlot/HaikuPlot $appsDir/HaikuPlot
+	cp -r demo $appsDir/HaikuPlot/demo
 	addAppDeskbarSymlink $appsDir/HaikuPlot/HaikuPlot
 }


### PR DESCRIPTION
In this PR I have updated HaikuPlot's recipe in the following ways

- Update to use latest commit
- Update install to only install the demo and the application (no source files)