### PR TITLE
lighttpd: bump to 1.4.42, with mod_geoip and 6 other modules.

### DIFF
--- a/www-servers/lighttpd/additional-files/create-lighttpd-directories.sh
+++ b/www-servers/lighttpd/additional-files/create-lighttpd-directories.sh
@@ -11,3 +11,4 @@ if [ ! -e var/www/htdocs/index.lighttpd.html ]; then
 fi
 
 mkdir -p var/log/lighttpd var/lib/lighttpd var/cache/lighttpd var/tmp/lighttpd
+mkdir -p var/run

--- a/www-servers/lighttpd/additional-files/geoip.shtml
+++ b/www-servers/lighttpd/additional-files/geoip.shtml
@@ -1,0 +1,22 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>GeoIP</title>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+</head>
+<body>
+<div><table><caption>GeoIP data for <!--#echo var="REMOTE_ADDR" --></caption>
+<tr><th>GEOIP_COUNTRY_CODE</th><td><!--#echo var="GEOIP_COUNTRY_CODE" --></td></tr>
+<tr><th>GEOIP_COUNTRY_CODE3</th><td><!--#echo var="GEOIP_COUNTRY_CODE3" --></td></tr>
+<tr><th>GEOIP_COUNTRY_NAME</th><td><!--#echo var="GEOIP_COUNTRY_NAME" --></td></tr>
+<tr><th>GEOIP_CITY_NAME</th><td><!--#echo var="GEOIP_CITY_NAME" --></td></tr>
+<tr><th>GEOIP_CITY_POSTAL_CODE</th><td><!--#echo var="GEOIP_CITY_POSTAL_CODE" --></td></tr>
+<tr><th>GEOIP_CITY_LATITUDE</th><td><!--#echo var="GEOIP_CITY_LATITUDE" --></td></tr>
+<tr><th>GEOIP_CITY_LONG_LATITUDE</th><td><!--#echo var="GEOIP_CITY_LONG_LATITUDE" --></td></tr>
+<tr><th>GEOIP_CITY_DMA_CODE</th><td><!--#echo var="GEOIP_CITY_DMA_CODE" --></td></tr>
+<tr><th>GEOIP_CITY_AREA_CODE</th><td><!--#echo var="GEOIP_CITY_AREA_CODE" --></td></tr>
+</table></div>
+<div>GeoIP databases from <a href="http://maxmind.com/">http://maxmind.com/</a></div>
+</body>
+</html>

--- a/www-servers/lighttpd/additional-files/quickstart-geoip.txt
+++ b/www-servers/lighttpd/additional-files/quickstart-geoip.txt
@@ -1,0 +1,20 @@
+A GeoIP module is officialy included in lighttpd since release 1.4.42.
+To use it you have to download the GeoIP.dat or GeoLiteCity.dat databases from
+http://maxmind.com/
+You can do so manually, or with the geoipupdate command from the geoipupdate
+package or the geoipupdate.sh script from the geoip package (which provides the 
+libGeoIP.so shared library needed by mod_geoip.)
+
+You will also need to edit /system/settings/lighttpd/conf.d/geoip.conf to
+uncomment the line with the geoip.db-filename parameter.
+Finally, you will need to edit /system/settings/lighttpd/modules.conf to
+enable mod_geoip by uncommenting the line with the following directive:
+include "conf.d/geoip.conf"
+
+A demo geoip page is /system/data/www/htdocs/geoip/index.lighttpd.shtml
+and can be accessed by pointing your browser to http://yourserver/geoip/
+
+Reminder: GeoIP data is not available for private network addresses as defined
+in rfc1918 (e.g. 192.168.x.y) so you won't see any GeoIP data unless you access
+your web server from a public IPv4 address.
+Warning: You should only expose your web server if you know what you are doing.

--- a/www-servers/lighttpd/additional-files/quickstart.txt
+++ b/www-servers/lighttpd/additional-files/quickstart.txt
@@ -8,4 +8,4 @@ With the default configuration, access.log and error.log live in /var/log/lightt
 lighttpd can be started with:
     lighttpd -f /system/settings/lighttpd/lighttpd.conf
 and stopped with:
-    kill $(cat /var/lighttpd.pid)
+    kill $(cat /var/run/lighttpd.pid)

--- a/www-servers/lighttpd/lighttpd-1.4.42.recipe
+++ b/www-servers/lighttpd/lighttpd-1.4.42.recipe
@@ -10,12 +10,14 @@ HOMEPAGE="https://www.lighttpd.net/"
 COPYRIGHT="2003-2016 Jan Kneschke"
 LICENSE="BSD (3-clause)"
 REVISION="1"
-SOURCE_URI="https://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-$portVersion.tar.gz"
-CHECKSUM_SHA256="8a5749e218237fafc3119dd8a4fcf510ea728728b3fcf1193fcad7209be4b6d7"
+SOURCE_URI="https://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-$portVersion.tar.xz"
+CHECKSUM_SHA256="b2c9069ed0bade9362c27b469a9b884641786aea1c3d686f9fd9f01d15e2a15f"
 ADDITIONAL_FILES="
 	create-lighttpd-directories.sh
 	index.template
+	geoip.shtml
 	quickstart.txt
+	quickstart-geoip.txt
 	"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64 ?arm ?ppc"
@@ -35,9 +37,14 @@ PROVIDES="
 	lib:mod_accesslog
 	lib:mod_alias
 	lib:mod_auth
+	lib:mod_authn_file
+	lib:mod_authn_gssapi
+	lib:mod_authn_ldap
+	lib:mod_authn_mysql
 	lib:mod_cgi
 	lib:mod_cml
 	lib:mod_compress
+	lib:mod_deflate
 	lib:mod_dirlisting
 	lib:mod_evasive
 	lib:mod_evhost
@@ -60,6 +67,7 @@ PROVIDES="
 	lib:mod_staticfile
 	lib:mod_status
 	lib:mod_trigger_b4_dl
+	lib:mod_uploadprogress
 	lib:mod_userdir
 	lib:mod_usertrack
 	lib:mod_webdav
@@ -78,6 +86,15 @@ REQUIRES="
 	lib:libz$secondaryArchSuffix
 	"
 
+PROVIDES_mod_geoip="
+	lighttpd${secondaryArchSuffix}_mod_geoip = $portVersion
+	lib:mod_geoip
+	"
+REQUIRES_mod_geoip="
+	lighttpd$secondaryArchSuffix == $portVersion base
+	lib:libGeoIP$secondaryArchSuffix
+	"
+
 PROVIDES_devel="
 	lighttpd${secondaryArchSuffix}_devel = $portVersion
 	"
@@ -89,6 +106,7 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libbz2$secondaryArchSuffix
 	devel:libcrypto$secondaryArchSuffix
+	devel:libGeoIP$secondaryArchSuffix
 	devel:libldap$secondaryArchSuffix
 	devel:liblua$secondaryArchSuffix
 	devel:libpcre$secondaryArchSuffix
@@ -126,7 +144,6 @@ GLOBAL_WRITABLE_FILES="
 	settings/lighttpd/conf.d/evhost.conf keep-old
 	settings/lighttpd/conf.d/expire.conf keep-old
 	settings/lighttpd/conf.d/fastcgi.conf keep-old
-	settings/lighttpd/conf.d/geoip.conf keep-old
 	settings/lighttpd/conf.d/magnet.conf keep-old
 	settings/lighttpd/conf.d/mime.conf keep-old
 	settings/lighttpd/conf.d/mysql_vhost.conf keep-old
@@ -140,6 +157,10 @@ GLOBAL_WRITABLE_FILES="
 	settings/lighttpd/conf.d/trigger_b4_dl.conf keep-old
 	settings/lighttpd/conf.d/userdir.conf keep-old
 	settings/lighttpd/conf.d/webdav.conf keep-old
+	"
+
+GLOBAL_WRITABLE_FILES_mod_geoip="
+	settings/lighttpd/conf.d/geoip.conf keep-old
 	"
 
 USER_SETTINGS_FILES="
@@ -157,7 +178,6 @@ USER_SETTINGS_FILES="
 	settings/lighttpd/conf.d/evhost.conf template data/lighttpd/template-settings/conf.d/evhost.conf
 	settings/lighttpd/conf.d/expire.conf template data/lighttpd/template-settings/conf.d/expire.conf
 	settings/lighttpd/conf.d/fastcgi.conf template data/lighttpd/template-settings/conf.d/fastcgi.conf
-	settings/lighttpd/conf.d/geoip.conf template data/lighttpd/template-settings/conf.d/geoip.conf
 	settings/lighttpd/conf.d/magnet.conf template data/lighttpd/template-settings/conf.d/magnet.conf
 	settings/lighttpd/conf.d/mime.conf template data/lighttpd/template-settings/conf.d/mime.conf
 	settings/lighttpd/conf.d/mysql_vhost.conf template data/lighttpd/template-settings/conf.d/mysql_vhost.conf
@@ -173,6 +193,10 @@ USER_SETTINGS_FILES="
 	settings/lighttpd/conf.d/webdav.conf template data/lighttpd/template-settings/conf.d/webdav.conf
 	"
 
+USER_SETTINGS_FILES_mod_geoip="
+	settings/lighttpd/conf.d/geoip.conf template data/lighttpd/template-settings/conf.d/geoip.conf
+	"
+
 POST_INSTALL_SCRIPTS="
 	$relativePostInstallDir/create-lighttpd-directories.sh
 	"
@@ -186,7 +210,8 @@ BUILD()
 		--libdir=$libDir/lighttpd --sbindir=$commandBinDir \
 		--with-openssl --with-zlib --with-bzip2 --with-pcre \
 		--with-libxml --with-ldap --with-lua --with-sqlite \
-		--with-uuid --with-webdav-locks --with-webdav-props
+		--with-uuid --with-webdav-locks --with-webdav-props \
+		--with-geoip
 	make $jobArgs
 }
 
@@ -205,7 +230,15 @@ INSTALL()
 		$settingsDir/lighttpd/conf.d \
 		$dataDir/lighttpd \
 		$docDir
-	cp -f $portDir/additional-files/quickstart.txt $docDir
+	cp -f \
+		$portDir/additional-files/quickstart.txt \
+		$portDir/additional-files/quickstart-geoip.txt \
+		$docDir
+
+	constantSystemSettingsDir="`finddir B_SYSTEM_SETTINGS_DIRECTORY`"
+	constantSystemCacheDir="`finddir B_SYSTEM_CACHE_DIRECTORY`"
+	constantSystemDataDir="`finddir B_SYSTEM_DATA_DIRECTORY`"
+	constantSystemVarDir="`finddir B_SYSTEM_VAR_DIRECTORY`"
 
 # Tweak lighttpd.conf to have a working config with mod_ssi enabled.
 # Tweak ssi.conf to add index.shtml as index-file.names for mod_indexfile.
@@ -215,19 +248,18 @@ INSTALL()
 
 	cp doc/config/lighttpd.conf $settingsDir/lighttpd
 	sed -i \
+		-e "s|^\(## \)/etc\(/lighttpd/lighttpd\.conf\)|\1$constantSystemSettingsDir\2|" \
+		-e "s|^\(## check \)/etc\(/lighttpd/conf\.d/\)|\1$constantSystemSettingsDir\2|" \
 		-e "/^var\.log_root/ \
-			s|\"/var\(/log/lighttpd\"\)|\"$localStateDir\1|" \
+			s|\"/var\(/log/lighttpd\"\)|\"$constantSystemVarDir\1|" \
 		-e "/^var\.server_root/ \
-			s|\"/srv/www\"|\"$dataDir/lighttpd/www\"|" \
+			s|\"/srv/www\"|\"$constantSystemDataDir/lighttpd/www\"|" \
 		-e "/^var\.server_root/ \
-		  a #var.server_root = \"/$relativeSharedStateDir/www\"" \
-		-e "/^var\.state_dir/ s|\"/var/run\"|\"$localStateDir\"|" \
-		-e "/^var\.home_dir/ \
-		  s|\"/var/lib/lighttpd\"|\"$localStateDir/lib/lighttpd\"|" \
+			a #var.server_root = \"/$relativeSharedStateDir/www\"" \
+		-e "/^var\.state_dir/ \
+			s|\"/var/run\"|\"$constantSystemVarDir/run\"|" \
 		-e "/^var\.conf_dir/ \
-		  s|\"/etc\(/lighttpd\"\)|\"/system/$relativeSettingsDir\1|" \
-		-e "/^var\.cache_dir/ \
-			s|\"/var\(/cache/lighttpd\"\)|\"$localStateDir\1|" \
+			s|\"/etc\(/lighttpd\"\)|\"$constantSystemSettingsDir\1|" \
 		-e "/^server\.use-ipv6 / s|\"enable\"|\"disable\"|" \
 		-e "s|^server\.username |#&|" \
 		-e "s|^server\.groupname |#&|" \
@@ -237,28 +269,49 @@ INSTALL()
 		-e "/^server\.event-handler/ \
 			s|\"linux-sysepoll\"|\"select\"|" \
 		-e "/^server\.upload-dirs/ \
-			s|\"/var/tmp\"|\"$localStateDir/tmp/lighttpd\"|" \
+			s|\"/var/tmp\"|\"$constantSystemVarDir/tmp/lighttpd\"|" \
+		-e "/^## \$ cat / \
+			s|/etc\(/ssl/private/lighttpd\.key\)|$constantSystemSettingsDir\1|" \
+		-e "/^## \$ cat / \
+			s|/etc\(/ssl/certs/lighttpd\.crt\)|$constantSystemSettingsDir\1|" \
+		-e "s| /etc\(/ssl/private/lighttpd\.pem\)| $constantSystemSettingsDir\1|" \
 		-e "/^#ssl\.pemfile/ \
-			s|\"/etc/ssl\(/private/lighttpd.pem\"\)|\"$dataDir\1|" \
+			s|\"/etc\(/ssl/private/lighttpd.pem\"\)|\"$constantSystemSettingsDir\1|" \
+		-e "/^ssl\.pemfile/ \
+			s|\"/etc\(/ssl/private/www\.example\.com\.pem\"\)|\"$constantSystemSettingsDir\1|" \
+		-e "/^#include_shell \"cat \/etc/ \
+			s|/etc\(/lighttpd/\)|\"$constantSystemSettingsDir\1|" \
 		-e "/^include \"modules\.conf\"/ \
 			a index-file.names += ( \"index.lighttpd.html\" )" \
 		$settingsDir/lighttpd/lighttpd.conf
 
 	cp doc/config/modules.conf $settingsDir/lighttpd
+	# Insert commented inclusion of geoip.conf before ssi.conf
 	sed -i \
+		-e '/^## mod_ssi/ i ## mod_geoip\
+##\
+#include "conf.d/geoip.conf"\
+\
+##' \
 		-e "s|^#\(include \"conf\.d/ssi\.conf\"\)|\1|" \
 		$settingsDir/lighttpd/modules.conf
 
 	cp doc/config/conf.d/*.conf $settingsDir/lighttpd/conf.d
+
 	sed -i \
 		-e "/^ssi\.extension/ \
 			a index-file.names += ( \"index.lighttpd.shtml\" )" \
 		$settingsDir/lighttpd/conf.d/ssi.conf
 
+	sed -i \
+		-e "/^#geoip\.db-filename =/ \
+			s|/path/to/GeoCityLite\.dat|$constantSystemCacheDir/GeoIP/GeoLiteCity.dat|" \
+		$settingsDir/lighttpd/conf.d/geoip.conf
+
 	# Create a read-only copy of the settings
 	cp -rp $settingsDir/lighttpd $dataDir/lighttpd/template-settings
 
-	mkdir -p $dataDir/lighttpd/www/htdocs
+	mkdir -p $dataDir/lighttpd/www/htdocs/geoip
 
 # Create and install a static index.lighttpd.html test page from the template.
 
@@ -271,7 +324,7 @@ INSTALL()
 		-e "s|@LIGHTTPD_VERSION@|lighttpd/$portVersion|" \
 		$dataDir/lighttpd/www/htdocs/index.lighttpd.html
 
-# Create and install the SSI index.shtml test page from the template.
+# Create and install the SSI index.lighttpd.shtml test page from the template.
 
 	cp $portDir/additional-files/index.template \
 		$dataDir/lighttpd/www/htdocs/index.lighttpd.shtml
@@ -281,6 +334,11 @@ INSTALL()
 		-e "s|@HOSTNAME@|<!--#echo var=\"HTTP_HOST\"-->|" \
 		-e "s|@LIGHTTPD_VERSION@|<!--#echo var=\"SERVER_SOFTWARE\"-->|" \
 		$dataDir/lighttpd/www/htdocs/index.lighttpd.shtml
+
+# Create and install the geoip.shtml demo page.
+
+	cp $portDir/additional-files/geoip.shtml \
+		$dataDir/lighttpd/www/htdocs/geoip/index.lighttpd.shtml
 
 # Install headers in $includeDir/lighttpd/ for building third-party modules.
 	mkdir -p  $includeDir/lighttpd
@@ -295,7 +353,15 @@ INSTALL()
 		rm -f $includeDir/lighttpd/$i
 	done
 
-	packageEntries devel $developDir
+	packageEntries mod_geoip \
+		$libDir/lighttpd/mod_geoip.so \
+		$settingsDir/lighttpd/conf.d/geoip.conf \
+		$dataDir/lighttpd/template-settings/conf.d/geoip.conf \
+		$dataDir/lighttpd/www/htdocs/geoip \
+		$docDir/quickstart-geoip.txt
+
+	packageEntries devel \
+		$developDir
 }
 
 TEST()


### PR DESCRIPTION
* This release of lighttpd comes with 7 new modules: mod_deflate, mod_authn_{file,gssapi,ldap,mysql}, mod_uploadprogress and mod_geoip.
* The GeoIP module is being added in a separate sub-package to limit the dependency on the geoip package to that sub-package only.
* Add a quickstart-geoip.txt and a demo geoip page for novice users.
* In lighttpd.conf don't use paths that change when the package is updated.
* Keep lighttpd.pid in **`/var/run`** instead of **`/var`**.
* Switch SOURCE_URI from tar.gz to tar.xz ;-)