### PR TITLE
libxpm: enable 2nd arch, drop libXpm.la.

### DIFF
--- a/x11-libs/libxpm/libxpm-3.5.11.recipe
+++ b/x11-libs/libxpm/libxpm-3.5.11.recipe
@@ -5,27 +5,30 @@ The development work is being done in conjunction with the freedesktop.org \
 community. \
 The X.Org Foundation is the educational non-profit corporation whose \
 Board serves this effort, and whose Members lead this work."
-HOMEPAGE="http://xorg.freedesktop.org/"
+HOMEPAGE="https://www.x.org/"
 COPYRIGHT="1989-95 GROUPE BULL
 	1998 Arnaud LE HORS
-	1996 Lorens Younes
-	"
+	1996 Lorens Younes"
 # TODO: check all the licenses in the COPYING file in the next century.
 LICENSE="MIT"
-REVISION="2"
-SOURCE_URI="http://xorg.freedesktop.org/releases/individual/lib/libXpm-3.5.11.tar.gz"
+REVISION="3"
+SOURCE_URI="https://www.x.org/releases/individual/lib/libXpm-$portVersion.tar.gz"
 CHECKSUM_SHA256="53ddf924441b7ed2de994d4934358c13d9abf4828b1b16e1255ade5032b31df7"
 SOURCE_DIR="libXpm-$portVersion"
 
-#PATCHES="libx11-1.6.3.patchset"
-
-ARCHITECTURES="?x86 x86_gcc2 ?x86_64"
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
 PROVIDES="
 	libxpm$secondaryArchSuffix = $portVersion
 	lib:libxpm$secondaryArchSuffix = $portVersion
-	cmd:cxpm = $portVersion
 	"
+if [ -z "$secondaryArchSuffix" ]; then
+	PROVIDES="$PROVIDES
+		cmd:cxpm = $portVersion
+		"
+fi
+
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libx11$secondaryArchSuffix
@@ -39,6 +42,9 @@ PROVIDES_devel="
 	"
 REQUIRES_devel="
 	libxpm$secondaryArchSuffix == $portVersion base
+	devel:libx11$secondaryArchSuffix
+	devel:libxcb$secondaryArchSuffix
+	devel:libxau$secondaryArchSuffix
 	"
 
 # looks like all x11 deps are needed
@@ -60,9 +66,10 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
-	cmd:libtoolize
+	cmd:libtoolize$secondaryArchSuffix
 	cmd:automake
 	cmd:autoconf
+	cmd:autoreconf
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
 	"
@@ -79,12 +86,23 @@ INSTALL()
 {
 	make install
 
+	# remove libtool library file
+	rm $libDir/libXpm.la
+
 	prepareInstalledDevelLibs \
 		libXpm
 
 	fixPkgconfig
 
+	if [ -n "$secondaryArchSuffix" ]; then
+		rm -rf $binDir $documentationDir
+	fi
+
 	packageEntries devel \
 		$developDir
 }
 
+TEST()
+{
+	make check
+}


### PR DESCRIPTION
* Enable 2nd arch and drop documentation when building for them.
* Drop the libtool library file since we don't need it.
* ~~Remove unneeded **`lib:lib{xau,xcb}`** from REQUIRES.~~
* Add **`devel:lib{x11,xcb,x11}`** to REQUIRES_devel.
* Add **`$secondaryArchSuffix`** to **`cmd:libtoolize`** in BUILD_PREREQUIRES.
* HOMEPAGE: http://xorg.freedesktop.org/ moved to https://www.x.org/.
* ARCHITECTURES: Mark as tested on x86 and x86_64.