### PR TITLE
libunistring, cleaned out layout according to the generic file, added…

### DIFF
--- a/dev-libs/libunistring/libunistring-0.9.6.recipe
+++ b/dev-libs/libunistring/libunistring-0.9.6.recipe
@@ -2,35 +2,44 @@ SUMMARY="A library for manipulating Unicode strings"
 DESCRIPTION="libunistring provides functions for manipulating Unicode strings and for \
 manipulating C strings according to the Unicode standard."
 HOMEPAGE="http://www.gnu.org/software/libunistring/"
-SOURCE_URI="http://ftp.gnu.org/gnu/libunistring/libunistring-$portVersion.tar.gz"
-LICENSE="GNU LGPL v2.1"
 COPYRIGHT="1998-2014 Free Software Fundation, Inc."
+LICENSE="GNU LGPL v2.1"
+REVISION="2"
+SOURCE_URI="http://ftpmirror.gnu.org/libunistring/libunistring-$portVersion.tar.gz"
 CHECKSUM_SHA256="9625eec2507f4789ebb6fc48ebda98be0e0168979a2f68aa8b680bf8eeabbd47"
-REVISION="1"
+PATCHES="libunistring-$portVersion.patchset"
+
 ARCHITECTURES="x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
-
-PATCHES="libunistring-$portVersion.patchset"
 
 PROVIDES="
 	libunistring$secondaryArchSuffix = $portVersion compat >= 0
 	lib:libunistring$secondaryArchSuffix = 2.0.0 compat >= 2
 	"
-
 REQUIRES="
 	haiku$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
 	"
 
-BUILD_REQUIRES=""
+PROVIDES_devel="
+	libunistring${secondaryArchSuffix}_devel = $portVersion
+	devel:libunistring$secondaryArchSuffix = 2.0.0 compat >= 0
+	"
+REQUIRES_devel="
+	libunistring$secondaryArchSuffix == $portVersion base
+	"
 
-BUILD_PREREQUIRES="
+BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	cmd:make
-	cmd:libtoolize
-	cmd:git
+	devel:libiconv$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
 	cmd:autoconf
 	cmd:gcc$secondaryArchSuffix
+	cmd:git
 	cmd:gperf
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
 	"
 
 BUILD()
@@ -48,12 +57,7 @@ INSTALL()
 		$developDir
 }
 
-# ----- Development package -----
-
-PROVIDES_devel="
-	libunistring${secondaryArchSuffix}_devel = $portVersion
-	devel:libunistring$secondaryArchSuffix = 2.0.0 compat >= 0
-	"
-REQUIRES_devel="
-	libunistring$secondaryArchSuffix == $portVersion base
-	"
+TEST()
+{
+	make check
+}


### PR DESCRIPTION
… support for iconv
In the generic_lib file for haikuporter there seems to be a double mention for "#haiku${secondaryArchSuffix}_devel" is that right? 