### PR TITLE
OpenSSH global-writeable settings with "keep-old" flag

### DIFF
--- a/net-misc/openssh/additional-files/fix_openssh_config_paths.sh
+++ b/net-misc/openssh/additional-files/fix_openssh_config_paths.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+SYSTEM_SETTINGS_DIR="`finddir B_SYSTEM_SETTINGS_DIRECTORY`"
+USER_SETTINGS_DIR="`finddir B_USER_SETTINGS_DIRECTORY`"
+VAR_DIR="`finddir B_SYSTEM_VAR_DIRECTORY`"
+LIB_DIR="`finddir B_SYSTEM_LIB_DIRECTORY`"
+
+SSH_CONFIG="$SYSTEM_SETTINGS_DIR/ssh/ssh_config"
+SSHD_CONFIG="$SYSTEM_SETTINGS_DIR/ssh/sshd_config"
+
+if [ -f "$SSH_CONFIG" ] && grep -q 'IdentityFile ~/\.ssh/' "$SSH_CONFIG"; then
+	sed --in-place=.bak \
+		-e "s| ~/\.ssh/| $USER_SETTINGS_DIR/ssh/|" \
+		$SYSTEM_SETTINGS_DIR/ssh/ssh_config
+fi
+
+if [ -f "$SSHD_CONFIG" ] && grep -q '/packages/openssh-' "$SSHD_CONFIG"; then
+	sed --in-place=.bak \
+		-e "s|/packages/openssh-[-0-9p\.]\{3,\}/\.settings/ssh/|$SYSTEM_SETTINGS_DIR/ssh/|" \
+		-e "s|/packages/openssh-[-0-9p\.]\{3,\}/\.self/var/run/|$VAR_DIR/run/|" \
+		-e "s|/packages/openssh-[-0-9p\.]\{3,\}/\.self/lib/openssh/|$LIB_DIR/openssh/|" \
+		$SYSTEM_SETTINGS_DIR/ssh/sshd_config
+fi
+
+true

--- a/net-misc/openssh/openssh-7.1p1.recipe
+++ b/net-misc/openssh/openssh-7.1p1.recipe
@@ -16,7 +16,7 @@ ssh-keyscan, ssh-keygen and sftp-server."
 HOMEPAGE="http://www.openssh.com/"
 COPYRIGHT="2005-2015 Tatu Ylonen et al."
 LICENSE="OpenSSH"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="http://ftp.fr.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$portVersion.tar.gz"
 CHECKSUM_SHA256="fc0a6d2d1d063d5c66dffd952493d0cda256cad204f681de0f84ef85b2ad8428"
 PATCHES="sshd_config.patch
@@ -25,7 +25,10 @@ PATCHES="sshd_config.patch
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
 
-ADDITIONAL_FILES="sshd_keymaker.sh"
+ADDITIONAL_FILES="
+	sshd_keymaker.sh
+	fix_openssh_config_paths.sh
+	"
 
 PROVIDES="
 	openssh = $portVersion compat >= 5
@@ -44,8 +47,10 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku
+	cmd:grep
 	cmd:login
 	cmd:passwd
+	cmd:sed
 	lib:libcrypto
 	lib:libedit
 	lib:libncurses
@@ -74,12 +79,17 @@ BUILD_PREREQUIRES="
 
 GLOBAL_WRITABLE_FILES="
 	settings/ssh directory keep-old
+	settings/ssh/ssh_config keep-old
+	settings/ssh/sshd_config keep-old
 	"
 USER_SETTINGS_FILES="
 	settings/ssh directory
+	settings/ssh/ssh_config template data/openssh/ssh_config.default
+	settings/ssh/sshd_config template data/openssh/sshd_config.default
 	"
 POST_INSTALL_SCRIPTS="
 	$relativePostInstallDir/sshd_keymaker.sh
+	$relativePostInstallDir/fix_openssh_config_paths.sh
 	"
 sshdUserHomeDir="/packages/$portVersionedName-$REVISION/.self/$relativeDataDir/openssh/empty"
 PACKAGE_USERS="
@@ -125,6 +135,25 @@ INSTALL()
 	make install-nokeys
 	mkdir -p $postInstallDir
 	cp -f $portDir/additional-files/sshd_keymaker.sh $postInstallDir
+	cp -f $portDir/additional-files/fix_openssh_config_paths.sh $postInstallDir
+
+	local USER_SETTINGS_DIR="`finddir B_USER_SETTINGS_DIRECTORY`"
+	sed -i \
+		-e "s| ~/\.ssh/| $USER_SETTINGS_DIR/ssh/|" \
+		$sysconfDir/ssh/ssh_config
+
+	local SYSTEM_SETTINGS_DIR="`finddir B_SYSTEM_SETTINGS_DIRECTORY`"
+	local VAR_DIR="`finddir B_SYSTEM_VAR_DIRECTORY`"
+	local LIB_DIR="`finddir B_SYSTEM_LIB_DIRECTORY`"
+	sed -i \
+		-e "s|$sysconfDir/ssh/|$SYSTEM_SETTINGS_DIR/ssh/|" \
+		-e "s|$prefix/var/run/|$VAR_DIR/run/|" \
+		-e "s|$libExecDir/openssh/|$LIB_DIR/openssh/|" \
+		$sysconfDir/ssh/sshd_config
+
+	mkdir -p $dataDir/openssh
+	cp $sysconfDir/ssh/ssh_config $dataDir/openssh/ssh_config.default
+	cp $sysconfDir/ssh/sshd_config $dataDir/openssh/sshd_config.default
 }
 
 TEST()

--- a/net-misc/openssh/openssh-7.1p2.recipe
+++ b/net-misc/openssh/openssh-7.1p2.recipe
@@ -16,7 +16,7 @@ ssh-keyscan, ssh-keygen and sftp-server."
 HOMEPAGE="http://www.openssh.com/"
 COPYRIGHT="2005-2016 Tatu Ylonen et al."
 LICENSE="OpenSSH"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://ftp.fr.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$portVersion.tar.gz"
 CHECKSUM_SHA256="dd75f024dcf21e06a0d6421d582690bf987a1f6323e32ad6619392f3bfde6bbd"
 PATCHES="sshd_config.patch
@@ -25,7 +25,10 @@ PATCHES="sshd_config.patch
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
 
-ADDITIONAL_FILES="sshd_keymaker.sh"
+ADDITIONAL_FILES="
+	sshd_keymaker.sh
+	fix_openssh_config_paths.sh
+	"
 
 PROVIDES="
 	openssh = $portVersion compat >= 5
@@ -44,8 +47,10 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku
+	cmd:grep
 	cmd:login
 	cmd:passwd
+	cmd:sed
 	lib:libcrypto
 	lib:libedit
 	lib:libncurses
@@ -74,12 +79,17 @@ BUILD_PREREQUIRES="
 
 GLOBAL_WRITABLE_FILES="
 	settings/ssh directory keep-old
+	settings/ssh/ssh_config keep-old
+	settings/ssh/sshd_config keep-old
 	"
 USER_SETTINGS_FILES="
 	settings/ssh directory
+	settings/ssh/ssh_config template data/openssh/ssh_config.default
+	settings/ssh/sshd_config template data/openssh/sshd_config.default
 	"
 POST_INSTALL_SCRIPTS="
 	$relativePostInstallDir/sshd_keymaker.sh
+	$relativePostInstallDir/fix_openssh_config_paths.sh
 	"
 sshdUserHomeDir="/packages/$portVersionedName-$REVISION/.self/$relativeDataDir/openssh/empty"
 PACKAGE_USERS="
@@ -125,6 +135,25 @@ INSTALL()
 	make install-nokeys
 	mkdir -p $postInstallDir
 	cp -f $portDir/additional-files/sshd_keymaker.sh $postInstallDir
+	cp -f $portDir/additional-files/fix_openssh_config_paths.sh $postInstallDir
+
+	local USER_SETTINGS_DIR="`finddir B_USER_SETTINGS_DIRECTORY`"
+	sed -i \
+		-e "s| ~/\.ssh/| $USER_SETTINGS_DIR/ssh/|" \
+		$sysconfDir/ssh/ssh_config
+
+	local SYSTEM_SETTINGS_DIR="`finddir B_SYSTEM_SETTINGS_DIRECTORY`"
+	local VAR_DIR="`finddir B_SYSTEM_VAR_DIRECTORY`"
+	local LIB_DIR="`finddir B_SYSTEM_LIB_DIRECTORY`"
+	sed -i \
+		-e "s|$sysconfDir/ssh/|$SYSTEM_SETTINGS_DIR/ssh/|" \
+		-e "s|$prefix/var/run/|$VAR_DIR/run/|" \
+		-e "s|$libExecDir/openssh/|$LIB_DIR/openssh/|" \
+		$sysconfDir/ssh/sshd_config
+
+	mkdir -p $dataDir/openssh
+	cp $sysconfDir/ssh/ssh_config $dataDir/openssh/ssh_config.default
+	cp $sysconfDir/ssh/sshd_config $dataDir/openssh/sshd_config.default
 }
 
 TEST()

--- a/net-misc/openssh/openssh-7.2p2.recipe
+++ b/net-misc/openssh/openssh-7.2p2.recipe
@@ -16,7 +16,7 @@ ssh-keyscan, ssh-keygen and sftp-server."
 HOMEPAGE="http://www.openssh.com/"
 COPYRIGHT="2005-2016 Tatu Ylonen et al."
 LICENSE="OpenSSH"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://ftp.fr.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$portVersion.tar.gz"
 CHECKSUM_SHA256="a72781d1a043876a224ff1b0032daa4094d87565a68528759c1c2cab5482548c"
 PATCHES="sshd_config.patch
@@ -25,7 +25,10 @@ PATCHES="sshd_config.patch
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
 
-ADDITIONAL_FILES="sshd_keymaker.sh"
+ADDITIONAL_FILES="
+	sshd_keymaker.sh
+	fix_openssh_config_paths.sh
+	"
 
 PROVIDES="
 	openssh = $portVersion compat >= 5
@@ -43,8 +46,10 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku
+	cmd:grep
 	cmd:login
 	cmd:passwd
+	cmd:sed
 	lib:libcrypto
 	lib:libedit
 	lib:libncurses
@@ -73,12 +78,17 @@ BUILD_PREREQUIRES="
 
 GLOBAL_WRITABLE_FILES="
 	settings/ssh directory keep-old
+	settings/ssh/ssh_config keep-old
+	settings/ssh/sshd_config keep-old
 	"
 USER_SETTINGS_FILES="
 	settings/ssh directory
+	settings/ssh/ssh_config template data/openssh/ssh_config.default
+	settings/ssh/sshd_config template data/openssh/sshd_config.default
 	"
 POST_INSTALL_SCRIPTS="
 	$relativePostInstallDir/sshd_keymaker.sh
+	$relativePostInstallDir/fix_openssh_config_paths.sh
 	"
 sshdUserHomeDir="/packages/$portVersionedName-$REVISION/.self/$relativeDataDir/openssh/empty"
 PACKAGE_USERS="
@@ -126,6 +136,25 @@ INSTALL()
 	make install-nokeys
 	mkdir -p $postInstallDir
 	cp -f $portDir/additional-files/sshd_keymaker.sh $postInstallDir
+	cp -f $portDir/additional-files/fix_openssh_config_paths.sh $postInstallDir
+
+	local USER_SETTINGS_DIR="`finddir B_USER_SETTINGS_DIRECTORY`"
+	sed -i \
+		-e "s| ~/\.ssh/| $USER_SETTINGS_DIR/ssh/|" \
+		$sysconfDir/ssh/ssh_config
+
+	local SYSTEM_SETTINGS_DIR="`finddir B_SYSTEM_SETTINGS_DIRECTORY`"
+	local VAR_DIR="`finddir B_SYSTEM_VAR_DIRECTORY`"
+	local LIB_DIR="`finddir B_SYSTEM_LIB_DIRECTORY`"
+	sed -i \
+		-e "s|$sysconfDir/ssh/|$SYSTEM_SETTINGS_DIR/ssh/|" \
+		-e "s|$prefix/var/run/|$VAR_DIR/run/|" \
+		-e "s|$libExecDir/openssh/|$LIB_DIR/openssh/|" \
+		$sysconfDir/ssh/sshd_config
+
+	mkdir -p $dataDir/openssh
+	cp $sysconfDir/ssh/ssh_config $dataDir/openssh/ssh_config.default
+	cp $sysconfDir/ssh/sshd_config $dataDir/openssh/sshd_config.default
 }
 
 TEST()


### PR DESCRIPTION
I updated my Haiku install, and then tried to log in through sftp. It worked before, but not anymore. I was able to log in through SSH, but not with SFTP.

I located the problem, it is the keep-old flag of the /boot/system/settings/ssh/sshd_config file.

It had the following line:
Subsystem	sftp	/packages/openssh-6.6p1-1/.self/lib/openssh/sftp-server
but the correct path is:
Subsystem	sftp	/packages/openssh-7.1p1-1/.self/lib/openssh/sftp-server

We should somehow update this file after each openssh update.