### PR TITLE
imagemagick: bump to 6.9.6.6. Improve layout. Minor changes.

### DIFF
--- a/media-gfx/imagemagick/imagemagick-6.9.6.6.recipe
+++ b/media-gfx/imagemagick/imagemagick-6.9.6.6.recipe
@@ -9,9 +9,11 @@ HOMEPAGE="https://www.imagemagick.org/"
 COPYRIGHT="1999-2016 ImageMagick Studio LLC"
 LICENSE="IMAGEMAGICK"
 REVISION="1"
-SOURCE_URI="http://www.imagemagick.org/download/releases/ImageMagick-6.9.6-4.tar.xz"
-CHECKSUM_SHA256="d523c2c45dc2ff55f1bc27aa0cfa6e00e6f80dc182e8d6c27fcac99461c462d7"
-SOURCE_DIR="ImageMagick-6.9.6-4"
+SOURCE_URI="http://www.imagemagick.org/download/releases/ImageMagick-6.9.6-6.tar.xz
+	https://sourceforge.net/projects/imagemagick/files/old-sources/6.x/6.9/ImageMagick-6.9.6-6.tar.xz
+	http://gentoo.mirrors.ovh.net/gentoo-distfiles/distfiles/ImageMagick-6.9.6-6.tar.xz"
+CHECKSUM_SHA256="9cd1fe001d3ecb68b7d053ede40950d411956d47afc5267acc3ca57a77070d0a"
+SOURCE_DIR="ImageMagick-6.9.6-6"
 PATCHES="imagemagick-$portVersion.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
@@ -19,11 +21,6 @@ SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	imagemagick$secondaryArchSuffix = $portVersion
-	cmd:Magick++_config$secondaryArchSuffix
-	cmd:Magick_config$secondaryArchSuffix
-	cmd:MagickCore_config$secondaryArchSuffix
-	cmd:MagickWand_config$secondaryArchSuffix
-	cmd:Wand_config$secondaryArchSuffix
 	cmd:animate$secondaryArchSuffix
 	cmd:compare$secondaryArchSuffix
 	cmd:composite$secondaryArchSuffix
@@ -43,7 +40,6 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libbz2$secondaryArchSuffix
 	lib:libfreetype$secondaryArchSuffix
-	lib:libgomp$secondaryArchSuffix
 	lib:libjpeg$secondaryArchSuffix
 	lib:libltdl$secondaryArchSuffix
 	lib:libpng16$secondaryArchSuffix
@@ -52,15 +48,25 @@ REQUIRES="
 	lib:libxml2$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
+if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+	REQUIRES="$REQUIRES
+		lib:libgomp$secondaryArchSuffix
+		"
+fi
 
 PROVIDES_devel="
 	imagemagick${secondaryArchSuffix}_devel = $portVersion
+	cmd:Magick++_config$secondaryArchSuffix
+	cmd:Magick_config$secondaryArchSuffix
+	cmd:MagickCore_config$secondaryArchSuffix
+	cmd:MagickWand_config$secondaryArchSuffix
+	cmd:Wand_config$secondaryArchSuffix
 	devel:libMagick++_6.Q16$secondaryArchSuffix = 6.0.0 compat >= 6
 	devel:libMagickCore_6.Q16$secondaryArchSuffix = 2.0.0 compat >= 2
 	devel:libMagickWand_6.Q16$secondaryArchSuffix = 2.0.0 compat >= 2
 	"
 REQUIRES_devel="
-	imagemagick${secondaryArchSuffix} == $portVersion base
+	imagemagick$secondaryArchSuffix == $portVersion base
 	"
 
 BUILD_REQUIRES="
@@ -88,7 +94,6 @@ BUILD_PREREQUIRES="
 	cmd:perl
 	cmd:pkg_config$secondaryArchSuffix
 	cmd:sed
-	cmd:svnversion
 	"
 
 GLOBAL_WRITABLE_FILES="
@@ -121,8 +126,22 @@ INSTALL()
 {
 	make install
 
+	# remove libtool files
+	rm -f $libDir/libMagick*.la
+
 	prepareInstalledDevelLibs libMagick++-6.Q16 libMagickCore-6.Q16 \
 		libMagickWand-6.Q16
+	fixPkgconfig
 
-	packageEntries devel $developDir
+	packageEntries devel \
+		$developDir \
+		$binDir/*-config \
+		$manDir/man1/*-config.1 \
+		$dataDir/doc/ImageMagick-6/www/api.html \
+		$dataDir/doc/ImageMagick-6/www/api
+}
+
+TEST()
+{
+	make check
 }

--- a/media-gfx/imagemagick/patches/imagemagick-6.9.6.6.patchset
+++ b/media-gfx/imagemagick/patches/imagemagick-6.9.6.6.patchset
@@ -1091,7 +1091,7 @@ Using a variable named LIBRARY_PATH is not a good idea on Haiku. Just
 rename it.
 
 diff --git a/configure.ac b/configure.ac
-index 92e5c40..4d1ecb5 100644
+index 8ce84b4..946d206 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -2885,15 +2885,15 @@ AC_DEFINE_UNQUOTED(EXECUTABLE_PATH,"$DEFINE_EXECUTABLE_PATH",[Directory where ex


### PR DESCRIPTION
* Remove **`lib:libgomp`** from REQUIRES on x86_gcc2 primary arch, since gcc_syslibs_devel does not provide it on that arch.
* Remove unneeded cmd:svnversion from BUILD_PREREQUIRES.
* Drop libtool files.
* Add TEST with **`make check`**.
* Improve layout by moving some items from the base package to the _devel subpackage: **`lib/pkgconfig/*.pc`** (thanks to fixPkgconfig), **`bin/*-config`** (and their associated man1 manual pages), and some docs: **`data/doc/ImageMagick-6/www/api{.html,/}`**.
* Add two extra download locations to SOURCE_URI to make sure the tarball will still be available after a new version is released.