### PR TITLE
libebml: fix libebml.la for all archies other than x86_gcc2.

### DIFF
--- a/dev-libs/libebml/libebml-1.3.3.recipe
+++ b/dev-libs/libebml/libebml-1.3.3.recipe
@@ -1,9 +1,9 @@
 SUMMARY="A C++ library to parse EBML content (read/write)"
 DESCRIPTION="libebml is a C++ library to parse EBML content (read/write)."
-HOMEPAGE="http://www.matroska.org/"
-COPYRIGHT="2005-2013 CoreCodec, Inc."
+HOMEPAGE="https://www.matroska.org/"
+COPYRIGHT="2005-2015 Matroska"
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://dl.matroska.org/downloads/libebml/libebml-$portVersion.tar.bz2"
 CHECKSUM_SHA256="35fb44daa41961f94a0ac1b8f06801e88cc9bf2ad6f562ced8ab7c1f1a875499"
 PATCHES="libebml-$portVersion.patchset"
@@ -26,6 +26,11 @@ PROVIDES_devel="
 REQUIRES_devel="
 	libebml$secondaryArchSuffix == $portVersion base
 	"
+if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+	REQUIRES_devel="$REQUIRES_devel
+		gcc$secondaryArchSuffix
+		"
+fi
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
@@ -37,7 +42,7 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:libtool
+	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
 	"
 
@@ -55,5 +60,18 @@ INSTALL()
 	prepareInstalledDevelLibs libebml
 	fixPkgconfig
 
+	if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+		local develPkgLinksDir="${portPackageLinksDir/$portName/${portName}_devel}"
+		local libstdcpp="$develPkgLinksDir/gcc$secondaryArchSuffix"
+		sed -i \
+			-e "s,/packages/gcc$secondaryArchSuffix-[^\ /]*/\.self/\(develop/tools$secondaryArchSubDir/lib/gcc/$effectiveTargetMachineTriple/[^\ /]*/libstdc++.la\),$libstdcpp/\1," \
+			$developLibDir/libebml.la
+	fi
+
 	packageEntries devel $developDir
+}
+
+TEST()
+{
+	make check
 }


### PR DESCRIPTION
* On all architectures other than x86_gcc2 the generated definition of dependency_libs in **`libebml.la`** includes a path to **`libstdc++.la`** that hard-codes the full version of the gcc package being used to build libebml. Keeping that path unchanged would result in a hidden dependency of libebml_devel on a specific revision of the gcc package. So fix that path using a _package-links dir_ that starts with e.g. **`/packages/libebml_x86_devel-*/gcc_x86/develop/tools/x86/lib/gcc/...`**
* Add **`gcc$secondaryArchSuffix`** to REQUIRES_devel when building for an architecture other than x86_gcc2 because **`libebml.la`** needs it.
* Add TEST() with **`make check`**.