### PR TITLE
libcaca: shrink 2nd arch packages to avoid duplicate files.

### DIFF
--- a/media-libs/libcaca/libcaca-0.99.beta19.recipe
+++ b/media-libs/libcaca/libcaca-0.99.beta19.recipe
@@ -2,8 +2,6 @@ SUMMARY="An ASCII art rendering library"
 DESCRIPTION="libcaca is a software library which allows applications to \
 automatically convert still and moving images into colored ASCII art."
 HOMEPAGE="http://caca.zoy.org/wiki/libcaca"
-# FIXME: the offical website is down right now. Using mirror provided by the
-#        MXE project.
 COPYRIGHT="1998, 1999, 2001 Jan Hubicka
 	2003-2008 Sam Hocevar
 	2003-2008 Jean-Yves Lamoureux
@@ -12,9 +10,8 @@ COPYRIGHT="1998, 1999, 2001 Jan Hubicka
 	2007-2008 Pascal Terjan"
 LICENSE="WTFPL
 	GNU GPL v2"
-REVISION="2"
-SOURCE_URI="http://caca.zoy.org/raw-attachment/wiki/libcaca/libcaca-$portVersion.tar.gz
-	http://s3.amazonaws.com/mxe-pkg/libcaca-$portVersion.tar.gz"
+REVISION="3"
+SOURCE_URI="http://caca.zoy.org/raw-attachment/wiki/libcaca/libcaca-$portVersion.tar.gz"
 CHECKSUM_SHA256="128b467c4ed03264c187405172a4e83049342cc8cc2f655f53a2d0ee9d3772f4"
 SOURCE_DIR="libcaca-$portVersion"
 PATCHES="libcaca-${portVersion}.patchset"
@@ -24,16 +21,20 @@ SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
 PROVIDES="
 	libcaca$secondaryArchSuffix = $portVersion compat >= 0
-	lib:libcaca$secondaryArchSuffix = 0.99.19  compat >= 0
-	lib:libcaca++$secondaryArchSuffix = 0.99.19  compat >= 0
-	cmd:cacaclock$secondaryArchSuffix = $portVersion compat >= 0
-	cmd:cacademo$secondaryArchSuffix = $portVersion compat >= 0
-	cmd:cacafire$secondaryArchSuffix = $portVersion compat >= 0
-	cmd:cacaserver$secondaryArchSuffix = $portVersion compat >= 0
-	cmd:cacaview$secondaryArchSuffix = $portVersion compat >= 0
-	cmd:cacaplay$secondaryArchSuffix = $portVersion compat >= 0
-	cmd:img2txt$secondaryArchSuffix = $portVersion compat >= 0
+	lib:libcaca$secondaryArchSuffix = 0.99.19 compat >= 0
+	lib:libcaca++$secondaryArchSuffix = 0.99.19 compat >= 0
 	"
+if [ -z "$secondaryArchSuffix" ]; then
+	PROVIDES="$PROVIDES
+		cmd:cacaclock = $portVersion compat >= 0
+		cmd:cacademo = $portVersion compat >= 0
+		cmd:cacafire = $portVersion compat >= 0
+		cmd:cacaserver = $portVersion compat >= 0
+		cmd:cacaview = $portVersion compat >= 0
+		cmd:cacaplay = $portVersion compat >= 0
+		cmd:img2txt = $portVersion compat >= 0
+		"
+fi
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libncursesw$secondaryArchSuffix
@@ -52,6 +53,14 @@ REQUIRES_devel="
 	lib:libncursesw$secondaryArchSuffix
 	devel:libncursesw$secondaryArchSuffix
 	"
+
+if [ -z "$secondaryArchSuffix" ]; then
+	ARCHITECTURES_doc="any"
+	PROVIDES_doc="
+		libcaca_doc = $portVersion
+		"
+	REQUIRES_doc=""
+fi
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
@@ -74,7 +83,7 @@ BUILD_PREREQUIRES="
 
 PATCH()
 {
-        sed -i 's/AM_CONFIG_HEADER/AC_CONFIG_HEADERS/g' configure.ac
+	sed -i -e 's/AM_CONFIG_HEADER/AC_CONFIG_HEADERS/g' configure.ac
 }
 
 BUILD()
@@ -91,6 +100,16 @@ BUILD()
 INSTALL()
 {
 	make install
+
+	if [ -n "$secondaryArchSuffix" ]; then
+		rm -rf $dataDir/libcaca $developDocDir $documentationDir
+		rmdir $developDir/documentation
+	else
+		packageEntries doc \
+			$developDocDir \
+			$documentationDir/man/man3
+	fi
+
 	prepareInstalledDevelLibs libcaca libcaca++
 	rm $developLibDir/*.la
 	fixPkgconfig
@@ -98,6 +117,14 @@ INSTALL()
 	# devel package
 	packageEntries devel \
 		$binDir/caca-config \
-		$developDir \
-		$manDir/man3
+		$developDir
+
+	if [ -n "$secondaryArchSuffix" ]; then
+		rm -rf $binDir
+	fi
+}
+
+TEST()
+{
+	make check
 }


### PR DESCRIPTION
* Drop the mirror for SOURCE_URI, since the official website is back.
* Add **`TEST()`** with **`make check`** since this target exists.
* No changes in primary arch packages, except for the SOURCE_URI.
* On secondary arch there is no need to ship man pages, data files and runtimes (except for caca-config-*), since they are already in the primary arch packages. All we need for 2nd arch packages is:
 * in the base package: the shared libs;
 * in the devel package: **`caca-config-*`** and **`develop/{headers,lib}`**.
  The only file we need to keep in every package is the licence.
* Cosmetic edits: duplicate white spaces, fake tab, **`-e`** for sed.