### PR TITLE
Update HaikuPlot & Tipster

### DIFF
--- a/haiku-apps/haikuplot/haikuplot-1.0.0.recipe
+++ b/haiku-apps/haikuplot/haikuplot-1.0.0.recipe
@@ -5,27 +5,28 @@ HOMEPAGE="https://github.com/HaikuArchives/HaikuPlot"
 COPYRIGHT="2015 Vale Tolpegin"
 LICENSE="MIT"
 REVISION="3"
-CHECKSUM_SHA256="6a057e52af317d10bd07c4e54643a4c6f61a4b384871a6cabfb3569800879ada"
-SOURCE_URI="git+https://github.com/HaikuArchives/HaikuPlot.git#6def19ed31aeed80ab9fbcd0abe70de975598de2"
+CHECKSUM_SHA256="66f67cfdf45bb60e5ba5fca36c324ec36ec3c86c634bb76d27542a86f1d9e1c8"
+SOURCE_URI="https://github.com/HaikuArchives/HaikuPlot/archive/6def19ed31aeed80ab9fbcd0abe70de975598de2.tar.gz"
+SOURCE_DIR="HaikuPlot-6def19ed31aeed80ab9fbcd0abe70de975598de2"
 
 ARCHITECTURES="x86_gcc2 x86"
-SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	haikuplot$secondaryArchSuffix = $portVersion
+	haikuplot = $portVersion
 	app:HaikuPlot = $portVersion
 	"
 REQUIRES="
-	haiku$secondaryArchSuffix
+	haiku
+	cmd:gnuplot
 	"
 
 BUILD_REQUIRES="
-	haiku${secondaryArchSuffix}_devel
+	haiku_devel
 	"
 BUILD_PREREQUIRES="
 	makefile_engine
 	cmd:make
-	cmd:gcc$secondaryArchSuffix
+	cmd:gcc
 	"
 
 BUILD()

--- a/haiku-apps/tipster/tipster-1.0.0.recipe
+++ b/haiku-apps/tipster/tipster-1.0.0.recipe
@@ -4,27 +4,28 @@ features about haiku."
 HOMEPAGE="https://github.com/HaikuArchives/Tipster"
 COPYRIGHT="2015 Vale Tolpegin"
 LICENSE="MIT"
-REVISION="1"
-SOURCE_URI="git+https://github.com/DarkmatterVale/Tipster.git#48dd8093bccaffc4ce8bba71b52ebdf75654ffa3"
+REVISION="2"
+CHECKSUM_SHA256="648f681cb80dfaf879e79f5d99676c03925abafcf61cc47764e6ece83a329cca"
+SOURCE_URI="https://github.com/HaikuArchives/Tipster/archive/9cf96df980d6d4feea8a5793737e1687c4620249.tar.gz"
+SOURCE_DIR="Tipster-9cf96df980d6d4feea8a5793737e1687c4620249"
 
 ARCHITECTURES="x86 x86_gcc2"
-SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	tipster$secondaryArchSuffix = $portVersion
-	app:tipster$secondaryArchSuffix = $portVersion
+	tipster = $portVersion
+	app:tipster = $portVersion
 	"
 REQUIRES="
-	haiku$secondaryArchSuffix
+	haiku
 	"
 
 BUILD_REQUIRES="
-	haiku${secondaryArchSuffix}_devel
+	haiku_devel
 	"
 BUILD_PREREQUIRES="
 	makefile_engine
 	cmd:make
-	cmd:gcc$secondaryArchSuffix
+	cmd:gcc
 	"
 
 BUILD()


### PR DESCRIPTION
In this PR I have updated both the tipster and haiku plot recipes. I edited the following things:

1) Remove secondaryArchSuffix because it is not needed
2) Update the github links to use archives (which are safe sources)
3) Use the HaikuArchives Tipster repo, not mine