### PR TITLE
gettext: fix incorrect sed for libasprintf.la on x86 2nd arch.

### DIFF
--- a/sys-devel/gettext/gettext-0.19.8.1.recipe
+++ b/sys-devel/gettext/gettext-0.19.8.1.recipe
@@ -16,7 +16,7 @@ preparing these sets, or bringing them up to date.
 HOMEPAGE="https://www.gnu.org/software/gettext/"
 COPYRIGHT="1998-2016 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://ftpmirror.gnu.org/gettext/gettext-$portVersion.tar.gz"
 CHECKSUM_SHA256="ff942af0e438ced4a8b0ea4b0b6e0d6d657157c5e2364de57baa279c1c125c43"
 PATCHES="gettext-$portVersion.patchset"
@@ -135,7 +135,7 @@ INSTALL()
 	if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
 		local libstdcpp="$portPackageLinksDir/gcc$secondaryArchSuffix"
 		sed -i \
-			-e "s,/packages/gcc$secondaryArchSuffix-[^\ /]*/\.self/\(develop/tools/$relativeLibDir/gcc/$effectiveTargetMachineTriple/[^\ /]*/libstdc++.la\),$libstdcpp/\1," \
+			-e "s,/packages/gcc$secondaryArchSuffix-[^\ /]*/\.self/\(develop/tools$secondaryArchSubDir/lib/gcc/$effectiveTargetMachineTriple/[^\ /]*/libstdc++.la\),$libstdcpp/\1," \
 			$developLibDir/libasprintf.la
 	fi
 


### PR DESCRIPTION
The search pattern used in the sed call to fix **`libasprintf.la`** did match and work fine on primary architectures, but failed on x86 secondary, resulting in a package that would become invalid if gcc_x86 got upgraded later. The correct search pattern to match e.g. **`develop/tools/x86/lib/gcc/`** is not **`develop/tools/$relativeLibDir/gcc/`** but **`develop/tools$secondaryArchSubDir/lib/gcc/`** and works for all architectures, including secondary, of course.