### PR TITLE
erlang: bump version and enable ssl

### DIFF
--- a/dev-lang/erlang/erlang-19.02.recipe
+++ b/dev-lang/erlang/erlang-19.02.recipe
@@ -1,0 +1,72 @@
+SUMMARY="The programming language Erlang/OTP"
+DESCRIPTION="Erlang is a programming language used to build massively \
+scalable soft real-time systems with requirements on high availability. \
+Some of its uses are in telecoms, banking, e-commerce, computer telephony \
+and instant messaging. Erlang's runtime system has built-in support for \
+concurrency, distribution and fault tolerance."
+HOMEPAGE="http://www.erlang.org"
+COPYRIGHT="1997-2013 Ericsson AB"
+LICENSE="EPL"
+REVISION="1"
+SOURCE_URI="http://www.erlang.org/download/otp_src_19.2.tar.gz"
+CHECKSUM_SHA256="a016b3ef5dac1e532972617b2715ef187ecb616f7cd7ddcfe0f1d502f5d24870"
+SOURCE_DIR="otp_src_19.2"
+PATCHES="erlang-19.02.patchset"
+
+ARCHITECTURES="x86_gcc2 x86"
+
+PROVIDES="
+	erl = $portVersion
+	cmd:erl = $portVersion
+	cmd:ct_run = $portVersion
+	cmd:dialyzer = $portVersion
+	cmd:epmd = $portVersion
+	cmd:erlc = $portVersion
+	cmd:escript = $portVersion
+	cmd:run_erl = $portVersion
+	cmd:to_erl = $portVersion
+	cmd:typer = $portVersion
+	"
+REQUIRES="
+	haiku
+	cmd:libtool
+	cmd:perl
+	cmd:gcc
+	lib:libcrypto
+	lib:libssl
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+
+BUILD_PREREQUIRES="
+	cmd:perl
+	cmd:make
+	cmd:gcc
+	cmd:tar
+	cmd:uname
+	cmd:pkg_config
+	devel:libncurses
+	devel:libssl
+	devel:libcrypto
+	"
+
+ERLANG_CFLAGS="-DETHR_X86_OUT_OF_ORDER -DHAVE_NET_IF_DL_H -DETHR_HAVE_ETHREAD_DEFINES -DETHR_PTHREADS -DETHR_SIZEOF_PTR=4 -DHAVE_CONFIG_H -D_BSD_SOURCE=1 -I../i586-pc-haiku -I../../i586-pc-haiku -I../include/internal -I../../include/internal -I../../emulator/sys/unix -I../../include/i586-pc-haiku -I../../emulator/beam -I../../../erts/include/internal/i586-pc-haiku -I../../../erts/i586-pc-haiku -Imisc -I../include -Iepmd -Iconnect -I../../../erts/emulator/beam -I../../../erts/include/i586-pc-haiku -I../../../../erts/emulator/beam -I../../../../erts/include/i586-pc-haiku -I../../../../erts/i586-pc-haiku"
+
+BUILD()
+{
+	rm -rf `finddir B_SYSTEM_SETTINGS_DIRECTORY`/network
+	mkdir -p `finddir B_SYSTEM_SETTINGS_DIRECTORY`/network
+	touch `finddir B_SYSTEM_SETTINGS_DIRECTORY`/network/hostname
+	runConfigure --omit-dirs "docDir dataRootDir" configure --prefix="$prefix" --disable-ipv6 --enable-dynamic-ssl-lib --with-ssl="/boot/system/develop" --disable-hipe CFLAGS="-I/boot/system/develop/headers" LDFLAGS="-lnetwork"
+	echo "#undef ERTS_SMP" >> erts/i586-pc-haiku/config.h
+	echo "#undef USE_THREADS" >> erts/i586-pc-haiku/config.h
+	echo "Skip" > lib/megaco/SKIP
+	HOME=/boot/home make CFLAGS="$ERLANG_CFLAGS"
+}
+
+INSTALL()
+{
+	HOME=/boot/home make CFLAGS="$ERLANG_CFLAGS" install
+}

--- a/dev-lang/erlang/patches/erlang-19.02.patchset
+++ b/dev-lang/erlang/patches/erlang-19.02.patchset
@@ -1,0 +1,159 @@
+From c547fa95eaca6428dbd26630c92584834240da82 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Mon, 27 Feb 2017 14:21:40 +0000
+Subject: [PATCH] Haiku fixes
+
+---
+ erts/configure                              | 8 +++++---
+ erts/emulator/sys/unix/sys.c                | 2 +-
+ erts/epmd/src/Makefile.in                   | 2 +-
+ erts/etc/common/Makefile.in                 | 2 +-
+ erts/etc/common/erlexec.c                   | 2 +-
+ erts/include/internal/ethread.h             | 4 +---
+ erts/include/internal/i386/ethr_dw_atomic.h | 2 ++
+ lib/asn1/c_src/Makefile                     | 2 +-
+ lib/erl_interface/src/connect/ei_connect.c  | 2 ++
+ 9 files changed, 15 insertions(+), 11 deletions(-)
+
+diff --git a/erts/configure b/erts/configure
+index 88643b7..2d083d3 100755
+--- a/erts/configure
++++ b/erts/configure
+@@ -6868,7 +6868,7 @@ if test "${ac_cv_lib_m_sin+set}" = set; then
+   echo $ECHO_N "(cached) $ECHO_C" >&6
+ else
+   ac_check_lib_save_LIBS=$LIBS
+-LIBS="-lm  $LIBS"
++LIBS=" $LIBS"
+ cat >conftest.$ac_ext <<_ACEOF
+ /* confdefs.h.  */
+ _ACEOF
+@@ -6931,7 +6931,7 @@ if test $ac_cv_lib_m_sin = yes; then
+ #define HAVE_LIBM 1
+ _ACEOF
+ 
+-  LIBS="-lm $LIBS"
++  LIBS=" $LIBS"
+ 
+ fi
+ 
+@@ -21553,7 +21553,9 @@ _ACEOF
+     if test "$gcc_dw_cmpxchg_asm" = "yes"; then
+ 
+ cat >>confdefs.h <<\_ACEOF
+-#define ETHR_GCC_HAVE_DW_CMPXCHG_ASM_SUPPORT 1
++#undef ETHR_GCC_HAVE_DW_CMPXCHG_ASM_SUPPORT
++#undef ERTS_SMP
++#undef USE_THREADS
+ _ACEOF
+ 
+     fi;;
+diff --git a/erts/emulator/sys/unix/sys.c b/erts/emulator/sys/unix/sys.c
+index 4b2edac..07b1582 100644
+--- a/erts/emulator/sys/unix/sys.c
++++ b/erts/emulator/sys/unix/sys.c
+@@ -611,7 +611,7 @@ prepare_crash_dump(int secs)
+ 	if (nice_val > 39) {
+ 	    nice_val = 39;
+ 	}
+-	erts_silence_warn_unused_result(nice(nice_val));
++	erts_silence_warn_unused_result(nice_val);
+     }
+ 
+     UnUseTmpHeapNoproc(NUFBUF);
+diff --git a/erts/epmd/src/Makefile.in b/erts/epmd/src/Makefile.in
+index da4370d..d72a002 100644
+--- a/erts/epmd/src/Makefile.in
++++ b/erts/epmd/src/Makefile.in
+@@ -56,7 +56,7 @@ else
+ ifeq ($(findstring vxworks,$(TARGET)),vxworks)
+ ERTS_INTERNAL_LIBS=-L../../lib/internal/$(TARGET) -lerts_internal$(ERTS_LIB_TYPEMARKER) @ERTS_INTERNAL_X_LIBS@
+ else
+-ERTS_INTERNAL_LIBS=-L../../lib/internal/$(TARGET) -lerts_internal$(ERTS_LIB_TYPEMARKER) @ERTS_INTERNAL_X_LIBS@ -lm
++ERTS_INTERNAL_LIBS=-L../../lib/internal/$(TARGET) -lerts_internal$(ERTS_LIB_TYPEMARKER) @ERTS_INTERNAL_X_LIBS@ 
+ endif
+ endif
+ 
+diff --git a/erts/etc/common/Makefile.in b/erts/etc/common/Makefile.in
+index cb053a1..a018799 100644
+--- a/erts/etc/common/Makefile.in
++++ b/erts/etc/common/Makefile.in
+@@ -99,7 +99,7 @@ endif
+ ifeq ($(TARGET),win32)
+ ERTS_INTERNAL_LIBS=-L../../lib/internal/$(TARGET) -lerts_internal_r$(ERTS_LIB_TYPEMARKER) @ERTS_INTERNAL_X_LIBS@
+ else
+-ERTS_INTERNAL_LIBS=-L../../lib/internal/$(TARGET) -lerts_internal$(ERTS_LIB_TYPEMARKER) @ERTS_INTERNAL_X_LIBS@ -lm
++ERTS_INTERNAL_LIBS=-L../../lib/internal/$(TARGET) -lerts_internal$(ERTS_LIB_TYPEMARKER) @ERTS_INTERNAL_X_LIBS@ 
+ endif
+ 
+ ERTS_LIB = $(ERL_TOP)/erts/lib_src/obj/$(TARGET)/$(TYPE)/MADE
+diff --git a/erts/etc/common/erlexec.c b/erts/etc/common/erlexec.c
+index 2b2e0e4..b27fba4 100644
+--- a/erts/etc/common/erlexec.c
++++ b/erts/etc/common/erlexec.c
+@@ -2049,7 +2049,7 @@ initial_argv_massage(int *argc, char ***argv)
+ 
+     vix = 0;
+ 
+-    av = build_args_from_env("ERL_OTP" OTP_SYSTEM_VERSION "_FLAGS");
++    av = build_args_from_env("ERL_HAIKU_FLAGS");
+     if (av)
+ 	avv[vix++].argv = av;
+ 
+diff --git a/erts/include/internal/ethread.h b/erts/include/internal/ethread.h
+index b23644d..343b9ef 100644
+--- a/erts/include/internal/ethread.h
++++ b/erts/include/internal/ethread.h
+@@ -27,9 +27,7 @@
+ #ifndef ETHREAD_H__
+ #define ETHREAD_H__
+ 
+-#ifndef ETHR_HAVE_ETHREAD_DEFINES
+-#  include "ethread_header_config.h"
+-#endif
++#include "ethread_header_config.h"
+ 
+ #include <stdlib.h>
+ #include "ethread_inline.h"
+diff --git a/erts/include/internal/i386/ethr_dw_atomic.h b/erts/include/internal/i386/ethr_dw_atomic.h
+index 91acdb0..83bfb2a 100644
+--- a/erts/include/internal/i386/ethr_dw_atomic.h
++++ b/erts/include/internal/i386/ethr_dw_atomic.h
+@@ -26,6 +26,8 @@
+ #ifndef ETHR_X86_DW_ATOMIC_H__
+ #define ETHR_X86_DW_ATOMIC_H__
+ 
++#include "ethread_header_config.h"
++
+ #ifdef ETHR_GCC_HAVE_DW_CMPXCHG_ASM_SUPPORT
+ 
+ #define ETHR_HAVE_NATIVE_DW_ATOMIC
+diff --git a/lib/asn1/c_src/Makefile b/lib/asn1/c_src/Makefile
+index 1f714df..cb606fd 100644
+--- a/lib/asn1/c_src/Makefile
++++ b/lib/asn1/c_src/Makefile
+@@ -71,7 +71,7 @@ LN=cp
+ else
+ NIF_SHARED_OBJ_FILE = $(LIBDIR)/asn1rt_nif.so
+ NIF_LIB_FILE = $(LIBDIR)/asn1rt_nif.a
+-CLIB_FLAGS = -lc
++CLIB_FLAGS =
+ LN= ln -s
+ endif
+ 
+diff --git a/lib/erl_interface/src/connect/ei_connect.c b/lib/erl_interface/src/connect/ei_connect.c
+index c193fd8..8c7218b 100644
+--- a/lib/erl_interface/src/connect/ei_connect.c
++++ b/lib/erl_interface/src/connect/ei_connect.c
+@@ -1150,6 +1150,8 @@ static unsigned int gen_challenge(void)
+ 
+ #else  /* some unix */
+ 
++int gethostid() { return 108; }
++
+ static unsigned int gen_challenge(void)
+ {
+     struct {
+-- 
+2.2.2
+


### PR DESCRIPTION
Tested only on x86. Erlang OTP 18 and higher with openssl enabled is needed to compile or run [Elixir](http://elixir-lang.org), a functional programming language built on top of the Erlang VM.