### PR TITLE
links: use libpng16 instead of libpng.

### DIFF
--- a/www-client/links/links-2.8.recipe
+++ b/www-client/links/links-2.8.recipe
@@ -1,54 +1,55 @@
 SUMMARY="A graphics and text mode web browser"
 DESCRIPTION="Links is a multi-platform web browser you can run in Terminal."
 HOMEPAGE="http://links.twibright.com/"
-COPYRIGHT="1999 - 2011 Mikulas Patocka
-	2000 - 2011 Petr Kulhavy, Karel Kulhavy, Martin Pergel"
+COPYRIGHT="1999-2013 Mikulas Patocka
+	2000-2011 Petr Kulhavy, Karel Kulhavy, Martin Pergel"
 LICENSE="GNU GPL v2"
-REVISION="2"
-SOURCE_URI="http://links.twibright.com/download/links-2.8.tar.gz"
+REVISION="3"
+SOURCE_URI="http://links.twibright.com/download/links-$portVersion.tar.gz"
 CHECKSUM_SHA256="5070a759af7f107ca4f9572833b8f086cd9f7c21ef5e1fce8482a2883a743c7a"
-PATCHES="links-2.8.patch"
+PATCHES="links-$portVersion.patch"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
 PROVIDES="
-	links$secondaryArchSuffix = $portVersion
-	cmd:links$secondaryArchSuffix = $portVersion
+	links = $portVersion
+	cmd:links = $portVersion
 	"
 REQUIRES="
-	haiku$secondaryArchSuffix
-	lib:libpng$secondaryArchSuffix
-	lib:libjpeg$secondaryArchSuffix
-#	lib:libtiff$secondaryArchSuffix
-	lib:libz$secondaryArchSuffix
-	openssl$secondaryArchSuffix >= 1.0.0
+	haiku
+	lib:libcrypto
+	lib:libpng16
+	lib:libjpeg
+	lib:libssl
+#	lib:libtiff
+	lib:libz
 	"
 
 BUILD_REQUIRES="
-	haiku${secondaryArchSuffix}_devel
-#	devel:libGL$secondaryArchSuffix
-	devel:libglu$secondaryArchSuffix
-	devel:libpng$secondaryArchSuffix
-	devel:libjpeg$secondaryArchSuffix
-#	devel:libtiff$secondaryArchSuffix
-	devel:libz$secondaryArchSuffix >= 1.2.8
-	openssl${secondaryArchSuffix}_devel >= 1.0.0
+	haiku_devel
+	devel:libcrypto
+#	devel:libGL
+	devel:libglu
+	devel:libpng16
+	devel:libjpeg
+	devel:libssl
+#	devel:libtiff
+	devel:libz >= 1.2.8
 	"
 BUILD_PREREQUIRES="
 	cmd:autoconf
 	cmd:libtool
 	cmd:aclocal
 	cmd:make
-	cmd:gcc$secondaryArchSuffix
-	cmd:ld$secondaryArchSuffix
-	cmd:pkg_config$secondaryArchSuffix
+	cmd:gcc
+	cmd:ld
+	cmd:pkg_config
 	"
 
 BUILD()
 {
 	STDCPPLIBS=-lstdc++
-	if [ "$targetArchitecture" = x86_gcc2 ]; then
+	if [ "$effectiveTargetArchitecture" = x86_gcc2 ]; then
 		STDCPPLIBS=-lstdc++.r4
 	fi
 	aclocal
@@ -66,4 +67,9 @@ INSTALL()
 {
 	make install
 	addAppDeskbarSymlink $binDir/links Links
+}
+
+TEST()
+{
+	make check
 }


### PR DESCRIPTION
* Drop unneeded support for secondary architectures.
* Depend on libssl and libcrypto instead of openssl.
* Use **`$effectiveTargetArchitecture`** (instead of **`$targetArchitecture`**) when defining STDCPPLIBS (as **`-lstdc++`** or *``lbstdc++.r5`**) in order to have a working code for both primary and secondary architectures,
  should that code snippet be copied to other recipes.
* Add TEST() with **`make check`**.