### PR TITLE
libsodium: drop libtool file, configure with --disable-ssp.

### DIFF
--- a/dev-libs/libsodium/libsodium-1.0.11.recipe
+++ b/dev-libs/libsodium/libsodium-1.0.11.recipe
@@ -4,42 +4,45 @@ fork of NaCl, with a compatible API, and an extended API to improve usability \
 even further.
 Its goal is to provide all of the core operations needed to build higher-level \
 cryptographic tools.
-The design choices emphasize security, and \"magic constants\" have clear rationales.
+The design choices emphasize security, and \"magic constants\" have clear \
+rationales.
 Despite the emphasis on high security, primitives are faster across-the-board \
 than most implementations of the NIST standards."
 HOMEPAGE="https://github.com/jedisct1/libsodium"
-COPYRIGHT="2013-2016  Frank Denis"
+COPYRIGHT="2013-2016 Frank Denis"
 LICENSE="ISC"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://download.libsodium.org/libsodium/releases/libsodium-$portVersion.tar.gz"
 CHECKSUM_SHA256="a14549db3c49f6ae2170cbbf4664bd48ace50681045e8dbea7c8d9fb96f9c765"
 PATCHES="libsodium-$portVersion.patchset"
 
-ARCHITECTURES="x86_gcc2 x86"
+ARCHITECTURES="x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
 PROVIDES="
-	libsodium${secondaryArchSuffix} = $portVersion
+	libsodium$secondaryArchSuffix = $portVersion
 	cmd:libsodium = $portVersion
-	lib:libsodium${secondaryArchSuffix} = $portVersion
+	lib:libsodium$secondaryArchSuffix = 18.1.1
 	"
 REQUIRES="
-	haiku${secondaryArchSuffix}
+	haiku$secondaryArchSuffix
 	"
+
 PROVIDES_devel="
 	libsodium${secondaryArchSuffix}_devel = $portVersion
-	devel:libsodium$secondaryArchSuffix = $portVersion
+	devel:libsodium$secondaryArchSuffix = 18.1.1
 	"
 REQUIRES_devel="
 	libsodium$secondaryArchSuffix == $portVersion base
 	"
+
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
 	cmd:automake
 	cmd:autoconf
-	cmd:libtool
+	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
 	cmd:awk
 	cmd:gcc$secondaryArchSuffix
@@ -47,14 +50,18 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	runConfigure ./configure
+	runConfigure ./configure --disable-ssp
 	make
 }
 
 INSTALL()
 {
 	make install
-	prepareInstalledDevelLibs libsodium
+
+	# remove libtool file
+	rm -f $libDir/libsodium.la
+
+	prepareInstalledDevelLib libsodium
 	fixPkgconfig
 	packageEntries devel $developDir
 }


### PR DESCRIPTION
* **`configure --disable-ssp`** to avoid the dependency on libssp.
* Enable x86_64.
* Use 18.1.1 for the lib version, instead of **`$portVersion`**.
* Replace **`cmd:libtool`** by **`cmd:libtoolize$secondaryArchSuffix`**.
* Change prepareInstalledDevel**Libs** to prepareInstalledDevel**Lib**, since we have only one lib here.