### PR TITLE
Vim patchset: vim GUI requires libstdc++

### DIFF
--- a/app-editors/vim/patches/vim-8.0.0046.patchset
+++ b/app-editors/vim/patches/vim-8.0.0046.patchset
@@ -505,7 +505,7 @@ index fd07946..84c64fa 100644
 +HAIKUGUI_IPATH	=
 +HAIKUGUI_LIBS_DIR =
 +HAIKUGUI_LIBS1	= -lbe -lroot -ltracker -ltranslation
-+ifeq ($(strip $(word 1, $(subst -, , $(subst ., , $(shell $(CC) -dumpversion))))), 4)
++ifeq ($(strip $(word 1, $(subst -, , $(subst ., , $(shell $(CC) -dumpversion))))), 5)
 +HAIKUGUI_LIBS1	+= -lsupc++
 +endif
 +HAIKUGUI_LIBS2	=


### PR DESCRIPTION
With this patch i was able to build it on x64 Haiku.