### PR TITLE
imgcat: new recipe

### DIFF
--- a/app-misc/imgcat/imgcat-1.1.1.recipe
+++ b/app-misc/imgcat/imgcat-1.1.1.recipe
@@ -1,0 +1,57 @@
+SUMMARY="Print images onto your terminal"
+DESCRIPTION="imgcat prints images to your terminal screen. Yes, indeed it does. \
+By default, the image is printed at the full width and colour depth \
+detected for your terminal. These can be overridden using -w to adjust \
+the maximum width or -R to prevent resizing, even if the image is too \
+big to fit in the terminal; and -d to explicitly the set color depth. \
+
+
+If the output stream is not a terminal (that is, output is redirected to \
+a file, or piped into another program), then the image is not resized to \
+the size of the terminal. It does, however, uses the color depth of terminal \
+set in the TERM environment variable. Overriding both width and color \
+depth still work.
+"
+HOMEPAGE="https://github.com/eddieantonio/imgcat"
+COPYRIGHT="2014, 2016 Eddie Antonio Santos"
+LICENSE="ISC"
+REVISION="1"
+SOURCE_URI="https://github.com/eddieantonio/imgcat/archive/v$portVersion.zip"
+CHECKSUM_SHA256="217d301cb3132747c2c820990bf4fc9abf1624c6fdd92d9cb4f9101b7f6eba1d"
+
+ARCHITECTURES="?x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	imgcat = $portVersion
+	cmd:imgcat = $portVersion
+	"
+REQUIRES="
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc
+	cmd:ld
+	cmd:make
+	"
+
+BUILD()
+{
+	make production=true $jobArgs
+}
+
+INSTALL()
+{
+	mkdir -p $binDir
+	mkdir -p $manDir/man1
+	cp src/imgcat $binDir
+	cp doc/imgcat.1 $manDir/man1
+}
+
+TEST()
+{
+	make test
+}

--- a/app-misc/imgcat/licenses/ISC
+++ b/app-misc/imgcat/licenses/ISC
@@ -1,0 +1,17 @@
+ISC License
+========================
+
+Copyright (c) 2014,
+Eddie Antonio Santos <easantos@ualberta.ca>
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.


### PR DESCRIPTION
Small utility to display images onto the terminal, should work on all architectures and tested only on zsh and bash.