### PR TITLE
libzip: add recipe for 1.1.3, disable static lib, fix install.

### DIFF
--- a/dev-libs/libzip/libzip-1.1.3.recipe
+++ b/dev-libs/libzip/libzip-1.1.3.recipe
@@ -1,0 +1,98 @@
+SUMMARY="A C library for reading, creating, and modifying zip archives"
+DESCRIPTION="libzip is a C library for reading, creating, and modifying zip \
+archives."
+HOMEPAGE="http://www.nih.at/libzip/"
+COPYRIGHT="1999-2016 Dieter Baron and Thomas Klausner"
+LICENSE="BSD (3-clause)"
+REVISION="1"
+SOURCE_URI="http://www.nih.at/libzip/libzip-$portVersion.tar.gz"
+CHECKSUM_SHA256="1faa5a524dd4a12c43b6344e618edce1bf8050dfdb9d0f73f3cc826929a002b0"
+PATCHES="libzip-$portVersion.patchset"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86_gcc2 x86"
+
+PROVIDES="
+	libzip$secondaryArchSuffix = $portVersion
+	lib:libzip$secondaryArchSuffix = 4.0.0 compat >= 4.0.0
+	"
+if [ -z "$secondaryArchSuffix" ]; then
+	PROVIDES="$PROVIDES
+		cmd:zipcmp
+		cmd:zipmerge
+		cmd:ziptool
+		"
+fi
+
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	libzip${secondaryArchSuffix}_devel = $portVersion
+	devel:libzip$secondaryArchSuffix = 4.0.0 compat >= 4.0.0
+	"
+REQUIRES_devel="
+	libzip$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:automake
+	cmd:autoheader
+	cmd:make
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	"
+
+PATCH()
+{
+	sed -i -e 's/^LN=ln -f$/&rs/' man/Makefile.am
+}
+
+BUILD()
+{
+	runConfigure ./configure --disable-static
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	prepareInstalledDevelLibs libzip
+	fixPkgconfig
+
+	# Move zipconf.h from lib/libzip/include/ to develop/headers/libzip/
+	mkdir -p $includeDir/libzip
+	mv $libDir/libzip/include/zipconf.h $includeDir/libzip
+	rmdir $libDir/libzip/include $libDir/libzip
+
+	# Adjust libincludedir to make it point to where zipconf.h was moved.
+	sed -i -e "s,^\(libincludedir=\)$libDir"'\(/libzip\)/include$,\1${prefix}/'"${relativeIncludeDir}\2," \
+		$developLibDir/pkgconfig/libzip.pc
+
+	if [ -z "$secondaryArchSuffix" ]; then
+		maybe_manDir_man3=$manDir/man3
+	else
+		maybe_manDir_man3=
+		rm -rf $binDir
+		rm -rf $documentationDir
+	fi
+
+	# devel package
+	packageEntries devel \
+		$developDir \
+		$maybe_manDir_man3
+}
+
+TEST()
+{
+	make check
+}

--- a/dev-libs/libzip/patches/libzip-1.1.3.patchset
+++ b/dev-libs/libzip/patches/libzip-1.1.3.patchset
@@ -1,0 +1,30 @@
+From 83469244d644593a2ef27f179102b0b4e1975caf Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Sat, 28 May 2016 09:50:37 +0000
+Subject: gcc2 patch
+
+
+diff --git a/src/zipcmp.c b/src/zipcmp.c
+index cf9b572..032c838 100644
+--- a/src/zipcmp.c
++++ b/src/zipcmp.c
+@@ -313,6 +313,7 @@ list_directory(const char *name, struct archive *a)
+     FTS *fts;
+     FTSENT *ent;
+     zip_uint64_t nalloc;
++    size_t prefix_length;
+ 
+     char * const names[2] = { (char *)name, NULL };
+ 
+@@ -321,7 +322,7 @@ list_directory(const char *name, struct archive *a)
+ 	fprintf(stderr, "%s: can't open directory '%s': %s\n", prg, name, strerror(errno));
+ 	return -1;
+     }
+-    size_t prefix_length = strlen(name)+1;
++    prefix_length = strlen(name)+1;
+ 
+     nalloc = 0;
+ 
+-- 
+2.7.0
+


### PR DESCRIPTION
* Add recipe for 1.1.3 but call configure with «**`--disable-static`**». This is OK since there are currently no recipes depending on libzip.
* **`make install`** puts **`zipconf.h`** in **`lib/libzip/include/`** so we need to move it to **`develop/headers/libzip/`** and fix **`libzip.pc`**.
* Change «**`LN=ln -f`**» into «**`LN=ln -frs`**» in **`man/Makefile.am`** to make **`ln`** create relative symlinks. This works fine and also saves space.