### PR TITLE
zlib: switch source tarball format to tar.xz

### DIFF
--- a/sys-libs/zlib/licenses/Zlib
+++ b/sys-libs/zlib/licenses/Zlib
@@ -1,4 +1,4 @@
-Copyright (C) 1995-2005 Jean-loup Gailly and Mark Adler
+Copyright (C) 1995-2013 Jean-loup Gailly and Mark Adler
 
 This software is provided 'as-is', without any express or implied
 warranty.  In no event will the authors be held liable for any damages

--- a/sys-libs/zlib/zlib-1.2.8.recipe
+++ b/sys-libs/zlib/zlib-1.2.8.recipe
@@ -11,13 +11,13 @@ expands the data. (LZW can double or triple the file size in extreme cases.) \
 zlib's memory footprint is also independent of the input data and can be \
 reduced, if necessary, at some cost in compression."
 HOMEPAGE="http://www.zlib.net/"
-COPYRIGHT="1995-2005 Jean-loup Gailly and Mark Adler"
+COPYRIGHT="1995-2013 Jean-loup Gailly and Mark Adler"
 LICENSE="Zlib"
 REVISION="4"
-SOURCE_URI="http://zlib.net/zlib-1.2.8.tar.gz"
-CHECKSUM_SHA256="36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d"
+SOURCE_URI="http://zlib.net/zlib-1.2.8.tar.xz"
+CHECKSUM_SHA256="831df043236df8e9a7667b9e3bb37e1fcb1220a0f163b6de2626774b9590d057"
 
-ARCHITECTURES="x86_gcc2 x86 x86_64 arm"
+ARCHITECTURES="x86_gcc2 x86 x86_64 arm ?ppc"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
 PROVIDES="


### PR DESCRIPTION
* Switch source tarball format from tar.gz to tar.xz.
* Add "?ppc" to ARCHITECTURES.
* Refresh Copyright year (as shown in http://www.zlib.net/) in recipe and Zlib license file.