### PR TITLE
Update zaz-1.0.0.recipe to use provided patch

### DIFF
--- a/games-puzzle/zaz/zaz-1.0.0.recipe
+++ b/games-puzzle/zaz/zaz-1.0.0.recipe
@@ -12,7 +12,7 @@ modify, love and hate it."
 HOMEPAGE="http://zaz.sourceforge.net" 
 SOURCE_URI="http://sourceforge.net/projects/zaz/files/zaz-$portVersion.tar.bz2"
 CHECKSUM_SHA256="e332cc1a6559e18a2b632940c53d20e2f2d2b583ba9dc1fd02a586437f9f0397"
-PATCHES="zaz$portVersion.patchset"
+PATCHES="zaz-$portVersion.patchset"
 REVISION="1"
 
 ARCHITECTURES="x86_gcc2"


### PR DESCRIPTION
There appears to be a typo in the recipe preventing the patch from being used.

I will also try building the recipe with this change.