### PR TITLE
Amend "calc: new recipe for a C-style arbitrary precision calculator"

### DIFF
--- a/sci-mathematics/calc/calc-2.12.5.3.recipe
+++ b/sci-mathematics/calc/calc-2.12.5.3.recipe
@@ -1,0 +1,156 @@
+SUMMARY="C-style arbitrary precision calculator"
+DESCRIPTION="Calc is an interactive calculator which provides for easy large \
+numeric calculations, but which also can be easily programmed for difficult or \
+long calculations. It can accept a command line argument, in which case it \
+executes that single command and exits. Otherwise, it enters interactive mode. \
+In this mode, it accepts commands one at a time, processes them, and displays \
+the answers. In the simplest case, commands are simply expressions which are \
+evaluated."
+HOMEPAGE="http://www.isthe.com/chongo/tech/comp/calc/"
+COPYRIGHT="1999-2016 Landon Curt Noll"
+LICENSE="GNU LGPL v2.1"
+REVISION="1"
+SOURCE_URI="http://www.isthe.com/chongo/src/calc/calc-$portVersion.tar.bz2"
+CHECKSUM_SHA256="0fcf60917efb10aab145f1180c278a3ab63d789aad6d5e5f066a4458b5f9b692"
+PATCHES="calc-$portVersion.patchset"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86_gcc2 x86"
+
+PROVIDES="
+	calc$secondaryArchSuffix = $portVersion
+	cmd:calc$secondaryArchSuffix = $portVersion
+	cmd:cscript$secondaryArchSuffix = $portVersion
+	lib:libcalc$secondaryArchSuffix
+	lib:libcustcalc$secondaryArchSuffix
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libreadline$secondaryArchSuffix
+	lib:libhistory$secondaryArchSuffix
+	lib:libncurses$secondaryArchSuffix
+	calc_data == $portVersion
+	"
+
+if [ -z "$secondaryArchSuffix" ]; then
+	SUMMARY_data="Standard resource files for calc"
+	ARCHITECTURES_data="any"
+	PROVIDES_data="
+		calc_data = $portVersion
+		"
+	REQUIRES_data=""
+fi
+
+PROVIDES_devel="
+	calc${secondaryArchSuffix}_devel = $portVersion
+	devel:libcalc$secondaryArchSuffix
+	devel:libcustcalc$secondaryArchSuffix
+	"
+REQUIRES_devel="
+	calc$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libreadline$secondaryArchSuffix
+	devel:libhistory$secondaryArchSuffix
+	devel:libncurses$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:awk
+	cmd:sed
+	cmd:diff
+	cmd:egrep
+	cmd:ctags
+	cmd:xargs
+	cmd:cmp
+	cmd:touch
+	cmd:less
+	cmd:strip
+	cmd:ld$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	make target=Haiku \
+		INCDIR=$includeDir \
+		LIBDIR=$libDir \
+		BINDIR=$binDir \
+		SCRIPTDIR=$libDir/calc/cscript \
+		CALC_SHAREDIR=$dataDir/calc \
+		MANDIR=$manDir/man1 \
+		BLD_TYPE=calc-dynamic-only \
+		HAVE_UNISTD_H=YES \
+		HAVE_FPOS_POS=1 \
+		HAVE_UID_T=1 \
+		HAVE_USTAT=1 \
+		EXTRA_CFLAGS="-DUSE_TERMIOS" \
+	 	USE_READLINE=-DUSE_READLINE \
+		READLINE_LIB=-lreadline \
+		READLINE_EXTRAS="-lhistory -lncurses" \
+		LN="ln -s" \
+		LDCONFIG=ld \
+		WNO_ERROR_LONG_LONG=
+}
+
+INSTALL()
+{
+	make install \
+		target=Haiku \
+		INCDIR=$includeDir \
+		LIBDIR=$libDir \
+		BINDIR=$binDir \
+		SCRIPTDIR=$libDir/calc/cscript \
+		CALC_SHAREDIR=$dataDir/calc \
+		MANDIR=$manDir/man1 \
+		BLD_TYPE=calc-dynamic-only \
+		HAVE_UNISTD_H=YES \
+		HAVE_FPOS_POS=1 \
+		HAVE_UID_T=1 \
+		HAVE_USTAT=1 \
+		EXTRA_CFLAGS="-DUSE_TERMIOS" \
+	 	USE_READLINE=-DUSE_READLINE \
+		READLINE_LIB=-lreadline \
+		READLINE_EXTRAS="-lhistory -lncurses" \
+		LN="ln -s" \
+		LDCONFIG=ld \
+		WNO_ERROR_LONG_LONG=
+
+	prepareInstalledDevelLibs libcalc libcustcalc
+	fixPkgconfig
+
+	if [ -z "$secondaryArchSuffix" ]; then
+		# Shorten some paths in the man page.
+		sed -i \
+			-e "s|#!$binDir/calc\>|#!/$relativeBinDir/calc|" \
+			-e "s|$prefix/|/system/|" \
+			$manDir/man1/calc.1
+
+		# Some files in $dataDir/calc/help/ have code snippets with
+		# long shebangs that we can shorten. Currently, these files are
+		# cscript, full, libcalc and usage.
+		sed -i \
+			-e "s|$binDir/calc\>|/$relativeBinDir/calc|" \
+			-e "s|$prefix/|/system/|g" \
+			$dataDir/calc/help/*
+
+		packageEntries data \
+			$dataDir/calc
+	else
+		rm -rf $dataDir/calc $manDir
+	fi
+
+	# Shorten the paths to bin/calc in several shebangs.
+	sed -i -e "1 s|$binDir/calc\>|/$relativeBinDir/calc|" \
+		$libDir/calc/cscript/*
+
+	packageEntries devel \
+		$developDir
+}
+
+TEST()
+{
+	make check
+}

--- a/sci-mathematics/calc/patches/calc-2.12.5.3.patchset
+++ b/sci-mathematics/calc/patches/calc-2.12.5.3.patchset
@@ -1,0 +1,95 @@
+From 8738841646cfb2f1a00ea5a676d31295b13d2d39 Mon Sep 17 00:00:00 2001
+From: raefaldhia <raefaldhiamartya@gmail.com>
+Date: Wed, 14 Dec 2016 12:56:02 +0700
+Subject: Add compatibility to build with haikuporter
+
+
+diff --git a/Makefile b/Makefile
+index 79d7089..ab7e494 100644
+--- a/Makefile
++++ b/Makefile
+@@ -457,8 +457,8 @@ ALIGN32=
+ #
+ # When in doubt, leave HAVE_STDLIB_H empty.
+ #
+-HAVE_STDLIB_H=
+-#HAVE_STDLIB_H= YES
++#HAVE_STDLIB_H=
++HAVE_STDLIB_H= YES
+ #HAVE_STDLIB_H= NO
+ 
+ # Determine if we have the <string.h> include file.
+@@ -471,8 +471,8 @@ HAVE_STDLIB_H=
+ #
+ # When in doubt, leave HAVE_STRING_H empty.
+ #
+-HAVE_STRING_H=
+-#HAVE_STRING_H= YES
++#HAVE_STRING_H=
++HAVE_STRING_H= YES
+ #HAVE_STRING_H= NO
+ 
+ # Determine if we have the <times.h> include file.
+@@ -499,8 +499,8 @@ HAVE_TIMES_H=
+ #
+ # When in doubt, leave HAVE_SYS_TIMES_H empty.
+ #
+-HAVE_SYS_TIMES_H=
+-#HAVE_SYS_TIMES_H= YES
++#HAVE_SYS_TIMES_H=
++HAVE_SYS_TIMES_H= YES
+ #HAVE_SYS_TIMES_H= NO
+ 
+ # Determine if we have the <time.h> include file.
+@@ -513,8 +513,8 @@ HAVE_SYS_TIMES_H=
+ #
+ # When in doubt, leave HAVE_TIME_H empty.
+ #
+-HAVE_TIME_H=
+-#HAVE_TIME_H= YES
++#HAVE_TIME_H=
++HAVE_TIME_H= YES
+ #HAVE_TIME_H= NO
+ 
+ # Determine if we have the <sys/time.h> include file.
+@@ -527,8 +527,8 @@ HAVE_TIME_H=
+ #
+ # When in doubt, leave HAVE_SYS_TIME_H empty.
+ #
+-HAVE_SYS_TIME_H=
+-#HAVE_SYS_TIME_H= YES
++#HAVE_SYS_TIME_H=
++HAVE_SYS_TIME_H= YES
+ #HAVE_SYS_TIME_H= NO
+ 
+ # Determine if we have the <unistd.h> include file.
+@@ -1131,7 +1131,7 @@ COMMON_LDFLAGS= ${EXTRA_LDFLAGS}
+ # Linux target #
+ ################
+ 
+-ifeq ($(target),Linux)
++ifeq ($(target),Haiku)
+ #
+ BLD_TYPE= calc-dynamic-only
+ #
+@@ -1993,7 +1993,7 @@ TARGETS= ${EARLY_TARGETS} ${BLD_TYPE} ${LATE_TARGETS}
+ #
+ ###
+ 
+-all: check_include ${BLD_TYPE} CHANGES
++all: ${BLD_TYPE} CHANGES
+ 
+ check_include:
+ 	$(Q) if [ ! -d /usr/include ]; then \
+@@ -2149,7 +2149,7 @@ calc.usage: calc.1 ${MAKE_FILE}
+ 	    LESSCHARSET=iso8859 ${CALCPAGER} calc.1; \
+ 	else \
+ 	    ${NROFF} -man calc.1; \
+-	fi | ${COL} -b > $@
++	fi > $@
+ 	${Q} echo calc.usage formed
+ 
+ 
+-- 
+2.7.0
+


### PR DESCRIPTION
Oppss.

In current recipe we removed ldconfig due to there's no ldconfig, but i just found out that ldconfig is exist with name ld in haiku.

I found that from:
https://github.com/haikuports/haikuports/blob/75a3cf5384f650242f4b8a1094ab305d33ed99e7/app-emulation/pcem/pcem-10.1.recipe#L39

should i revert or make new pr?

But look like there's no big impact either we add it or not.

Amend haikuports/haikuports#901
