### PR TITLE
Added pngquant recipe

### DIFF
--- a/media-gfx/pngquant/pngquant-2.7.2.recipe
+++ b/media-gfx/pngquant/pngquant-2.7.2.recipe
@@ -10,7 +10,7 @@ COPYRIGHT="2009-2016 by Kornel Lesiński"
 LICENSE="GNU GPL v3"
 REVISION="1"
 SOURCE_URI="https://github.com/pornel/pngquant/archive/$portVersion.tar.gz"
-CHECKSUM_SHA256="7c37ce149174adfbd51af59aaa87f076f18c525a2b04c093e44f3b4f294aa998"
+CHECKSUM_SHA256="071e1af157ed2044d68522f4a18c5d94c5b6cbd83827a08e1bdf0ec0649f9cc9"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
 

--- a/media-gfx/pngquant/pngquant-2.7.2.recipe
+++ b/media-gfx/pngquant/pngquant-2.7.2.recipe
@@ -11,7 +11,6 @@ LICENSE="GNU GPL v3"
 REVISION="1"
 SOURCE_URI="https://github.com/pornel/pngquant/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="071e1af157ed2044d68522f4a18c5d94c5b6cbd83827a08e1bdf0ec0649f9cc9"
-#PATCHES="pngquant_x86-2.7.2.patchset"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="!x86_gcc2 x86"

--- a/media-gfx/pngquant/pngquant-2.7.2.recipe
+++ b/media-gfx/pngquant/pngquant-2.7.2.recipe
@@ -11,25 +11,32 @@ LICENSE="GNU GPL v3"
 REVISION="1"
 SOURCE_URI="https://github.com/pornel/pngquant/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="071e1af157ed2044d68522f4a18c5d94c5b6cbd83827a08e1bdf0ec0649f9cc9"
+#PATCHES="pngquant_x86-2.7.2.patchset"
 
-ARCHITECTURES="x86_gcc2 x86 x86_64"
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
 
 PROVIDES="
-	pngquant = $portVersion
+	pngquant$secondaryArchSuffix = $portVersion
 	cmd:pngquant = $portVersion
 	"
 REQUIRES="
-	haiku
+	haiku$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
+	haiku${secondaryArchSuffix}_devel
+	devel:libpng16$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:gcc
+	cmd:gcc$secondaryArchSuffix
 	cmd:make
 	cmd:awk
-  cmd:git
+	cmd:git
+	cmd:pkg_config$secondaryArchSuffix
 	"
 
 BUILD()
@@ -41,4 +48,7 @@ BUILD()
 INSTALL()
 {
 	make install
+	mkdir -p $manDir
+	cp $prefix/share/man/man1/* $manDir
+	rm -rf $prefix/share
 }

--- a/media-gfx/pngquant/pngquant-2.8.0.recipe
+++ b/media-gfx/pngquant/pngquant-2.8.0.recipe
@@ -1,0 +1,44 @@
+SUMMARY="A utility for lossy compression of PNG images"
+DESCRIPTION="Pngquant converts 32-bit RGBA PNGs to 8-bit (or smaller) \
+RGBA-palette PNGs, optionally using Floyd-Steinberg dithering.
+
+The conversion reduces file sizes significantly (often as much as 70%) and \
+preserves full alpha transparency. Generated images are compatible with all \
+modern web browsers, and have better fallback in IE6 than 24-bit PNGs."
+HOMEPAGE="https://pngquant.org/"
+COPYRIGHT="2009-2016 by Kornel Lesiński"
+LICENSE="GNU GPL v3"
+REVISION="1"
+SOURCE_URI="https://github.com/pornel/pngquant/archive/$portVersion.tar.gz"
+CHECKSUM_SHA256="7c37ce149174adfbd51af59aaa87f076f18c525a2b04c093e44f3b4f294aa998"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	pngquant = $portVersion
+	cmd:pngquant = $portVersion
+	"
+REQUIRES="
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc
+	cmd:make
+	cmd:awk
+  cmd:git
+	"
+
+BUILD()
+{
+	runConfigure ./configure
+	make
+}
+
+INSTALL()
+{
+	make install
+}


### PR DESCRIPTION
This recipe adds the pngquant command. It is incompatible with GCC2 so consequently only uses the x86. There are definitely some oddities to the package, such as (how `./configure` only accepts prefix).  As such, I am not rebasing at the moment and will do so once it is determined "done" and to a state where we can merge. :-)