### PR TITLE
lighttpd: also patch configure (std=gnu99 → std=gnu9x)

### DIFF
--- a/www-servers/lighttpd/patches/lighttpd-1.4.39.patch
+++ b/www-servers/lighttpd/patches/lighttpd-1.4.39.patch
@@ -9,3 +9,25 @@
  fi
  
  AC_ARG_ENABLE(extra-warnings,
+--- lighttpd-1.4.39/configure	2016-01-02 11:47:11.000000000 +0000
++++ lighttpd-1.4.39-haiku/configure
+@@ -16726,8 +16726,8 @@ ac_link='$CC -o conftest$ac_exeext $CFLA
+ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+ 
+ 
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -std=gnu99" >&5
+-$as_echo_n "checking if $CC supports -std=gnu99... " >&6; }
++    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -std=gnu9x" >&5
++$as_echo_n "checking if $CC supports -std=gnu9x... " >&6; }
+   ac_ext=c
+ ac_cpp='$CPP $CPPFLAGS'
+ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -16735,7 +16735,7 @@ ac_link='$CC -o conftest$ac_exeext $CFLA
+ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+ 
+   ac_try_cflags_saved_cflags="${CFLAGS}"
+-  CFLAGS="${CFLAGS} -std=gnu99"
++  CFLAGS="${CFLAGS} -std=gnu9x"
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 


### PR DESCRIPTION
Workaround an issue about the configure script not being regenerated from configure.ac.
Instead of changing the BUILD block of the recipe, adding a tiny patch for the configure script is easy and works fine.