### PR TITLE
lighttpd: bump to 1.4.44.

### DIFF
--- a/www-servers/lighttpd/lighttpd-1.4.44.recipe
+++ b/www-servers/lighttpd/lighttpd-1.4.44.recipe
@@ -11,7 +11,7 @@ COPYRIGHT="2003-2016 Jan Kneschke"
 LICENSE="BSD (3-clause)"
 REVISION="1"
 SOURCE_URI="https://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-$portVersion.tar.xz"
-CHECKSUM_SHA256="b2c9069ed0bade9362c27b469a9b884641786aea1c3d686f9fd9f01d15e2a15f"
+CHECKSUM_SHA256="adb66ca985651957feb209c91c55ebbf917d23630bfc3a216a2f70043c7b5422"
 ADDITIONAL_FILES="
 	create-lighttpd-directories.sh
 	index.template
@@ -38,9 +38,9 @@ PROVIDES="
 	lib:mod_alias
 	lib:mod_auth
 	lib:mod_authn_file
-	lib:mod_authn_gssapi
+#	lib:mod_authn_gssapi
 	lib:mod_authn_ldap
-	lib:mod_authn_mysql
+#	lib:mod_authn_mysql
 	lib:mod_cgi
 	lib:mod_cml
 	lib:mod_compress
@@ -54,7 +54,7 @@ PROVIDES="
 	lib:mod_flv_streaming
 	lib:mod_indexfile
 	lib:mod_magnet
-	lib:mod_mysql_vhost
+#	lib:mod_mysql_vhost
 	lib:mod_proxy
 	lib:mod_redirect
 	lib:mod_rewrite
@@ -66,7 +66,7 @@ PROVIDES="
 	lib:mod_ssi
 	lib:mod_staticfile
 	lib:mod_status
-	lib:mod_trigger_b4_dl
+#	lib:mod_trigger_b4_dl
 	lib:mod_uploadprogress
 	lib:mod_userdir
 	lib:mod_usertrack
@@ -203,9 +203,6 @@ POST_INSTALL_SCRIPTS="
 
 BUILD()
 {
-	aclocal
-	autoconf
-	automake
 	runConfigure --omit-dirs "libDir sbinDir" ./configure \
 		--libdir=$libDir/lighttpd --sbindir=$commandBinDir \
 		--with-openssl --with-zlib --with-bzip2 --with-pcre \
@@ -286,13 +283,8 @@ INSTALL()
 		$settingsDir/lighttpd/lighttpd.conf
 
 	cp doc/config/modules.conf $settingsDir/lighttpd
-	# Insert commented inclusion of geoip.conf before ssi.conf
+	# Enable mod_ssi
 	sed -i \
-		-e '/^## mod_ssi/ i ## mod_geoip\
-##\
-#include "conf.d/geoip.conf"\
-\
-##' \
 		-e "s|^#\(include \"conf\.d/ssi\.conf\"\)|\1|" \
 		$settingsDir/lighttpd/modules.conf
 
@@ -305,7 +297,7 @@ INSTALL()
 
 	sed -i \
 		-e "/^#geoip\.db-filename =/ \
-			s|/path/to/GeoCityLite\.dat|$constantSystemCacheDir/GeoIP/GeoLiteCity.dat|" \
+			s|/path/to/|$constantSystemCacheDir/GeoIP/|" \
 		$settingsDir/lighttpd/conf.d/geoip.conf
 
 	# Create a read-only copy of the settings


### PR DESCRIPTION
* Do not call aclocal, autoconf and automake anymore, as this is no longer required given that we don't need to fix `Makefile.am` anymore.
* Update PROVIDES by commenting out `lib:mod_authn_{gssapi,mysql}`, `lib:mod_mysql_vhost` and `lib:mod_trigger_b4_dl` because 1.4.44 no longer creates empty modules when dependencies are missing.
* Simplify the on-the-fly patch for` lighttpd/conf.d/geoip.conf` as upstream now suggests `GeoLiteCity.dat` instead of `GeoCityLite.dat`.
* Inclusion of mod_geoip before mod_ssi has been applied upstream.