### PR TITLE
m4: bump to 1.4.18.

### DIFF
--- a/sys-devel/m4/m4-1.4.18.recipe
+++ b/sys-devel/m4/m4-1.4.18.recipe
@@ -11,12 +11,12 @@ integer arithmetic, manipulating text in various ways, recursion, etc. M4 can \
 be used either as a front-end to a compiler or as a macro processor in its own \
 right.
 One of the biggest users of M4 is the GNU Autoconf project."
-HOMEPAGE="http://www.gnu.org/software/m4/"
-COPYRIGHT="2000, 2005-2011 Free Software Foundation, Inc."
+HOMEPAGE="https://www.gnu.org/software/m4/"
+COPYRIGHT="2000, 2005-2016 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3"
-REVISION="3"
-SOURCE_URI="http://ftp.gnu.org/gnu/m4/m4-$portVersion.tar.gz"
-CHECKSUM_SHA256="3ce725133ee552b8b4baca7837fb772940b25e81b2a9dc92537aeaf733538c9e"
+REVISION="1"
+SOURCE_URI="https://ftp.gnu.org/gnu/m4/m4-$portVersion.tar.gz"
+CHECKSUM_SHA256="ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab"
 ARCHITECTURES="x86_gcc2 x86 x86_64 arm"
 
 PROVIDES="
@@ -33,11 +33,16 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	cmd:awk
 	cmd:gcc
+	cmd:grep
 	cmd:ld
 	cmd:make
-	cmd:awk
 	cmd:sed
-	cmd:grep
+	"
+
+TEST_REQUIRES="
+	cmd:cmp
+	cmd:diff
+	cmd:help2man
 	"
 
 defineDebugInfoPackage m4 \
@@ -46,7 +51,7 @@ defineDebugInfoPackage m4 \
 BUILD()
 {
 	runConfigure ./configure \
-		--disable-rpath --with-gnu-ld \
+		--with-gnu-ld \
 		--enable-changeword --disable-gcc-warnings
 	make $jobArgs
 }


### PR DESCRIPTION
* Switch HOMEPAGE & SOURCE_URI to https.
* ~~Add missing cmd:{cmp,diff,help2man} to BUILD_PREREQUIRES as TEST() needs them. Sort BUILD_PREREQUIRES while at it.~~
* ~~BTW, unlike 1.4.17, 1.4.18 fails to build (on Haiku) without help2man.~~
* Do not pass **`--disable-rpath`** to configure, otherwise the build fails if **`cmd:help2man`** is not in BUILD_PREREQUIRES.
* Define TEST_REQUIRES with **`cmd:{cmp,diff,help2man}`**. It might be used by HaikuPorter in the future.
* Remove duplicate **`cmd:awk`** in BUILD_PREREQUIRES (and sort it).