### PR TITLE
Update taglib to version 1.10

### DIFF
--- a/media-libs/taglib/patches/taglib-1.10.patchset
+++ b/media-libs/taglib/patches/taglib-1.10.patchset
@@ -1,0 +1,31 @@
+From d574f41680950f9e2608e4899bec9de94fb5854f Mon Sep 17 00:00:00 2001
+From: Markus Himmel <markus@himmel-villmar.de>
+Date: Mon, 28 Dec 2015 23:04:09 +0100
+Subject: [PATCH] Drop FORCE in CMake
+
+---
+ CMakeLists.txt | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f2455a7..631925f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -32,10 +32,10 @@ set(TESTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/tests/")
+ 
+ ## the following are directories where stuff will be installed to
+ set(LIB_SUFFIX "" CACHE STRING "Define suffix of directory name (32/64)")
+-set(EXEC_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}" CACHE PATH "Base directory for executables and libraries" FORCE)
+-set(BIN_INSTALL_DIR "${EXEC_INSTALL_PREFIX}/bin" CACHE PATH "The subdirectory to the binaries prefix (default prefix/bin)" FORCE)
+-set(LIB_INSTALL_DIR "${EXEC_INSTALL_PREFIX}/lib${LIB_SUFFIX}" CACHE PATH "The subdirectory relative to the install prefix where libraries will be installed (default is /lib${LIB_SUFFIX})" FORCE)
+-set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "The subdirectory to the header prefix" FORCE)
++set(EXEC_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}" CACHE PATH "Base directory for executables and libraries")
++set(BIN_INSTALL_DIR "${EXEC_INSTALL_PREFIX}/bin" CACHE PATH "The subdirectory to the binaries prefix (default prefix/bin)")
++set(LIB_INSTALL_DIR "${EXEC_INSTALL_PREFIX}/lib${LIB_SUFFIX}" CACHE PATH "The subdirectory relative to the install prefix where libraries will be installed (default is /lib${LIB_SUFFIX})")
++set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "The subdirectory to the header prefix")
+ 
+ if(APPLE)
+ 	option(BUILD_FRAMEWORK "Build an OS X framework" OFF)
+-- 
+2.2.2
+

--- a/media-libs/taglib/taglib-1.10.recipe
+++ b/media-libs/taglib/taglib-1.10.recipe
@@ -1,0 +1,79 @@
+SUMMARY="An audio meta-data library"
+DESCRIPTION="TagLib is a free library written in C++ for reading and editing \
+metadata that has been embedded into audio files. It is able to read and \
+edit all relevant metadata formats for audio files, including APEv2, ID3 and \
+Vorbis. It can find tags in multiple formats such as .mp3 .wma .wav .m4a \
+.flac etc. TagLib is platform independent."
+HOMEPAGE="http://github.com/taglib"
+COPYRIGHT="2002-2015 Scott Wheeler"
+LICENSE="GNU LGPL v2
+	MPL v1.1"
+REVISION="1"
+SOURCE_URI="http://taglib.github.io/releases/taglib-$portVersion.tar.gz"
+CHECKSUM_SHA256="24c32d50042cb0ddf162eb263f8ac75c5a158e12bf32ed534c1d5c71ee369baa"
+PATCHES="taglib-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 x86 ?x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	taglib$secondaryArchSuffix = $portVersion
+	cmd:taglib_config$secondaryArchSuffix
+	lib:libtag$secondaryArchSuffix = 1.15.1 compat = 1
+	lib:libtag_c$secondaryArchSuffix = 0.0.0 compat = 0
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	taglib${secondaryArchSuffix}_devel = $portVersion compat >= 1.10
+	cmd:taglib_config$secondaryArchSuffix = $portVersion compat >= 1.10
+	devel:libtag$secondaryArchSuffix = 1.15.1 compat = 1
+	devel:libtag_c$secondaryArchSuffix = 0.0.0 compat = 0
+	"
+REQUIRES_devel="
+	taglib$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:cmake
+	cmd:make
+	cmd:sed
+	cmd:grep
+	"
+
+BUILD()
+{
+	cmake	-DCMAKE_INSTALL_PREFIX:PATH=$prefix \
+			-DBIN_INSTALL_DIR:PATH=$binDir \
+			-DLIB_INSTALL_DIR:PATH=$libDir \
+			-DINCLUDE_INSTALL_DIR:PATH=$includeDir \
+			.
+	make
+}
+
+INSTALL()
+{
+	make install
+
+	prepareInstalledDevelLibs \
+			libtag \
+			libtag_c
+
+	fixPkgconfig
+
+	fixDevelopLibDirReferences $binDir/taglib-config
+	sed -i -e "s,\/.*/include,$includeDir," $binDir/taglib-config
+
+	# devel package
+	packageEntries devel \
+		$developDir \
+		$binDir
+}


### PR DESCRIPTION
~~Unlike the 1.9.1 recipe, this has been patched to build on gcc2, which is nice to have.~~ Removed this by @scottmc's request. [Corresponding GCI task](https://codein.withgoogle.com/dashboard/task-instances/4915095117234176/?sp-page=1).