### PR TITLE
git: bump to 2.9.0, add TEST() with "makeGit test".

### DIFF
--- a/dev-vcs/git/git-2.9.0.recipe
+++ b/dev-vcs/git/git-2.9.0.recipe
@@ -7,19 +7,19 @@ Git is easy to learn and has a tiny footprint with lightning fast performance. \
 It outclasses SCM tools like Subversion, CVS, Perforce, and ClearCase with \
 features like cheap local branching, convenient staging areas, and multiple \
 workflows."
-HOMEPAGE="http://git-scm.com/"
+HOMEPAGE="https://git-scm.com/"
 COPYRIGHT="2005-2016 Git Authors (see git web site for list)"
 LICENSE="GNU GPL v2"
 REVISION="1"
 
 SOURCE_URI="https://www.kernel.org/pub/software/scm/git/git-$portVersion.tar.xz"
-CHECKSUM_SHA256="7d8e6c274a88b4a73b3c98c70d3438ec12871300ce8bb4ca179ea19fcf74aa91"
+CHECKSUM_SHA256="f41fa97949948fbf49af94a43d779e072a5452c6b5039d86ffa41ebab747b409"
 
 SOURCE_URI_2="https://www.kernel.org/pub/software/scm/git/git-manpages-$portVersion.tar.xz"
-CHECKSUM_SHA256_2="9d25e10c2bc327fdc59820bb00075799487095059d652fb32fea1cdb3a898bc6"
+CHECKSUM_SHA256_2="dc85c1afa923fd709d651a49d0a720d50a3c248cb16c6c09517cceae88fe8445"
 
 SOURCE_URI_3="https://www.kernel.org/pub/software/scm/git/git-htmldocs-$portVersion.tar.xz"
-CHECKSUM_SHA256_3="df9aa1f374ca49dd65f47a8bb1498c11567d963e30cf00e097aa89c495d3ccde"
+CHECKSUM_SHA256_3="664dc1aa20966a91cf6b90d282bb5f93b4e4c831a32a0791f43218389ce3b955"
 
 PATCHES="git-$portVersion.patchset"
 
@@ -233,4 +233,9 @@ INSTALL()
 		documentation/packages/git/git-svn.html \
 		documentation/man/man1/git-svn.1 \
 		lib/git-core/git-svn
+}
+
+TEST()
+{
+	makeGit test
 }

--- a/dev-vcs/git/patches/git-2.9.0.patchset
+++ b/dev-vcs/git/patches/git-2.9.0.patchset
@@ -30,12 +30,12 @@ Subject: On Haiku use the user settings directory instead of HOME
 
 
 diff --git a/path.c b/path.c
-index 3cd155e..a258488 100644
+index 259aeed..99f3559 100644
 --- a/path.c
 +++ b/path.c
-@@ -6,6 +6,11 @@
- #include "string-list.h"
+@@ -7,6 +7,11 @@
  #include "dir.h"
+ #include "worktree.h"
  
 +#ifdef __HAIKU__
 +#include <FindDirectory.h>
@@ -45,7 +45,7 @@ index 3cd155e..a258488 100644
  static int get_st_mode_bits(const char *path, int *mode)
  {
  	struct stat st;
-@@ -1186,10 +1191,18 @@ char *xdg_config_home(const char *filename)
+@@ -1226,10 +1231,18 @@ char *xdg_config_home(const char *filename)
  {
  	const char *home, *config_home;
  
@@ -75,10 +75,10 @@ Subject: Ensure config-directory exists before using it.
 
 
 diff --git a/config.c b/config.c
-index 86a5eb2..fee1d81 100644
+index f51c56b..ca95131 100644
 --- a/config.c
 +++ b/config.c
-@@ -1958,6 +1958,7 @@ int git_config_set_multivar_in_file(const char *config_filename,
+@@ -1996,6 +1996,7 @@ int git_config_set_multivar_in_file_gently(const char *config_filename,
  	int ret;
  	struct lock_file *lock = NULL;
  	char *filename_buf = NULL;
@@ -86,7 +86,7 @@ index 86a5eb2..fee1d81 100644
  	char *contents = NULL;
  	size_t contents_sz;
  
-@@ -1971,6 +1972,12 @@ int git_config_set_multivar_in_file(const char *config_filename,
+@@ -2009,6 +2010,12 @@ int git_config_set_multivar_in_file_gently(const char *config_filename,
  	if (!config_filename)
  		config_filename = filename_buf = git_pathdup("config");
  
@@ -111,10 +111,10 @@ Subject: Move credential cache to the config directory.
 Do not clutter the home dir.
 
 diff --git a/credential-cache.c b/credential-cache.c
-index f4afdc6..19a150e 100644
+index 86e21de..bde0ae2 100644
 --- a/credential-cache.c
 +++ b/credential-cache.c
-@@ -105,7 +105,7 @@ int main(int argc, const char **argv)
+@@ -106,7 +106,7 @@ int main(int argc, const char **argv)
  	op = argv[0];
  
  	if (!socket_path)


### PR DESCRIPTION
TEST() does not work yet because of haikuports/haikuporter/issues/90 but adding **`BUILD_PACKAGE_ACTIVATION_PHASE=TEST`** and playing with the time stamp of the recipe (once built) can help workaround this error:
```
Testing ...
    SUBDIR perl
/bin/sh: /packages/git-2.9.0-1/cmd~perl/bin/perl: No such file or directory
```