### PR TITLE
bebuilder: added recipe

### DIFF
--- a/haiku-apps/bebuilder/bebuilder-0.5.2~git.recipe
+++ b/haiku-apps/bebuilder/bebuilder-0.5.2~git.recipe
@@ -1,0 +1,46 @@
+SUMMARY="GUI designer for BeOS"
+DESCRIPTION="BeBuilder is a GUI designer for BeOS."
+HOMEPAGE="https://github.com/HaikuArchives/BeBuilder"
+COPYRIGHT="1999 Jerome Fillmon"
+LICENSE="Public Domain"
+REVISION="1"
+commit="a488ce807404481b74f989eac179398b5a48c1d5"
+SOURCE_URI="https://github.com/HaikuArchives/BeBuilder/archive/$commit.tar.gz"
+CHECKSUM_SHA256="a42815e7672c7c393850ee282f1e66acd195d4faaea33f1884a4418f4853a82f"
+SOURCE_FILENAME="BeBuilder-$commit.tar.gz"
+SOURCE_DIR="BeBuilder-$commit"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	bebuilder = $portVersion
+	app:BeBuilder = $portVersion
+	"
+
+REQUIRES="
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	makefile_engine
+	cmd:g++
+	cmd:ld
+	cmd:make
+	"
+
+BUILD()
+{
+	cd V0.5.2BeBuilder
+	mkdir -p bin
+	make $jobArgs TARGET_DIR=bin
+}
+
+INSTALL()
+{
+	install -d $appsDir
+	install -t $appsDir V0.5.2BeBuilder/bin/BeBuilder
+	addAppDeskbarSymlink $appsDir/BeBuilder
+}


### PR DESCRIPTION
Added recipe for BeBuilder BeOS GUI builder. 

Since the source code was not building properly because some parts of it were not standard compliant (using `string` instead of `std::string`, some missing libraries in the makefile, etc.), I had to write a patch to fix this. I think it would be best if I opened a PR on the BeBuilder repo and submit the patch there, like I did in #1030.