### PR TITLE
libbluray: bump to 0.9.3, fix libbluray.pc and REQUIRES_devel.

### DIFF
--- a/media-libs/libbluray/libbluray-0.9.3.recipe
+++ b/media-libs/libbluray/libbluray-0.9.3.recipe
@@ -1,18 +1,18 @@
 SUMMARY="Library for playback of Blu-ray movies"
 DESCRIPTION="This library is simply a tool for playback of Blu-ray movies."
 HOMEPAGE="https://www.videolan.org/developers/libbluray.html"
-COPYRIGHT="2010-2015 VideoLAN"
+COPYRIGHT="2010-2016 VideoLAN"
 LICENSE="GNU LGPL v2.1"
 REVISION="1"
 SOURCE_URI="https://download.videolan.org/pub/videolan/libbluray/$portVersion/libbluray-$portVersion.tar.bz2"
-CHECKSUM_SHA256="efc994f42d2bce6af2ce69d05ba89dbbd88bcec7aca065de094fb3a7880ce7ea"
+CHECKSUM_SHA256="a6366614ec45484b51fe94fcd1975b3b8716f90f038a33b24d59978de3863ce0"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64 ?arm ?ppc"
-SECONDARY_ARCHITECTURES="x86"
+SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
 
 PROVIDES="
 	libbluray$secondaryArchSuffix = $portVersion compat >= 0.7
-	lib:libbluray$secondaryArchSuffix = 1.9.2 compat >= 1
+	lib:libbluray$secondaryArchSuffix = 1.10.0 compat >= 1
 	cmd:bd_info$secondaryArchSuffix
 	"
 REQUIRES="
@@ -28,10 +28,13 @@ REQUIRES="
 
 PROVIDES_devel="
 	libbluray${secondaryArchSuffix}_devel = $portVersion compat >= 0.7
-	devel:libbluray$secondaryArchSuffix = 1.9.2 compat >= 1
+	devel:libbluray$secondaryArchSuffix = 1.10.0 compat >= 1
 	"
 REQUIRES_devel="
 	libbluray$secondaryArchSuffix == $portVersion base
+	devel:libfontconfig$secondaryArchSuffix
+	devel:libfreetype$secondaryArchSuffix
+	devel:libxml2$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
@@ -47,17 +50,17 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	cmd:aclocal
 	cmd:autoconf
+	cmd:autom4te
 	cmd:automake
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
-	cmd:libtoolize
+	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
 BUILD()
 {
-	autoreconf -fi
 	runConfigure ./configure --disable-bdjava
 	make $jobArgs
 }
@@ -71,7 +74,24 @@ INSTALL()
 	prepareInstalledDevelLibs libbluray
 	fixPkgconfig
 
+	local develPackageName="${portName}_devel-$portFullVersion"
+	local packageLinksDir="`dirname "$portPackageLinksDir"`"
+	local develPkgLinksDir="$packageLinksDir/$develPackageName"
+	local libfontconfig="$develPkgLinksDir/devel~libfontconfig$secondaryArchSuffix/$relativeDevelopLibDir"
+	local libfreetype="$develPkgLinksDir/devel~libfreetype$secondaryArchSuffix/$relativeDevelopLibDir"
+	local libxml2="$develPkgLinksDir/devel~libxml2$secondaryArchSuffix/$relativeDevelopLibDir"
+	sed -i \
+		-e "/^Libs\.private:/ s,-L/packages/fontconfig$secondaryArchSuffix-[^\ /]*/\.self/develop/$relativeLibDir,-L$libfontconfig,g" \
+		-e "/^Libs\.private:/ s,-L/packages/freetype$secondaryArchSuffix-[^\ /]*/\.self/develop/$relativeLibDir,-L$libfreetype,g" \
+		-e "/^Libs\.private:/ s,-L/packages/libxml2$secondaryArchSuffix-[^\ /]*/\.self/develop/$relativeLibDir,-L$libxml2,g" \
+		$developLibDir/pkgconfig/libbluray.pc
+
 	# devel package
 	packageEntries devel \
 		$developDir
+}
+
+TEST()
+{
+	make check
 }


### PR DESCRIPTION
* Bump to 0.9.3 ~~with a big gcc2 patch~~, add TEST() with **`make check`**.
* Fix **`Libs.private`** paths in **`pkgconfig/libbluray.pc`**.
* Add **`devel:lib{fontconfig,freetype,xml2}`** to REQUIRES_devel.
* Drop explicit call to autoreconf as configure works without it.
* ~~Drop~~ **Keep** the static lib ~~as~~ **although** handbrake, mpv and vlc do not need it.