### PR TITLE
mpg123: bump to 1.23.4 with miscellaneous minor changes.

### DIFF
--- a/media-sound/mpg123/mpg123-1.23.4.recipe
+++ b/media-sound/mpg123/mpg123-1.23.4.recipe
@@ -6,19 +6,19 @@ COPYRIGHT="1995-2016 Michael Hipp and others"
 LICENSE="GNU LGPL v2.1"
 REVISION="1"
 SOURCE_URI="http://downloads.sf.net/mpg123/mpg123-$portVersion.tar.bz2"
-CHECKSUM_SHA256="5c431da7e7446fae586c9207772dc0038ce2bfe75f0274a7933d1b4a7d84e6c6"
+CHECKSUM_SHA256="3495e678dec9a60f29cbcd4fc698abc4c811ec60d1276e744f7a10ac35023b48"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86 x86_gcc2"
 
 PROVIDES="
 	mpg123$secondaryArchSuffix = $portVersion
-	lib:libmpg123$secondaryArchSuffix = 0.42.1 compat >= 0
-	lib:libout123$secondaryArchSuffix = 0.1.1 compat >= 0
-	cmd:mpg123$secondaryArchSuffix
-	cmd:mpg123_id3dump$secondaryArchSuffix
-	cmd:mpg123_strip$secondaryArchSuffix
-	cmd:out123$secondaryArchSuffix
+	lib:libmpg123$secondaryArchSuffix = 0.42.2 compat >= 0
+	lib:libout123$secondaryArchSuffix = 0.1.3 compat >= 0
+	cmd:mpg123$secondaryArchSuffix = $portVersion
+	cmd:mpg123_id3dump$secondaryArchSuffix = $portVersion
+	cmd:mpg123_strip$secondaryArchSuffix = $portVersion
+	cmd:out123$secondaryArchSuffix = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -27,8 +27,8 @@ REQUIRES="
 
 PROVIDES_devel="
 	mpg123${secondaryArchSuffix}_devel = $portVersion
-	devel:libmpg123$secondaryArchSuffix = 0.42.1 compat >= 0
-	devel:libout123$secondaryArchSuffix = 0.1.1 compat >= 0
+	devel:libmpg123$secondaryArchSuffix = 0.42.2 compat >= 0
+	devel:libout123$secondaryArchSuffix = 0.1.3 compat >= 0
 	"
 REQUIRES_devel="
 	haiku$secondaryArchSuffix
@@ -39,23 +39,20 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:autoheader
+	cmd:automake
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
-	cmd:make
-	cmd:awk
-	cmd:find
-	cmd:autoconf
-	cmd:autoreconf
-	cmd:libtool
 	cmd:libtoolize$secondaryArchSuffix
-	cmd:aclocal
+	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
 BUILD()
 {
-	autoreconf -fi
-	LDFLAGS="-lnetwork" runConfigure ./configure --disable-aligncheck
+	runConfigure ./configure
 	make $jobArgs
 }
 
@@ -67,4 +64,9 @@ INSTALL()
 		libout123
 	fixPkgconfig
 	packageEntries devel $developDir
+}
+
+TEST()
+{
+	make check
 }


### PR DESCRIPTION
* Drop unrecognized «**`--disable-aligncheck`**» configure option.
* Add «**` = $portVersion`**» to every **`cmd:`** in PROVIDES.
* Add **`cmd:autoheader`** and **`cmd:automake`** to BUILD_PREREQUIRES.
* Drop **`cmd:{awk,find,autoreconf}`** and unneeded call to autoreconf.
* Drop unneeded «**`LDFLAGS=-lnetwork`**» as configure finds it anyway.