### PR TITLE
curl: bump to version 7.48.0

### DIFF
--- a/net-misc/curl/curl-7.48.0.recipe
+++ b/net-misc/curl/curl-7.48.0.recipe
@@ -1,16 +1,17 @@
 SUMMARY="A commandline-tool and library for downloading data from URLs"
 DESCRIPTION="Curl is a command line tool for transferring data with URL \
 syntax, supporting DICT, FILE, FTP, FTPS, Gopher, HTTP, HTTPS, IMAP, IMAPS, \
-LDAP, LDAPS, POP3, POP3S, RTMP, RTSP, SCP, SFTP, SMTP, SMTPS, Telnet and TFTP. curl supports SSL certificates, HTTP POST, HTTP PUT, FTP uploading, HTTP form \
+LDAP, LDAPS, POP3, POP3S, RTMP, RTSP, SCP, SFTP, SMTP, SMTPS, Telnet and TFTP.
+curl supports SSL certificates, HTTP POST, HTTP PUT, FTP uploading, HTTP form \
 based upload, proxies, cookies, user+password authentication (Basic, Digest, \
 NTLM, Negotiate, kerberos...), file transfer resume, proxy tunneling and a \
 busload of other useful tricks."
-HOMEPAGE="http://curl.haxx.se"
+HOMEPAGE="https://curl.haxx.se/"
 COPYRIGHT="1996-2016, Daniel Stenberg"
 LICENSE="Curl"
 REVISION="1"
-SOURCE_URI="http://curl.haxx.se/download/curl-$portVersion.tar.bz2"
-CHECKSUM_SHA256="ddc643ab9382e24bbe4747d43df189a0a6ce38fcb33df041b9cb0b3cd47ae98f"
+SOURCE_URI="https://curl.haxx.se/download/curl-$portVersion.tar.bz2"
+CHECKSUM_SHA256="864e7819210b586d42c674a1fdd577ce75a78b3dda64c63565abe5aefd72c753"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64 arm"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
@@ -31,11 +32,6 @@ REQUIRES="
 	lib:libssl$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
-BUILD_REQUIRES="
-	haiku${secondaryArchSuffix}_devel
-	devel:libssl$secondaryArchSuffix
-	devel:libz$secondaryArchSuffix
-	"
 
 PROVIDES_devel="
 	curl${secondaryArchSuffix}_devel = $portVersion
@@ -48,11 +44,16 @@ REQUIRES_devel="
 	devel:libz$secondaryArchSuffix
 	"
 
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libssl$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
 BUILD_PREREQUIRES="
 	cmd:autoconf
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
-	cmd:libtoolize
+	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
 	cmd:nroff
 	cmd:python


### PR DESCRIPTION
* Bump version.
* Move BUILD_REQUIRES to the recommended place.
* Use **`cmd:libtoolize$secondaryArchSuffix`** instead of **`cmd:libtoolize`** in BUILD_PREREQUIRES to make sure we don't accidentally pull libintl from the primary arch when building for a secondary arch.