### PR TITLE
git: bump to 2.9.3, pass PERL_PATH=/bin/perl to make.

### DIFF
--- a/dev-vcs/git/git-2.9.3.recipe
+++ b/dev-vcs/git/git-2.9.3.recipe
@@ -13,13 +13,13 @@ LICENSE="GNU GPL v2"
 REVISION="1"
 
 SOURCE_URI="https://www.kernel.org/pub/software/scm/git/git-$portVersion.tar.xz"
-CHECKSUM_SHA256="f8f546648f77f246f1302e3ec4037c81db25af1f02931597148c5bf61fac2db5"
+CHECKSUM_SHA256="9f1473350c1792310b51af03a9cb5cce841f68202f835b20d46312a30232fa63"
 
 SOURCE_URI_2="https://www.kernel.org/pub/software/scm/git/git-manpages-$portVersion.tar.xz"
-CHECKSUM_SHA256_2="4c5c516ee4c0412b9475739e2125a257f6022e7c7bd006827c376fe70d47c323"
+CHECKSUM_SHA256_2="14e0e84af19b8d6b4f0b006b6e33486a0c40bca01e604e77f004efe564d54b4d"
 
 SOURCE_URI_3="https://www.kernel.org/pub/software/scm/git/git-htmldocs-$portVersion.tar.xz"
-CHECKSUM_SHA256_3="6dddb003184f2ab68aa6b54e02e1e55c82c774fe6e74602e9dbefdf06826fb1c"
+CHECKSUM_SHA256_3="abfa0e160c062a36956beaa5e8bf4d6e2db93f235c892f94681bd6f1feb71865"
 
 PATCHES="git-$portVersion.patchset"
 
@@ -147,7 +147,7 @@ makeGit()
 		NEEDS_LIBICONV=YesPlease \
 		NO_R_TO_GCC_LINKER=YesPlease \
 		GNU_ROFF=YesPlease \
-		PERL_PATH=$portPackageLinksDir/cmd~perl/bin/perl \
+		PERL_PATH=/bin/perl \
 		NO_PYTHON=YesPlease \
 		NO_TCLTK=YesPlease \
 		OBJECT_CREATION_USES_RENAMES=YesPlease \

--- a/dev-vcs/git/patches/git-2.9.3.patchset
+++ b/dev-vcs/git/patches/git-2.9.3.patchset
@@ -30,7 +30,7 @@ Subject: On Haiku use the user settings directory instead of HOME
 
 
 diff --git a/path.c b/path.c
-index 259aeed..99f3559 100644
+index 17551c4..6d093db 100644
 --- a/path.c
 +++ b/path.c
 @@ -7,6 +7,11 @@


### PR DESCRIPTION
Passing **`/bin/perl`** (instead of **`$portPackageLinksDir/cmd~perl/bin/perl`**) as PERL_PATH to **`make`** in **`makeGit`** solves the issue about perl not being found when **`haikuporter --test git`** is run. FWIW, that path is used to set the PERL and FULLPERL variables in **`$sourceDir/perl/perl.mak`**.