### PR TITLE
vala: add recipe

### DIFF
--- a/dev-lang/vala/patches/vala-0.30.1.patchset
+++ b/dev-lang/vala/patches/vala-0.30.1.patchset
@@ -1,0 +1,31 @@
+From 5e9c794a7b3cecb5a016fdf2609cd1c3cb2b65ca Mon Sep 17 00:00:00 2001
+From: Kostadin Damyanov <maxmight@gmail.com>
+Date: Thu, 4 Feb 2016 05:01:46 +0200
+Subject: remove the dbus tests
+
+
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index 1666826..974c838 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -196,17 +196,6 @@ TESTS = \
+ 	asynchronous/bug661961.vala \
+ 	asynchronous/bug742621.vala \
+ 	asynchronous/closures.vala \
+-	dbus/basic-types.test \
+-	dbus/arrays.test \
+-	dbus/structs.test \
+-	dbus/errors.test \
+-	dbus/async.test \
+-	dbus/async-errors.test \
+-	dbus/signals.test \
+-	dbus/filedescriptor.test \
+-	dbus/dicts.test \
+-	dbus/bug596862.vala \
+-	dbus/bug602003.test \
+ 	gir/bug651773.test \
+ 	gir/bug667751.test \
+ 	gir/bug742012.test \
+-- 
+2.7.0
+

--- a/dev-lang/vala/vala-0.30.1.recipe
+++ b/dev-lang/vala/vala-0.30.1.recipe
@@ -1,0 +1,91 @@
+SUMMARY="An object-oriented programming language that uses the GObject system"
+DESCRIPTION="Vala is a new programming language that aims to bring modern \
+programming language features to GNOME developers without imposing any \
+additional runtime requirements and without using a different ABI \
+compared to applications and libraries written in C."
+HOMEPAGE="https://wiki.gnome.org/Projects/Vala"
+COPYRIGHT="2006-2016 Jürg Billeter
+	2006-2016 Raffaele Sandrini"
+LICENSE="GNU LGPL v2.1"
+REVISION="1"
+SOURCE_URI="https://download.gnome.org/sources/vala/0.30/vala-$portVersion.tar.xz"
+CHECKSUM_SHA256="23add78e5c6a5e6df019d4a885c9c79814c9e0b957519ec8a4f4d826c4e5df2c"
+SOURCE_DIR="vala-$portVersion"
+PATCHES="vala-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 x86 ?x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	vala = $portVersion
+	cmd:vala$secondaryArchSuffix
+	cmd:valac$secondaryArchSuffix
+	cmd:vapicheck$secondaryArchSuffix
+	cmd:vapigen$secondaryArchSuffix
+	cmd:vala_gen_introspect$secondaryArchSuffix
+	cmd:vala_0.30$secondaryArchSuffix
+	cmd:vala_gen_introspect_0.30$secondaryArchSuffix
+	cmd:valac_0.30$secondaryArchSuffix
+	cmd:vapicheck_0.30$secondaryArchSuffix
+	cmd:vapigen_0.30$secondaryArchSuffix
+	lib:libvala_0.30$secondaryArchSuffix
+	"
+PROVIDES_common="
+	vala_common = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	glib2${secondaryArchSuffix} >= 2.32.0
+	vala_common$secondaryArchSuffix == $portVersion
+	lib:libffi$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	"
+REQUIRES_common="
+	haiku$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	glib2${secondaryArchSuffix}_devel >= 2.32.0
+	"
+BUILD_PREREQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	cmd:autoconf
+	cmd:awk
+	cmd:bison
+	cmd:cmp
+	cmd:diff
+	cmd:flex
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:libtool
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	runConfigure ./configure
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	# remove libtool library files
+	rm $libDir/lib*.la
+
+	fixPkgconfig
+
+	packageEntries common \
+		$dataDir/aclocal/vapigen.m4 \
+		$dataDir/aclocal/vala.m4 \
+		$dataDir/vala/Makefile.vapigen
+}
+
+TEST()
+{
+	sed -i 's/-lm/-lroot/g' $sourceDir/tests/testrunner.sh
+	make check
+}


### PR DESCRIPTION
This is as close as we can get to to C# folks :)

I separated this in two packages like it is done in portage.
Before this is merged I want to start a discussion on something I am not sure how to do.
Originally I decided to add secondary arch support to the recipe so we could have `vala` and `vala_x86`.
The thing is that the vala compiler works by generating C code and then invoking `cc` and `pkg_config` to configure and compile the code. The executable names can be passed as parameters but by default they  are initialized like [this](https://github.com/GNOME/vala/blob/883284a25f034be8e9cd2d7edde9852b254a04ff/codegen/valaccodecompiler.vala#L91) and [this](https://github.com/GNOME/vala/blob/883284a25f034be8e9cd2d7edde9852b254a04ff/codegen/valaccodecompiler.vala#L55).

So the problem is even if we have `vala_x86` it still calls `gcc2` and `pkg-config` by default (and not the x86 version as one would expect).

It uses the x86 stuff only if you explicitly pass the executable names as parameters like this:
```
~> valac-x86 --cc=gcc-x86 --pkg-config=pkg-config-x86 hello.vala 
~> ./hello 
Hello World
```

There are two options in my opinion but I am not sure how to proceed:
1. I could patch the executable names in the source when building for secondary arch.
2. We might not need secondary arch support at all. The compiler just generates C sources and invokes `CC` and `pkg-config` so we can let `setarch` handle this for us.

Feedback is welcome. 