### PR TITLE
vim: bump version, updated patchset

### DIFF
--- a/app-editors/vim/patches/vim-8.0.0473.patchset
+++ b/app-editors/vim/patches/vim-8.0.0473.patchset
@@ -1,7 +1,7 @@
-From 5f44984b751eca36fa78d9e74ec35df980371b45 Mon Sep 17 00:00:00 2001
+From 5c9e6699e38f7ec07fd2322115801eb1af74f722 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
-Date: Tue, 6 Dec 2016 19:27:42 +0100
-Subject: [PATCH] Haiku supporting code
+Date: Sat, 18 Mar 2017 11:55:19 +0100
+Subject: [PATCH] Updated Haiku supporting patches
 
 ---
  runtime/doc/eval.txt           |    2 +
@@ -51,10 +51,10 @@ Subject: [PATCH] Haiku supporting code
  create mode 100644 src/proto/gui_haiku.pro
 
 diff --git a/runtime/doc/eval.txt b/runtime/doc/eval.txt
-index 1f54372..44b2a8e 100644
+index efa5b9d..fd6f720 100644
 --- a/runtime/doc/eval.txt
 +++ b/runtime/doc/eval.txt
-@@ -8339,12 +8339,14 @@ gui_gnome		Compiled with Gnome support (gui_gtk is also defined).
+@@ -8414,12 +8414,14 @@ gui_gnome		Compiled with Gnome support (gui_gtk is also defined).
  gui_gtk			Compiled with GTK+ GUI (any version).
  gui_gtk2		Compiled with GTK+ 2 GUI (gui_gtk is also defined).
  gui_gtk3		Compiled with GTK+ 3 GUI (gui_gtk is also defined).
@@ -94,10 +94,10 @@ index 58049f6..318e434 100644
  |os_vms.txt|	VMS
  |os_win32.txt|	MS-Windows 95/98/NT
 diff --git a/runtime/doc/options.txt b/runtime/doc/options.txt
-index 5e0d060..08b364c 100644
+index 9a88edb..6753ebf 100644
 --- a/runtime/doc/options.txt
 +++ b/runtime/doc/options.txt
-@@ -3785,7 +3785,7 @@ A jump table for the options with a short description can be found at |Q_op|.
+@@ -3844,7 +3844,7 @@ A jump table for the options with a short description can be found at |Q_op|.
  		'guitablabel' can be used to change the text in the labels.
  		When 'e' is missing a non-GUI tab pages line may be used.
  		The GUI tabs are only supported on some systems, currently
@@ -106,7 +106,7 @@ index 5e0d060..08b364c 100644
  								*'go-f'*
  	  'f'	Foreground: Don't use fork() to detach the GUI from the shell
  		where it was started.  Use this for programs that wait for the
-@@ -6089,7 +6089,12 @@ A jump table for the options with a short description can be found at |Q_op|.
+@@ -6201,7 +6201,12 @@ A jump table for the options with a short description can be found at |Q_op|.
  						$VIM/vimfiles,
  						$VIMRUNTIME,
  						$VIM/vimfiles/after,
@@ -120,7 +120,7 @@ index 5e0d060..08b364c 100644
  			global
  			{not in Vi}
  	This is a list of directories which will be searched for runtime
-@@ -7547,6 +7552,7 @@ A jump table for the options with a short description can be found at |Q_op|.
+@@ -7660,6 +7665,7 @@ A jump table for the options with a short description can be found at |Q_op|.
  					 on MiNT: "vt52"
  				       on MS-DOS: "pcterm"
  					 on OS/2: "os2ansi"
@@ -237,7 +237,7 @@ index 0000000..b95e13d
 +$USER_SETTINGS_DIR is the symbolic name for the place where Haiku
 +configuration and settings files are stored.
 +
-+The normal value is /boot/home/condig/settings.
++The normal value is /boot/home/config/settings.
 +
 +
 +6. Drag & Drop						*haiku-dragndrop*
@@ -358,10 +358,10 @@ index 0000000..b95e13d
 +
 + vim:tw=78:ts=8:ft=help:norl:
 diff --git a/runtime/doc/starting.txt b/runtime/doc/starting.txt
-index 49b1407..5c51890 100644
+index eb1fdc8..970e294 100644
 --- a/runtime/doc/starting.txt
 +++ b/runtime/doc/starting.txt
-@@ -780,6 +780,7 @@ accordingly.  Vim proceeds in this order:
+@@ -781,6 +781,7 @@ accordingly.  Vim proceeds in this order:
  				or $VIM/_vimrc
  		Amiga		s:.vimrc, home:.vimrc, home:vimfiles:vimrc
  				or $VIM/.vimrc
@@ -369,7 +369,7 @@ index 49b1407..5c51890 100644
  
  	The files are searched in the order specified above and only the first
  	one that is found is read.
-@@ -826,6 +827,7 @@ accordingly.  Vim proceeds in this order:
+@@ -827,6 +828,7 @@ accordingly.  Vim proceeds in this order:
  		    "$HOME/_vimrc"	   (for MS-DOS and Win32) (*)
  		    "$HOME/vimfiles/vimrc" (for MS-DOS and Win32) (*)
  		    "$VIM/_vimrc"	   (for MS-DOS and Win32) (*)
@@ -377,7 +377,7 @@ index 49b1407..5c51890 100644
  		Note: For Unix, OS/2 and Amiga, when ".vimrc" does not exist,
  		"_vimrc" is also tried, in case an MS-DOS compatible file
  		system is used.  For MS-DOS and Win32 ".vimrc" is checked
-@@ -936,6 +938,7 @@ sessions.  Put it in a place so that it will be found by 3b:
+@@ -937,6 +939,7 @@ sessions.  Put it in a place so that it will be found by 3b:
  	~/.vimrc	(Unix and OS/2)
  	s:.vimrc	(Amiga)
  	$VIM\_vimrc	(MS-DOS and Win32)
@@ -386,10 +386,10 @@ index 49b1407..5c51890 100644
  by default.  See |compatible-default|.
  
 diff --git a/runtime/doc/tags b/runtime/doc/tags
-index 3ce8dc0..a9706c8 100644
+index 68c611b..49f60a9 100644
 --- a/runtime/doc/tags
 +++ b/runtime/doc/tags
-@@ -4544,6 +4544,7 @@ GetLatestVimScripts-copyright	pi_getscript.txt	/*GetLatestVimScripts-copyright*
+@@ -4560,6 +4560,7 @@ GetLatestVimScripts-copyright	pi_getscript.txt	/*GetLatestVimScripts-copyright*
  GetLatestVimScripts_dat	pi_getscript.txt	/*GetLatestVimScripts_dat*
  Gnome	gui_x11.txt	/*Gnome*
  H	motion.txt	/*H*
@@ -397,7 +397,7 @@ index 3ce8dc0..a9706c8 100644
  I	insert.txt	/*I*
  ICCF	uganda.txt	/*ICCF*
  IM-server	mbyte.txt	/*IM-server*
-@@ -6596,6 +6597,20 @@ g~	change.txt	/*g~*
+@@ -6616,6 +6617,20 @@ g~	change.txt	/*g~*
  g~g~	change.txt	/*g~g~*
  g~~	change.txt	/*g~~*
  h	motion.txt	/*h*
@@ -418,7 +418,7 @@ index 3ce8dc0..a9706c8 100644
  hangul	hangulin.txt	/*hangul*
  hangulin.txt	hangulin.txt	/*hangulin.txt*
  has()	eval.txt	/*has()*
-@@ -7698,6 +7713,7 @@ os_390.txt	os_390.txt	/*os_390.txt*
+@@ -7719,6 +7734,7 @@ os_390.txt	os_390.txt	/*os_390.txt*
  os_amiga.txt	os_amiga.txt	/*os_amiga.txt*
  os_beos.txt	os_beos.txt	/*os_beos.txt*
  os_dos.txt	os_dos.txt	/*os_dos.txt*
@@ -481,7 +481,7 @@ index 7f5bae0..77d3a0a 100644
  " When started as "evim", evim.vim will already have done these settings.
  if v:progname =~? "evim"
 diff --git a/src/Makefile b/src/Makefile
-index a24eb7b..f2d6f30 100644
+index 1af1e17..80bfeb8 100644
 --- a/src/Makefile
 +++ b/src/Makefile
 @@ -1364,6 +1364,23 @@ CARBONGUI_BUNDLE = gui_bundle
@@ -508,7 +508,7 @@ index a24eb7b..f2d6f30 100644
  # All GUI files
  ALL_GUI_SRC  = gui.c gui_gtk.c gui_gtk_f.c gui_motif.c gui_xmdlg.c gui_xmebw.c gui_athena.c gui_gtk_x11.c gui_x11.c gui_at_sb.c gui_at_fs.c pty.c
  ALL_GUI_PRO  = gui.pro gui_gtk.pro gui_motif.pro gui_xmdlg.pro gui_athena.pro gui_gtk_x11.pro gui_x11.pro gui_w32.pro gui_photon.pro
-@@ -2967,6 +2984,9 @@ objects/gui_gtk_gresources.o: auto/gui_gtk_gresources.c
+@@ -3030,6 +3047,9 @@ objects/gui_gtk_gresources.o: auto/gui_gtk_gresources.c
  objects/gui_gtk_x11.o: gui_gtk_x11.c
  	$(CCC) -o $@ gui_gtk_x11.c
  
@@ -518,7 +518,7 @@ index a24eb7b..f2d6f30 100644
  objects/gui_motif.o: gui_motif.c
  	$(CCC) -o $@ gui_motif.c
  
-@@ -3086,6 +3106,9 @@ objects/option.o: option.c
+@@ -3153,6 +3173,9 @@ objects/option.o: option.c
  objects/os_beos.o: os_beos.c
  	$(CCC) -o $@ os_beos.c
  
@@ -528,7 +528,7 @@ index a24eb7b..f2d6f30 100644
  objects/os_qnx.o: os_qnx.c
  	$(CCC) -o $@ os_qnx.c
  
-@@ -3254,6 +3277,63 @@ $(APPDIR)/Contents:
+@@ -3321,6 +3344,63 @@ $(APPDIR)/Contents:
  
  
  ###############################################################################
@@ -593,10 +593,10 @@ index a24eb7b..f2d6f30 100644
  ### Dependencies:
  objects/arabic.o: arabic.c vim.h auto/config.h feature.h os_unix.h auto/osdef.h \
 diff --git a/src/configure.ac b/src/configure.ac
-index 3a31f97..4101037 100644
+index 6251681..50fafdb 100644
 --- a/src/configure.ac
 +++ b/src/configure.ac
-@@ -114,6 +114,12 @@ case `uname` in
+@@ -118,6 +118,12 @@ case `uname` in
      *)		BEOS=no; AC_MSG_RESULT(no);;
  esac
  
@@ -609,7 +609,7 @@ index 3a31f97..4101037 100644
  dnl If QNX is found, assume we don't want to use Xphoton
  dnl unless it was specifically asked for (--with-x)
  AC_MSG_CHECKING(for QNX)
-@@ -1979,7 +1985,11 @@ fi
+@@ -1983,7 +1989,11 @@ fi
  
  if test "$enable_channel" = "yes"; then
    dnl On Solaris we need the socket and nsl library.
@@ -622,7 +622,7 @@ index 3a31f97..4101037 100644
    AC_CHECK_LIB(nsl, gethostbyname)
    AC_MSG_CHECKING(whether compiling with process communication is possible)
    AC_TRY_LINK([
-@@ -2184,11 +2194,11 @@ else
+@@ -2188,11 +2198,11 @@ else
    fi
  fi
  
@@ -636,7 +636,7 @@ index 3a31f97..4101037 100644
  
  dnl Canonicalize the --enable-gui= argument so that it can be easily compared.
  dnl Do not use character classes for portability with old tools.
-@@ -2203,10 +2213,23 @@ SKIP_MOTIF=YES
+@@ -2207,10 +2217,23 @@ SKIP_MOTIF=YES
  SKIP_ATHENA=YES
  SKIP_NEXTAW=YES
  SKIP_PHOTON=YES
@@ -661,7 +661,7 @@ index 3a31f97..4101037 100644
    SKIP_PHOTON=
    case "$enable_gui_canon" in
      no)		AC_MSG_RESULT(no GUI support)
-@@ -2370,6 +2393,7 @@ if test "x$MACOSX" = "xyes" -a -z "$SKIP_CARBON" -a "x$CARBON" = "xyes"; then
+@@ -2374,6 +2397,7 @@ if test "x$MACOSX" = "xyes" -a -z "$SKIP_CARBON" -a "x$CARBON" = "xyes"; then
    SKIP_ATHENA=YES;
    SKIP_NEXTAW=YES;
    SKIP_PHOTON=YES;
@@ -669,7 +669,7 @@ index 3a31f97..4101037 100644
    SKIP_CARBON=YES
  fi
  
-@@ -2990,6 +3014,11 @@ if test "x$GUITYPE:$enable_fontset" = "xGTK:yes"; then
+@@ -2994,6 +3018,11 @@ if test "x$GUITYPE:$enable_fontset" = "xGTK:yes"; then
    enable_fontset="no"
  fi
  
@@ -682,10 +682,10 @@ index 3a31f97..4101037 100644
    GUITYPE=PHOTONGUI
  fi
 diff --git a/src/evalfunc.c b/src/evalfunc.c
-index 08be12b..a648649 100644
+index 21b75c1..8f2fa0f 100644
 --- a/src/evalfunc.c
 +++ b/src/evalfunc.c
-@@ -5463,6 +5463,9 @@ f_has(typval_T *argvars, typval_T *rettv)
+@@ -5457,6 +5457,9 @@ f_has(typval_T *argvars, typval_T *rettv)
  #ifdef __BEOS__
  	"beos",
  #endif
@@ -695,7 +695,7 @@ index 08be12b..a648649 100644
  #ifdef MACOS
  	"mac",
  #endif
-@@ -5640,6 +5643,9 @@ f_has(typval_T *argvars, typval_T *rettv)
+@@ -5634,6 +5637,9 @@ f_has(typval_T *argvars, typval_T *rettv)
  #ifdef FEAT_GUI_GNOME
  	"gui_gnome",
  #endif
@@ -706,7 +706,7 @@ index 08be12b..a648649 100644
  	"gui_mac",
  #endif
 diff --git a/src/ex_cmds.c b/src/ex_cmds.c
-index 206ead1..9ca1df4 100644
+index 0c4dffb..b4e070c 100644
 --- a/src/ex_cmds.c
 +++ b/src/ex_cmds.c
 @@ -14,6 +14,9 @@
@@ -719,7 +719,7 @@ index 206ead1..9ca1df4 100644
  #ifdef FEAT_FLOAT
  # include <float.h>
  #endif
-@@ -1839,6 +1842,8 @@ write_viminfo(char_u *file, int forceit)
+@@ -1837,6 +1840,8 @@ write_viminfo(char_u *file, int forceit)
      int		hidden = FALSE;
  #endif
  
@@ -728,7 +728,7 @@ index 206ead1..9ca1df4 100644
      if (no_viminfo())
  	return;
  
-@@ -1846,6 +1851,19 @@ write_viminfo(char_u *file, int forceit)
+@@ -1844,6 +1849,19 @@ write_viminfo(char_u *file, int forceit)
      if (fname == NULL)
  	return;
  
@@ -749,10 +749,10 @@ index 206ead1..9ca1df4 100644
      if (fp_in == NULL)
      {
 diff --git a/src/ex_docmd.c b/src/ex_docmd.c
-index 439467c..0d8988a 100644
+index 96e2b3f..6fe19dc 100644
 --- a/src/ex_docmd.c
 +++ b/src/ex_docmd.c
-@@ -7740,6 +7740,7 @@ ex_shell(exarg_T *eap UNUSED)
+@@ -7924,6 +7924,7 @@ ex_shell(exarg_T *eap UNUSED)
  	|| (defined(FEAT_GUI_GTK) && defined(FEAT_DND)) \
  	|| defined(FEAT_GUI_MSWIN) \
  	|| defined(FEAT_GUI_MAC) \
@@ -826,7 +826,7 @@ index 138279e..b211727 100644
  # ifndef ALWAYS_USE_GUI
  #  define FEAT_CON_DIALOG
 diff --git a/src/gui.c b/src/gui.c
-index 87b0839..bfeaa25 100644
+index 7d44db1..b730821 100644
 --- a/src/gui.c
 +++ b/src/gui.c
 @@ -424,7 +424,7 @@ gui_init_check(void)
@@ -874,18 +874,18 @@ index 87b0839..bfeaa25 100644
      if (gui_has_tabline())
  	base_height += gui.tabline_height;
  # endif
-@@ -1461,6 +1468,10 @@ gui_resize_shell(int pixel_width, int pixel_height)
- again:
+@@ -1463,6 +1470,10 @@ again:
+     new_pixel_height = 0;
      busy = TRUE;
  
-+#ifdef FEAT_GUI_HAIKU
++    #ifdef FEAT_GUI_HAIKU
 +    vim_lock_screen();
-+#endif
++    #endif
 +
      /* Flush pending output before redrawing */
      out_flush();
  
-@@ -1483,6 +1494,10 @@ again:
+@@ -1485,6 +1496,10 @@ again:
  	    || gui.num_rows != Rows || gui.num_cols != Columns)
  	shell_resized();
  
@@ -896,7 +896,7 @@ index 87b0839..bfeaa25 100644
      gui_update_scrollbars(TRUE);
      gui_update_cursor(FALSE, TRUE);
  #if defined(FEAT_XIM) && !defined(FEAT_GUI_GTK)
-@@ -4248,9 +4263,9 @@ gui_update_scrollbars(
+@@ -4247,9 +4262,9 @@ gui_update_scrollbars(
  		y += gui.menu_height;
  #endif
  
@@ -908,7 +908,7 @@ index 87b0839..bfeaa25 100644
  		y += gui.toolbar_height;
  # else
  #  ifdef FEAT_GUI_MSWIN
-@@ -4259,7 +4274,7 @@ gui_update_scrollbars(
+@@ -4258,7 +4273,7 @@ gui_update_scrollbars(
  # endif
  #endif
  
@@ -917,7 +917,7 @@ index 87b0839..bfeaa25 100644
  	    if (gui_has_tabline())
  		y += gui.tabline_height;
  #endif
-@@ -4988,9 +5003,10 @@ ex_gui(exarg_T *eap)
+@@ -4987,9 +5002,10 @@ ex_gui(exarg_T *eap)
  }
  
  #if ((defined(FEAT_GUI_X11) || defined(FEAT_GUI_GTK) || defined(FEAT_GUI_W32) \
@@ -999,7 +999,7 @@ index 4769716..8a321e4 100644
      MenuHandle	MacOSHelpMenu;	    /* Help menu provided by the MacOS */
 diff --git a/src/gui_haiku.cc b/src/gui_haiku.cc
 new file mode 100644
-index 0000000..3a4fae5
+index 0000000..ab9191a
 --- /dev/null
 +++ b/src/gui_haiku.cc
 @@ -0,0 +1,5294 @@
@@ -3129,7 +3129,7 @@ index 0000000..3a4fae5
 +	do {
 +		int32 end = strButtons.FindFirst('\n');
 +		if(end != B_ERROR)
-+			strButtons[end] = '\0';
++			strButtons.SetByteAt(end, '\0');
 +
 +		BButton *button = _CreateButton(which++, strButtons.String());
 +		view->AddChild(button);
@@ -6355,7 +6355,7 @@ index 0000000..414d127
 +
 +#endif
 diff --git a/src/misc1.c b/src/misc1.c
-index 3630d7b..03f13cc 100644
+index 951467d..c45d62e 100644
 --- a/src/misc1.c
 +++ b/src/misc1.c
 @@ -14,6 +14,10 @@
@@ -6369,7 +6369,7 @@ index 3630d7b..03f13cc 100644
  static char_u *vim_version_dir(char_u *vimdir);
  static char_u *remove_tail(char_u *p, char_u *pend, char_u *name);
  #if defined(FEAT_CMDL_COMPL)
-@@ -4214,7 +4218,16 @@ vim_getenv(char_u *name, int *mustfree)
+@@ -4221,7 +4225,16 @@ vim_getenv(char_u *name, int *mustfree)
  
      vimruntime = (STRCMP(name, "VIMRUNTIME") == 0);
      if (!vimruntime && STRCMP(name, "VIM") != 0)
@@ -6388,10 +6388,10 @@ index 3630d7b..03f13cc 100644
      /*
       * When expanding $VIMRUNTIME fails, try using $VIM/vim<version> or $VIM.
 diff --git a/src/normal.c b/src/normal.c
-index 5d0796f..78769e1 100644
+index 53bda6c..3f96002 100644
 --- a/src/normal.c
 +++ b/src/normal.c
-@@ -2647,13 +2647,14 @@ do_mouse(
+@@ -2652,13 +2652,14 @@ do_mouse(
  	    if (!is_click)
  		return FALSE;
  #endif
@@ -6409,7 +6409,7 @@ index 5d0796f..78769e1 100644
  	    {
  		jump_flags = 0;
 diff --git a/src/option.h b/src/option.h
-index 13acabf..5d9bc4a 100644
+index 2c6aeef..2a3141d 100644
 --- a/src/option.h
 +++ b/src/option.h
 @@ -10,6 +10,8 @@
@@ -6421,7 +6421,7 @@ index 13acabf..5d9bc4a 100644
  /*
   * Default values for 'errorformat'.
   * The "%f|%l| %m" one is used for when the contents of the quickfix window is
-@@ -1185,5 +1187,7 @@ enum
+@@ -1195,5 +1197,7 @@ enum
      , WV_COUNT	    /* must be the last one */
  };
  
@@ -6466,7 +6466,7 @@ index 0000000..c9bfe75
 +#endif
 diff --git a/src/os_haiku.rdef b/src/os_haiku.rdef
 new file mode 100644
-index 0000000..215269e
+index 0000000..733035a
 --- /dev/null
 +++ b/src/os_haiku.rdef
 @@ -0,0 +1,143 @@
@@ -6614,10 +6614,10 @@ index 0000000..215269e
 +	$"FF17F6CF36F92F1B9E631E8B8F3FBC0000000049454E44AE426082"
 +};
 diff --git a/src/os_unix.c b/src/os_unix.c
-index aa3c3e5..fa8751c 100644
+index f0a5621..12460fe 100644
 --- a/src/os_unix.c
 +++ b/src/os_unix.c
-@@ -2159,7 +2159,7 @@ mch_settitle(char_u *title, char_u *icon)
+@@ -2165,7 +2165,7 @@ mch_settitle(char_u *title, char_u *icon)
      if (get_x11_windis() == OK)
  	type = 1;
  #else
@@ -6626,7 +6626,7 @@ index aa3c3e5..fa8751c 100644
      if (gui.in_use)
  	type = 1;
  # endif
-@@ -2187,7 +2187,7 @@ mch_settitle(char_u *title, char_u *icon)
+@@ -2193,7 +2193,7 @@ mch_settitle(char_u *title, char_u *icon)
  # endif
  	    set_x11_title(title);		/* x11 */
  #endif
@@ -6635,7 +6635,7 @@ index aa3c3e5..fa8751c 100644
  	|| defined(FEAT_GUI_PHOTON) || defined(FEAT_GUI_MAC)
  	else
  	    gui_mch_settitle(title, icon);
-@@ -4295,7 +4295,7 @@ mch_call_shell(
+@@ -4301,7 +4301,7 @@ mch_call_shell(
      {
  	SIGSET_DECL(curset)
  
@@ -6645,7 +6645,7 @@ index aa3c3e5..fa8751c 100644
  # endif
  
 diff --git a/src/os_unix.h b/src/os_unix.h
-index d28aa4d..1c6efd2 100644
+index 695affa..b9bc2e3 100644
 --- a/src/os_unix.h
 +++ b/src/os_unix.h
 @@ -364,6 +364,8 @@ typedef struct dsc$descriptor   DESC;
@@ -6792,7 +6792,7 @@ index 20ab65b..7d6517f 100644
  static char TtyProto[] = "/dev/tt/XY";
  #  else
 diff --git a/src/screen.c b/src/screen.c
-index 45e7c7c..40fba6a 100644
+index 82c5ba5..72d7e1d 100644
 --- a/src/screen.c
 +++ b/src/screen.c
 @@ -89,6 +89,15 @@
@@ -6811,7 +6811,7 @@ index 45e7c7c..40fba6a 100644
  #define MB_FILLER_CHAR '<'  /* character used when a double-width character
  			     * doesn't fit. */
  
-@@ -8574,6 +8583,10 @@ retry:
+@@ -8591,6 +8600,10 @@ retry:
  
      win_new_shellsize();    /* fit the windows in the new sized shell */
  
@@ -6822,7 +6822,7 @@ index 45e7c7c..40fba6a 100644
      comp_col();		/* recompute columns for shown command and ruler */
  
      /*
-@@ -8817,6 +8830,10 @@ give_up:
+@@ -8834,6 +8847,10 @@ give_up:
      }
  #endif
  
@@ -6833,7 +6833,7 @@ index 45e7c7c..40fba6a 100644
      entered = FALSE;
      --RedrawingDisabled;
  
-@@ -9675,6 +9692,10 @@ screen_ins_lines(
+@@ -9692,6 +9709,10 @@ screen_ins_lines(
  	clip_scroll_selection(-line_count);
  #endif
  
@@ -6844,7 +6844,7 @@ index 45e7c7c..40fba6a 100644
  #ifdef FEAT_GUI
      /* Don't update the GUI cursor here, ScreenLines[] is invalid until the
       * scrolling is actually carried out. */
-@@ -9727,6 +9748,10 @@ screen_ins_lines(
+@@ -9744,6 +9765,10 @@ screen_ins_lines(
  	}
      }
  
@@ -6855,7 +6855,7 @@ index 45e7c7c..40fba6a 100644
      screen_stop_highlight();
      windgoto(cursor_row, 0);
  
-@@ -9896,6 +9921,10 @@ screen_del_lines(
+@@ -9913,6 +9938,10 @@ screen_del_lines(
  	clip_scroll_selection(line_count);
  #endif
  
@@ -6866,7 +6866,7 @@ index 45e7c7c..40fba6a 100644
  #ifdef FEAT_GUI
      /* Don't update the GUI cursor here, ScreenLines[] is invalid until the
       * scrolling is actually carried out. */
-@@ -9956,6 +9985,10 @@ screen_del_lines(
+@@ -9973,6 +10002,10 @@ screen_del_lines(
  	}
      }
  
@@ -6878,10 +6878,10 @@ index 45e7c7c..40fba6a 100644
  
  #ifdef FEAT_WINDOWS
 diff --git a/src/structs.h b/src/structs.h
-index 3fdfb5f..a3f0ab1 100644
+index 475280a..a3ffe09 100644
 --- a/src/structs.h
 +++ b/src/structs.h
-@@ -3037,6 +3037,13 @@ struct VimMenu
+@@ -3066,6 +3066,13 @@ struct VimMenu
      HMENU	submenu_id;	    /* If this is submenu, add children here */
      HWND	tearoff_handle;	    /* hWnd of tearoff if created */
  #endif
@@ -6896,10 +6896,10 @@ index 3fdfb5f..a3f0ab1 100644
  /*  MenuHandle	id; */
  /*  short	index;	*/	    /* the item index within the father menu */
 diff --git a/src/term.c b/src/term.c
-index a9c2c57..e9c2311 100644
+index 75c9fbf..353c011 100644
 --- a/src/term.c
 +++ b/src/term.c
-@@ -1314,6 +1314,11 @@ termgui_mch_get_rgb(guicolor_T color)
+@@ -1320,6 +1320,11 @@ termgui_mch_get_rgb(guicolor_T color)
  # define DEFAULT_TERM	(char_u *)"beos-ansi"
  #endif
  
@@ -6912,10 +6912,10 @@ index a9c2c57..e9c2311 100644
  # define DEFAULT_TERM	(char_u *)"dumb"
  #endif
 diff --git a/src/ui.c b/src/ui.c
-index ad29190..9de4d2e 100644
+index 0bd2edc..415d689 100644
 --- a/src/ui.c
 +++ b/src/ui.c
-@@ -3122,7 +3122,7 @@ mouse_find_win(int *rowp, int *colp UNUSED)
+@@ -3129,7 +3129,7 @@ mouse_find_win(int *rowp, int *colp UNUSED)
  
  #if defined(FEAT_GUI_MOTIF) || defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MAC) \
  	|| defined(FEAT_GUI_ATHENA) || defined(FEAT_GUI_MSWIN) \
@@ -6925,10 +6925,10 @@ index ad29190..9de4d2e 100644
   * Translate window coordinates to buffer position without any side effects
   */
 diff --git a/src/version.c b/src/version.c
-index 490e150..db6a473 100644
+index 8237679..ed10520 100644
 --- a/src/version.c
 +++ b/src/version.c
-@@ -1299,6 +1299,9 @@ list_version(void)
+@@ -1997,6 +1997,9 @@ list_version(void)
      MSG_PUTS(_("with X11-Athena GUI."));
  #    endif
  #   else
@@ -6938,7 +6938,7 @@ index 490e150..db6a473 100644
  #     ifdef FEAT_GUI_PHOTON
      MSG_PUTS(_("with Photon GUI."));
  #     else
-@@ -1316,6 +1319,7 @@ list_version(void)
+@@ -2014,6 +2017,7 @@ list_version(void)
  #	  endif
  #	 endif
  #	endif
@@ -6947,7 +6947,7 @@ index 490e150..db6a473 100644
  #    endif
  #   endif
 diff --git a/src/vim.h b/src/vim.h
-index ef75ea2..fc0a00d 100644
+index dd571df..716b825 100644
 --- a/src/vim.h
 +++ b/src/vim.h
 @@ -115,6 +115,7 @@
@@ -6970,7 +6970,7 @@ index ef75ea2..fc0a00d 100644
  #if (defined(UNIX) || defined(VMS)) \
  	&& (!defined(MACOS_X) || defined(HAVE_CONFIG_H))
  # include "os_unix.h"	    /* bring lots of system header files */
-@@ -2077,6 +2083,9 @@ typedef struct VimClipboard
+@@ -2071,6 +2077,9 @@ typedef struct VimClipboard
      int_u	format;		/* Vim's own special clipboard format */
      int_u	format_raw;	/* Vim's raw text clipboard format */
  # endif
@@ -6980,7 +6980,7 @@ index ef75ea2..fc0a00d 100644
  } VimClipboard;
  #else
  typedef int VimClipboard;	/* This is required for the prototypes. */
-@@ -2116,7 +2125,7 @@ typedef enum
+@@ -2111,7 +2120,7 @@ typedef enum {
   * been seen at that stage.  But it must be before globals.h, where error_ga
   * is declared. */
  #if !defined(FEAT_GUI_W32) && !defined(FEAT_GUI_X11) \
@@ -6990,5 +6990,5 @@ index ef75ea2..fc0a00d 100644
  # define display_errors()	fflush(stderr)
  # define mch_msg(str)		printf("%s", (str))
 -- 
-2.10.2
+2.11.0
 

--- a/app-editors/vim/vim-8.0.0473.recipe
+++ b/app-editors/vim/vim-8.0.0473.recipe
@@ -14,7 +14,7 @@ COPYRIGHT="Bram Moleenar et al."
 LICENSE="Vim"
 REVISION="1"
 SOURCE_URI="https://github.com/vim/vim/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="8d15d4a9f9ea94a84679c540f636316a2fe18fa306b7c238d260767f8ec96855"
+CHECKSUM_SHA256="724b56ae54eb3c46909f73c16e4e17ebd348c53680f0b65f908f235bfa9d2b08"
 SOURCE_DIR="vim-$portVersion"
 PATCHES="vim-$portVersion.patchset"
 


### PR DESCRIPTION
It makes https://github.com/haikuports/haikuports/pull/1210 outdated as it contains this patch already. Thanks @freddietilley !