### PR TITLE
fix secondary arch _x86, switch to static build

### DIFF
--- a/net-ftp/lftp/lftp-4.4.16.recipe
+++ b/net-ftp/lftp/lftp-4.4.16.recipe
@@ -14,9 +14,12 @@ COPYRIGHT="1996-2012 Alexander V. Lukyanov"
 LICENSE="GNU GPL v3"
 REVISION="1"
 ARCHITECTURES="!x86_gcc2 x86 x86_64 arm"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	lftp = $portVersion
+	cmd:lftp$secondaryArchSuffix = $portVersion
+	cmd:lftpget$secondaryArchSuffix = $portVersion
 	lib:liblftp_jobs$secondaryArchSuffix = 0.0.0 compat >= 0
 	lib:liblftp_tasks$secondaryArchSuffix = 0.0.0 compat >= 0
 	"
@@ -76,8 +79,7 @@ BUILD()
 	aclocal -I m4
 	autoconf
 	automake
-	runConfigure ./configure --with-openssl --enable-static \
-		--with-modules
+	runConfigure ./configure --with-openssl --enable-static
 	make $jobArgs
 }
 
@@ -93,11 +95,6 @@ INSTALL()
 	packageEntries devel \
 		$developDir
 
-	# Remove stuff we don't need in the secondary architecture base package.
-	if [ -n "$secondaryArchSuffix" ]; then
-		rm -rf $binDir
-		rm -rf $documentationDir
-	fi
 }
 
 TEST()


### PR DESCRIPTION
I disabled the --with-modules flag that split the commands and protocols out as .so files because LFTP was looking in the wrong directories for them.  The hpkg generated from this recipe is tested and working on hrev50951 gcc2h.