### PR TITLE
sdl2_mixer, updated recipe

### DIFF
--- a/media-libs/sdl2_mixer/sdl2_mixer-2.0.1.recipe
+++ b/media-libs/sdl2_mixer/sdl2_mixer-2.0.1.recipe
@@ -7,14 +7,14 @@ Ogg Vorbis, and SMPEG MP3 libraries."
 HOMEPAGE="http://www.libsdl.org/projects/SDL_mixer/"
 COPYRIGHT="1997-2012 Sam Lantinga"
 LICENSE="Zlib"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-$portVersion.tar.gz"
 CHECKSUM_SHA256="5a24f62a610249d744cbd8d28ee399d8905db7222bf3bdbc8a8b4a76e597695f"
 SOURCE_DIR="SDL2_mixer-$portVersion"
 PATCHES="sdl2_mixer-${portVersion}.patch"
 
-ARCHITECTURES="x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="x86_gcc2 x86 x86_64"
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	sdl2_mixer$secondaryArchSuffix = $portVersion compat >= 2.0
@@ -23,9 +23,10 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libSDL2_2.0$secondaryArchSuffix
+	lib:libgl$secondaryArchSuffix
+	lib:libsdl2_2.0$secondaryArchSuffix
 	lib:libogg$secondaryArchSuffix
-	lib:libFLAC$secondaryArchSuffix
+	lib:libflac$secondaryArchSuffix
 	lib:libfluidsynth$secondaryArchSuffix
 	lib:libmad$secondaryArchSuffix
 	lib:libvorbis$secondaryArchSuffix
@@ -66,7 +67,7 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	libtoolize --force --copy --install
+	libtoolize -fci
 	aclocal --force --install -I acinclude
 	autoconf
 	runConfigure ./configure


### PR DESCRIPTION
Build doesn't work for gcc2 (SDL2_mixer-2.0.1/wavestream.c:94: field `loops' has incomplete type), I don't have the skills to patch this one
Missing libgl as a requirement