### PR TITLE
stripped flickcurl, freetype, glu, jpeg, and readline in recipes and …

### DIFF
--- a/media-libs/flickcurl/flickcurl-1.26.recipe
+++ b/media-libs/flickcurl/flickcurl-1.26.recipe
@@ -21,7 +21,7 @@ GNU LGPL v2.1
 "
 SOURCE_URI="http://download.dajobe.org/flickcurl/flickcurl-$portVersion.tar.gz"
 CHECKSUM_SHA256="ff42a36c7c1c7d368246f6bc9b7d792ed298348e5f0f5d432e49f6803562f5a3"
-REVISION="1"
+REVISION="2"
 ARCHITECTURES="x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
@@ -58,6 +58,11 @@ BUILD_PREREQUIRES="
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
 	"
+
+defineDebugInfoPackage flickcurl \
+	$binDir/flickcurl \
+	$binDir/flickrdf \
+	$libDir/libflickcurl.so.0.0.0
 
 BUILD()
 {

--- a/media-libs/freetype/freetype-2.6.2.recipe
+++ b/media-libs/freetype/freetype-2.6.2.recipe
@@ -7,7 +7,7 @@ LICENSE="FreeType"
 COPYRIGHT="1996-2013 David Turner, Robert Wilhelm, Werner Lemberg, et al."
 SOURCE_URI="http://download.savannah.gnu.org/releases/freetype/freetype-$portVersion.tar.bz2"
 CHECKSUM_SHA256="baf6bdef7cdcc12ac270583f76ef245efe936267dbecef835f02a3409fcbb892"
-REVISION="1"
+REVISION="2"
 ARCHITECTURES="x86_gcc2 x86 x86_64 arm"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
@@ -51,6 +51,9 @@ BUILD_PREREQUIRES="
 	cmd:make
 	cmd:which
 	"
+
+defineDebugInfoPackage freetype \
+	$libDir/libfreetype.so.6.12.2
 
 BUILD()
 {

--- a/media-libs/jpeg/jpeg-9a.recipe
+++ b/media-libs/jpeg/jpeg-9a.recipe
@@ -11,7 +11,7 @@ on many machines ranging from PCs to Crays."
 HOMEPAGE="http://www.ijg.org"
 COPYRIGHT="1991-2014, Thomas G. Lane, Guido Vollbeding"
 LICENSE="JPEG"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://www.ijg.org/files/jpegsrc.v$portVersion.tar.gz"
 CHECKSUM_SHA256="3a753ea48d917945dd54a2d97de388aa06ca2eb1066cbfdc6652036349fe05a7"
 PATCHES="jpeg-9.patchset"
@@ -64,6 +64,9 @@ BUILD_PREREQUIRES="
 	cmd:libtoolize
 	cmd:make
 	"
+
+defineDebugInfoPackage jpeg \
+	$libDir/libjpeg.so.9.1.0
 
 BUILD()
 {

--- a/sys-libs/glu/glu-9.0.0.recipe
+++ b/sys-libs/glu/glu-9.0.0.recipe
@@ -5,7 +5,7 @@ higher-level drawing routines from the more primitive routines that OpenGL provi
 HOMEPAGE="http://freedesktop.org"
 COPYRIGHT="1999-2012 Brian Paul and others"
 LICENSE="MIT"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="ftp://freedesktop.org/pub/mesa/glu/glu-9.0.0.tar.gz"
 CHECKSUM_SHA256="4387476a1933f36fec1531178ea204057bbeb04cc2d8396c9ea32720a1f7e264"
 
@@ -40,6 +40,9 @@ BUILD_PREREQUIRES="
 	cmd:make
 	cmd:sed
 	"
+
+defineDebugInfoPackage glu \
+	$libDir/libGLU.so.1.3.1
 
 BUILD()
 {

--- a/sys-libs/readline/readline-6.3.8.recipe
+++ b/sys-libs/readline/readline-6.3.8.recipe
@@ -11,7 +11,7 @@ Readline in applications which desire its capabilities."
 HOMEPAGE="http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html"
 COPYRIGHT="1989-2011 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="ftp://ftp.gnu.org/gnu/readline/readline-6.3.tar.gz"
 CHECKSUM_SHA256="56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43"
 for i in {001..008}; do
@@ -71,6 +71,10 @@ PATCH()
 			| patch -p0
 	done
 }
+
+defineDebugInfoPackage readline \
+	$libDir/libhistory.so.6.3 \
+	$libDir/libreadline.so.6.3
 
 BUILD()
 {


### PR DESCRIPTION
…created debug packages

freetype and readline libraries don't have a install-strip rule for make, so I used the strip command directly after make install.

![strip libraries](https://cloud.githubusercontent.com/assets/9368722/12181143/5448f456-b535-11e5-9497-97b7e1d84490.png)
