### PR TITLE
New recipe: cmark

### DIFF
--- a/dev-util/cmark/cmark-0.26.1.recipe
+++ b/dev-util/cmark/cmark-0.26.1.recipe
@@ -1,0 +1,76 @@
+SUMMARY="CommonMark parsing and rendering library and program in C"
+DESCRIPTION="cmark is the C reference implementation of CommonMark, \
+a rationalized version of Markdown syntax with a spec. \
+(For the JavaScript reference implementation, see commonmark.js.) \
+It provides a shared library (libcmark) with functions for parsing \
+CommonMark documents to an abstract syntax tree (AST), manipulating the AST, \
+and rendering the document to HTML, groff man, LaTeX, CommonMark, or an XML \
+representation of the AST. It also provides a command-line program (cmark) \
+for parsing and rendering CommonMark documents."
+HOMEPAGE="https://github.com/jgm/cmark"
+COPYRIGHT="2014 John MacFarlane"
+LICENSE="BSD (2-clause)"
+REVISION="1"
+SOURCE_URI="https://github.com/jgm/cmark/archive/$portVersion.tar.gz"
+CHECKSUM_SHA256="b50615a97f9c19e353d65f3bdbd6898ed1443a6f49e38f0aa888d5b58867f5d6"
+
+ARCHITECTURES="x86 !x86_gcc2 ?x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	libcmark$secondaryArchSuffix = $portVersion compat >= 0
+	lib:libcmark$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:cmark$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:api_test$secondaryArchSuffix = $portVersion compat >= 0
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	libcmark${secondaryArchSuffix}_devel = $portVersion compat >= 0
+	devel:libcmark$secondaryArchSuffix = $portVersion compat >= 0
+	"
+REQUIRES_devel="
+	libcmark$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:automake
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	cmd:cmake
+	cmd:python3
+	"
+
+BUILD()
+{
+	mkdir build
+	cd build
+	cmake .. $cmakeDirArgs
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	prepareInstalledDevelLib libcmark
+	fixPkgconfig
+
+	# devel package
+	packageEntries devel \
+		$developDir
+}
+
+TEST()
+{
+	make test
+}


### PR DESCRIPTION
cmark is a CommonMark parser program and rendering library written in C. It is able to generate LaTeX, HTML, groff man and CommonMark XML from plaintext formatted Markdown. x86_gcc2 is currently not supported.