### PR TITLE
curl: bump to 7.49.1, use _BSD_SOURCE (required for make check).

### DIFF
--- a/net-misc/curl/additional-files/curl.rdef
+++ b/net-misc/curl/additional-files/curl.rdef
@@ -1,0 +1,10 @@
+
+resource app_version {
+	major = @MAJOR@,
+	middle = @MIDDLE@,
+	minor = @MINOR@,
+	variety = B_APPV_FINAL,
+	internal = 0,
+	short_info = "curl",
+	long_info = "curl ©1996-2016 Daniel Stenberg"
+};

--- a/net-misc/curl/curl-7.49.1.recipe
+++ b/net-misc/curl/curl-7.49.1.recipe
@@ -7,11 +7,12 @@ based upload, proxies, cookies, user+password authentication (Basic, Digest, \
 NTLM, Negotiate, kerberos...), file transfer resume, proxy tunneling and a \
 busload of other useful tricks."
 HOMEPAGE="https://curl.haxx.se/"
-COPYRIGHT="1996-2016, Daniel Stenberg"
+COPYRIGHT="1996-2016 Daniel Stenberg"
 LICENSE="Curl"
 REVISION="1"
 SOURCE_URI="https://curl.haxx.se/download/curl-$portVersion.tar.bz2"
-CHECKSUM_SHA256="14f44ed7b5207fea769ddb2c31bd9e720d37312e1c02315def67923a4a636078"
+CHECKSUM_SHA256="eb63cec4bef692eab9db459033f409533e6d10e20942f4b060b32819e81885f1"
+ADDITIONAL_FILES="curl.rdef"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64 arm"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
@@ -19,12 +20,8 @@ SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 PROVIDES="
 	curl$secondaryArchSuffix = $portVersion
 	lib:libcurl$secondaryArchSuffix = 4.4.0 compat >= 4
+	cmd:curl$secondaryArchSuffix = $portVersion compat >= 7.16
 	"
-if [ -z "$secondaryArchSuffix" ]; then
-	PROVIDES="$PROVIDES
-		cmd:curl = $portVersion compat >= 7.16
-		"
-fi
 
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -50,7 +47,11 @@ BUILD_REQUIRES="
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
+	cmd:aclocal
 	cmd:autoconf
+	cmd:automake
+	cmd:autoheader
+	cmd:cut
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
 	cmd:libtoolize$secondaryArchSuffix
@@ -58,6 +59,7 @@ BUILD_PREREQUIRES="
 	cmd:nroff
 	cmd:python
 	cmd:pkg_config$secondaryArchSuffix
+	cmd:sed
 	"
 
 BUILD()
@@ -65,9 +67,8 @@ BUILD()
 	certsInstallDir="$portPackageLinksDir/ca_root_certificates"
 	certsDir="$certsInstallDir/$relativeDataRootDir/ssl"
 
-	libtoolize --force --copy --install
 	autoconf
-	runConfigure ./configure \
+	CFLAGS=-D_BSD_SOURCE CXXFLAGS=-D_BSD_SOURCE runConfigure ./configure \
 		--enable-ipv6 --enable-manual \
 		--with-ca-bundle="$certsDir/CARootCertificates.pem"
 	make $jobArgs
@@ -77,34 +78,54 @@ INSTALL()
 {
 	make install
 
+	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
+	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
+	local MINOR="`echo "$portVersion" | cut -d. -f3`"
+	sed \
+		-e "s|@MAJOR@|$MAJOR|" \
+		-e "s|@MIDDLE@|$MIDDLE|" \
+		-e "s|@MINOR@|$MINOR|" \
+		$portDir/additional-files/curl.rdef > curl.rdef
+
+	addResourcesToBinaries curl.rdef \
+		$binDir/curl
+
 	# prepare develop/lib
 	prepareInstalledDevelLibs libcurl
 	fixPkgconfig
 
 	# fix curl-config
 	fixDevelopLibDirReferences $binDir/curl-config
-	sed -i -e "s,--libexecdir=$developLibDir,--libexecdir=$libExecDir,g" \
-		-e "s,--libdir=$developLibDir,--libdir=$libDir,g" $binDir/curl-config
+	sed -i \
+		-e "s,--libexecdir=$developLibDir,--libexecdir=$libExecDir,g" \
+		-e "s,--libdir=$developLibDir,--libdir=$libDir,g" \
+		$binDir/curl-config
 
-	# install html documentation for curl
-	mkdir -p "$docDir"
-	install -c -m 644 "docs/curl.html" "$docDir"
+	if [ -n "$secondaryArchSuffix" ]; then
+		maybe_manDir_man1_curl_config=
+		maybe_manDir_man3=
+	else
+		maybe_manDir_man1_curl_config=$manDir/man1/curl-config.1
+		maybe_manDir_man3=$manDir/man3
 
-	# install html development documentation for libcurl
-	mkdir -p "$developDocDir"
-	for h in docs/libcurl/*.html; do
-		install -c -m 644 "$h" "$developDocDir"
-	done
+		install -d -m 755 "$docDir" "$developDocDir"
+
+		# install html documentation for curl
+		install -c -m 444 "docs/curl.html" "$docDir"
+
+		# install html development documentation for libcurl
+		install -t $developDocDir -c -m 444 docs/libcurl/*.html
+	fi
 
 	# devel package
 	packageEntries devel \
 		$binDir/curl-config \
 		$developDir \
-		$manDir/man3
+		$maybe_manDir_man1_curl_config \
+		$maybe_manDir_man3
 
 	# Remove stuff we don't need in the secondary architecture base package.
 	if [ -n "$secondaryArchSuffix" ]; then
-		rm -rf $binDir
 		rm -rf $documentationDir
 	fi
 }


### PR DESCRIPTION
* Bump to 7.49.1 and call **`runConfigure`** with **`CFLAGS=_BSD_SOURCE`** and **`CXXFLAGS=-D_BSD_SOURCE`** otherwise **`make check`** fails to build.
* Drop **`$manDir/man3`** on 2nd arch devel packages.
* Move the manual page of **`curl-config(1)`** to the devel package.
* Use **`install`** (instead of mkdir and cp) to simplify **`INSTALL()`**.
* Keep $binDir for 2nd arch since x86_gcc2 fails many tests.
* No need to call libtoolize. Keep autoconf (needed on x86_64).
* Add version info in rdef file to have "Get Info" show it.