### PR TITLE
curl: bump to 7.51.0, drop html documentation.

### DIFF
--- a/net-misc/curl/curl-7.51.0.recipe
+++ b/net-misc/curl/curl-7.51.0.recipe
@@ -11,7 +11,7 @@ COPYRIGHT="1996-2016 Daniel Stenberg"
 LICENSE="Curl"
 REVISION="1"
 SOURCE_URI="https://curl.haxx.se/download/curl-$portVersion.tar.bz2"
-CHECKSUM_SHA256="7b7347d976661d02c84a1f4d6daf40dee377efdc45b9e2c77dedb8acf140d8ec"
+CHECKSUM_SHA256="7f8240048907e5030f67be0a6129bc4b333783b9cca1391026d700835a788dde"
 ADDITIONAL_FILES="curl.rdef"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64 arm"
@@ -110,14 +110,6 @@ INSTALL()
 	else
 		maybe_manDir_man1_curl_config=$manDir/man1/curl-config.1
 		maybe_manDir_man3=$manDir/man3
-
-		install -d -m 755 "$docDir" "$developDocDir"
-
-		# install html documentation for curl
-		install -c -m 444 "docs/curl.html" "$docDir"
-
-		# install html development documentation for libcurl
-		install -t $developDocDir -c -m 444 docs/libcurl/*.html
 	fi
 
 	# devel package


### PR DESCRIPTION
Upstream does not ship **`docs/libcurl/*.html`** anymore. Although these may be generated with "make html", we would need roffit or any other MAN2HTML conversion utility, so let's just drop the html doc.