### PR TITLE
simutrans and related packages updated to new version 120.2

### DIFF
--- a/games-simulation/simutrans/simutrans-120.2.2.recipe
+++ b/games-simulation/simutrans/simutrans-120.2.2.recipe
@@ -1,0 +1,87 @@
+SUMMARY="A transport simulation game"
+DESCRIPTION="Simutrans is a freeware and open-source transportation \
+simulator. Your goal is to establish a successful transport company. \
+Transport passengers, mail and goods by rail, road, ship, and even air. \
+Interconnect districts, cities, public buildings, industries and \
+tourist attractions by building a transport network you always dreamed \
+of."
+HOMEPAGE="http://www.simutrans.com"
+COPYRIGHT="1997-2004 Hj. Malthaner
+	2005-2017 The Simutrans Team"
+LICENSE="Artistic"
+REVISION="1"
+SvnRevision="8162"
+GitRevision="fb14bfcef06f3c15e0cc5d8368a0bdfe411de65d"
+SOURCE_URI="https://github.com/aburch/simutrans/archive/$GitRevision.tar.gz"
+CHECKSUM_SHA256="7a9c6c2318c0098c84d58518248761d57f34bdbaabbaae5f66d16c3aed1a2227"
+SOURCE_FILENAME="simutrans-$portVersion.tar.gz"
+SOURCE_DIR="simutrans-$GitRevision"
+SOURCE_URI_2="https://downloads.sourceforge.net/project/simutrans/simutrans/120-2-2/simutrans-src-120-2-2.zip"
+CHECKSUM_SHA256_2="7f22c144377abf1a0ee49432f3f6f5eb9a620567960df31d2ea6399b17cf26fa"
+SOURCE_FILENAME_2="simutrans-sf-$portVersion.zip"
+SOURCE_DIR_2=""
+
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	simutrans$secondaryArchSuffix = $portVersion
+	app:simutrans$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	simutrans_pakset$secondaryArchSuffix >= 120.2
+	timgmsoundfont
+	lib:libbz2$secondaryArchSuffix
+	lib:libpng$secondaryArchSuffix
+	lib:libsdl$secondaryArchSuffix
+	lib:libsdl_mixer$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libbz2$secondaryArchSuffix
+	devel:libpng$secondaryArchSuffix
+	devel:libsdl$secondaryArchSuffix
+	devel:libsdl_mixer$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoreconf
+	cmd:g++$secondaryArchSuffix
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:sdl_config$secondaryArchSuffix
+	cmd:strip$secondaryArchSuffix
+	"
+
+GLOBAL_WRITABLE_FILES="
+	non-packaged/$relativeAppsDir/simutrans/config directory keep-old
+	"
+
+BUILD()
+{
+	autoreconf configure.ac
+	export CFLAGS+=-DREVISION=$SvnRevision
+	runConfigure ./configure
+	make $jobArgs
+	strip sim
+}
+
+INSTALL()
+{
+	cp $sourceDir2/simutrans/text/*.tab simutrans/text/
+	cp sim simutrans/simutrans
+	mkdir -p $appsDir/simutrans
+	mkdir -p $prefix/non-packaged/$relativeAppsDir/simutrans/config
+	cp -r  simutrans $appsDir/
+	mv  $appsDir/simutrans/config \
+		$prefix/non-packaged/$relativeAppsDir/simutrans/
+	ln -s $prefix/non-packaged/$relativeAppsDir/simutrans/config \
+		$appsDir/simutrans/config
+
+	addAppDeskbarSymlink $appsDir/simutrans/simutrans "Simutrans"
+}

--- a/games-simulation/simutrans/simutrans-120.3~nightly.recipe
+++ b/games-simulation/simutrans/simutrans-120.3~nightly.recipe
@@ -10,13 +10,12 @@ bugs that will destroy your game, or not even run. They are for bug testing \
 only."
 HOMEPAGE="http://www.simutrans.com"
 COPYRIGHT="1997-2004 Hj. Malthaner
-	2005-2015 The Simutrans Team"
+	2005-2017 The Simutrans Team"
 LICENSE="Artistic"
-REVISION="3"
-SOURCE_URI="svn://tron.yamagi.org/simutrans/simutrans/trunk \
-	--username=anon --password="
+REVISION="1"
+SOURCE_URI="svn://servers.simutrans.org/simutrans/trunk"
 SOURCE_FILENAME="simutrans-$portVersion"
-SOURCE_DIR="trunk"
+SOURCE_DIR=""
 
 ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
@@ -27,10 +26,11 @@ GLOBAL_WRITABLE_FILES="
 
 PROVIDES="
 	simutrans$secondaryArchSuffix = $portVersion
+	app:simutrans$secondaryArchSuffix = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	simutrans_pakset$secondaryArchSuffix >= 120.0.1
+	simutrans_pakset$secondaryArchSuffix >= 120.2
 	timgmsoundfont
 	lib:libbz2$secondaryArchSuffix
 	lib:libpng$secondaryArchSuffix
@@ -50,8 +50,8 @@ BUILD_PREREQUIRES="
 	cmd:aclocal
 	cmd:autoreconf
 	cmd:curl
+	cmd:g++$secondaryArchSuffix
 	cmd:gcc$secondaryArchSuffix
-	cmd:git
 	cmd:ld$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
@@ -71,7 +71,6 @@ BUILD()
 
 INSTALL()
 {
-	fixPkgconfig
 	cp sim simutrans/simutrans
 	mkdir -p $appsDir/simutrans
 	mkdir -p $prefix/non-packaged/$relativeAppsDir/simutrans/config

--- a/games-simulation/simutrans_pak128/simutrans_pak128-2.7.recipe
+++ b/games-simulation/simutrans_pak128/simutrans_pak128-2.7.recipe
@@ -1,0 +1,41 @@
+SUMMARY="Pakset for Simutrans"
+DESCRIPTION="A 'pakset' is the data set that Simutrans needs to run: \
+it contains all the data for the graphics of individual items (vehicles, \
+roads, railways, buildings, etc.) and all of the balancing information \
+(such as prices, speeds, capacities and so forth) necessary to make \
+the game complete.
+When Simutrans could only support 64px size graphics, pak128 already \
+started. First pak to feature a complex economy and have a very wide \
+variety of objects. It contains roughly 7 time more graphics data than \
+pak64 and thus requires by far the largest amount of RAM and \
+processing power of all Simutrans sets."
+HOMEPAGE="http://www.simutrans.com"
+COPYRIGHT="2004-2007 Tomas Kubes
+	2008-2017 The pak128-Team"
+LICENSE="Artistic"
+REVISION="1"
+SOURCE_URI="https://downloads.sourceforge.net/project/simutrans/pak128/pak128%20for%20ST%20120.2.2%20%282.7%2C%20minor%20changes%29/pak128.zip"
+CHECKSUM_SHA256="8fb29a07290a24495e7b2419de8659c28a2962f094b1c806f472c3b09d37cff4"
+SOURCE_FILENAME="simupak_128-$portVersion.zip"
+SOURCE_DIR="simutrans"
+ARCHITECTURES="any"
+
+PROVIDES="
+	simutrans_pak128 = $portVersion
+	simutrans_pakset = 120.2 compat >= 120.2
+	"
+
+GLOBAL_WRITABLE_FILES="
+	non-packaged/$relativeAppsDir/simutrans/pak128/config directory keep-old
+	"
+
+INSTALL()
+{
+	mkdir -p $appsDir/simutrans
+	mkdir -p $prefix/non-packaged/$relativeAppsDir/simutrans/pak128/config
+	cp -r pak128 $appsDir/simutrans/
+	mv $appsDir/simutrans/pak128/config \
+		$prefix/non-packaged/$relativeAppsDir/simutrans/pak128/
+	ln -s $prefix/non-packaged/$relativeAppsDir/simutrans/pak128/config \
+		$appsDir/simutrans/pak128/config
+}

--- a/games-simulation/simutrans_pak128/simutrans_pak128-2.7~nightly.recipe
+++ b/games-simulation/simutrans_pak128/simutrans_pak128-2.7~nightly.recipe
@@ -15,7 +15,7 @@ bugs that will destroy your game, or not even run. They are for bug testing \
 only."
 HOMEPAGE="http://www.simutrans.com"
 COPYRIGHT="2004-2007 Tomas Kubes
-	2008-2015 The pak128-Team"
+	2008-2017 The pak128-Team"
 LICENSE="Artistic"
 REVISION="1"
 SOURCE_URI="svn+https://svn.code.sf.net/p/simutrans/code/pak128/"
@@ -31,11 +31,11 @@ GLOBAL_WRITABLE_FILES="
 
 PROVIDES="
 	simutrans_pak128$secondaryArchSuffix = $portVersion
-	simutrans_pakset$secondaryArchSuffix = $portVersion compat >= 120.0.1
+	simutrans_pakset$secondaryArchSuffix = $portVersion compat >= 120.2
 	"
 
 BUILD_PREREQUIRES="
-	cmd:makeobj$secondaryArchSuffix == 55.4
+	cmd:makeobj$secondaryArchSuffix == 60.0
 	cmd:python
 	cmd:svn
 	"

--- a/games-simulation/simutrans_pak64/simutrans_pak64-120.2.recipe
+++ b/games-simulation/simutrans_pak64/simutrans_pak64-120.2.recipe
@@ -8,45 +8,27 @@ Pak64 is the main and a base set for Simutrans developed along with \
 Simutrans executable. It always contains the most recent features. It is \
 neatly painted pixel by pixel with motherly care. On the other hand it \
 might look too tiny on high resolution displays. Many artists contributed \
-to this pak set, from the 8 bit age on.
-Nightly builds are versions only for debugging and testing. They may contain \
-changes which make your savegames unreadable by any official version, or \
-bugs that will destroy your game, or not even run. They are for bug testing \
-only."
+to this pak set, from the 8 bit age on."
 HOMEPAGE="http://www.simutrans.com"
 COPYRIGHT="1997-2004 Hj. Malthaner
-	2005-2015 The Simutrans Team"
+	2005-2017 The Simutrans Team"
 LICENSE="Artistic"
-REVISION="2"
-SOURCE_URI="svn+https://svn.code.sf.net/p/simutrans/code/pak64/"
-SOURCE_FILENAME="simupak_64-$portVersion"
+REVISION="1"
+SOURCE_URI="https://downloads.sourceforge.net/project/simutrans/pak64/120-2/simupak64-120-2.zip"
+CHECKSUM_SHA256="b3ce4fc99468e6a2601a606251f156e554d2d78f2cc5679c0d9a64a5f50561e8"
+SOURCE_FILENAME="simupak_64-$portVersion.zip"
 SOURCE_DIR=""
 
-ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="any"
+
+PROVIDES="
+	simutrans_pak64 = $portVersion
+	simutrans_pakset = $portVersion compat >= 120.2
+	"
 
 GLOBAL_WRITABLE_FILES="
 	non-packaged/$relativeAppsDir/simutrans/pak/config directory keep-old
 	"
-
-PROVIDES="
-	simutrans_pak64$secondaryArchSuffix = $portVersion
-	simutrans_pakset$secondaryArchSuffix = $portVersion compat >= 120.0.1
-	"
-
-BUILD_PREREQUIRES="
-	cmd:find
-	cmd:make
-	cmd:makeobj$secondaryArchSuffix == 55.4
-	cmd:svn
-	cmd:zip
-	"
-
-BUILD()
-{
-	export MAKEOBJ=makeobj
-	make $jobArgs
-}
 
 INSTALL()
 {

--- a/games-simulation/simutrans_pak64/simutrans_pak64-120.3~nightly.recipe
+++ b/games-simulation/simutrans_pak64/simutrans_pak64-120.3~nightly.recipe
@@ -1,0 +1,60 @@
+SUMMARY="Pakset for Simutrans"
+DESCRIPTION="A 'pakset' is the data set that Simutrans needs to run: \
+it contains all the data for the graphics of individual items (vehicles, \
+roads, railways, buildings, etc.) and all of the balancing information \
+(such as prices, speeds, capacities and so forth) necessary to make \
+the game complete.
+Pak64 is the main and a base set for Simutrans developed along with \
+Simutrans executable. It always contains the most recent features. It is \
+neatly painted pixel by pixel with motherly care. On the other hand it \
+might look too tiny on high resolution displays. Many artists contributed \
+to this pak set, from the 8 bit age on.
+Nightly builds are versions only for debugging and testing. They may contain \
+changes which make your savegames unreadable by any official version, or \
+bugs that will destroy your game, or not even run. They are for bug testing \
+only."
+HOMEPAGE="http://www.simutrans.com"
+COPYRIGHT="1997-2004 Hj. Malthaner
+	2005-2017 The Simutrans Team"
+LICENSE="Artistic"
+REVISION="2"
+SOURCE_URI="svn+https://svn.code.sf.net/p/simutrans/code/pak64/"
+SOURCE_FILENAME="simupak_64-$portVersion"
+SOURCE_DIR=""
+
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+GLOBAL_WRITABLE_FILES="
+	non-packaged/$relativeAppsDir/simutrans/pak/config directory keep-old
+	"
+
+PROVIDES="
+	simutrans_pak64$secondaryArchSuffix = $portVersion
+	simutrans_pakset$secondaryArchSuffix = $portVersion compat >= 120.2
+	"
+
+BUILD_PREREQUIRES="
+	cmd:find
+	cmd:make
+	cmd:makeobj$secondaryArchSuffix == 60.0
+	cmd:svn
+	cmd:zip
+	"
+
+BUILD()
+{
+	export MAKEOBJ=makeobj
+	make $jobArgs
+}
+
+INSTALL()
+{
+	mkdir -p $appsDir/simutrans
+	mkdir -p $prefix/non-packaged/$relativeAppsDir/simutrans/pak/config
+	cp -r simutrans $appsDir/
+	mv $appsDir/simutrans/pak/config \
+		$prefix/non-packaged/$relativeAppsDir/simutrans/pak/
+	ln -s $prefix/non-packaged/$relativeAppsDir/simutrans/pak/config \
+		$appsDir/simutrans/pak/config
+}

--- a/games-util/makeobj/makeobj-60.0.recipe
+++ b/games-util/makeobj/makeobj-60.0.recipe
@@ -1,0 +1,61 @@
+SUMMARY="Tool for creating Simutrans paksets"
+DESCRIPTION="Makeobj is a tool for graphics/pakset developers \
+and is not needed for playing the game.
+Makeobj joins both the image and the data files in a single \
+compressed pak-file that will then be read by the game engine."
+HOMEPAGE="http://www.simutrans.com"
+COPYRIGHT="1997-2004 Hj. Malthaner
+	2005-2017 The Simutrans Team"
+LICENSE="Artistic"
+REVISION="1"
+GitRevision="ea08f1eed3fd8ffdd017a522898450047f83d768"
+SOURCE_URI="https://github.com/aburch/simutrans/archive/$GitRevision.tar.gz"
+CHECKSUM_SHA256="96dca621cde48466b38fa6cf7116e18c72d8c6cadca6733cfdc1f2a4048d2e6b"
+SOURCE_FILENAME="makeobj-$portVersion.tar.gz"
+SOURCE_DIR="simutrans-$GitRevision"
+
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	makeobj$secondaryArchSuffix = $portVersion
+	cmd:makeobj$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libbz2$secondaryArchSuffix
+	lib:libpng$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libbz2$secondaryArchSuffix
+	devel:libpng$secondaryArchSuffix
+	devel:libsdl$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoreconf
+	cmd:g++$secondaryArchSuffix
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:sdl_config$secondaryArchSuffix
+	cmd:strip$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	autoreconf configure.ac
+	runConfigure ./configure
+	make makeobj $jobArgs
+	strip makeobj/makeobj
+}
+
+INSTALL()
+{
+	mkdir -p $binDir
+	cp -r makeobj/makeobj $binDir/
+}

--- a/games-util/makeobj/makeobj-60.1~nightly.recipe
+++ b/games-util/makeobj/makeobj-60.1~nightly.recipe
@@ -5,20 +5,19 @@ Makeobj joins both the image and the data files in a single \
 compressed pak-file that will then be read by the game engine."
 HOMEPAGE="http://www.simutrans.com"
 COPYRIGHT="1997-2004 Hj. Malthaner
-	2005-2015 The Simutrans Team"
+	2005-2017 The Simutrans Team"
 LICENSE="Artistic"
-REVISION="3"
-SOURCE_URI="svn://tron.yamagi.org/simutrans/simutrans/trunk \
-	--username=anon --password="
-SOURCE_FILENAME="simutrans-$portVersion"
-SOURCE_DIR="trunk"
+REVISION="1"
+SOURCE_URI="svn://servers.simutrans.org/simutrans/trunk"
+SOURCE_FILENAME="makeobj-$portVersion"
+SOURCE_DIR=""
 
 ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	makeobj$secondaryArchSuffix = $portVersion
-	cmd:makeobj$secondaryArchSuffix = 55.4
+	cmd:makeobj$secondaryArchSuffix = 60.0
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -37,6 +36,7 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	cmd:aclocal
 	cmd:autoreconf
+	cmd:g++$secondaryArchSuffix
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
 	cmd:make
@@ -56,7 +56,6 @@ BUILD()
 
 INSTALL()
 {
-	fixPkgconfig
 	mkdir -p $binDir
 	cp -r makeobj/makeobj $binDir/
 }


### PR DESCRIPTION
Any ideas how to use "secure" source files? Is there a way to get tarballs from sourceforge for a certain revision? As far as I can tell, snapshots must be requested before they are added for a limited time (probably not more than a day).