### PR TITLE
flac123: new recipe for a commandline FLAC player

### DIFF
--- a/media-sound/flac123/flac123-0.0.12.recipe
+++ b/media-sound/flac123/flac123-0.0.12.recipe
@@ -1,0 +1,60 @@
+SUMMARY="A command-line program for playing FLAC audio files"
+DESCRIPTION="flac-tools aims to be a complete set of tools for playing and \
+manipulating audio files stored in the FLAC format. flac123 is the only \
+component of flac-tools at this time."
+HOMEPAGE="http://flac-tools.sourceforge.net/"
+COPYRIGHT="2003-2012 Jake Angerman, Dan Johnson, Hans Oesterholt"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="https://downloads.sourceforge.net/flac-tools/flac123-$portVersion-release.tar.gz"
+CHECKSUM_SHA256="1976efd54a918eadd3cb10b34c77cee009e21ae56274148afa01edf32654e47d"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	flac123 = $portVersion
+	cmd:flac123 = $portVersion
+	"
+REQUIRES="
+	haiku
+	lib:libFLAC
+	lib:libao
+	lib:libogg
+	lib:libpopt
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	devel:libFLAC
+	devel:libao
+	devel:libogg
+	devel:libpopt
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:autoheader
+	cmd:automake
+	cmd:awk
+	cmd:gcc
+	cmd:make
+	"
+
+BUILD()
+{
+	aclocal
+	automake --add-missing
+	runConfigure ./configure
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+}
+
+TEST()
+{
+	# No real test at the moment
+	make check
+}


### PR DESCRIPTION
Adding new recipe for flac123, a commandline program for playing FLAC audio files.