### PR TITLE
TuxMath, bump version to the latest version

### DIFF
--- a/games-kids/tuxmath/patches/tuxmath-2.0.1.patchset
+++ b/games-kids/tuxmath/patches/tuxmath-2.0.1.patchset
@@ -1,0 +1,45 @@
+From 48800293db9ef023357bb18251cba45c15c0d8eb Mon Sep 17 00:00:00 2001
+From: begasus <begasus@gmail.com>
+Date: Sat, 8 Apr 2017 00:34:38 +0200
+Subject: TuxMath, fix Haiku build
+
+
+diff --git a/src/tuxmathadmin.c b/src/tuxmathadmin.c
+index 7884384..1a90862 100644
+--- a/src/tuxmathadmin.c
++++ b/src/tuxmathadmin.c
+@@ -38,6 +38,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ #include <error.h>
+ #else
+ # ifndef HAVE_FSYNC
++# elif defined(__HAIKU__)
+ #  define fsync
+ # endif
+ # define error(status, errnum, rest...) \
+-- 
+2.7.0
+
+
+From ec4ddf4bfb12911699d6e16ca38b23262a91a9c6 Mon Sep 17 00:00:00 2001
+From: begasus <begasus@gmail.com>
+Date: Sat, 8 Apr 2017 01:32:25 +0200
+Subject: fix warning for gettext version  AC_REQUIRE([AM_PROG_MKDIR_P])dnl
+ defined by automake
+
+
+diff --git a/configure.ac b/configure.ac
+index fa8647a..ceb3e48 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -45,7 +45,7 @@ AC_PROG_YACC
+ # Gettext support:
+ # ---------------------------------------------------------------------
+ 
+-AM_GNU_GETTEXT_VERSION([0.18.1])
++AM_GNU_GETTEXT_VERSION([0.19])
+ dnl Note that having a bundled intl/ directory is now deprecated 
+ AM_GNU_GETTEXT([external])
+ 
+-- 
+2.7.0
+

--- a/games-kids/tuxmath/tuxmath-2.0.1.recipe
+++ b/games-kids/tuxmath/tuxmath-2.0.1.recipe
@@ -1,0 +1,92 @@
+SUMMARY="Tux4Kids' math tutor for kids"
+DESCRIPTION="TuxMath is an educational math tutor for kids starring Tux, \
+the Linux penguin. This educational game comes with two different games for \
+practicing math, and having a great time doing it."
+HOMEPAGE="https://tux4kids.alioth.debian.org/"
+COPYRIGHT="2000-2009 Sam Hart"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="https://sourceforge.net/projects/tuxmath/files/tuxmath-source/TuxMath%202.0.1%20-%20Source/tuxmath_w_fonts-2.0.1.tar.gz"
+CHECKSUM_SHA256="6d26c08672edf5cce0ef2f685555867a7016c8a186282518276378b6c58774f4"
+SOURCE_DIR="tuxmath_w_fonts-$portVersion"
+PATCHES="tuxmath-$portVersion.patchset"
+ADDITIONAL_FILES="tuxmath.rdef"
+
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	tuxmath$secondaryArchSuffix
+	cmd:generate_lesson$secondaryArchSuffix
+	cmd:tuxmath$secondaryArchSuffix
+	cmd:tuxmathadmin$secondaryArchSuffix
+	cmd:tuxmathserver$secondaryArchSuffix
+	cmd:tuxmathtestclient$secondaryArchSuffix
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libsdl$secondaryArchSuffix
+	lib:libsdl_image$secondaryArchSuffix
+	lib:libsdl_mixer$secondaryArchSuffix
+	lib:libsdl_net_1.2$secondaryArchSuffix
+	lib:libt4k_common$secondaryArchSuffix
+	lib:libxml2$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libiconv$secondaryArchSuffix
+	devel:libintl$secondaryArchSuffix
+	devel:libsdl$secondaryArchSuffix
+	devel:libsdl_image$secondaryArchSuffix
+	devel:libsdl_mixer$secondaryArchSuffix
+	devel:libsdl_net_1.2$secondaryArchSuffix
+	devel:libt4k_common$secondaryArchSuffix
+	devel:libxml2$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:awk
+	cmd:bison
+	cmd:find
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	autoreconf -vfi
+
+	LDFLAGS="-lintl -lnetwork" runConfigure ./configure --without-rsvg
+
+	echo "#define ICONV_CONST const" >> config.h
+	make $jobArgs
+}
+
+INSTALL()
+{
+	mkdir -p $appsDir
+
+	make install
+
+	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
+	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
+	local MINOR="`echo "$portVersion" | cut -d. -f3`"
+	sed \
+		-e "s|@MAJOR@|$MAJOR|" \
+		-e "s|@MIDDLE@|$MIDDLE|" \
+		-e "s|@MINOR@|$MINOR|" \
+		$portDir/additional-files/tuxmath.rdef > tuxmath.rdef
+
+	addResourcesToBinaries tuxmath.rdef \
+		$binDir/tuxmath
+
+	ln -s $binDir/tuxmath $appsDir/TuxMath
+
+	addAppDeskbarSymlink $binDir/tuxmath TuxMath
+}


### PR DESCRIPTION
Still haven't been able to disable fullscreen on start-up, otherwise working ok on gcc2h (x86), it can be launched from Terminal with "tuxmath-x86 -w" in windowed mode ...