### PR TITLE
hunspell-1.6.0, fix recipe

### DIFF
--- a/app-text/hunspell/hunspell-1.6.0.recipe
+++ b/app-text/hunspell/hunspell-1.6.0.recipe
@@ -9,7 +9,7 @@ COPYRIGHT="2007-2016 Hunspell developers et al.
 LICENSE="GNU GPL v2
 	GNU LGPL v2.1
 	MPL v1.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/hunspell/hunspell/archive/v$portVersion.tar.gz"
 SOURCE_FILENAME="hunspell-$portVersion.tar.gz"
 CHECKSUM_SHA256="512e7d2ee69dad0b35ca011076405e56e0f10963a02d4859dbcc4faf53ca68e2"
@@ -20,8 +20,8 @@ srcGitRev_2="5a4a9178064530f81ab0872bf262e16b0d60cb57"
 SOURCE_URI_2="https://gitweb.gentoo.org/repo/gentoo.git/plain/app-text/hunspell/files/$SOURCE_FILENAME_2?id=$srcGitRev_2#noarchive"
 CHECKSUM_SHA256_2="ce11943935aac39c5e038fabfff01d2f30450b73c3cb62005675f209cce66036"
 
-ARCHITECTURES="!x86_gcc2 !x86 !x86_64"
-SECONDARY_ARCHITECTURES="!x86_gcc2 !x86"
+ARCHITECTURES="!x86_gcc2 x86 ?x86_64"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	$portName = $portVersion
@@ -41,6 +41,9 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
@@ -53,11 +56,12 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	devel:libiconv$secondaryArchSuffix
+	devel:libintl$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:aclocal
 	cmd:autoconf
-	cmd:automake
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
 	cmd:libtoolize$secondaryArchSuffix
@@ -71,10 +75,7 @@ PATCH()
 
 BUILD()
 {
-	libtoolize --force --copy --install
-	aclocal -I m4
-	autoconf
-	automake --add-missing
+	autoreconf -fi
 	runConfigure ./configure
 	make $jobArgs
 }
@@ -83,24 +84,16 @@ INSTALL()
 {
 	make install
 
-	rm $libDir/charset.alias $libDir/*.la
+	rm $libDir/*.la
 
 	# remove any existing (but empty) data/locale/*/LC_MESSAGES directory
-	rmdir $dataDir/locale/*/LC_MESSAGES $dataDir/locale/* || true
-
-	if [ -n "$secondaryArchSuffix" ]; then
-		rm -rf $dataDir $documentationDir
-		maybe_manDir_man3=
-	else
-		maybe_manDir_man3=$manDir/man3
-	fi
+	rm -r $dataDir/locale
 
 	prepareInstalledDevelLibs libhunspell-${portVersion%.*}
 	fixPkgconfig
 
 	packageEntries devel \
-		$developDir \
-		$maybe_manDir_man3
+		$developDir
 }
 
 TEST()


### PR DESCRIPTION
broken for x86_gcc2, one can nonetheless install hunspell-1.4.2 for x86_gcc2, which can eventually conflict