### PR TITLE
Freetype: add patch to activate subpixel rendering

### DIFF
--- a/media-libs/freetype/freetype-2.7.1.recipe
+++ b/media-libs/freetype/freetype-2.7.1.recipe
@@ -8,6 +8,7 @@ LICENSE="FreeType"
 REVISION="1"
 SOURCE_URI="https://download.savannah.gnu.org/releases/freetype/freetype-$portVersion.tar.bz2"
 CHECKSUM_SHA256="3a3bb2c4e15ffb433f2032f50a5b5a92558206822e22bfe8cbe339af4aa82f88"
+#PATCHES="freetype-subpixel.patchset" # enable patented subpixel rendering
 
 ARCHITECTURES="x86_gcc2 x86 x86_64 arm"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"

--- a/media-libs/freetype/patches/freetype-subpixel.patchset
+++ b/media-libs/freetype/patches/freetype-subpixel.patchset
@@ -1,0 +1,22 @@
+From fd9b7dd32ca353efef65a47e508dd48149cfb278 Mon Sep 17 00:00:00 2001
+From: Humdinger <humdingerb@gmail.com>
+Date: Thu, 2 Feb 2017 08:50:24 +0100
+Subject: Enable subpixel rendering
+
+
+diff --git a/include/freetype/config/ftoption.h b/include/freetype/config/ftoption.h
+index 90c123e..67a361d 100644
+--- a/include/freetype/config/ftoption.h
++++ b/include/freetype/config/ftoption.h
+@@ -122,7 +122,7 @@ FT_BEGIN_HEADER
+   /* This is done to allow FreeType clients to run unmodified, forcing     */
+   /* them to display normal gray-level anti-aliased glyphs.                */
+   /*                                                                       */
+-/* #define FT_CONFIG_OPTION_SUBPIXEL_RENDERING */
++#define FT_CONFIG_OPTION_SUBPIXEL_RENDERING
+ 
+ 
+   /*************************************************************************/
+-- 
+2.7.0
+


### PR DESCRIPTION
PATCHES is still commented out in the recipe. Added for easy testing.