### PR TITLE
mesa: add pkg-config entry and missing header(s) for EGL

### DIFF
--- a/sys-libs/mesa/mesa-17.0.3.recipe
+++ b/sys-libs/mesa/mesa-17.0.3.recipe
@@ -6,7 +6,7 @@ providing 3D rendering to Haiku applications."
 HOMEPAGE="http://www.mesa3d.org/"
 COPYRIGHT="1999-2017 Brian Paul"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://mesa.freedesktop.org/archive/mesa-${portVersion}.tar.xz"
 CHECKSUM_SHA256="ca646f5075a002d60ef9123c8a4331cede155c01712ef945a65c59a5e69fe7ed"
 PATCHES="mesa-$portVersion.patchset"
@@ -106,6 +106,13 @@ INSTALL()
 	# Create GL symlink in opengl kit
 	symlinkRelative -s $includeDir/EGL $includeDir/os/opengl/EGL
 
+	# KHR headers for EGL
+	mkdir -p $includeDir/KHR
+	cp ./include/KHR/* $includeDir/KHR
+
+	# Create KHR symlink in opengl kit
+	symlinkRelative -s $includeDir/EGL $includeDir/os/opengl/KHR
+
 	mkdir -p $developLibDir/pkgconfig
 	cat > $developLibDir/pkgconfig/gl.pc << EOF
 prefix=${prefix}
@@ -119,7 +126,18 @@ Version: $portVersion
 Libs: -L${developLibDir} -lGL
 Libs.private: -lm
 EOF
+	cat > $developLibDir/pkgconfig/egl.pc << EOF
+prefix=${prefix}
+exec_prefix=${prefix}
+libdir=${libDir}
+includedir=${includeDir}
 
+Name: egl
+Description: Mesa EGL library
+Version: $portVersion
+Libs: -L${developLibDir} -lEGL
+Libs.private: -lm
+EOF
 	# devel package
 	packageEntries devel \
 		$developDir


### PR DESCRIPTION
The KHR/khrplatform.h header is required by libepoxy for running its testsuite. This commit also adds a
pkg-config entry for EGL, also used by libepoxy.