### PR TITLE
check: fix PROVIDES for secondary arch & improve pkg splitting.

### DIFF
--- a/dev-libs/check/check-0.10.0.recipe
+++ b/dev-libs/check/check-0.10.0.recipe
@@ -9,7 +9,7 @@ HOMEPAGE="https://libcheck.github.io/check/"
 COPYRIGHT="2001-2015 Arien Malec, Branden Archer, Chris Pickett, Fredrik \
 Hugosson, and Robert Lemmen."
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/libcheck/check/files/71408/check-$portVersion.tar.gz"
 CHECKSUM_SHA256="f5f50766aa6f8fe5a2df752666ca01a950add45079aa06416b83765b1cf71052"
 PATCHES="check-$portVersion.patch"
@@ -19,34 +19,35 @@ SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
 PROVIDES="
 	check$secondaryArchSuffix = $portVersion
-	lib:libcheck$secondaryArchSuffix = 0.0.0 compat >= 0
+	cmd:checkmk$secondaryArchSuffix = $portVersion
+	lib:libcheck$secondaryArchSuffix = 0.0.0
 	"
-if [ -z "$secondaryArchSuffix" ]; then
-	PROVIDES="$PROVIDES
-		cmd:checkmk = $portVersion
-		"
-fi
-
 REQUIRES="
 	haiku$secondaryArchSuffix
+	check_common
+	cmd:gawk
 	"
-if [ -n "$secondaryArchSuffix" ]; then
-	REQUIRES="$REQUIRES
-		check == $portVersion base
+
+if [ -z "$secondaryArchSuffix" ]; then
+	ARCHITECTURES_common="any"
+	PROVIDES_common="
+		check_common = $portVersion
 		"
+	REQUIRES_common=""
 fi
 
 PROVIDES_devel="
 	check${secondaryArchSuffix}_devel = $portVersion
-	devel:libcheck$secondaryArchSuffix = 0.0.0 compat >= 0
+	devel:libcheck$secondaryArchSuffix = 0.0.0
 	"
-
 REQUIRES_devel="
 	check$secondaryArchSuffix == $portVersion base
 	"
 
 BUILD_PREREQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	cmd:diff
+	cmd:find
 	cmd:gawk
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
@@ -55,25 +56,28 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	runConfigure ./configure
+	runConfigure ./configure --disable-static
 	make $jobArgs
 }
 
 INSTALL()
 {
 	make install
-	if [ "$targetArchitecture" != "$effectiveTargetArchitecture" ]; then
-# We are building for the secondary architecture, so let's remove some files.
-		rm -fr $dataDir $manDir $infoDir $binDir
-# $binDir/checkmk is a script and it is identical to the one in the base package.
-# So we can replace it by a symbolic link to the main one.
-		mkdir -p $binDir
-		ln -s ../checkmk $binDir
+
+	if [ -z "$secondaryArchSuffix" ]; then
+		packageEntries common \
+			$dataDir/doc \
+			$documentationDir
+	else
+		rm -rf $dataDir/doc $documentationDir
 	fi
+
+	rm $libDir/libcheck.la
 	prepareInstalledDevelLib libcheck
 	fixPkgconfig
 
 	packageEntries devel \
+		$dataDir/aclocal \
 		$developDir
 }
 

--- a/dev-libs/check/check-0.9.13.recipe
+++ b/dev-libs/check/check-0.9.13.recipe
@@ -1,64 +1,86 @@
 SUMMARY="Unit Testing Framework for C"
-DESCRIPTION="
-Check is a unit testing framework for C. It features a simple interface for \
-defining unit tests, putting little in the way of the developer. Tests are \
-run in a separate address space, so both assertion failures and code errors \
-that cause segmentation faults or other signals can be caught. Test results \
-are reportable in the following: Subunit, TAP, XML, and a generic logging \
-format.
-"
+DESCRIPTION="Check is a unit testing framework for C. It features a simple \
+interface for defining unit tests, putting little in the way of the developer.
+Tests are run in a separate address space, so both assertion failures and code \
+errors that cause segmentation faults or other signals can be caught. Test \
+results are reportable in the following: Subunit, TAP, XML, and a generic \
+logging format."
 HOMEPAGE="http://check.sourceforge.net/"
+COPYRIGHT="2001-2014 Arien Malec, Branden Archer, Chris Pickett, Fredrik \
+Hugosson, and Robert Lemmen."
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
-ARCHITECTURES="x86_gcc2 x86 x86_64"
+REVISION="2"
 SOURCE_URI="http://sourceforge.net/projects/check/files/check/$portVersion/check-$portVersion.tar.gz"
 CHECKSUM_SHA256="ca6589c34f9c60ffd4c3e198ce581e944a9f040ca9352ed54068dd61bebb5cb7"
-COPYRIGHT="xxx"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
 PROVIDES="
-	check = $portVersion
-
-	cmd:checkmk
-	lib:libcheck = $portVersion
-"
-
+	check$secondaryArchSuffix = $portVersion
+	cmd:checkmk$secondaryArchSuffix = $portVersion
+	lib:libcheck$secondaryArchSuffix = 0.0.0
+	"
 REQUIRES="
-	haiku
-"
+	haiku$secondaryArchSuffix
+	check_common
+	cmd:gawk
+	"
+
+if [ -z "$secondaryArchSuffix" ]; then
+	ARCHITECTURES_common="any"
+	PROVIDES_common="
+		check_common = $portVersion
+		"
+	REQUIRES_common=""
+fi
+
+PROVIDES_devel="
+	check${secondaryArchSuffix}_devel = $portVersion
+	devel:libcheck$secondaryArchSuffix = 0.0.0
+	"
+REQUIRES_devel="
+	check$secondaryArchSuffix == $portVersion base
+	"
 
 BUILD_PREREQUIRES="
-	haiku_devel
-	cmd:awk
-	cmd:gcc
+	haiku${secondaryArchSuffix}_devel
+	cmd:diff
+	cmd:find
+	cmd:gawk
+	cmd:gcc$secondaryArchSuffix
 	cmd:make
-"
+	cmd:pkg_config$secondaryArchSuffix
+	"
 
 BUILD()
 {
-	runConfigure ./configure
-	make
+	runConfigure ./configure --disable-static
+	make $jobArgs
 }
 
 INSTALL()
 {
 	make install
 
+	if [ -z "$secondaryArchSuffix" ]; then
+		packageEntries common \
+			$dataDir/doc \
+			$documentationDir
+	else
+		rm -rf $dataDir/doc $documentationDir
+	fi
+
+	rm $libDir/libcheck.la
 	prepareInstalledDevelLib libcheck
 	fixPkgconfig
-	packageEntries devel $developDir
+
+	packageEntries devel \
+		$dataDir/aclocal \
+		$developDir
 }
 
 TEST()
 {
 	make check
 }
-
-# ----- devel package -------------------------------------------------------
-
-PROVIDES_devel="
-	check_devel = $portVersion
-	devel:libcheck = $portVersion
-	"
-REQUIRES_devel="
-	check == $portVersion base
-	"

--- a/dev-libs/check/check-0.9.14.recipe
+++ b/dev-libs/check/check-0.9.14.recipe
@@ -1,38 +1,43 @@
 SUMMARY="Unit Testing Framework for C"
-DESCRIPTION="
-Check is a unit testing framework for C. It features a simple interface for \
-defining unit tests, putting little in the way of the developer. Tests are \
-run in a separate address space, so both assertion failures and code errors \
-that cause segmentation faults or other signals can be caught. Test results \
-are reportable in the following: Subunit, TAP, XML, and a generic logging \
-format.
-"
+DESCRIPTION="Check is a unit testing framework for C. It features a simple \
+interface for defining unit tests, putting little in the way of the developer.
+Tests are run in a separate address space, so both assertion failures and code \
+errors that cause segmentation faults or other signals can be caught. Test \
+results are reportable in the following: Subunit, TAP, XML, and a generic \
+logging format."
 HOMEPAGE="http://check.sourceforge.net/"
 COPYRIGHT="2001-2014 Arien Malec, Branden Archer, Chris Pickett, Fredrik \
 Hugosson, and Robert Lemmen."
 LICENSE="GNU LGPL v2.1"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="http://sourceforge.net/projects/check/files/check/$portVersion/check-$portVersion.tar.gz"
 CHECKSUM_SHA256="c272624645b1b738cf57fd5d81a3e4d9b722b99d6133ee3f3c4007d4d279840a"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
-# NOTE: on x86_64 haikuporter/python 2.7.6 cannot extract correctly the archive
-# because it contains hard links. One has to extract manually, put flag.unpack
-# build, then copy the packages. No source package can be produced.
-SECONDARY_ARCHITECTURES="x86"
+SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
 PROVIDES="
 	check$secondaryArchSuffix = $portVersion
-	cmd:checkmk$secondaryArchSuffix
-	lib:libcheck$secondaryArchSuffix = $portVersion
+	cmd:checkmk$secondaryArchSuffix = $portVersion
+	lib:libcheck$secondaryArchSuffix = 0.0.0
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	check_common
+	cmd:gawk
 	"
+
+if [ -z "$secondaryArchSuffix" ]; then
+	ARCHITECTURES_common="any"
+	PROVIDES_common="
+		check_common = $portVersion
+		"
+	REQUIRES_common=""
+fi
 
 PROVIDES_devel="
 	check${secondaryArchSuffix}_devel = $portVersion
-	devel:libcheck$secondaryArchSuffix = $portVersion
+	devel:libcheck$secondaryArchSuffix = 0.0.0
 	"
 REQUIRES_devel="
 	check$secondaryArchSuffix == $portVersion base
@@ -40,24 +45,39 @@ REQUIRES_devel="
 
 BUILD_PREREQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	cmd:awk
+	cmd:diff
+	cmd:find
+	cmd:gawk
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
 	"
 
 BUILD()
 {
-	runConfigure ./configure
-	make
+	runConfigure ./configure --disable-static
+	make $jobArgs
 }
 
 INSTALL()
 {
 	make install
 
+	if [ -z "$secondaryArchSuffix" ]; then
+		packageEntries common \
+			$dataDir/doc \
+			$documentationDir
+	else
+		rm -rf $dataDir/doc $documentationDir
+	fi
+
+	rm $libDir/libcheck.la
 	prepareInstalledDevelLib libcheck
 	fixPkgconfig
-	packageEntries devel $developDir
+
+	packageEntries devel \
+		$dataDir/aclocal \
+		$developDir
 }
 
 TEST()


### PR DESCRIPTION
* 0.9.13, 0.9.14 and 0.10.0 were missing a **`cmd:gawk`** in REQUIRES.
* Fixed 2nd arch for 0.10.0 and improved the package splitting.
* Switch 0.9.13 and 0.9.14 to the same layout as 0.10.0.