### PR TITLE
godot: add recipe

### DIFF
--- a/games-engines/godot/godot-2.0.recipe
+++ b/games-engines/godot/godot-2.0.recipe
@@ -1,0 +1,50 @@
+SUMMARY="A free and open source game engine"
+DESCRIPTION="Godot is an advanced, feature packed, multi-platform 2D \
+and 3D game engine. It provides a huge set of common tools, so you can \
+just focus on making your game without reinventing the wheel."
+HOMEPAGE="http://www.godotengine.org/"
+COPYRIGHT="2007-2016 Juan Linietsky, Ariel Manzur"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://github.com/godotengine/godot/archive/2.0-stable.tar.gz"
+CHECKSUM_SHA256="5947331b210f046f7cbd0b88aba1cc4216a50347983662c46b1e91ae581e5a7c"
+SOURCE_DIR="godot-${portVersion}-stable"
+
+ARCHITECTURES="!x86_gcc2 x86 ?x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	godot$secondaryArchSuffix = $portVersion
+	app:Godot = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix >= $haikuVersion
+	lib:libGL$secondaryArchSuffix
+	lib:libGLEW$secondaryArchSuffix
+	lib:libGLU$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	devel:libGL$secondaryArchSuffix
+	devel:libGLEW$secondaryArchSuffix
+	devel:libGLU$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	cmd:g++$secondaryArchSuffix
+	cmd:scons
+	"
+
+BUILD()
+{
+	scons platform=haiku target=release_debug $jobArgs
+}
+
+INSTALL()
+{
+	mkdir -p $appsDir
+	cp bin/godot.haiku.opt.tools.* $appsDir/Godot
+	addAppDeskbarSymlink $appsDir/Godot
+}


### PR DESCRIPTION
This is the recipe for the recently released 2.0 version of the Godot game engine with native support for Haiku.