### PR TITLE
libx11: enable 2nd arch, drop libtool files.

### DIFF
--- a/x11-libs/libx11/libx11-1.6.3.recipe
+++ b/x11-libs/libx11/libx11-1.6.3.recipe
@@ -5,7 +5,7 @@ The development work is being done in conjunction with the freedesktop.org \
 community. \
 The X.Org Foundation is the educational non-profit corporation whose \
 Board serves this effort, and whose Members lead this work."
-HOMEPAGE="http://xorg.freedesktop.org/"
+HOMEPAGE="https://www.x.org/"
 # TODO: sort & merge
 COPYRIGHT="2003-2006,2008 Jamey Sharp, Josh Triplett
 	2009 Red Hat, Inc.
@@ -67,13 +67,13 @@ COPYRIGHT="2003-2006,2008 Jamey Sharp, Josh Triplett
 # TODO: check all the licenses in the COPYING file in the next century.
 LICENSE="MIT"
 REVISION="2"
-SOURCE_URI="http://xorg.freedesktop.org/releases/individual/lib/libX11-1.6.3.tar.gz"
+SOURCE_URI="https://www.x.org/releases/individual/lib/libX11-$portVersion.tar.gz"
 CHECKSUM_SHA256="0b03b9d22f4c9e59b4ba498f294e297f013cae27050dfa0f3496640200db5376"
 SOURCE_DIR="libX11-$portVersion"
+PATCHES="libx11-$portVersion.patchset"
 
-PATCHES="libx11-1.6.3.patchset"
-
-ARCHITECTURES="?x86 x86_gcc2 ?x86_64"
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
 # TODO: patch to detect libnetwork
 
@@ -95,11 +95,14 @@ PROVIDES_devel="
 	"
 REQUIRES_devel="
 	libx11$secondaryArchSuffix == $portVersion base
+	devel:libxcb$secondaryArchSuffix
+	devel:libxau$secondaryArchSuffix
 	"
-
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	lib:libxcb$secondaryArchSuffix
+	lib:libxau$secondaryArchSuffix
 	devel:util_macros$secondaryArchSuffix
 	devel:xproto$secondaryArchSuffix
 	devel:xtrans$secondaryArchSuffix
@@ -115,7 +118,7 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
-	cmd:libtoolize
+	cmd:libtoolize$secondaryArchSuffix
 	cmd:autoconf
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
@@ -135,13 +138,27 @@ INSTALL()
 {
 	make install
 
+	rm -f $libDir/lib*.la
+
 	prepareInstalledDevelLibs \
 		libX11 \
 		libX11-xcb
 
 	fixPkgconfig
 
+	if [ -n "$secondaryArchSuffix" ]; then
+		rm -rf $documentationDir
+		maybe_manDir_man3=
+	else
+		maybe_manDir_man3=$manDir/man3
+	fi
+
 	packageEntries devel \
-		$developDir
+		$developDir \
+		$maybe_manDir_man3
 }
 
+TEST()
+{
+	make check
+}


### PR DESCRIPTION
* Enable 2nd arch and drop documentation when building for them.
* Drop libtool library files since we don't need them.
* ~~Remove unneeded **`{lib,devel}:libxau`** from **`REQUIRES{,_devel}`**.~~
* Add **`devel:libxcb`** to REQUIRES_devel.
* Add **`$secondaryArchSuffix`** to **`cmd:libtoolize`** in BUILD_PREREQUIRES.
* Move section 3 man pages to the _devel sub-package.
* Add **`TEST()`** with **`make check`**. Testsuite summary: TOTAL = PASS = 1.
* HOMEPAGE: http://xorg.freedesktop.org/ moved to https://www.x.org/.
* ARCHITECTURES: Mark as tested on x86 and x86_64.