### PR TITLE
gnutls: bump version to 3.4.10.

### DIFF
--- a/net-libs/gnutls/gnutls-3.4.10.recipe
+++ b/net-libs/gnutls/gnutls-3.4.10.recipe
@@ -12,7 +12,7 @@ COPYRIGHT="2000-2016 Free Software Fundation Inc.
 LICENSE="GNU LGPL v2.1"
 REVISION="1"
 SOURCE_URI="ftp://ftp.gnutls.org/gcrypt/gnutls/v3.4/gnutls-$portVersion.tar.xz"
-CHECKSUM_SHA256="48594fadba33d450f796ec69526cf2bce6ff9bc3dc90fbd7bf38dc3601f57c3f"
+CHECKSUM_SHA256="6a32c2b4acbd33ff7eefcbd1357009da04c94c60146ef61320b6c076b1bdf59f"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64 ?arm ?ppc"
 SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
@@ -23,12 +23,11 @@ PROVIDES="
 	cmd:gnutls_cli$secondaryArchSuffix
 	cmd:gnutls_cli_debug$secondaryArchSuffix
 	cmd:gnutls_serv$secondaryArchSuffix
-	cmd:psktool$secondaryArchSuffix
 	cmd:ocsptool$secondaryArchSuffix
+	cmd:psktool$secondaryArchSuffix
 	cmd:srptool$secondaryArchSuffix
-	cmd:systemkey$secondaryArchSuffix
 	lib:libgnutls_openssl$secondaryArchSuffix = 27.0.2 compat >= 27
-	lib:libgnutls$secondaryArchSuffix = 30.6.1 compat >= 30
+	lib:libgnutls$secondaryArchSuffix = 30.6.2 compat >= 30
 	lib:libgnutlsxx$secondaryArchSuffix = 28.1.0 compat >= 28
 	"
 REQUIRES="
@@ -42,9 +41,9 @@ REQUIRES="
 	"
 
 PROVIDES_devel="
-	gnutls_devel$secondaryArchSuffix = $portVersion
+	gnutls${secondaryArchSuffix}_devel = $portVersion
 	devel:libgnutls_openssl$secondaryArchSuffix = 27.0.2 compat >= 27
-	devel:libgnutls$secondaryArchSuffix = 30.6.1 compat >= 30
+	devel:libgnutls$secondaryArchSuffix = 30.6.2 compat >= 30
 	devel:libgnutlsxx$secondaryArchSuffix = 28.1.0 compat >= 28
 	"
 REQUIRES_devel="
@@ -52,6 +51,20 @@ REQUIRES_devel="
 	devel:libnettle$secondaryArchSuffix
 	devel:libtasn1$secondaryArchSuffix
 	"
+
+if [ -z "$secondaryArchSuffix" ]; then
+# HaikuPorter does not yet support creating architecture-independent packages
+# for secondary-arch builds. So build it only if we're on a primary arch.
+	SUMMARY_doc="Documentation for GnuTLS"
+	ARCHITECTURES_doc="any"
+
+	PROVIDES_doc="
+		gnutls_doc = $portVersion
+		"
+	REQUIRES_doc="
+		haiku
+		"
+fi
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
@@ -75,8 +88,9 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	runConfigure ./configure --without-p11-kit --disable-doc --disable-nls \
-		--enable-openssl-compatibility
+	runConfigure ./configure --without-p11-kit --disable-nls \
+		--enable-openssl-compatibility \
+		${secondaryArchSuffix+--disable-doc}
 	make $jobArgs
 }
 
@@ -88,4 +102,8 @@ INSTALL()
 	fixPkgconfig
 
 	packageEntries devel $developDir
+
+	if [ -z "$secondaryArchSuffix" ]; then
+		packageEntries doc $documentationDir
+	fi
 }


### PR DESCRIPTION
* Bump version to 3.4.10.
* ~~Install **`systemkey`** as **`systemkey-tool`** (to follow the man page name) as neither the command nor its manual page are being installed by default.~~
* Drop the **`--disable-doc`** switch during configuration and put all docs in a separate package, gnutls_doc.
* Add «**`= $portVersion compat >= 3.4`**» for each «**`cmd:`**» line in PROVIDES.
* Swap the lines for «**`cmd:psktool`**» and «**`cmd:ocsptool`**» as they were not sorted.
* Drop the «**`cmd:systemkey`**» line in PROVIDES as it is not installed by default.