### PR TITLE
radare2: bump version to 1.1.0

### DIFF
--- a/dev-util/radare2/patches/radare2-1.1.0.patchset
+++ b/dev-util/radare2/patches/radare2-1.1.0.patchset
@@ -1,0 +1,25 @@
+From 7ba1179263ea8643ccf12e5b33f6726a157f7b50 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Fri, 27 Jan 2017 14:18:45 +0000
+Subject: [PATCH] disable pty in libr_socket
+
+---
+ libr/socket/run.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libr/socket/run.c b/libr/socket/run.c
+index 95d984e..3a16d7c 100644
+--- a/libr/socket/run.c
++++ b/libr/socket/run.c
+@@ -46,7 +46,7 @@
+ #endif
+ #endif
+ 
+-#define HAVE_PTY __UNIX__ && !__ANDROID__ && LIBC_HAVE_FORK
++#define HAVE_PTY __UNIX__ && !__ANDROID__ && LIBC_HAVE_FORK && !defined(__HAIKU__)
+ 
+ R_API RRunProfile *r_run_new(const char *str) {
+ 	RRunProfile *p = R_NEW (RRunProfile);
+-- 
+2.7.4
+

--- a/dev-util/radare2/radare2-1.1.0.recipe
+++ b/dev-util/radare2/radare2-1.1.0.recipe
@@ -8,16 +8,18 @@ COPYRIGHT="2009-2015 nibble, pancake"
 LICENSE="GNU GPL v3
 	GNU LGPL v3"
 REVISION="1"
-SOURCE_URI="http://radare.org/get/radare2-$portVersion.tar.xz"
-CHECKSUM_SHA256="024adba5255f12e58c2c1a5e2263fada75aad6e71b082461dea4a2b94b29df32"
+SOURCE_URI="http://cloud.radare.org/get/1.1.0/radare2-$portVersion.tar.gz"
+CHECKSUM_SHA256="7bc1e206a2b4def6bdb8684c2af0281b007986a0b5b5da652bd03be264ca0fa5"
+PATCHES="radare2-1.1.0.patchset"
 
-ARCHITECTURES="?x86"
+ARCHITECTURES="?x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	radare2$secondaryArchSuffix = $portVersion
 	cmd:r2$secondaryArchSuffix
 	cmd:r2agent$secondaryArchSuffix
+	cmd:r2pm$secondaryArchSuffix
 	cmd:rabin2$secondaryArchSuffix
 	cmd:radare2$secondaryArchSuffix
 	cmd:radiff2$secondaryArchSuffix
@@ -28,7 +30,7 @@ PROVIDES="
 	cmd:rarun2$secondaryArchSuffix
 	cmd:rasm2$secondaryArchSuffix
 	cmd:rax2$secondaryArchSuffix
-	lib:libr2$secondaryArchSuffix = 0.9.9
+	lib:libr2$secondaryArchSuffix = 1.1.0
 	lib:libr_anal$secondaryArchSuffix
 	lib:libr_asm$secondaryArchSuffix
 	lib:libr_bin$secondaryArchSuffix
@@ -40,7 +42,7 @@ PROVIDES="
 	lib:libr_db$secondaryArchSuffix
 	lib:libr_debug$secondaryArchSuffix
 	lib:libr_egg$secondaryArchSuffix
-	lib:libr_flags$secondaryArchSuffix
+	lib:libr_flag$secondaryArchSuffix
 	lib:libr_fs$secondaryArchSuffix
 	lib:libr_hash$secondaryArchSuffix
 	lib:libr_io$secondaryArchSuffix
@@ -61,7 +63,7 @@ REQUIRES="
 
 PROVIDES_devel="
 	radare2${secondaryArchSuffix}_devel = $portVersion
-	devel:libr2$secondaryArchSuffix = 0.9.9
+	devel:libr2$secondaryArchSuffix = 1.1.0
 	"
 REQUIRES_devel="
 	radare2${secondaryArchSuffix} == $portVersion base
@@ -79,6 +81,9 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:git
 	cmd:make
+	cmd:find
+	cmd:sh
+	cmd:patch
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
@@ -95,7 +100,7 @@ INSTALL()
 	cp libr/*/libr_*.so $libDir
 
 	mkdir -p `dirname $docDir`
-	mv $prefix/share/doc $docDir
+	mv $prefix/data/doc $docDir
 	rm -rf $prefix/share
 
 	prepareInstalledDevelLib libr2

--- a/dev-util/radare2/radare2-1.1.0.recipe
+++ b/dev-util/radare2/radare2-1.1.0.recipe
@@ -8,7 +8,7 @@ COPYRIGHT="2009-2015 nibble, pancake"
 LICENSE="GNU GPL v3
 	GNU LGPL v3"
 REVISION="1"
-SOURCE_URI="http://cloud.radare.org/get/1.1.0/radare2-$portVersion.tar.gz"
+SOURCE_URI="http://cloud.radare.org/get/$portVersion/radare2-$portVersion.tar.gz"
 CHECKSUM_SHA256="7bc1e206a2b4def6bdb8684c2af0281b007986a0b5b5da652bd03be264ca0fa5"
 PATCHES="radare2-1.1.0.patchset"
 


### PR DESCRIPTION
Tested on both x86 and x86_64, but not x86_gcc2. This patch fixes issues with the login_pty symbol when running radare2.