### PR TITLE
mksh: bump version, add x86{,_64} with a patch.

### DIFF
--- a/app-shells/mksh/licenses/ISC
+++ b/app-shells/mksh/licenses/ISC
@@ -1,0 +1,21 @@
+ISC Licence (OSI approved)
+========================
+
+strlcpy.c is
+Copyright (c) 2006, 2008, 2009, 2013
+	mirabilos <m@mirbsd.org>
+Copyright (c) 1998
+	Todd C. Miller <Todd.Miller@courtesan.com>
+
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/app-shells/mksh/licenses/MirOS
+++ b/app-shells/mksh/licenses/MirOS
@@ -1,0 +1,30 @@
+The MirOS Licence (OSI approved)
+==============================
+
+The MirBSD Korn Shell (mksh) is
+Copyright (c) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+	      2011, 2012, 2013, 2014, 2015, 2016
+	mirabilos <m@mirbsd.org>
+All rights reserved.
+
+The mksh logo is
+Copyright (c) 2008, 2009
+	Lukas U. <smultron@midnightbsd.org>
+Copyright (c) 2008, 2009
+	mirabilos <m@mirbsd.org>
+
+
+Provided that these terms and disclaimer and all copyright notices
+are retained or reproduced in an accompanying document, permission
+is granted to deal in this work without restriction, including un-
+limited rights to use, publicly perform, distribute, sell, modify,
+merge, give away, or sublicence.
+
+This work is provided "AS IS" and WITHOUT WARRANTY of any kind, to
+the utmost extent permitted by applicable law, neither express nor
+implied; without malicious intent or gross negligence. In no event
+may a licensor, author or contributor be held liable for indirect,
+direct, other damage, loss, or other issues arising in any way out
+of dealing in the work, even if advised of the possibility of such
+damage or existence of a defect, except proven that it results out
+of said person's immediate fault when using the work as intended.

--- a/app-shells/mksh/mksh-52c.recipe
+++ b/app-shells/mksh/mksh-52c.recipe
@@ -11,25 +11,34 @@ mksh aims to replace pdksh in all but very rare use cases (such as support for \
 checking the Unix mbox) and in all operating environments (thus including \
 patches from pdksh on e.g. Debian)."
 HOMEPAGE="https://www.mirbsd.org/mksh.htm"
-COPYRIGHT="2002-2014 Thorsten Glaser"
-LICENSE="BSD (3-clause)"
+COPYRIGHT="2002-2016 Thorsten Glaser"
+LICENSE="MirOS
+	BSD (3-clause)
+	ISC"
 REVISION="1"
-SOURCE_URI="https://www.mirbsd.org/MirOS/dist/mir/mksh/mksh-R50c.tgz"
-CHECKSUM_SHA256="494ed3339e4d5c490e32b3c27dd3b642e493d86982ac60e15c8d6769e3b598ec"
+SOURCE_URI="https://www.mirbsd.org/MirOS/dist/mir/mksh/mksh-R$portVersion.tgz"
+CHECKSUM_SHA256="c6341acea725103f782c14e994d6e12dabaee69e60fe1bc78603a41258d43ba6"
 SOURCE_DIR="mksh"
+if [ "$targetArchitecture" != x86_gcc2 ]; then
+	PATCHES="mksh-$portVersion.patch"
+fi
 
-ARCHITECTURES="x86_gcc2"
+ARCHITECTURES="x86_gcc2 x86 x86_64"
 
 PROVIDES="
 	mksh = $portVersion
 	cmd:mksh
-	cmd:sh
 	"
 REQUIRES="
 	haiku
 	"
-BUILD_PREREQUIRES="
+
+BUILD_REQUIRES="
 	haiku_devel
+	"
+
+BUILD_PREREQUIRES="
+	cmd:awk
 	cmd:ed
 	cmd:gcc
 	cmd:grep
@@ -46,19 +55,12 @@ BUILD()
 
 INSTALL()
 {
-	mkdir -p $binDir
-	mkdir -p $docDir/mksh/examples/
-	mkdir -p $manDir/man1
-
 	# Installing the shell:
-	install -c -s -m 555 mksh $binDir/mksh
-	# grep -x /bin/mksh /etc/shells >/dev/null || echo /bin/mksh >>/etc/shells
-	install -c -m 444 dot.mkshrc $docDir/mksh/examples/
+	install -D -c -s -m 555 mksh $binDir/mksh
+	install -D -c -m 444 dot.mkshrc $docDir/examples/dot.mkshrc
 
 	# Installing the manual:
-	install -c -m 444 mksh.1 $manDir/man1/mksh.1
-
-	ln -s mksh $binDir/sh
+	install -D -c -m 444 mksh.1 $manDir/man1/mksh.1
 }
 
 TEST()

--- a/app-shells/mksh/patches/mksh-52c.patch
+++ b/app-shells/mksh/patches/mksh-52c.patch
@@ -1,0 +1,12 @@
+--- a/Build.sh
++++ b/Build.sh
+@@ -1420,9 +1420,6 @@
+ 	# mksh is not written in CFrustFrust!
+ 	ac_flags 1 no_eh_frame -fno-asynchronous-unwind-tables
+ 	ac_flags 1 fnostrictaliasing -fno-strict-aliasing
+-	ac_flags 1 fstackprotectorstrong -fstack-protector-strong
+-	test 1 = $HAVE_CAN_FSTACKPROTECTORSTRONG || \
+-	    ac_flags 1 fstackprotectorall -fstack-protector-all
+ 	test $cm = dragonegg && case " $CC $CFLAGS $LDFLAGS " in
+ 	*\ -fplugin=*dragonegg*) ;;
+ 	*) ac_flags 1 fplugin_dragonegg -fplugin=dragonegg ;;


### PR DESCRIPTION
* Drop the "r" prefix in version.
* Bump version to 52c and use portVersion where appropriate.
* Fix wrong LICENSE declaration and add missing licenses.
* Move haiku_devel from BUILD_PREREQUIRES to BUILD_REQUIRES to be consistent with most other recipes.
* Add missing cmd:awk to BUILD_PREREQUIRES.
* Add x86{,_64} to ARCHITECTURES with a tiny conditional patch to make the recipe build on these architectures.
* Do not create the «**`sh -> mksh`**» symbolic link anymore as changing the default «**`sh -> bash`**» symbolic link might create problems. Users willing to set /bin/mksh as their default shell just need to edit /etc/passwd.