### PR TITLE
intltool: add recipe for 0.51.0 & fix 0.40.6

### DIFF
--- a/dev-util/intltool/intltool-0.51.0.recipe
+++ b/dev-util/intltool/intltool-0.51.0.recipe
@@ -10,11 +10,11 @@ files (.c, .h) in po/PACKAGE.pot.
 - Merge back the translations from .po files into .xml, .desktop and oaf \
 files. This merge step will happen at build resp. installation time."
 HOMEPAGE="http://freedesktop.org/wiki/Software/intltool"
-COPYRIGHT="1994-1996, 1999-2002, 2004, 2005 Free Software Foundation, Inc."
+COPYRIGHT="1994-1996, 1999-2002, 2004-2015 Free Software Foundation, Inc."
 LICENSE="GNU GPL v2"
-REVISION="4"
-SOURCE_URI="ftp://ftp.gnome.org/pub/gnome/sources/intltool/0.40/intltool-0.40.6.tar.gz"
-CHECKSUM_SHA256="36cd8fe249d0cc20918b6d4583267208bf74c8d541c67a5fe63316846344f9f7"
+REVISION="1"
+SOURCE_URI="https://launchpad.net/intltool/trunk/$portVersion/+download/intltool-$portVersion.tar.gz"
+CHECKSUM_SHA256="67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"


### PR DESCRIPTION
* Add recipe for 0.51.0
* Fix recipe for 0.40.6: the `PROVIDES` section was missing a `$secondaryArchSuffix`.