### PR TITLE
erlang: fix build

### DIFF
--- a/dev-lang/erlang/erlang-16.03.recipe
+++ b/dev-lang/erlang/erlang-16.03.recipe
@@ -49,7 +49,7 @@ BUILD_PREREQUIRES="
 	devel:libcrypto
 	"
 
-ERLANG_CFLAGS="-DETHR_X86_OUT_OF_ORDER -DHAVE_NET_IF_DL_H -DETHR_HAVE_ETHREAD_DEFINES -DETHR_PTHREADS -DETHR_SIZEOF_PTR=4 -DHAVE_CONFIG_H -I../i586-pc-haiku -I../../i586-pc-haiku -I../include/internal -I../../include/internal -I../../emulator/sys/unix -I../../include/i586-pc-haiku -I../../emulator/beam -I../../../erts/include/internal/i586-pc-haiku -I../../../erts/i586-pc-haiku -Imisc -I../include -Iepmd -Iconnect -I../../../erts/emulator/beam -I../../../erts/include/i586-pc-haiku -I../../../../erts/emulator/beam -I../../../../erts/include/i586-pc-haiku -I../../../../erts/i586-pc-haiku"
+ERLANG_CFLAGS="-DETHR_X86_OUT_OF_ORDER -DHAVE_NET_IF_DL_H -DETHR_HAVE_ETHREAD_DEFINES -DETHR_PTHREADS -DETHR_SIZEOF_PTR=4 -DHAVE_CONFIG_H -D_BSD_SOURCE=1 -I../i586-pc-haiku -I../../i586-pc-haiku -I../include/internal -I../../include/internal -I../../emulator/sys/unix -I../../include/i586-pc-haiku -I../../emulator/beam -I../../../erts/include/internal/i586-pc-haiku -I../../../erts/i586-pc-haiku -Imisc -I../include -Iepmd -Iconnect -I../../../erts/emulator/beam -I../../../erts/include/i586-pc-haiku -I../../../../erts/emulator/beam -I../../../../erts/include/i586-pc-haiku -I../../../../erts/i586-pc-haiku"
 
 BUILD()
 {


### PR DESCRIPTION
This commit fixes a compilation issue with the ifaddrs.h library that Erlang needs. Tested on x86 only. x86_gcc2 needs to be tested.