### PR TITLE
Fix typo in libmysqlclient recipe

### DIFF
--- a/dev-db/libmysqlclient/libmysqlclient-6.1.6.recipe
+++ b/dev-db/libmysqlclient/libmysqlclient-6.1.6.recipe
@@ -31,7 +31,7 @@ REQUIRES="
 PROVIDES_devel="
 	libmysqlclient${secondaryArchSuffix}_devel = 18.3.0 compat >= 18.3
 	devel:libmysqlclient$secondaryArchSuffix = 18.3.0 compat >= 18.3
-	devel:libmysqlclient_r$secondaryArchSuffix = 18.3.0 comat >= 18.3
+	devel:libmysqlclient_r$secondaryArchSuffix = 18.3.0 compat >= 18.3
 	"
 REQUIRES_devel="
 	libmysqlclient$secondaryArchSuffix == 18.3.0


### PR DESCRIPTION
There was a little typo error.