### PR TITLE
mupdf: bump to 1.10~a.

### DIFF
--- a/app-text/mupdf/mupdf-1.10~a.recipe
+++ b/app-text/mupdf/mupdf-1.10~a.recipe
@@ -1,0 +1,117 @@
+SUMMARY="A lightweight XPS and PDF rendering library"
+DESCRIPTION="The renderer in MuPDF is tailored for high quality anti-aliased \
+graphics. It renders text with metrics and spacing accurate to within \
+fractions of a pixel for the highest fidelity in reproducing the look of a \
+printed page on screen.
+
+MuPDF is also small, fast, and yet complete. It supports PDF 1.7 with \
+transparency, encryption, hyperlinks, annotations, searching and more. It also \
+reads XPS/OpenXPS documents and CBZ (Comic Book archive) files."
+HOMEPAGE="http://www.mupdf.com/"
+COPYRIGHT="2006-2016 Artifex Software, Inc"
+LICENSE="AGPL-3.0"
+REVISION="1"
+SOURCE_URI="http://mupdf.com/downloads/archive/mupdf-${portVersion/\~/}-source.tar.gz"
+CHECKSUM_SHA256="aacc1f36b9180f562022ef1ab3439b009369d944364f3cff8a2a898834e3a836"
+SOURCE_DIR="mupdf-${portVersion/\~/}-source"
+PATCHES="
+	mupdf-$portVersion.patchset
+	mupdf-$portVersion-openjpeg21.patchset
+	mupdf-$portVersion-harfbuzz.patchset
+	"
+
+ARCHITECTURES="!x86_gcc2 !x86 !x86_64"
+SECONDARY_ARCHITECTURES="!x86"
+
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+PROVIDES="
+	mupdf$secondaryArchSuffix = $portVersion compat >= 1.1
+	lib:libmupdf$secondaryArchSuffix
+	cmd:mudraw$commandSuffix
+	cmd:mujstest$commandSuffix
+	cmd:muraster$commandSuffix
+	cmd:mutool$commandSuffix
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libfreetype$secondaryArchSuffix
+	lib:libglib_2.0$secondaryArchSuffix
+	lib:libharfbuzz$secondaryArchSuffix
+	lib:libjbig2dec$secondaryArchSuffix
+	lib:libjpeg$secondaryArchSuffix
+	lib:libopenjp2$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	mupdf${secondaryArchSuffix}_devel = $portVersion
+	devel:libmupdf$secondaryArchSuffix
+	devel:libmupdfthird$secondaryArchSuffix
+	"
+REQUIRES_devel="
+	mupdf$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	devel:libfreetype$secondaryArchSuffix
+	devel:libglib_2.0$secondaryArchSuffix
+	devel:libharfbuzz$secondaryArchSuffix
+	devel:libjbig2dec$secondaryArchSuffix
+	devel:libjpeg$secondaryArchSuffix
+	devel:libopenjp2$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	cmd:find
+	cmd:freetype_config$secondaryArchSuffix
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	# don't use builtin libs
+	rm -rf thirdparty
+
+	# static lib
+	my_soname=libmupdf.so.$portVersion
+	my_soname_js_none=libmupdf-js-none.so.$portVersion
+	sed -e "\$a\$(MUPDF_LIB): \$(MUPDF_JS_NONE_LIB)" \
+		-e "\$a\\\t\$(QUIET_LINK) \$(CC) \$(LDFLAGS) --shared -Wl,-soname -Wl,${my_soname} -Wl,--no-undefined -o \$@ \$^ \$(MUPDF_JS_NONE_LIB) \$(LIBS)" \
+		-e "/^MUPDF_LIB :=/s:=.*:= \$(OUT)/${my_soname}:" \
+		-e "\$a\$(MUPDF_JS_NONE_LIB):" \
+		-e "\$a\\\t\$(QUIET_LINK) \$(CC) \$(LDFLAGS) --shared -Wl,-soname -Wl,${my_soname_js_none} -Wl,--no-undefined -o \$@ \$^ \$(LIBS)" \
+		-e "/install/s: COPYING : :" \
+		-i Makefile || die
+	make XCFLAGS=-fpic build=release $jobArgs
+}
+
+INSTALL()
+{
+	make build=release install \
+		prefix=$prefix \
+		bindir=$binDir \
+		docdir=$docDir \
+		libdir=$libDir \
+		incdir=$includeDir \
+		mandir=$manDir
+
+#	ln -s libmupdf.so.$portVersion $libDir/libmupdf.so
+
+	prepareInstalledDevelLibs \
+		libmupdf \
+		libmupdfthird
+	fixPkgconfig
+
+	# devel package
+	packageEntries devel \
+		$developDir
+}

--- a/app-text/mupdf/patches/mupdf-1.10~a-harfbuzz.patchset
+++ b/app-text/mupdf/patches/mupdf-1.10~a-harfbuzz.patchset
@@ -1,0 +1,52 @@
+From 1523c988bf2755d2db8358b04010a3f62c684211 Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Mon, 28 Nov 2016 13:37:54 +0000
+Subject: Fix includes for hb.h and hb-ft.h.
+
+
+diff --git a/source/fitz/font.c b/source/fitz/font.c
+index 4e30579..f784739 100644
+--- a/source/fitz/font.c
++++ b/source/fitz/font.c
+@@ -3,8 +3,8 @@
+ #include "font-imp.h"
+ 
+ #include <ft2build.h>
+-#include "hb.h"
+-#include "hb-ft.h"
++#include <harfbuzz/hb.h>
++#include <harfbuzz/hb-ft.h>
+ 
+ #include FT_FREETYPE_H
+ #include FT_ADVANCES_H
+diff --git a/source/fitz/harfbuzz.c b/source/fitz/harfbuzz.c
+index e2b4e83..84bcf48 100644
+--- a/source/fitz/harfbuzz.c
++++ b/source/fitz/harfbuzz.c
+@@ -5,7 +5,7 @@
+ 
+ #include "mupdf/fitz.h"
+ 
+-#include "hb.h"
++#include <harfbuzz/hb.h>
+ 
+ /* Harfbuzz has some major design flaws.
+  *
+diff --git a/source/html/html-layout.c b/source/html/html-layout.c
+index 95f2a76..31b1d1f 100644
+--- a/source/html/html-layout.c
++++ b/source/html/html-layout.c
+@@ -1,8 +1,8 @@
+ #include "mupdf/html.h"
+ #include "mupdf/svg.h"
+ 
+-#include "hb.h"
+-#include "hb-ft.h"
++#include <harfbuzz/hb.h>
++#include <harfbuzz/hb-ft.h>
+ #include <ft2build.h>
+ 
+ #undef DEBUG_HARFBUZZ
+-- 
+2.11.0
+

--- a/app-text/mupdf/patches/mupdf-1.10~a-openjpeg21.patchset
+++ b/app-text/mupdf/patches/mupdf-1.10~a-openjpeg21.patchset
@@ -1,0 +1,28 @@
+From 218fa2f41479cce876896632d9ce3a159b29eaf0 Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Mon, 28 Nov 2016 13:37:54 +0000
+Subject: Skip unneeded workaround in source/fitz/load-jpx.c
+
+
+diff --git a/source/fitz/load-jpx.c b/source/fitz/load-jpx.c
+index b1d77c7..d37f90d 100644
+--- a/source/fitz/load-jpx.c
++++ b/source/fitz/load-jpx.c
+@@ -481,14 +481,6 @@ fz_load_jpx_info(fz_context *ctx, unsigned char *data, size_t size, int *wp, int
+ 
+ #else /* HAVE_LURATECH */
+ 
+-/* Without the definition of OPJ_STATIC, compilation fails on windows
+- * due to the use of __stdcall. We believe it is required on some
+- * linux toolchains too. */
+-#define OPJ_STATIC
+-#ifndef _MSC_VER
+-#define OPJ_HAVE_STDINT_H
+-#endif
+-
+ #include <openjpeg.h>
+ 
+ /* OpenJPEG does not provide a safe mechanism to intercept
+-- 
+2.11.0
+

--- a/app-text/mupdf/patches/mupdf-1.10~a.patchset
+++ b/app-text/mupdf/patches/mupdf-1.10~a.patchset
@@ -1,0 +1,157 @@
+From 822c66106b347a8483d72db3ac8adffd1bf1aacc Mon Sep 17 00:00:00 2001
+From: Gerasim Troeglazov <3dEyes@gmail.com>
+Date: Tue, 21 Apr 2015 12:57:05 +0300
+Subject: gcc2 fixes
+
+
+diff --git a/include/mupdf/fitz/system.h b/include/mupdf/fitz/system.h
+index 1723824..565024d 100644
+--- a/include/mupdf/fitz/system.h
++++ b/include/mupdf/fitz/system.h
+@@ -81,6 +81,12 @@
+ #define fz_jmp_buf jmp_buf
+ #endif
+ 
++#ifdef __HAIKU__
++#if __GNUC__ < 3
++#define va_copy __va_copy
++#endif
++#endif
++
+ #ifdef _MSC_VER /* Microsoft Visual C */
+ 
+ /* MSVC up to VS2012 */
+diff --git a/scripts/cmapdump.c b/scripts/cmapdump.c
+index 4da2e32..42d4152 100644
+--- a/scripts/cmapdump.c
++++ b/scripts/cmapdump.c
+@@ -28,6 +28,24 @@
+ #include "../source/fitz/time.c"
+ #endif
+ 
++#ifdef __HAIKU__
++#if __GNUC__ < 3
++#include "../source/fitz/output.c"
++
++unsigned int
++fz_pixmap_size(fz_context *ctx, fz_pixmap * pix)
++{
++	if (pix == NULL)
++		return 0;
++	return sizeof(*pix) + pix->n * pix->w * pix->h;
++}
++int pdf_objcmp_resolve(fz_context *ctx, pdf_obj *a, pdf_obj *b)
++{
++	return 0;
++}
++#endif
++#endif
++
+ #include "../source/pdf/pdf-lex.c"
+ #include "../source/pdf/pdf-cmap.c"
+ #include "../source/pdf/pdf-cmap-parse.c"
+-- 
+2.7.0
+
+
+From 72fa503df92c304b9bfc3d181424cfe1083b4cfe Mon Sep 17 00:00:00 2001
+From: Chris Roberts <cpr420@gmail.com>
+Date: Mon, 18 Nov 2013 01:10:58 -0700
+Subject: Remove libm and add install-libs target
+
+
+diff --git a/Makefile b/Makefile
+index 886a017..62ee1c7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -16,7 +16,7 @@ include Makethird
+ # XCFLAGS or XLIBS instead. Make ignores any lines in the makefile that
+ # set a variable that was set on the command line.
+ CFLAGS += $(XCFLAGS) -Iinclude -I$(GEN)
+-LIBS += $(XLIBS) -lm
++LIBS += $(XLIBS)
+ 
+ LIBS += $(FREETYPE_LIBS)
+ LIBS += $(HARFBUZZ_LIBS)
+@@ -363,7 +363,17 @@ extra: $(CURL_LIB) $(GLFW_LIB)
+ libs: $(INSTALL_LIBS)
+ apps: $(INSTALL_APPS)
+ 
+-install: libs apps
++install: install-libs apps
++	install -d $(DESTDIR)$(bindir)
++	install $(INSTALL_APPS) $(DESTDIR)$(bindir)
++
++	install -d $(DESTDIR)$(mandir)/man1
++	install docs/man/*.1 $(DESTDIR)$(mandir)/man1
++
++	install -d $(DESTDIR)$(docdir)
++	install README COPYING CHANGES docs/*.txt $(DESTDIR)$(docdir)
++
++install-libs: libs
+ 	install -d $(DESTDIR)$(incdir)/mupdf
+ 	install -d $(DESTDIR)$(incdir)/mupdf/fitz
+ 	install -d $(DESTDIR)$(incdir)/mupdf/pdf
+@@ -374,14 +384,6 @@ install: libs apps
+ 	install -d $(DESTDIR)$(libdir)
+ 	install $(INSTALL_LIBS) $(DESTDIR)$(libdir)
+ 
+-	install -d $(DESTDIR)$(bindir)
+-	install $(INSTALL_APPS) $(DESTDIR)$(bindir)
+-
+-	install -d $(DESTDIR)$(mandir)/man1
+-	install docs/man/*.1 $(DESTDIR)$(mandir)/man1
+-
+-	install -d $(DESTDIR)$(docdir)
+-	install README COPYING CHANGES docs/*.txt $(DESTDIR)$(docdir)
+ 
+ tarball:
+ 	bash scripts/archive.sh
+-- 
+2.7.0
+
+
+From 3d729e50178ddaa7a0671bb8deecd6e34f33508a Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Tue, 31 Jan 2017 18:59:49 +0100
+Subject: fixes to link against several libs
+
+
+diff --git a/Makerules b/Makerules
+index 8a17d77..ad2e262 100644
+--- a/Makerules
++++ b/Makerules
+@@ -102,6 +102,30 @@ AR = xcrun ar
+ LD = xcrun ld
+ RANLIB_CMD = xcrun ranlib $@
+ 
++else ifeq "$(OS)" "Haiku"
++
++ifeq "$(shell pkg-config --exists libcrypto && echo yes)" "yes"
++HAVE_LIBCRYPTO = yes
++SYS_LIBCRYPTO_CFLAGS = -DHAVE_LIBCRYPTO $(shell pkg-config --cflags libcrypto)
++SYS_LIBCRYPTO_LIBS = $(shell pkg-config --libs libcrypto)
++endif
++
++ifeq "$(shell pkg-config --exists libcurl && echo yes)" "yes"
++HAVE_CURL = yes
++SYS_CURL_CFLAGS = $(shell pkg-config --cflags libcurl)
++SYS_CURL_LIBS = $(shell pkg-config --libs libcurl)
++endif
++
++SYS_HARFBUZZ_CFLAGS = $(shell pkg-config --cflags harfbuzz)
++SYS_HARFBUZZ_LIBS = $(shell pkg-config --libs harfbuzz)
++SYS_FREETYPE_CFLAGS = $(shell pkg-config --cflags freetype2)
++SYS_FREETYPE_LIBS = $(shell pkg-config --libs freetype2)
++SYS_OPENJPEG_CFLAGS = $(shell pkg-config --cflags libopenjp2)
++SYS_OPENJPEG_LIBS = $(shell pkg-config --libs libopenjp2)
++SYS_JBIG2DEC_LIBS = -ljbig2dec
++SYS_JPEG_LIBS = -ljpeg
++SYS_ZLIB_LIBS = -lz
++
+ # Linux uses pkg-config for system libraries.
+ else ifeq "$(OS)" "Linux"
+ 
+-- 
+2.10.2
+


### PR DESCRIPTION
* Updated patches from 1.8 to 1.10~a.
* Added patches to fix includes for hb.h and hb-ft.h and to skip unneeded workaround in source/fitz/load-jpx.c
* Merged/replaced old patch with one from @korli.
* Add dependency on libharfbuzz and libglib_2.0 too, as it is required by harfbuzz.

**TODO:**
* Build libmupdf.so.
* Do not build libmupdfthird.a.