### PR TITLE
Haiku mime support for Fish

### DIFF
--- a/app-shells/fish/patches/fish-2.3.1.patchset
+++ b/app-shells/fish/patches/fish-2.3.1.patchset
@@ -72,3 +72,34 @@ index 290975c..bcbb65a 100644
                      ! strcmp((const char*)p->ifa_name, interface))
 -- 
 2.7.0
+
+From 4fc160f28d37f7cf2dff76da2dca53cba3c1a646 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
+Date: Mon, 24 Oct 2016 17:32:16 +0200
+Subject: [PATCH] Support for Haiku's /bin/open to open files from cli with the
+ installed programs.
+
+---
+ share/functions/open.fish | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/share/functions/open.fish b/share/functions/open.fish
+index 533b3df..dd56e4c 100644
+--- a/share/functions/open.fish
++++ b/share/functions/open.fish
+@@ -21,6 +21,12 @@ if not test (uname) = Darwin
+ 			for i in $argv
+ 				xdg-open $i
+ 			end
++		#HAIKU have open in /bin
++		else if type -q -f /bin/open
++			for i in $argv
++				/bin/open $i
++			end
++		#HAIKU
+ 		else
+ 			echo (_ 'No open utility found. Try installing "xdg-open" or "xdg-utils".')
+ 		end
+-- 
+2.10.0
+


### PR DESCRIPTION
Use /bin/open on Haiku to open files with the associated programs from cli.

Slowly enabling advanced features in fish.....