### PR TITLE
(GCI) Added recipe for app-crypt/stegsnow

### DIFF
--- a/app-crypt/stegsnow/stegsnow-20130616.recipe
+++ b/app-crypt/stegsnow/stegsnow-20130616.recipe
@@ -1,0 +1,47 @@
+SUMMARY="Hides information in text files using trailing whitespace"
+DESCRIPTION="SNOW (Steganographic Nature Of Whitespace) is a steganography \
+tool which conceals messages in ASCII text by appending spaces to the end of \
+lines. Optional encryption is supported to further secure the message."
+HOMEPAGE="http://www.darkside.com.au/snow/"
+COPYRIGHT="1998-2013 Matthew Kwan"
+LICENSE="Apache v2"
+REVISION="1"
+SOURCE_URI="http://www.darkside.com.au/snow/snow-$portVersion.tar.gz"
+CHECKSUM_SHA256="c0b71aa74ed628d121f81b1cd4ae07c2842c41cfbdf639b50291fc527c213865"
+SOURCE_DIR="snow-$portVersion"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	stegsnow = $portVersion
+	cmd:stegsnow = $portVersion
+	"
+REQUIRES="
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc
+	cmd:make
+	"
+
+PATCH()
+{
+	sed -i 's/snow/steg&/g; s/SNOW/STEG&/g;' snow.1
+}
+
+BUILD()
+{
+	make $jobArgs
+}
+
+INSTALL()
+{
+	# Upstream Makefile has no install target
+	install -d -m 755 $binDir $manDir/man1
+	install -m 555 -s -T snow $binDir/stegsnow
+	install -m 444 -T snow.1 $manDir/man1/stegsnow.1
+}


### PR DESCRIPTION
Added a recipe for SNOW (Steganographic Nature Of Whitespace), a steganography tool for hiding information in plaintext files using trailing whitespace.