### PR TITLE
lnlauncher: various fixes

### DIFF
--- a/haiku-apps/lnlauncher/lnlauncher-1.1.2.recipe
+++ b/haiku-apps/lnlauncher/lnlauncher-1.1.2.recipe
@@ -8,14 +8,13 @@ The latest version, 1.1.2, was adapted for Haiku by Daniel Weber - thank you!"
 HOMEPAGE="http://eiman.tv/LnLauncher"
 COPYRIGHT="2000-2015 Mikael Eiman"
 LICENSE="MIT"
-REVISION="6"
-commit="ccb19f1e8780"
+REVISION="7"
+commit="ddd60a641c31"
 SOURCE_URI="https://bitbucket.org/m_eiman/lnlauncher/get/$commit.zip"
-CHECKSUM_SHA256="a4cd316b70e7469c83363bc04fded506960efaaae90364f66780e3ff5133f320"
+CHECKSUM_SHA256="9b8f1452a2f22a916954e6954e775cb4593b380e33ddf2bd3a3c3fd1d9a37cf6"
 SOURCE_DIR="m_eiman-lnlauncher-$commit"
-PATCHES="lnlauncher-$portVersion.patchset"
 
-ARCHITECTURES="x86_gcc2"
+ARCHITECTURES="x86_gcc2 x86 x86_64"
 
 PROVIDES="
 	lnlauncher = $portVersion


### PR DESCRIPTION
Translations are working again, builds with gcc5 and on x86_64 are working now.
