### PR TITLE
ffmpeg: bump to version 3.0.1.

### DIFF
--- a/media-video/ffmpeg/ffmpeg-3.0.1.recipe
+++ b/media-video/ffmpeg/ffmpeg-3.0.1.recipe
@@ -2,16 +2,17 @@ SUMMARY="Audio and video recording, conversion, and streaming library"
 DESCRIPTION="FFmpeg is a complete, cross-platform solution to record, convert \
 and stream audio and video. It includes libavcodec - the leading audio/video \
 codec library."
-HOMEPAGE="http://www.ffmpeg.org"
-LICENSE="GNU LGPL v2.1
-	GNU GPL v2"
+HOMEPAGE="https://ffmpeg.org/"
 COPYRIGHT="2000-2003 Fabrice Bellard
 	2003-2016 the FFmpeg developers"
-SOURCE_URI="http://ffmpeg.org/releases/ffmpeg-$portVersion.tar.xz"
-CHECKSUM_SHA256="12f32cee41c74435f608c30793fd616bdf53467bb513278e273e135a4c58e470"
+LICENSE="GNU LGPL v2.1
+	GNU GPL v2"
 REVISION="1"
+SOURCE_URI="https://ffmpeg.org/releases/ffmpeg-$portVersion.tar.xz"
+CHECKSUM_SHA256="c389ca5e3c29e758dd82ee6981130fe79e73b06e26db1a3aa971daea63598bc1"
+
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="x86"
+SECONDARY_ARCHITECTURES="!x86_gcc2 ?x86"
 
 PROVIDES="
 	ffmpeg$secondaryArchSuffix = $portVersion compat >= 3.0
@@ -28,7 +29,6 @@ PROVIDES="
 	lib:libswresample$secondaryArchSuffix = 2.0.101 compat >= 2
 	lib:libpostproc$secondaryArchSuffix = 54.0.100 compat >= 54
 	"
-
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libbz2$secondaryArchSuffix
@@ -98,18 +98,23 @@ GLOBAL_WRITABLE_FILES="
 PATCH()
 {
 	# patch hard-coded config file path
-	sed -i "s,/etc/ffserver.conf,$sysconfDir/ffserver.conf," \
+	sed -i -e "s,/etc/ffserver.conf,$sysconfDir/ffserver.conf," \
 		ffserver.c \
 		doc/ffserver.texi
 
 	# patch hard-coded paths to perl
-	sed -i "s,/usr/bin/perl,$portPackageLinksDir/cmd~perl/bin/perl," \
+	sed -i -e "s,/usr/bin/perl,$portPackageLinksDir/cmd~perl/bin/perl," \
 		doc/Doxyfile \
 		doc/texi2pod.pl
 }
 
 BUILD()
 {
+	if [ "$effectiveTargetArchitecture" = "x86_gcc2" ]; then
+		extra_flags="--disable-asm --disable-stripping"
+	else
+		extra_flags=
+	fi
 	# not an autotools configure
 	./configure \
 		--prefix=$prefix \
@@ -127,7 +132,8 @@ BUILD()
 		--enable-libtheora \
 		--enable-libvpx \
 		--enable-gpl \
-		--enable-avresample
+		--enable-avresample \
+		$extra_flags
 
 	if [ $targetArchitecture = x86_64 ]; then
 		cflags="-fPIC -std=c99"


### PR DESCRIPTION
* Bump version.
* Reorder sections.
* Use https instead of http in HOMEPAGE and SOURCE_URI.
* Add **`-e`** to **`sed`** to improve the portability of the recipe.
* Add !x86_gcc2 to SECONDARY_ARCHITECTURES.
* Mark x86 secondary arch as untested since both 3.0 and 3.0.1 fail to build on x86_gcc2, even with **`--disable-asm`**.