### PR TITLE
gettext: bump to 0.19.8.1, keep & fix lib*.la, sync patch.

### DIFF
--- a/sys-devel/gettext/gettext-0.19.8.1.recipe
+++ b/sys-devel/gettext/gettext-0.19.8.1.recipe
@@ -13,30 +13,30 @@ massage in various ways the sets of translatable strings, or already \
 translated strings. A special GNU Emacs mode also helps interested parties in \
 preparing these sets, or bringing them up to date.
 "
-HOMEPAGE="http://www.gnu.org/software/gettext/"
+HOMEPAGE="https://www.gnu.org/software/gettext/"
+COPYRIGHT="1998-2016 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3"
-COPYRIGHT="1998, 2010 Free Software Foundation, Inc."
-SOURCE_URI="http://ftp.gnu.org/pub/gnu/gettext/gettext-$portVersion.tar.gz"
-CHECKSUM_SHA256="5386d2a40500295783c6a52121adcf42a25519e2d23675950619c9e69558c23f"
 REVISION="1"
+SOURCE_URI="http://ftpmirror.gnu.org/gettext/gettext-$portVersion.tar.gz"
+CHECKSUM_SHA256="ff942af0e438ced4a8b0ea4b0b6e0d6d657157c5e2364de57baa279c1c125c43"
+PATCHES="gettext-$portVersion.patchset"
+
 ARCHITECTURES="x86_gcc2 x86 x86_64 arm"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
-
-PATCHES="gettext-$portVersion.patchset"
 
 PROVIDES="
 	gettext$secondaryArchSuffix = $portVersion compat >= 0.18
 	devel:libasprintf$secondaryArchSuffix = 0.0.0 compat >= 0
 	devel:libgettextlib$secondaryArchSuffix = $portVersion
-	devel:libgettextlib_0.19.7$secondaryArchSuffix = $portVersion
-	devel:libgettextpo$secondaryArchSuffix = 0.5.3 compat >= 0
+	devel:libgettextlib_$portVersion$secondaryArchSuffix
+	devel:libgettextpo$secondaryArchSuffix = 0.5.4 compat >= 0
 	devel:libgettextsrc$secondaryArchSuffix = $portVersion
-	devel:libgettextsrc_0.19.7$secondaryArchSuffix = $portVersion
-	devel:libintl$secondaryArchSuffix = 8.1.4 compat >= 8
+	devel:libgettextsrc_$portVersion$secondaryArchSuffix
+	devel:libintl$secondaryArchSuffix = 8.1.5 compat >= 8
 	lib:libasprintf$secondaryArchSuffix = 0.0.0 compat >= 0
-	lib:libgettextlib_0.19.7$secondaryArchSuffix = $portVersion
-	lib:libgettextpo$secondaryArchSuffix = 0.5.3 compat >= 0
-	lib:libgettextsrc_0.19.7$secondaryArchSuffix = $portVersion
+	lib:libgettextlib_$portVersion$secondaryArchSuffix
+	lib:libgettextpo$secondaryArchSuffix = 0.5.4 compat >= 0
+	lib:libgettextsrc_$portVersion$secondaryArchSuffix
 	cmd:autopoint$secondaryArchSuffix = $portVersion compat >= 0
 	cmd:envsubst$secondaryArchSuffix = $portVersion compat >= 0
 	cmd:gettext$secondaryArchSuffix = $portVersion compat >= 0
@@ -60,32 +60,51 @@ PROVIDES="
 	cmd:recode_sr_latin$secondaryArchSuffix = $portVersion compat >= 0
 	cmd:xgettext$secondaryArchSuffix = $portVersion compat >= 0
 	"
-
 REQUIRES="
 	haiku$secondaryArchSuffix
 	gettext${secondaryArchSuffix}_libintl == $portVersion base
 	lib:libiconv$secondaryArchSuffix
 	lib:libncurses$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
+	devel:libncurses$secondaryArchSuffix
 	"
+if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+	REQUIRES="$REQUIRES
+		lib:libgomp$secondaryArchSuffix
+		gcc$secondaryArchSuffix
+		"
+fi
+
+SUMMARY_libintl="The gettext internationalization library"
+PROVIDES_libintl="
+	gettext${secondaryArchSuffix}_libintl = $portVersion compat >= 0.18
+	lib:libintl${secondaryArchSuffix} = 8.1.5 compat >= 8
+	"
+REQUIRES_libintl="
+	haiku${secondaryArchSuffix}
+	lib:libiconv${secondaryArchSuffix}
+	"
+
 BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
 	devel:libiconv$secondaryArchSuffix
 	devel:libncurses$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	haiku${secondaryArchSuffix}_devel
-	cmd:find
+	cmd:aclocal
+	cmd:autoconf
+	cmd:automake
+	cmd:autoheader
 	cmd:gcc$secondaryArchSuffix
 	cmd:groff
 	cmd:ld$secondaryArchSuffix
-	cmd:libtoolize
+	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
 	cmd:makeinfo
-	cmd:xargs
 	"
 
 BUILD()
 {
-	find . -name configure | xargs touch
 	runConfigure ./configure \
 		--disable-java --without-git \
 		--disable-rpath --disable-maintainer-mode
@@ -97,11 +116,28 @@ INSTALL()
 	make install AUTOCONF=: AUTOMAKE=: AUTOHEADER=: ACLOCAL=:
 
 	rm $libDir/charset.alias
-	rm $libDir/lib*.la
 
 	prepareInstalledDevelLibs libasprintf libgettextpo libintl
 	prepareInstalledDevelLib libgettextlib '*.so' '*'
 	prepareInstalledDevelLib libgettextsrc '*.so' '*'
+
+	# The libtool files reference other libraries using paths which
+	# become invalid if libiconv and/or ncurses6 are upgraded. We need to
+	# get rid of the versioning of libiconv and ncurses6 in our lib*.la.
+	local libiconv="$portPackageLinksDir/devel~libiconv$secondaryArchSuffix/$relativeDevelopLibDir"
+	local libncurses="$portPackageLinksDir/devel~libncurses$secondaryArchSuffix/$relativeDevelopLibDir"
+	sed -i \
+		-e "s,/packages/libiconv$secondaryArchSuffix-[^\ /]*/\.self/develop/$relativeLibDir/\(libiconv.la\),$libiconv/\1," \
+		-e "s,/packages/ncurses6$secondaryArchSuffix-[^\ /]*/\.self/develop/$relativeLibDir/\(libncurses.la\),$libncurses/\1," \
+		-e "/^dependency_libs=/ s/ -L[^'\ ]*//g" \
+		$developLibDir/lib*.la
+
+	if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+		local libstdcpp="$portPackageLinksDir/gcc$secondaryArchSuffix"
+		sed -i \
+			-e "s,/packages/gcc$secondaryArchSuffix-[^\ /]*/\.self/\(develop/tools/$relativeLibDir/gcc/$effectiveTargetMachineTriple/[^\ /]*/libstdc++.la\),$libstdcpp/\1," \
+			$developLibDir/libasprintf.la
+	fi
 
 	# libintl package
 	packageEntries libintl \
@@ -112,15 +148,3 @@ TEST()
 {
 	make check
 }
-
-# ----- libintl package -------------------------------------------------------
-
-SUMMARY_libintl="The gettext internationalization library"
-PROVIDES_libintl="
-	gettext${secondaryArchSuffix}_libintl = $portVersion compat >= 0.18
-	lib:libintl${secondaryArchSuffix} = 8.1.4 compat >= 8
-	"
-REQUIRES_libintl="
-	haiku${secondaryArchSuffix}
-	lib:libiconv${secondaryArchSuffix}
-	"

--- a/sys-devel/gettext/patches/gettext-0.19.8.1.patchset
+++ b/sys-devel/gettext/patches/gettext-0.19.8.1.patchset
@@ -5,7 +5,7 @@ Subject: haiku patch
 
 
 diff --git a/gettext-tools/src/x-lua.c b/gettext-tools/src/x-lua.c
-index 5050838..28c3d91 100644
+index 78ac24f..4e3335f 100644
 --- a/gettext-tools/src/x-lua.c
 +++ b/gettext-tools/src/x-lua.c
 @@ -281,9 +281,9 @@ phase2_getc ()
@@ -19,7 +19,7 @@ index 5050838..28c3d91 100644
                while (c == '=')
                  {
                    esigns++;
-@@ -703,11 +703,11 @@ phase3_get (token_ty *tp)
+@@ -709,11 +709,11 @@ phase3_get (token_ty *tp)
              }
            break;
  
@@ -33,7 +33,7 @@ index 5050838..28c3d91 100644
            while (c == '=')
              {
                esigns++;
-@@ -739,10 +739,10 @@ phase3_get (token_ty *tp)
+@@ -745,10 +745,10 @@ phase3_get (token_ty *tp)
  
                if (c == ']')
                  {
@@ -45,7 +45,7 @@ index 5050838..28c3d91 100644
                    while (c == '=')
                      {
                        esigns2++;
-@@ -792,7 +792,7 @@ phase3_get (token_ty *tp)
+@@ -798,7 +798,7 @@ phase3_get (token_ty *tp)
                  }
              }
            break;
@@ -65,7 +65,7 @@ Subject: Fix C99ism in tests.
 
 
 diff --git a/gettext-tools/gnulib-lib/uniname/uniname.c b/gettext-tools/gnulib-lib/uniname/uniname.c
-index 8f9f1b4..7a77a85 100644
+index 5da6ced..19ad886 100644
 --- a/gettext-tools/gnulib-lib/uniname/uniname.c
 +++ b/gettext-tools/gnulib-lib/uniname/uniname.c
 @@ -375,6 +375,8 @@ unicode_name_character (const char *name)
@@ -87,10 +87,10 @@ index 8f9f1b4..7a77a85 100644
              const char *p1 = buf;
              for (;;)
 diff --git a/gettext-tools/gnulib-tests/test-quotearg-simple.c b/gettext-tools/gnulib-tests/test-quotearg-simple.c
-index b579af7..cf3cb23 100644
+index 6bb4b35..8b07c5d 100644
 --- a/gettext-tools/gnulib-tests/test-quotearg-simple.c
 +++ b/gettext-tools/gnulib-tests/test-quotearg-simple.c
-@@ -309,14 +309,16 @@ main (int argc _GL_UNUSED, char *argv[])
+@@ -331,14 +331,16 @@ main (int argc _GL_UNUSED, char *argv[])
          size_t q_len = 1024;
          char *q = malloc (q_len + 1);
          char buf[10];
@@ -109,7 +109,7 @@ index b579af7..cf3cb23 100644
          z -= s_len + 1;
          memcpy (z, str, s_len + 1);
  
-@@ -324,7 +326,7 @@ main (int argc _GL_UNUSED, char *argv[])
+@@ -346,7 +348,7 @@ main (int argc _GL_UNUSED, char *argv[])
          /* Whether this actually triggers a SEGV depends on the
             implementation of memcmp: whether it compares only byte-at-
             a-time, and from left to right (no SEGV) or some other way.  */


### PR DESCRIPTION
Some recipes, e.g. mc (Midnight Commander), need libintl.la, but we were previously dropping all **`develop/lib/lib*.la`** files in gettext.
We now ship them and also fix them to make sure they don't become unusable in case devel:libiconv or devel:libncurses get updated.
On x86 and x86_64 we also fix **`$developLibDir/libasprintf.la`** to use a path to libstdc++.la that does not depend on the revision of the gcc package.