### PR TITLE
vala: fix missing $secondaryArchSuffix in PROVIDES{,_common}.

### DIFF
--- a/dev-lang/vala/vala-0.30.1.recipe
+++ b/dev-lang/vala/vala-0.30.1.recipe
@@ -17,7 +17,7 @@ ARCHITECTURES="!x86_gcc2 x86 ?x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	vala = $portVersion
+	vala$secondaryArchSuffix = $portVersion
 	cmd:vala$secondaryArchSuffix
 	cmd:valac$secondaryArchSuffix
 	cmd:vapicheck$secondaryArchSuffix
@@ -31,7 +31,7 @@ PROVIDES="
 	lib:libvala_0.30$secondaryArchSuffix
 	"
 PROVIDES_common="
-	vala_common = $portVersion
+	vala_common$secondaryArchSuffix = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix


### PR DESCRIPTION
The **`$secondaryArchSuffix`** suffix was missing for vala in PROVIDES and for vala_common in PROVIDES_common. This is required on x86_gcc2 because vala_x86 requires vala_common_x86.