### PR TITLE
Make libmusicbrainz usable with the Makefile engine

### DIFF
--- a/media-libs/musicbrainz/musicbrainz-5.1.0.recipe
+++ b/media-libs/musicbrainz/musicbrainz-5.1.0.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="The MusicBrainz Client Library (libmusicbrainz), also known as \
 mb_client, is a development library geared towards developers who wish to \
 add MusicBrainz lookup capabilities to their applications."
 
-REVISION="1"
+REVISION="2"
 HOMEPAGE="http://musicbrainz.org/doc/libmusicbrainz"
 SOURCE_URI="https://github.com/metabrainz/libmusicbrainz/releases/download/release-5.1.0/libmusicbrainz-5.1.0.tar.gz"
 CHECKSUM_SHA256="6749259e89bbb273f3f5ad7acdffb7c47a2cf8fcaeab4c4695484cef5f4c6b46"

--- a/media-libs/musicbrainz/patches/musicbrainz-5.1.0.patchset
+++ b/media-libs/musicbrainz/patches/musicbrainz-5.1.0.patchset
@@ -102,3 +102,45 @@ index c91a565..160d5c0 100644
 -- 
 1.8.3.4
 
+From 22d7535c6e9b9fc9b014360333a2dd7e8f497977 Mon Sep 17 00:00:00 2001
+From: Markus Himmel <markus@himmel-villmar.de>
+Date: Sun, 17 Jan 2016 10:47:49 +0100
+Subject: [PATCH] Fix includes of local files in public headers
+
+Usually, when including a header, gcc's "working directory" changes to the
+directory that header is in. When this header includes another header in the
+same directory, the correct thing happens because the compiler's current working
+directory is always a search path for local includes. However, if the -I- option
+is given to the compiler, this is no longer the case. All directories that should
+be in the search path have to be given in -I directives.
+
+The Makefile Engine on gcc2 sets -I- unconditionally, so the files included
+without musicbrainz5/ cannot not be found (gcc4 uses the preferred -iquote option
+instead of -I-, so there are  no problems with gcc4). One workaround would be to
+add the musicbrainz5/ directory as an include path, but this library has files
+such as List.h and Message.h, so there will be chaos.
+
+This commit just fixes the two includes which caused the problem.
+---
+ include/musicbrainz5/Query.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/musicbrainz5/Query.h b/include/musicbrainz5/Query.h
+index f6e15e3..1e5e013 100644
+--- a/include/musicbrainz5/Query.h
++++ b/include/musicbrainz5/Query.h
+@@ -26,9 +26,9 @@
+ #ifndef _MUSICBRAINZ5_QUERY_H
+ #define _MUSICBRAINZ5_QUERY_H
+ 
+-#include "defines.h"
++#include "musicbrainz5/defines.h"
+ 
+-#include "Entity.h"
++#include "musicbrainz5/Entity.h"
+ 
+ #include "musicbrainz5/ReleaseList.h"
+ #include "musicbrainz5/Metadata.h"
+-- 
+2.7.0
+


### PR DESCRIPTION
Just a small thing that came up when I was working on https://codein.withgoogle.com/dashboard/task-instances/4824242864521216/?sp-page=1.