### PR TITLE
zeal: new recipe

### DIFF
--- a/app-doc/zeal/patches/zeal-0.3.1.patchset
+++ b/app-doc/zeal/patches/zeal-0.3.1.patchset
@@ -1,0 +1,132 @@
+From 0ad02f549ecf15428bfeb1f3ed1b0cdb14a6922c Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Wed, 22 Feb 2017 20:13:41 +0000
+Subject: [PATCH] Disable global shortcuts for haiku support
+
+---
+ src/libs/ui/mainwindow.cpp                          | 15 ++++++++-------
+ src/libs/ui/mainwindow.h                            |  4 ++--
+ src/libs/ui/qxtglobalshortcut/qxtglobalshortcut.pri |  2 +-
+ src/libs/ui/ui.pri                                  |  5 ++---
+ 4 files changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/src/libs/ui/mainwindow.cpp b/src/libs/ui/mainwindow.cpp
+index d7766c6..a2f8c50 100644
+--- a/src/libs/ui/mainwindow.cpp
++++ b/src/libs/ui/mainwindow.cpp
+@@ -28,7 +28,8 @@
+ #include "docsetsdialog.h"
+ #include "searchitemdelegate.h"
+ #include "settingsdialog.h"
+-#include "qxtglobalshortcut/qxtglobalshortcut.h"
++// TODO: Implement global shortcuts for Haiku
++// #include "qxtglobalshortcut/qxtglobalshortcut.h"
+ 
+ #include <core/application.h>
+ #include <core/settings.h>
+@@ -179,7 +180,7 @@ MainWindow::MainWindow(Core::Application *app, QWidget *parent) :
+     m_application(app),
+     m_settings(app->settings()),
+     m_zealListModel(new Registry::ListModel(app->docsetRegistry(), this)),
+-    m_globalShortcut(new QxtGlobalShortcut(m_settings->showShortcut, this)),
++    //m_globalShortcut(new QxtGlobalShortcut(m_settings->showShortcut, this)),
+     m_openDocsetTimer(new QTimer(this))
+ {
+     ui->setupUi(this);
+@@ -194,7 +195,7 @@ MainWindow::MainWindow(Core::Application *app, QWidget *parent) :
+         createTrayIcon();
+ 
+     // initialise key grabber
+-    connect(m_globalShortcut, &QxtGlobalShortcut::activated, this, &MainWindow::toggleWindow);
++    //connect(m_globalShortcut, &QxtGlobalShortcut::activated, this, &MainWindow::toggleWindow);
+ 
+     setupTabBar();
+ 
+@@ -223,10 +224,10 @@ MainWindow::MainWindow(Core::Application *app, QWidget *parent) :
+     connect(ui->actionFind, &QAction::triggered, ui->webView, &SearchableWebView::showSearchBar);
+ 
+     connect(ui->actionPreferences, &QAction::triggered, [this]() {
+-        m_globalShortcut->setEnabled(false);
++        //m_globalShortcut->setEnabled(false);
+         QScopedPointer<SettingsDialog> dialog(new SettingsDialog(m_application, this));
+         dialog->exec();
+-        m_globalShortcut->setEnabled(true);
++        //m_globalShortcut->setEnabled(true);
+     });
+ 
+     ui->actionBack->setShortcut(QKeySequence::Back);
+@@ -899,7 +900,7 @@ void MainWindow::keyPressEvent(QKeyEvent *keyEvent)
+ 
+ void MainWindow::applySettings()
+ {
+-    m_globalShortcut->setShortcut(m_settings->showShortcut);
++    //m_globalShortcut->setShortcut(m_settings->showShortcut);
+ 
+     if (m_settings->showSystrayIcon)
+         createTrayIcon();
+@@ -909,7 +910,7 @@ void MainWindow::applySettings()
+ 
+ void MainWindow::toggleWindow()
+ {
+-    const bool checkActive = sender() == m_globalShortcut;
++    const bool checkActive = sender(); //== m_globalShortcut;
+ 
+     if (!isVisible() || (checkActive && !isActiveWindow())) {
+ #ifdef USE_APPINDICATOR
+diff --git a/src/libs/ui/mainwindow.h b/src/libs/ui/mainwindow.h
+index 7d886d7..81f6c09 100644
+--- a/src/libs/ui/mainwindow.h
++++ b/src/libs/ui/mainwindow.h
+@@ -34,7 +34,7 @@ struct _AppIndicator;
+ struct _GtkWidget;
+ #endif
+ 
+-class QxtGlobalShortcut;
++//class QxtGlobalShortcut;
+ 
+ class QModelIndex;
+ class QSystemTrayIcon;
+@@ -116,7 +116,7 @@ private:
+ 
+     Zeal::Registry::CancellationToken m_cancelSearch;
+ 
+-    QxtGlobalShortcut *m_globalShortcut = nullptr;
++//    QxtGlobalShortcut *m_globalShortcut = nullptr;
+ 
+     QTabBar *m_tabBar = nullptr;
+ 
+diff --git a/src/libs/ui/qxtglobalshortcut/qxtglobalshortcut.pri b/src/libs/ui/qxtglobalshortcut/qxtglobalshortcut.pri
+index d4c3e3c..7ce3d36 100644
+--- a/src/libs/ui/qxtglobalshortcut/qxtglobalshortcut.pri
++++ b/src/libs/ui/qxtglobalshortcut/qxtglobalshortcut.pri
+@@ -1,6 +1,6 @@
+ HEADERS += $$files($$PWD/*.h)
+ SOURCES += $$PWD/qxtglobalshortcut.cpp
+ 
+-unix:!macx:SOURCES += $$PWD/qxtglobalshortcut_x11.cpp
++unix:!macx:!haiku:SOURCES += $$PWD/qxtglobalshortcut_x11.cpp
+ win32:SOURCES += $$PWD/qxtglobalshortcut_win.cpp
+ macx:SOURCES += $$PWD/qxtglobalshortcut_mac.cpp
+diff --git a/src/libs/ui/ui.pri b/src/libs/ui/ui.pri
+index ca5169d..db95b89 100644
+--- a/src/libs/ui/ui.pri
++++ b/src/libs/ui/ui.pri
+@@ -3,13 +3,12 @@ ZEAL_LIB_NAME = Ui
+ QT += widgets
+ 
+ # QxtGlobalShortcut dependencies
+-unix:!macx {
+-    QT += x11extras
++unix:!macx:!haiku{
++   QT += x11extras
+ 
+     CONFIG += link_pkgconfig
+     PKGCONFIG += x11 xcb xcb-keysyms
+ }
+-
+ macx {
+     LIBS += -framework Carbon
+ }
+-- 
+2.11.0
+

--- a/app-doc/zeal/zeal-0.3.1.recipe
+++ b/app-doc/zeal/zeal-0.3.1.recipe
@@ -1,0 +1,59 @@
+SUMMARY="A simple offline documentation browser inspired by Dash"
+DESCRIPTION="Zeal is a cross-platform, open source, offline \
+documentation browser for software developers, inspired by Dash Docs \
+for macOS and iOS. Zeal has over 195+ docsets and are all compatible \
+with Dash docsets. "
+HOMEPAGE="https://zealdocs.org"
+COPYRIGHT="2013, 2017 Oleg Shparber"
+LICENSE="GNU GPL v3"
+REVISION="1"
+SOURCE_URI="https://github.com/zealdocs/zeal/archive/v$portVersion.tar.gz"
+CHECKSUM_SHA256="55f8511977818612e00ae87a4fddaa346210189531469690f2e3961bb4c2c318"
+PATCHES="zeal-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 x86 ?x86_64"
+
+PROVIDES="
+	zeal${secondaryArchSuffix} = $portVersion
+	app:Zeal${secondaryArchSuffix} = $portVersion
+	"
+REQUIRES="
+	haiku${secondaryArchSuffix}
+	qt5${secondaryArchSuffix} >= 5.5.1
+	lib:libarchive${secondaryArchSuffix}
+	lib:libz$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	qt5${secondaryArchSuffix}_devel >= 5.5.1
+	devel:libarchive$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc${secondaryArchSuffix}
+	cmd:g++${secondaryArchSuffix}
+	cmd:ld
+	cmd:make
+	cmd:qmake${secondaryArchSuffix} >= 5.5.1
+	cmd:pkg_config${secondaryArchSuffix}
+	"
+
+BUILD()
+{
+	/bin/qmake .
+	make $jobArgs
+}
+
+INSTALL()
+{
+	# TODO Add a rdef icon for Zeal
+	mkdir -p $appsDir/Zeal
+	cp bin/zeal $appsDir/Zeal/Zeal
+	addAppDeskbarSymlink $appsDir/Zeal/Zeal
+}
+
+TEST()
+{
+	make test
+}

--- a/app-doc/zeal/zeal-0.3.1.recipe
+++ b/app-doc/zeal/zeal-0.3.1.recipe
@@ -12,15 +12,16 @@ CHECKSUM_SHA256="55f8511977818612e00ae87a4fddaa346210189531469690f2e3961bb4c2c31
 PATCHES="zeal-$portVersion.patchset"
 
 ARCHITECTURES="!x86_gcc2 x86 ?x86_64"
+SECONDARY_ARCHITECTURES="?x86"
 
 PROVIDES="
-	zeal${secondaryArchSuffix} = $portVersion
-	app:Zeal${secondaryArchSuffix} = $portVersion
+	zeal$secondaryArchSuffix = $portVersion
+	app:Zeal$secondaryArchSuffix = $portVersion
 	"
 REQUIRES="
-	haiku${secondaryArchSuffix}
-	qt5${secondaryArchSuffix} >= 5.5.1
-	lib:libarchive${secondaryArchSuffix}
+	haiku$secondaryArchSuffix
+	qt5$secondaryArchSuffix >= 5.5.1
+	lib:libarchive$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
 
@@ -31,12 +32,12 @@ BUILD_REQUIRES="
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:gcc${secondaryArchSuffix}
-	cmd:g++${secondaryArchSuffix}
+	cmd:gcc$secondaryArchSuffix
+	cmd:g++$secondaryArchSuffix
 	cmd:ld
 	cmd:make
-	cmd:qmake${secondaryArchSuffix} >= 5.5.1
-	cmd:pkg_config${secondaryArchSuffix}
+	cmd:qmake$secondaryArchSuffix >= 5.5.1
+	cmd:pkg_config$secondaryArchSuffix
 	"
 
 BUILD()


### PR DESCRIPTION
[Zeal](https://zealdocs.org/) is a documentation browser just like [Dash Docs](https://kapeli.com/dash) iOS and MacOS. Strangely, apps compiled with Qt do run but no windows are visible. Tested only on x86 but should work on x86_64.