### PR TITLE
[FPC]Recipe to construct a fpc 3.0.0 package for Haiku, based on the official package.

### DIFF
--- a/dev-lang/fpc/fpc_bin-3.0.0.recipe
+++ b/dev-lang/fpc/fpc_bin-3.0.0.recipe
@@ -1,0 +1,89 @@
+SUMMARY="Pre-built binaries for the FPC build"
+DESCRIPTION="Pre-built FPC binaries for Haiku i386."
+HOMEPAGE="http://www.freepascal.org"
+COPYRIGHT="1993-2015 Florian Klaempfl and others"
+LICENSE="GNU LGPL v3
+	GNU GPL v3"
+REVISION="1"
+SOURCE_URI="http://sourceforge.net/projects/freepascal/files/Haiku/3.0.0/fpc-3.0.0.i386-haiku.tar"
+CHECKSUM_SHA256="a81bf8ca23472bf04a7934c3c881c5c26d1a3a801c36360a9a667d1625d8d1f2"
+
+ARCHITECTURES="x86_gcc2 x86"
+
+PROVIDES="
+	fpc_bin = $portVersion
+	cmd:fpc = $portVersion
+	cmd:ppc386 = $portVersion
+	cmd:bin2obj = $portVersion
+	cmd:chmcmd = $portVersion
+	cmd:chmls = $portVersion
+	cmd:data2inc = $portVersion
+	cmd:delp = $portVersion
+	cmd:fd2pascal = $portVersion
+	cmd:fp = $portVersion
+	cmd:fpcjres = $portVersion
+	cmd:fpclasschart = $portVersion
+	cmd:fpcmake = $portVersion
+	cmd:fpcmkcfg = $portVersion
+	cmd:fpcres = $portVersion
+	cmd:fpcsubst = $portVersion
+	cmd:fpdoc = $portVersion
+	cmd:fppkg = $portVersion
+	cmd:fprcp = $portVersion
+	cmd:h2pas = $portVersion
+	cmd:h2paspp = $portVersion
+	cmd:instantfpc = $portVersion
+	cmd:makeskel = $portVersion
+	cmd:mkarmins = $portVersion
+	cmd:mkinsadd = $portVersion
+	cmd:mkx86ins = $portVersion
+	cmd:pas2fpm = $portVersion
+	cmd:pas2jni = $portVersion
+	cmd:pas2ut = $portVersion
+	cmd:plex = $portVersion
+	cmd:postw32 = $portVersion
+	cmd:ppdep = $portVersion
+	cmd:ppudump = $portVersion
+	cmd:ppufiles = $portVersion
+	cmd:ppumove = $portVersion
+	cmd:ptop = $portVersion
+	cmd:pyacc = $portVersion
+	cmd:rmcvsdir = $portVersion
+	cmd:rstconv = $portVersion
+	cmd:unitdiff = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	ncurses6
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	binutils
+	cmd:tar
+	cmd:fpc
+	"
+
+SOURCE_DIR="fpc-3.0.0.i386-haiku"
+
+BUILD()
+{
+	true
+}
+
+INSTALL()
+{
+	for f in `tar tf binary.i386-haiku.tar`; do
+		tar -xOf binary.i386-haiku.tar $f | tar -C $prefix -xzf -
+	done
+	mkdir -p $docDir/examples
+	tar -xzf doc-pdf.tar.gz -C $docDir --strip 1
+	tar -xzf demo.tar.gz -C $docDir/examples
+	ln -s ../lib/fpc/3.0.0/ppc386 ../../packaging/fpc_bin/bin/ppc386
+	# generate configuration file
+	pwd
+	mkdir -p ../../packaging/fpc_bin/lib/fpc/etc
+	../../packaging/fpc_bin/lib/fpc/3.0.0/samplecfg /boot/system/lib/fpc/3.0.0 ../../packaging/fpc_bin/lib/fpc/etc
+}


### PR DESCRIPTION
Recipe to construct a fpc 3.0.0 package for Haiku, based on the official package. It will help bootstrapping a more classical recipe that will construct the package from sources. Based on work on 2.6.2 at BeGeistert 029 with Korli.

The corresponding package is available at http://nan.tf/download/fpc_bin-3.0.0-1-x86_gcc2.hpkg