### PR TITLE
games-arcade/alex4: create recipe for Alex the Allegator 4. (WIP)

### DIFF
--- a/games-arcade/alex4/alex4-1.0.recipe
+++ b/games-arcade/alex4/alex4-1.0.recipe
@@ -1,0 +1,67 @@
+SUMMARY="A small jump'n'run platform game"
+DESCRIPTION="Alex the Allegator 4 is a true jump'n'run, just like the old \
+classic ones. Guide Alex through the jungle in order to save his girlfriend \
+Lola from evil humans who want to make a bag of her."
+HOMEPAGE="https://sourceforge.net/projects/allegator/files/Alex4/"
+COPYRIGHT="2003 Johan Peitz"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="http://downloads.sourceforge.net/allegator/alex4src_data.zip"
+CHECKSUM_SHA256="d266d7fba64fbfedf13240d3d0eb21b8bacbedeaa5f22b26a27d472c8d23f103"
+SOURCE_URI_2="http://downloads.sourceforge.net/allegator/alex4_beos_src.zip"
+CHECKSUM_SHA256_2="b5333034638c19643a7bd8f6e54033b10b354bbcd4e8771b4ac7cd4a33c9e7cf"
+SOURCE_DIR="alex4src"
+SOURCE_DIR_2="alex4_BeOS_src"
+PATCHES_2="alex4-$portVersion.patch"
+# TODO: Check if it would be OK to also import the patches in:
+# http://data.gpo.zugaina.org/gamerlay/games-arcade/alex4/files/
+# and sync with alex4-1.1 in http://gpo.zugaina.org/games-arcade/alex4
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	alex4 = $portVersion
+	app:Alex4 = $portVersion
+	"
+REQUIRES="
+	haiku
+	lib:libaldmb_0.9.3
+	lib:liballeg
+	lib:libdumb_0.9.3
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	devel:libaldmb
+	devel:liballeg
+	devel:libdumb
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc
+	cmd:make
+	cmd:patch
+	"
+
+PATCH()
+{
+	patch -p6 -u -i $sourceDir2/alex4_BeOS.diff
+}
+
+BUILD()
+{
+	cp $sourceDir2/Makefile src
+	cp $sourceDir2/alex4.rsrc .
+
+	make -C src $jobArgs
+}
+
+INSTALL()
+{
+	install -m 755 -d $appsDir/Alex4BeOS $appsDir/Alex4BeOS/data
+	install -m 444 -t $appsDir/Alex4BeOS readme.txt
+	install -m 444 -t $appsDir/Alex4BeOS/data data/*
+	install -T alex4 $appsDir/Alex4BeOS/Alex4
+
+	addAppDeskbarSymlink $appsDir/Alex4BeOS/Alex4
+	ln -s Alex4BeOS/Alex4 $appsDir
+}

--- a/games-arcade/alex4/patches/alex4-1.0.patch
+++ b/games-arcade/alex4/patches/alex4-1.0.patch
@@ -1,0 +1,16 @@
+--- alex4_BeOS_src/Makefile.orig	2003-08-07 22:25:19.000000000 +0000
++++ alex4_BeOS_src/Makefile
+@@ -1,11 +1,11 @@
+ CC=g++
+ CFLAGS=-c -O1 -c `allegro-config --cflags`
+-LDFLAGS=`allegro-config --libs` -ldumb
++LDFLAGS=`allegro-config --libs` -ldumb -laldmb
+ SOURCES=actor.c edit.c map.c player.c shooter.c bullet.c hisc.c options.c script.c timer.c control.c main.c particle.c scroller.c token.c
+ OBJECTS :=$(SOURCES:%.c=%.o)
+ all:  clean compile
+ 	strip --strip-all alex4
+-	xres -o alex4 alex4.rsrc
++	xres -o alex4 ../alex4.rsrc
+ 	mimeset -f alex4
+ 	mv alex4 ../alex4
+ 


### PR DESCRIPTION
**TODO:** Check if it would be OK to also import the patches in:
http://data.gpo.zugaina.org/gamerlay/games-arcade/alex4/files/
and sync with alex4-1.1 in http://gpo.zugaina.org/games-arcade/alex4

Maybe we should use a (modified) rdef instead of the **`alex4_BeOS_src/alex4.rsrc`** in alex4_beos_src.zip, because when Alex4 is launched from command line we see this warning:
```
Signature in rsrc doesn't match constructor arg. (application/x-vnd.Allegro-Alex4, application/x-vnd.freelunchdesign-alex4)
```