### PR TITLE
commandtimer: added recipe

### DIFF
--- a/haiku-apps/commandtimer/commandtimer-2.0~git.recipe
+++ b/haiku-apps/commandtimer/commandtimer-2.0~git.recipe
@@ -1,0 +1,46 @@
+SUMMARY="Launch or repeat commands after a user-chosen countdown"
+DESCRIPTION="CommandTimer counts down to zero then executes whatever command \
+is in the top box."
+HOMEPAGE="https://github.com/HaikuArchives/CommandTimer"
+COPYRIGHT="1999 Jason Scaroni"
+LICENSE="Public Domain"
+REVISION="1"
+commit="c85fda361d2190688680319fd19d0ee00fb0d4ad"
+SOURCE_URI="https://github.com/HaikuArchives/CommandTimer/archive/$commit.tar.gz"
+CHECKSUM_SHA256="33652430ce0d44e6e9a403ce38b1a5f6bfb40119bab99348692e02923eaf6cad"
+SOURCE_FILENAME="CommandTimer-$commit.tar.gz"
+SOURCE_DIR="CommandTimer-$commit"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	commandtimer = $portVersion
+	app:CommandTimer = $portVersion
+	"
+REQUIRES="
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	makefile_engine
+	cmd:g++
+	cmd:ld
+	cmd:make
+	"
+
+BUILD()
+{
+	cd src
+	mkdir -p bin
+	make $jobArgs TARGET_DIR=bin
+}
+
+INSTALL()
+{
+	install -d $appsDir
+	install -t $appsDir src/bin/CommandTimer
+	addAppDeskbarSymlink $appsDir/CommandTimer
+}


### PR DESCRIPTION
Added recipe for CommandTimer timed command execution utility.

I unfortunately could not find a year to put in the copyright section. If someone knows the year this program was written, I will update the commit with the correct data.
As with #1030, if needed, I could submit a PR to the CommandTimer repo with the Makefile, in order not to include it with the recipe as an additional file.