### PR TITLE
libmatroska: fix REQUIRES_devel, drop libtool file, add TEST().

### DIFF
--- a/media-libs/libmatroska/libmatroska-1.4.4.recipe
+++ b/media-libs/libmatroska/libmatroska-1.4.4.recipe
@@ -1,9 +1,9 @@
 SUMMARY="A library to parse Matroska files"
 DESCRIPTION="libmatroska is a C++ libary to parse Matroska files."
-HOMEPAGE="http://www.matroska.org/"
-COPYRIGHT="2005-2013 CoreCodec, Inc."
+HOMEPAGE="https://www.matroska.org/"
+COPYRIGHT="2003-2015 Matroska"
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://dl.matroska.org/downloads/libmatroska/libmatroska-$portVersion.tar.bz2"
 CHECKSUM_SHA256="d3efaa9f6d3964351a05bea0f848a8d5dc570e4791f179816ce9a93730296bd7"
 if [ $effectiveTargetArchitecture = x86_gcc2 ]; then
@@ -30,6 +30,7 @@ PROVIDES_devel="
 	"
 REQUIRES_devel="
 	libmatroska$secondaryArchSuffix == $portVersion base
+	devel:libebml$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
@@ -43,10 +44,11 @@ BUILD_PREREQUIRES="
 	cmd:aclocal
 	cmd:autoconf
 	cmd:automake
+	cmd:autoreconf
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:libtool
+	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
 	"
 
@@ -55,7 +57,6 @@ BUILD()
 	autoreconf -f -i
 	runConfigure ./configure
 	make $jobArgs
-
 }
 
 INSTALL()
@@ -64,6 +65,12 @@ INSTALL()
 
 	prepareInstalledDevelLibs libmatroska
 	fixPkgconfig
+	rm $developLibDir/libmatroska.la
 
 	packageEntries devel $developDir
+}
+
+TEST()
+{
+	make check
 }


### PR DESCRIPTION
* **`libmatroska.la`** has a path which will become invalid if libebml gets updated. Dropping that **`.la`** file is OK because we don't need it.
* Add **`devel:libebml`** to REQUIRES_devel.
* ~~Also add gcc to REQUIRES_devel on effective architectures other than x86_gcc2 to make sure it will have libstdc++.~~
* Add **`TEST()`** with **`make check`**.