### PR TITLE
Build BePDF with locales

### DIFF
--- a/haiku-apps/bepdf/bepdf-2.0.1~beta1.recipe
+++ b/haiku-apps/bepdf/bepdf-2.0.1~beta1.recipe
@@ -54,6 +54,7 @@ BUILD()
 	popd
 	pushd bepdf
 	make $@
+	make bindcatalogs
 	popd
 
 	pushd docs

--- a/haiku-apps/bepdf/bepdf-2.0.1~beta1.recipe
+++ b/haiku-apps/bepdf/bepdf-2.0.1~beta1.recipe
@@ -7,7 +7,7 @@ COPYRIGHT="1997 Benoit Triquet
 	2000-2011 Michael Pfeiffer
 	2013-2016 waddlesplash"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 COMMIT="38b4cb53f073024f9b2e47f56d2feb9bcd91ddca"
 SOURCE_URI="https://github.com/HaikuArchives/BePDF/archive/$COMMIT.tar.gz"
 CHECKSUM_SHA256="d2f9f81b8b43a37f52dbda12967cc67eabd6c0f7812e85b33d6dc6a2319463ca"


### PR DESCRIPTION
BePDF was building without any additional locales. Added "make bindcatalogs" to BUILD() to correct and bumped revision as instructed.