### PR TITLE
lrzsz: added recipe

### DIFF
--- a/net-dialup/lrzsz/lrzsz-0.12.20.recipe
+++ b/net-dialup/lrzsz/lrzsz-0.12.20.recipe
@@ -1,0 +1,58 @@
+SUMMARY="Communication package providing the XMODEM, YMODEM & ZMODEM protocols"
+DESCRIPTION="lrzsz is a Unix package providing the XMODEM, YMODEM AND ZMODEM \
+file transfer protocols."
+HOMEPAGE="https://ohse.de/uwe/software/lrzsz.html"
+COPYRIGHT="1996-1998 Uwe Ohse"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="https://ohse.de/uwe/releases/lrzsz-$portVersion.tar.gz"
+CHECKSUM_SHA256="c28b36b14bddb014d9e9c97c52459852f97bd405f89113f30bee45ed92728ff1"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	lrzsz = $portVersion
+	cmd:lrz = $portVersion
+	cmd:lsz = $portVersion
+	cmd:lrb = $portVersion
+	cmd:lrx = $portVersion
+	cmd:lsb = $portVersion
+	cmd:lsx = $portVersion
+	"
+REQUIRES="
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc
+	cmd:ld
+	cmd:make
+	cmd:sed
+	"
+
+PATCH()
+{
+	sed -i -e "s|ln|ln -r -s|" src/Makefile.in
+}
+
+BUILD()
+{
+	runConfigure --omit-dirs "docDir dataRootDir" ./configure
+	make $jobArgs LIBS="-lnetwork"
+}
+
+INSTALL()
+{
+	make install
+	mkdir -p $dataDir
+	mv $prefix/share/* $dataDir
+	rmdir $prefix/share
+}
+
+TEST()
+{
+	make check
+}


### PR DESCRIPTION
Added recipe for lrzsz communication package.

I am aware that editing `Makefile.in` is not an optimal solution, but because of the package's age, it does not respond well when attempting to regenerate the configuration scripts with a modern version of the autotools. If someone is able to do it, I will be happy to update the commit, but until then, this is the solution I've come up with.