### PR TITLE
fontconfig: bump to 2.12.1, reorder sections, sync patch.

### DIFF
--- a/media-libs/fontconfig/fontconfig-2.12.1.recipe
+++ b/media-libs/fontconfig/fontconfig-2.12.1.recipe
@@ -1,19 +1,17 @@
 SUMMARY="A library for font customization and configuration"
-DESCRIPTION="
-Fontconfig is a library for font customization and configuration.
-"
-HOMEPAGE="http://www.freedesktop.org/wiki/Software/fontconfig"
-SOURCE_URI="http://www.freedesktop.org/software/fontconfig/release/fontconfig-$portVersion.tar.bz2"
-CHECKSUM_SHA256="b433e4efff1f68fdd8aac221ed1df3ff1e580ffedbada020a703fe64017d8224"
-LICENSE="MIT"
+DESCRIPTION="Fontconfig is a library for font customization and configuration."
+HOMEPAGE="https://www.freedesktop.org/wiki/Software/fontconfig"
 COPYRIGHT="2000-2005, 2006-2007 Keith Packard
 	2005 Patrick Lam
 	2009 Roozbeh Pournader
 	2008-2009 Red Hat, Inc.
 	2008 Danilo Segan
-	2012 Google, Inc.
-	"
+	2012 Google, Inc."
+LICENSE="MIT"
 REVISION="1"
+SOURCE_URI="https://www.freedesktop.org/software/fontconfig/release/fontconfig-$portVersion.tar.bz2"
+CHECKSUM_SHA256="b449a3e10c47e1d1c7a6ec6e2016cca73d3bd68fbbd4f0ae5cc6b573f7d6c7f3"
+PATCHES="fontconfig-$portVersion.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
@@ -28,9 +26,8 @@ PROVIDES="
 	cmd:fc_query$secondaryArchSuffix
 	cmd:fc_scan$secondaryArchSuffix
 	cmd:fc_validate$secondaryArchSuffix
-	lib:libfontconfig$secondaryArchSuffix = 1.9.1 compat >= 1
+	lib:libfontconfig$secondaryArchSuffix = 1.9.2 compat >= 1
 	"
-
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libfreetype$secondaryArchSuffix
@@ -40,29 +37,36 @@ REQUIRES="
 	lib:libbz2$secondaryArchSuffix
 	"
 
+PROVIDES_devel="
+	fontconfig${secondaryArchSuffix}_devel = $portVersion compat >= 2.1
+	devel:libfontconfig$secondaryArchSuffix = 1.9.2 compat >= 1
+	"
+REQUIRES_devel="
+	fontconfig$secondaryArchSuffix == $portVersion base
+	devel:libfreetype$secondaryArchSuffix
+	devel:libxml2$secondaryArchSuffix
+	"
+
 BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
 	devel:libfreetype$secondaryArchSuffix
 	devel:libxml2$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	devel:libpng$secondaryArchSuffix
 	devel:libbz2$secondaryArchSuffix
 	"
-
 BUILD_PREREQUIRES="
-	haiku${secondaryArchSuffix}_devel
-	cmd:libtool
 	cmd:aclocal
 	cmd:autoconf
 	cmd:automake
 	cmd:gcc$secondaryArchSuffix
 	cmd:gperf
 	cmd:ld$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
 	cmd:python
 	"
-
-PATCHES="fontconfig-2.11.1.patchset"
 
 GLOBAL_WRITABLE_FILES="
 	settings/fonts/conf.d directory keep-old
@@ -120,15 +124,14 @@ INSTALL()
 		$developDir \
 		$manDir \
 		$docDir
+
+	# Make symlinks relative
+	for i in $settingsDir/fonts/conf.d/*.conf; do
+		ln -f -r -s "`readlink "$i"`" "$i"
+	done
 }
 
-PROVIDES_devel="
-	fontconfig${secondaryArchSuffix}_devel = $portVersion compat >= 2.1
-	devel:libfontconfig$secondaryArchSuffix = 1.9.1 compat >= 1
-	"
-
-REQUIRES_devel="
-	fontconfig$secondaryArchSuffix == $portVersion base
-	devel:libfreetype$secondaryArchSuffix
-	devel:libxml2$secondaryArchSuffix
-	"
+TEST()
+{
+	make check
+}

--- a/media-libs/fontconfig/patches/fontconfig-2.12.1.patchset
+++ b/media-libs/fontconfig/patches/fontconfig-2.12.1.patchset
@@ -1,0 +1,22 @@
+From 59eff810d3a298cddd8283f02f64ae77bc74dfb1 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Tue, 10 Jun 2014 16:31:39 +0000
+Subject: haiku patch
+
+
+diff --git a/test/Makefile.am b/test/Makefile.am
+index 72923fa..77cb48d 100644
+--- a/test/Makefile.am
++++ b/test/Makefile.am
+@@ -34,7 +34,7 @@ TESTS += test-bz89617
+ noinst_PROGRAMS = $(check_PROGRAMS)
+ 
+ if !OS_WIN32
+-check_PROGRAMS += test-migration
++check_PROGRAMS += 
+ test_migration_LDADD = $(top_builddir)/src/libfontconfig.la
+ endif
+ 
+-- 
+1.8.3.4
+


### PR DESCRIPTION
* Convert the **`settings/fonts/conf.d/*.conf`** absolute symlinks into (relative) symlinks to **`../../data/fontconfig/conf.avail/`** instead of **`/packages/fontconfig-2.12.1-1/.self/data/fontconfig/conf.avail/`**.
* Switch HOMEPAGE and SOURCE_URI to https.
* Add **`TEST()`** with **`make check`**.