### PR TITLE
openssl: bump to 1.0.1t and 1.0.2h.

### DIFF
--- a/dev-libs/openssl/openssl-1.0.1t.recipe
+++ b/dev-libs/openssl/openssl-1.0.1t.recipe
@@ -17,7 +17,7 @@ COPYRIGHT="1995-1998 Eric Young
 LICENSE="OpenSSL"
 REVISION="1"
 SOURCE_URI="https://www.openssl.org/source/openssl-$portVersion.tar.gz"
-CHECKSUM_SHA256="e7e81d82f3cd538ab0cdba494006d44aab9dd96b7f6233ce9971fb7c7916d511"
+CHECKSUM_SHA256="4a6ee491a2fdb22e519c76fdc2a628bb3cec12762cd456861d207996c8a07088"
 PATCHES="openssl-$portVersion.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64 ?arm ?ppc"
@@ -55,6 +55,7 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	cmd:cmp
 	cmd:gcc${secondaryArchSuffix}
 	cmd:ld${secondaryArchSuffix}
 	cmd:make

--- a/dev-libs/openssl/openssl-1.0.2h.recipe
+++ b/dev-libs/openssl/openssl-1.0.2h.recipe
@@ -17,7 +17,7 @@ COPYRIGHT="1995-1998 Eric Young
 LICENSE="OpenSSL"
 REVISION="1"
 SOURCE_URI="https://www.openssl.org/source/openssl-$portVersion.tar.gz"
-CHECKSUM_SHA256="b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33"
+CHECKSUM_SHA256="1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919"
 PATCHES="openssl-$portVersion.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64 ?arm ?ppc"
@@ -55,6 +55,7 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	cmd:cmp
 	cmd:gcc${secondaryArchSuffix}
 	cmd:ld${secondaryArchSuffix}
 	cmd:make

--- a/dev-libs/openssl/patches/openssl-1.0.1t.patchset
+++ b/dev-libs/openssl/patches/openssl-1.0.1t.patchset
@@ -1,14 +1,14 @@
-From ebe71871447f0112adf84943c2e1e48c32343c77 Mon Sep 17 00:00:00 2001
+From 18b32231b9e09802ab2f4ac6bacb7c34f978861f Mon Sep 17 00:00:00 2001
 From: Alexander von Gluck IV <kallisti5@unixzen.com>
 Date: Wed, 18 Jun 2014 02:37:21 +0000
 Subject: Haiku: build fixes
 
 
 diff --git a/Configure b/Configure
-index c98107a..b508a92 100755
+index 93c4cc1..d03daf4 100755
 --- a/Configure
 +++ b/Configure
-@@ -506,6 +506,10 @@ my %table=(
+@@ -451,6 +451,10 @@ my %table=(
  "beos-x86-r5",   "gcc:-DL_ENDIAN -DTERMIOS -O3 -fomit-frame-pointer -mcpu=pentium -Wall::-D_REENTRANT:BEOS:-lbe -lnet:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:${x86_elf_asm}:beos:beos-shared:-fPIC -DPIC:-shared:.so",
  "beos-x86-bone", "gcc:-DL_ENDIAN -DTERMIOS -O3 -fomit-frame-pointer -mcpu=pentium -Wall::-D_REENTRANT:BEOS:-lbe -lbind -lsocket:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:${x86_elf_asm}:beos:beos-shared:-fPIC:-shared:.so",
  
@@ -20,7 +20,7 @@ index c98107a..b508a92 100755
  #
  # Originally we had like unixware-*, unixware-*-pentium, unixware-*-p6, etc.
 diff --git a/Makefile.shared b/Makefile.shared
-index a2aa980..2b585a0 100644
+index e753f44..cce510f 100644
 --- a/Makefile.shared
 +++ b/Makefile.shared
 @@ -594,10 +594,10 @@ symlink.hpux:
@@ -39,7 +39,7 @@ index a2aa980..2b585a0 100644
  link_a.bsd-shared: link_a.bsd
  link_app.bsd-shared: link_app.bsd
 diff --git a/config b/config
-index bba370c..d4d0620 100755
+index 41fa2a6..f390fc2 100755
 --- a/config
 +++ b/config
 @@ -134,6 +134,14 @@ case "${SYSTEM}:${RELEASE}:${VERSION}:${MACHINE}" in
@@ -57,7 +57,7 @@ index bba370c..d4d0620 100755
      HI-UX:*)
  	echo "${MACHINE}-hi-hiux"; exit 0
  	;;
-@@ -848,6 +856,9 @@ case "$GUESSOS" in
+@@ -829,6 +837,9 @@ case "$GUESSOS" in
  	    options="$options no-asm"
  	fi
  	;;
@@ -68,10 +68,10 @@ index bba370c..d4d0620 100755
    # *-dgux) OUT="dgux" ;;
    mips-sony-newsos4) OUT="newsos4-gcc" ;;
 -- 
-2.7.0
+2.2.2
 
 
-From 56aa0cc3ac136c72309364f6e723a61b1dac1462 Mon Sep 17 00:00:00 2001
+From c9f899f31eae393a8bada07d9109904323a75300 Mon Sep 17 00:00:00 2001
 From: Alexander von Gluck IV <kallisti5@unixzen.com>
 Date: Wed, 18 Jun 2014 02:39:12 +0000
 Subject: Haiku: Modify default Root CA filename
@@ -91,10 +91,10 @@ index fba180a..40c32df 100644
  # else
  #  define X509_CERT_AREA          "SSLROOT:[000000]"
 -- 
-2.7.0
+2.2.2
 
 
-From 9992048c0a9ef4a1fefdff9981a553c0a2130bc2 Mon Sep 17 00:00:00 2001
+From 733871bddd6fba30ddc938157d1e3b72a7a29e83 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Mon, 9 Nov 2015 19:44:10 +0100
 Subject: Do not use __INTEL__ to detect x86_64.
@@ -102,10 +102,10 @@ Subject: Do not use __INTEL__ to detect x86_64.
 * Haiku defines it for 32-bit x86 as well.
 
 diff --git a/crypto/evp/e_aes_cbc_hmac_sha1.c b/crypto/evp/e_aes_cbc_hmac_sha1.c
-index 8330964..8980582 100644
+index 1d598db..04fd1a5 100644
 --- a/crypto/evp/e_aes_cbc_hmac_sha1.c
 +++ b/crypto/evp/e_aes_cbc_hmac_sha1.c
-@@ -91,8 +91,7 @@ typedef struct {
+@@ -87,8 +87,7 @@ typedef struct {
  
  # if     defined(AES_ASM) &&     ( \
          defined(__x86_64)       || defined(__x86_64__)  || \
@@ -113,32 +113,18 @@ index 8330964..8980582 100644
 -        defined(__INTEL__)      )
 +        defined(_M_AMD64)       || defined(_M_X64)      )
  
- extern unsigned int OPENSSL_ia32cap_P[];
- #  define AESNI_CAPABLE   (1<<(57-32))
+ #  if defined(__GNUC__) && __GNUC__>=2 && !defined(PEDANTIC)
+ #   define BSWAP(x) ({ unsigned int r=(x); asm ("bswapl %0":"=r"(r):"0"(r)); r; })
 -- 
-2.7.0
+2.2.2
 
 
-From f3b305a87bf7d6c514190f23545d4df20c07c016 Mon Sep 17 00:00:00 2001
+From 0f6d820c9a8684b16551d90eb3dab35f230f5ddb Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Mon, 9 Nov 2015 20:32:09 +0100
 Subject: more __intel__ fixes...
 
 
-diff --git a/crypto/evp/e_aes_cbc_hmac_sha256.c b/crypto/evp/e_aes_cbc_hmac_sha256.c
-index 3780021..fff6e0c 100644
---- a/crypto/evp/e_aes_cbc_hmac_sha256.c
-+++ b/crypto/evp/e_aes_cbc_hmac_sha256.c
-@@ -91,8 +91,7 @@ typedef struct {
- 
- # if     defined(AES_ASM) &&     ( \
-         defined(__x86_64)       || defined(__x86_64__)  || \
--        defined(_M_AMD64)       || defined(_M_X64)      || \
--        defined(__INTEL__)      )
-+        defined(_M_AMD64)       || defined(_M_X64)      )
- 
- extern unsigned int OPENSSL_ia32cap_P[];
- #  define AESNI_CAPABLE   (1<<(57-32))
 diff --git a/crypto/evp/e_rc4_hmac_md5.c b/crypto/evp/e_rc4_hmac_md5.c
 index 2da1117..d41ba7f 100644
 --- a/crypto/evp/e_rc4_hmac_md5.c
@@ -153,20 +139,6 @@ index 2da1117..d41ba7f 100644
          !(defined(__APPLE__) && defined(__MACH__))
  #  define STITCHED_CALL
  # endif
-diff --git a/ssl/s3_pkt.c b/ssl/s3_pkt.c
-index 3798902..8caca14 100644
---- a/ssl/s3_pkt.c
-+++ b/ssl/s3_pkt.c
-@@ -125,8 +125,7 @@
- #if     defined(OPENSSL_SMALL_FOOTPRINT) || \
-         !(      defined(AES_ASM) &&     ( \
-                 defined(__x86_64)       || defined(__x86_64__)  || \
--                defined(_M_AMD64)       || defined(_M_X64)      || \
--                defined(__INTEL__)      ) \
-+                defined(_M_AMD64)       || defined(_M_X64)      ) \
-         )
- # undef EVP_CIPH_FLAG_TLS1_1_MULTIBLOCK
- # define EVP_CIPH_FLAG_TLS1_1_MULTIBLOCK 0
 -- 
-2.7.0
+2.2.2
 

--- a/dev-libs/openssl/patches/openssl-1.0.2h.patchset
+++ b/dev-libs/openssl/patches/openssl-1.0.2h.patchset
@@ -1,14 +1,14 @@
-From 18b32231b9e09802ab2f4ac6bacb7c34f978861f Mon Sep 17 00:00:00 2001
+From ebe71871447f0112adf84943c2e1e48c32343c77 Mon Sep 17 00:00:00 2001
 From: Alexander von Gluck IV <kallisti5@unixzen.com>
 Date: Wed, 18 Jun 2014 02:37:21 +0000
 Subject: Haiku: build fixes
 
 
 diff --git a/Configure b/Configure
-index 93c4cc1..d03daf4 100755
+index c98107a..b508a92 100755
 --- a/Configure
 +++ b/Configure
-@@ -451,6 +451,10 @@ my %table=(
+@@ -506,6 +506,10 @@ my %table=(
  "beos-x86-r5",   "gcc:-DL_ENDIAN -DTERMIOS -O3 -fomit-frame-pointer -mcpu=pentium -Wall::-D_REENTRANT:BEOS:-lbe -lnet:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:${x86_elf_asm}:beos:beos-shared:-fPIC -DPIC:-shared:.so",
  "beos-x86-bone", "gcc:-DL_ENDIAN -DTERMIOS -O3 -fomit-frame-pointer -mcpu=pentium -Wall::-D_REENTRANT:BEOS:-lbe -lbind -lsocket:BN_LLONG ${x86_gcc_des} ${x86_gcc_opts}:${x86_elf_asm}:beos:beos-shared:-fPIC:-shared:.so",
  
@@ -20,7 +20,7 @@ index 93c4cc1..d03daf4 100755
  #
  # Originally we had like unixware-*, unixware-*-pentium, unixware-*-p6, etc.
 diff --git a/Makefile.shared b/Makefile.shared
-index e753f44..cce510f 100644
+index a2aa980..2b585a0 100644
 --- a/Makefile.shared
 +++ b/Makefile.shared
 @@ -594,10 +594,10 @@ symlink.hpux:
@@ -39,7 +39,7 @@ index e753f44..cce510f 100644
  link_a.bsd-shared: link_a.bsd
  link_app.bsd-shared: link_app.bsd
 diff --git a/config b/config
-index 41fa2a6..f390fc2 100755
+index bba370c..d4d0620 100755
 --- a/config
 +++ b/config
 @@ -134,6 +134,14 @@ case "${SYSTEM}:${RELEASE}:${VERSION}:${MACHINE}" in
@@ -57,7 +57,7 @@ index 41fa2a6..f390fc2 100755
      HI-UX:*)
  	echo "${MACHINE}-hi-hiux"; exit 0
  	;;
-@@ -829,6 +837,9 @@ case "$GUESSOS" in
+@@ -848,6 +856,9 @@ case "$GUESSOS" in
  	    options="$options no-asm"
  	fi
  	;;
@@ -68,10 +68,10 @@ index 41fa2a6..f390fc2 100755
    # *-dgux) OUT="dgux" ;;
    mips-sony-newsos4) OUT="newsos4-gcc" ;;
 -- 
-2.2.2
+2.7.0
 
 
-From c9f899f31eae393a8bada07d9109904323a75300 Mon Sep 17 00:00:00 2001
+From 56aa0cc3ac136c72309364f6e723a61b1dac1462 Mon Sep 17 00:00:00 2001
 From: Alexander von Gluck IV <kallisti5@unixzen.com>
 Date: Wed, 18 Jun 2014 02:39:12 +0000
 Subject: Haiku: Modify default Root CA filename
@@ -91,10 +91,10 @@ index fba180a..40c32df 100644
  # else
  #  define X509_CERT_AREA          "SSLROOT:[000000]"
 -- 
-2.2.2
+2.7.0
 
 
-From 733871bddd6fba30ddc938157d1e3b72a7a29e83 Mon Sep 17 00:00:00 2001
+From 9992048c0a9ef4a1fefdff9981a553c0a2130bc2 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Mon, 9 Nov 2015 19:44:10 +0100
 Subject: Do not use __INTEL__ to detect x86_64.
@@ -102,10 +102,10 @@ Subject: Do not use __INTEL__ to detect x86_64.
 * Haiku defines it for 32-bit x86 as well.
 
 diff --git a/crypto/evp/e_aes_cbc_hmac_sha1.c b/crypto/evp/e_aes_cbc_hmac_sha1.c
-index d1f5928..55d8b8e 100644
+index 6dfd590..bc571e5 100644
 --- a/crypto/evp/e_aes_cbc_hmac_sha1.c
 +++ b/crypto/evp/e_aes_cbc_hmac_sha1.c
-@@ -86,8 +86,7 @@ typedef struct {
+@@ -92,8 +92,7 @@ typedef struct {
  
  # if     defined(AES_ASM) &&     ( \
          defined(__x86_64)       || defined(__x86_64__)  || \
@@ -113,18 +113,32 @@ index d1f5928..55d8b8e 100644
 -        defined(__INTEL__)      )
 +        defined(_M_AMD64)       || defined(_M_X64)      )
  
- #  if defined(__GNUC__) && __GNUC__>=2 && !defined(PEDANTIC)
- #   define BSWAP(x) ({ unsigned int r=(x); asm ("bswapl %0":"=r"(r):"0"(r)); r; })
+ extern unsigned int OPENSSL_ia32cap_P[];
+ #  define AESNI_CAPABLE   (1<<(57-32))
 -- 
-2.2.2
+2.7.0
 
 
-From 0f6d820c9a8684b16551d90eb3dab35f230f5ddb Mon Sep 17 00:00:00 2001
+From f3b305a87bf7d6c514190f23545d4df20c07c016 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Mon, 9 Nov 2015 20:32:09 +0100
 Subject: more __intel__ fixes...
 
 
+diff --git a/crypto/evp/e_aes_cbc_hmac_sha256.c b/crypto/evp/e_aes_cbc_hmac_sha256.c
+index 46c9d03..4a9ad27 100644
+--- a/crypto/evp/e_aes_cbc_hmac_sha256.c
++++ b/crypto/evp/e_aes_cbc_hmac_sha256.c
+@@ -92,8 +92,7 @@ typedef struct {
+ 
+ # if     defined(AES_ASM) &&     ( \
+         defined(__x86_64)       || defined(__x86_64__)  || \
+-        defined(_M_AMD64)       || defined(_M_X64)      || \
+-        defined(__INTEL__)      )
++        defined(_M_AMD64)       || defined(_M_X64)      )
+ 
+ extern unsigned int OPENSSL_ia32cap_P[];
+ #  define AESNI_CAPABLE   (1<<(57-32))
 diff --git a/crypto/evp/e_rc4_hmac_md5.c b/crypto/evp/e_rc4_hmac_md5.c
 index 2da1117..d41ba7f 100644
 --- a/crypto/evp/e_rc4_hmac_md5.c
@@ -139,6 +153,20 @@ index 2da1117..d41ba7f 100644
          !(defined(__APPLE__) && defined(__MACH__))
  #  define STITCHED_CALL
  # endif
+diff --git a/ssl/s3_pkt.c b/ssl/s3_pkt.c
+index 3798902..8caca14 100644
+--- a/ssl/s3_pkt.c
++++ b/ssl/s3_pkt.c
+@@ -125,8 +125,7 @@
+ #if     defined(OPENSSL_SMALL_FOOTPRINT) || \
+         !(      defined(AES_ASM) &&     ( \
+                 defined(__x86_64)       || defined(__x86_64__)  || \
+-                defined(_M_AMD64)       || defined(_M_X64)      || \
+-                defined(__INTEL__)      ) \
++                defined(_M_AMD64)       || defined(_M_X64)      ) \
+         )
+ # undef EVP_CIPH_FLAG_TLS1_1_MULTIBLOCK
+ # define EVP_CIPH_FLAG_TLS1_1_MULTIBLOCK 0
 -- 
-2.2.2
+2.7.0
 


### PR DESCRIPTION
* Bump versions.
* Use **`-e`** for **`sed`** to make the recipe more portable, since some systems have sed implementations that require it.
* Add **`cmd:cmp`** to BUILD_PREREQUIRES since **`make test`** needs it.