### PR TITLE
libexecinfo: fix symlink paths

### DIFF
--- a/sys-libs/libexecinfo/libexecinfo-1.1.recipe
+++ b/sys-libs/libexecinfo/libexecinfo-1.1.recipe
@@ -53,7 +53,7 @@ INSTALL()
 
 	cp libexecinfo.a $libDir
 	cp libexecinfo.so $libDir/libexecinfo.so.1.1
-	ln -s $libDir/libexecinfo.so-1.1 $libDir/libexecinfo.so
+	ln -s $libDir/libexecinfo.so.1.1 $libDir/libexecinfo.so
 	cp execinfo.h $includeDir
 
 	prepareInstalledDevelLibs libexecinfo


### PR DESCRIPTION
Swift uses this to support backtracing, but trying to build with libexecinfo support fails due to a broken symlink. This commit fixes this issue.