### PR TITLE
swift-lang: new recipe

### DIFF
--- a/dev-lang/swift_lang/patches/swift_lang-3.1.patchset
+++ b/dev-lang/swift_lang/patches/swift_lang-3.1.patchset
@@ -1,0 +1,57 @@
+From d41dc9086b655f737a1b3fb58e9fb10758b7ab84 Mon Sep 17 00:00:00 2001
+From: Hugh Bellamy <hughbellars@gmail.com>
+Date: Tue, 21 Mar 2017 18:54:39 +0700
+Subject: Fix top of tree Clang compilation errors
+
+
+diff --git a/lib/SIL/Projection.cpp b/lib/SIL/Projection.cpp
+index fe46b37..00767df 100644
+--- a/lib/SIL/Projection.cpp
++++ b/lib/SIL/Projection.cpp
+@@ -905,7 +905,7 @@ processUsersOfValue(ProjectionTree &Tree,
+     DEBUG(llvm::dbgs() << "        " << *User);
+ 
+     // First try to create a Projection for User.
+-    auto P = Projection::Projection(User);
++    auto P = Projection(User);
+ 
+     // If we fail to create a projection, add User as a user to this node and
+     // continue.
+diff --git a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+index 09a13f2..1efd3b8 100644
+--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
++++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+@@ -488,7 +488,7 @@ static bool tryToSpeculateTarget(FullApplySite AI,
+     if (auto EMT = SubType.getAs<AnyMetatypeType>()) {
+       auto InstTy = ClassType.getSwiftRValueType();
+       auto *MetaTy = MetatypeType::get(InstTy, EMT->getRepresentation());
+-      auto CanMetaTy = CanMetatypeType::CanTypeWrapper(MetaTy);
++      auto CanMetaTy = CanMetatypeType(MetaTy);
+       ClassOrMetatypeType = SILType::getPrimitiveObjectType(CanMetaTy);
+     }
+ 
+diff --git a/lib/SILOptimizer/Utils/Local.cpp b/lib/SILOptimizer/Utils/Local.cpp
+index 8b265a7..4f0a2fb 100644
+--- a/lib/SILOptimizer/Utils/Local.cpp
++++ b/lib/SILOptimizer/Utils/Local.cpp
+@@ -2248,7 +2248,7 @@ CastOptimizer::optimizeCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
+         auto EMT = dyn_cast<AnyMetatypeType>(EmiTy.getSwiftRValueType());
+         auto *MetaTy = MetatypeType::get(LoweredConcreteTy.getSwiftRValueType(),
+                                          EMT->getRepresentation());
+-        auto CanMetaTy = CanMetatypeType::CanTypeWrapper(MetaTy);
++        auto CanMetaTy = CanTypeWrapper<MetatypeType>(MetaTy);
+         auto SILMetaTy = SILType::getPrimitiveObjectType(CanMetaTy);
+         SILBuilderWithScope B(Inst);
+         auto *MI = B.createMetatype(FoundIEI->getLoc(), SILMetaTy);
+@@ -2303,7 +2303,7 @@ CastOptimizer::optimizeCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
+         // Get the SIL metatype of this type.
+         auto EMT = dyn_cast<AnyMetatypeType>(EMI->getType().getSwiftRValueType());
+         auto *MetaTy = MetatypeType::get(ConcreteTy, EMT->getRepresentation());
+-        auto CanMetaTy = CanMetatypeType::CanTypeWrapper(MetaTy);
++        auto CanMetaTy = CanTypeWrapper<MetatypeType>(MetaTy);
+         auto SILMetaTy = SILType::getPrimitiveObjectType(CanMetaTy);
+         SILBuilderWithScope B(Inst);
+         auto *MI = B.createMetatype(FoundIERI->getLoc(), SILMetaTy);
+-- 
+2.14.2
+

--- a/dev-lang/swift_lang/swift_lang-3.1.recipe
+++ b/dev-lang/swift_lang/swift_lang-3.1.recipe
@@ -9,7 +9,8 @@ easier for the developer."
 HOMEPAGE="https://swift.org"
 LICENSE="Apache v2"
 COPYRIGHT="2017 Apple Inc"
-srcGitRev="afca67566b0ed82f80ded873417a03392b6ff3df"
+REVISION="1"
+srcGitRev="94e444f22015d32b81e6dc1a0316a8243360559b"
 srcGitRev2="2c9b458a0db83c1aecafb12cef1ccc2d479d09bd"
 srcGitRev3="be1632fd0514632ae51073e5ed109b00b68e1cfd"
 srcGitRev4="912d9d4ccbfa41ba225c37351a217b678358cc3e"
@@ -17,7 +18,7 @@ SOURCE_URI="https://github.com/return/swift/archive/$srcGitRev.zip"
 SOURCE_URI_2="https://github.com/return/swift-clang/archive/$srcGitRev2.zip"
 SOURCE_URI_3="https://github.com/return/swift-llvm/archive/$srcGitRev3.zip"
 SOURCE_URI_4="https://github.com/return/swift-cmark/archive/$srcGitRev4.zip"
-CHECKSUM_SHA256="52cd87b622895f697bad0c21ff188e737e7e4e72c48cb20019f1aea565c4f910"
+CHECKSUM_SHA256="e0d3e048e57ee0fc85b41392d5d075dc037ce5c03f13e41f15bd45d647322155"
 CHECKSUM_SHA256_2="e0aaa0a0a38e47f1306ac5ad540c0e663ecf42a4d290d93601527421cbc3da16"
 CHECKSUM_SHA256_3="49789886819989bc97ec83dc7c5cfbca768bd76aa9e507882799f52c5a222270"
 CHECKSUM_SHA256_4="cf7dae35aa844bc438cbca8f335494416c32eee3fa491eaee5a36e2625bc73be"
@@ -25,13 +26,12 @@ SOURCE_DIR="swift-$srcGitRev"
 SOURCE_DIR_2="swift-clang-$srcGitRev2"
 SOURCE_DIR_3="swift-llvm-$srcGitRev3"
 SOURCE_DIR_4="swift-cmark-$srcGitRev4"
-REVISION="1"
 
 ARCHITECTURES="!x86_gcc2 !x86 x86_64"
-SECONDARY_ARCHITECTURES="?x86"
+SECONDARY_ARCHITECTURES="!x86"
 
 PROVIDES="
-	swift_lang$secondaryArchSuffix = $portVersion compat >= 1.2
+	swift_lang$secondaryArchSuffix = $portVersion
 	cmd:swift$secondaryArchSuffix = $portVersion
 	cmd:swiftc$secondaryArchSuffix = $portVersion
 	cmd:swift_api_digester$secondaryArchSuffix = $portVersion
@@ -94,7 +94,6 @@ BUILD_PREREQUIRES="
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
 	cmd:python2
-	cmd:python3
 	cmd:swig
 	cmd:sed
 	cmd:which
@@ -122,23 +121,48 @@ BUILD()
 
 	# Build faster by building only for X86
 	python2 ./swift/utils/build-script -R -m \
-	--extra-cmake-options='-DLLVM_ENABLE_ASSERTIONS=TRUE \
-	 -DCMAKE_SKIP_RPATH=FALSE -DLLVM_ENABLE_RTTI=ON \
-	 -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_THREADS=NO \
-	 -DCMAKE_C_FLAGS=-fPIC -DCMAKE_CXX_FLAGS=-fPIC' \
-	 --stdlib-deployment-targets=haiku-x86_64 $jobArgs \
-	 --reconfigure
+		--extra-cmake-options='-DLLVM_ENABLE_ASSERTIONS=TRUE \
+			-DCMAKE_SKIP_RPATH=FALSE -DLLVM_ENABLE_RTTI=ON \
+			-DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_THREADS=YES \
+			-DCMAKE_C_FLAGS=-fPIC -DCMAKE_CXX_FLAGS=-fPIC' \
+		--stdlib-deployment-targets=haiku-x86_64 $jobArgs
 }
 
 INSTALL()
 {
 	mkdir -p $binDir $libDir
+	mkdir -p $libDir/swift
+	mkdir -p $libDir/swift/shims $libDir/swift/haiku/x86_64 $libDir/swift/clang/include
 
 	cd ../build/Unix_Makefiles-ReleaseAssert/swift-haiku-x86_64
 
+	# Copy the executables into the binDir.
 	cp ./bin/* $binDir
+	cd ./lib/swift/
 
-	cp -R ./lib/swift $libDir
+	# Symlink and copy the clang headers.
+	ln -sfn ../../../llvm-haiku-x86_64/lib/clang/4.0.0/include/ clang
+	cp -R ./clang/* $libDir/swift/clang/include
+	cp -R ./shims/* $libDir/swift/shims
+
+	# Copy the specific library files.
+	cp ./haiku/libswiftCore.so $libDir/swift/haiku
+	cp ./haiku/libswiftGlibc.so $libDir/swift/haiku
+	cp ./haiku/libswiftRemoteMirror.so $libDir/swift/haiku
+	cp ./haiku/libswiftSwiftOnoneSupport.so $libDir/swift/haiku
+
+	# Copy the essential swiftmodule files.
+	cp ./haiku/x86_64/SwiftOnoneSupport.swiftmodule $libDir/swift/haiku/x86_64
+	cp ./haiku/x86_64/Glibc.swiftmodule $libDir/swift/haiku/x86_64
+	cp ./haiku/x86_64/Swift.swiftmodule $libDir/swift/haiku/x86_64
+
+	# Copy the essential swiftdoc files.
+	cp ./haiku/x86_64/SwiftOnoneSupport.swiftdoc $libDir/swift/haiku/x86_64
+	cp ./haiku/x86_64/Glibc.swiftdoc $libDir/swift/haiku/x86_64
+	cp ./haiku/x86_64/Swift.swiftdoc $libDir/swift/haiku/x86_64
+	cp ./haiku/x86_64/glibc.modulemap  $libDir/swift/haiku/x86_64
+	cp ./haiku/x86_64/swift_begin.o  $libDir/swift/haiku/x86_64
+	cp ./haiku/x86_64/swift_end.o   $libDir/swift/haiku/x86_64
 }
 
 TEST()

--- a/dev-lang/swift_lang/swift_lang-3.1.recipe
+++ b/dev-lang/swift_lang/swift_lang-3.1.recipe
@@ -30,6 +30,7 @@ SOURCE_DIR_2="swift-clang-$srcGitRev2"
 SOURCE_DIR_3="swift-llvm-$srcGitRev3"
 SOURCE_DIR_4="swift-cmark-$srcGitRev4"
 SOURCE_DIR_5="swift-compiler-rt-$srcGitRev5"
+PATCHES="swift_lang-3.1.patchset"
 
 ARCHITECTURES="!x86_gcc2 !x86 x86_64"
 SECONDARY_ARCHITECTURES="!x86"

--- a/dev-lang/swift_lang/swift_lang-3.1.recipe
+++ b/dev-lang/swift_lang/swift_lang-3.1.recipe
@@ -1,0 +1,147 @@
+SUMMARY="A modern high performance safe general-purpose programming language"
+DESCRIPTION="Swift is a general-purpose programming language built using a \
+modern approach to safety, performance, and software design patterns. \
+The goal of the Swift project is to create the best available \
+language for uses ranging from systems programming to mobile \
+and desktop apps, scaling up to cloud services. Most importantly, \
+Swift  is designed to make writing and maintaining correct programs \
+easier for the developer."
+HOMEPAGE="https://swift.org"
+LICENSE="Apache v2"
+COPYRIGHT="2017 Apple Inc"
+srcGitRev="afca67566b0ed82f80ded873417a03392b6ff3df"
+srcGitRev2="2c9b458a0db83c1aecafb12cef1ccc2d479d09bd"
+srcGitRev3="be1632fd0514632ae51073e5ed109b00b68e1cfd"
+srcGitRev4="912d9d4ccbfa41ba225c37351a217b678358cc3e"
+SOURCE_URI="https://github.com/return/swift/archive/$srcGitRev.zip"
+SOURCE_URI_2="https://github.com/return/swift-clang/archive/$srcGitRev2.zip"
+SOURCE_URI_3="https://github.com/return/swift-llvm/archive/$srcGitRev3.zip"
+SOURCE_URI_4="https://github.com/return/swift-cmark/archive/$srcGitRev4.zip"
+CHECKSUM_SHA256="52cd87b622895f697bad0c21ff188e737e7e4e72c48cb20019f1aea565c4f910"
+CHECKSUM_SHA256_2="e0aaa0a0a38e47f1306ac5ad540c0e663ecf42a4d290d93601527421cbc3da16"
+CHECKSUM_SHA256_3="49789886819989bc97ec83dc7c5cfbca768bd76aa9e507882799f52c5a222270"
+CHECKSUM_SHA256_4="cf7dae35aa844bc438cbca8f335494416c32eee3fa491eaee5a36e2625bc73be"
+SOURCE_DIR="swift-$srcGitRev"
+SOURCE_DIR_2="swift-clang-$srcGitRev2"
+SOURCE_DIR_3="swift-llvm-$srcGitRev3"
+SOURCE_DIR_4="swift-cmark-$srcGitRev4"
+REVISION="1"
+
+ARCHITECTURES="!x86_gcc2 !x86 x86_64"
+SECONDARY_ARCHITECTURES="?x86"
+
+PROVIDES="
+	swift_lang$secondaryArchSuffix = $portVersion compat >= 1.2
+	cmd:swift$secondaryArchSuffix = $portVersion
+	cmd:swiftc$secondaryArchSuffix = $portVersion
+	cmd:swift_api_digester$secondaryArchSuffix = $portVersion
+	cmd:swift_autolink_extract$secondaryArchSuffix = $portVersion
+	cmd:swift_demangle$secondaryArchSuffix = $portVersion
+	cmd:swift_format$secondaryArchSuffix = $portVersion
+	cmd:swift_ide_test$secondaryArchSuffix = $portVersion
+	cmd:swift_llvm_opt$secondaryArchSuffix = $portVersion
+	cmd:swift_reflection_dump$secondaryArchSuffix = $portVersion
+	cmd:swift_remoteast_test$secondaryArchSuffix = $portVersion
+	cmd:sil_func_extractor$secondaryArchSuffix = $portVersion
+	cmd:sil_opt$secondaryArchSuffix = $portVersion
+	cmd:sil_nm$secondaryArchSuffix = $portVersion
+	cmd:sil_passpipeline_dumper$secondaryArchSuffix = $portVersion
+	cmd:lldb_moduleimport_test$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcharset$secondaryArchSuffix
+	lib:libedit$secondaryArchSuffix
+	lib:libexecinfo$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libicudata$secondaryArchSuffix
+	lib:libicui18n$secondaryArchSuffix
+	lib:libicuuc$secondaryArchSuffix
+	llvm$secondaryArchSuffix >= 3.7.0 base
+	lib:libncurses$secondaryArchSuffix
+	lib:libsqlite3$secondaryArchSuffix
+	lib:libuuid$secondaryArchSuffix
+	lib:libxml2$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libcharset$secondaryArchSuffix
+	devel:libedit$secondaryArchSuffix
+	devel:libexecinfo$secondaryArchSuffix
+	gcc_syslibs$secondaryArchSuffix_devel
+	devel:libgcc$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
+	devel:libicudata$secondaryArchSuffix
+	devel:libicui18n$secondaryArchSuffix
+	devel:libicuuc$secondaryArchSuffix
+	devel:libncurses$secondaryArchSuffix
+	devel:libsqlite3$secondaryArchSuffix
+	devel:libuuid$secondaryArchSuffix
+	devel:libxml2$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:clang$secondaryArchSuffix
+	cmd:clang++$secondaryArchSuffix
+	cmd:cmake
+	cmd:diff
+	cmd:find
+	cmd:gcc$secondaryArchSuffix
+	cmd:grep
+	cmd:groff
+	cmd:ld$secondaryArchSuffix
+	cmd:libtool$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:python2
+	cmd:python3
+	cmd:swig
+	cmd:sed
+	cmd:which
+	"
+
+BUILD()
+{
+	cd ..
+
+	mkdir -p swift clang llvm cmark
+
+	# Copy all the source files
+	cp -rd $sourceDir/* swift
+	cp -rd $sourceDir2/* clang
+	cp -rd $sourceDir3/* llvm
+	cp -rd $sourceDir4/* cmark
+
+	# Fix permisssions for build-script.
+	chmod +x ./swift/utils/build-script
+	chmod +x ./swift/utils/build-script-impl
+	chmod -R 755 ./swift/utils
+
+	export HOST_CC="/bin/clang"
+	export HOST_CXX="/bin/clang++"
+
+	# Build faster by building only for X86
+	python2 ./swift/utils/build-script -R -m \
+	--extra-cmake-options='-DLLVM_ENABLE_ASSERTIONS=TRUE \
+	 -DCMAKE_SKIP_RPATH=FALSE -DLLVM_ENABLE_RTTI=ON \
+	 -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_THREADS=NO \
+	 -DCMAKE_C_FLAGS=-fPIC -DCMAKE_CXX_FLAGS=-fPIC' \
+	 --stdlib-deployment-targets=haiku-x86_64 $jobArgs \
+	 --reconfigure
+}
+
+INSTALL()
+{
+	mkdir -p $binDir $libDir
+
+	cd ../build/Unix_Makefiles-ReleaseAssert/swift-haiku-x86_64
+
+	cp ./bin/* $binDir
+
+	cp -R ./lib/swift $libDir
+}
+
+TEST()
+{
+	python2 utils/build-script -R -t
+}

--- a/dev-lang/swift_lang/swift_lang-3.1.recipe
+++ b/dev-lang/swift_lang/swift_lang-3.1.recipe
@@ -14,18 +14,22 @@ srcGitRev="94e444f22015d32b81e6dc1a0316a8243360559b"
 srcGitRev2="2c9b458a0db83c1aecafb12cef1ccc2d479d09bd"
 srcGitRev3="be1632fd0514632ae51073e5ed109b00b68e1cfd"
 srcGitRev4="912d9d4ccbfa41ba225c37351a217b678358cc3e"
+srcGitRev5="9732781059bddc467677396562c987db4587074c"
 SOURCE_URI="https://github.com/return/swift/archive/$srcGitRev.zip"
 SOURCE_URI_2="https://github.com/return/swift-clang/archive/$srcGitRev2.zip"
 SOURCE_URI_3="https://github.com/return/swift-llvm/archive/$srcGitRev3.zip"
 SOURCE_URI_4="https://github.com/return/swift-cmark/archive/$srcGitRev4.zip"
+SOURCE_URI_5="https://github.com/return/swift-compiler-rt/archive/$srcGitRev5.zip"
 CHECKSUM_SHA256="e0d3e048e57ee0fc85b41392d5d075dc037ce5c03f13e41f15bd45d647322155"
 CHECKSUM_SHA256_2="e0aaa0a0a38e47f1306ac5ad540c0e663ecf42a4d290d93601527421cbc3da16"
 CHECKSUM_SHA256_3="49789886819989bc97ec83dc7c5cfbca768bd76aa9e507882799f52c5a222270"
 CHECKSUM_SHA256_4="cf7dae35aa844bc438cbca8f335494416c32eee3fa491eaee5a36e2625bc73be"
+CHECKSUM_SHA256_5="58b0aa642cf15b99d889b923c7624cb7c092facb86a5329449efa42a6443fc5d"
 SOURCE_DIR="swift-$srcGitRev"
 SOURCE_DIR_2="swift-clang-$srcGitRev2"
 SOURCE_DIR_3="swift-llvm-$srcGitRev3"
 SOURCE_DIR_4="swift-cmark-$srcGitRev4"
+SOURCE_DIR_5="swift-compiler-rt-$srcGitRev5"
 
 ARCHITECTURES="!x86_gcc2 !x86 x86_64"
 SECONDARY_ARCHITECTURES="!x86"
@@ -103,13 +107,14 @@ BUILD()
 {
 	cd ..
 
-	mkdir -p swift clang llvm cmark
+	mkdir -p swift clang llvm cmark compiler-rt
 
 	# Copy all the source files
 	cp -rd $sourceDir/* swift
 	cp -rd $sourceDir2/* clang
 	cp -rd $sourceDir3/* llvm
 	cp -rd $sourceDir4/* cmark
+	cp -rd $sourceDir5/* compiler-rt
 
 	# Fix permisssions for build-script.
 	chmod +x ./swift/utils/build-script


### PR DESCRIPTION
This port of Swift 3.1 will only work on x86_64 and requires installing llvm-4.0.0-2 because of this [commit](https://github.com/return/haikuports/commit/b6316842ed1d62ccb0a12d8f7353edea96e536bf). 

Further progress and documentation of the swift port can be found on the [swift-haiku-build](https://github.com/return/swift-haiku-build) repository.

What works so far:
* Running Swift programs through the interpreter. 
* Importing libraries. (Passing -sdk '/' to compiler or export SDKROOT="/")
* SIL/IR Code Generation.
* Emitting object code.
* Developer tools.
* Generating executables with swiftc
 
(UPDATE 18th June 2017):
Partial support for running swift programs via interpreter.
_(Removing some concurrency related code in the MetadataCache class, allows swift programs to run in the interpreter, but this hack only serves as a proof of concept showing that swift programs can run in Haiku.)_

(UPDATE 6th July 2017):
Compiling swift source files into executables now seem to work. 