### PR TITLE
Added recipe for libextractor

### DIFF
--- a/media-libs/libextractor/libextractor-1.3.recipe
+++ b/media-libs/libextractor/libextractor-1.3.recipe
@@ -1,0 +1,109 @@
+SUMMARY="Meta data extraction tool and library"
+DESCRIPTION="GNU libextractor is a library used to extract meta data from files of \
+arbitrary type.  It is designed to use helper-libraries to perform the \
+actual extraction, and to be trivially extendable by linking against \
+external extractors for additional file types.  Common use-cases for \
+GNU libextractor include detail-views in file managers, detailed \
+search results in file-sharing networks and general information \
+gathering in forensics investigations and penetration testing."
+HOMEPAGE="https://www.gnu.org/software/libextractor/"
+COPYRIGHT="2013 GNU Project"
+LICENSE="GNU GPL v3"
+REVISION="1"
+SOURCE_URI="ftp://ftp.gnu.org/gnu/libextractor/libextractor-1.3.tar.gz"
+CHECKSUM_SHA256="868ad64c9a056d6b923d451d746935bffb1ddf5d89c3eb4f67d786001a3f7b7f"
+if [ $effectiveTargetArchitecture = x86_gcc2 ]; then
+	PATCHES="libextractor-1.3_gcc2.patchset"
+fi
+
+# x86_gcc2 is disabled because the following dependencies are broken on it:
+# libarchive
+# libexiv2
+# libgsf
+# libgstreamer
+ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
+
+PROVIDES="
+	libextractor$secondaryArchSuffix = $portVersion
+	cmd:extract$secondaryArchSuffix = $portVersion
+	lib:libextractor$secondaryArchSuffix = $portVersion compat >= 0
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libarchive$secondaryArchSuffix
+	lib:libtiff$secondaryArchSuffix
+	lib:libbz2$secondaryArchSuffix
+	lib:libavutil$secondaryArchSuffix
+	lib:libexiv2$secondaryArchSuffix
+	lib:libflac$secondaryArchSuffix
+	lib:libgif$secondaryArchSuffix
+	lib:libgsf$secondaryArchSuffix
+	lib:libgstreamer$secondaryArchSuffix
+	lib:libjpeg$secondaryArchSuffix
+	lib:libmagic$secondaryArchSuffix
+	lib:libmpeg2$secondaryArchSuffix
+	lib:libmp4v2$secondaryArchSuffix
+	lib:libtidy$secondaryArchSuffix
+	lib:libvorbis$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	libextractor${secondaryArchSuffix}_devel = $portVersion
+	devel:libextractor$secondaryArchSuffix = $portVersion compat >= 0
+	"
+REQUIRES_devel="
+	libextractor$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libcurl$secondaryArchSuffix
+	devel:libltdl$secondaryArchSuffix
+	devel:libarchive$secondaryArchSuffix
+	devel:libtiff$secondaryArchSuffix
+	devel:libbz2$secondaryArchSuffix
+	devel:libavutil$secondaryArchSuffix
+	devel:libexiv2$secondaryArchSuffix
+	devel:libflac$secondaryArchSuffix
+	devel:libgif$secondaryArchSuffix
+	devel:libgsf$secondaryArchSuffix
+	devel:libgstreamer$secondaryArchSuffix
+	devel:libjpeg$secondaryArchSuffix
+	devel:libmagic$secondaryArchSuffix
+	devel:libmpeg2$secondaryArchSuffix
+	devel:libmp4v2$secondaryArchSuffix
+	devel:libtidy$secondaryArchSuffix
+	devel:libvorbis$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	"
+
+BUILD()
+{
+	runConfigure ./configure --disable-dependency-tracking
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	prepareInstalledDevelLib libextractor
+	fixPkgconfig
+
+	if [ -n "$secondaryArchSuffix" ]; then
+		rm -rf $manDir
+	fi
+
+	packageEntries devel \
+			$developDir
+}
+
+TEST()
+{
+	make check
+}

--- a/media-libs/libextractor/patches/libextractor-1.3_gcc2.patchset
+++ b/media-libs/libextractor/patches/libextractor-1.3_gcc2.patchset
@@ -1,0 +1,30 @@
+From c3b20ed658c8372414e64dd9a24399c2743a54c3 Mon Sep 17 00:00:00 2001
+From: Tudor Nazarie <nazarietudor@gmail.com>
+Date: Tue, 27 Dec 2016 18:28:02 +0000
+Subject: Build fixes for gcc2
+
+
+diff --git a/src/main/extractor_datasource.c b/src/main/extractor_datasource.c
+index 190834a..c41258a 100644
+--- a/src/main/extractor_datasource.c
++++ b/src/main/extractor_datasource.c
+@@ -564,14 +564,8 @@ cfs_init_decompressor_zlib (struct CompressedFileSource *cfs,
+    *
+    * ZLIB_VERNUM isn't defined by zlib version 1.1.4 ;
+    * there might be a better check.
+-   */
+-  if (Z_OK != inflateInit2 (&cfs->strm,
+-#ifdef ZLIB_VERNUM
+-      15 + 32
+-#else
+-      - MAX_WBITS
+-#endif
+-      ))
++   */ 
++   if (Z_OK != inflateInit(&cfs->strm))
+     {
+       LOG ("Failed to initialize zlib decompression\n");
+       return -1;
+-- 
+2.7.0
+


### PR DESCRIPTION
Added recipe for building and installing GNU libextractor.

At this moment it does not compile because of a missing POSIX library in Haiku (sys/shm.h), and such it is noted as untested. It is noted as broken on x86_gcc2 because some of its dependencies are broken on that architecture.