### PR TITLE
libepubgen: added recipe

### DIFF
--- a/app-text/libepubgen/libepubgen-0.0.0.recipe
+++ b/app-text/libepubgen/libepubgen-0.0.0.recipe
@@ -1,0 +1,82 @@
+SUMMARY="EPUB generator for librevenge"
+DESCRIPTION="libepubgen is an EPUB generator for librevenge. It supports \
+librevenge's text document interface and--currently in a very limited \
+way--presentation and vector drawing interfaces."
+HOMEPAGE="https://sourceforge.net/projects/libepubgen"
+COPYRIGHT="2016 David Tardon"
+LICENSE="MPL v2.0"
+REVISION="1"
+SOURCE_URI="https://downloads.sourceforge.net/libepubgen/libepubgen-$portVersion.tar.gz"
+CHECKSUM_SHA256="966f903626a5cea06e197e93d2b11c36c8ccc67655392dc8445856168bb9fe68"
+
+ARCHITECTURES="!x86_gcc2 x86 ?x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	libepubgen$secondaryArchSuffix = $portVersion compat >= 0
+	lib:libepubgen_0.0$secondaryArchSuffix = $portVersion compat >= 0
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:librevenge_0.0$secondaryArchSuffix
+	lib:librevenge_generators_0.0$secondaryArchSuffix
+	lib:librevenge_stream_0.0$secondaryArchSuffix
+	lib:libboost_system$secondaryArchSuffix
+	lib:libcppunit$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	libepubgen${secondaryArchSuffix}_devel = $portVersion compat >= 0
+	devel:libepubgen_0.0$secondaryArchSuffix = $portVersion compat >= 0
+	"
+REQUIRES_devel="
+	libepubgen$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:librevenge_0.0$secondaryArchSuffix
+	devel:librevenge_generators_0.0$secondaryArchSuffix
+	devel:librevenge_stream_0.0$secondaryArchSuffix
+	devel:libboost_system$secondaryArchSuffix
+	devel:libcppunit$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:autoheader
+	cmd:automake
+	cmd:awk
+	cmd:diff
+	cmd:g++$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	libtoolize --force --copy --install
+	aclocal
+	autoheader
+	automake -a -c --foreign
+	autoconf
+	runConfigure ./configure --without-docs --disable-werror
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+	rm $libDir/libepubgen.la
+
+	prepareInstalledDevelLib libepubgen
+	fixPkgconfig
+	packageEntries devel $developDir
+}
+
+TEST()
+{
+	make check
+}


### PR DESCRIPTION
Added recipe for libepubgen.

In its current state I'm getting a compile error related to libboost. You can see the errror I'm gettting [here](https://gist.github.com/xdizzaster/258756af114c9ca8828f3e3e00c170dd). To me, it seems to be something wrong inside the boost header files. I got boost from the HaikuDepot.
I tried asking around on IRC, but nobody could figure out what I was doing wrong and I wasn't able to solve it on my own.