### PR TITLE
exiftool: move from media-gfx to media-libs, drop old, add new.

### DIFF
--- a/media-libs/exiftool/exiftool-10.15.recipe
+++ b/media-libs/exiftool/exiftool-10.15.recipe
@@ -9,10 +9,10 @@ LICENSE="GNU GPL v1
 	Artistic"
 REVISION="1"
 SOURCE_URI="http://www.sno.phy.queensu.ca/~phil/exiftool/Image-ExifTool-$portVersion.tar.gz"
-CHECKSUM_SHA256="26ef376283de7321a155bdf402afd7f0dcd046b6f5461d99e8c6729f9ac107b5"
+CHECKSUM_SHA256="e1a94fdd1717e81bad4625e3fc51644b6cc3b6667024d29afe7a9bbe5457e935"
 SOURCE_DIR="Image-ExifTool-$portVersion"
 
-ARCHITECTURES="x86_gcc2 x86 x86_64"
+ARCHITECTURES="any"
 
 PROVIDES="
 	exiftool = $portVersion
@@ -20,7 +20,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku
-	perl >= 5.0.0
+	cmd:perl >= 5.0.0
 	"
 
 BUILD_REQUIRES="

--- a/media-libs/exiftool/exiftool-10.16.recipe
+++ b/media-libs/exiftool/exiftool-10.16.recipe
@@ -9,10 +9,10 @@ LICENSE="GNU GPL v1
 	Artistic"
 REVISION="1"
 SOURCE_URI="http://www.sno.phy.queensu.ca/~phil/exiftool/Image-ExifTool-$portVersion.tar.gz"
-CHECKSUM_SHA256="830ad5e28bc049ec69950c2a48e5703aff2cb05956b80ed21aa65167afab56a9"
+CHECKSUM_SHA256="d9e8f91c6e9b3a5a1d1274491c5be38272ced7b58f7305ea21fd18f8ef3da596"
 SOURCE_DIR="Image-ExifTool-$portVersion"
 
-ARCHITECTURES="x86 x86_gcc2"
+ARCHITECTURES="any"
 
 PROVIDES="
 	exiftool = $portVersion
@@ -20,7 +20,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku
-	perl >= 5.0.0
+	cmd:perl >= 5.0.0
 	"
 
 BUILD_REQUIRES="


### PR DESCRIPTION
* Drop 10.13 and 10.14, which were in media-gfx/exiftool.
* Add 10.15 and 10.16 in media-libs/exiftool to follow Gentoo.
* Switch to **`ARCHITECTURES="any"`**.
* Use **`cmd:perl`** (in REQUIRES) instead of just **`perl`**.