### PR TITLE
pkgconfig: fix 0.27.1, 0.28 and 0.29, add 0.29.1.

### DIFF
--- a/dev-util/pkgconfig/patches/pkgconfig-0.29.1.patchset
+++ b/dev-util/pkgconfig/patches/pkgconfig-0.29.1.patchset
@@ -1,0 +1,78 @@
+From 6e759ba387f142a59edb1b3f70f1a2b3c710b3ab Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Sun, 29 Nov 2015 15:49:57 +0000
+Subject: Haiku patch
+
+* Actually use pc_path when building pkgconfig.
+* skip network libs in glib.
+
+diff --git a/Makefile.am b/Makefile.am
+index e46c798..b431bcb 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -22,7 +22,7 @@ AM_CPPFLAGS = \
+ 	-DPKG_CONFIG_SYSTEM_LIBRARY_PATH="\"$(system_library_path)\""
+ endif
+ 
+-AM_CFLAGS = \
++AM_CFLAGS = $(AM_CPPFLAGS)\
+ 	$(WARN_CFLAGS) \
+ 	$(GCOV_CFLAGS) \
+ 	$(GLIB_CFLAGS)
+diff --git a/glib/configure.ac b/glib/configure.ac
+index ffa7869..48f7537 100644
+--- a/glib/configure.ac
++++ b/glib/configure.ac
+@@ -1094,49 +1094,6 @@ AS_IF([test $glib_native_win32 = yes], [
+                                          [AC_MSG_ERROR([could not compile test program either way])])])])
+   AC_SUBST(NAMESER_COMPAT_INCLUDE)
+ 
+-  # We can't just use AC_CHECK_FUNC/AC_CHECK_LIB here. Bug 586150
+-  NETWORK_LIBS=""
+-  AC_MSG_CHECKING([for res_query])
+-  AC_TRY_LINK([#include <sys/types.h>
+-	       #include <netinet/in.h>
+-	       #include <arpa/nameser.h>
+-	       #include <resolv.h>
+-              ],[
+-	       res_query("test", 0, 0, (void *)0, 0);
+-              ],[AC_MSG_RESULT([yes])],
+-              [save_libs="$LIBS"
+-               LIBS="-lresolv $LIBS"
+-               AC_TRY_LINK([#include <sys/types.h>
+-			    #include <netinet/in.h>
+-			    #include <arpa/nameser.h>
+-			    #include <resolv.h>
+-			   ],[
+-			    res_query("test", 0, 0, (void *)0, 0);
+-			   ],[AC_MSG_RESULT([in -lresolv])
+-                              NETWORK_LIBS="-lresolv $NETWORK_LIBS"],
+-                           [LIBS="-lbind $save_libs"
+-                            AC_TRY_LINK([#include <resolv.h>],
+-                                        [res_query("test", 0, 0, (void *)0, 0);],
+-                                        [AC_MSG_RESULT([in -lbind])
+-                                         NETWORK_LIBS="-lbind $NETWORK_LIBS"],
+-                                        [AC_MSG_ERROR(not found)])])
+-               LIBS="$save_libs"])
+-  AC_CHECK_FUNC(socket, :, AC_CHECK_LIB(socket, socket,
+-				        [NETWORK_LIBS="-lsocket $NETWORK_LIBS"],
+-				        [AC_MSG_ERROR(Could not find socket())]))
+-  save_libs="$LIBS"
+-  LIBS="$LIBS $NETWORK_LIBS"
+-  AC_MSG_CHECKING([for res_init])
+-  AC_TRY_LINK([#include <sys/types.h>
+-	       #include <netinet/in.h>
+-	       #include <arpa/nameser.h>
+-	       #include <resolv.h>
+-              ],[
+-	       res_init();
+-              ],[AC_MSG_RESULT([yes])
+-	         AC_DEFINE(HAVE_RES_INIT, 1, [Define to 1 if you have the 'res_init' function.])
+-	      ],[AC_MSG_RESULT([no])])
+-  LIBS="$save_libs"
+ ])
+ AC_SUBST(NETWORK_LIBS)
+ 
+-- 
+2.2.2
+

--- a/dev-util/pkgconfig/pkgconfig-0.27.1.recipe
+++ b/dev-util/pkgconfig/pkgconfig-0.27.1.recipe
@@ -4,14 +4,14 @@ command line so an application can use 'gcc -o test test.cpkg-config --libs \
 --cflags glib-2.0' for instance, rather than hard-coding values on where to \
 find glib (or other libraries). It is language-agnostic, so it can be used \
 for defining the location of documentation tools, for instance."
-HOMEPAGE="http://pkg-config.freedesktop.org/wiki/"
-COPYRIGHT="1998, 2001-2006 Red Hat Inc."
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/pkg-config/"
+COPYRIGHT="1994-1996, 1999-2002, 2004-2012 Free Software Foundation, Inc."
 LICENSE="GNU GPL v2"
-REVISION="2"
-SOURCE_URI="http://pkgconfig.freedesktop.org/releases/pkg-config-0.27.1.tar.gz"
+REVISION="3"
+SOURCE_URI="https://pkg-config.freedesktop.org/releases/pkg-config-$portVersion.tar.gz"
 CHECKSUM_SHA256="4f63d0df3035101b12949250da5231af49e3c3afcd8fb18554fa7c3cb92d8c17"
-SOURCE_DIR="pkg-config-0.27.1"
-PATCHES="pkgconfig-0.27.1.patchset"
+SOURCE_DIR="pkg-config-$portVersion"
+PATCHES="pkgconfig-$portVersion.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
@@ -38,7 +38,7 @@ BUILD_PREREQUIRES="
 	cmd:find
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
-	cmd:libtoolize
+	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
 	cmd:xargs
 	"
@@ -61,7 +61,7 @@ BUILD()
 
 	runConfigure ./configure \
 		--with-internal-glib \
-		--with-pc_path="$pcPath"
+		--with-pc-path="$pcPath"
 	make $jobArgs
 }
 

--- a/dev-util/pkgconfig/pkgconfig-0.29.1.recipe
+++ b/dev-util/pkgconfig/pkgconfig-0.29.1.recipe
@@ -5,13 +5,13 @@ command line so an application can use 'gcc -o test test.cpkg-config --libs \
 find glib (or other libraries). It is language-agnostic, so it can be used \
 for defining the location of documentation tools, for instance."
 HOMEPAGE="https://www.freedesktop.org/wiki/Software/pkg-config/"
-COPYRIGHT="1994-1996, 1999-2002, 2004-2013 Free Software Foundation, Inc."
+COPYRIGHT="1994-1996, 1999-2002, 2004-2016 Free Software Foundation, Inc."
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://pkg-config.freedesktop.org/releases/pkg-config-$portVersion.tar.gz"
-CHECKSUM_SHA256="6b6eb31c6ec4421174578652c7e141fdaae2dabad1021f420d8713206ac1f845"
+CHECKSUM_SHA256="beb43c9e064555469bd4390dcfd8030b1536e0aa103f08d7abf7ae8cac0cb001"
 SOURCE_DIR="pkg-config-$portVersion"
-PATCHES="pkgconfig-$portVersion.patch"
+PATCHES="pkgconfig-$portVersion.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"

--- a/dev-util/pkgconfig/pkgconfig-0.29.recipe
+++ b/dev-util/pkgconfig/pkgconfig-0.29.recipe
@@ -4,11 +4,11 @@ command line so an application can use 'gcc -o test test.cpkg-config --libs \
 --cflags glib-2.0' for instance, rather than hard-coding values on where to \
 find glib (or other libraries). It is language-agnostic, so it can be used \
 for defining the location of documentation tools, for instance."
-HOMEPAGE="http://pkg-config.freedesktop.org/wiki/"
-COPYRIGHT="1998, 2001-2006 Red Hat Inc."
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/pkg-config/"
+COPYRIGHT="1994-1996, 1999-2002, 2004-2015 Free Software Foundation, Inc."
 LICENSE="GNU GPL v2"
-REVISION="1"
-SOURCE_URI="http://pkgconfig.freedesktop.org/releases/pkg-config-$portVersion.tar.gz"
+REVISION="2"
+SOURCE_URI="https://pkg-config.freedesktop.org/releases/pkg-config-$portVersion.tar.gz"
 CHECKSUM_SHA256="c8507705d2a10c67f385d66ca2aae31e81770cc0734b4191eb8c489e864a006b"
 SOURCE_DIR="pkg-config-$portVersion"
 PATCHES="pkgconfig-$portVersion.patchset"
@@ -38,7 +38,7 @@ BUILD_PREREQUIRES="
 	cmd:find
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
-	cmd:libtoolize
+	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
 	cmd:xargs
 	"
@@ -59,14 +59,11 @@ BUILD()
 	autoreconf -i -f
 	export CFLAGS=-D_BSD_SOURCE
 	COMMON_DOCS=$docDir
-	./configure --prefix=$prefix \
-		--datadir=$dataDir \
-		--docdir=$docDir \
-		--mandir=$manDir \
+	runConfigure ./configure \
 		--disable-host-tool \
 		--with-internal-glib \
 		--with-pc-path="$pcPath"
-	make
+	make $jobArgs
 }
 
 INSTALL()


### PR DESCRIPTION
* Add recipe for version 0.29.1.
* Use the runConfigure wrapper.
* Use exact copy of the patchset for 0.29 as there are no offset mismatches.

For 0.27.1:
* Call configure wuth «**`--with-pc-path`**» instead of «**`--with-pc_path`**».

For 0.28:
    * Several changes to make it build and look almost like 0.29.1.

For 0.29:
* Switch to runConfigure in order to prevent pkg-config on secondary arch from shadowing that of the primary arch.

For 0.27.1, 0.28, 0.29 and 0.29.1:
* Fix COPYRIGHT.
* Update HOMEPAGE and SOURCE_URI to avoid «301 Moved Permanently».