### PR TITLE
Updated XaoS recipe SHA-256 hash

### DIFF
--- a/haiku-apps/xaos/xaos-3.4.recipe
+++ b/haiku-apps/xaos/xaos-3.4.recipe
@@ -24,7 +24,7 @@ and J.B. Langston. Countless other improvements have been contributed by \
 volunteers around the world. You can help improve XaoS, too."
 HOMEPAGE="http://xaos.sf.net"
 SOURCE_URI="https://github.com/xaos-project/XaoS/archive/release-$portVersion.zip"
-CHECKSUM_SHA256="00ae75ee6ecfb8493286330d1ccadc91e8e915a5867387a2c08a0ff72d59bb24"
+CHECKSUM_SHA256="7b2a802c638ed880a86db4b2feccc7fc949599916329b799807758dca61d6eb8"
 ARCHITECTURES="x86_gcc2 ?x86 ?x86_64"
 REVISION="1"
 LICENSE="GNU GPL v2"


### PR DESCRIPTION
The XaoS recipe has the incorrect SHA256 hash for its version and fails to verify when using haikuporter. This small PR addresses this issue.