### PR TITLE
mplayer: bump version, updated patchset

### DIFF
--- a/media-video/mplayer/mplayer-1.3.0.recipe
+++ b/media-video/mplayer/mplayer-1.3.0.recipe
@@ -19,98 +19,127 @@ European/ISO 8859-1,2 (Hungarian, English, Czech, etc), Cyrillic and Korean \
 fonts are supported along with 12 subtitle formats (MicroDVD, SubRip, OGM, \
 SubViewer, Sami, VPlayer, RT, SSA, AQTitle, JACOsub, PJS and our own: MPsub). \
 DVD subtitles (SPU streams, VOBsub and Closed Captions) are supported as well."
-HOMEPAGE="http://www.mplayerhq.hu"
-COPYRIGHT="2001-2013 The MPlayer Team"
+HOMEPAGE="http://www.mplayerhq.hu/"
+COPYRIGHT="2001-2016 The MPlayer Team"
 LICENSE="GNU LGPL v2.1"
-REVISION="3"
-SOURCE_URI="http://www.mplayerhq.hu/MPlayer/releases/MPlayer-1.1.1.tar.xz"
-CHECKSUM_SHA256="ce8fc7c3179e6a57eb3a58cb7d1604388756b8a61764cc93e095e7aff3798c76"
-SOURCE_DIR="MPlayer-1.1.1"
-PATCHES="mplayer_x86-1.1.1.patchset"
+REVISION="1"
+SOURCE_URI="http://www.mplayerhq.hu/MPlayer/releases/MPlayer-$portVersion.tar.xz"
+CHECKSUM_SHA256="3ad0846c92d89ab2e4e6fb83bf991ea677e7aa2ea775845814cbceb608b09843"
+SOURCE_DIR="MPlayer-$portVersion"
+PATCHES="mplayer_x86-1.3.0.patchset"
 
-ARCHITECTURES="x86_gcc2 x86"
+ARCHITECTURES="x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	mplayer$secondaryArchSuffix = $portVersion
-	cmd:mplayer
 	cmd:mencoder
+	cmd:mplayer
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	ffmpeg$secondaryArchSuffix
+	cdrtools$secondaryArchSuffix
+	#lib:live555$secondaryArchSuffix
 	lib:liba52$secondaryArchSuffix
 	lib:libbz2$secondaryArchSuffix
+	lib:libcaca$secondaryArchSuffix
+	#lib:libcddb$secondaryArchSuffix
+	lib:libcdio$secondaryArchSuffix
 	lib:libdca$secondaryArchSuffix
 	lib:libdv$secondaryArchSuffix
 	lib:libdvdcss$secondaryArchSuffix
 	lib:libdvdnav$secondaryArchSuffix
 	lib:libdvdread$secondaryArchSuffix
+	lib:libfaac$secondaryArchSuffix
 	lib:libfaad$secondaryArchSuffix
+	lib:libflac$secondaryArchSuffix
+	lib:libfontconfig$secondaryArchSuffix
 	lib:libfreetype$secondaryArchSuffix
 	lib:libfribidi$secondaryArchSuffix
-	lib:libfontconfig$secondaryArchSuffix
+	lib:libgif$secondaryArchSuffix
+	lib:libgl$secondaryArchSuffix
+	lib:libgnutls$secondaryArchSuffix
 	lib:libiconv$secondaryArchSuffix
-	lib:libGL$secondaryArchSuffix
 	lib:libjpeg$secondaryArchSuffix
 	lib:liblzo2$secondaryArchSuffix
 	lib:libmad$secondaryArchSuffix
 	lib:libmng$secondaryArchSuffix
 	lib:libmp3lame$secondaryArchSuffix
+	#lib:libmpcdec$secondaryArchSuffix
+	lib:libmpeg2$secondaryArchSuffix
 	lib:libmpg123$secondaryArchSuffix
+	lib:libncursesw$secondaryArchSuffix
+	lib:libogg$secondaryArchSuffix
 	lib:libopenal$secondaryArchSuffix
+	#lib:libopenjp2$secondaryArchSuffix
+	lib:libopus$secondaryArchSuffix
 	lib:libpng$secondaryArchSuffix
-#	lib:libsdl_1.2$secondaryArchSuffix
+	#lib:libschroedinger_1.0$secondaryArchSuffix
+	#lib:libsdl$secondaryArchSuffix
+	lib:libsmbclient$secondaryArchSuffix
 	lib:libspeex$secondaryArchSuffix
+	lib:libtheora$secondaryArchSuffix
 	lib:libtwolame$secondaryArchSuffix
+	lib:libvorbis$secondaryArchSuffix
 	lib:libvpx$secondaryArchSuffix
+	lib:libx264$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
+	ffmpeg${secondaryArchSuffix}_devel
+	#devel:live555$secondaryArchSuffix
 	devel:liba52$secondaryArchSuffix
 	devel:libbz2$secondaryArchSuffix
-#	devel:libcaca$secondaryArchSuffix
-#	devel:libcdio$secondaryArchSuffix
+	devel:libcaca$secondaryArchSuffix
+	#devel:libcddb$secondaryArchSuffix
+	devel:libcdio$secondaryArchSuffix
 	devel:libdca$secondaryArchSuffix
 	devel:libdv$secondaryArchSuffix
 	devel:libdvdcss$secondaryArchSuffix
 	devel:libdvdnav$secondaryArchSuffix
 	devel:libdvdread$secondaryArchSuffix
-#	devel:libfaac$secondaryArchSuffix
+	devel:libfaac$secondaryArchSuffix
 	devel:libfaad$secondaryArchSuffix
 	devel:libflac$secondaryArchSuffix
 	devel:libfontconfig$secondaryArchSuffix
 	devel:libfreetype$secondaryArchSuffix
 	devel:libfribidi$secondaryArchSuffix
-#	devel:libgif$secondaryArchSuffix
+	devel:libgif$secondaryArchSuffix
 	devel:libgl$secondaryArchSuffix
+	devel:libgnutls$secondaryArchSuffix
 	devel:libiconv$secondaryArchSuffix
 	devel:libjpeg$secondaryArchSuffix
 	devel:liblzo2$secondaryArchSuffix
 	devel:libmad$secondaryArchSuffix
 	devel:libmng$secondaryArchSuffix
 	devel:libmp3lame$secondaryArchSuffix
-#	devel:libmpcdec$secondaryArchSuffix
+	#devel:libmpcdec$secondaryArchSuffix
+	devel:libmpeg2$secondaryArchSuffix
 	devel:libmpg123$secondaryArchSuffix
+	devel:libncursesw$secondaryArchSuffix
 	devel:libogg$secondaryArchSuffix
 	devel:libopenal$secondaryArchSuffix
-	devel:libopenjp2$secondaryArchSuffix
-#	devel:libparanoia$secondaryArchSuffix
+	#devel:libopenjp2$secondaryArchSuffix
+	devel:libopus$secondaryArchSuffix
+	devel:libparanoia$secondaryArchSuffix
 	devel:libpng$secondaryArchSuffix
-#	devel:libschroedinger$secondaryArchSuffix
-	devel:libsdl$secondaryArchSuffix
-#	devel:libsmbclient$secondaryArchSuffix
+	#devel:libschroedinger_1.0$secondaryArchSuffix
+	#devel:libsdl$secondaryArchSuffix
+	devel:libsmbclient$secondaryArchSuffix
 	devel:libspeex$secondaryArchSuffix
+	devel:libtheora$secondaryArchSuffix
 	devel:libtwolame$secondaryArchSuffix
 	devel:libvorbis$secondaryArchSuffix
 	devel:libvpx$secondaryArchSuffix
-#	devel:libx264$secondaryArchSuffix
+	devel:libx264$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	cmd:gcc$secondaryArchSuffix
-	cmd:libtoolize
+	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
 	cmd:yasm
@@ -118,17 +147,21 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
+	export CFLAGS="-D_BSD_SOURCE"
+	export LDFLAGS="-lnetwork -lbsd"
+
 	libtoolize --force --copy --install
 	configure --prefix=$prefix --datadir=$dataDir \
 		--confdir=$settingsDir/mplayer --mandir=$manDir \
-		--disable-x264 --disable-x264-lavc --disable-dvdread-internal \
-		--enable-dvdread --extra-libs=-ldvdcss --disable-mp3lib --enable-menu \
-		--enable-haiku --disable-sdl --enable-runtime-cpudetection
-		#--disable-ffmpeg_a --enable-ffmpeg_so --enable-smb
-	make
+		--enable-dvdread --extra-libs="-ldvdcss -ldvdnav -ldvdread" --enable-menu \
+		--enable-haiku --disable-sdl --enable-runtime-cpudetection \
+		--enable-smb
+		#--disable-ffmpeg_a --enable-ffmpeg_so
+	make $jobArgs
 }
 
 INSTALL()
 {
 	make install
+	strip $binDir/*
 }

--- a/media-video/mplayer/patches/mplayer_x86-1.3.0.patchset
+++ b/media-video/mplayer/patches/mplayer_x86-1.3.0.patchset
@@ -1,14 +1,50 @@
-From 8a689c685def90b00d11f471fecf2a0d7d8375f8 Mon Sep 17 00:00:00 2001
-From: Sergei Reznikov <diver@gelios.net>
-Date: Thu, 12 Mar 2015 14:26:35 +0300
-Subject: Haiku: configure fixes
+From 683eb6964591da827fe9f7c7827507d999a12696 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
+Date: Mon, 26 Dec 2016 17:18:13 +0100
+Subject: [PATCH] Haiku supporting code from Sergei Reznikov
 
+---
+ Makefile               |   3 +
+ configure              |  42 ++++++-
+ libao2/ao_haiku.cpp    | 195 +++++++++++++++++++++++++++++++
+ libao2/audio_out.c     |   7 ++
+ libvo/haiku_common.cpp | 304 +++++++++++++++++++++++++++++++++++++++++++++++++
+ libvo/haiku_common.h   |  69 +++++++++++
+ libvo/haiku_view.cpp   | 171 ++++++++++++++++++++++++++++
+ libvo/haiku_view.h     |  36 ++++++
+ libvo/haiku_window.cpp | 125 ++++++++++++++++++++
+ libvo/haiku_window.h   |  31 +++++
+ libvo/video_out.c      |   4 +
+ libvo/vo_haiku.cpp     | 201 ++++++++++++++++++++++++++++++++
+ 12 files changed, 1185 insertions(+), 3 deletions(-)
+ create mode 100644 libao2/ao_haiku.cpp
+ create mode 100644 libvo/haiku_common.cpp
+ create mode 100644 libvo/haiku_common.h
+ create mode 100644 libvo/haiku_view.cpp
+ create mode 100644 libvo/haiku_view.h
+ create mode 100644 libvo/haiku_window.cpp
+ create mode 100644 libvo/haiku_window.h
+ create mode 100644 libvo/vo_haiku.cpp
 
+diff --git a/Makefile b/Makefile
+index f59f635..3d422c3 100644
+--- a/Makefile
++++ b/Makefile
+@@ -544,6 +544,9 @@ SRCS_MPLAYER-$(S3FB)          += libvo/vo_s3fb.c
+ SRCS_MPLAYER-$(SDL)           += libao2/ao_sdl.c                        \
+                                  libvo/vo_sdl.c                         \
+                                  libvo/sdl_common.c
++SRCS_MPLAYER-$(HAIKU)         += libao2/ao_haiku.cpp                    \
++                                 libvo/vo_haiku.cpp                     \
++                                 libvo/haiku_common.cpp
+ SRCS_MPLAYER-$(SGIAUDIO)      += libao2/ao_sgi.c
+ SRCS_MPLAYER-$(SNDIO)         += libao2/ao_sndio.c
+ SRCS_MPLAYER-$(SUNAUDIO)      += libao2/ao_sun.c
 diff --git a/configure b/configure
-index 722b8a4..5b5d52e 100755
+index d18543d..02f2004 100755
 --- a/configure
 +++ b/configure
-@@ -242,6 +242,7 @@ qnx()       { issystem "QNX"; }
+@@ -228,6 +228,7 @@ qnx()       { issystem "QNX"; }
  sunos()     { issystem "SunOS"; }
  wine()      { issystem "Wine"; }
  win32()     { cygwin || mingw32 || wine; }
@@ -16,7 +52,7 @@ index 722b8a4..5b5d52e 100755
  
  # arch test boolean functions
  # x86/x86pc is used by QNX
-@@ -486,6 +487,7 @@ Video output:
+@@ -469,6 +470,7 @@ Video output:
    --enable-vesa            enable VESA video output [autodetect]
    --enable-svga            enable SVGAlib video output [autodetect]
    --enable-sdl             enable SDL video output [autodetect]
@@ -24,15 +60,15 @@ index 722b8a4..5b5d52e 100755
    --enable-kva             enable KVA video output [autodetect]
    --enable-aa              enable AAlib video output [autodetect]
    --enable-caca            enable CACA  video output [autodetect]
-@@ -696,6 +698,7 @@ _xv=auto
- _xvmc=no  #auto when complete
+@@ -678,6 +680,7 @@ _xvmc=no  #auto when complete
+ _vda=auto
  _vdpau=auto
  _sdl=auto
 +_haiku=auto
  _kva=auto
  _direct3d=auto
  _directx=auto
-@@ -1039,6 +1042,8 @@ for ac_option do
+@@ -1028,6 +1031,8 @@ for ac_option do
    --disable-vdpau)      _vdpau=no       ;;
    --enable-sdl)         _sdl=yes        ;;
    --disable-sdl)        _sdl=no         ;;
@@ -41,55 +77,7 @@ index 722b8a4..5b5d52e 100755
    --enable-kva)         _kva=yes        ;;
    --disable-kva)        _kva=no         ;;
    --enable-direct3d)    _direct3d=yes   ;;
-@@ -1513,14 +1518,15 @@ if test -z "$_target" ; then
- 
-   # host's CPU/instruction set
-   case "$(uname -m 2>&1)" in
--      x86_64|amd64|i[3-9]86*|i86pc|x86|x86pc|k5|k6|k6_2|k6_3|k6-2|k6-3|pentium*|athlon*|i586_i686|i586-i686) host_arch=i386 ;;
-+      x86_64|amd64|i[3-9]86*|i86pc|x86|x86pc|k5|k6|k6_2|k6_3|k6-2|k6-3|pentium*|athlon*|i586_i686|i586-i686|BePC) host_arch=i386 ;;
-       ia64) host_arch=ia64 ;;
-       macppc|ppc*|Power*) host_arch=ppc ;;
-       alpha) host_arch=alpha ;;
-       sun4*|sparc*) host_arch=sparc ;;
-       parisc*|hppa*|9000*) host_arch=hppa ;;
--      arm*|zaurus|cats) host_arch=arm ;;
--      sh3|sh4|sh4a) host_arch=sh ;;
-+      arm*|zaurus|cats|evbarm) host_arch=arm ;;
-+      sh3*) host_arch=sh ;;
-+      sh4|sh4a) host_arch=sh4 ;;
-       s390) host_arch=s390 ;;
-       s390x) host_arch=s390x ;;
-       *mips*) host_arch=mips ;;
-@@ -1545,6 +1551,7 @@ else # if test -z "$_target"
-       amigaos) system_name=AmigaOS ;;
-       mingw32*) system_name=MINGW32 ;;
-       wine) system_name=Wine ;;
-+      haiku) system_name=Haiku ;;
-     esac
-   done
-   # We need to convert underscores so that values like k6-2 and pentium-mmx can be passed
-@@ -1555,7 +1562,7 @@ else # if test -z "$_target"
- fi
- 
- extra_cflags="-I. -Iffmpeg $extra_cflags"
--extra_ldflags="-lm $extra_ldflags"
-+extra_ldflags="$extra_ldflags"
- _timer=timer-linux.c
- _getch=getch2.c
- 
-@@ -1619,6 +1626,11 @@ if wine ; then
-   extra_cflags="-fno-pic -UWIN32 -U_WIN32 -U__WIN32 -U__WIN32__ -DWINE_NOWINSOCK -Dstricmp=strcasecmp $extra_cflags"
- fi
- 
-+if haiku ; then
-+  extra_ldflags="$extra_ldflags -lbe -lmedia -lsupc++"
-+  extra_cflags="-fno-pic $extra_cflags"
-+fi
-+
- for tmpdir in "$TMPDIR" "$TEMPDIR" "/tmp" ; do
-   test "$tmpdir" && break
- done
-@@ -1674,7 +1686,7 @@ else
+@@ -1640,7 +1645,7 @@ else
        cc_name=$cc_name_tmp
        echocheck "$_cc version"
        cc_vendor=gnu
@@ -98,7 +86,36 @@ index 722b8a4..5b5d52e 100755
        case $cc_version in
          2.96*)
            cc_fail=yes
-@@ -5393,6 +5405,29 @@ fi
+@@ -1710,7 +1715,7 @@ if test -z "$_target" ; then
+   # host's CPU/instruction set
+   set_host_arch() {
+   case "$1" in
+-      x86_64|amd64|i[3-9]86*|i86pc|x86|x86pc|k5|k6|k6_2|k6_3|k6-2|k6-3|pentium*|athlon*|i586_i686|i586-i686) host_arch=i386 ;;
++      x86_64|amd64|i[3-9]86*|i86pc|x86|x86pc|k5|k6|k6_2|k6_3|k6-2|k6-3|pentium*|athlon*|i586_i686|i586-i686|BePC) host_arch=i386 ;;
+       ia64) host_arch=ia64 ;;
+       macppc|ppc*|Power*) host_arch=ppc ;;
+       alpha) host_arch=alpha ;;
+@@ -1749,6 +1754,7 @@ else # if test -z "$_target"
+       amigaos) system_name=AmigaOS ;;
+       mingw32*) system_name=MINGW32 ;;
+       wine) system_name=Wine ;;
++      haiku) system_name=Haiku ;;
+     esac
+   done
+   # We need to convert underscores so that values like k6-2 and pentium-mmx can be passed
+@@ -1825,6 +1831,11 @@ if wine ; then
+   extra_cflags="-fno-pic -UWIN32 -U_WIN32 -U__WIN32 -U__WIN32__ -DWINE_NOWINSOCK $extra_cflags"
+ fi
+ 
++if haiku ; then
++  extra_ldflags="$extra_ldflags -lbe -lmedia -lsupc++"
++  extra_cflags="-fno-pic $extra_cflags"
++fi
++
+ if darwin && test "$cc_vendor" != "clang" ; then
+   extra_cflags="-falign-loops=16 -shared-libgcc $extra_cflags"
+ fi
+@@ -5766,6 +5777,29 @@ fi
  echores "$_v4l2"
  
  
@@ -128,7 +145,7 @@ index 722b8a4..5b5d52e 100755
  
  #########
  # AUDIO #
-@@ -7639,7 +7674,7 @@ fi
+@@ -8005,7 +8039,7 @@ fi
  # (FIXME: 'echocheck "dynamic linking"' above and modify here accordingly)
  ld_dl_dynamic=''
  freebsd || netbsd || openbsd || dragonfly || bsdos && ld_dl_dynamic='-rdynamic'
@@ -137,15 +154,15 @@ index 722b8a4..5b5d52e 100755
    ld_dl_dynamic='-rdynamic'
  fi
  
-@@ -8150,6 +8185,7 @@ RADIO_CAPTURE=$_radio_capture
+@@ -8498,6 +8532,7 @@ RADIO_CAPTURE=$_radio_capture
  REAL_CODECS = $_real
  S3FB = $_s3fb
  SDL = $_sdl
 +HAIKU = $_haiku
+ SDL_IMAGE = $sdl_image
  SPEEX = $_speex
  STREAM_CACHE = $_stream_cache
- SGIAUDIO = $_sgiaudio
-@@ -8647,6 +8683,7 @@ $def_quartz
+@@ -9080,6 +9115,7 @@ $def_quartz
  $def_s3fb
  $def_sdl
  $def_sdl_sdl_h
@@ -153,28 +170,6 @@ index 722b8a4..5b5d52e 100755
  $def_svga
  $def_tdfxfb
  $def_tdfxvid
--- 
-2.2.2
-
-
-From 1e10d843d1128b9d6a9084b44bf2211299b0f3d5 Mon Sep 17 00:00:00 2001
-From: Gerasim Troeglazov <3deyes@gmail.com>
-Date: Thu, 12 Mar 2015 14:27:24 +0300
-Subject: Haiku: add native audio/video output modules
-
-
-diff --git a/Makefile b/Makefile
-index 940d43b..ec1163e 100644
---- a/Makefile
-+++ b/Makefile
-@@ -591,6 +591,7 @@ SRCS_MPLAYER-$(PULSE)         += libao2/ao_pulse.c
- SRCS_MPLAYER-$(QUARTZ)        += libvo/vo_quartz.c libvo/osx_common.c
- SRCS_MPLAYER-$(S3FB)          += libvo/vo_s3fb.c
- SRCS_MPLAYER-$(SDL)           += libao2/ao_sdl.c libvo/vo_sdl.c libvo/sdl_common.c
-+SRCS_MPLAYER-$(HAIKU)         += libao2/ao_haiku.cpp libvo/vo_haiku.cpp libvo/haiku_common.cpp
- SRCS_MPLAYER-$(SGIAUDIO)      += libao2/ao_sgi.c
- SRCS_MPLAYER-$(SUNAUDIO)      += libao2/ao_sun.c
- SRCS_MPLAYER-$(SVGA)          += libvo/vo_svga.c
 diff --git a/libao2/ao_haiku.cpp b/libao2/ao_haiku.cpp
 new file mode 100644
 index 0000000..e201f17
@@ -377,18 +372,18 @@ index 0000000..e201f17
 +    return (float)(buffered + ao_data.buffersize)/(float)ao_data.bps;
 +}
 diff --git a/libao2/audio_out.c b/libao2/audio_out.c
-index 6021ae1..2fa6bd8 100644
+index 197a63b..7f7baff 100644
 --- a/libao2/audio_out.c
 +++ b/libao2/audio_out.c
-@@ -42,6 +42,7 @@ extern const ao_functions_t audio_out_null;
- extern const ao_functions_t audio_out_alsa;
+@@ -43,6 +43,7 @@ extern const ao_functions_t audio_out_alsa;
+ extern const ao_functions_t audio_out_sndio;
  extern const ao_functions_t audio_out_nas;
  extern const ao_functions_t audio_out_sdl;
 +extern const ao_functions_t audio_out_haiku;
  extern const ao_functions_t audio_out_sun;
  extern const ao_functions_t audio_out_sgi;
  extern const ao_functions_t audio_out_win32;
-@@ -104,6 +105,12 @@ const ao_functions_t* const audio_out_drivers[] =
+@@ -108,6 +109,12 @@ const ao_functions_t* const audio_out_drivers[] =
  #ifdef CONFIG_SDL
          &audio_out_sdl,
  #endif
@@ -1174,10 +1169,10 @@ index 0000000..34513df
 +
 +
 diff --git a/libvo/video_out.c b/libvo/video_out.c
-index 813de7f..281ee3f 100644
+index bcf5174..c797ae8 100644
 --- a/libvo/video_out.c
 +++ b/libvo/video_out.c
-@@ -102,6 +102,7 @@ extern const vo_functions_t video_out_gl2;
+@@ -109,6 +109,7 @@ extern const vo_functions_t video_out_gl_tiled;
  extern const vo_functions_t video_out_matrixview;
  extern const vo_functions_t video_out_dga;
  extern const vo_functions_t video_out_sdl;
@@ -1185,7 +1180,7 @@ index 813de7f..281ee3f 100644
  extern const vo_functions_t video_out_3dfx;
  extern const vo_functions_t video_out_tdfxfb;
  extern const vo_functions_t video_out_s3fb;
-@@ -204,6 +205,9 @@ const vo_functions_t* const video_out_drivers[] =
+@@ -211,6 +212,9 @@ const vo_functions_t* const video_out_drivers[] =
  #ifdef CONFIG_SDL
          &video_out_sdl,
  #endif
@@ -1403,5 +1398,5 @@ index 0000000..614c8ff
 +
 +
 -- 
-2.2.2
+2.10.2
 


### PR DESCRIPTION
> ~ ❯❯❯ mplayer -v
> MPlayer 1.3.0-5.4.0 (C) 2000-2016 MPlayer Team
> CPU vendor name: GenuineIntel  max cpuid level: 10
> CPU: Intel(R) Core(TM)2 Duo CPU     L9300  @ 1.60GHz (Family: 6, Model: 23, Stepping: 6)
> extended cpuid-level: 8
> extended cache-info: 402686016
> Detected cache-line size is 64 bytes
> CPUflags:  MMX: 1 MMX2: 1 3DNow: 0 3DNowExt: 0 SSE: 1 SSE2: 1 SSE3: 1 SSSE3: 1 SSE4: 1 SSE4.2: 0 AVX: 0
> Compiled with runtime CPU detection.

I think the runtime cpu detection works now. We should close this issue: https://github.com/haikuports/haikuports/issues

Oh, and it is already tested on x86_64.