### PR TITLE
VIM: bump version, recipe cleanup, enable python, fix ruby

### DIFF
--- a/app-editors/vim/patches/vim-8.0.0599.patchset
+++ b/app-editors/vim/patches/vim-8.0.0599.patchset
@@ -6474,7 +6474,7 @@ index 0000000..733035a
 + * os_haiku.rdef
 + */
 +
-+resource app_signature "application/x-vnd.Haiku-Vim-7";
++resource app_signature "application/x-vnd.Haiku-Vim-8";
 +
 +resource app_version {
 +	major  = @MAJOR@,

--- a/app-editors/vim/patches/vim-8.0.0599.patchset
+++ b/app-editors/vim/patches/vim-8.0.0599.patchset
@@ -4034,7 +4034,7 @@ index 0000000..ab9191a
 +/* ---------------- ---------------- */
 +
 +// some global variables
-+static char appsig[] = "application/x-vnd.Haiku-Vim-7";
++static char appsig[] = "application/x-vnd.Haiku-Vim-8";
 +key_map *keyMap;
 +char *keyMapChars;
 +int main_exitcode = 127;

--- a/app-editors/vim/patches/vim-8.0.0599.patchset
+++ b/app-editors/vim/patches/vim-8.0.0599.patchset
@@ -1,60 +1,14 @@
-From 5c9e6699e38f7ec07fd2322115801eb1af74f722 Mon Sep 17 00:00:00 2001
+From 5e00e427ea9422cceba41dd18f973f8b8d5d1749 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
 Date: Sat, 18 Mar 2017 11:55:19 +0100
-Subject: [PATCH] Updated Haiku supporting patches
+Subject: Updated Haiku supporting patches
 
----
- runtime/doc/eval.txt           |    2 +
- runtime/doc/gui.txt            |    1 +
- runtime/doc/help.txt           |    1 +
- runtime/doc/options.txt        |   10 +-
- runtime/doc/os_haiku.txt       |  223 ++
- runtime/doc/starting.txt       |    3 +
- runtime/doc/tags               |   16 +
- runtime/doc/vi_diff.txt        |    3 +-
- runtime/gvimrc_example.vim     |    1 +
- runtime/lang/menu_pl.utf-8.vim |    3 +
- runtime/vimrc_example.vim      |    1 +
- src/Makefile                   |   80 +
- src/configure.ac               |   37 +-
- src/evalfunc.c                 |    6 +
- src/ex_cmds.c                  |   18 +
- src/ex_docmd.c                 |    1 +
- src/feature.h                  |   19 +-
- src/gui.c                      |   34 +-
- src/gui.h                      |   21 +-
- src/gui_haiku.cc               | 5294 ++++++++++++++++++++++++++++++++++++++++
- src/gui_haiku.h                |   51 +
- src/misc1.c                    |   15 +-
- src/normal.c                   |    5 +-
- src/option.h                   |    4 +
- src/os_haiku.h                 |   29 +
- src/os_haiku.rdef              |  143 ++
- src/os_unix.c                  |    6 +-
- src/os_unix.h                  |    4 +
- src/proto.h                    |    3 +
- src/proto/gui_haiku.pro        |   92 +
- src/pty.c                      |    2 +-
- src/screen.c                   |   33 +
- src/structs.h                  |    7 +
- src/term.c                     |    5 +
- src/ui.c                       |    2 +-
- src/version.c                  |    4 +
- src/vim.h                      |   11 +-
- 37 files changed, 6159 insertions(+), 31 deletions(-)
- create mode 100644 runtime/doc/os_haiku.txt
- create mode 100644 runtime/lang/menu_pl.utf-8.vim
- create mode 100644 src/gui_haiku.cc
- create mode 100644 src/gui_haiku.h
- create mode 100644 src/os_haiku.h
- create mode 100644 src/os_haiku.rdef
- create mode 100644 src/proto/gui_haiku.pro
 
 diff --git a/runtime/doc/eval.txt b/runtime/doc/eval.txt
-index efa5b9d..fd6f720 100644
+index 141f586..9aacec5 100644
 --- a/runtime/doc/eval.txt
 +++ b/runtime/doc/eval.txt
-@@ -8414,12 +8414,14 @@ gui_gnome		Compiled with Gnome support (gui_gtk is also defined).
+@@ -8482,12 +8482,14 @@ gui_gnome		Compiled with Gnome support (gui_gtk is also defined).
  gui_gtk			Compiled with GTK+ GUI (any version).
  gui_gtk2		Compiled with GTK+ 2 GUI (gui_gtk is also defined).
  gui_gtk3		Compiled with GTK+ 3 GUI (gui_gtk is also defined).
@@ -94,7 +48,7 @@ index 58049f6..318e434 100644
  |os_vms.txt|	VMS
  |os_win32.txt|	MS-Windows 95/98/NT
 diff --git a/runtime/doc/options.txt b/runtime/doc/options.txt
-index 9a88edb..6753ebf 100644
+index 927931c..e187452 100644
 --- a/runtime/doc/options.txt
 +++ b/runtime/doc/options.txt
 @@ -3844,7 +3844,7 @@ A jump table for the options with a short description can be found at |Q_op|.
@@ -120,7 +74,7 @@ index 9a88edb..6753ebf 100644
  			global
  			{not in Vi}
  	This is a list of directories which will be searched for runtime
-@@ -7660,6 +7665,7 @@ A jump table for the options with a short description can be found at |Q_op|.
+@@ -7659,6 +7664,7 @@ A jump table for the options with a short description can be found at |Q_op|.
  					 on MiNT: "vt52"
  				       on MS-DOS: "pcterm"
  					 on OS/2: "os2ansi"
@@ -130,7 +84,7 @@ index 9a88edb..6753ebf 100644
  				       on Win 32: "win32")
 diff --git a/runtime/doc/os_haiku.txt b/runtime/doc/os_haiku.txt
 new file mode 100644
-index 0000000..b95e13d
+index 0000000..ebcb247
 --- /dev/null
 +++ b/runtime/doc/os_haiku.txt
 @@ -0,0 +1,223 @@
@@ -386,10 +340,10 @@ index eb1fdc8..970e294 100644
  by default.  See |compatible-default|.
  
 diff --git a/runtime/doc/tags b/runtime/doc/tags
-index 68c611b..49f60a9 100644
+index af843e3..e58dcc6 100644
 --- a/runtime/doc/tags
 +++ b/runtime/doc/tags
-@@ -4560,6 +4560,7 @@ GetLatestVimScripts-copyright	pi_getscript.txt	/*GetLatestVimScripts-copyright*
+@@ -4574,6 +4574,7 @@ GetLatestVimScripts-copyright	pi_getscript.txt	/*GetLatestVimScripts-copyright*
  GetLatestVimScripts_dat	pi_getscript.txt	/*GetLatestVimScripts_dat*
  Gnome	gui_x11.txt	/*Gnome*
  H	motion.txt	/*H*
@@ -397,7 +351,7 @@ index 68c611b..49f60a9 100644
  I	insert.txt	/*I*
  ICCF	uganda.txt	/*ICCF*
  IM-server	mbyte.txt	/*IM-server*
-@@ -6616,6 +6617,20 @@ g~	change.txt	/*g~*
+@@ -6648,6 +6649,20 @@ g~	change.txt	/*g~*
  g~g~	change.txt	/*g~g~*
  g~~	change.txt	/*g~~*
  h	motion.txt	/*h*
@@ -418,7 +372,7 @@ index 68c611b..49f60a9 100644
  hangul	hangulin.txt	/*hangul*
  hangulin.txt	hangulin.txt	/*hangulin.txt*
  has()	eval.txt	/*has()*
-@@ -7719,6 +7734,7 @@ os_390.txt	os_390.txt	/*os_390.txt*
+@@ -7755,6 +7770,7 @@ os_390.txt	os_390.txt	/*os_390.txt*
  os_amiga.txt	os_amiga.txt	/*os_amiga.txt*
  os_beos.txt	os_beos.txt	/*os_beos.txt*
  os_dos.txt	os_dos.txt	/*os_dos.txt*
@@ -481,10 +435,10 @@ index 7f5bae0..77d3a0a 100644
  " When started as "evim", evim.vim will already have done these settings.
  if v:progname =~? "evim"
 diff --git a/src/Makefile b/src/Makefile
-index 1af1e17..80bfeb8 100644
+index ddb61dc..626affe 100644
 --- a/src/Makefile
 +++ b/src/Makefile
-@@ -1364,6 +1364,23 @@ CARBONGUI_BUNDLE = gui_bundle
+@@ -1365,6 +1365,23 @@ CARBONGUI_BUNDLE = gui_bundle
  APPDIR = $(VIMNAME).app
  CARBONGUI_TESTARG = VIMPROG=../$(APPDIR)/Contents/MacOS/$(VIMTARGET)
  
@@ -508,7 +462,7 @@ index 1af1e17..80bfeb8 100644
  # All GUI files
  ALL_GUI_SRC  = gui.c gui_gtk.c gui_gtk_f.c gui_motif.c gui_xmdlg.c gui_xmebw.c gui_athena.c gui_gtk_x11.c gui_x11.c gui_at_sb.c gui_at_fs.c pty.c
  ALL_GUI_PRO  = gui.pro gui_gtk.pro gui_motif.pro gui_xmdlg.pro gui_athena.pro gui_gtk_x11.pro gui_x11.pro gui_w32.pro gui_photon.pro
-@@ -3030,6 +3047,9 @@ objects/gui_gtk_gresources.o: auto/gui_gtk_gresources.c
+@@ -3045,6 +3062,9 @@ objects/gui_gtk_gresources.o: auto/gui_gtk_gresources.c
  objects/gui_gtk_x11.o: gui_gtk_x11.c
  	$(CCC) -o $@ gui_gtk_x11.c
  
@@ -518,7 +472,7 @@ index 1af1e17..80bfeb8 100644
  objects/gui_motif.o: gui_motif.c
  	$(CCC) -o $@ gui_motif.c
  
-@@ -3153,6 +3173,9 @@ objects/option.o: option.c
+@@ -3168,6 +3188,9 @@ objects/option.o: option.c
  objects/os_beos.o: os_beos.c
  	$(CCC) -o $@ os_beos.c
  
@@ -528,7 +482,7 @@ index 1af1e17..80bfeb8 100644
  objects/os_qnx.o: os_qnx.c
  	$(CCC) -o $@ os_qnx.c
  
-@@ -3321,6 +3344,63 @@ $(APPDIR)/Contents:
+@@ -3335,6 +3358,63 @@ $(APPDIR)/Contents:
  
  
  ###############################################################################
@@ -593,7 +547,7 @@ index 1af1e17..80bfeb8 100644
  ### Dependencies:
  objects/arabic.o: arabic.c vim.h auto/config.h feature.h os_unix.h auto/osdef.h \
 diff --git a/src/configure.ac b/src/configure.ac
-index 6251681..50fafdb 100644
+index d424550..b262417 100644
 --- a/src/configure.ac
 +++ b/src/configure.ac
 @@ -118,6 +118,12 @@ case `uname` in
@@ -682,10 +636,10 @@ index 6251681..50fafdb 100644
    GUITYPE=PHOTONGUI
  fi
 diff --git a/src/evalfunc.c b/src/evalfunc.c
-index 21b75c1..8f2fa0f 100644
+index b16b260..9649de2 100644
 --- a/src/evalfunc.c
 +++ b/src/evalfunc.c
-@@ -5457,6 +5457,9 @@ f_has(typval_T *argvars, typval_T *rettv)
+@@ -5479,6 +5479,9 @@ f_has(typval_T *argvars, typval_T *rettv)
  #ifdef __BEOS__
  	"beos",
  #endif
@@ -695,7 +649,7 @@ index 21b75c1..8f2fa0f 100644
  #ifdef MACOS
  	"mac",
  #endif
-@@ -5634,6 +5637,9 @@ f_has(typval_T *argvars, typval_T *rettv)
+@@ -5656,6 +5659,9 @@ f_has(typval_T *argvars, typval_T *rettv)
  #ifdef FEAT_GUI_GNOME
  	"gui_gnome",
  #endif
@@ -706,7 +660,7 @@ index 21b75c1..8f2fa0f 100644
  	"gui_mac",
  #endif
 diff --git a/src/ex_cmds.c b/src/ex_cmds.c
-index 0c4dffb..b4e070c 100644
+index 309474c..bb0e470 100644
 --- a/src/ex_cmds.c
 +++ b/src/ex_cmds.c
 @@ -14,6 +14,9 @@
@@ -749,10 +703,10 @@ index 0c4dffb..b4e070c 100644
      if (fp_in == NULL)
      {
 diff --git a/src/ex_docmd.c b/src/ex_docmd.c
-index 96e2b3f..6fe19dc 100644
+index 13d5fe4..8621b58 100644
 --- a/src/ex_docmd.c
 +++ b/src/ex_docmd.c
-@@ -7924,6 +7924,7 @@ ex_shell(exarg_T *eap UNUSED)
+@@ -7908,6 +7908,7 @@ ex_shell(exarg_T *eap UNUSED)
  	|| (defined(FEAT_GUI_GTK) && defined(FEAT_DND)) \
  	|| defined(FEAT_GUI_MSWIN) \
  	|| defined(FEAT_GUI_MAC) \
@@ -6355,7 +6309,7 @@ index 0000000..414d127
 +
 +#endif
 diff --git a/src/misc1.c b/src/misc1.c
-index 951467d..c45d62e 100644
+index bc927b1..3284d7d 100644
 --- a/src/misc1.c
 +++ b/src/misc1.c
 @@ -14,6 +14,10 @@
@@ -6388,7 +6342,7 @@ index 951467d..c45d62e 100644
      /*
       * When expanding $VIMRUNTIME fails, try using $VIM/vim<version> or $VIM.
 diff --git a/src/normal.c b/src/normal.c
-index 53bda6c..3f96002 100644
+index 25c0986..b0579b7 100644
 --- a/src/normal.c
 +++ b/src/normal.c
 @@ -2652,13 +2652,14 @@ do_mouse(
@@ -6466,7 +6420,7 @@ index 0000000..c9bfe75
 +#endif
 diff --git a/src/os_haiku.rdef b/src/os_haiku.rdef
 new file mode 100644
-index 0000000..733035a
+index 0000000..bf55aa9
 --- /dev/null
 +++ b/src/os_haiku.rdef
 @@ -0,0 +1,143 @@
@@ -6614,7 +6568,7 @@ index 0000000..733035a
 +	$"FF17F6CF36F92F1B9E631E8B8F3FBC0000000049454E44AE426082"
 +};
 diff --git a/src/os_unix.c b/src/os_unix.c
-index f0a5621..12460fe 100644
+index 8ed3a67..d63be68 100644
 --- a/src/os_unix.c
 +++ b/src/os_unix.c
 @@ -2165,7 +2165,7 @@ mch_settitle(char_u *title, char_u *icon)
@@ -6792,7 +6746,7 @@ index 20ab65b..7d6517f 100644
  static char TtyProto[] = "/dev/tt/XY";
  #  else
 diff --git a/src/screen.c b/src/screen.c
-index 82c5ba5..72d7e1d 100644
+index 325d9ae..10ade64 100644
 --- a/src/screen.c
 +++ b/src/screen.c
 @@ -89,6 +89,15 @@
@@ -6811,7 +6765,7 @@ index 82c5ba5..72d7e1d 100644
  #define MB_FILLER_CHAR '<'  /* character used when a double-width character
  			     * doesn't fit. */
  
-@@ -8591,6 +8600,10 @@ retry:
+@@ -8647,6 +8656,10 @@ retry:
  
      win_new_shellsize();    /* fit the windows in the new sized shell */
  
@@ -6822,7 +6776,7 @@ index 82c5ba5..72d7e1d 100644
      comp_col();		/* recompute columns for shown command and ruler */
  
      /*
-@@ -8834,6 +8847,10 @@ give_up:
+@@ -8890,6 +8903,10 @@ give_up:
      }
  #endif
  
@@ -6833,7 +6787,7 @@ index 82c5ba5..72d7e1d 100644
      entered = FALSE;
      --RedrawingDisabled;
  
-@@ -9692,6 +9709,10 @@ screen_ins_lines(
+@@ -9756,6 +9773,10 @@ screen_ins_lines(
  	clip_scroll_selection(-line_count);
  #endif
  
@@ -6844,7 +6798,7 @@ index 82c5ba5..72d7e1d 100644
  #ifdef FEAT_GUI
      /* Don't update the GUI cursor here, ScreenLines[] is invalid until the
       * scrolling is actually carried out. */
-@@ -9744,6 +9765,10 @@ screen_ins_lines(
+@@ -9808,6 +9829,10 @@ screen_ins_lines(
  	}
      }
  
@@ -6855,7 +6809,7 @@ index 82c5ba5..72d7e1d 100644
      screen_stop_highlight();
      windgoto(cursor_row, 0);
  
-@@ -9913,6 +9938,10 @@ screen_del_lines(
+@@ -9977,6 +10002,10 @@ screen_del_lines(
  	clip_scroll_selection(line_count);
  #endif
  
@@ -6866,7 +6820,7 @@ index 82c5ba5..72d7e1d 100644
  #ifdef FEAT_GUI
      /* Don't update the GUI cursor here, ScreenLines[] is invalid until the
       * scrolling is actually carried out. */
-@@ -9973,6 +10002,10 @@ screen_del_lines(
+@@ -10037,6 +10066,10 @@ screen_del_lines(
  	}
      }
  
@@ -6878,10 +6832,10 @@ index 82c5ba5..72d7e1d 100644
  
  #ifdef FEAT_WINDOWS
 diff --git a/src/structs.h b/src/structs.h
-index 475280a..a3ffe09 100644
+index 0175017..6d0e302 100644
 --- a/src/structs.h
 +++ b/src/structs.h
-@@ -3066,6 +3066,13 @@ struct VimMenu
+@@ -3072,6 +3072,13 @@ struct VimMenu
      HMENU	submenu_id;	    /* If this is submenu, add children here */
      HWND	tearoff_handle;	    /* hWnd of tearoff if created */
  #endif
@@ -6896,10 +6850,10 @@ index 475280a..a3ffe09 100644
  /*  MenuHandle	id; */
  /*  short	index;	*/	    /* the item index within the father menu */
 diff --git a/src/term.c b/src/term.c
-index 75c9fbf..353c011 100644
+index d23d8cb..007b845 100644
 --- a/src/term.c
 +++ b/src/term.c
-@@ -1320,6 +1320,11 @@ termgui_mch_get_rgb(guicolor_T color)
+@@ -1322,6 +1322,11 @@ termgui_mch_get_rgb(guicolor_T color)
  # define DEFAULT_TERM	(char_u *)"beos-ansi"
  #endif
  
@@ -6912,10 +6866,10 @@ index 75c9fbf..353c011 100644
  # define DEFAULT_TERM	(char_u *)"dumb"
  #endif
 diff --git a/src/ui.c b/src/ui.c
-index 0bd2edc..415d689 100644
+index 8691ab7..2fb26bd 100644
 --- a/src/ui.c
 +++ b/src/ui.c
-@@ -3129,7 +3129,7 @@ mouse_find_win(int *rowp, int *colp UNUSED)
+@@ -3139,7 +3139,7 @@ mouse_find_win(int *rowp, int *colp UNUSED)
  
  #if defined(FEAT_GUI_MOTIF) || defined(FEAT_GUI_GTK) || defined(FEAT_GUI_MAC) \
  	|| defined(FEAT_GUI_ATHENA) || defined(FEAT_GUI_MSWIN) \
@@ -6925,10 +6879,10 @@ index 0bd2edc..415d689 100644
   * Translate window coordinates to buffer position without any side effects
   */
 diff --git a/src/version.c b/src/version.c
-index 8237679..ed10520 100644
+index a572ae3..96522e2 100644
 --- a/src/version.c
 +++ b/src/version.c
-@@ -1997,6 +1997,9 @@ list_version(void)
+@@ -2249,6 +2249,9 @@ list_version(void)
      MSG_PUTS(_("with X11-Athena GUI."));
  #    endif
  #   else
@@ -6938,7 +6892,7 @@ index 8237679..ed10520 100644
  #     ifdef FEAT_GUI_PHOTON
      MSG_PUTS(_("with Photon GUI."));
  #     else
-@@ -2014,6 +2017,7 @@ list_version(void)
+@@ -2266,6 +2269,7 @@ list_version(void)
  #	  endif
  #	 endif
  #	endif
@@ -6947,7 +6901,7 @@ index 8237679..ed10520 100644
  #    endif
  #   endif
 diff --git a/src/vim.h b/src/vim.h
-index dd571df..716b825 100644
+index cbe14e5..b4f8b1a 100644
 --- a/src/vim.h
 +++ b/src/vim.h
 @@ -115,6 +115,7 @@
@@ -6970,7 +6924,7 @@ index dd571df..716b825 100644
  #if (defined(UNIX) || defined(VMS)) \
  	&& (!defined(MACOS_X) || defined(HAVE_CONFIG_H))
  # include "os_unix.h"	    /* bring lots of system header files */
-@@ -2071,6 +2077,9 @@ typedef struct VimClipboard
+@@ -2073,6 +2079,9 @@ typedef struct VimClipboard
      int_u	format;		/* Vim's own special clipboard format */
      int_u	format_raw;	/* Vim's raw text clipboard format */
  # endif
@@ -6980,7 +6934,7 @@ index dd571df..716b825 100644
  } VimClipboard;
  #else
  typedef int VimClipboard;	/* This is required for the prototypes. */
-@@ -2111,7 +2120,7 @@ typedef enum {
+@@ -2113,7 +2122,7 @@ typedef enum {
   * been seen at that stage.  But it must be before globals.h, where error_ga
   * is declared. */
  #if !defined(FEAT_GUI_W32) && !defined(FEAT_GUI_X11) \
@@ -6990,5 +6944,29 @@ index dd571df..716b825 100644
  # define display_errors()	fflush(stderr)
  # define mch_msg(str)		printf("%s", (str))
 -- 
-2.11.0
+2.12.2
+
+
+From 8427ad54f8261b6b8f9166bb58c2c8872861ab67 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
+Date: Wed, 17 May 2017 22:00:16 +0200
+Subject: Haiku: bzero workaround
+
+
+diff --git a/src/osdef1.h.in b/src/osdef1.h.in
+index 5519104..9820c7b 100644
+--- a/src/osdef1.h.in
++++ b/src/osdef1.h.in
+@@ -66,7 +66,9 @@ extern void	memmove(char *, char *, int);
+ # endif
+ #endif
+ /* used inside of FD_ZERO macro: */
++#ifndef __HAIKU__
+ extern void	bzero(void *, size_t);
++#endif
+ #ifdef HAVE_SETSID
+ extern pid_t	setsid(void);
+ #endif
+-- 
+2.12.2
 

--- a/app-editors/vim/vim-8.0.0599.recipe
+++ b/app-editors/vim/vim-8.0.0599.recipe
@@ -39,8 +39,6 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku
-	cmd:python2
-	cmd:ruby
 	lib:libiconv
 	lib:libintl
 	lib:libncurses
@@ -70,8 +68,11 @@ BUILD()
 	cd src
 	autoconf
 
-	pythonVersion=$(python --version 2>&1 | sed 's/Python //' | head -c3)
-	export CPPFLAGS="-I`finddir B_SYSTEM_HEADERS_DIRECTORY`/python$pythonVersion -fPIC"
+	python2Version=$(python --version 2>&1 | sed 's/Python //' | head -c3)
+
+	#For python2 support
+	export CPPFLAGS="-I`finddir B_SYSTEM_HEADERS_DIRECTORY`/python$python2Version \
+		-fPIC"
 
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
 	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
@@ -85,12 +86,10 @@ BUILD()
 
 	runConfigure ./configure \
 		--with-features=big \
-		--enable-rubyinterp \
-		--enable-pythoninterp=yes \
-		--enable-rubyinterp \
-		--enable-multibyte \
 		--enable-cscope \
-		--with-compiledby=$packager
+		--enable-multibyte \
+		--enable-pythoninterp=dynamic \
+		--enable-rubyinterp=dynamic
 
 	echo "Patching auto/config.h"
 	sed --in-place '/HAVE_BCMP/d' auto/config.h

--- a/app-editors/vim/vim-8.0.0599.recipe
+++ b/app-editors/vim/vim-8.0.0599.recipe
@@ -68,7 +68,7 @@ BUILD()
 	cd src
 	autoconf
 
-	python2Version=$(python --version 2>&1 | sed 's/Python //' | head -c3)
+	python2Version=$(python2 --version 2>&1 | sed 's/Python //' | head -c3)
 
 	#For python2 support
 	export CPPFLAGS="-I`finddir B_SYSTEM_HEADERS_DIRECTORY`/python$python2Version \

--- a/app-editors/vim/vim-8.0.0599.recipe
+++ b/app-editors/vim/vim-8.0.0599.recipe
@@ -48,8 +48,10 @@ BUILD_REQUIRES="
 	haiku_devel
 	devel:libiconv
 	devel:libintl
+#	devel:liblua
 	devel:libncurses
 	devel:libruby
+	devel:libtclstub8.5
 	"
 BUILD_PREREQUIRES="
 	cmd:autoconf
@@ -58,31 +60,54 @@ BUILD_PREREQUIRES="
 	cmd:gettext
 	cmd:grep
 	cmd:make
+#	cmd:perl
 	cmd:python2
+#	cmd:python3
 	cmd:ruby
 	cmd:sed
 	"
 
 BUILD()
 {
+
+# Global ----------------------------------------
+
 	cd src
 	autoconf
 
-	python2Version=$(python2 --version 2>&1 | sed 's/Python //' | head -c3)
-
 	#For python2 support
-	export CPPFLAGS="-I`finddir B_SYSTEM_HEADERS_DIRECTORY`/python$python2Version \
+	python2Version=$(python2 --version 2>&1 | sed 's/Python //' | head -c3)
+	export CFLAGS="\
+		-I`finddir B_SYSTEM_HEADERS_DIRECTORY`/python$python2Version \
 		-fPIC"
 
-	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
-	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
-	local MINOR="`echo "$portVersion" | cut -d. -f3`"
+# CLI -------------------------------------------
 
-	sed \
-		-e "s|@MAJOR@|$MAJOR|" \
-		-e "s|@MIDDLE@|$MIDDLE|" \
-		-e "s|@MINOR@|$MINOR|" \
-		os_haiku.rdef
+	runConfigure ./configure \
+		--disable-gui \
+		--with-features=big \
+		--enable-cscope \
+		--enable-multibyte \
+		--enable-pythoninterp=dynamic \
+		--enable-rubyinterp=dynamic \
+		--enable-tclinterp=dynamic \
+		--with-compiledby=Haikuports
+#		--enable-perlinterp=dynamic not dynamic yet
+#		--enable-python3interp=dynamic currently broken
+#		--enable-luainterp=dynamic currently broken
+
+	make $jobArgs
+	cp vim vim.con # preserve gui-less executable
+	rm objects/*.o
+
+# GUI -------------------------------------------
+
+	MAJOR="`echo "$portVersion" | cut -d. -f1`"
+	MIDDLE="`echo "$portVersion" | cut -d. -f2`"
+	MINOR="`echo "$portVersion" | cut -d. -f3`"
+		sed -i "s|@MAJOR@|$MAJOR|" os_haiku.rdef
+		sed -i "s|@MIDDLE@|$MIDDLE|" os_haiku.rdef
+		sed -i "s|@MINOR@|$MINOR|" os_haiku.rdef
 
 	runConfigure ./configure \
 		--with-features=big \
@@ -90,13 +115,11 @@ BUILD()
 		--enable-multibyte \
 		--enable-pythoninterp=dynamic \
 		--enable-rubyinterp=dynamic \
+		--enable-tclinterp==dynamic \
 		--with-compiledby=Haikuports
-
-	echo "Patching auto/config.h"
-	sed --in-place '/HAVE_BCMP/d' auto/config.h
-
-	echo "Patching auto/osdef.h"
-	sed --in-place '/bzero/d' osdef1.h.in
+#		--enable-perlinterp=dynamic not dynamic yet
+#		--enable-python3interp=dynamic currently broken
+#		--enable-luainterp=dynamic currently broken
 
 	make $jobArgs
 }

--- a/app-editors/vim/vim-8.0.0599.recipe
+++ b/app-editors/vim/vim-8.0.0599.recipe
@@ -89,7 +89,8 @@ BUILD()
 		--enable-cscope \
 		--enable-multibyte \
 		--enable-pythoninterp=dynamic \
-		--enable-rubyinterp=dynamic
+		--enable-rubyinterp=dynamic \
+		--with-compiledby=Haikuports
 
 	echo "Patching auto/config.h"
 	sed --in-place '/HAVE_BCMP/d' auto/config.h

--- a/app-editors/vim/vim-8.0.0599.recipe
+++ b/app-editors/vim/vim-8.0.0599.recipe
@@ -14,7 +14,7 @@ COPYRIGHT="Bram Moleenar et al."
 LICENSE="Vim"
 REVISION="1"
 SOURCE_URI="https://github.com/vim/vim/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="724b56ae54eb3c46909f73c16e4e17ebd348c53680f0b65f908f235bfa9d2b08"
+CHECKSUM_SHA256="bca607d016a3bf91c52e26a418f090845fd3844db5395bca350d80a9060a5ee2"
 SOURCE_DIR="vim-$portVersion"
 PATCHES="vim-$portVersion.patchset"
 
@@ -39,6 +39,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku
+	cmd:python2
 	cmd:ruby
 	lib:libiconv
 	lib:libintl
@@ -50,6 +51,7 @@ BUILD_REQUIRES="
 	devel:libiconv
 	devel:libintl
 	devel:libncurses
+	devel:libruby
 	"
 BUILD_PREREQUIRES="
 	cmd:autoconf
@@ -58,48 +60,33 @@ BUILD_PREREQUIRES="
 	cmd:gettext
 	cmd:grep
 	cmd:make
+	cmd:python2
+	cmd:ruby
 	cmd:sed
 	"
 
 BUILD()
 {
-
-# Global ----------------------------------------
-
 	cd src
 	autoconf
 
-# CLI -------------------------------------------
+	pythonVersion=$(python --version 2>&1 | sed 's/Python //' | head -c3)
+	export CPPFLAGS="-I`finddir B_SYSTEM_HEADERS_DIRECTORY`/python$pythonVersion -fPIC"
+
+	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
+	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
+	local MINOR="`echo "$portVersion" | cut -d. -f3`"
+
+	sed \
+		-e "s|@MAJOR@|$MAJOR|" \
+		-e "s|@MIDDLE@|$MIDDLE|" \
+		-e "s|@MINOR@|$MINOR|" \
+		os_haiku.rdef
 
 	runConfigure ./configure \
-		--disable-gui \
 		--with-features=big \
 		--enable-rubyinterp \
-		--enable-multibyte \
-		--enable-cscope \
-		--with-compiledby=$packager
-
-	echo "Patching auto/config.h"
-	sed --in-place '/HAVE_BCMP/d' auto/config.h
-
-	echo "Patching auto/osdef.h"
-	sed --in-place '/bzero/d' osdef1.h.in
-
-	make $jobArgs
-	cp vim vim.con # preserve gui-less executable
-	rm objects/*.o
-
-# GUI -------------------------------------------
-
-	MAJOR="`echo "$portVersion" | cut -d. -f1`"
-	MIDDLE="`echo "$portVersion" | cut -d. -f2`"
-	MINOR="`echo "$portVersion" | cut -d. -f3`"
-		sed -i "s|@MAJOR@|$MAJOR|" os_haiku.rdef
-		sed -i "s|@MIDDLE@|$MIDDLE|" os_haiku.rdef
-		sed -i "s|@MINOR@|$MINOR|" os_haiku.rdef
-
-	runConfigure ./configure \
-		--with-features=big \
+		--enable-pythoninterp=yes \
 		--enable-rubyinterp \
 		--enable-multibyte \
 		--enable-cscope \
@@ -127,4 +114,10 @@ INSTALL()
 	ln -s vim $binDir/vi
 
 	addAppDeskbarSymlink $binDir/gvim Vim
+}
+
+TEST()
+{
+	cd src
+	make check
 }


### PR DESCRIPTION
No need to build a CLI and a GUI version as the GUI version already provides the CLI version.
Tested on x64 with GUI and in Terminal.