### PR TITLE
libgcrypt: bump to 1.7.3, fix REQUIRES_devel, add TEST.

### DIFF
--- a/dev-libs/libgcrypt/libgcrypt-1.7.3.recipe
+++ b/dev-libs/libgcrypt/libgcrypt-1.7.3.recipe
@@ -1,48 +1,49 @@
 SUMMARY="GNU's basic cryptographic library"
 DESCRIPTION="Libgcrypt is a general purpose crypto library based on the code \
 used in GnuPG."
-HOMEPAGE="http://directory.fsf.org/project/libgcrypt/"
+HOMEPAGE="https://gnupg.org/related_software/libgcrypt/"
 COPYRIGHT="2000-2016 Free Software Foundation, Inc."
 LICENSE="GNU LGPL v3"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-$portVersion.tar.bz2"
-CHECKSUM_SHA256="3d35df906d6eab354504c05d749a9b021944cb29ff5f65c8ef9c3dd5f7b6689f"
+CHECKSUM_SHA256="ddac6111077d0a1612247587be238c5294dd0ee4d76dc7ba783cc55fb0337071"
 PATCHES="libgcrypt-$portVersion.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	libgcrypt${secondaryArchSuffix} = $portVersion compat >= 1.6
-	lib:libgcrypt${secondaryArchSuffix} = 20.1.2 compat >= 20
+	libgcrypt$secondaryArchSuffix = $portVersion compat >= 1.6
+	lib:libgcrypt$secondaryArchSuffix = 20.1.3 compat >= 20
 	"
 REQUIRES="
-	haiku${secondaryArchSuffix}
-	lib:libgpg_error${secondaryArchSuffix}
+	haiku$secondaryArchSuffix
+	lib:libgpg_error$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
 	libgcrypt${secondaryArchSuffix}_devel = $portVersion compat >= 1.6
-	devel:libgcrypt$secondaryArchSuffix = 20.1.2 compat >= 20
+	devel:libgcrypt$secondaryArchSuffix = 20.1.3 compat >= 20
 	cmd:dumpsexp$secondaryArchSuffix = $portVersion compat >= 1.6
 	cmd:libgcrypt_config$secondaryArchSuffix = $portVersion compat >= 1.6
 	cmd:hmac256$secondaryArchSuffix = $portVersion compat >= 1.6
 	cmd:mpicalc$secondaryArchSuffix = $portVersion compat >= 1.6
 	"
 REQUIRES_devel="
-	libgcrypt${secondaryArchSuffix} == $portVersion base
-	haiku${secondaryArchSuffix}
-	devel:libgpg_error${secondaryArchSuffix}
+	libgcrypt$secondaryArchSuffix == $portVersion base
+	haiku$secondaryArchSuffix
+	lib:libgpg_error$secondaryArchSuffix
+	devel:libgpg_error$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libgpg_error${secondaryArchSuffix}
+	devel:libgpg_error$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:autoconf
 	cmd:make
-	cmd:gcc${secondaryArchSuffix}
+	cmd:gcc$secondaryArchSuffix
 	"
 
 BUILD()
@@ -55,12 +56,30 @@ BUILD()
 INSTALL()
 {
 	make install
-	
+
 	#remove libtool file
 	rm -f $libDir/libgcrypt.la
 
-	prepareInstalledDevelLibs libgcrypt
+	prepareInstalledDevelLib libgcrypt
+
+	if [ -z "$secondaryArchSuffix" ]; then
+		maybe_infoDir=$infoDir
+		maybe_manDir=$manDir
+	else
+		maybe_infoDir=
+		maybe_manDir=
+		rm -rf $documentationDir
+	fi
 
 	packageEntries devel \
-		$developDir $binDir $manDir $dataDir $infoDir
+		$developDir \
+		$binDir \
+		$dataDir \
+		$maybe_infoDir \
+		$maybe_manDir
+}
+
+TEST()
+{
+	make check
 }

--- a/dev-libs/libgcrypt/patches/libgcrypt-1.7.3.patchset
+++ b/dev-libs/libgcrypt/patches/libgcrypt-1.7.3.patchset
@@ -5,10 +5,10 @@ Subject: haiku patch
 
 
 diff --git a/configure.ac b/configure.ac
-index f683e21..dabca44 100644
+index 273a7d2..81a3ad3 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -747,6 +747,7 @@ fi
+@@ -763,6 +763,7 @@ fi
  AC_SEARCH_LIBS(setsockopt, [socket], ,
  	[AC_SEARCH_LIBS(setsockopt, [socket], , , [-lnsl])])
  AC_SEARCH_LIBS(setsockopt, [nsl])


### PR DESCRIPTION
* Add **`lib:libgpg_error`** to REQUIRES_devel, as **`cmd:mpicalc`** needs it.
* Drop documentation on secondary architectures.
* Add **`TEST()`** with **`make check`**.