### PR TITLE
HandBrake: Work on the Haiku GUI

### DIFF
--- a/media-video/handbrake/handbrake-0.10.2.recipe
+++ b/media-video/handbrake/handbrake-0.10.2.recipe
@@ -11,7 +11,7 @@ SOURCE_URI="https://handbrake.fr/rotation.php?file=HandBrake-$portVersion.tar.bz
 SOURCE_FILENAME="HandBrake-$portVersion.tar.bz2"
 CHECKSUM_SHA256="4cc3828393b26a982dbe00febd700c5090d3443c1d45492e0b373e02da73c699"
 SOURCE_DIR="HandBrake-$portVersion"
-ARCHITECTURES="x86_gcc2 x86 x86_64"
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 PATCHES="handbrake-0.10.2.patchset"
@@ -84,6 +84,9 @@ BUILD_PREREQUIRES="
 	cmd:m4
 	cmd:tar
 	"
+
+# Please check the file state.md in this directory for a detailed description
+# of the current state of the HandBrake port
 
 PATCH()
 {

--- a/media-video/handbrake/patches/handbrake-0.10.2.patchset
+++ b/media-video/handbrake/patches/handbrake-0.10.2.patchset
@@ -3766,3 +3766,485 @@ index 7d1049a..d536a18 100644
 -- 
 2.7.0
 
+From 50eb4bfe1a62c07569e8801e4a290c5fa76bdbe2 Mon Sep 17 00:00:00 2001
+From: Markus Himmel <markus@himmel-villmar.de>
+Date: Thu, 21 Jan 2016 16:17:17 +0100
+Subject: [PATCH] Fix build of the BeOS GUI
+
+This does not actually make it work properly (though it fixes a small number
+of issues). See https://github.com/haikuports/haikuports/issues/411.
+---
+ haiku/HBApp.cpp      |   1 +
+ haiku/MainWindow.cpp |  36 ++++++++-----
+ haiku/Makefile       | 133 +++++++++++++++++++++++++++++++++++++++++++++
+ haiku/PicWindow.cpp  |  24 +++++----
+ haiku/makefile       | 148 ---------------------------------------------------
+ 5 files changed, 169 insertions(+), 173 deletions(-)
+ create mode 100644 haiku/Makefile
+ delete mode 100644 haiku/makefile
+
+diff --git a/haiku/HBApp.cpp b/haiku/HBApp.cpp
+index f878308..cfd7345 100644
+--- a/haiku/HBApp.cpp
++++ b/haiku/HBApp.cpp
+@@ -4,6 +4,7 @@
+ 
+ int main()
+ {
++    hb_global_init();
+     HBApp * app = new HBApp();
+     app->Run();
+     delete app;
+diff --git a/haiku/MainWindow.cpp b/haiku/MainWindow.cpp
+index d536a18..8d5dda8 100644
+--- a/haiku/MainWindow.cpp
++++ b/haiku/MainWindow.cpp
+@@ -169,10 +169,13 @@ MainView::MainView( hb_handle_t * handle )
+     fVidRatePopUp = new BPopUpMenu( "" );
+     fVidRatePopUp->AddItem( new BMenuItem( "Same as source",
+         new BMessage() ) );
+-    for( int i = 0; i < hb_video_rates_count; i++ )
++
++    const hb_rate_t * current_video_rate = hb_video_framerate_get_next( NULL );
++    while( current_video_rate != NULL )
+     {
+-        fVidRatePopUp->AddItem( new BMenuItem( hb_video_rates[i].string,
++        fVidRatePopUp->AddItem( new BMenuItem( current_video_rate->name,
+             new BMessage() ) );
++        current_video_rate = hb_video_framerate_get_next( current_video_rate );
+     }
+     fVidRatePopUp->ItemAt( 0 )->SetMarked( true );
+     fVidRateMenu = new BMenuField( r, NULL, "Framerate (fps):",
+@@ -267,11 +270,15 @@ MainView::MainView( hb_handle_t * handle )
+     box->AddChild( fAudLang2Menu );
+     r = BRect( 10,65,b.right-10,85 );
+     fAudRatePopUp = new BPopUpMenu( "" );
+-    for( int i = 0; i < hb_audio_rates_count; i++ )
++    const hb_rate_t * current_audio_samples = hb_audio_samplerate_get_next( NULL );
++    while( current_audio_samples != NULL )
+     {
+-        fAudRatePopUp->AddItem( new BMenuItem( hb_audio_rates[i].string,
+-            new BMessage ) );
++        fAudRatePopUp->AddItem( new BMenuItem( current_audio_samples->name,
++            new BMessage() ) );
++        current_audio_samples =
++            hb_audio_samplerate_get_next( current_audio_samples );
+     }
++
+ 	#if 0
+ 	// TODO: hb_audio_rates_default
+     fAudRatePopUp->ItemAt( hb_audio_rates_default )->SetMarked( true );
+@@ -281,10 +288,12 @@ MainView::MainView( hb_handle_t * handle )
+     box->AddChild( fAudRateMenu );
+     r = BRect( 10,90,b.right-10,110 );
+     fAudBitratePopUp = new BPopUpMenu( "" );
+-    for( int i = 0; i < hb_audio_bitrates_count; i++ )
++    const hb_rate_t * current_audio_bits = hb_audio_bitrate_get_next( NULL );
++    while( current_audio_bits != NULL)
+     {
+-        fAudBitratePopUp->AddItem( new BMenuItem(
+-            hb_audio_bitrates[i].string, new BMessage ) );
++        fAudBitratePopUp->AddItem( new BMenuItem( current_audio_bits->name,
++            new BMessage() ) );
++        current_audio_bits = hb_audio_bitrate_get_next( current_audio_bits );
+     }
+     #if 0
+     // TODO: hb_audio_bitrates_default
+@@ -676,7 +685,7 @@ void MainView::TitlePopUpChanged()
+         fAudLang2PopUp->AddItem( new BMenuItem( audio->lang, new BMessage() ) );
+         #endif
+     }
+-    fAudLang1PopUp->ItemAt( 1 )->SetMarked( true );
++    fAudLang1PopUp->ItemAt( 0 )->SetMarked( true );
+     fAudLang2PopUp->ItemAt( 0 )->SetMarked( true );
+ }
+ 
+@@ -799,7 +808,7 @@ void MainView::CodecsPopUpChanged()
+ 
+ void MainView::CheckExtension()
+ {
+-    char * ext = NULL;
++    const char * ext = NULL;
+     switch( fDstFormat )
+     {
+         case 0:
+@@ -882,11 +891,10 @@ void MainView::AddJob()
+     }
+ 
+     int index;
+-    index = fVidRatePopUp->IndexOf(
+-        fVidRatePopUp->FindMarked() );
+-    if( index > 0 )
++    BMenuItem* marked = fVidRatePopUp->FindMarked();
++    if( marked != NULL )
+     {
+-        job->vrate_base = hb_video_rates[index-1].rate;
++        job->vrate_base = hb_video_framerate_get_from_name( marked->Label() );
+     }
+     else
+     {
+diff --git a/haiku/Makefile b/haiku/Makefile
+new file mode 100644
+index 0000000..e0ac283
+--- /dev/null
++++ b/haiku/Makefile
+@@ -0,0 +1,133 @@
++## Haiku Generic Makefile v2.6 ## 
++
++## Fill in this file to specify the project being created, and the referenced
++## Makefile-Engine will do all of the hard work for you. This handles any
++## architecture of Haiku.
++
++# The name of the binary.
++NAME = HandBrake
++
++# The type of binary, must be one of:
++#	APP:	Application
++#	SHARED:	Shared library or add-on
++#	STATIC:	Static library archive
++#	DRIVER: Kernel driver
++TYPE = APP
++
++# 	If you plan to use localization, specify the application's MIME signature.
++APP_MIME_SIG = 
++
++#	The following lines tell Pe and Eddie where the SRCS, RDEFS, and RSRCS are
++#	so that Pe and Eddie can fill them in for you.
++#%{
++# @src->@ 
++
++#	Specify the source files to use. Full paths or paths relative to the 
++#	Makefile can be included. All files, regardless of directory, will have
++#	their object files created in the common object directory. Note that this
++#	means this Makefile will not work correctly if two source files with the
++#	same name (source.c or source.cpp) are included from different directories.
++#	Also note that spaces in folder names do not work well with this Makefile.
++SRCS = HBApp.cpp MainWindow.cpp PicWindow.cpp QueueWindow.cpp ScanWindow.cpp Stepper.cpp
++
++#	Specify the resource definition files to use. Full or relative paths can be
++#	used.
++RDEFS = 
++
++#	Specify the resource files to use. Full or relative paths can be used.
++#	Both RDEFS and RSRCS can be utilized in the same Makefile.
++RSRCS = 
++
++# End Pe/Eddie support.
++# @<-src@ 
++#%}
++
++#	Specify libraries to link against.
++#	There are two acceptable forms of library specifications:
++#	-	if your library follows the naming pattern of libXXX.so or libXXX.a,
++#		you can simply specify XXX for the library. (e.g. the entry for
++#		"libtracker.so" would be "tracker")
++#
++#	-	for GCC-independent linking of standard C++ libraries, you can use
++#		$(STDCPPLIBS) instead of the raw "stdc++[.r4] [supc++]" library names.
++#
++#	- 	if your library does not follow the standard library naming scheme,
++#		you need to specify the path to the library and it's name.
++#		(e.g. for mylib.a, specify "mylib.a" or "path/mylib.a")
++LIBS = be network tracker $(STDCPPLIBS) bz2 \
++	ass fribidi ogg theora vorbis vorbisenc iconv samplerate fontconfig \
++	freetype z a52 avdevice avformat avcodec avresample avutil bluray dvdnav \
++	dvdread faac mkv mp3lame mp4v2 mpeg2 mpeg2convert swscale x264 \
++	handbrake
++
++
++#	Specify additional paths to directories following the standard libXXX.so
++#	or libXXX.a naming scheme. You can specify full paths or paths relative
++#	to the Makefile. The paths included are not parsed recursively, so
++#	include all of the paths where libraries must be found. Directories where
++#	source files were specified are	automatically included.
++LIBPATHS = ../build/libhb
++
++#	Additional paths to look for system headers. These use the form
++#	"#include <header>". Directories that contain the files in SRCS are
++#	NOT auto-included here.
++SYSTEM_INCLUDE_PATHS = 
++
++#	Additional paths paths to look for local headers. These use the form
++#	#include "header". Directories that contain the files in SRCS are
++#	automatically included.
++LOCAL_INCLUDE_PATHS = ../build/libhb ../build/contrib/include/
++
++#	Specify the level of optimization that you want. Specify either NONE (O0),
++#	SOME (O1), FULL (O2), or leave blank (for the default optimization level).
++OPTIMIZE := 
++
++# 	Specify the codes for languages you are going to support in this
++# 	application. The default "en" one must be provided too. "make catkeys"
++# 	will recreate only the "locales/en.catkeys" file. Use it as a template
++# 	for creating catkeys for other languages. All localization files must be
++# 	placed in the "locales" subdirectory.
++LOCALES = 
++
++#	Specify all the preprocessor symbols to be defined. The symbols will not
++#	have their values set automatically; you must supply the value (if any) to
++#	use. For example, setting DEFINES to "DEBUG=1" will cause the compiler
++#	option "-DDEBUG=1" to be used. Setting DEFINES to "DEBUG" would pass
++#	"-DDEBUG" on the compiler's command line.
++DEFINES = 
++
++#	Specify the warning level. Either NONE (suppress all warnings),
++#	ALL (enable all warnings), or leave blank (enable default warnings).
++WARNINGS = 
++
++#	With image symbols, stack crawls in the debugger are meaningful.
++#	If set to "TRUE", symbols will be created.
++SYMBOLS := 
++
++#	Includes debug information, which allows the binary to be debugged easily.
++#	If set to "TRUE", debug info will be created.
++DEBUGGER := 
++
++#	Specify any additional compiler flags to be used.
++COMPILER_FLAGS = 
++
++#	Specify any additional linker flags to be used.
++LINKER_FLAGS = 
++
++#	Specify the version of this binary. Example:
++#		-app 3 4 0 d 0 -short 340 -long "340 "`echo -n -e '\302\251'`"1999 GNU GPL"
++#	This may also be specified in a resource.
++APP_VERSION := 
++
++#	(Only used when "TYPE" is "DRIVER"). Specify the desired driver install
++#	location in the /dev hierarchy. Example:
++#		DRIVER_PATH = video/usb
++#	will instruct the "driverinstall" rule to place a symlink to your driver's
++#	binary in ~/add-ons/kernel/drivers/dev/video/usb, so that your driver will
++#	appear at /dev/video/usb when loaded. The default is "misc".
++DRIVER_PATH = 
++
++## Include the Makefile-Engine
++DEVEL_DIRECTORY := \
++	$(shell findpaths -r "makefile_engine" B_FIND_PATH_DEVELOP_DIRECTORY)
++include $(DEVEL_DIRECTORY)/etc/makefile-engine
+diff --git a/haiku/PicWindow.cpp b/haiku/PicWindow.cpp
+index b93c393..3ff3045 100644
+--- a/haiku/PicWindow.cpp
++++ b/haiku/PicWindow.cpp
+@@ -26,7 +26,7 @@ PicView::PicView( hb_handle_t * handle, int index )
+     hb_list_t * list;
+     list   = hb_get_titles( fHandle );
+     fTitle = (hb_title_t *) hb_list_item( list, index );
+-    fJob   = fTitle->job;
++    fJob   = hb_job_init(fTitle);
+ 
+     /* We'll start with the first picture */
+     fIndex = 0;
+@@ -83,7 +83,7 @@ PicView::PicView( hb_handle_t * handle, int index )
+     r = BRect( 10,65,b.right-10,85 );
+     fRatioCheck = new BCheckBox( r, NULL, "Keep aspect ratio",
+                                  new BMessage( MSG_WIDTH ) );
+-    fRatioCheck->SetValue( fJob->keep_ratio );
++    fRatioCheck->SetValue( fJob->anamorphic.keep_display_aspect );
+     box->AddChild( fRatioCheck );
+ 
+     /* "Crop" box */
+@@ -254,35 +254,37 @@ void PicView::RadioChanged()
+ 
+ void PicView::UpdateSettings( uint32 what )
+ {
+-    fJob->width       = fWidthStepper->Value();
+-    fJob->height      = fHeightStepper->Value();
+-    fJob->keep_ratio  = fRatioCheck->Value();
+-    fJob->deinterlace = fDeintCheck->Value();
++    fJob->width                           = fWidthStepper->Value();
++    fJob->height                          = fHeightStepper->Value();
++    fJob->anamorphic.keep_display_aspect  = fRatioCheck->Value();
++    fJob->deinterlace                     = fDeintCheck->Value();
+     for( int i = 0; i < 4; i++ )
+     {
+         fJob->crop[i] = fCropSteppers[i]->Value();
+     }
+ 
+-    if( fJob->keep_ratio )
++    if( fJob->anamorphic.keep_display_aspect )
+     {
+         if( what == MSG_WIDTH )
+         {
+-            hb_fix_aspect( fJob, HB_KEEP_WIDTH );
+             if( fJob->height > fTitle->height )
+             {
+                 fJob->height = fTitle->height;
+-                hb_fix_aspect( fJob, HB_KEEP_HEIGHT );
+             }
+         }
+         else
+         {
+-            hb_fix_aspect( fJob, HB_KEEP_HEIGHT );
+             if( fJob->width > fTitle->width )
+             {
+                 fJob->width = fTitle->width;
+-                hb_fix_aspect( fJob, HB_KEEP_WIDTH );
+             }
+         }
++        int width, height, par_width, par_height;
++        hb_set_anamorphic_size(fJob, &width, &height, &par_width, &par_height);
++        fJob->width = width;
++        fJob->height = height;
++        fJob->anamorphic.par_width = par_width;
++        fJob->anamorphic.par_height = par_height;
+     }
+ 
+     fWidthStepper->SetValue( fJob->width );
+diff --git a/haiku/makefile b/haiku/makefile
+deleted file mode 100644
+index 44da58a..0000000
+--- a/haiku/makefile
++++ /dev/null
+@@ -1,148 +0,0 @@
+-## BeOS Generic Makefile v2.5 ##
+-
+-## Fill in this file to specify the project being created, and the referenced
+-## makefile-engine will do all of the hard work for you.  This handles both
+-## Intel and PowerPC builds of the BeOS and Haiku.
+-
+-## Application Specific Settings ---------------------------------------------
+-
+-# specify the name of the binary
+-NAME=HandBrake
+-
+-# specify the type of binary
+-#	APP:	Application
+-#	SHARED:	Shared library or add-on
+-#	STATIC:	Static library archive
+-#	DRIVER: Kernel Driver
+-TYPE=APP
+-
+-# 	if you plan to use localization features 
+-# 	specify the application MIME siganture
+-APP_MIME_SIG= 
+-
+-#	add support for new Pe and Eddie features
+-#	to fill in generic makefile
+-
+-#%{
+-# @src->@ 
+-
+-#	specify the source files to use
+-#	full paths or paths relative to the makefile can be included
+-# 	all files, regardless of directory, will have their object
+-#	files created in the common object directory.
+-#	Note that this means this makefile will not work correctly
+-#	if two source files with the same name (source.c or source.cpp)
+-#	are included from different directories.  Also note that spaces
+-#	in folder names do not work well with this makefile.
+-SRCS=HBApp.cpp MainWindow.cpp PicWindow.cpp QueueWindow.cpp ScanWindow.cpp Stepper.cpp
+-
+-#	specify the resource definition files to use
+-#	full path or a relative path to the resource file can be used.
+-RDEFS= 
+-	
+-#	specify the resource files to use. 
+-#	full path or a relative path to the resource file can be used.
+-#	both RDEFS and RSRCS can be defined in the same makefile.
+-RSRCS= 
+-
+-# @<-src@ 
+-#%}
+-
+-#	end support for Pe and Eddie
+-
+-#	specify additional libraries to link against
+-#	there are two acceptable forms of library specifications
+-#	-	if your library follows the naming pattern of:
+-#		libXXX.so or libXXX.a you can simply specify XXX
+-#		library: libbe.so entry: be
+-#
+-#	-	for version-independent linking of standard C++ libraries please add
+-#		$(STDCPPLIBS) instead of raw "stdc++[.r4] [supc++]" library names
+-#
+-#	-	for localization support add following libs:
+-#		locale localestub
+-#		
+-#	- 	if your library does not follow the standard library
+-#		naming scheme you need to specify the path to the library
+-#		and it's name
+-#		library: my_lib.a entry: my_lib.a or path/my_lib.a
+-LIBS=be network tracker stdc++ bz2 \
+-	ass fribidi ogg theora vorbis vorbisenc iconv samplerate fontconfig \
+-	freetype z a52 avdevice avformat avcodec avresample avutil bluray dvdnav \
+-	dvdread faac mkv mp3lame mp4v2 mpeg2 mpeg2convert swscale x264 \
+-	libhandbrake.a
+-
+-
+-#	specify additional paths to directories following the standard
+-#	libXXX.so or libXXX.a naming scheme.  You can specify full paths
+-#	or paths relative to the makefile.  The paths included may not
+-#	be recursive, so include all of the paths where libraries can
+-#	be found.  Directories where source files are found are
+-#	automatically included.
+-LIBPATHS= 
+-
+-#	additional paths to look for system headers
+-#	thes use the form: #include <header>
+-#	source file directories are NOT auto-included here
+-SYSTEM_INCLUDE_PATHS = 
+-
+-#	additional paths to look for local headers
+-#	thes use the form: #include "header"
+-#	source file directories are automatically included
+-LOCAL_INCLUDE_PATHS = ../build/libhb/ ../build/contrib/include/
+-
+-#	specify the level of optimization that you desire
+-#	NONE, SOME, FULL
+-OPTIMIZE= 
+-
+-# 	specify here the codes for languages you are going
+-# 	to support in this application. The default "en"
+-# 	one must be provided too. "make catkeys" will recreate only
+-# 	locales/en.catkeys file. Use it as template for creating other
+-# 	languages catkeys. All localization files must be placed
+-# 	in "locales" sub-directory.
+-LOCALES=
+-
+-#	specify any preprocessor symbols to be defined.  The symbols will not
+-#	have their values set automatically; you must supply the value (if any)
+-#	to use.  For example, setting DEFINES to "DEBUG=1" will cause the
+-#	compiler option "-DDEBUG=1" to be used.  Setting DEFINES to "DEBUG"
+-#	would pass "-DDEBUG" on the compiler's command line.
+-DEFINES=
+-
+-#	specify special warning levels
+-#	if unspecified default warnings will be used
+-#	NONE = supress all warnings
+-#	ALL = enable all warnings
+-WARNINGS = 
+-
+-#	specify whether image symbols will be created
+-#	so that stack crawls in the debugger are meaningful
+-#	if TRUE symbols will be created
+-SYMBOLS = 
+-
+-#	specify debug settings
+-#	if TRUE will allow application to be run from a source-level
+-#	debugger.  Note that this will disable all optimzation.
+-DEBUGGER = 
+-
+-#	specify additional compiler flags for all files
+-COMPILER_FLAGS =
+-
+-#	specify additional linker flags
+-LINKER_FLAGS =
+-
+-#	specify the version of this particular item
+-#	(for example, -app 3 4 0 d 0 -short 340 -long "340 "`echo -n -e '\302\251'`"1999 GNU GPL") 
+-#	This may also be specified in a resource.
+-APP_VERSION = 
+-
+-#	(for TYPE == DRIVER only) Specify desired location of driver in the /dev
+-#	hierarchy. Used by the driverinstall rule. E.g., DRIVER_PATH = video/usb will
+-#	instruct the driverinstall rule to place a symlink to your driver's binary in
+-#	~/add-ons/kernel/drivers/dev/video/usb, so that your driver will appear at
+-#	/dev/video/usb when loaded. Default is "misc".
+-DRIVER_PATH = 
+-
+-## include the makefile-engine
+-include $(BUILDHOME)/etc/makefile-engine
+-- 
+2.7.0
+

--- a/media-video/handbrake/state.md
+++ b/media-video/handbrake/state.md
@@ -1,0 +1,185 @@
+HandBrake, the well-known DVD ripping and video transcoding tool, was initially
+developed for BeOS and had a fully featured BeOS GUI. However, support for
+Haiku is not as great as this suggests. BeOS support was dropped in early 2007
+([commit c0b2eca](https://github.com/HandBrake/HandBrake/commit/c0b2eca)),
+though the GUI was already considered deprecated at this point. The last
+HandBrake release which included the BeOS code was
+[0.7.1](https://github.com/HandBrake/HandBrake/releases/tag/0.7.1) (Feb 24,
+2006).
+
+# What has been done
+All versions of HandBrake currently on HaikuPorter are versions that do not
+include the BeOS GUI. The only way that HandBrake can be used on Haiku at the
+current moment is using the command line tool HandBrakeCLI.
+
+## HaikuBrake
+### Versioning
+There has been an attempt to bring the BeOS GUI back to Haiku. @kallisti5's
+[HaikuBrake](https://github.com/kallisti5/HaikuBrake) is based on a commit with
+a commit message starting with "WinGui: Fix a number of potential...."
+([4eb9b19](https://github.com/kallisti5/HaikuBrake/commit/4eb9b19d3758c089fdea16adcf2243cca22de909)
+on HaikuBrake and
+[feb7340](https://github.com/HandBrake/HandBrake/commit/feb7340) in the offical
+HandBrake repo) from December 8, 2012. This commit was on master and descended
+from version [0.9.6](https://github.com/HandBrake/HandBrake/releases/tag/0.9.6)
+(it is 519 commits ahead, to be precise). Note that the commit acutally
+occurred after 0.9.8 in terms of time, but HandBrake branched right after 0.9.6
+(at [78052b5](https://github.com/HandBrake/HandBrake/commit/78052b5)) into a
+branch moving towards 0.10.0 and a 0.9.x branch. The 0.9.x branch *was not
+merged*, but I think that at least some fixes were cherry-picked from 0.9.x to
+0.10. The commit HaikuBrake is based on is part of the branch for 0.10.0.
+
+### Fixes
+All in all, the code in this repo is changed in the following way: It puts in
+the BeOS GUI code, adds a Makefile for that, removes the dependency on the
+contrib packages so that system versions of the libraries are used instead, and
+"fixes" the BeOS GUI so that it builds. One notable commit is
+[86e06dd](https://github.com/kallisti5/HaikuBrake/commit/86e06dd04d93108a8156f2aa73c8fb404ade92ea).
+It makes the BeOS code compile again. *However*, this is mainly done by
+enclosing all code which does not interface in `#if 0`, disabling a lot of the
+functionality to the point of the GUI not being remotely useful anymore. For
+instance, audio support is simply dropped (e.g.
+[here](https://github.com/kallisti5/HaikuBrake/commit/86e06dd04d93108a8156f2aa73c8fb404ade92ea#diff-a1dffb371a1de8a96b3df30cd292ac0fR899)).
+Needless to say, even if the GUI built again with these changes, it basically
+was not usable. A checkout of HaikuBrake did not compile on my machine,
+apparently due to library version mismatches (though I did not try too hard to
+make it work, so it might be possible).
+
+## The HaikuPorts patches
+The HaikuPorts patches for version 0.10.2 as of
+[005299](https://github.com/haikuports/haikuports/commit/005299) are a mixture
+of patches to fix the build of the main library and CLI, some commits from
+HaikuBrake, as well as some more patches which seem to address some additional
+issues which may have come up due to even more changes. As these patches run
+against version 0.10.2, there are a lot of additional incompatibilities due to
+API changes, which is why the build of the BeOS code is once again broken.
+
+# What I have done
+## Work off of 0.10.2
+The Haiku API is mostly stable, but the libhandbrake API is not (this is no
+surprise. All software which officially targets libhandbrake is in the
+HandBrake repository itself. This includes the .NET bindings as well as the
+GUIs for the various platforms. When a breaking API change is made, the
+corresponding frontends can immediately be fixed. Unfortunately, right now, the
+Haiku code does not have this luxury and [likely won't have it anytime
+soon](https://reviews.handbrake.fr/r/480/)). Off of the patchset for 0.10.2,
+getting the code to *build* is just a matter of replacing a handful of library
+calls with their respective updated versions. However, getting it to *work* is
+a different matter entirely: All calls have to be verified to work. You have to
+verify what exactly the replacement for a certain library call is and whether
+it does anything different or unexpected. Also, a lot of calls and
+functionality is currently put in `#if 0`. All of it has to be restored and
+updated calls have to be found. A section "Tools" below will go into detail on
+how I went about finding these sorts of replacements. I got the code to build
+and started fixing a few bugs. However, the library interaction is still
+broken. Currently, the most pressing problem is the fact that muxer and encoder
+are not set at all, resulting in an empty output.  I will make a pull request
+with the handful of improvements I have made once I am done writing this.
+
+## Work off of 0.7.1
+I have evaluated the feasibility of the approach of updating the GUI code off
+of this version. See below for results; if someone is interested in the changes
+that I made to the build system I can upload them here.
+
+# Tools
+After fixing a few library calls and getting up to date on HandBrake history,
+here are a few techniques that have been successful for me when searching for
+things.
+## `git`
+Git is an extremely useful tool for tracking down library changes. Your best
+friend is [`git bisect`](https://git-scm.com/docs/git-bisect). This of course
+requires the [actual HandBrake
+repository](https://github.com/HandBrake/HandBrake) and not just the download
+in the haikuports work folder. If you know that a library call existed back in
+0.7.1 but does not exist at master just bisect and look for the commit that
+removed it. To check whether it is still there in a specific revision use
+`grep` or even better [`ag`](https://git-scm.com/docs/git-bisect). The commit
+that removes a specific library call will most likely also change its uses in
+the CLI and GUIs, so you know what to replace the call with.
+
+To find out what time and version a revision belings to, use `git show` and
+`git describe` and possibly `git merge-base`.
+## Usage in the HandBrake repository
+The HandBrake repository also contains HandBrakeCLI at test/test.c and also
+several GUIs. See how they implemented a certain functionality and adapt the
+code for the Haiku GUI.
+
+# What has to be done
+## Fix problems with HandBrake itself
+There still seem to be bugs in HandBrake which are specific to Haiku but not
+related to the BeOS GUI. For example, I do testing with a .iso which works
+perfectly fine with HandBrake 0.10.2 on Windows, but crashes HandBrakeCLI on
+Haiku. These bugs have to be investigated.
+
+## Get the GUI to work, preferrably on a modern version
+There are several ways to go about this.
+
+### Start with a modern version, put in the code, and fix stuff until it works
+This is basically what happens in the 0.10.2 patchset. Library calls are
+replaced with their successors. However, this causes some problems which are
+hard to fix, as sometimes, non-obvious changes have to be reflected in the GUI.
+For example,
+[16deb21428](https://github.com/HandBrake/HandBrake/commit/16deb21428) (June 3,
+2013) introduced a function `hb_global_init` which has to be called before any
+other function in the library. If it is not called, the library starts
+segfaulting in unpredictable places. As libhandbrake is not intended to be used
+outside of its own repository, no documentation exists. At all. It is therefore
+impossible to be absolutely sure that you are driving the library correctly.
+
+### Start with a version which supported the GUI and incrementally work upwards from there
+This is a multi-step approach: Get the code for version 0.7.1 to work on Haiku
+and then update it in rather small steps until it is up to date.  The advantage
+of this approach is that "unannounced" breaking changes are more easily found.
+
+However, there is an enormous drawback to this approach: **Dependencies**. On
+most platforms, HandBrake automatically pulls in and builds the exact versions
+of the libraries it needs. The libraries are built statically and therefore are
+put into the executable. However, on Haiku, this approach does not work, as
+many of these libraries need Haiku-spacific patches which would need to be
+mirrored into the HandBrake code. This is clearly a suboptimal solution, and
+instead Haiku opts to simply use the system versions of these libraries (in the
+process, all patches HandBrake wanted to make to these libraries are of course
+discarded. I wonder if the impact of this has been evaluated, as one would
+expect these patches to be somehow required for HandBrake to interact with the
+library properly).  However, older versions of HandBrake require older versions
+of its dependencies. For each version of HandBrake which is built, a slightly
+different API for the libraries is used. For the build to succeed, compatible
+versions of the library have to be installed on the system. Here is the list of
+specific versions which have to be installed just to get HandBrake 0.7.1 up and
+running:
+
+      library | version
+--------------|---------
+        a52de | 0.7.4
+         faac | 1.24
+       ffmpeg | 20060201
+         lame | 3.96.1
+    libdvdcss | 1.2.9
+   libdvdread | 20050928
+       libogg | 1.1.2
+libsamplerate | 0.1.2
+    libvorbis | 1.1.1
+     mpeg2dec | 20051112
+      mpeg4ip | 1.3
+         x264 | r401
+     xvidcore | 1.1.0
+
+Here is another problem with starting from 0.7.1: It uses a different build
+system. Luckily, this looks like it is a minor problem, as it's based on jam.
+After telling it to disregard to contrib folder and link against system
+libraries, it didn't seem to pose much of a problem, although I never saw it
+finish a build due to the dependency problem described above.
+
+### Rewrite the GUI from scratch
+Possibly check other GUIs for inspiration.
+
+## Enhance the GUI
+The GUI essentially reflects the feature-set of HandBrake about ten years ago.
+The library has changed a lot since then, and accordingly, the well-supported
+GUIs have added a lot more controls and features. It is probably a good idea to
+get those controls into the BeOS GUI as well.
+
+Additionally, the GUI should be updated to use the Layout API.
+
+One could also consider restyling the code, as the current code style is
+inconsistent with the rest of HandBrake.


### PR DESCRIPTION
See #411.
This also marks HandBrake 0.10.2 as broken on x86_gcc2 as there is no version
of FFmpeg which works on x86_gcc2 that provides the library version required
by HandBrake.

As of https://codein.withgoogle.com/dashboard/task-instances/6140613900632064/?sp-page=1