### PR TITLE
openssl: bump version (1.0.2g & 1.0.1s)

### DIFF
--- a/dev-libs/openssl/openssl-1.0.1s.recipe
+++ b/dev-libs/openssl/openssl-1.0.1s.recipe
@@ -15,9 +15,9 @@ HOMEPAGE="https://www.openssl.org/"
 COPYRIGHT="1995-1998 Eric Young
 	1998-2016 The OpenSSL Project."
 LICENSE="OpenSSL"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://www.openssl.org/source/openssl-$portVersion.tar.gz"
-CHECKSUM_SHA256="932b4ee4def2b434f85435d9e3e19ca8ba99ce9a065a61524b429a9d5e9b2e9c"
+CHECKSUM_SHA256="e7e81d82f3cd538ab0cdba494006d44aab9dd96b7f6233ce9971fb7c7916d511"
 PATCHES="openssl-$portVersion.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64 ?arm ?ppc"
@@ -73,7 +73,7 @@ BUILD()
 	PERL="/bin/env perl" \
 	./config --prefix=$prefix --libdir=$relativeLibDir \
 		--openssldir=$dataRootDir/ssl \
-		zlib shared
+		enable-ssl2 zlib shared
 	make
 		# multi-job builds don't work correctly
 }

--- a/dev-libs/openssl/openssl-1.0.2g.recipe
+++ b/dev-libs/openssl/openssl-1.0.2g.recipe
@@ -17,7 +17,7 @@ COPYRIGHT="1995-1998 Eric Young
 LICENSE="OpenSSL"
 REVISION="1"
 SOURCE_URI="https://www.openssl.org/source/openssl-$portVersion.tar.gz"
-CHECKSUM_SHA256="784bd8d355ed01ce98b812f873f8b2313da61df7c7b5677fcf2e57b0863a3346"
+CHECKSUM_SHA256="b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33"
 PATCHES="openssl-$portVersion.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64 ?arm ?ppc"
@@ -73,7 +73,7 @@ BUILD()
 	PERL="/bin/env perl" \
 	./config --prefix=$prefix --libdir=$relativeLibDir \
 		--openssldir=$dataRootDir/ssl \
-		zlib shared
+		enable-ssl2 zlib shared
 	make
 		# multi-job builds don't work correctly
 }

--- a/dev-libs/openssl/patches/openssl-1.0.1s.patchset
+++ b/dev-libs/openssl/patches/openssl-1.0.1s.patchset
@@ -1,10 +1,14 @@
+From 18b32231b9e09802ab2f4ac6bacb7c34f978861f Mon Sep 17 00:00:00 2001
 From: Alexander von Gluck IV <kallisti5@unixzen.com>
 Date: Wed, 18 Jun 2014 02:37:21 +0000
-Subject: [PATCH 1/2] Haiku: build fixes
+Subject: Haiku: build fixes
 
+
+diff --git a/Configure b/Configure
+index 93c4cc1..d03daf4 100755
 --- a/Configure
 +++ b/Configure
-@@ -447,6 +447,10 @@ my %table=(
+@@ -451,6 +451,10 @@ my %table=(
  "beos-x86-r5",   "gcc:-DL_ENDIAN -DTERMIOS -O3 -fomit-frame-pointer -mcpu=pentium -Wall::-D_REENTRANT:BEOS:-lbe -lnet:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:${x86_elf_asm}:beos:beos-shared:-fPIC -DPIC:-shared:.so",
  "beos-x86-bone", "gcc:-DL_ENDIAN -DTERMIOS -O3 -fomit-frame-pointer -mcpu=pentium -Wall::-D_REENTRANT:BEOS:-lbe -lbind -lsocket:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:${x86_elf_asm}:beos:beos-shared:-fPIC:-shared:.so",
  
@@ -15,6 +19,8 @@ Subject: [PATCH 1/2] Haiku: build fixes
  #### SCO/Caldera targets.
  #
  # Originally we had like unixware-*, unixware-*-pentium, unixware-*-p6, etc.
+diff --git a/Makefile.shared b/Makefile.shared
+index e753f44..cce510f 100644
 --- a/Makefile.shared
 +++ b/Makefile.shared
 @@ -594,10 +594,10 @@ symlink.hpux:
@@ -32,9 +38,11 @@ Subject: [PATCH 1/2] Haiku: build fixes
  link_o.bsd-shared: link_o.bsd
  link_a.bsd-shared: link_a.bsd
  link_app.bsd-shared: link_app.bsd
+diff --git a/config b/config
+index 41fa2a6..f390fc2 100755
 --- a/config
 +++ b/config
-@@ -134,6 +134,14 @@ case "${SYSTEM}:${RELEASE}:${VERSION}:${
+@@ -134,6 +134,14 @@ case "${SYSTEM}:${RELEASE}:${VERSION}:${MACHINE}" in
  	echo "${MACHINE}-dg-dgux"; exit 0
  	;;
  
@@ -59,12 +67,18 @@ Subject: [PATCH 1/2] Haiku: build fixes
    # these are all covered by the catchall below
    # *-dgux) OUT="dgux" ;;
    mips-sony-newsos4) OUT="newsos4-gcc" ;;
+-- 
+2.2.2
 
 
+From c9f899f31eae393a8bada07d9109904323a75300 Mon Sep 17 00:00:00 2001
 From: Alexander von Gluck IV <kallisti5@unixzen.com>
 Date: Wed, 18 Jun 2014 02:39:12 +0000
-Subject: [PATCH 2/2] Haiku: Modify default Root CA filename
+Subject: Haiku: Modify default Root CA filename
 
+
+diff --git a/crypto/cryptlib.h b/crypto/cryptlib.h
+index fba180a..40c32df 100644
 --- a/crypto/cryptlib.h
 +++ b/crypto/cryptlib.h
 @@ -82,7 +82,7 @@ extern "C" {
@@ -76,3 +90,55 @@ Subject: [PATCH 2/2] Haiku: Modify default Root CA filename
  #  define X509_PRIVATE_DIR        OPENSSLDIR "/private"
  # else
  #  define X509_CERT_AREA          "SSLROOT:[000000]"
+-- 
+2.2.2
+
+
+From 733871bddd6fba30ddc938157d1e3b72a7a29e83 Mon Sep 17 00:00:00 2001
+From: Adrien Destugues <pulkomandy@pulkomandy.tk>
+Date: Mon, 9 Nov 2015 19:44:10 +0100
+Subject: Do not use __INTEL__ to detect x86_64.
+
+* Haiku defines it for 32-bit x86 as well.
+
+diff --git a/crypto/evp/e_aes_cbc_hmac_sha1.c b/crypto/evp/e_aes_cbc_hmac_sha1.c
+index d1f5928..55d8b8e 100644
+--- a/crypto/evp/e_aes_cbc_hmac_sha1.c
++++ b/crypto/evp/e_aes_cbc_hmac_sha1.c
+@@ -86,8 +86,7 @@ typedef struct {
+ 
+ # if     defined(AES_ASM) &&     ( \
+         defined(__x86_64)       || defined(__x86_64__)  || \
+-        defined(_M_AMD64)       || defined(_M_X64)      || \
+-        defined(__INTEL__)      )
++        defined(_M_AMD64)       || defined(_M_X64)      )
+ 
+ #  if defined(__GNUC__) && __GNUC__>=2 && !defined(PEDANTIC)
+ #   define BSWAP(x) ({ unsigned int r=(x); asm ("bswapl %0":"=r"(r):"0"(r)); r; })
+-- 
+2.2.2
+
+
+From 0f6d820c9a8684b16551d90eb3dab35f230f5ddb Mon Sep 17 00:00:00 2001
+From: Adrien Destugues <pulkomandy@pulkomandy.tk>
+Date: Mon, 9 Nov 2015 20:32:09 +0100
+Subject: more __intel__ fixes...
+
+
+diff --git a/crypto/evp/e_rc4_hmac_md5.c b/crypto/evp/e_rc4_hmac_md5.c
+index 2da1117..d41ba7f 100644
+--- a/crypto/evp/e_rc4_hmac_md5.c
++++ b/crypto/evp/e_rc4_hmac_md5.c
+@@ -101,8 +101,7 @@ static int rc4_hmac_md5_init_key(EVP_CIPHER_CTX *ctx,
+ 
+ # if     !defined(OPENSSL_NO_ASM) &&     ( \
+         defined(__x86_64)       || defined(__x86_64__)  || \
+-        defined(_M_AMD64)       || defined(_M_X64)      || \
+-        defined(__INTEL__)              ) && \
++        defined(_M_AMD64)       || defined(_M_X64)      ) && \
+         !(defined(__APPLE__) && defined(__MACH__))
+ #  define STITCHED_CALL
+ # endif
+-- 
+2.2.2
+

--- a/dev-libs/openssl/patches/openssl-1.0.2g.patchset
+++ b/dev-libs/openssl/patches/openssl-1.0.2g.patchset
@@ -1,11 +1,14 @@
+From ebe71871447f0112adf84943c2e1e48c32343c77 Mon Sep 17 00:00:00 2001
 From: Alexander von Gluck IV <kallisti5@unixzen.com>
 Date: Wed, 18 Jun 2014 02:37:21 +0000
 Subject: Haiku: build fixes
 
 
+diff --git a/Configure b/Configure
+index c98107a..b508a92 100755
 --- a/Configure
 +++ b/Configure
-@@ -502,6 +502,10 @@ my %table=(
+@@ -506,6 +506,10 @@ my %table=(
  "beos-x86-r5",   "gcc:-DL_ENDIAN -DTERMIOS -O3 -fomit-frame-pointer -mcpu=pentium -Wall::-D_REENTRANT:BEOS:-lbe -lnet:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:${x86_elf_asm}:beos:beos-shared:-fPIC -DPIC:-shared:.so",
  "beos-x86-bone", "gcc:-DL_ENDIAN -DTERMIOS -O3 -fomit-frame-pointer -mcpu=pentium -Wall::-D_REENTRANT:BEOS:-lbe -lbind -lsocket:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:${x86_elf_asm}:beos:beos-shared:-fPIC:-shared:.so",
  
@@ -16,6 +19,8 @@ Subject: Haiku: build fixes
  #### SCO/Caldera targets.
  #
  # Originally we had like unixware-*, unixware-*-pentium, unixware-*-p6, etc.
+diff --git a/Makefile.shared b/Makefile.shared
+index a2aa980..2b585a0 100644
 --- a/Makefile.shared
 +++ b/Makefile.shared
 @@ -594,10 +594,10 @@ symlink.hpux:
@@ -33,9 +38,11 @@ Subject: Haiku: build fixes
  link_o.bsd-shared: link_o.bsd
  link_a.bsd-shared: link_a.bsd
  link_app.bsd-shared: link_app.bsd
+diff --git a/config b/config
+index bba370c..d4d0620 100755
 --- a/config
 +++ b/config
-@@ -134,6 +134,14 @@ case "${SYSTEM}:${RELEASE}:${VERSION}:${
+@@ -134,6 +134,14 @@ case "${SYSTEM}:${RELEASE}:${VERSION}:${MACHINE}" in
  	echo "${MACHINE}-dg-dgux"; exit 0
  	;;
  
@@ -60,14 +67,18 @@ Subject: Haiku: build fixes
    # these are all covered by the catchall below
    # *-dgux) OUT="dgux" ;;
    mips-sony-newsos4) OUT="newsos4-gcc" ;;
+-- 
+2.7.0
 
 
-
+From 56aa0cc3ac136c72309364f6e723a61b1dac1462 Mon Sep 17 00:00:00 2001
 From: Alexander von Gluck IV <kallisti5@unixzen.com>
 Date: Wed, 18 Jun 2014 02:39:12 +0000
 Subject: Haiku: Modify default Root CA filename
 
 
+diff --git a/crypto/cryptlib.h b/crypto/cryptlib.h
+index fba180a..40c32df 100644
 --- a/crypto/cryptlib.h
 +++ b/crypto/cryptlib.h
 @@ -82,7 +82,7 @@ extern "C" {
@@ -79,15 +90,19 @@ Subject: Haiku: Modify default Root CA filename
  #  define X509_PRIVATE_DIR        OPENSSLDIR "/private"
  # else
  #  define X509_CERT_AREA          "SSLROOT:[000000]"
+-- 
+2.7.0
 
 
-
+From 9992048c0a9ef4a1fefdff9981a553c0a2130bc2 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Mon, 9 Nov 2015 19:44:10 +0100
 Subject: Do not use __INTEL__ to detect x86_64.
 
 * Haiku defines it for 32-bit x86 as well.
 
+diff --git a/crypto/evp/e_aes_cbc_hmac_sha1.c b/crypto/evp/e_aes_cbc_hmac_sha1.c
+index 8330964..8980582 100644
 --- a/crypto/evp/e_aes_cbc_hmac_sha1.c
 +++ b/crypto/evp/e_aes_cbc_hmac_sha1.c
 @@ -91,8 +91,7 @@ typedef struct {
@@ -100,15 +115,18 @@ Subject: Do not use __INTEL__ to detect x86_64.
  
  extern unsigned int OPENSSL_ia32cap_P[];
  #  define AESNI_CAPABLE   (1<<(57-32))
+-- 
+2.7.0
 
 
-
+From f3b305a87bf7d6c514190f23545d4df20c07c016 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Mon, 9 Nov 2015 20:32:09 +0100
 Subject: more __intel__ fixes...
 
 
 diff --git a/crypto/evp/e_aes_cbc_hmac_sha256.c b/crypto/evp/e_aes_cbc_hmac_sha256.c
+index 3780021..fff6e0c 100644
 --- a/crypto/evp/e_aes_cbc_hmac_sha256.c
 +++ b/crypto/evp/e_aes_cbc_hmac_sha256.c
 @@ -91,8 +91,7 @@ typedef struct {
@@ -121,9 +139,11 @@ diff --git a/crypto/evp/e_aes_cbc_hmac_sha256.c b/crypto/evp/e_aes_cbc_hmac_sha2
  
  extern unsigned int OPENSSL_ia32cap_P[];
  #  define AESNI_CAPABLE   (1<<(57-32))
+diff --git a/crypto/evp/e_rc4_hmac_md5.c b/crypto/evp/e_rc4_hmac_md5.c
+index 2da1117..d41ba7f 100644
 --- a/crypto/evp/e_rc4_hmac_md5.c
 +++ b/crypto/evp/e_rc4_hmac_md5.c
-@@ -101,8 +101,7 @@ static int rc4_hmac_md5_init_key(EVP_CIP
+@@ -101,8 +101,7 @@ static int rc4_hmac_md5_init_key(EVP_CIPHER_CTX *ctx,
  
  # if     !defined(OPENSSL_NO_ASM) &&     ( \
          defined(__x86_64)       || defined(__x86_64__)  || \
@@ -133,6 +153,8 @@ diff --git a/crypto/evp/e_aes_cbc_hmac_sha256.c b/crypto/evp/e_aes_cbc_hmac_sha2
          !(defined(__APPLE__) && defined(__MACH__))
  #  define STITCHED_CALL
  # endif
+diff --git a/ssl/s3_pkt.c b/ssl/s3_pkt.c
+index 3798902..8caca14 100644
 --- a/ssl/s3_pkt.c
 +++ b/ssl/s3_pkt.c
 @@ -125,8 +125,7 @@
@@ -145,3 +167,6 @@ diff --git a/crypto/evp/e_aes_cbc_hmac_sha256.c b/crypto/evp/e_aes_cbc_hmac_sha2
          )
  # undef EVP_CIPH_FLAG_TLS1_1_MULTIBLOCK
  # define EVP_CIPH_FLAG_TLS1_1_MULTIBLOCK 0
+-- 
+2.7.0
+


### PR DESCRIPTION
* bump 1.0.2 series to 1.0.2g with **`enable-ssl2`** to prevent API breakage.

* bump 1.0.1 series to 1.0.1s with **`enable-ssl2`** to prevent API breakage.

* Fix the patchset for the 1.0.1 series:
 1. by using a copy of patch «**`Do not use __INTEL__ to detect x86_64`**»
from the 1.0.2 series for **`crypto/evp/e_aes_cbc_hmac_sha1.c`**.
 2. by using a copy of the 2nd chunk of patch «**`more __intel__ fixes...`**»
from the 1.0.2 series for **`crypto/evp/e_rc4_hmac_md5.c`**.