### PR TITLE
Add recipe for curlftpfs

### DIFF
--- a/net-fs/curlftpfs/additional-files/readme.txt
+++ b/net-fs/curlftpfs/additional-files/readme.txt
@@ -1,0 +1,16 @@
+CurlFtpFS needs a file system wrapper called UserlandFS which is available as an optional package on Haiku for most primary architectures from the corresponding Haiku repository. That package provides FUSE capability, which is needed by CurlFtpFS.
+
+If /system/servers/userlandfs_server is missing on your system then this means the userland_fs package is not installed. You can install that package using the HaikuDepot application or by typing the following command on a Terminal window:
+pkgman install userland_fs
+
+At the moment the integration of CurlFtpFS is either not finished or not fully tested.
+This means you might need to follow these steps to use it:
+
+First start the userland_fs server:
+	/system/servers/userlandfs_server curlftpfs &
+
+Then mount an ftp share:
+mount -t userlandfs -p 'curlftpfs -o option1,option2 \
+	ftp://someserver.somewhere/some/directory' /local/mount/directory
+
+curlftpfs has a manual page which lists all possible options, including support for SSLv3, TLSv1, proxies and many more.

--- a/net-fs/curlftpfs/curlftpfs-0.9.2.recipe
+++ b/net-fs/curlftpfs/curlftpfs-0.9.2.recipe
@@ -1,0 +1,83 @@
+SUMMARY="Filesystem for accessing FTP hosts"
+DESCRIPTION="A file system for accessing ftp hosts based on FUSE and \
+libcurl.
+As the FTP protocol is not very feature rich, this filesystem does not \
+fulfill every constraint of a real filesystem, but it should be usable \
+for simple tasks like copying and editing files.
+
+CurlFtpFS differentiates itself from other FTP filesystems because it \
+features:
+
+* SSLv3 and TLSv1 support
+* connecting through tunneling HTTP proxies
+* automatically reconnection if the server times out
+* transform absolute symlinks to point back into the ftp file system
+
+Instructions for using CurlFtpFS on Haiku are available in \
+/system/documentation/packages/curlftpfs/readme.txt."
+HOMEPAGE="http://curlftpfs.sourceforge.net/"
+COPYRIGHT="2006-2008 Robson Braga Araujo"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="http://downloads.sourceforge.net/curlftpfs/curlftpfs-$portVersion.tar.gz"
+CHECKSUM_SHA256="4eb44739c7078ba0edde177bdd266c4cfb7c621075f47f64c85a06b12b3c6958"
+PATCHES="curlftpfs-$portVersion.patchset"
+ADDITIONAL_FILES="readme.txt"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	curlftpfs = $portVersion
+	addon:curlftpfs
+	cmd:curlftpfs
+	"
+REQUIRES="
+	haiku
+	userland_fs
+	lib:libglib_2.0
+	lib:libcurl
+	lib:libintl
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	userland_fs
+	devel:libglib_2.0
+	devel:libcurl
+	devel:libintl
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoreconf
+	cmd:gcc
+	cmd:gettext
+	cmd:ld
+	cmd:libtoolize
+	cmd:make
+	cmd:pkg_config
+	"
+
+BUILD()
+{
+	autoreconf -i
+	export FUSE_CFLAGS="-D_FILE_OFFSET_BITS=64 -I/system/develop/headers/userlandfs/fuse -DB_USE_POSITIVE_POSIX_ERRORS"
+	export FUSE_LIBS="-L/system/lib -luserlandfs_fuse -lposix_error_mapper"
+	export ac_cv_func_malloc_0_nonnull=yes
+	export ac_cv_func_realloc_0_nonnull=yes
+	runConfigure ./configure
+	make
+}
+
+INSTALL()
+{
+	install -d -m 755 \
+		$addOnsDir/userlandfs \
+		$manDir/man1 \
+		$docDir
+	install -t $addOnsDir/userlandfs \
+		curlftpfs
+	install -t $manDir/man1 \
+		doc/curlftpfs.1
+	install -t $docDir \
+		$portDir/additional-files/readme.txt
+}

--- a/net-fs/curlftpfs/patches/curlftpfs-0.9.2.patchset
+++ b/net-fs/curlftpfs/patches/curlftpfs-0.9.2.patchset
@@ -1,0 +1,634 @@
+From a814296060607ab57faaec270d92a0de926319ac Mon Sep 17 00:00:00 2001
+From: Ed Robbins <edd.robbins@gmail.com>
+Date: Thu, 21 Jul 2016 18:24:37 +0000
+Subject: Use off_t instead of __off_t
+
+__off_t is an internal C library type, which shouldn't be used by
+applications. It doesn't work on haiku, so use off_t instead
+
+diff --git a/ftpfs.c b/ftpfs.c
+index 0346354..ac95c55 100644
+--- a/ftpfs.c
++++ b/ftpfs.c
+@@ -687,7 +687,7 @@ static int test_exists(const char* path)
+ 	return ftpfs_getattr(path, &sbuf);
+ }
+ 
+-static __off_t test_size(const char* path)
++static off_t test_size(const char* path)
+ {
+ 	struct stat sbuf;
+ 	int err = ftpfs_getattr(path, &sbuf);
+@@ -950,7 +950,7 @@ static int ftpfs_truncate(const char* path, off_t offset) {
+ 
+   /* fix openoffice problem, truncating exactly to file length */
+   
+-  __off_t size = (long long int)test_size(path); 
++  off_t size = (long long int)test_size(path); 
+   DEBUG(1, "ftpfs_truncate: %s check filesize=%lld\n", path, (long long int)size);
+   
+   if (offset == size)  
+@@ -978,7 +978,7 @@ static int ftpfs_ftruncate(const char * path , off_t offset, struct fuse_file_in
+   }
+   /* fix openoffice problem, truncating exactly to file length */
+   
+-  __off_t size = test_size(path); 
++  off_t size = test_size(path); 
+   DEBUG(1, "ftpfs_ftruncate: %s check filesize=%lld\n", path, (long long int)size);
+   
+   if (offset == size)  
+-- 
+2.7.0
+
+
+From f8df824306a9bbc1bd71024ef71ce43a8cfeb3d3 Mon Sep 17 00:00:00 2001
+From: Ed Robbins <edd.robbins@gmail.com>
+Date: Thu, 21 Jul 2016 18:58:55 +0000
+Subject: Search libbsd for getpass
+
+
+diff --git a/configure.ac b/configure.ac
+index c0373f3..0c58258 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -53,6 +53,7 @@ AC_FUNC_SELECT_ARGTYPES
+ AC_FUNC_STRFTIME
+ AC_FUNC_UTIME_NULL
+ AC_CHECK_FUNCS([ftruncate getpass memmove memset mkdir realpath rmdir select strchr strdup strrchr strstr strtoull utime])
++AC_SEARCH_LIBS([getpass],[bsd],[HAVE_GETPASS=1],,)
+ 
+ # Check for iconv
+ AM_ICONV
+-- 
+2.7.0
+
+
+From b67fc9332e89d08630a7b79e0d8e7979d74ec8e5 Mon Sep 17 00:00:00 2001
+From: Ed Robbins <edd.robbins@gmail.com>
+Date: Thu, 21 Jul 2016 20:31:06 +0000
+Subject: C89 compatibility: move declarations to beginning of scope
+
+
+diff --git a/ftpfs-ls.c b/ftpfs-ls.c
+index 15f83a2..ce3f006 100644
+--- a/ftpfs-ls.c
++++ b/ftpfs-ls.c
+@@ -41,6 +41,8 @@ static int parse_dir_unix(const char *line,
+   struct tm tm;
+   time_t tt;
+   int res;
++  char *link_marker; 
++  int i;
+ 
+   memset(file, 0, sizeof(char)*1024);
+   memset(&tm, 0, sizeof(tm));
+@@ -75,13 +77,13 @@ static int parse_dir_unix(const char *line,
+   }
+ #undef SPACES
+ 
+-  char *link_marker = strstr(file, " -> ");
++  link_marker = strstr(file, " -> ");
+   if (link_marker) {
+     strcpy(link, link_marker + 4);
+     *link_marker = '\0';
+   }
+ 
+-  int i = 0;
++  i = 0;
+   if (mode[i] == 'd') {
+     sbuf->st_mode |= S_IFDIR;
+   } else if (mode[i] == 'l') {
+@@ -213,6 +215,7 @@ int parse_dir(const char* list, const char* dir,
+ 
+   while ((end = strchr(start, '\n')) != NULL) {
+     char* line;
++    int res;
+ 
+     memset(&stat_buf, 0, sizeof(stat_buf));
+ 
+@@ -228,7 +231,7 @@ int parse_dir(const char* list, const char* dir,
+     }
+ 
+     file[0] = link[0] = '\0';
+-    int res = parse_dir_unix(line, &stat_buf, file, link) ||
++    res = parse_dir_unix(line, &stat_buf, file, link) ||
+               parse_dir_win(line, &stat_buf, file, link) ||
+               parse_dir_netware(line, &stat_buf, file, link);
+ 
+@@ -237,12 +240,13 @@ int parse_dir(const char* list, const char* dir,
+ 
+       if (link[0]) {
+         char *reallink;
++        int linksize;
+         if (link[0] == '/' && ftpfs.symlink_prefix_len) {
+           reallink = g_strdup_printf("%s%s", ftpfs.symlink_prefix, link);
+         } else {
+           reallink = g_strdup(link);
+         }
+-        int linksize = strlen(reallink);
++        linksize = strlen(reallink);
+         cache_add_link(full_path, reallink, linksize+1);
+         DEBUG(1, "cache_add_link: %s %s\n", full_path, reallink);
+         if (linkbuf && linklen) {
+diff --git a/ftpfs.c b/ftpfs.c
+index ac95c55..f2f1015 100644
+--- a/ftpfs.c
++++ b/ftpfs.c
+@@ -191,13 +191,14 @@ static struct ftpfs_file *get_ftpfs_file(struct fuse_file_info *fi)
+ 
+ static void cancel_previous_multi()
+ {
++  CURLMcode curlMCode;
+   //curl_multi_cleanup(ftpfs.multi);
+   
+   if (!ftpfs.attached_to_multi) return;
+   
+   DEBUG(1, "cancel previous multi\n");
+   
+-  CURLMcode curlMCode = curl_multi_remove_handle(ftpfs.multi, ftpfs.connection);
++  curlMCode = curl_multi_remove_handle(ftpfs.multi, ftpfs.connection);
+   if (curlMCode != CURLE_OK)
+   {
+       fprintf(stderr, "curl_multi_remove_handle problem: %d\n", curlMCode);
+@@ -220,8 +221,9 @@ static int op_return(int err, char * operation)
+ 
+ static size_t write_data(void *ptr, size_t size, size_t nmemb, void *data) {
+   struct ftpfs_file* fh = (struct ftpfs_file*)data;
++  size_t to_copy;
+   if (fh == NULL) return 0;
+-  size_t to_copy = size * nmemb;
++  to_copy = size * nmemb;
+   if (to_copy > fh->buf.len - fh->copied) {
+     to_copy = fh->buf.len - fh->copied;
+   }
+@@ -256,10 +258,10 @@ static int ftpfs_getdir(const char* path, fuse_cache_dirh_t h,
+                         fuse_cache_dirfil_t filler) {
+   int err = 0;
+   CURLcode curl_res;
++  struct buffer buf;
+   char* dir_path = get_fulldir_path(path);
+ 
+   DEBUG(1, "ftpfs_getdir: %s\n", dir_path);
+-  struct buffer buf;
+   buf_init(&buf);
+ 
+   pthread_mutex_lock(&ftpfs.lock);
+@@ -287,9 +289,10 @@ static int ftpfs_getattr(const char* path, struct stat* sbuf) {
+   int err;
+   CURLcode curl_res;
+   char* dir_path = get_dir_path(path);
++  struct buffer buf;
++  char* name;
+ 
+   DEBUG(2, "ftpfs_getattr: %s dir_path=%s\n", path, dir_path);
+-  struct buffer buf;
+   buf_init(&buf);
+ 
+   pthread_mutex_lock(&ftpfs.lock);
+@@ -304,7 +307,7 @@ static int ftpfs_getattr(const char* path, struct stat* sbuf) {
+   }
+   buf_null_terminate(&buf);
+ 
+-  char* name = strrchr(path, '/');
++  name = strrchr(path, '/');
+   ++name;
+   err = parse_dir((char*)buf.p, dir_path + strlen(ftpfs.host) - 1,
+                   name, sbuf, NULL, 0, NULL, NULL); 
+@@ -329,6 +332,7 @@ static size_t ftpfs_read_chunk(const char* full_path, char* rbuf,
+   int running_handles = 0;
+   int err = 0;
+   struct ftpfs_file* fh = get_ftpfs_file(fi);
++  size_t to_copy;
+ 
+   DEBUG(2, "ftpfs_read_chunk: %s %p %zu %lld %p %p\n",
+         full_path, rbuf, size, offset, fi, fh);
+@@ -345,6 +349,7 @@ static size_t ftpfs_read_chunk(const char* full_path, char* rbuf,
+         offset < fh->buf.begin_offset ||
+         offset > fh->buf.begin_offset + fh->buf.len ||
+         !check_running()) {
++      CURLMcode curlMCode;
+       DEBUG(1, "We need to restart the connection %p\n", ftpfs.connection);
+       DEBUG(2, "current_fh=%p fh=%p\n", ftpfs.current_fh, fh);
+       DEBUG(2, "buf.begin_offset=%lld offset=%lld\n", fh->buf.begin_offset, offset);
+@@ -363,7 +368,7 @@ static size_t ftpfs_read_chunk(const char* full_path, char* rbuf,
+         curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_RANGE, range);
+       }
+       
+-      CURLMcode curlMCode =  curl_multi_add_handle(ftpfs.multi, ftpfs.connection);
++      curlMCode =  curl_multi_add_handle(ftpfs.multi, ftpfs.connection);
+       if (curlMCode != CURLE_OK)
+       {
+           fprintf(stderr, "curl_multi_add_handle problem: %d\n", curlMCode);
+@@ -421,7 +426,7 @@ static size_t ftpfs_read_chunk(const char* full_path, char* rbuf,
+     }
+   }
+ 
+-  size_t to_copy = fh->buf.len + fh->buf.begin_offset - offset;
++  to_copy = fh->buf.len + fh->buf.begin_offset - offset;
+   size = size > to_copy ? to_copy : size;
+   if (rbuf) {
+     memcpy(rbuf, fh->buf.p + offset - fh->buf.begin_offset, size);
+@@ -497,7 +502,8 @@ int write_thread_ctr = 0;
+ static void *ftpfs_write_thread(void *data) {
+   struct ftpfs_file *fh = data;
+   char range[15];
+-  
++  CURLcode curl_res;
++
+   DEBUG(2, "enter streaming write thread #%d path=%s pos=%lld\n", ++write_thread_ctr, fh->full_path, fh->pos);
+   
+   
+@@ -522,7 +528,7 @@ static void *ftpfs_write_thread(void *data) {
+ 	//curl_easy_setopt_or_die(fh->write_conn, CURLOPT_RESUME_FROM_LARGE, (curl_off_t)fh->pos);
+   }   
+   
+-  CURLcode curl_res = curl_easy_perform(fh->write_conn);
++  curl_res = curl_easy_perform(fh->write_conn);
+   
+   curl_easy_setopt_or_die(fh->write_conn, CURLOPT_UPLOAD, 0);
+ 
+@@ -622,11 +628,12 @@ static int buffer_file(struct ftpfs_file *fh) {
+   // If we want to write to the file, we have to load it all at once,
+   // modify it in memory and then upload it as a whole as most FTP servers
+   // don't support resume for uploads.
++  CURLcode curl_res;
+   pthread_mutex_lock(&ftpfs.lock);
+   cancel_previous_multi();
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_URL, fh->full_path);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_WRITEDATA, &fh->buf);
+-  CURLcode curl_res = curl_easy_perform(ftpfs.connection);
++  curl_res = curl_easy_perform(ftpfs.connection);
+   pthread_mutex_unlock(&ftpfs.lock);
+ 
+   if (curl_res != 0) {
+@@ -641,6 +648,7 @@ static int create_empty_file(const char * path)
+   int err = 0;
+ 
+   char *full_path = get_full_path(path);
++  CURLcode curl_res;
+ 
+   pthread_mutex_lock(&ftpfs.lock);
+   cancel_previous_multi();
+@@ -648,7 +656,7 @@ static int create_empty_file(const char * path)
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_INFILESIZE, 0);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_UPLOAD, 1);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_READDATA, NULL);
+-  CURLcode curl_res = curl_easy_perform(ftpfs.connection);
++  curl_res = curl_easy_perform(ftpfs.connection);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_UPLOAD, 0);
+   pthread_mutex_unlock(&ftpfs.lock);
+ 
+@@ -700,10 +708,11 @@ static int ftpfs_open_common(const char* path, mode_t mode,
+                              struct fuse_file_info* fi) {
+ 	
+   char * flagsAsStr = flags_to_string(fi->flags);
+-  DEBUG(2, "ftpfs_open_common: %s\n", flagsAsStr);
++  struct ftpfs_file* fh;
+   int err = 0;
++  DEBUG(2, "ftpfs_open_common: %s\n", flagsAsStr);
+ 
+-  struct ftpfs_file* fh =
++  fh =
+     (struct ftpfs_file*) malloc(sizeof(struct ftpfs_file));
+ 
+   memset(fh, 0, sizeof(*fh));
+@@ -730,10 +739,11 @@ static int ftpfs_open_common(const char* path, mode_t mode,
+     if (fi->flags & O_CREAT) {
+       err = ftpfs_mknod(path, (mode & 07777) | S_IFREG, 0);
+     } else {
++      size_t size;
+       // If it's read-only, we can load the file a bit at a time, as necessary.
+       DEBUG(1, "opening %s O_RDONLY\n", path);
+       fh->can_shrink = 1;
+-      size_t size = ftpfs_read_chunk(fh->full_path, NULL, 1, 0, fi, 0);
++      size = ftpfs_read_chunk(fh->full_path, NULL, 1, 0, fi, 0);
+ 
+       if (size == CURLFTPFS_BAD_READ) {
+         DEBUG(1, "initial read failed size=%d\n", size);
+@@ -761,8 +771,9 @@ static int ftpfs_open_common(const char* path, mode_t mode,
+ 	  
+ 	  if ((fi->flags & O_EXCL))
+ 	  {
+-		DEBUG(1, "opening %s with O_EXCL - testing existence\n", path);
+-		int exists_r = test_exists(path);
++		int exists_r;
++                DEBUG(1, "opening %s with O_EXCL - testing existence\n", path);
++		exists_r = test_exists(path);
+ 		if (exists_r != -ENOENT)
+ 			err = -EACCES;
+ 	  }
+@@ -824,7 +835,9 @@ static int ftpfs_read(const char* path, char* rbuf, size_t size, off_t offset,
+                       struct fuse_file_info* fi) {
+   int ret;
+   struct ftpfs_file *fh = get_ftpfs_file(fi);
+-  
++  char *full_path;
++  size_t size_read;
++
+   DEBUG(1, "ftpfs_read: %s size=%zu offset=%lld has_write_conn=%d pos=%lld\n", path, size, (long long) offset, fh->write_conn!=0, fh->pos);
+   
+   if (fh->pos>0 || fh->write_conn!=NULL)
+@@ -833,8 +846,8 @@ static int ftpfs_read(const char* path, char* rbuf, size_t size, off_t offset,
+ 	  return op_return(-EIO, "ftpfs_read");
+   }
+   
+-  char *full_path = get_full_path(path);
+-  size_t size_read = ftpfs_read_chunk(full_path, rbuf, size, offset, fi, 1);
++  full_path = get_full_path(path);
++  size_read = ftpfs_read_chunk(full_path, rbuf, size, offset, fi, 1);
+   free(full_path);
+   if (size_read == CURLFTPFS_BAD_READ) {
+     ret = -EIO;
+@@ -847,9 +860,9 @@ static int ftpfs_read(const char* path, char* rbuf, size_t size, off_t offset,
+ }
+ 
+ static int ftpfs_mknod(const char* path, mode_t mode, dev_t rdev) {
++  int err = 0;
+   (void) rdev;
+ 
+-  int err = 0;
+ 
+   DEBUG(1, "ftpfs_mknode: mode=%d\n", (int)mode);
+   
+@@ -876,6 +889,7 @@ static int ftpfs_chmod(const char* path, mode_t mode) {
+   char* filename = get_file_name(path);
+   char* cmd = g_strdup_printf("SITE CHMOD %.3o %s", mode_c, filename);
+   struct buffer buf;
++  CURLcode curl_res;
+   buf_init(&buf);
+ 
+   header = curl_slist_append(header, cmd);
+@@ -886,7 +900,7 @@ static int ftpfs_chmod(const char* path, mode_t mode) {
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_URL, full_path);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_WRITEDATA, &buf);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_NOBODY, ftpfs.safe_nobody);
+-  CURLcode curl_res = curl_easy_perform(ftpfs.connection);
++  curl_res = curl_easy_perform(ftpfs.connection);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_POSTQUOTE, NULL);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_NOBODY, 0);
+   pthread_mutex_unlock(&ftpfs.lock);
+@@ -906,8 +920,7 @@ static int ftpfs_chmod(const char* path, mode_t mode) {
+ static int ftpfs_chown(const char* path, uid_t uid, gid_t gid) {
+   int err = 0;
+   
+-  DEBUG(1, "ftpfs_chown: %d %d\n", (int)uid, (int)gid);
+-  
++  CURLcode curl_res;
+   struct curl_slist* header = NULL;
+   char* full_path = get_dir_path(path);
+   char* filename = get_file_name(path);
+@@ -915,6 +928,7 @@ static int ftpfs_chown(const char* path, uid_t uid, gid_t gid) {
+   char* cmd2 = g_strdup_printf("SITE CHGID %i %s", gid, filename);
+   struct buffer buf;
+   buf_init(&buf);
++  DEBUG(1, "ftpfs_chown: %d %d\n", (int)uid, (int)gid);
+ 
+   header = curl_slist_append(header, cmd);
+   header = curl_slist_append(header, cmd2);
+@@ -925,7 +939,7 @@ static int ftpfs_chown(const char* path, uid_t uid, gid_t gid) {
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_URL, full_path);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_WRITEDATA, &buf);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_NOBODY, ftpfs.safe_nobody);
+-  CURLcode curl_res = curl_easy_perform(ftpfs.connection);
++  curl_res = curl_easy_perform(ftpfs.connection);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_POSTQUOTE, NULL);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_NOBODY, 0);
+   pthread_mutex_unlock(&ftpfs.lock);
+@@ -944,13 +958,14 @@ static int ftpfs_chown(const char* path, uid_t uid, gid_t gid) {
+ }
+ 
+ static int ftpfs_truncate(const char* path, off_t offset) {
++  off_t size;
+   DEBUG(1, "ftpfs_truncate: %s len=%lld\n", path, offset);
+   /* we can't use ftpfs_mknod here, because we don't know the right permissions */
+   if (offset == 0) return op_return(create_empty_file(path), "ftpfs_truncate");
+ 
+   /* fix openoffice problem, truncating exactly to file length */
+   
+-  off_t size = (long long int)test_size(path); 
++  size = (long long int)test_size(path); 
+   DEBUG(1, "ftpfs_truncate: %s check filesize=%lld\n", path, (long long int)size);
+   
+   if (offset == size)  
+@@ -964,8 +979,10 @@ static int ftpfs_truncate(const char* path, off_t offset) {
+ 
+ static int ftpfs_ftruncate(const char * path , off_t offset, struct fuse_file_info * fi)
+ {
++  struct ftpfs_file *fh;
++  off_t size;
+   DEBUG(1, "ftpfs_ftruncate: %s len=%lld\n", path, offset);
+-  struct ftpfs_file *fh = get_ftpfs_file(fi);
++  fh = get_ftpfs_file(fi);
+ 
+   if (offset == 0) 
+   {
+@@ -978,7 +995,7 @@ static int ftpfs_ftruncate(const char * path , off_t offset, struct fuse_file_in
+   }
+   /* fix openoffice problem, truncating exactly to file length */
+   
+-  off_t size = test_size(path); 
++  size = test_size(path); 
+   DEBUG(1, "ftpfs_ftruncate: %s check filesize=%lld\n", path, (long long int)size);
+   
+   if (offset == size)  
+@@ -1001,6 +1018,7 @@ static int ftpfs_rmdir(const char* path) {
+   char* full_path = get_dir_path(path);
+   char* filename = get_file_name(path);
+   char* cmd = g_strdup_printf("RMD %s", filename);
++  CURLcode curl_res;
+   struct buffer buf;
+   buf_init(&buf);
+ 
+@@ -1015,7 +1033,7 @@ static int ftpfs_rmdir(const char* path) {
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_URL, full_path);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_WRITEDATA, &buf);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_NOBODY, ftpfs.safe_nobody);
+-  CURLcode curl_res = curl_easy_perform(ftpfs.connection);
++  curl_res = curl_easy_perform(ftpfs.connection);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_POSTQUOTE, NULL);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_NOBODY, 0);
+   pthread_mutex_unlock(&ftpfs.lock);
+@@ -1038,6 +1056,7 @@ static int ftpfs_mkdir(const char* path, mode_t mode) {
+   char* full_path = get_dir_path(path);
+   char* filename = get_file_name(path);
+   char* cmd = g_strdup_printf("MKD %s", filename);
++  CURLcode curl_res;
+   struct buffer buf;
+   buf_init(&buf);
+ 
+@@ -1049,7 +1068,7 @@ static int ftpfs_mkdir(const char* path, mode_t mode) {
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_URL, full_path);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_WRITEDATA, &buf);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_NOBODY, ftpfs.safe_nobody);
+-  CURLcode curl_res = curl_easy_perform(ftpfs.connection);
++  curl_res = curl_easy_perform(ftpfs.connection);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_POSTQUOTE, NULL);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_NOBODY, 0);
+   pthread_mutex_unlock(&ftpfs.lock);
+@@ -1076,6 +1095,7 @@ static int ftpfs_unlink(const char* path) {
+   char* full_path = get_dir_path(path);
+   char* filename = get_file_name(path);
+   char* cmd = g_strdup_printf("DELE %s", filename);
++  CURLcode curl_res;
+   struct buffer buf;
+   buf_init(&buf);
+ 
+@@ -1087,7 +1107,7 @@ static int ftpfs_unlink(const char* path) {
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_URL, full_path);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_WRITEDATA, &buf);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_NOBODY, ftpfs.safe_nobody);
+-  CURLcode curl_res = curl_easy_perform(ftpfs.connection);
++  curl_res = curl_easy_perform(ftpfs.connection);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_POSTQUOTE, NULL);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_NOBODY, 0);
+   pthread_mutex_unlock(&ftpfs.lock);
+@@ -1106,8 +1126,8 @@ static int ftpfs_unlink(const char* path) {
+ 
+ static int ftpfs_write(const char *path, const char *wbuf, size_t size,
+                        off_t offset, struct fuse_file_info *fi) {
+-  (void) path;
+   struct ftpfs_file *fh = get_ftpfs_file(fi);
++  (void) path;
+ 
+   DEBUG(1, "ftpfs_write: %s size=%zu offset=%lld has_write_conn=%d pos=%lld\n", path, size, (long long) offset, fh->write_conn!=0, fh->pos);
+ 
+@@ -1119,6 +1139,7 @@ static int ftpfs_write(const char *path, const char *wbuf, size_t size,
+   
+   if (!fh->write_conn && fh->pos == 0 && offset == 0)
+   {
++    int success;
+     DEBUG(1, "ftpfs_write: starting a streaming write at pos=%lld\n", fh->pos);
+     
+     /* check if the file has been truncated to zero or has been newly created */
+@@ -1132,7 +1153,7 @@ static int ftpfs_write(const char *path, const char *wbuf, size_t size,
+     	}
+     }
+     
+-	int success = start_write_thread(fh);
++    success = start_write_thread(fh);
+     if (!success)
+     {
+       return op_return(-EIO, "ftpfs_write");
+@@ -1143,10 +1164,11 @@ static int ftpfs_write(const char *path, const char *wbuf, size_t size,
+   
+   if (!fh->write_conn && fh->pos >0 && offset == fh->pos)
+   {
++    int success;
+     /* resume a streaming write */
+     DEBUG(1, "ftpfs_write: resuming a streaming write at pos=%lld\n", fh->pos);
+ 	  
+-    int success = start_write_thread(fh);
++    success = start_write_thread(fh);
+     if (!success)
+     {
+       return op_return(-EIO, "ftpfs_write");
+@@ -1199,11 +1221,10 @@ static int ftpfs_flush(const char *path, struct fuse_file_info *fi) {
+   DEBUG(1, "ftpfs_flush: buf.len=%zu buf.pos=%lld write_conn=%d\n", fh->buf.len, fh->pos, fh->write_conn!=0);
+   
+   if (fh->write_conn) {
++    struct stat sbuf;
+     err = finish_write_thread(fh);
+     if (err) return op_return(err, "ftpfs_flush");
+     
+-    struct stat sbuf;
+-    
+     /* check if the resulting file has the correct size
+      this is important, because we use APPE for continuing
+      writing after a premature flush */
+@@ -1235,9 +1256,9 @@ static int ftpfs_fsync(const char *path, int isdatasync,
+ }
+ 
+ static int ftpfs_release(const char* path, struct fuse_file_info* fi) {
+-
++  struct ftpfs_file* fh;
+   DEBUG(1, "ftpfs_release %s\n", path);
+-  struct ftpfs_file* fh = get_ftpfs_file(fi);
++  fh = get_ftpfs_file(fi);
+   ftpfs_flush(path, fi);
+   pthread_mutex_lock(&ftpfs.lock);
+   if (ftpfs.current_fh == fh) {
+@@ -1256,13 +1277,14 @@ static int ftpfs_release(const char* path, struct fuse_file_info* fi) {
+ 
+ 
+ static int ftpfs_rename(const char* from, const char* to) {
+-  DEBUG(1, "ftpfs_rename from %s to %s\n", from, to);
+   int err = 0;
+   char* rnfr = g_strdup_printf("RNFR %s", from + 1);
+   char* rnto = g_strdup_printf("RNTO %s", to + 1);
++  CURLcode curl_res;
+   struct buffer buf;
+-  buf_init(&buf);
+   struct curl_slist* header = NULL;
++  buf_init(&buf);
++  DEBUG(1, "ftpfs_rename from %s to %s\n", from, to);
+ 
+   if (ftpfs.codepage) {
+     convert_charsets(ftpfs.iocharset, ftpfs.codepage, &rnfr);
+@@ -1278,7 +1300,7 @@ static int ftpfs_rename(const char* from, const char* to) {
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_URL, ftpfs.host);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_WRITEDATA, &buf);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_NOBODY, ftpfs.safe_nobody);
+-  CURLcode curl_res = curl_easy_perform(ftpfs.connection);
++  curl_res = curl_easy_perform(ftpfs.connection);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_POSTQUOTE, NULL);
+   curl_easy_setopt_or_die(ftpfs.connection, CURLOPT_NOBODY, 0);
+   pthread_mutex_unlock(&ftpfs.lock);
+@@ -1299,9 +1321,10 @@ static int ftpfs_readlink(const char *path, char *linkbuf, size_t size) {
+   int err;
+   CURLcode curl_res;
+   char* dir_path = get_dir_path(path);
++  struct buffer buf;
++  char* name;
+ 
+   DEBUG(2, "dir_path: %s %s\n", path, dir_path);
+-  struct buffer buf;
+   buf_init(&buf);
+ 
+   pthread_mutex_lock(&ftpfs.lock);
+@@ -1316,7 +1339,7 @@ static int ftpfs_readlink(const char *path, char *linkbuf, size_t size) {
+   }
+   buf_null_terminate(&buf);
+ 
+-  char* name = strrchr(path, '/');
++  name = strrchr(path, '/');
+   ++name;
+   err = parse_dir((char*)buf.p, dir_path + strlen(ftpfs.host) - 1,
+                   name, NULL, linkbuf, size, NULL, NULL); 
+@@ -1578,6 +1601,8 @@ static void set_common_curl_stuff(CURL* easy) {
+    * with version 7.15.4 */
+   if (ftpfs.use_ssl > CURLFTPSSL_TRY &&
+       ftpfs.curl_version->version_num <= CURLFTPFS_BAD_SSL) {
++    int i;
++    const int time_to_wait = 10;
+     fprintf(stderr,
+ "WARNING: you are using libcurl %s.\n"
+ "This version of libcurl does not respect the mandatory SSL flag.\n" 
+@@ -1585,8 +1610,6 @@ static void set_common_curl_stuff(CURL* easy) {
+ "SSL. Please upgrade to libcurl version 7.15.4 or higher.\n"
+ "You can abort the connection now by pressing ctrl+c.\n",
+             ftpfs.curl_version->version);
+-    int i;
+-    const int time_to_wait = 10;
+     for (i = 0; i < time_to_wait; i++) {
+       fprintf(stderr, "%d.. ", time_to_wait - i);
+       sleep(1);
+diff --git a/path_utils.c b/path_utils.c
+index db3d7e4..de39f3d 100644
+--- a/path_utils.c
++++ b/path_utils.c
+@@ -16,10 +16,11 @@
+ 
+ char* get_file_name(const char* path) {
+   const char* filename = strrchr(path, '/');
++  char* ret;
+   if (filename == NULL) filename = path;
+   else ++filename;
+ 
+-  char* ret = strdup(filename);
++  ret = strdup(filename);
+   if (ftpfs.codepage) {
+     convert_charsets(ftpfs.iocharset, ftpfs.codepage, &ret);
+   }
+-- 
+2.7.0
+


### PR DESCRIPTION
Recipe and patch attached. This goes in net-fs/curlftpfs

I know there are some small scale issues with the way dependencies are listed, but I don't have more time for this now so I wanted to get it submitted before it rots (it does work).

[curlftpfs-0.9.2.recipe.txt](https://github.com/haikuports/haikuports/files/384841/curlftpfs-0.9.2.recipe.txt)
[curlftpfs-0.9.2.patchset.txt](https://github.com/haikuports/haikuports/files/384840/curlftpfs-0.9.2.patchset.txt)



