### PR TITLE
Add broken elftoolchain recipe

### DIFF
--- a/sys-devel/elftoolchain/elftoolchain-0.6.1.recipe
+++ b/sys-devel/elftoolchain/elftoolchain-0.6.1.recipe
@@ -1,0 +1,91 @@
+SUMMARY="BSD-licensed replacement for some of the GNU binutils"
+DESCRIPTION="elftoolchain is an attempt to provide the full set of tools \
+required for the creation and manipulation of object files in the popular \
+ELF format. It operates using a common library, so additional tools that \
+operate on ELF files can be implemented easily. elftoolchain is part of the \
+larger BSD Toolchain Project, which aims to make the entire C/C++ compilation \
+process which is usually driven by copyleft GNU tools available under a \
+permissive license. Besides the ELF Tool Chain Project, the BSD Toolchain \
+project includes ClangBSD, libc++ and libcxxrt."
+HOMEPAGE="http://sourceforge.net/project/elftoolchain"
+COPYRIGHT="2001 Jake Burkholder
+	2003 David O'Brien
+	2006, 2008, 2010-2011 Joseph Koshy
+	2007 S.Sam Arun Raj
+	2007 John Birrell
+	2007 Tim Kientzle
+	2008 Hyogeol Lee
+	2009, 2010 Kai Wang"
+LICENSE="BSD (2-clause)"
+REVISION="1"
+SOURCE_URI="http://sourceforge.net/projects/elftoolchain/files/Sources/elftoolchain-0.6.1/elftoolchain-0.6.1.tar.bz2"
+CHECKSUM_SHA256="a3e0c11ed9b0fe2f40b687b11849e7d52cb6675ebc60745c85d37a3ae4272cab"
+PATCHES="elftoolchain-0.6.1.patchset"
+
+# How borken this recipe is depends on how Haiku ticket #12617 turns out
+ARCHITECTURES="!x86_gcc2 !x86 !x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	elftoolchain$secondaryArchSuffix = $portVersion
+	cmd:ar$secondaryArchSuffix = $portVersion
+	cmd:brandelf$secondaryArchSuffix = $portVersion
+	cmd:c++filt$secondaryArchSuffix = $portVersion
+	cmd:elfdump$secondaryArchSuffix = $portVersion
+	cmd:isa$secondaryArchSuffix = $portVersion
+	cmd:ld$secondaryArchSuffix = $portVersion
+	cmd:nm$secondaryArchSuffix = $portVersion
+	cmd:mcs$secondaryArchSuffix = $portVersion
+	cmd:ranlib$secondaryArchSuffix = $portVersion
+	cmd:size$secondaryArchSuffix = $portVersion
+	cmd:strings$secondaryArchSuffix = $portVersion
+	cmd:strip$secondaryArchSuffix = $portVersion
+	cmd:addr2line$secondaryArchSuffix = $portVersion
+	cmd:elfcopy$secondaryArchSuffix = $portVersion
+	cmd:findtextrel$secondaryArchSuffix = $portVersion
+	cmd:objdump$secondaryArchSuffix = $portVersion
+	cmd:readelf$secondaryArchSuffix = $portVersion
+	lib:libdwarf$secondaryArchSuffix = 3
+	lib:libelf$secondaryArchSuffix = 1
+	lib:libelftc$secondaryArchSuffix = 1
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libarchive$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	elftoolchain${secondaryArchSuffix}_devel = $portVersion
+	devel:libdwarf$secondaryArchSuffix = 3
+	devel:libelf$secondaryArchSuffix = 1
+	devel:libelftc$secondaryArchSuffix = 1
+	"
+REQUIRES_devel="
+	elftoolchain$secondaryArchSuffix == $portVersion base
+	haiku$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	devel:libarchive$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	cmd:awk
+	cmd:bmake
+	cmd:flex
+	cmd:gcc$secondaryArchSuffix
+	cmd:nroff
+	cmd:sed
+	cmd:yacc
+	"
+
+BUILD()
+{
+	bmake
+}
+
+INSTALL()
+{
+	# TODO
+	sleep 0
+}

--- a/sys-devel/elftoolchain/patches/elftoolchain-0.6.1.patchset
+++ b/sys-devel/elftoolchain/patches/elftoolchain-0.6.1.patchset
@@ -1,0 +1,160 @@
+From 1b06f121703f28684117730e001eb84c5537ac54 Mon Sep 17 00:00:00 2001
+From: Markus Himmel <markus@himmel-villmar.de>
+Date: Mon, 25 Jan 2016 17:54:59 +0100
+Subject: [PATCH] First steps toward building on Haiku
+
+---
+ ar/ar.h                 |  2 ++
+ common/_elftc.h         |  5 +++--
+ common/os.Haiku.mk      | 12 ++++++++++++
+ libelf/_libelf_config.h |  5 +++--
+ libelf/libelf.h         |  1 +
+ libelftc/libelftc.h     |  1 +
+ mk/elftoolchain.inc.mk  |  3 ++-
+ mk/os.Haiku.mk          | 23 +++++++++++++++++++++++
+ 8 files changed, 47 insertions(+), 5 deletions(-)
+ create mode 100644 common/os.Haiku.mk
+ create mode 100644 mk/os.Haiku.mk
+
+diff --git a/ar/ar.h b/ar/ar.h
+index a75b9a9..368ffc1 100644
+--- a/ar/ar.h
++++ b/ar/ar.h
+@@ -27,6 +27,8 @@
+  */
+ 
+ #include <libelf.h>
++#include <sys/queue.h>
++#include <stdio.h>
+ 
+ #include "_elftc.h"
+ 
+diff --git a/common/_elftc.h b/common/_elftc.h
+index e114cad..b7db279 100644
+--- a/common/_elftc.h
++++ b/common/_elftc.h
+@@ -216,7 +216,8 @@ struct name {							\
+ #define	ELFTC_VCSID(ID)		__FBSDID(ID)
+ #endif
+ 
+-#if defined(__linux__) || defined(__GNU__) || defined(__GLIBC__)
++#if defined(__linux__) || defined(__GNU__) || defined(__GLIBC__) || \
++	defined(__HAIKU__)
+ #if defined(__GNUC__)
+ #define	ELFTC_VCSID(ID)		__asm__(".ident\t\"" ID "\"")
+ #else
+@@ -253,7 +254,7 @@ struct name {							\
+ #ifndef	ELFTC_GETPROGNAME
+ 
+ #if defined(__DragonFly__) || defined(__FreeBSD__) || defined(__minix) || \
+-    defined(__NetBSD__)
++    defined(__NetBSD__) || defined(__HAIKU__)
+ 
+ #include <stdlib.h>
+ 
+diff --git a/common/os.Haiku.mk b/common/os.Haiku.mk
+new file mode 100644
+index 0000000..c65d2c8
+--- /dev/null
++++ b/common/os.Haiku.mk
+@@ -0,0 +1,12 @@
++#
++# Build recipes for the Haiku operating system.
++#
++
++_NATIVE_ELF_FORMAT = native-elf-format
++
++.BEGIN:	${_NATIVE_ELF_FORMAT}.h
++
++${_NATIVE_ELF_FORMAT}.h:
++	${.CURDIR}/${_NATIVE_ELF_FORMAT} > ${.TARGET} || rm ${.TARGET}
++
++CLEANFILES += ${_NATIVE_ELF_FORMAT}.h
+diff --git a/libelf/_libelf_config.h b/libelf/_libelf_config.h
+index b9442fd..e012b27 100644
+--- a/libelf/_libelf_config.h
++++ b/libelf/_libelf_config.h
+@@ -154,9 +154,10 @@
+  *     kernel such as GNU/kFreeBSD.
+  */
+ 
+-#if defined(__linux__) || defined(__GNU__) || defined(__GLIBC__)
++#if defined(__linux__) || defined(__GNU__) || defined(__GLIBC__) || \
++	defined(__HAIKU__)
+ 
+-#if defined(__linux__)
++#if defined(__linux__) || defined(__HAIKU__)
+ 
+ #include "native-elf-format.h"
+ 
+diff --git a/libelf/libelf.h b/libelf/libelf.h
+index d3219d7..a33d80d 100644
+--- a/libelf/libelf.h
++++ b/libelf/libelf.h
+@@ -30,6 +30,7 @@
+ #define	_LIBELF_H_
+ 
+ #include <sys/types.h>
++#include <sys/cdefs.h>
+ 
+ #include <elfdefinitions.h>
+ 
+diff --git a/libelftc/libelftc.h b/libelftc/libelftc.h
+index 406791e..f9a77d4 100644
+--- a/libelftc/libelftc.h
++++ b/libelftc/libelftc.h
+@@ -30,6 +30,7 @@
+ #ifndef	_LIBELFTC_H_
+ #define	_LIBELFTC_H_
+ 
++#include <sys/cdefs.h>
+ #include <sys/stat.h>
+ 
+ typedef struct _Elftc_Bfd_Target Elftc_Bfd_Target;
+diff --git a/mk/elftoolchain.inc.mk b/mk/elftoolchain.inc.mk
+index 73b0a77..858af17 100644
+--- a/mk/elftoolchain.inc.mk
++++ b/mk/elftoolchain.inc.mk
+@@ -11,8 +11,9 @@
+ 
+ .include <bsd.own.mk>
+ 
++
+ .if ${OS_HOST} == "DragonFly" || ${OS_HOST} == "FreeBSD" || \
+-	${OS_HOST} == "OpenBSD"
++	${OS_HOST} == "OpenBSD" || ${OS_HOST} == "Haiku"
+ # Simulate <bsd.inc.mk>.
+ .PHONY:		incinstall
+ includes:	${INCS}	incinstall
+diff --git a/mk/os.Haiku.mk b/mk/os.Haiku.mk
+new file mode 100644
+index 0000000..ea46874
+--- /dev/null
++++ b/mk/os.Haiku.mk
+@@ -0,0 +1,23 @@
++# Build definitions for Haiku
++
++MKDOC?=		no
++MKTESTS?=	no
++MKTEX?=		no
++MKNOWEB?=	no
++
++# Haiku has a dedicated libbsd
++LDADD+=-lbsd
++
++# BSD has __offsetof, Haiku has GNU-style offsetof
++CFLAGS+=-D__offsetof=offsetof
++
++OBJECT_FMT=ELF
++
++# This tells bmake to pass GNU-ld-style flags to ld rather than
++# elftoolchain-ld-style flags
++TARGET_OSNAME=Linux
++
++COMPILER_TYPE=gnu
++AR=ar
++LD=ld
++LEX=flex
+-- 
+2.7.0
+


### PR DESCRIPTION
elftoolchain requires BSD headers which Haiku doesn't ship (yet). I have created https://dev.haiku-os.org/ticket/12617 to get the necessary headers into the tree. I have tested this recipe on a modified Haiku version which has `<sys/queue.h>` and `<ar.h>` (which Haiku master currently does not). The recipe builds common, libelf, libdwarf, libelftc and addr2line successfully and finally fails building ar because of the missing BSD header `<sys/endian.h>`. 
