### PR TITLE
Libuv: update patchset, disable on every archs

### DIFF
--- a/dev-libs/libuv/libuv-1.12.0.recipe
+++ b/dev-libs/libuv/libuv-1.12.0.recipe
@@ -7,11 +7,12 @@ COPYRIGHT="2009-2017 Ryan Dahl and others"
 LICENSE="MIT"
 REVISION="1"
 SOURCE_URI="https://github.com/libuv/libuv/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="2d740a2adea0f1a19058626f55a076ac41a4ac1f95d4e57cae0c8a634a6cd63b"
+CHECKSUM_SHA256="41ce914a88da21d3b07a76023beca57576ca5b376c6ac440c80bc581cbca1250"
 PATCHES="libuv-$portVersion.patchset"
 
-ARCHITECTURES="x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="x86_gcc2 x86"
+# libuv requires platform-specific implementations, no piggy-back, really broken
+ARCHITECTURES="!x86_gcc2 !x86 !x86_64"
+SECONDARY_ARCHITECTURES="!x86_gcc2 !x86"
 
 PROVIDES="
 	libuv$secondaryArchSuffix = $portVersion
@@ -68,5 +69,5 @@ INSTALL()
 
 TEST()
 {
-	make check || true # Test suite doesn't pass
+	make check #|| true # Test suite doesn't pass
 }

--- a/dev-libs/libuv/patches/libuv-1.12.0.patchset
+++ b/dev-libs/libuv/patches/libuv-1.12.0.patchset
@@ -1,25 +1,24 @@
-From 73e0087955f2351fe1380697aa5192a75167451e Mon Sep 17 00:00:00 2001
+From d1477d1d6bddccb53eb92edcc8039d131eda5224 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
-Date: Thu, 12 Jan 2017 10:19:18 +0100
+Date: Sat, 10 Jun 2017 12:04:15 +0200
 Subject: [PATCH] Haiku supporting patches
 
 ---
  configure.ac    |  7 +++++++
- src/unix/core.c | 32 +++++++++++++++++++++++++++++++-
+ src/unix/core.c | 31 ++++++++++++++++++++++++++++++-
  test/test-fs.c  |  3 ++-
- 3 files changed, 40 insertions(+), 2 deletions(-)
+ 3 files changed, 39 insertions(+), 2 deletions(-)
 
 diff --git a/configure.ac b/configure.ac
-index abaf971..b53e4db 100644
+index 8ac06f7..5f78510 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -41,14 +41,17 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+@@ -42,13 +42,16 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
  LT_INIT
  # TODO(bnoordhuis) Check for -pthread vs. -pthreads
  AC_CHECK_LIB([dl], [dlopen])
 +AC_CHECK_LIB([root], [dlopen])
  AC_CHECK_LIB([kstat], [kstat_lookup])
- AC_CHECK_LIB([kvm], [kvm_open])
  AC_CHECK_LIB([nsl], [gethostbyname])
 +AC_CHECK_LIB([network], [gethostbyname])
  AC_CHECK_LIB([perfstat], [perfstat_cpu])
@@ -31,7 +30,7 @@ index abaf971..b53e4db 100644
  AC_SYS_LARGEFILE
  AM_CONDITIONAL([AIX],      [AS_CASE([$host_os],[aix*],          [true], [false])])
  AM_CONDITIONAL([ANDROID],  [AS_CASE([$host_os],[linux-android*],[true], [false])])
-@@ -61,9 +64,13 @@ AM_CONDITIONAL([OPENBSD],  [AS_CASE([$host_os],[openbsd*],      [true], [false])
+@@ -63,9 +66,13 @@ AM_CONDITIONAL([OPENBSD],  [AS_CASE([$host_os],[openbsd*],      [true], [false])
  AM_CONDITIONAL([OS390],    [AS_CASE([$host_os],[openedition*],  [true], [false])])
  AM_CONDITIONAL([SUNOS],    [AS_CASE([$host_os],[solaris*],      [true], [false])])
  AM_CONDITIONAL([WINNT],    [AS_CASE([$host_os],[mingw*],        [true], [false])])
@@ -42,17 +41,17 @@ index abaf971..b53e4db 100644
 +AS_CASE([$host_os],[haiku*], [
 +    LIBS="$LIBS -lnetwork"
 +])
- AC_CHECK_HEADERS([sys/ahafs_evProds.h])
- AC_CHECK_PROG(PKG_CONFIG, pkg-config, yes)
- AM_CONDITIONAL([HAVE_PKG_CONFIG], [test "x$PKG_CONFIG" != "x"])
+ AS_CASE([$host_os], [openbsd*], [], [
+     AC_CHECK_LIB([kvm], [kvm_open])
+ ])
 diff --git a/src/unix/core.c b/src/unix/core.c
-index 6283ed3..ef4b53d 100644
+index 8276c60..f9a96e2 100644
 --- a/src/unix/core.c
 +++ b/src/unix/core.c
-@@ -55,6 +55,19 @@
+@@ -57,6 +57,19 @@
  # endif
  #endif
- 
+
 +#ifdef __HAIKU__
 +# include <fcntl.h>
 +# if defined(O_CLOEXEC)
@@ -69,19 +68,19 @@ index 6283ed3..ef4b53d 100644
  #if defined(__DragonFly__)      || \
      defined(__FreeBSD__)        || \
      defined(__FreeBSD_kernel__)
-@@ -921,7 +934,7 @@ int uv_getrusage(uv_rusage_t* rusage) {
+@@ -928,7 +941,7 @@ int uv_getrusage(uv_rusage_t* rusage) {
    rusage->ru_stime.tv_sec = usage.ru_stime.tv_sec;
    rusage->ru_stime.tv_usec = usage.ru_stime.tv_usec;
- 
+
 -#if !defined(__MVS__)
 +#if !defined(__MVS__) && !defined(__HAIKU__)
    rusage->ru_maxrss = usage.ru_maxrss;
    rusage->ru_ixrss = usage.ru_ixrss;
    rusage->ru_idrss = usage.ru_idrss;
-@@ -938,6 +951,23 @@ int uv_getrusage(uv_rusage_t* rusage) {
+@@ -944,6 +957,22 @@ int uv_getrusage(uv_rusage_t* rusage) {
+   rusage->ru_nvcsw = usage.ru_nvcsw;
    rusage->ru_nivcsw = usage.ru_nivcsw;
  #endif
- 
 +#if defined(__HAIKU__)
 +  rusage->ru_maxrss = 0;
 +  rusage->ru_ixrss = 0;
@@ -98,16 +97,15 @@ index 6283ed3..ef4b53d 100644
 +  rusage->ru_nvcsw = 0;
 +  rusage->ru_nivcsw = 0;
 +#endif
-+
+
    return 0;
  }
- 
 diff --git a/test/test-fs.c b/test/test-fs.c
-index 70a2399..2c998dc 100644
+index c482ab5..1af17e1 100644
 --- a/test/test-fs.c
 +++ b/test/test-fs.c
 @@ -29,7 +29,8 @@
- 
+
  /* FIXME we shouldn't need to branch in this file */
  #if defined(__unix__) || defined(__POSIX__) || \
 -    defined(__APPLE__) || defined(_AIX) || defined(__MVS__)
@@ -116,6 +114,6 @@ index 70a2399..2c998dc 100644
  #include <unistd.h> /* unlink, rmdir, etc. */
  #else
  # include <direct.h>
--- 
-2.11.0
+--
+2.12.2
 


### PR DESCRIPTION
It needs platform specific implementation, so this commit disables it on every arch.