### PR TITLE
Fish: hide socket warning at start.

### DIFF
--- a/app-shells/fish/patches/fish-2.4.0.patchset
+++ b/app-shells/fish/patches/fish-2.4.0.patchset
@@ -107,3 +107,30 @@ index eb5dc5c..097f384 100755
 -- 
 2.10.0
 
+From 298f3f2a13cac920da136525a9c936788876033c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
+Date: Thu, 22 Dec 2016 16:01:19 +0100
+Subject: [PATCH] Fish: hide socket warning at start. HACK!
+
+---
+ src/fish.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/fish.cpp b/src/fish.cpp
+index 644e62a..d81e173 100644
+--- a/src/fish.cpp
++++ b/src/fish.cpp
+@@ -210,7 +210,9 @@ static int try_connect_socket(std::string &name) {
+     /// fails with EPROTOTYPE, the connection is probably a STREAM; if it succeeds or fails any
+     /// other way, there is no cause for alarm. With thanks to Andrew Lutomirski <github.com/amluto>
+     if ((s = socket(AF_UNIX, SOCK_DGRAM, 0)) == -1) {
+-        wperror(L"socket");
++    	#ifndef __HAIKU__
++            wperror(L"socket");
++        #endif
+         return -1;
+     }
+ 
+-- 
+2.10.2
+


### PR DESCRIPTION
Not an ideal solution, but works and doesn't breaks anything.