### PR TITLE
Fix vim 8 build on x86 gcc-5

### DIFF
--- a/app-editors/vim/patches/vim-8.0.0124.patchset
+++ b/app-editors/vim/patches/vim-8.0.0124.patchset
@@ -3129,7 +3129,7 @@ index 0000000..3a4fae5
 +	do {
 +		int32 end = strButtons.FindFirst('\n');
 +		if(end != B_ERROR)
-+			strButtons[end] = '\0';
++			strButtons.ReplaceFirst('\n','\0');
 +
 +		BButton *button = _CreateButton(which++, strButtons.String());
 +		view->AddChild(button);


### PR DESCRIPTION
This patch fixes a lvalue required as left operand assignment error when trying to build vim with gcc-5.4.0