### PR TITLE
openldap: bump version to 2.4.44.

### DIFF
--- a/net-nds/openldap/openldap-2.4.44.recipe
+++ b/net-nds/openldap/openldap-2.4.44.recipe
@@ -4,37 +4,30 @@ robust, commercial-grade, fully featured, and open source LDAP suite of \
 applications and development tools. The project is managed by a worldwide \
 coummunity of volunteers that use the Internet to communicate, plan, and \
 develop the OpenLDAP Suite and its related documentation."
+COPYRIGHT="1998-2016 The OpenLDAP Foundation"
 HOMEPAGE="http://www.openldap.org/"
-SOURCE_URI="ftp://ftp.openldap.org/pub/OpenLDAP/openldap-release/openldap-2.4.40.tgz"
-CHECKSUM_SHA256="d12611a5c25b6499293c2bb7b435dc2b174db73e83f5a8cb7e34f2ce5fa6dadb"
-REVISION="1"
 LICENSE="OpenLDAP Public License"
-COPYRIGHT="1998-2014 The OpenLDAP Foundation"
+REVISION="1"
+SOURCE_URI="ftp://ftp.openldap.org/pub/OpenLDAP/openldap-release/openldap-$portVersion.tgz"
+CHECKSUM_SHA256="d7de6bf3c67009c95525dde3a0212cc110d0a70b92af2af8e3ee800e81b88400"
 
-ARCHITECTURES="?x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="?x86_gcc2 ?x86"
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
 GLOBAL_WRITABLE_FILES="settings/openldap/ldap.conf keep-old"
 USER_SETTINGS_FILES="
 	settings/openldap/ldap.conf template data/openldap/ldap.conf.default
 "
 
-PATCH()
-{
-	sed -i 's/-lnet/-lnetwork/g' configure.in
-	sed -i 's/net, socket/network, socket/g' configure.in
-}
-
 PROVIDES="
 	openldap$secondaryArchSuffix = $portVersion
-	lib:liblber$secondaryArchSuffix = 2.10.3
-	lib:liblber_2.4$secondaryArchSuffix = 2.10.3
-	lib:libldap$secondaryArchSuffix = 2.10.3
-	lib:libldap_2.4$secondaryArchSuffix = 2.10.3
-	lib:libldap_r$secondaryArchSuffix = 2.10.3
-	lib:libldap_r_2.4$secondaryArchSuffix = 2.10.3
+	lib:liblber$secondaryArchSuffix = 2.10.7 compat >= 2.10
+	lib:liblber_2.4$secondaryArchSuffix = 2.10.7 compat >= 2.10
+	lib:libldap$secondaryArchSuffix = 2.10.7 compat >= 2.10
+	lib:libldap_2.4$secondaryArchSuffix = 2.10.7 compat >= 2.10
+	lib:libldap_r$secondaryArchSuffix = 2.10.7 compat >= 2.10
+	lib:libldap_r_2.4$secondaryArchSuffix = 2.10.7 compat >= 2.10
 "
-
 if [ -z "$secondaryArchSuffix" ]; then
 	PROVIDES="$PROVIDES
 		cmd:ldapadd
@@ -56,12 +49,24 @@ REQUIRES="
 	lib:libssl$secondaryArchSuffix
 "
 
+PROVIDES_devel="
+	openldap${secondaryArchSuffix}_devel = $portVersion
+	devel:liblber$secondaryArchSuffix = 2.10.7 compat >= 2.10
+	devel:liblber_2.4$secondaryArchSuffix = 2.10.7 compat >= 2.10
+	devel:libldap$secondaryArchSuffix = 2.10.7 compat >= 2.10
+	devel:libldap_2.4$secondaryArchSuffix = 2.10.7 compat >= 2.10
+	devel:libldap_r$secondaryArchSuffix = 2.10.7 compat >= 2.10
+	devel:libldap_r_2.4$secondaryArchSuffix = 2.10.7 compat >= 2.10
+"
+REQUIRES_devel="
+	openldap$secondaryArchSuffix == $portVersion base
+"
+
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libcrypto$secondaryArchSuffix
 	devel:libssl$secondaryArchSuffix
 "
-
 BUILD_PREREQUIRES="
 	cmd:libtoolize
 	cmd:aclocal
@@ -71,6 +76,14 @@ BUILD_PREREQUIRES="
 	cmd:ld$secondaryArchSuffix
 	cmd:soelim
 "
+
+PATCH()
+{
+	sed \
+		-e 's/-\<lnet\>/&work/g' \
+		-e 's/net, socket/network, socket/g' \
+		-i configure.in
+}
 
 BUILD()
 {
@@ -93,23 +106,12 @@ INSTALL()
 	mkdir -p $dataDir/openldap
 	mv $settingsDir/openldap/ldap.conf.default $dataDir/openldap/
 
-	packageEntries devel $developDir $documentationDir/man/man3
-
-	if [ -n "$secondaryArchSuffix" ]; then
-		rm -rf $binDir
+	if [ -z "$secondaryArchSuffix" ]; then
+# On primary architectures: move man3 to devel package
+		packageEntries devel $developDir $documentationDir/man/man3
+	else
+# On secondary architectures: delete binDir and documentationDir
+		rm -rf $binDir $documentationDir
+		packageEntries devel $developDir
 	fi
 }
-
-PROVIDES_devel="
-	openldap${secondaryArchSuffix}_devel = $portVersion
-	devel:liblber$secondaryArchSuffix = 2.10.3
-	devel:liblber_2.4$secondaryArchSuffix = 2.10.3
-	devel:libldap$secondaryArchSuffix = 2.10.3
-	devel:libldap_2.4$secondaryArchSuffix = 2.10.3
-	devel:libldap_r$secondaryArchSuffix = 2.10.3
-	devel:libldap_r_2.4$secondaryArchSuffix = 2.10.3
-"
-
-REQUIRES_devel="
-	openldap$secondaryArchSuffix == $portVersion base
-"


### PR DESCRIPTION
* Bump version to 2.4.44.
* Mark all architectures as tested.
* Remove documentation for secondary architectures.
* Reorder sections.
* Fix **`PATCH()`** to avoid replacing «-lnetwork» by «**`-lnetworkwork`**».