### PR TITLE
make: add recipe for 4.2, add TEST(), switch to mirror.

### DIFF
--- a/sys-devel/make/make-4.2.recipe
+++ b/sys-devel/make/make-4.2.recipe
@@ -1,0 +1,68 @@
+SUMMARY="Standard tool to compile source trees"
+DESCRIPTION="Make is a tool which controls the generation of executables and \
+other non-source files of a program from the program's source files.
+Make gets its knowledge of how to build your program from a file called the \
+makefile, which lists each of the non-source files and how to compute it from \
+other files. When you write a program, you should write a makefile for it, so \
+that it is possible to use Make to build and install the program."
+HOMEPAGE="https://www.gnu.org/software/make/"
+COPYRIGHT="1988-2016 Free Software Foundation, Inc."
+LICENSE="GNU GPL v3"
+REVISION="1"
+SOURCE_URI="http://ftpmirror.gnu.org/make/make-$portVersion.tar.bz2"
+CHECKSUM_SHA256="4e5ce3b62fe5d75ff8db92b7f6df91e476d10c3aceebf1639796dc5bfece655f"
+PATCHES="make-$portVersion.patchset"
+SOURCE_FILENAME_2="make-4.1-fix_double_colon_rules_plus_parallel_builds.patch"
+SOURCE_URI_2="https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-devel/make/files/$SOURCE_FILENAME_2#noarchive"
+CHECKSUM_SHA256_2="8186ff3732ae1384e5cba27dfedf68af6994c4bf048804b337db74a6428d4eb6"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64 arm"
+
+PROVIDES="
+	make = $portVersion compat >= 3.82
+	cmd:make = $portVersion compat >= 3.82
+	"
+REQUIRES="
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc
+	cmd:ld
+	cmd:libtoolize
+	cmd:sed
+	cmd:grep
+	"
+if [ "$recipeAction" = TEST ]; then
+	BUILD_PREREQUIRES="$BUILD_PREREQUIRES
+		cmd:file
+		"
+fi
+
+defineDebugInfoPackage make \
+	$binDir/make
+
+PATCH()
+{
+	patch --reverse -p1 -i $sourceDir2/$SOURCE_FILENAME_2
+}
+
+BUILD()
+{
+	runConfigure ./configure \
+		--disable-rpath --with-gnu-ld
+	./build.sh
+}
+
+INSTALL()
+{
+	./make install
+}
+
+TEST()
+{
+	./make check
+}

--- a/sys-devel/make/patches/make-4.2.patchset
+++ b/sys-devel/make/patches/make-4.2.patchset
@@ -1,0 +1,22 @@
+From aa0681736940d18a5eb4a7bfad3b70f77159ef83 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Fri, 26 Feb 2016 14:51:15 +0000
+Subject: Haiku patch
+
+
+diff --git a/arscan.c b/arscan.c
+index 549fe1e..17430f5 100644
+--- a/arscan.c
++++ b/arscan.c
+@@ -331,7 +331,7 @@ ar_scan (const char *archive, ar_member_func_t function, const void *varg)
+ #endif
+ 
+ #ifndef WINDOWS32
+-# if !defined (__ANDROID__) && !defined (__BEOS__)
++# if !defined (__ANDROID__) && !defined (__BEOS__) && !defined (__HAIKU__)
+ #  include <ar.h>
+ # else
+    /* These platforms don't have <ar.h> but have archives in the same format
+-- 
+2.2.2
+


### PR DESCRIPTION
Also _revert an upstream commit until a real fix is available_, just like Gentoo did with 4.2-r1.
See https://bugs.gentoo.org/583812
(This was blocking **`haikuporter --test make-4.2`**.)
Finally, remove unneeded call to libtoolize.