### PR TITLE
clang: Enable thread-local storage in clang

### DIFF
--- a/sys-devel/llvm/llvm-4.0.0.recipe
+++ b/sys-devel/llvm/llvm-4.0.0.recipe
@@ -31,7 +31,7 @@ other than the ones listed above.
 HOMEPAGE="http://www.llvm.org/"
 COPYRIGHT="2003-2014 University of Illinois at Urbana-Champaign"
 LICENSE="UIUC"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://llvm.org/releases/${portVersion}/llvm-${portVersion}.src.tar.xz"
 SOURCE_URI_2="http://llvm.org/releases/${portVersion}/cfe-${portVersion}.src.tar.xz"
 SOURCE_URI_3="http://llvm.org/releases/${portVersion}/clang-tools-extra-${portVersion}.src.tar.xz"

--- a/sys-devel/llvm/patches/clang-4.0.0.patchset
+++ b/sys-devel/llvm/patches/clang-4.0.0.patchset
@@ -1,14 +1,28 @@
-From 390990971be7f22ef0b1186564d5df4e7dacb1ca Mon Sep 17 00:00:00 2001
+From 6c7bd2f1da283aebc727f51fb8f1b8438d12e611 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Mon, 18 Jul 2016 14:13:19 +0200
-Subject: support for secondary arch.
+Subject: [PATCH] support for secondary arch.
 
+add a test for haiku driver.
+
+* upstream wants a case for libcxx in ToolChains.cpp, so add it.
+
+Enable thread-local storage and disable PIE by default
+---
+ CMakeLists.txt                    |  4 ++++
+ lib/Basic/Targets.cpp             |  2 --
+ lib/Driver/ToolChains.cpp         | 15 ++++++++++++++-
+ lib/Driver/ToolChains.h           |  4 +---
+ lib/Frontend/InitHeaderSearch.cpp | 25 +++++++++++++++++++++++++
+ test/Driver/haiku.c               | 12 ++++++++++++
+ 6 files changed, 56 insertions(+), 6 deletions(-)
+ create mode 100644 test/Driver/haiku.c
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 422beda..30cfe2d 100644
+index ff1ff21..3739e5b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -384,6 +384,10 @@ endif()
+@@ -392,6 +392,10 @@ endif()
  if(CLANG_ENABLE_STATIC_ANALYZER)
    add_definitions(-DCLANG_ENABLE_STATIC_ANALYZER)
  endif()
@@ -19,11 +33,24 @@ index 422beda..30cfe2d 100644
  
  # Clang version information
  set(CLANG_EXECUTABLE_VERSION
+diff --git a/lib/Basic/Targets.cpp b/lib/Basic/Targets.cpp
+index 1a95ff2..f4ec19b 100644
+--- a/lib/Basic/Targets.cpp
++++ b/lib/Basic/Targets.cpp
+@@ -420,8 +420,6 @@ public:
+     this->IntPtrType = TargetInfo::SignedLong;
+     this->PtrDiffType = TargetInfo::SignedLong;
+     this->ProcessIDType = TargetInfo::SignedLong;
+-    this->TLSSupported = false;
+-
+   }
+ };
+ 
 diff --git a/lib/Driver/ToolChains.cpp b/lib/Driver/ToolChains.cpp
-index a06a0f8..5905908 100644
+index 9bc9ae4..3484367 100644
 --- a/lib/Driver/ToolChains.cpp
 +++ b/lib/Driver/ToolChains.cpp
-@@ -3546,6 +3546,13 @@ SanitizerMask CloudABI::getDefaultSanitizers() const {
+@@ -3592,6 +3592,13 @@ SanitizerMask CloudABI::getDefaultSanitizers() const {
  Haiku::Haiku(const Driver &D, const llvm::Triple& Triple, const ArgList &Args)
    : Generic_ELF(D, Triple, Args) {
  
@@ -37,7 +64,7 @@ index a06a0f8..5905908 100644
  }
  
  std::string Haiku::findLibCxxIncludePath() const {
-@@ -3554,8 +3561,14 @@ std::string Haiku::findLibCxxIncludePath() const {
+@@ -3600,8 +3607,14 @@ std::string Haiku::findLibCxxIncludePath() const {
  
  void Haiku::addLibStdCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
                                       llvm::opt::ArgStringList &CC1Args) const {
@@ -53,8 +80,23 @@ index a06a0f8..5905908 100644
  }
  
  /// OpenBSD - OpenBSD tool chain which can call as(1) and ld(1) directly.
+diff --git a/lib/Driver/ToolChains.h b/lib/Driver/ToolChains.h
+index 3240357..bcd0f87 100644
+--- a/lib/Driver/ToolChains.h
++++ b/lib/Driver/ToolChains.h
+@@ -736,9 +736,7 @@ public:
+   Haiku(const Driver &D, const llvm::Triple &Triple,
+           const llvm::opt::ArgList &Args);
+ 
+-  bool isPIEDefault() const override {
+-    return getTriple().getArch() == llvm::Triple::x86_64;
+-  }
++  bool isPIEDefault() const override { return false; }
+ 
+   std::string findLibCxxIncludePath() const override;
+   void addLibStdCxxIncludePaths(
 diff --git a/lib/Frontend/InitHeaderSearch.cpp b/lib/Frontend/InitHeaderSearch.cpp
-index c76ccea..bd14950 100644
+index d50fb6d..8c0a978 100644
 --- a/lib/Frontend/InitHeaderSearch.cpp
 +++ b/lib/Frontend/InitHeaderSearch.cpp
 @@ -233,7 +233,20 @@ void InitHeaderSearch::AddDefaultCIncludePaths(const llvm::Triple &triple,
@@ -105,17 +147,6 @@ index c76ccea..bd14950 100644
      AddPath("/boot/system/develop/headers",  System, false);
      break;
    case llvm::Triple::RTEMS:
--- 
-2.2.2
-
-
-From 668a883775cbea7930f7459d82f5ed9790c632e7 Mon Sep 17 00:00:00 2001
-From: Jerome Duval <jerome.duval@gmail.com>
-Date: Thu, 7 Apr 2016 18:30:52 +0000
-Subject: add a test for haiku driver.
-
-* upstream wants a case for libcxx in ToolChains.cpp, so add it.
-
 diff --git a/test/Driver/haiku.c b/test/Driver/haiku.c
 new file mode 100644
 index 0000000..9591739
@@ -135,5 +166,5 @@ index 0000000..9591739
 +// CHECK-X86: gcc{{.*}}" "-o" "a.out" "{{.*}}.o"
 +
 -- 
-2.2.2
+2.12.2
 


### PR DESCRIPTION
This commit solves issue #789 by enabling TLS support in clang by default. This is known to work on x86_64 by passing the -fPIC flag, but I haven't tested it on x86 yet. 