### PR TITLE
Added Flag to build without stack protector in perl recipe

### DIFF
--- a/dev-lang/perl/perl-5.18.2.recipe
+++ b/dev-lang/perl/perl-5.18.2.recipe
@@ -119,7 +119,7 @@ BUILD()
 		-Dlibs=-lnetwork -Dcc=gcc -Dld=gcc \
 		-Ud_link -Ddont_use_nlink -Ud_syserrlst \
 		-Dldlibpthname=LIBRARY_PATH -Dstartperl="#! perl" \
-		-Dccdlflags="-Wl,-rpath=$libDir/perl5/$portVersion/$perlArchName/CORE" \
+		-Dccdlflags="-Wl,-fno-stack-protector,-rpath=$libDir/perl5/$portVersion/$perlArchName/CORE" \
 		-Dusesitecustomize \
 		-de
 

--- a/net-irc/irssi/irssi-1.0.0.recipe
+++ b/net-irc/irssi/irssi-1.0.0.recipe
@@ -34,12 +34,12 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	haiku_devel
+	cmd:lynx
 	cmd:aclocal
 	cmd:autoreconf
 	cmd:gcc
 	cmd:git
 	cmd:libtoolize
-	cmd:links
 	cmd:ld
 	cmd:make
 	cmd:perl
@@ -53,8 +53,7 @@ GLOBAL_WRITABLE_FILES="
 BUILD()
 {
 	chmod +x autogen.sh irssi-version.sh file2header.sh
-	./autogen.sh $configureDirArgs --with-perl=module --with-socks \
-		--with-proxy --enable-true-color
+	./autogen.sh $configureDirArgs --with-perl=no
 	make $jobArgs
 }
 

--- a/net-irc/irssi/irssi-1.0.2.recipe
+++ b/net-irc/irssi/irssi-1.0.2.recipe
@@ -8,7 +8,7 @@ COPYRIGHT="1999-2016 Timo Sirainen"
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://github.com/irssi/irssi/releases/download/$portVersion/irssi-$portVersion.tar.gz"
-CHECKSUM_SHA256="790eb3b62d8889d1fb3973845d8ca5d7c2578620632abc671ffdff3da13aa487"
+CHECKSUM_SHA256="8e4f79797a269cc5e026f084b4b0017c4818bb83735f0d0011153df371335ab9"
 SOURCE_DIR="irssi-$portVersion"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
@@ -53,13 +53,12 @@ GLOBAL_WRITABLE_FILES="
 BUILD()
 {
 	chmod +x autogen.sh irssi-version.sh file2header.sh
-	./autogen.sh $configureDirArgs --with-perl=no
+	./autogen.sh $configureDirArgs --with-perl=module --with-socks \
+	  --with-proxy --enable-true-color
 	make $jobArgs
 }
 
 INSTALL()
 {
 	make install-strip
-
-	rm $libDir/irssi/modules/lib*.la
 }


### PR DESCRIPTION
This Commit modify the perl recipe:
    1. added no stack protecter flags for compiling
    2. added latest irssi recipie with perl support

fixes #1377 