### PR TITLE
Sanity 0.6 recipe fails

### DIFF
--- a/haiku-apps/sanity/patches/sanity-0.6.patchset
+++ b/haiku-apps/sanity/patches/sanity-0.6.patchset
@@ -1,0 +1,22 @@
+From 02b4f5b1eaf9997ca1e1b26499089f6442807bd8 Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Fri, 20 May 2016 22:52:29 +0000
+Subject: BLocker assignment operator is private since hrev50310.
+
+
+diff --git a/ScannerOptionView.cpp b/ScannerOptionView.cpp
+index 389ffec..45cb9ab 100644
+--- a/ScannerOptionView.cpp
++++ b/ScannerOptionView.cpp
+@@ -23,7 +23,7 @@ static bool			reload_option(void *ov, void *device);
+ // ------------------------
+ 
+ BList ScannerOptionView::m_options_list = BList();
+-BLocker ScannerOptionView::m_options_list_locker = BLocker();
++BLocker ScannerOptionView::m_options_list_locker;
+ 
+ 
+ // --------------------------------------------------------------
+-- 
+2.7.0
+

--- a/haiku-apps/sanity/sanity-0.6.recipe
+++ b/haiku-apps/sanity/sanity-0.6.recipe
@@ -3,12 +3,14 @@ DESCRIPTION="A graphical Haiku scanner application, using SANE.
 SanityTranslator allows applications to use scanner devices through the \
 translation kit."
 HOMEPAGE="http://philippe.houdoin.free.fr/phil/beos/sanity/index-en.html"
-COPYRIGHT="2001-2004, Philippe Houdoin"
+COPYRIGHT="2001-2015 Philippe Houdoin"
 LICENSE="MIT"
-REVISION="2"
-SOURCE_URI="https://github.com/diversys/sanity/archive/f40f575.tar.gz"
-CHECKSUM_SHA256="fdd0cabb3ff5f8718f6cf56190260c7d106c258936b34e3d40607f0edc7f20aa"
-SOURCE_DIR="sanity-f40f57540683ecaade60585de6b379c61aa0ca7c"
+REVISION="3"
+srcGitRev="5ca4267486bf6060389b5352391c2919a37c69ed"
+SOURCE_URI="https://github.com/diversys/sanity/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="04b80d1d6373108223c4a0458f2c5f9625e94e79fca26357673c01486a46b8e4"
+SOURCE_DIR="sanity-$srcGitRev"
+PATCHES="sanity-$portVersion.patchset"
 
 ARCHITECTURES="x86_gcc2 ?x86 !x86_64"
 


### PR DESCRIPTION
Attempting to build Sanity 0,6 recipe on Haiku fails with error

Welcome to the Haiku shell.

~> haikuporter -S -j4 --get-dependencies --no-source-packages sanity
                                    
Checking if package dependencies need to be updated ...
        updating dependency infos of sanity-0.6
----------------------------------------------------------------------
haiku-apps::sanity-0.6
        /boot/home/haikuports/haiku-apps/sanity/sanity-0.6.recipe
----------------------------------------------------------------------

Downloading: https://github.com/diversys/sanity/archive/f40f575.tar.gz ...
--2016-05-18 10:10:55--  https://github.com/diversys/sanity/archive/f40f575.tar.gz
Resolving github.com... 192.30.252.120
Connecting to github.com|192.30.252.120|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://codeload.github.com/diversys/sanity/tar.gz/f40f57540683ecaade60585de6b379c61aa0ca7c [following]
--2016-05-18 10:10:56--  https://codeload.github.com/diversys/sanity/tar.gz/f40f57540683ecaade60585de6b379c61aa0ca7c
Resolving codeload.github.com... 192.30.252.163
Connecting to codeload.github.com|192.30.252.163|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [application/x-gzip]
Saving to: ‘/boot/home/haikuports/haiku-apps/sanity/download/f40f575.tar.gz’

/boot/home/haikupor     [ <=>                ]  43.54K   220KB/s    in 0.2s    

2016-05-18 10:10:56 (220 KB/s) - ‘/boot/home/haikuports/haiku-apps/sanity/download/f40f575.tar.gz’ saved [44583]

Validating checksum of f40f575.tar.gz
Unpacking source of f40f575.tar.gz
Initialized empty Git repository in /boot/home/haikuports/haiku-apps/sanity/work-0.6/sources/sanity-f40f57540683ecaade60585de6b379c61aa0ca7c/.git/
Fetching package for devel:libsane ...
chroot has these packages active:
        /boot/system/packages/bash-4.3.42-1-x86_gcc2.hpkg
        /boot/system/packages/binutils-2.17_2013_04_21-2-x86_gcc2.hpkg
        /boot/system/packages/bzip2-1.0.6-5-x86_gcc2.hpkg
        /boot/system/packages/ca_root_certificates-2015_10_28-1-any.hpkg
        /boot/system/packages/coreutils-8.24-1-x86_gcc2.hpkg
        /boot/system/packages/curl-7.45.0-2-x86_gcc2.hpkg
        /boot/system/packages/expat-2.1.0-1-x86_gcc2.hpkg
        /boot/system/packages/freetype-2.6.3-1-x86_gcc2.hpkg
        /boot/system/packages/gcc-2.95.3_2014_10_14-3-x86_gcc2.hpkg
        /boot/system/packages/gettext_libintl-0.19.6-2-x86_gcc2.hpkg
        /boot/system/packages/giflib6-5.0.5-2-x86_gcc2.hpkg
        /boot/system/packages/grep-2.20-1-x86_gcc2.hpkg
        /boot/system/packages/gutenprint-5.2.11-2-x86_gcc2.hpkg
        /boot/system/packages/gzip-1.6-2-x86_gcc2.hpkg
        /boot/system/packages/haiku-r1~alpha4_pm_hrev50321-1-x86_gcc2.hpkg
        /boot/system/packages/haiku_devel-r1~alpha4_pm_hrev50321-1-x86_gcc2.hpkg
        /boot/system/packages/icu-56.1-1-x86_gcc2.hpkg
        /boot/system/packages/jasper-1.900.1-4-x86_gcc2.hpkg
        /boot/system/packages/jpeg-9-3-x86_gcc2.hpkg
        /boot/system/packages/libicns-0.8.1-3-x86_gcc2.hpkg
        /boot/system/packages/libiconv-1.13.1-6-x86_gcc2.hpkg
        /boot/system/packages/libpng-1.5.25-1-x86_gcc2.hpkg
        /boot/system/packages/libpng16-1.6.20-1-x86_gcc2.hpkg
        /boot/system/packages/libsolv-0.3.0_haiku_2014_12_22-1-x86_gcc2.hpkg
        /boot/system/packages/libusb-1.0.20-2-x86_gcc2.hpkg
        /boot/system/packages/libwebp-0.5.0-1-x86_gcc2.hpkg
        /boot/system/packages/make-4.1-1-x86_gcc2.hpkg
        /boot/system/packages/makefile_engine-r1~alpha4_pm_hrev50321-1-any.hpkg
        /boot/system/packages/mesa-7.9.2-10-x86_gcc2.hpkg
        /boot/system/packages/mkdepend-1.7-3-x86_gcc2.hpkg
        /boot/system/packages/ncurses-5.9-9-x86_gcc2.hpkg
        /boot/system/packages/ncurses6-6.0-1-x86_gcc2.hpkg
        /boot/system/packages/openssl-1.0.2g-1-x86_gcc2.hpkg
        /boot/system/packages/qrencode-3.3.0-1-x86_gcc2.hpkg
        /boot/system/packages/readline-6.3.8-1-x86_gcc2.hpkg
        /boot/system/packages/sane_backends-1.0.25-3-x86_gcc2.hpkg
        /boot/system/packages/sane_backends_devel-1.0.25-3-x86_gcc2.hpkg
        /boot/system/packages/sed-4.2.1-6-x86_gcc2.hpkg
        /boot/system/packages/tar-1.26-6-x86_gcc2.hpkg
        /boot/system/packages/tiff-3.9.6-2-x86_gcc2.hpkg
        /boot/system/packages/tiff4-4.0.6-1-x86_gcc2.hpkg
        /boot/system/packages/unzip-6.0-2-x86_gcc2.hpkg
        /boot/system/packages/vl_gothic-20141206-1-any.hpkg
        /boot/system/packages/zlib-1.2.8-4-x86_gcc2.hpkg
----- Package Info ----------------
header size:                     80
heap size:                      648
TOC size:                        41
package attributes size:        630
total size:                     728
-----------------------------------
waiting for build package sanity-0.6-2 to be activated
Building ...
mkdir -p objects; \
mkdepend  -I./  -Iobjects/ -p .cpp:objects/%n.o -m -f "objects/TranslatorSavePanel.d" TranslatorSavePanel.cpp
mkdir -p objects; \
mkdepend  -I./  -Iobjects/ -p .cpp:objects/%n.o -m -f "objects/StackView.d" StackView.cpp
mkdir -p objects; \
mkdepend  -I./  -Iobjects/ -p .cpp:objects/%n.o -m -f "objects/SpinControl.d" SpinControl.cpp
mkdir -p objects; \
mkdepend  -I./  -Iobjects/ -p .cpp:objects/%n.o -m -f "objects/SpinButton.d" SpinButton.cpp
mkdir -p objects; \
mkdepend  -I./  -Iobjects/ -p .cpp:objects/%n.o -m -f "objects/ScannerWindow.d" ScannerWindow.cpp
mkdir -p objects; \
mkdepend  -I./  -Iobjects/ -p .cpp:objects/%n.o -m -f "objects/ScannerOptionView.d" ScannerOptionView.cpp
mkdir -p objects; \
mkdepend  -I./  -Iobjects/ -p .cpp:objects/%n.o -m -f "objects/ScannerInfoView.d" ScannerInfoView.cpp
mkdir -p objects; \
mkdepend  -I./  -Iobjects/ -p .cpp:objects/%n.o -m -f "objects/Sanity.d" Sanity.cpp
mkdir -p objects; \
mkdepend  -I./  -Iobjects/ -p .cpp:objects/%n.o -m -f "objects/SANETranslator.d" SANETranslator.cpp
mkdir -p objects; \
mkdepend  -I./  -Iobjects/ -p .cpp:objects/%n.o -m -f "objects/PreviewView.d" PreviewView.cpp
mkdir -p objects; \
mkdepend  -I./  -Iobjects/ -p .cpp:objects/%n.o -m -f "objects/CollapsableBox.d" CollapsableBox.cpp
mkdir -p objects; \
mkdepend  -I./  -Iobjects/ -p .cpp:objects/%n.o -m -f "objects/CheckerBitmap.d" CheckerBitmap.cpp
g++ -c CheckerBitmap.cpp  -I./  -Iobjects/ -I-   -O3    -o "objects/CheckerBitmap.o"
g++ -c CollapsableBox.cpp  -I./  -Iobjects/ -I-   -O3    -o "objects/CollapsableBox.o"
g++ -c PreviewView.cpp  -I./  -Iobjects/ -I-   -O3    -o "objects/PreviewView.o"
g++ -c SANETranslator.cpp  -I./  -Iobjects/ -I-   -O3    -o "objects/SANETranslator.o"
g++ -c Sanity.cpp  -I./  -Iobjects/ -I-   -O3    -o "objects/Sanity.o"
g++ -c ScannerInfoView.cpp  -I./  -Iobjects/ -I-   -O3    -o "objects/ScannerInfoView.o"
g++ -c ScannerOptionView.cpp  -I./  -Iobjects/ -I-   -O3    -o "objects/ScannerOptionView.o"
g++ -c ScannerWindow.cpp  -I./  -Iobjects/ -I-   -O3    -o "objects/ScannerWindow.o"
g++ -c SpinButton.cpp  -I./  -Iobjects/ -I-   -O3    -o "objects/SpinButton.o"
g++ -c SpinControl.cpp  -I./  -Iobjects/ -I-   -O3    -o "objects/SpinControl.o"
g++ -c StackView.cpp  -I./  -Iobjects/ -I-   -O3    -o "objects/StackView.o"
g++ -c TranslatorSavePanel.cpp  -I./  -Iobjects/ -I-   -O3    -o "objects/TranslatorSavePanel.o"
/boot/system/develop/headers/os/support/Locker.h: In function `void __static_initialization_and_destruction_0(int, int)':
/boot/system/develop/headers/os/support/Locker.h:35: `BLocker::BLocker(const BLocker &)' is private
/sources/sanity-f40f57540683ecaade60585de6b379c61aa0ca7c/ScannerOptionView.cpp:26: within this context
/boot/system/develop/etc/makefile-engine:291: recipe for target 'objects/ScannerOptionView.o' failed
make: *** [objects/ScannerOptionView.o] Error 1
make: *** Waiting for unfinished jobs....
Command '['bash', '-c', '. /wrapper-script']' returned non-zero exit status 2
keeping chroot folder /boot/home/haikuports/haiku-apps/sanity/work-0.6 intact for inspection
Error: Build has failed - stopping.
~> 





















