### PR TITLE
Remove libaacs-0.8.1 patchset file

### DIFF
--- a/media-libs/libaacs/libaacs-0.8.1.recipe
+++ b/media-libs/libaacs/libaacs-0.8.1.recipe
@@ -4,7 +4,6 @@ System (AACS) specification."
 HOMEPAGE="https://www.videolan.org/developers/libaacs.html"
 SOURCE_URI="https://download.videolan.org/pub/videolan/libaacs/$portVersion/libaacs-$portVersion.tar.bz2"
 CHECKSUM_SHA256="95c344a02c47c9753c50a5386fdfb8313f9e4e95949a5c523a452f0bcb01bbe8"
-#PATCHES="libaacs-$portVersion.patchset"
 COPYRIGHT="
 	2009-2013  npzacs
 	2010  gates


### PR DESCRIPTION
Remove [lint error](https://gist.github.com/ohnx/676338c83bd396261dd294029387cf7c#file-haikuports-errors-txt-L72).

The file is empty anyways.

(re-submission of https://github.com/haikuports/haikuports/pull/899)