### PR TITLE
sane_backends: Enable pnm backend build.

### DIFF
--- a/media-gfx/sane_backends/sane_backends-1.0.24.recipe
+++ b/media-gfx/sane_backends/sane_backends-1.0.24.recipe
@@ -11,15 +11,16 @@ operating systems, including GNU/Linux, OS/2, Win32 and various Unices and is \
 available under the GNU General Public License (commercial applications and \
 backends are welcome, too, however).
 
-This package includes the command line frontend scanimage, the saned server \
-and the sane-find-scanner utility, along with their documentation.
+This package includes scanners backends, the command line frontend scanimage, \
+the saned server and the sane-find-scanner utility, along with their \
+documentation.
 "
 
 HOMEPAGE="http://www.sane-project.org"
 LICENSE="GNU LGPL v2"
 COPYRIGHT="David Mosberger-Tang, Andy Beck"
 SOURCE_URI="git://git.debian.org/sane/sane-backends.git#f6896e0de481fad5c63bf7ffc271aca89b9cbb01"
-REVISION="2"
+REVISION="3"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
@@ -87,6 +88,7 @@ BUILD()
 		--disable-translations \
 		--enable-libusb_1_0 \
 		--enable-rpath \
+		--enable-pnm-backend \
 		LIBS=-lnetwork
 #		LIBUSB_1_0_LIBS=-lusb-1.0
 

--- a/media-gfx/sane_backends/sane_backends-1.0.25.recipe
+++ b/media-gfx/sane_backends/sane_backends-1.0.25.recipe
@@ -11,8 +11,9 @@ operating systems, including GNU/Linux, OS/2, Win32 and various Unices and is \
 available under the GNU General Public License (commercial applications and \
 backends are welcome, too, however).
 
-This package includes the command line frontend scanimage, the saned server \
-and the sane-find-scanner utility, along with their documentation.
+This package includes scanners backends, the command line frontend scanimage, \
+the saned server and the sane-find-scanner utility, along with their \
+documentation.
 "
 
 HOMEPAGE="http://www.sane-project.org"
@@ -21,7 +22,7 @@ COPYRIGHT="David Mosberger-Tang, Andy Beck"
 SOURCE_URI="https://alioth.debian.org/frs/download.php/file/4146/sane-backends-$portVersion.tar.gz"
 CHECKSUM_SHA256="a4d7ba8d62b2dea702ce76be85699940992daf3f44823ddc128812da33dc6e2c"
 SOURCE_DIR="sane-backends-$portVersion"
-REVISION="4"
+REVISION="5"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
@@ -100,6 +101,7 @@ BUILD()
 		--disable-translations \
 		--enable-libusb_1_0 \
 		--enable-rpath \
+		--enable-pnm-backend \
 		LIBS=-lnetwork
 
 	make


### PR DESCRIPTION
This backend still wont be available by default, but it's easier
for SANE frontends developers to uncomment in dll.conf to load it
than having to rebuild their own sane_backends package...