### PR TITLE
update yab and yab-ide

### DIFF
--- a/dev-lang/yab/yab-1.7.5.3.recipe
+++ b/dev-lang/yab/yab-1.7.5.3.recipe
@@ -4,11 +4,11 @@ language, with special commands designed for Haiku."
 HOMEPAGE="http://yab.orgfree.com"
 COPYRIGHT="1995-2006 Marc-Oliver Ihm (yabasic)
 	2006-2009 Jan Bungeroth (yab improvements)
-	2013-2015 Jim Saxton (yab improvements)"
+	2013-2016 Jim Saxton (yab improvements)"
 LICENSE="Artistic"
 REVISION="1"
 SOURCE_URI="https://github.com/bbjimmy/YAB/archive/$portVersion.tar.gz"
-CHECKSUM_SHA256="06922796ea4d981c8d972ec2b890509d818cf0ba1dfe74c094ae4b689ec98208"
+CHECKSUM_SHA256="c71ab577e9f88e51dfca08ba71190199d6ad13356bce2838caf85de0a88416cd"
 SOURCE_DIR="YAB-$portVersion"
 
 ARCHITECTURES="x86_gcc2 !x86 ?x86_64"

--- a/haiku-apps/yab_ide/yab_ide-2.2.6.recipe
+++ b/haiku-apps/yab_ide/yab_ide-2.2.6.recipe
@@ -8,7 +8,7 @@ environment, which of course is programmed in yab itself."
 HOMEPAGE="http://yab.orgfree.com"
 COPYRIGHT="2006-2015 Jan Bungeroth"
 LICENSE="Artistic"
-REVISION="3"
+REVISION="1"
 SOURCE_URI="https://github.com/bbjimmy/YAB/archive/1.7.5.3.tar.gz"
 CHECKSUM_SHA256="c71ab577e9f88e51dfca08ba71190199d6ad13356bce2838caf85de0a88416cd"
 SOURCE_DIR=YAB-1.7.5.3

--- a/haiku-apps/yab_ide/yab_ide-2.2.6.recipe
+++ b/haiku-apps/yab_ide/yab_ide-2.2.6.recipe
@@ -9,9 +9,9 @@ HOMEPAGE="http://yab.orgfree.com"
 COPYRIGHT="2006-2015 Jan Bungeroth"
 LICENSE="Artistic"
 REVISION="3"
-SOURCE_URI="https://github.com/bbjimmy/YAB/archive/1.7.5.2.tar.gz"
-CHECKSUM_SHA256="06922796ea4d981c8d972ec2b890509d818cf0ba1dfe74c094ae4b689ec98208"
-SOURCE_DIR=YAB-1.7.5.2
+SOURCE_URI="https://github.com/bbjimmy/YAB/archive/1.7.5.3.tar.gz"
+CHECKSUM_SHA256="c71ab577e9f88e51dfca08ba71190199d6ad13356bce2838caf85de0a88416cd"
+SOURCE_DIR=YAB-1.7.5.3
 
 ARCHITECTURES="x86_gcc2 x86 ?x86_64"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
@@ -23,7 +23,7 @@ PROVIDES="
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
-	yab$secondaryArchSuffix >= 1.7.5.2
+	yab$secondaryArchSuffix >= 1.7.5.3
 	devel:libz$secondaryArchSuffix
 	"
 # devel:libz$secondaryArchSuffix is needed both to build and for the BuildFactory to do its work.


### PR DESCRIPTION
yab Version 1.7.5.3, yab-IDE version 2.2.6
- gcc4 now compiles
- fix system shutdown bug
- remove un-needed BuildFactory files
- add https:// to texturl
- BuildFactory use declared appsig
- yab-IDE use declared appsig, or use filename for appsig
