### PR TITLE
harfbuzz: bump to 1.2.7, add TEST() with "make check". (WIP)

### DIFF
--- a/media-libs/harfbuzz/harfbuzz-1.2.7.recipe
+++ b/media-libs/harfbuzz/harfbuzz-1.2.7.recipe
@@ -1,33 +1,43 @@
 SUMMARY="An OpenType text shaping engine"
 DESCRIPTION="HarfBuzz is an OpenType text shaping engine. It is used to \
 layout complex text such as the Indic and Arabic alphabets."
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/HarfBuzz/"
-COPYRIGHT="2010,2011,2012 Google, Inc.
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/HarfBuzz/"
+COPYRIGHT="2004-2016 Behdad Esfahbod
+	2000-2005 Owen Taylor
+	2013, 2015-2016 Khaled Hosny
+	2010,2011,2012 Google, Inc.
 	2012 Mozilla Foundation
 	2011 Codethink Limited
 	2008,2010 Nokia Corporation and/or its subsidiary(-ies)
 	2009 Keith Stribley
 	2009 Martin Hosken and SIL International
 	2007 Chris Wilson
-	2006 Behdad Esfahbod
 	2005 David Turner
 	2004,2007,2008,2009,2010 Red Hat, Inc.
 	1998-2004 David Turner and Werner Lemberg"
 LICENSE="MIT"
 REVISION="1"
-SOURCE_URI="http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-$portVersion.tar.bz2"
-CHECKSUM_SHA256="7537bacccb3524df0cd2a4d5bc7e168bcc10e8171e0324f3cd522583868192c1"
-#PATCHES="harfbuzz-$portVersion.patchset"
+SOURCE_URI="https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-$portVersion.tar.bz2"
+CHECKSUM_SHA256="bba0600ae08b84384e6d2d7175bea10b5fc246c4583dc841498d01894d479026"
+PATCHES="harfbuzz-$portVersion.patchset"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="x86"
+SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
+
+if [ "$targetArchitecture" != x86_gcc2 ]; then
+	commandSuffix=$secondaryArchSuffix
+	commandBinDir=$binDir
+else
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
 
 PROVIDES="
 	harfbuzz$secondaryArchSuffix = $portVersion compat >= 0.9
-	lib:libharfbuzz$secondaryArchSuffix = 0.10200.6 compat >= 0
-	lib:libharfbuzz_icu$secondaryArchSuffix = 0.10200.6 compat >= 0
-	cmd:hb_ot_shape_closure$secondaryArchSuffix
-	cmd:hb_shape$secondaryArchSuffix
+	lib:libharfbuzz$secondaryArchSuffix = 0.10200.7 compat >= 0
+	lib:libharfbuzz_icu$secondaryArchSuffix = 0.10200.7 compat >= 0
+	cmd:hb_ot_shape_closure$commandSuffix
+	cmd:hb_shape$commandSuffix
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -44,7 +54,8 @@ REQUIRES="
 
 PROVIDES_devel="
 	harfbuzz${secondaryArchSuffix}_devel = $portVersion compat >= 0.9
-	devel:libharfbuzz$secondaryArchSuffix = 0.10200.6 compat >= 0
+	devel:libharfbuzz$secondaryArchSuffix = 0.10200.7 compat >= 0
+	devel:libharfbuzz_icu$secondaryArchSuffix = 0.10200.7 compat >= 0
 	"
 REQUIRES_devel="
 	harfbuzz$secondaryArchSuffix == $portVersion base
@@ -63,22 +74,24 @@ BUILD_REQUIRES="
 	devel:libgraphite2$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:automake
-	cmd:autoreconf
 	cmd:aclocal
+	cmd:automake
+	cmd:autoconf
 	cmd:gcc$secondaryArchSuffix
-	cmd:ld$secondaryArchSuffix
-	cmd:libtool$secondaryArchSuffix
-	cmd:make
 	cmd:grep
-	cmd:sed
+	cmd:ld$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
+	cmd:python
+	cmd:sed
+	cmd:which
 	"
 
 BUILD()
 {
-	autoreconf -fi
-	runConfigure ./configure --with-graphite2=yes --with-icu
+	runConfigure --omit-dirs binDir ./configure --bindir=$commandBinDir \
+		--with-graphite2=yes --with-icu
 	make $jobArgs
 }
 
@@ -89,12 +102,18 @@ INSTALL()
 	# remove libtool library files
 	rm $libDir/libharfbuzz*.la
 
-	prepareInstalledDevelLibs libharfbuzz
+	prepareInstalledDevelLibs \
+		libharfbuzz \
+		libharfbuzz-icu
 	fixPkgconfig
 
 	# devel package
 	packageEntries devel \
 		$developDir \
 		$dataDir
+}
 
+TEST()
+{
+	make check
 }

--- a/media-libs/harfbuzz/patches/harfbuzz-1.2.7.patchset
+++ b/media-libs/harfbuzz/patches/harfbuzz-1.2.7.patchset
@@ -1,0 +1,75 @@
+From 8a356acde10854278b098ca2db391506bd91ead6 Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Sun, 19 Jun 2016 14:41:51 +0000
+Subject: Fix scripts in the test suite to better filter the output of nm.
+
+src/check-defs.sh and src/check-symbols.sh compare the list of
+symbols in libharfbuzz.so against a known list. This patch teaches
+these scripts that they shoud ignore two symbols that are Haiku-specific:
+_gSharedObjectHaikuABI and _gSharedObjectHaikuVersion.
+
+diff --git a/src/check-defs.sh b/src/check-defs.sh
+index 65a2467..f4b2cd4 100755
+--- a/src/check-defs.sh
++++ b/src/check-defs.sh
+@@ -21,7 +21,7 @@ for def in $defs; do
+ 	lib=`echo "$def" | sed 's/[.]def$//;s@.*/@@'`
+ 	so=.libs/lib${lib}.so
+ 
+-	EXPORTED_SYMBOLS="`nm "$so" | grep ' [BCDGINRSTVW] ' | grep -v ' _fini\>\| _init\>\| _fdata\>\| _ftext\>\| _fbss\>\| __bss_start\>\| __bss_start__\>\| __bss_end__\>\| _edata\>\| _end\>\| _bss_end__\>\| __end__\>\| __gcov_flush\>\| llvm_' | cut -d' ' -f3`"
++	EXPORTED_SYMBOLS="`nm "$so" | grep ' [BCDGINRSTVW] ' | grep -v ' _fini\>\| _init\>\| _fdata\>\| _ftext\>\| _fbss\>\| __bss_start\>\| __bss_start__\>\| __bss_end__\>\| _edata\>\| _end\>\| _bss_end__\>\| __end__\>\| __gcov_flush\>\| _gSharedObjectHaikuABI\>\| _gSharedObjectHaikuVersion\>\| llvm_' | cut -d' ' -f3`"
+ 
+ 	if test -f "$so"; then
+ 
+diff --git a/src/check-symbols.sh b/src/check-symbols.sh
+index b2bf43f..6c0ede9 100755
+--- a/src/check-symbols.sh
++++ b/src/check-symbols.sh
+@@ -20,7 +20,7 @@ for suffix in so dylib; do
+ 	so=.libs/libharfbuzz.$suffix
+ 	if ! test -f "$so"; then continue; fi
+ 	
+-	EXPORTED_SYMBOLS="`nm "$so" | grep ' [BCDGINRSTVW] ' | grep -v ' _fini\>\| _init\>\| _fdata\>\| _ftext\>\| _fbss\>\| __bss_start\>\| __bss_start__\>\| __bss_end__\>\| _edata\>\| _end\>\| _bss_end__\>\| __end__\>\| __gcov_flush\>\| llvm_' | cut -d' ' -f3`"
++	EXPORTED_SYMBOLS="`nm "$so" | grep ' [BCDGINRSTVW] ' | grep -v ' _fini\>\| _init\>\| _fdata\>\| _ftext\>\| _fbss\>\| __bss_start\>\| __bss_start__\>\| __bss_end__\>\| _edata\>\| _end\>\| _bss_end__\>\| __end__\>\| __gcov_flush\>\| _gSharedObjectHaikuABI\>\| _gSharedObjectHaikuVersion\>\| llvm_' | cut -d' ' -f3`"
+ 
+ 	prefix=`basename "$so" | sed 's/libharfbuzz/hb/; s/-/_/g; s/[.].*//'`
+ 
+-- 
+2.7.0
+
+
+From c8b977379a62f5119a799c8b14d48dc9031b9994 Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Sun, 19 Jun 2016 17:53:12 +0000
+Subject: Patch src/check-libstdc++.sh to use objdump instead of ldd.
+
+
+diff --git a/src/check-libstdc++.sh b/src/check-libstdc++.sh
+index b541828..7a1595a 100755
+--- a/src/check-libstdc++.sh
++++ b/src/check-libstdc++.sh
+@@ -7,10 +7,10 @@ test -z "$srcdir" && srcdir=.
+ stat=0
+ 
+ 
+-if which ldd 2>/dev/null >/dev/null; then
++if which objdump 2>/dev/null >/dev/null; then
+ 	:
+ else
+-	echo "check-libstdc++.sh: 'ldd' not found; skipping test"
++	echo "check-libstdc++.sh: 'objdump' not found; skipping test"
+ 	exit 77
+ fi
+ 
+@@ -20,7 +20,7 @@ for suffix in so dylib; do
+ 	if ! test -f "$so"; then continue; fi
+ 
+ 	echo "Checking that we are not linking to libstdc++ or libc++"
+-	if ldd $so | grep 'libstdc[+][+]\|libc[+][+]'; then
++	if objdump -x $so | grep NEEDED | grep 'libstdc[+][+]\|libc[+][+]'; then
+ 		echo "Ouch, linked to libstdc++ or libc++"
+ 		stat=1
+ 	fi
+-- 
+2.7.0
+


### PR DESCRIPTION
* Bump to version 1.2.7, add **`TEST()`** with **`make check`**.
* Add patch for 3 tests that would otherwise fail or be skipped.
* Add **`cmd:{python,which}`** to BUILD_PREREQ, as **`make check`** needs them.
* Drop explicit call to autoreconf as it is no longer needed.