### PR TITLE
gnutls: bump to 3.4.14 + 3.5.2,  drop lib*.la, add TEST().

### DIFF
--- a/net-libs/gnutls/gnutls-2.8.6.recipe
+++ b/net-libs/gnutls/gnutls-2.8.6.recipe
@@ -10,27 +10,37 @@ COPYRIGHT="2009-2010 Free Software Fundation Inc.
 	2004-2008 Simon Josefsson
 	2000-2004 Nikos Mavrogiannopoulos"
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
-SOURCE_URI="ftp://ftp.gnu.org/pub/gnu/gnutls/gnutls-2.8.6.tar.bz2"
+REVISION="2"
+SOURCE_URI="ftp://ftp.gnu.org/pub/gnu/gnutls/gnutls-$portVersion.tar.bz2"
 CHECKSUM_SHA256="d6f846a7064af3ee2c9aebd65dcee76953b767170cbcd719e990ed6b9688a356"
-PATCHES="gnutls-2.8.6.patch"
+PATCHES="gnutls-$portVersion.patch"
 
 ARCHITECTURES="x86_gcc2"
 
 PROVIDES="
 	gnutls = $portVersion
-	cmd:certtool
-	cmd:gnutls_cli
-	cmd:gnutls_cli_debug
-	cmd:gnutls_serv
-	cmd:psktool
-	cmd:srptool
 	lib:libgnutls_extra = 26.14.12 compat = 26
 	lib:libgnutls_openssl = 26.14.12 compat = 26
 	lib:libgnutls = 26.14.12 compat = 26
 	lib:libgnutlsxx = 26.14.12 compat = 26
 	"
 REQUIRES="
+	haiku
+	lib:libgcrypt
+	lib:libgpg_error
+	"
+
+PROVIDES_bin="
+	gnutls_bin = $portVersion
+	cmd:certtool
+	cmd:gnutls_cli
+	cmd:gnutls_cli_debug
+	cmd:gnutls_serv
+	cmd:psktool
+	cmd:srptool
+	"
+REQUIRES_bin="
+	gnutls == $portVersion base
 	haiku
 	lib:libgcrypt
 	lib:libgpg_error
@@ -45,6 +55,8 @@ PROVIDES_devel="
 	"
 REQUIRES_devel="
 	gnutls == $portVersion base
+	devel:libgcrypt
+	devel:libgpg_error
 	"
 
 BUILD_REQUIRES="
@@ -63,7 +75,7 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	libtoolize --force --copy --install
-    cd lib
+	cd lib
 		libtoolize --force --copy --install
 	cd ..
 	cd libextra
@@ -78,10 +90,23 @@ INSTALL()
 {
 	make install
 
-	prepareInstalledDevelLibs libgnutls-extra libgnutls-openssl libgnutls libgnutlsxx
+	rm -f $libDir/lib*.la
+
+	prepareInstalledDevelLibs \
+		libgnutls-extra \
+		libgnutls-openssl \
+		libgnutls \
+		libgnutlsxx
+
 	fixPkgconfig
 
-	packageEntries devel $developDir
+	packageEntries devel \
+		$developDir \
+		$manDir/man3
+
+	packageEntries bin \
+		$binDir \
+		$documentationDir
 }
 
 TEST()

--- a/net-libs/gnutls/gnutls34-3.4.14.recipe
+++ b/net-libs/gnutls/gnutls34-3.4.14.recipe
@@ -1,0 +1,143 @@
+SUMMARY="A TLS 1.0 and SSL 3.0 implementation for the GNU project"
+DESCRIPTION="GnuTLS is a secure communications library implementing the SSL, \
+TLS and DTLS protocols and technologies around them. It provides a simple C \
+language application programming interface (API) to access the secure \
+communications protocols as well as APIs to parse and write X.509, PKCS #12, \
+OpenPGP and other required structures. It is aimed to be portable and \
+efficient with focus on security and interoperability."
+HOMEPAGE="https://www.gnutls.org/"
+COPYRIGHT="2000-2016 Free Software Fundation Inc.
+	2004-2008 Simon Josefsson
+	2000-2004 Nikos Mavrogiannopoulos"
+LICENSE="GNU LGPL v2.1"
+REVISION="1"
+SOURCE_URI="ftp://ftp.gnutls.org/gcrypt/gnutls/v${portVersion%\.*}/gnutls-$portVersion.tar.xz"
+CHECKSUM_SHA256="35deddf2779b76ac11057de38bf380b8066c05de21b94263ad5b6dfa75dfbb23"
+SOURCE_DIR="gnutls-$portVersion"
+PATCHES="gnutls-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 x86 x86_64 ?arm ?ppc"
+SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
+
+PROVIDES="
+	gnutls34$secondaryArchSuffix = $portVersion
+	lib:libgnutls_openssl$secondaryArchSuffix = 27.0.2 compat >= 27
+	lib:libgnutls$secondaryArchSuffix = 30.6.6 compat >= 30
+	lib:libgnutlsxx$secondaryArchSuffix = 28.1.0 compat >= 28
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libgpg_error$secondaryArchSuffix
+	lib:libnettle$secondaryArchSuffix
+	lib:libgmp$secondaryArchSuffix
+	lib:libtasn1$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+#	lib:libgcrypt$secondaryArchSuffix
+CONFLICTS="
+	gnutls35$secondaryArchSuffix
+	"
+
+PROVIDES_bin="
+	gnutls34${secondaryArchSuffix}_bin = $portVersion
+	cmd:certtool$secondaryArchSuffix
+	cmd:gnutls_cli$secondaryArchSuffix
+	cmd:gnutls_cli_debug$secondaryArchSuffix
+	cmd:gnutls_serv$secondaryArchSuffix
+	cmd:ocsptool$secondaryArchSuffix
+	cmd:psktool$secondaryArchSuffix
+	cmd:srptool$secondaryArchSuffix
+	"
+REQUIRES_bin="
+	gnutls34$secondaryArchSuffix == $portVersion base
+	haiku$secondaryArchSuffix
+	lib:libgcrypt$secondaryArchSuffix
+	lib:libgpg_error$secondaryArchSuffix
+	lib:libnettle$secondaryArchSuffix
+	lib:libgmp$secondaryArchSuffix
+	lib:libtasn1$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+CONFLICTS_bin="
+	gnutls${secondaryArchSuffix}_bin
+	gnutls35${secondaryArchSuffix}_bin
+	"
+
+PROVIDES_devel="
+	gnutls${secondaryArchSuffix}_devel = $portVersion
+	devel:libgnutls_openssl$secondaryArchSuffix = 27.0.2 compat >= 27
+	devel:libgnutls$secondaryArchSuffix = 30.6.6 compat >= 30
+	devel:libgnutlsxx$secondaryArchSuffix = 28.1.0 compat >= 28
+	"
+REQUIRES_devel="
+	gnutls34$secondaryArchSuffix == $portVersion base
+	devel:libgcrypt$secondaryArchSuffix
+	devel:libgpg_error$secondaryArchSuffix
+	devel:libnettle$secondaryArchSuffix
+	devel:libtasn1$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+CONFLICTS_devel="
+	gnutls${secondaryArchSuffix}_devel
+	gnutls35${secondaryArchSuffix}_devel
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libgcrypt$secondaryArchSuffix
+	devel:libgpg_error$secondaryArchSuffix
+	devel:libnettle$secondaryArchSuffix
+	devel:libgmp$secondaryArchSuffix
+	devel:libtasn1$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:autoheader
+	cmd:autom4te
+	cmd:automake
+	cmd:find
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	cmd:makeinfo
+	cmd:perl
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:cvs
+	cmd:git
+	"
+
+BUILD()
+{
+	runConfigure ./configure --without-p11-kit --disable-nls \
+		--enable-openssl-compatibility
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	rm -f $libDir/lib*.la
+
+	prepareInstalledDevelLibs libgnutls-openssl libgnutls libgnutlsxx
+	fixPkgconfig
+
+	packageEntries devel \
+		$developDir \
+		$manDir/man3
+
+	packageEntries bin \
+		$binDir \
+		$documentationDir
+}
+
+TEST()
+{
+	make check
+}

--- a/net-libs/gnutls/gnutls35-3.5.2.recipe
+++ b/net-libs/gnutls/gnutls35-3.5.2.recipe
@@ -5,29 +5,24 @@ language application programming interface (API) to access the secure \
 communications protocols as well as APIs to parse and write X.509, PKCS #12, \
 OpenPGP and other required structures. It is aimed to be portable and \
 efficient with focus on security and interoperability."
-HOMEPAGE="http://www.gnutls.org/"
+HOMEPAGE="https://www.gnutls.org/"
 COPYRIGHT="2000-2016 Free Software Fundation Inc.
 	2004-2008 Simon Josefsson
 	2000-2004 Nikos Mavrogiannopoulos"
 LICENSE="GNU LGPL v2.1"
 REVISION="1"
-SOURCE_URI="ftp://ftp.gnutls.org/gcrypt/gnutls/v3.4/gnutls-$portVersion.tar.xz"
-CHECKSUM_SHA256="6a32c2b4acbd33ff7eefcbd1357009da04c94c60146ef61320b6c076b1bdf59f"
+SOURCE_URI="ftp://ftp.gnutls.org/gcrypt/gnutls/v${portVersion%\.*}/gnutls-$portVersion.tar.xz"
+CHECKSUM_SHA256="2b45e95cbfd21d76da6fc4846794d8845dbc66bb03c6aa1428881586cfbe8582"
+SOURCE_DIR="gnutls-$portVersion"
+PATCHES="gnutls-$portVersion.patchset"
 
-ARCHITECTURES="!x86_gcc2 x86 x86_64 ?arm ?ppc"
+ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64 ?arm ?ppc"
 SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
 
 PROVIDES="
-	gnutls$secondaryArchSuffix = $portVersion
-	cmd:certtool$secondaryArchSuffix
-	cmd:gnutls_cli$secondaryArchSuffix
-	cmd:gnutls_cli_debug$secondaryArchSuffix
-	cmd:gnutls_serv$secondaryArchSuffix
-	cmd:ocsptool$secondaryArchSuffix
-	cmd:psktool$secondaryArchSuffix
-	cmd:srptool$secondaryArchSuffix
+	gnutls35$secondaryArchSuffix = $portVersion
 	lib:libgnutls_openssl$secondaryArchSuffix = 27.0.2 compat >= 27
-	lib:libgnutls$secondaryArchSuffix = 30.6.2 compat >= 30
+	lib:libgnutls$secondaryArchSuffix = 30.8.1 compat >= 30
 	lib:libgnutlsxx$secondaryArchSuffix = 28.1.0 compat >= 28
 	"
 REQUIRES="
@@ -38,33 +33,56 @@ REQUIRES="
 	lib:libgmp$secondaryArchSuffix
 	lib:libtasn1$secondaryArchSuffix
 	lib:libiconv$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+CONFLICTS="
+	gnutls34$secondaryArchSuffix
+	"
+
+PROVIDES_bin="
+	gnutls35${secondaryArchSuffix}_bin = $portVersion
+	cmd:certtool$secondaryArchSuffix
+	cmd:gnutls_cli$secondaryArchSuffix
+	cmd:gnutls_cli_debug$secondaryArchSuffix
+	cmd:gnutls_serv$secondaryArchSuffix
+	cmd:ocsptool$secondaryArchSuffix
+	cmd:psktool$secondaryArchSuffix
+	cmd:srptool$secondaryArchSuffix
+	"
+REQUIRES_bin="
+	gnutls35$secondaryArchSuffix == $portVersion base
+	haiku$secondaryArchSuffix
+	lib:libgcrypt$secondaryArchSuffix
+	lib:libgpg_error$secondaryArchSuffix
+	lib:libnettle$secondaryArchSuffix
+	lib:libgmp$secondaryArchSuffix
+	lib:libtasn1$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+CONFLICTS_bin="
+	gnutls${secondaryArchSuffix}_bin
+	gnutls34${secondaryArchSuffix}_bin
 	"
 
 PROVIDES_devel="
 	gnutls${secondaryArchSuffix}_devel = $portVersion
 	devel:libgnutls_openssl$secondaryArchSuffix = 27.0.2 compat >= 27
-	devel:libgnutls$secondaryArchSuffix = 30.6.2 compat >= 30
+	devel:libgnutls$secondaryArchSuffix = 30.8.1 compat >= 30
 	devel:libgnutlsxx$secondaryArchSuffix = 28.1.0 compat >= 28
 	"
 REQUIRES_devel="
-	gnutls$secondaryArchSuffix == $portVersion base
+	gnutls35$secondaryArchSuffix == $portVersion base
+	devel:libgcrypt$secondaryArchSuffix
+	devel:libgpg_error$secondaryArchSuffix
 	devel:libnettle$secondaryArchSuffix
 	devel:libtasn1$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
 	"
-
-if [ -z "$secondaryArchSuffix" ]; then
-# HaikuPorter does not yet support creating architecture-independent packages
-# for secondary-arch builds. So build it only if we're on a primary arch.
-	SUMMARY_doc="Documentation for GnuTLS"
-	ARCHITECTURES_doc="any"
-
-	PROVIDES_doc="
-		gnutls_doc = $portVersion
-		"
-	REQUIRES_doc="
-		haiku
-		"
-fi
+CONFLICTS_devel="
+	gnutls${secondaryArchSuffix}_devel
+	gnutls34${secondaryArchSuffix}_devel
+	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
@@ -74,23 +92,30 @@ BUILD_REQUIRES="
 	devel:libgmp$secondaryArchSuffix
 	devel:libtasn1$secondaryArchSuffix
 	devel:libiconv$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
+	cmd:aclocal
 	cmd:autoconf
+	cmd:autoheader
+	cmd:autom4te
 	cmd:automake
 	cmd:find
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
-	cmd:libtoolize
+	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
+	cmd:makeinfo
+	cmd:perl
 	cmd:pkg_config$secondaryArchSuffix
+	cmd:cvs
+	cmd:git
 	"
 
 BUILD()
 {
 	runConfigure ./configure --without-p11-kit --disable-nls \
-		--enable-openssl-compatibility \
-		${secondaryArchSuffix+--disable-doc}
+		--enable-openssl-compatibility
 	make $jobArgs
 }
 
@@ -98,12 +123,21 @@ INSTALL()
 {
 	make install
 
+	rm -f $libDir/lib*.la
+
 	prepareInstalledDevelLibs libgnutls-openssl libgnutls libgnutlsxx
 	fixPkgconfig
 
-	packageEntries devel $developDir
+	packageEntries devel \
+		$developDir \
+		$manDir/man3
 
-	if [ -z "$secondaryArchSuffix" ]; then
-		packageEntries doc $documentationDir
-	fi
+	packageEntries bin \
+		$binDir \
+		$documentationDir
+}
+
+TEST()
+{
+	make check
 }

--- a/net-libs/gnutls/patches/gnutls-3.4.14.patchset
+++ b/net-libs/gnutls/patches/gnutls-3.4.14.patchset
@@ -1,0 +1,131 @@
+From 9ae7b7ca24f41d064b6020137e0aecf7e67c0893 Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Tue, 7 Jun 2016 03:05:44 +0000
+Subject: include sys/select.h
+
+
+diff --git a/tests/mini-dtls-mtu.c b/tests/mini-dtls-mtu.c
+index 6f52e33..4e8ee4d 100644
+--- a/tests/mini-dtls-mtu.c
++++ b/tests/mini-dtls-mtu.c
+@@ -24,6 +24,9 @@
+ 
+ #include <stdio.h>
+ #include <stdlib.h>
++#ifdef __HAIKU__
++#	include <sys/select.h>
++#endif
+ #include <stdint.h>
+ #include <string.h>
+ #include <errno.h>
+diff --git a/tests/mini-dtls-pthread.c b/tests/mini-dtls-pthread.c
+index 64cbba5..f447eab 100644
+--- a/tests/mini-dtls-pthread.c
++++ b/tests/mini-dtls-pthread.c
+@@ -26,6 +26,9 @@
+ 
+ #include <stdio.h>
+ #include <stdlib.h>
++#ifdef __HAIKU__
++#	include <sys/select.h>
++#endif
+ #include <stdint.h>
+ #include <string.h>
+ #include <errno.h>
+diff --git a/tests/mini-dtls-record-asym.c b/tests/mini-dtls-record-asym.c
+index 9087dc5..0c72b5a 100644
+--- a/tests/mini-dtls-record-asym.c
++++ b/tests/mini-dtls-record-asym.c
+@@ -26,6 +26,9 @@
+ 
+ #include <stdio.h>
+ #include <stdlib.h>
++#ifdef __HAIKU__
++#	include <sys/select.h>
++#endif
+ #include <stdint.h>
+ #include <string.h>
+ #include <errno.h>
+diff --git a/tests/mini-record-failure.c b/tests/mini-record-failure.c
+index a13e9a1..4e86760 100644
+--- a/tests/mini-record-failure.c
++++ b/tests/mini-record-failure.c
+@@ -26,6 +26,9 @@
+ 
+ #include <stdio.h>
+ #include <stdlib.h>
++#ifdef __HAIKU__
++#	include <sys/select.h>
++#endif
+ 
+ #if defined(_WIN32)
+ 
+-- 
+2.7.0
+
+
+From b09109e729147a22a6be72dfc32a8e00151fdb27 Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Tue, 7 Jun 2016 03:05:44 +0000
+Subject: link mini-dtls-pthread without libpthread.
+
+
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index d546dde..e012ab4 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -94,7 +94,7 @@ ctests = mini-record-2 simple gc set_pkcs12_cred certder certuniqueid	\
+ 	 mini-session-verify-function auto-verify mini-x509-default-prio \
+ 	 global-init-override pcert-list keylog-env
+ 
+-mini_dtls_pthread_LDADD = $(LDADD) -lpthread
++mini_dtls_pthread_LDADD = $(LDADD)
+ 
+ if ENABLE_PKCS11
+ if !WINDOWS
+-- 
+2.7.0
+
+
+From aa560535eef19064c892a1051492576fdd54183c Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Wed, 15 Jun 2016 11:04:44 +0000
+Subject: Do not skip the test-float test in gl/tests/.
+
+
+diff --git a/gl/tests/test-float.c b/gl/tests/test-float.c
+index 1c95b12..fbc2862 100644
+--- a/gl/tests/test-float.c
++++ b/gl/tests/test-float.c
+@@ -23,7 +23,7 @@
+ #include "fpucw.h"
+ #include "macros.h"
+ 
+-#if 0
++#if 1
+ 
+ /* Check that FLT_RADIX is a constant expression.  */
+ int a[] = { FLT_RADIX };
+-- 
+2.8.4
+
+
+From b2826162157672e4b8ea7d0ceb03282e596734e1 Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Wed, 6 Jul 2016 22:11:20 +0000
+Subject: Use /bin/perl instead of /usr/bin/perl.
+
+
+diff --git a/doc/scripts/split-texi.pl b/doc/scripts/split-texi.pl
+index 34978d3..96b1067 100755
+--- a/doc/scripts/split-texi.pl
++++ b/doc/scripts/split-texi.pl
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/bin/perl
+ 
+ # Copyright (C) 2011-2012 Free Software Foundation, Inc.
+ #
+-- 
+2.9.0
+

--- a/net-libs/gnutls/patches/gnutls-3.5.2.patchset
+++ b/net-libs/gnutls/patches/gnutls-3.5.2.patchset
@@ -1,0 +1,131 @@
+From 9ae7b7ca24f41d064b6020137e0aecf7e67c0893 Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Tue, 7 Jun 2016 03:05:44 +0000
+Subject: include sys/select.h
+
+
+diff --git a/tests/mini-dtls-mtu.c b/tests/mini-dtls-mtu.c
+index 6f52e33..4e8ee4d 100644
+--- a/tests/mini-dtls-mtu.c
++++ b/tests/mini-dtls-mtu.c
+@@ -24,6 +24,9 @@
+ 
+ #include <stdio.h>
+ #include <stdlib.h>
++#ifdef __HAIKU__
++#	include <sys/select.h>
++#endif
+ #include <stdint.h>
+ #include <string.h>
+ #include <errno.h>
+diff --git a/tests/mini-dtls-pthread.c b/tests/mini-dtls-pthread.c
+index 64cbba5..f447eab 100644
+--- a/tests/mini-dtls-pthread.c
++++ b/tests/mini-dtls-pthread.c
+@@ -26,6 +26,9 @@
+ 
+ #include <stdio.h>
+ #include <stdlib.h>
++#ifdef __HAIKU__
++#	include <sys/select.h>
++#endif
+ #include <stdint.h>
+ #include <string.h>
+ #include <errno.h>
+diff --git a/tests/mini-dtls-record-asym.c b/tests/mini-dtls-record-asym.c
+index 9087dc5..0c72b5a 100644
+--- a/tests/mini-dtls-record-asym.c
++++ b/tests/mini-dtls-record-asym.c
+@@ -26,6 +26,9 @@
+ 
+ #include <stdio.h>
+ #include <stdlib.h>
++#ifdef __HAIKU__
++#	include <sys/select.h>
++#endif
+ #include <stdint.h>
+ #include <string.h>
+ #include <errno.h>
+diff --git a/tests/mini-record-failure.c b/tests/mini-record-failure.c
+index a13e9a1..4e86760 100644
+--- a/tests/mini-record-failure.c
++++ b/tests/mini-record-failure.c
+@@ -26,6 +26,9 @@
+ 
+ #include <stdio.h>
+ #include <stdlib.h>
++#ifdef __HAIKU__
++#	include <sys/select.h>
++#endif
+ 
+ #if defined(_WIN32)
+ 
+-- 
+2.7.0
+
+
+From b09109e729147a22a6be72dfc32a8e00151fdb27 Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Tue, 7 Jun 2016 03:05:44 +0000
+Subject: link mini-dtls-pthread without libpthread.
+
+
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index e1f365f..385deee 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -114,7 +114,7 @@ if HAVE_SECCOMP_TESTS
+ ctests += dtls-with-seccomp tls-with-seccomp dtls-client-with-seccomp tls-client-with-seccomp
+ endif
+ 
+-mini_dtls_pthread_LDADD = $(LDADD) -lpthread
++mini_dtls_pthread_LDADD = $(LDADD)
+ 
+ resume_psk_CFLAGS = -DUSE_PSK
+ resume_psk_SOURCES = resume.c
+-- 
+2.7.0
+
+
+From aa560535eef19064c892a1051492576fdd54183c Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Wed, 15 Jun 2016 11:04:44 +0000
+Subject: Do not skip the test-float test in gl/tests/.
+
+
+diff --git a/gl/tests/test-float.c b/gl/tests/test-float.c
+index 1c95b12..fbc2862 100644
+--- a/gl/tests/test-float.c
++++ b/gl/tests/test-float.c
+@@ -23,7 +23,7 @@
+ #include "fpucw.h"
+ #include "macros.h"
+ 
+-#if 0
++#if 1
+ 
+ /* Check that FLT_RADIX is a constant expression.  */
+ int a[] = { FLT_RADIX };
+-- 
+2.8.4
+
+
+From b2826162157672e4b8ea7d0ceb03282e596734e1 Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Wed, 6 Jul 2016 22:11:20 +0000
+Subject: Use /bin/perl instead of /usr/bin/perl.
+
+
+diff --git a/doc/scripts/split-texi.pl b/doc/scripts/split-texi.pl
+index 34978d3..96b1067 100755
+--- a/doc/scripts/split-texi.pl
++++ b/doc/scripts/split-texi.pl
+@@ -1,4 +1,4 @@
+-#!/usr/bin/perl
++#!/bin/perl
+ 
+ # Copyright (C) 2011-2012 Free Software Foundation, Inc.
+ #
+-- 
+2.9.0
+


### PR DESCRIPTION
* Bump to 3.4.14 (current stable) and add 3.5.2, marked untested.
* ~~Fix paths of dependency_libs in **`develop/lib/lib*.la`** to make sure they will still be valid even if these dependencies are updated.~~
* Move **`$binDir`** to a _bin sub-package, for more flexibility with regards to package co-installation. 3.4.x and 3.5.x seem to be causing problems for other recipes, so this layout change, with some other changes (e.g. package basename renames) can help.
* Update the layout of 2.8.x ~~and add x86 and x86_64 as untested~~.
* Change the basename of the recipe of 3.4.x to gnutls34.
* Use gnutls35 as basename for the recipe of 3.5.x.
* Declare CONFLICTS, CONFLICTS_{bin,devel} in a way that allows gnutls-2.8.x to be installed with either gnutls-3.4.x or gnutls-3.5.x. On top of that, a single _bin package may be installed (provided the base package is also installed.) Same thing for _devel.
* Add **`cmd:{cvs,git}`** to BUILD_PREREQUIRES in order to make **`gl/tests/test-vc-list-files-{cvs,git}`** succeed.
* Patch **`gl/tests/test-float.c`** to enable that test.
* Add **`cmd:{perl,makeinfo}`** to BUILD_PREREQUIRES.