### PR TITLE
rocksndiamonds new recipe for 4.0.0.1

### DIFF
--- a/games-arcade/rocksndiamonds/rocksndiamonds-4.0.0.1.recipe
+++ b/games-arcade/rocksndiamonds/rocksndiamonds-4.0.0.1.recipe
@@ -1,0 +1,75 @@
+SUMMARY="Arcade style game in the style of Boulder Dash"
+DESCRIPTION="
+- network multiplayer games (upto 4 players)
+- local multiplayer games (upto 4 players)
+- soft scrolling with 50 frames per second
+- freely customizable keyboard and joystick support
+- stereo sound effects and music
+- music modules and fullscreen in SDL version
+- contains levels to play Boulder Dash, Emerald Mine and Sokoban
+- lots of additional levels available (over 10.000)"
+HOMEPAGE="http://www.artsoft.org/rocksndiamonds/"
+COPYRIGHT="2001-2017 Artsoft Entertainment"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="http://www.artsoft.org/RELEASES/unix/rocksndiamonds/rocksndiamonds-$portVersion.tar.gz"
+CHECKSUM_SHA256="8649a450419d9cee2ffd9463cae65e7ebcbbf48c2cc945a85d91bbcdd9be3249"
+ADDITIONAL_FILES="rocksndiamonds.rdef.in"
+
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	rocksndiamonds$secondaryArchSuffix = $portVersion
+	app:rocksndiamonds = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libsdl$secondaryArchSuffix
+	lib:libsdl_image$secondaryArchSuffix
+	lib:libsdl_mixer$secondaryArchSuffix
+	lib:libsdl_net_1.2$secondaryArchSuffix
+	lib:libsmpeg$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libsdl$secondaryArchSuffix
+	devel:libsdl_image$secondaryArchSuffix
+	devel:libsdl_mixer$secondaryArchSuffix
+	devel:libsdl_net$secondaryArchSuffix
+	devel:libsmpeg$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	"
+
+BUILD()
+{
+	make sdl RW_GAME_DIR=$settingsDir/rocksndiamonds
+}
+
+INSTALL()
+{
+	destdir=$appsDir/"Rocks'n'Diamonds"
+	mkdir -p $destdir
+	cp -r rocksndiamonds sounds graphics levels music $destdir
+
+	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
+	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
+	local MINOR="`echo "$portVersion" | cut -d. -f3`"
+	local INTERNAL="`echo "$portVersion" | cut -d. -f4`"
+	sed \
+		-e "s|@MAJOR@|$MAJOR|" \
+		-e "s|@MIDDLE@|$MIDDLE|" \
+		-e "s|@MINOR@|$MINOR|" \
+		-e "s|@INTERNAL@|$INTERNAL|" \
+		$portDir/additional-files/rocksndiamonds.rdef.in > rocksndiamonds.rdef
+
+	addResourcesToBinaries rocksndiamonds.rdef \
+		$destdir/rocksndiamonds
+
+	addAppDeskbarSymlink $destdir/rocksndiamonds "Rocks'n'Diamonds"
+}


### PR DESCRIPTION
didn't include the patch from previous version as they changed the source up to a point where I can't find the changes from the previous patchset, all config files are stored/created in ~/home/.rocksndiamonds 
