### PR TITLE
new recipe: libusbmuxd

### DIFF
--- a/app-pda/libusbmuxd/libusbmuxd-1.0.10.recipe
+++ b/app-pda/libusbmuxd/libusbmuxd-1.0.10.recipe
@@ -1,0 +1,90 @@
+SUMMARY="A client library to multiplex connections from and to iOS devices"
+DESCRIPTION="libusbmuxd is a client library to multiplex connections from and \
+to iOS devices by connecting to a socket provided by a usbmuxd daemon."
+HOMEPAGE="http://www.libimobiledevice.org/"
+COPYRIGHT="2013-2014 Nikias Bassen
+	2009-2014 Martin Szulecki"
+LICENSE="GNU GPL v2
+	GNU LGPL v2.1"
+REVISION="1"
+SOURCE_URI="http://www.libimobiledevice.org/downloads/libusbmuxd-$portVersion.tar.bz2"
+CHECKSUM_SHA256="1aa21391265d2284ac3ccb7cf278126d10d354878589905b35e8102104fec9f2"
+PATCHES="libusbmuxd-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
+
+if [ "$targetArchitecture" != x86_gcc2 ]; then
+	commandBinDir=$binDir
+else
+	commandBinDir=$prefix/bin
+fi
+
+PROVIDES="
+	libusbmuxd$secondaryArchSuffix = $portVersion compat >= 1
+	lib:libusbmuxd$secondaryArchSuffix = 4.0.0 compat >= 4
+	cmd:iproxy = $portVersion compat >= 1
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	lib:libxml2$secondaryArchSuffix
+	lib:libplist$secondaryArchSuffix
+	lib:libplist++$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	libusbmuxd${secondaryArchSuffix}_devel = $portVersion compat >= 1
+	devel:libusbmuxd$secondaryArchSuffix = 4.0.0 compat >= 4
+	"
+REQUIRES_devel="
+	libusbmuxd$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libxml2$secondaryArchSuffix
+	devel:libplist$secondaryArchSuffix
+	devel:libplist++$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:automake
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	libtoolize --force --copy --install
+	aclocal -I m4
+	autoconf
+	automake
+	runConfigure --omit-dirs binDir ./configure --bindir=$commandBinDir
+	make
+}
+
+INSTALL()
+{
+	make install
+
+	# remove libtool file
+	rm $libDir/libusbmuxd.la
+
+	prepareInstalledDevelLib libusbmuxd
+	fixPkgconfig
+
+	# devel package
+	packageEntries devel \
+		$developDir
+}
+
+TEST()
+{
+	make check
+}

--- a/app-pda/libusbmuxd/patches/libusbmuxd-1.0.10.patchset
+++ b/app-pda/libusbmuxd/patches/libusbmuxd-1.0.10.patchset
@@ -1,0 +1,25 @@
+From c9c0416a57d9489710980daa1cf69d1ea2157d77 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Fri, 6 Jan 2017 16:31:27 +0000
+Subject: [PATCH] Haiku compilation fixes
+
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index f44e26c..69fe662 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -8,7 +8,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES])
+ AC_CONFIG_SRCDIR([src/])
+ AC_CONFIG_HEADERS([config.h])
+ AC_CONFIG_MACRO_DIR([m4])
+-
++AC_SEARCH_LIBS(socket, network)
+ dnl libtool versioning
+ # +1 : 0 : +1  == adds new functions to the interface
+ # +1 : 0 : 0   == changes or removes functions (changes include both
+-- 
+2.7.4
+


### PR DESCRIPTION
libusbmuxd is needed to build libimobiledevice, libideviceactivation and ideviceinstaller. Tested on x86_64.