### PR TITLE
libsodium: reapply SECONDARY_ARCH suffix

### DIFF
--- a/dev-libs/libsodium/libsodium-1.0.12.recipe
+++ b/dev-libs/libsodium/libsodium-1.0.12.recipe
@@ -16,32 +16,33 @@ SOURCE_URI="https://download.libsodium.org/libsodium/releases/libsodium-$portVer
 CHECKSUM_SHA256="b8648f1bb3a54b0251cf4ffa4f0d76ded13977d4fa7517d988f4c902dd8e2f95"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
 PROVIDES="
-	libsodium = $portVersion
-	lib:libsodium = 18.1.1 compat >= 18
+	libsodium$secondaryArchSuffix = $portVersion
+	lib:libsodium$secondaryArchSuffix = 18.1.1 compat >= 18
 	"
 REQUIRES="
-	haiku
+	haiku$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
-	libsodium_devel = $portVersion
-	devel:libsodium = 18.1.1 compat >= 18
+	libsodium${secondaryArchSuffix}_devel = $portVersion
+	devel:libsodium$secondaryArchSuffix = 18.1.1 compat >= 18
 	"
 REQUIRES_devel="
-	libsodium == $portVersion base
+	libsodium$secondaryArchSuffix == $portVersion base
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
+	haiku${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
 	cmd:autoconf
 	cmd:automake
 	cmd:awk
-	cmd:gcc
-	cmd:libtoolize
+	cmd:gcc$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
 	"
 


### PR DESCRIPTION
Reapplies the recently removed suffix, as libraries can be needed for a secondary architecture.