### PR TITLE
openjpeg: bump to 2.1.2.

### DIFF
--- a/media-libs/openjpeg/openjpeg-2.1.2.recipe
+++ b/media-libs/openjpeg/openjpeg-2.1.2.recipe
@@ -20,7 +20,7 @@ LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="http://github.com/uclouvain/openjpeg/archive/v$portVersion.tar.gz"
 SOURCE_FILENAME="openjpeg-$portVersion.tar.gz"
-CHECKSUM_SHA256="82c27f47fc7219e2ed5537ac69545bf15ed8c6ba8e6e1e529f89f7356506dbaa"
+CHECKSUM_SHA256="4ce77b6ef538ef090d9bde1d5eeff8b3069ab56c4906f083475517c2c023dfa7"
 PATCHES="openjpeg-$portVersion.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
@@ -28,21 +28,26 @@ SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
 PROVIDES="
 	openjpeg$secondaryArchSuffix = $portVersion
-	cmd:opj_decompress = $portVersion
-	cmd:opj_compress = $portVersion
-	cmd:opj_dump = $portVersion
-	lib:libopenjp2$secondaryArchSuffix = 7.0.1 compat >= 7
+	cmd:opj_decompress$secondaryArchSuffix = $portVersion
+	cmd:opj_compress$secondaryArchSuffix = $portVersion
+	cmd:opj_dump$secondaryArchSuffix = $portVersion
+	lib:libopenjp2$secondaryArchSuffix = 7.0.2 compat >= 7
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libpng$secondaryArchSuffix
-	lib:libtiff$secondaryArchSuffix
+	lib:libtiff$secondaryArchSuffix >= 5
 	lib:libz$secondaryArchSuffix
 	"
+if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+	REQUIRES="$REQUIRES
+		lib:liblcms2$secondaryArchSuffix
+		"
+fi
 
 PROVIDES_devel="
 	openjpeg${secondaryArchSuffix}_devel = $portVersion
-	devel:libopenjp2$secondaryArchSuffix = 7.0.1 compat >= 7
+	devel:libopenjp2$secondaryArchSuffix = 7.0.2 compat >= 7
 	"
 REQUIRES_devel="
 	openjpeg$secondaryArchSuffix == $portVersion
@@ -51,9 +56,15 @@ REQUIRES_devel="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libpng$secondaryArchSuffix
-	devel:libtiff$secondaryArchSuffix
+	devel:libtiff$secondaryArchSuffix >= 5
 	devel:libz$secondaryArchSuffix
 	"
+if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+	BUILD_REQUIRES="$BUILD_REQUIRES
+		devel:liblcms2$secondaryArchSuffix
+		"
+fi
+
 BUILD_PREREQUIRES="
 	cmd:cmake
 	cmd:make
@@ -64,7 +75,8 @@ BUILD()
 {
 	mkdir -p build
 	cd build
-	cmake .. -DCMAKE_INSTALL_PREFIX=$prefix -DLIB_SUFFIX=$secondaryArchSubDir \
+	cmake .. -DCMAKE_INSTALL_PREFIX=$prefix \
+		-DOPENJPEG_INSTALL_BIN_DIR=$relativeBinDir \
 		-DOPENJPEG_INSTALL_LIB_DIR=$relativeLibDir \
 		-DOPENJPEG_INSTALL_INCLUDE_DIR=$relativeIncludeDir \
 		-DOPENJPEG_INSTALL_MAN_DIR=$relativeManDir
@@ -76,14 +88,9 @@ INSTALL()
 	cd build
 	make install
 
-	prepareInstalledDevelLibs libopenjp2
+	prepareInstalledDevelLib libopenjp2
 
 	fixPkgconfig
 
 	packageEntries devel $developDir
-}
-
-TEST()
-{
-	make check
 }

--- a/media-libs/openjpeg/patches/openjpeg-2.1.2.patchset
+++ b/media-libs/openjpeg/patches/openjpeg-2.1.2.patchset
@@ -57,7 +57,7 @@ index 5d3e288..c75a7f1 100644
  
    install(TARGETS ${exe}
 diff --git a/src/lib/openjp2/CMakeLists.txt b/src/lib/openjp2/CMakeLists.txt
-index 367a7a8..ca8d5d9 100644
+index 131ed73..a64144b 100644
 --- a/src/lib/openjp2/CMakeLists.txt
 +++ b/src/lib/openjp2/CMakeLists.txt
 @@ -83,7 +83,7 @@ if(WIN32)
@@ -69,15 +69,6 @@ index 367a7a8..ca8d5d9 100644
  endif()
  set_target_properties(${OPENJPEG_LIBRARY_NAME} PROPERTIES ${OPENJPEG_LIBRARY_PROPERTIES})
  if(${CMAKE_VERSION} VERSION_GREATER "2.8.11")
-@@ -114,7 +114,7 @@ endif()
- # no need to install:
- add_executable(t1_generate_luts t1_generate_luts.c)
- if(UNIX)
--  target_link_libraries(t1_generate_luts m)
-+  target_link_libraries(t1_generate_luts)
- endif()
- 
- # Experimental option; let's how cppcheck performs
 diff --git a/src/lib/openjp3d/CMakeLists.txt b/src/lib/openjp3d/CMakeLists.txt
 index 26bf178..5ceb7f3 100644
 --- a/src/lib/openjp3d/CMakeLists.txt


### PR DESCRIPTION
* Use **`binDir`** for secondary arch builds.
* Drop **`TEST()`** because it is useless without an additional data file.
* **`LIB_SUFFIX`** is not (or no longer) used so don't pass it to cmake.
* Depend on **`liblcms2`** on all architectures where it is available.
* Add «**`>= 5`**» for the dependency on **`libtiff`** to pull the latest.