### PR TITLE
Add gnu-efi recipe

### DIFF
--- a/sys-boot/gnu-efi/gnu_efi_kernel-3.0.4.recipe
+++ b/sys-boot/gnu-efi/gnu_efi_kernel-3.0.4.recipe
@@ -1,0 +1,29 @@
+SUMMARY="GNU EFI Library - Kernel support"
+DESCRIPTION="Develop EFI applications for ARM-64, ARM-32, x86_64, IA-64 (IPF), \
+and IA-32 (x86) platforms using the GNU toolchain and the EFI development \
+environment."
+HOMEPAGE="https://sourceforge.net/projects/gnu-efi/"
+COPYRIGHT="1999-2007 Hewlett-Packard Co.
+	2006-2010 Intel Co."
+LICENSE="BSD (3-clause)"
+REVISION="1"
+SOURCE_URI="http://downloads.sf.net/gnu-efi/gnu-efi-$portVersion.tar.bz2"
+CHECKSUM_SHA256="51a00428c3ccb96db24089ed8394843c4f83cf8f42c6a4dfddb4b7c23f2bf8af"
+SOURCE_DIR="gnu-efi-$portVersion"
+
+ARCHITECTURES="any"
+DISABLE_SOURCE_PACKAGE="yes"
+
+PROVIDES="
+	gnu_efi_kernel = $portVersion compat >= 0
+	"
+
+INSTALL()
+{
+	mkdir -p $includeDir/gnuefi
+	cd inc/ && rsync -avm --include='*.h' -f 'hide,! */' . $includeDir/gnuefi/ && cd ..
+	mkdir -p $developLibDir/gnuefi
+	cp gnuefi/*.lds $developLibDir/gnuefi/
+	cp gnuefi/*.S $developLibDir/gnuefi/
+	cp gnuefi/*.c $developLibDir/gnuefi/
+}


### PR DESCRIPTION
Missing dash in recipe name since haikuporter does not support
having dashes in filename.

Signed-off-by: Mason X <masonx.01@gmail.com>