### PR TITLE
Qmplay2 bump version

### DIFF
--- a/media-video/qmplay2/patches/qmplay2-17.06.09.patchset
+++ b/media-video/qmplay2/patches/qmplay2-17.06.09.patchset
@@ -1,0 +1,1036 @@
+From 5da065899b103067299a49c0f0917c32b3d8e9ee Mon Sep 17 00:00:00 2001
+From: Gerasim Troeglazov <3dEyes@gmail.com>
+Date: Wed, 14 Jun 2017 17:16:06 +0100
+Subject: Add Haiku support
+
+
+diff --git a/haiku/QMPlay2.rdef b/haiku/QMPlay2.rdef
+new file mode 100644
+index 0000000..e70bab0
+--- /dev/null
++++ b/haiku/QMPlay2.rdef
+@@ -0,0 +1,42 @@
++resource app_signature "application/x-vnd.QMPlay2";
++resource app_flags B_MULTIPLE_LAUNCH;
++resource app_version {
++	major  = 17,
++	middle = 04,
++	minor  = 21,
++
++	/* Application "variety" can be set to one of the following:
++	*	B_APPV_DEVELOPMENT,
++	*	B_APPV_ALPHA,
++	*	B_APPV_BETA,
++	*	B_APPV_GAMMA,
++	*	B_APPV_GOLDEN_MASTER,
++	*	B_APPV_FINAL
++	*/
++	variety = B_APPV_DEVELOPMENT,
++	internal = 0,
++
++	short_info = "QMPlay2",
++	long_info = "QMPlay2 © 2010-2017 Błażej Szczygieł"
++};
++
++resource file_types message {
++	"types" = "video",
++	"types" = "audio"
++};
++
++resource vector_icon array {
++	$"6E63696602012C165AF20314D77803000DB4D0B47BB4D0B47BB5A4B493B717B5"
++	$"6DB659B515BCBFB846C814BDF0C26CBB17C8CEBE53CA3FBF23C99BBE9CCA9ABF"
++	$"6BCA35C053CA92C00FC985C0E0C7E7C196C8ADC12DC276C452B78EC9BFBD01C7"
++	$"06B6C1CA20B523CAD9B601CAA4B4ACCAF9B426CA1EB421CA9DB41FC965B46DC7"
++	$"FBB44EC8B0B561C2E0B4A9B879B57FBD9BB485B770B428B55FB438B66BB41CB4"
++	$"F6B4D0B47BB466B48CB4D0B47B0209B627B6EDB6A3B714B640B838B6A7BACAB6"
++	$"89B97FB6F3BD1FB6E1C1D3B6F0BF7BB6D1C408B623C864B659C633B71AC816B8"
++	$"DBC716B7F4C787BC65C561C369C1D7BFF0C3ADC4D7C11DC7BDBFBFC64EC075C7"
++	$"1DBF3FC5A7BE96C65EBEEFC0EEBC47B790B783BC40B9E3B71CB7480209B627B6"
++	$"EDB640B838B6A3B714B790B783B71CB748BC40B9E3C5A7BE96C0EEBC47C65EBE"
++	$"EFC7BDBFBFC71DBF3FC64EC075C369C1D7C4D7C11DBFF0C3ADB8DBC716BC65C5"
++	$"61B7F4C787B623C864B71AC816B659C633B6E1C1D3B6D1C408B6F0BF7BB6A7BA"
++	$"CAB6F3BD1FB689B97F020A00020001000A01010200"
++};
+diff --git a/src/gui/Main.cpp b/src/gui/Main.cpp
+index a5a2c48..bb81eeb 100644
+--- a/src/gui/Main.cpp
++++ b/src/gui/Main.cpp
+@@ -456,6 +456,9 @@ int main(int argc, char *argv[])
+ 	signal(SIGTERM, signal_handler);
+ 	atexit(exitProcedure);
+ 
++#ifdef Q_OS_HAIKU
++	setenv("HOME", "/boot/home", 1);
++#endif
+ #if (defined(Q_OS_MAC) || defined(Q_OS_WIN)) && (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+ 	QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+ #endif
+@@ -544,7 +547,7 @@ int main(int argc, char *argv[])
+ 	}
+ 	if (!cmakeBuildFound)
+ 	{
+-#if !defined Q_OS_WIN && !defined Q_OS_MAC && !defined Q_OS_ANDROID
++#if !defined Q_OS_WIN && !defined Q_OS_MAC && !defined Q_OS_ANDROID && !defined Q_OS_HAIKU
+ 		sharePath = QCoreApplication::applicationDirPath() + "/../share/qmplay2";
+ 		libPath = QMPlay2CoreClass::getLibDir();
+ 		if (libPath.isEmpty() || !QDir(libPath).exists("qmplay2"))
+diff --git a/src/gui/MainWidget.cpp b/src/gui/MainWidget.cpp
+index 0962259..26aa2a9 100644
+--- a/src/gui/MainWidget.cpp
++++ b/src/gui/MainWidget.cpp
+@@ -158,7 +158,7 @@ MainWidget::MainWidget(QPair<QStringList, QStringList> &arguments) :
+ 		setIconSize({22, 22});
+ 
+ 	SettingsWidget::InitSettings();
+-#ifndef Q_OS_ANDROID
++#ifndef Q_OS_ANDROID && !defined Q_OS_HAIKU
+ 	settings.init("MainWidget/WidgetsLocked", false);
+ #else
+ 	settings.init("MainWidget/WidgetsLocked", true);
+diff --git a/src/modules/MediaKit/MediaKit.cpp b/src/modules/MediaKit/MediaKit.cpp
+new file mode 100644
+index 0000000..16e99c4
+--- /dev/null
++++ b/src/modules/MediaKit/MediaKit.cpp
+@@ -0,0 +1,65 @@
++#include <MediaKit.hpp>
++#include <MediaKitWriter.hpp>
++
++MediaKit::MediaKit() :
++	Module( "MediaKit" )
++{
++	m_icon = QIcon( ":/MediaKit" );
++
++	init( "WriterEnabled", true );
++	init( "Delay", 0.2 );
++}
++
++QList< MediaKit::Info > MediaKit::getModulesInfo( const bool showDisabled ) const
++{
++	QList< Info > modulesInfo;
++	if ( showDisabled || getBool( "WriterEnabled" ) )
++		modulesInfo += Info( MediaKitWriterName, WRITER, QStringList( "audio" ) );
++	return modulesInfo;
++}
++void *MediaKit::createInstance( const QString &name )
++{
++	if ( name == MediaKitWriterName && getBool( "WriterEnabled" ) )
++		return new MediaKitWriter( *this );
++	return NULL;
++}
++
++MediaKit::SettingsWidget *MediaKit::getSettingsWidget()
++{
++	return new ModuleSettingsWidget( *this );
++}
++
++QMPLAY2_EXPORT_MODULE( MediaKit )
++
++/**/
++
++#include <QDoubleSpinBox>
++#include <QGridLayout>
++#include <QCheckBox>
++#include <QLabel>
++
++ModuleSettingsWidget::ModuleSettingsWidget( Module &module ) :
++	Module::SettingsWidget( module )
++{
++	enabledB = new QCheckBox( tr( "Włączony" ) );
++	enabledB->setChecked( sets().getBool( "WriterEnabled" ) );
++
++	QLabel *delayL = new QLabel( tr( "Opóźnienie" ) + ": " );
++
++	delayB = new QDoubleSpinBox;
++	delayB->setRange( 0.01, 1.0 );
++	delayB->setSingleStep( 0.01 );
++	delayB->setSuffix( " " + tr( "sek" ) );
++	delayB->setValue( sets().getDouble( "Delay" ) );
++
++	QGridLayout *layout = new QGridLayout( this );
++	layout->addWidget( enabledB, 0, 0, 1, 2 );
++	layout->addWidget( delayL, 1, 0, 1, 1 );
++	layout->addWidget( delayB, 1, 1, 1, 1 );
++}
++
++void ModuleSettingsWidget::saveSettings()
++{
++	sets().set( "WriterEnabled", enabledB->isChecked() );
++	sets().set( "Delay", delayB->value() );
++}
+diff --git a/src/modules/MediaKit/MediaKit.hpp b/src/modules/MediaKit/MediaKit.hpp
+new file mode 100644
+index 0000000..16920f6
+--- /dev/null
++++ b/src/modules/MediaKit/MediaKit.hpp
+@@ -0,0 +1,31 @@
++#include <Module.hpp>
++
++class MediaKit : public Module
++{
++public:
++	MediaKit();
++private:
++	QList< Info > getModulesInfo( const bool ) const;
++	void *createInstance( const QString & );
++
++	SettingsWidget *getSettingsWidget();
++};
++
++/**/
++
++#include <QCoreApplication>
++
++class QDoubleSpinBox;
++class QCheckBox;
++
++class ModuleSettingsWidget : public Module::SettingsWidget
++{
++	Q_DECLARE_TR_FUNCTIONS( ModuleSettingsWidget )
++public:
++	ModuleSettingsWidget( Module & );
++private:
++	void saveSettings();
++
++	QCheckBox *enabledB;
++	QDoubleSpinBox *delayB;
++};
+diff --git a/src/modules/MediaKit/MediaKit.png b/src/modules/MediaKit/MediaKit.png
+new file mode 100644
+index 0000000000000000000000000000000000000000..36cb89c5e5200c5b613e4cf005b772df61aef49c
+GIT binary patch
+literal 5396
+zcmV+v73=DWP)<h;3K|Lk000e1NJLTq002M$002M;1^@s6s%dfF000!*Nkl<Zc%1E<
+zd6ZmLoyR}#zE`iRy1J{=omA4@>1<6FprHd1$Uua_7y$_eS%QE%L=ndUbzGUafkzy0
+z5K$OpK;(=98j&Cv0xD}p1ci`D!UV`lmhMivtC#AkuH~(F{<yDRS1-X%!12r(e&^iN
+z^<Lfg>VCh!<^JyP-iCMN9eGFoKa2J^{{5-INx%uf9AG-o2*iOHPz16-C$JUR1Uv)0
+z4)}kA@xEmdz^TAZC=l{6+g{*0V8&Y=(EpYNq<~KVA46#xfD;$A^5ILDFn9KJCQhuS
+zzCKB9Z8bI3Rd}AnvTQ8dp;&b2+@EIC=IuPZW*tvHy}tYk7x)k0TR_j@4D7E>Kojsq
+z;8Q>qz(+1QgAXh{h52o>X_?hX#Lz(-ISj4huQu%3_az;jy{uXLdp`ZSn<^h#jB<}d
+zlD`%Kao|h9SAx%6ckK!;Uj80tAJG(ak$+)GmEc7{QpGi}uRYB@_x*;ifAh}r!&d>f
+zAId=g8U&nyGRqc#?_Pg77hZ5GGpD5(0<Gegl+d5<r)OW9^qvD`_NN(WPgCj}z$+Co
+zlS!&3)l)a4kx4VB(s;ylCO0>r2_qmxfD}CP*dJJS!M~J$|69Pd;~nhVNkAO99{3!<
+z)nB-fPyf@|Oq)6}04zcJNa@qHx0@X=ZDrdN>&b2Z(-^Nx;Z@HCq6oJOt+XZlX2Q{@
+zbNoeTan#9eM9e6lgC=<G`R6%$@yc?yaa+RMMZhfJAz*$g1$W=RlC#fTfUXC?@o{a3
+z?HhNp@mJ5%vteEMpj&l1J=2%ao0?0ywuyA@L^6pQbTdMYX^@B-)ZtKD7+^xCgW5MX
+zl6dhhCd`?_`@eh{lczPJEJ5S7wLj<Ri|#JJdR#H#?I7Tk0Q}@jKXfYBU2_2~GgBa4
+zz{mGIwyxjCpMLUNayvFFI${gxobwU3H5|_$>!y+xItY!Fp%c{w2~#H;(L(~NB05zO
+zotPmoghrK9VB*V9G2!uRxahXeGr74DG#v)|S@VNSIQKi@*i!t3*+GAc;4c8y0JXP&
+z|1z#wxs=J1;vh?aO?qD^Pu#MG|Nhy}u=~4k>dt2S!f*4)30Lya<W{!Ek`&5;O=u)E
+z4MPYtp<(KRs4g%KK}1*05E{A=h)9&ujH9uRUP|X3w=n<AqtJB?qH*TcO~5Fu=b2Xk
+zl}!Ei%>cX=3%D4#56~aH?@G>F)`q6JAYDAyWy@2W*m&o?cs@AhiR?T5YW_6!B)VKd
+zcgZDf```sZQPTno5TFZcOr2`e7}EkG0WpTq&@`y(*v^Gj_t19Qe9#OS=x5*B%b9)!
+zpz?&-z@CGFI9v<309Xa+k3D!5%a$IAh6R);W;6WpN5A8ZUq1qXck=agU3xuTP4gJ^
+zHS(^+@g!LfH4Q+hhJ?^SD1f@qh#5MjA&5tGOkH5=0z;_pgr=HTJCTm3x3lPEsU`+9
+zN^Q?JCRKOwn~exmD!uOQB;XX3*+(8*{g1r=jF!OU^W+Y6^Wyi{klVHqE!Ilp;}77T
+zz8s=)Y)?{fCAKRmdJ@Bz6v{CYK+_ZfnnqM;L<|uU5H$o5QFZ~<gwW754Gr+?8fev@
+zqq;V#-ZfaFA@VXmP&$|e+{!@`4{?a#X8{ib(be~Ug!jL18puJA17!E^<JDVNA$zxC
+zHeN{bE5D)YU8j<a8YCiuWK^d<rc+}Isw0A^p$&IH3F$G0Xb9Cw4{{-0BLrT4yfmqq
+z*S0tyiy#Y7*F<wYEN%nT0&CvE038Yeaa6QV-Tu90oPW+tkU8-C$?x08-v4|A!%1V#
+zz7pfJKO)jF4O7>MM>LYA0zWwsp(d(R6H&n}rO;H6Aji~`9`w;PrF8*lBiMU>`w<}X
+ziiAWQA>h1)VTZ+U2Lb;I%)fMb8!IlIgGLtoEOt6g&o7=J;-&Fte2(4^-GCFX#gh_U
+z(=dca)X<a_n1ZJ2NN5F0okJkX;B7gY1rd_Ku;oFSGi%B$rF~fd-2>pbS>fZy9t@N*
+zPVi>{pHHRWy04x<JX!$1h?mckdH9bQUK%&`NjARk>%>Kj8b<+$>WYAvA*eCI@g-T?
+zCzXhhvwa2)LE4ev2PmW*3XJ|}5_C-)W&R+MzK>f|4}K0b3xs;MsXpv<P!|{v0dZ7r
+z&)v72P0I`o<N(qwQG8+xdcK`P{2U%Q?yD572r1ny4;S#&T&`>Q5sjp;Gb!$qwR8rm
+z3^FB;l<t%Ev?1V9jw*HNLPOUybd6EwF9WWeNKC~eVjv;_#3Et0CJrLwA>d0u%hjK4
+z<Lo8%;Aa5~cT+psfvsr9Jnn72mKUrTsk|FL<oJ?$41^{zb&aSl@FFlNZjiHm`br)X
+zVmbr1r)F!9Fc79HT)?O>eNEFwn7`7#=lkeF1O#|09{{351SAiafF{(Emd{+#f-VL@
+zmhjU#<exX93wSE=ZSJRms-p6{lIvr6mF8=JDZ+s0NkK!xAZvLHSRR>@hvoRBy`b0=
+zfOjigAT<5q_(Sa@C7$gl|3`wQzOS%=_~8=pMIip&Z?@6g=&SkOv*Cqp2n}`{EBS)H
+z0ITFu<Lg+yWKsqAAtDqBQC*`dB1oD#Q)?m&SRTCvm+q3QR4glEL51i+s8;^3;8$wj
+z_B`UnTtI*iC0ji=l;xBThk(hbN)8t;n-oOYBJAox>rLZpZQP_^M0+`-^F3_WSEa0=
+zmE1~aHV{!kL}=7R1&(hpIT2xE-le8cPK^mkNN8|$m4=9FxF{<S49%Jn@O+8qs|A;l
+z?Nj5!2TPeiuJG0fxE!duZsj~?HUs{k(*Da^(KJ}6eSy131`%A6_BB#cquZAheTnT!
+zY<Fbg)}SUTh#7*~C^RMvvb83?1sA*Iv0{qHX>;NnJ0r=Y2{DAG;kqu_e34x}Hh<2T
+z?3A^k_I=;S^*n6XV`i)~$Vh##iU4GW2<SXi0tBjn$;Ic@1*T=g?hF(m&sp4{{he~g
+zuvRNcJE#SY5BL%*Afn*P&>eJPP;CmTB7%lQguLUE%;q?KdWn{%B*|oySWLrnT^!%X
+zwr%WUo`l`ck%b;a)@19%6L5U6JrB!vDA+cq9JLi>;QYA^0DZX-&)!2NU=c9qqsvpw
+zo=IT-7QD6#G*~AtW1VJJ_-cjkdXV;2P)oT!gN`4%gXQ|zo@8oGgc?&PhRvjo7dR$j
+zQ5#L+c^<Z{{8!U7JkO(8ERxM;>FevGr>BQPdplmQgV(YU%W<(?7ss+VX2vsWj2@8L
+z1wii*0oxCifMo#Zystjcz6HH`7z9T<k=u<0q|iv07c*hZsvyEuZlNqfl5>X74inrS
+zc0Y4Jsbm$-lqp!2MX{(%*Rm|6lsJyV;NT$HY?hv$9y&TYXm4+)>(5)LYG}psAaB{!
+zckCo0_5dbioiLBsK4kbC4wZnV0P|Z>;H3i{fS%$N{iCcm;vgj{LE!&#L;@qjIV$bQ
+z&>B2XGH7}9ba$bzyOUH+lp3><LZLt`77M`(Awuov^LhIE`snKFqO-G;&dyG{4jf=Y
+z`!3x2W(p;X%bGR@;{-Cw4Qv<gSr_67HxkA}z*OL<6WgF=ItsjR!vR2tb;gO*XhP-d
+zK3Gzc5@o=?TG5pW3Ee`HF8Sa&6bl7-=0>JO3MBL?<n#Fue5q6-5>b=4<2dB=d9v9o
+z>2#WOI!$+XH(gy_^z`)LbnYfvm7+M1<?OQ`Qop5H(3b{aR~Kwlp71J4ed8wJB!CYu
+zPZ2R3kTw(m&!nUu!voP7#HB_gNK{OzOx%_d%hOaA7tRbaEC?edX<JhN(rTQpZRG3f
+zLhbs#PpMQQ7K@>28d6G1r4qSZj!Y&)e}6yebei7YUIqpR=<Dml$Yv<z^0dCOnONjm
+zAO!<}3L$KIBgFIQ!N4DkfOi4RorMCA1-W{NM0vwF3rv%!?-NC3YeoP#;!8}uk_;J=
+zp@@*AI=8}xdnhH76bc3U`}+Z9_StL}!!Qs+;JPk_LV<ifPbQNYMnpcJ$FeLkwh!4s
+zZuo~af%enG^t^V+>xZZqCjoN+Ce}mfSH%QGbarb;Qf2DIe3hCxK~VF2iS7HizQmJ~
+zxG!;ii6bSp=hN(i<$JK<Asok{P$;15I({(CB@zh?!$8+{JkP^*U5dqGXa%`kj={k}
+za=9GobUGNO$(il1(opw+x*P<8sJ~-B+_x^o^8-{K@aypsFdd-2w&ISPgb3_0rctdM
+zxD}~tIcIl$A3yl)cybge#g4t?Ha$eH;<cXVg^^weMXK-nIF1t%Wm#6J^&#*;q=s9r
+zxO?cjlQ1t?^{l$p+}uoid%FqTk8<tJ;~}6CpthD^dP{>$f@!lSGKsjR<BdT8=pg}R
+zf?QvQ#O&{Wopd@)DwQIa%VFDgXzF@J(q6Uz$8oT2do*x>wk6y!>vigDf{J$mrF{){
+zcf&QS)b09uRS;-zZ;t}E0jG_JfH*)+RRA8qs70D3x<w79HoAyZNeC#H82R1a*PjOn
+zNw6#n%d&_@qodwu1-bkv;ANS68Y`9s8=^kS_l5fWz;o($OG^u&NN8_w2X!vtB;du$
+zSB*tL48Ze(D+xrBxY0UvjB%BbM-qbc*|m9Sm#Pw2DwP`Z{z0W>0lUBaGP>5T#@369
+z`~vp%z|}uh-Qw|~6>v*S3%hph0yvLx5Ksh?mYpV1en+ed>Boq;<0~OXQ02a|*u^5W
+z?;5l3xIkCPC(pl-8B@Nhz?Xmwpo8ndZEJ`6Rk~F<w*XEa`M$9T$O2OWD^y~d=$?+@
+z51|@$rh%Yh6G$ahTGTu^qC=3D72n~GPpuqEzxxOgJoXaYxLSQ~Zf+j-oMD78TSmTf
+zER}Ww6f0NIF%3OxQZF0~p$eV4Hnd5hhxe4`jbPVC1mBrvjOMme-wJkUJ(ZU~vl6Wg
+zJ{OE$hn-#UiGLsJnn)yuJz8N6wTzIl2-phH*;R4JC_=1;X+|#C#tQ&4v_)0fw4mHy
+zVK2;GeE#9UR?@nd-aDUFfmx!Q)KjA`xbTf1L!~DrlgUc0SBf|C##jVw2H3Qv;*Qn{
+zkvKEWzTp5z)ac5hs@oD@1{E9MW9o@Z4h3>3Eh}yyd&kq%*PtT46Tr|w3i!#Ru<FU7
+z{%vh-)YjHwnr29X7e;hO1)Q-6cn09%-+^CV-T6;~p>agj{xJtxF6Wm)`%+bFJWn;p
+z^{8o{!=lf8?+}nL;Odn(v*U`dP!nUw@5^Hn@ZeK$)xQmY?D*r4r>?G!>gsCZ@i>NI
+z;JRV8dQ@FtEIWA}*!$$OOz$`V)0$9uHhY+ss3Mgq(e1^`(8E%I3|R0hh(Jng&qGRy
+z?Rv~O<D-bWMqa=FCem9sjt#tZ2^_PSJr}&f^wbxE>QV&(02(~@dszPE;g4Q&$tBF2
+zH;;}EwJ0cOmzhka+~uY55a0tp1-`N7aky$laMyVl5u3{ywcEJ2?^p#`As+?W3rxQZ
+zT>8GM+_*l8qZZM6^?cI%c2VqZCzsEulDJU?iF$rFa~JQO`(t!-mojyO@@|M4nSjTh
+zg{4;wAM~O{i#Ye(bHk#F5F%V$ZQHi3-0ks^U=MacVg|4SF!sI((;86hi_4JFW&FJT
+z-Mmzs7~mfb-1j^jUk(9xTx{Q`P_nRWhmvJeC|L{?OIRff9GmYLJ2`LmBh)2+t3XFk
+zDOo)Dtd0Tk;8U>tOQQ$8YSk(l8X6cF7@)tupRTSh_V3@%&Ye41yLK(8x?l?<0^z|D
+zy8+bsnuQZ5z-bFpsx;<pLi6GrSyx5ARLdSKjvHv&@jO-2^UA*OQF0uLwu9q(6m50t
+zGhZw*SS*n%Sv1=vt`V<u^R(5xyYYL(%^gEg)f@s2P_W>~zk(Iljvnk?cily6Yb(00
+z4{L^Duwlc7aw>ci@L%J#0DwsZQFG1R@PYTDOwa@THZad+hkFK3rCZogNQN5sg623b
+zCC61|YsaBrIoOUvqEz4l+0H4(D;%46jF_=LoX^7+sURQ%JG<3Xw`!CD!_7C}%)*5W
+zF-;RKD5IB`(Ob4`Vdct|Wren&Qm0|^X8Qs?sD1UPmt798{^4?tYFeW>@i)WZW@bBg
+zFgvlBZ1u_Pc8{TBu!aMr82y&OMk26CdO0SMp-Hqe)!0r`@@XR4meKR4huS0534@*M
+z!K2T^6}Jta=K<!;o5w{LUBuL>QyCl_B#}rEjYcsHgIFwvZQDHhXjlxoZY=Qd<`z(v
+zD}f&Zyt@8+j+(L)@^`Djx~PSSjhdg!e_e*=>vEF}kL2ZF_kzBXA>WU{z8u{41l;(m
+z(F1C2ZKbWPjTtj$(A3mKDwPVSKGQT2Lh#F9{*oJSyb)AEbW!jtqhvgbyY(m|{rex@
+z^%M(Ey^wkHKL$=cSZTFeT%MmjMo(KKxB2~ms3NM0Q({<H+T8;`S_eySgy&ux{%CV^
+zGc#w-q^_<GDJ8D!BBewK5&FFlg6E!lj%%;I7L@6q#TW_Dp%4J-lvNs7`iuLY#)#K5
+z>$o$iZMhh#mw<jOXtRK6KnlDn#hG6ZUKE@JloF6Hs38?mR#GNNgB?Ba!{5UP?|>&?
+z9S*v&v5|&`hA_wXg5089Jn=jaUDwexjTc{hk*|I2YoIj#LEfY!4u^hD@IAoO<%`>H
+z{b!baU=dRr>k+;Ub`c60)iV2`Zy#jSkn4it02D27(%^&R!Oje9>V&mh;l7HzsHLTa
+zcsxFANjp*u!yu7JkVqt`udgSSO3~5L!Rpnk%iu2o9{fvy4(FicB;XsU*kAxGS+an0
+z&soHA$4sXwRZYw<5_K}ftO4|a4szXHWV*ZQ>+7SpH_i4g_}R;_zJ2(Mo12@%GS+y+
+zFbv}HI6??IIy%Zlj{#sg@WgoD@m5ZX&Hz3RtRN_)9)`S%s@uPTs@|H1LPEJ<8qD*c
+z%>Bc>$zI?{c{>hE3)CT`#i-L*^H3*ClBhhc6tqrMHnttLSGS(wJ2vN{s<%;4ZV-t?
+z!g4tb6->vd5)YuJx?4F&wEw>%ZNRe(pF`fP?FGILjNflY$lv<k=Ef3%`Zv1sQ8m04
+yR3*nl%|zQ#*7G><0%H_8-jR3Y9eGE_EB^yvNfC*>uwT*u0000<MNUMnLSTZ?Yewh*
+
+literal 0
+HcmV?d00001
+
+diff --git a/src/modules/MediaKit/MediaKit.pro b/src/modules/MediaKit/MediaKit.pro
+new file mode 100644
+index 0000000..bf0c648
+--- /dev/null
++++ b/src/modules/MediaKit/MediaKit.pro
+@@ -0,0 +1,21 @@
++TEMPLATE = lib
++CONFIG += plugin
++
++QT += widgets
++
++DESTDIR = ../../../app/lib/qmplay2/modules
++
++QMAKE_LIBDIR += ../../../app/lib
++LIBS += -lqmplay2 -lmedia -lbe
++
++OBJECTS_DIR = build/obj
++MOC_DIR = build/moc
++RCC_DIR = build/rcc
++
++RESOURCES += icon.qrc
++
++INCLUDEPATH += . ../../qmplay2/headers
++DEPENDPATH += . ../../qmplay2/headers
++
++HEADERS += MediaKit.hpp MediaKitoWriter.hpp SndPlayer.hpp RingBuffer.hpp
++SOURCES += MediaKit.cpp MediaKitWriter.cpp SndPlayer.cpp RingBuffer.cpp
+diff --git a/src/modules/MediaKit/MediaKitWriter.cpp b/src/modules/MediaKit/MediaKitWriter.cpp
+new file mode 100644
+index 0000000..f8fad50
+--- /dev/null
++++ b/src/modules/MediaKit/MediaKitWriter.cpp
+@@ -0,0 +1,85 @@
++#include <MediaKitWriter.hpp>
++#include <QMPlay2Core.hpp>
++
++MediaKitWriter::MediaKitWriter( Module &module ) :
++	err( false )
++{
++	addParam( "delay" );
++	addParam( "chn" );
++	addParam( "rate" );
++
++	SetModule( module );
++}
++
++bool MediaKitWriter::set()
++{
++	if ( player.delay != sets().getDouble( "Delay" ) )
++	{
++		player.delay = sets().getDouble( "Delay" );
++		return false;
++	}
++	return sets().getBool( "WriterEnabled" );
++}
++
++bool MediaKitWriter::readyWrite() const
++{
++	return !err && player.isOpen();
++}
++
++bool MediaKitWriter::processParams( bool * )
++{
++	bool resetAudio = false;
++
++	uchar chn = getParam( "chn" ).toUInt();
++	if ( player.channels != chn )
++	{
++		resetAudio = true;
++		player.channels = chn;
++	}
++	uint rate = getParam( "rate" ).toUInt();
++	if ( player.sample_rate != rate )
++	{
++		resetAudio = true;
++		player.sample_rate = rate;
++	}
++
++	if ( resetAudio || err )
++	{
++		player.stop();
++		err = !player.start();
++		if ( !err )
++			modParam( "delay", player.delay );
++		else
++			QMPlay2Core.logError( "MediaKitWriter :: " + tr ( "Nie można otworzyć strumienia wyjścia dźwięku" ) );
++	}
++
++	return readyWrite();
++}
++qint64 MediaKitWriter::write( const QByteArray &arr )
++{
++	if ( !arr.size() || !readyWrite() )
++		return 0;
++
++	err = !player.write( arr );
++	if ( err )
++	{
++		QMPlay2Core.logError( "MediaKitWriter :: " + tr ( "Błąd podczas odtwarzania" ) );
++		return 0;
++	}
++
++	return arr.size();
++}
++
++qint64 MediaKitWriter::size() const
++{
++	return -1;
++}
++QString MediaKitWriter::name() const
++{
++	return MediaKitWriterName;
++}
++
++bool MediaKitWriter::open()
++{
++	return player.isOK();
++}
+diff --git a/src/modules/MediaKit/MediaKitWriter.hpp b/src/modules/MediaKit/MediaKitWriter.hpp
+new file mode 100644
+index 0000000..28fa249
+--- /dev/null
++++ b/src/modules/MediaKit/MediaKitWriter.hpp
+@@ -0,0 +1,30 @@
++#include <Writer.hpp>
++#include <SndPlayer.hpp>
++
++#include <QCoreApplication>
++
++class MediaKitWriter : public Writer
++{
++	Q_DECLARE_TR_FUNCTIONS( MediaKitWriter )
++public:
++	MediaKitWriter( Module & );
++private:
++	bool set();
++
++	bool readyWrite() const;
++
++	bool processParams( bool *paramsCorrected );
++	qint64 write( const QByteArray & );
++
++	qint64 size() const;
++	QString name() const;
++
++	bool open();
++
++	/**/
++
++	SndPlayer player;
++	bool err;
++};
++
++#define MediaKitWriterName "MediaKit Writer"
+diff --git a/src/modules/MediaKit/RingBuffer.cpp b/src/modules/MediaKit/RingBuffer.cpp
+new file mode 100644
+index 0000000..915becc
+--- /dev/null
++++ b/src/modules/MediaKit/RingBuffer.cpp
+@@ -0,0 +1,129 @@
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++
++#include "RingBuffer.hpp"
++
++RingBuffer::RingBuffer( int size )
++{
++	 initialized = false;
++     Buffer = new unsigned char[size];
++     if(Buffer!=NULL) {
++     	memset( Buffer, 0, size );
++	    BufferSize = size;     	
++     } else {
++     	BufferSize = 0;
++     }
++     reader = 0;
++     writer = 0;
++     writeBytesAvailable = size;
++     if((locker=create_sem(1,"locker")) >= B_OK) {
++     	initialized = true;
++     } else {
++     	if(Buffer!=NULL) {
++     		delete[] Buffer;     		
++     	}
++     }
++}
++
++RingBuffer::~RingBuffer( )
++{
++	 if(initialized) {
++     	delete[] Buffer;
++     	delete_sem(locker);
++	 }
++}
++
++bool 
++RingBuffer::Empty( void )
++{
++     memset( Buffer, 0, BufferSize );
++     reader = 0;
++     writer = 0;
++     writeBytesAvailable = BufferSize;
++     return true;
++}
++
++int 
++RingBuffer::Read( unsigned char *data, int size )
++{	
++	 acquire_sem(locker);
++	 
++     if( data == 0 || size <= 0 || writeBytesAvailable == BufferSize ) {
++     	 release_sem(locker);
++         return 0;
++     }
++
++     int readBytesAvailable = BufferSize - writeBytesAvailable;
++
++     if( size > readBytesAvailable ) {
++         size = readBytesAvailable;
++     }
++
++     if(size > BufferSize - reader) {
++         int len = BufferSize - reader;
++         memcpy(data, Buffer + reader, len);
++         memcpy(data + len, Buffer, size-len);
++     } else {
++         memcpy(data, Buffer + reader, size);
++     }
++
++     reader = (reader + size) % BufferSize;
++     writeBytesAvailable += size;
++	 
++	 release_sem(locker);
++     return size;
++}
++
++int 
++RingBuffer::Write( unsigned char *data, int size )
++{
++	 acquire_sem(locker);
++	 
++     if( data == 0 || size <= 0 || writeBytesAvailable == 0 ) {
++     	 release_sem(locker);
++         return 0;
++     }
++
++     if( size > writeBytesAvailable ) {
++         size = writeBytesAvailable;
++     }
++
++     if(size > BufferSize - writer) {
++         int len = BufferSize - writer;
++         memcpy(Buffer + writer, data, len);
++         memcpy(Buffer, data+len, size-len);
++     } else {
++         memcpy(Buffer + writer, data, size);
++     }
++
++     writer = (writer + size) % BufferSize;
++     writeBytesAvailable -= size;
++
++	 release_sem(locker);	 
++     return size;
++}
++
++int 
++RingBuffer::GetSize( void )
++{
++     return BufferSize;
++}
++
++int 
++RingBuffer::GetWriteAvailable( void )
++{
++     return writeBytesAvailable;
++}
++
++int 
++RingBuffer::GetReadAvailable( void )
++{
++     return BufferSize - writeBytesAvailable;
++}
++
++status_t 
++RingBuffer::InitCheck( void )
++{
++	return initialized?B_OK:B_ERROR;
++}
+diff --git a/src/modules/MediaKit/RingBuffer.hpp b/src/modules/MediaKit/RingBuffer.hpp
+new file mode 100644
+index 0000000..4715632
+--- /dev/null
++++ b/src/modules/MediaKit/RingBuffer.hpp
+@@ -0,0 +1,31 @@
++#ifndef __RING_BUFFER_H__
++#define __RING_BUFFER_H__
++
++#include <OS.h>
++
++class RingBuffer {
++
++public:
++     RingBuffer(int size);
++     ~RingBuffer();
++     int Read( unsigned char* dataPtr, int numBytes );
++     int Write( unsigned char *dataPtr, int numBytes );
++     
++     bool Empty( void );
++     int GetSize( );
++     int GetWriteAvailable( );
++     int GetReadAvailable( );
++     status_t InitCheck( );
++private:
++     unsigned char *Buffer;
++     int BufferSize;
++     int reader;
++     int writer;
++     int writeBytesAvailable;
++     
++     sem_id locker;
++     
++     bool 	initialized;
++};
++
++#endif
+diff --git a/src/modules/MediaKit/SndPlayer.cpp b/src/modules/MediaKit/SndPlayer.cpp
+new file mode 100644
+index 0000000..ca7ad89
+--- /dev/null
++++ b/src/modules/MediaKit/SndPlayer.cpp
+@@ -0,0 +1,103 @@
++#include <SndPlayer.hpp>
++
++#include <string.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <SoundPlayer.h>
++
++
++static void proc(void *cookie, void *buffer, size_t len, const media_raw_audio_format &format)
++{
++	RingBuffer *ring = (RingBuffer*)cookie;
++	unsigned char* ptr = (unsigned char*)buffer;
++	
++	int readed = ring->Read(ptr,len);
++	
++	if(readed <len)
++		memset(ptr+readed, 0, len - readed);
++}
++
++SndPlayer::SndPlayer()
++{	
++	channels = sample_rate = delay = 0;
++	player = NULL;
++	_isOK = true;	
++}
++
++bool SndPlayer::start()
++{
++	int gSoundBufferSize = 8192 * sizeof(float);
++		
++	media_raw_audio_format form = {
++		sample_rate,
++		channels,
++		media_raw_audio_format::B_AUDIO_FLOAT,
++		B_MEDIA_LITTLE_ENDIAN,
++		gSoundBufferSize
++	};
++	
++	ring = new RingBuffer(gSoundBufferSize * 3);
++	if(ring->InitCheck() != B_OK) {
++		delete ring; ring = 0;
++		return false;
++	}
++			
++	player = new BSoundPlayer(&form, "QMPlay2_BSoundPlayer", proc, NULL, (void*)ring);
++	
++	if(player->InitCheck() != B_OK) {
++		delete player;
++		player = NULL;
++		return false;
++	}
++	
++	player->Start();
++	player->SetHasData(true);	
++
++	_isOK = true;
++
++	return player;
++}
++void SndPlayer::stop()
++{
++	if ( player )
++	{
++		if(player) {
++			player->Stop();
++			delete player;
++			delete ring;
++		}
++	
++		player = NULL;
++		ring = NULL;
++	}	
++}
++
++double SndPlayer::getLatency()
++{
++	double lat = player->Latency() / (ring->GetSize()*4.0);	
++
++	return lat;
++}
++
++bool SndPlayer::write( const QByteArray &arr )
++{
++	int s = arr.size();
++	while ( s > 0 && s % 4 )
++		s--;
++	if ( s <= 0 )
++		return false;
++
++	int len=s;
++
++	unsigned char *src_ptr = (unsigned char *)arr.data();
++	
++	for(;;) {
++			int len2 = ring->Write(src_ptr,len);
++			if(len2 == len)break;
++			len -= len2;
++			src_ptr += len2;
++			snooze(100);
++	}
++		
++	return true;
++}
+diff --git a/src/modules/MediaKit/SndPlayer.hpp b/src/modules/MediaKit/SndPlayer.hpp
+new file mode 100644
+index 0000000..b0ca8c2
+--- /dev/null
++++ b/src/modules/MediaKit/SndPlayer.hpp
+@@ -0,0 +1,49 @@
++#ifndef PULSE_HPP
++#define PULSE_HPP
++
++#include <QByteArray>
++
++#include <SoundPlayer.h>
++
++#include <Window.h>
++#include <View.h>
++#include <TextControl.h>
++
++#include "RingBuffer.hpp"
++
++class SndPlayer
++{
++public:
++	SndPlayer();
++	inline ~SndPlayer()
++	{
++		stop();
++	}
++
++	inline bool isOK() const
++	{
++		return _isOK;
++	}
++	inline bool isOpen() const
++	{
++		return player;
++	}
++
++	bool start();
++	void stop();
++
++	double getLatency();
++
++	bool write( const QByteArray & );
++
++	double delay;
++	uchar channels;
++	uint sample_rate;
++		
++private:
++	bool _isOK;
++	BSoundPlayer *player;
++	RingBuffer *ring;
++};
++
++#endif
+diff --git a/src/modules/MediaKit/icon.qrc b/src/modules/MediaKit/icon.qrc
+new file mode 100644
+index 0000000..24b4ebd
+--- /dev/null
++++ b/src/modules/MediaKit/icon.qrc
+@@ -0,0 +1,3 @@
++<RCC><qresource>
++	<file alias="MediaKit">MediaKit.png</file>
++</qresource></RCC>
+diff --git a/src/qmplay2/QMPlay2Core.cpp b/src/qmplay2/QMPlay2Core.cpp
+index 9506f86..2bb12ee 100644
+--- a/src/qmplay2/QMPlay2Core.cpp
++++ b/src/qmplay2/QMPlay2Core.cpp
+@@ -167,7 +167,7 @@ void QMPlay2CoreClass::init(bool loadModules, bool modulesInSubdirs, const QStri
+ 		settingsDir = QCoreApplication::applicationDirPath() + "/settings/";
+ 	else
+ 	{
+-#if defined(Q_OS_WIN)
++#if defined(Q_OS_WIN) || defined(Q_OS_HAIKU)
+ 		settingsDir = QFileInfo(QSettings(QSettings::IniFormat, QSettings::UserScope, QString()).fileName()).absolutePath() + "/QMPlay2/";
+ #elif defined(Q_OS_MAC)
+ 		settingsDir = Functions::cleanPath(QStandardPaths::standardLocations(QStandardPaths::DataLocation).value(0, settingsDir));
+@@ -363,6 +363,11 @@ QStringList QMPlay2CoreClass::getModules(const QString &type, int typeLen) const
+ #elif defined Q_OS_WIN
+ 	if (type == "videoWriters")
+ 		defaultModules << "OpenGL 2" << "DirectDraw";
++#elif defined Q_OS_HAIKU
++	if ( type == "videoWriters" )
++		defaultModules << "QPainter";
++	else if ( type == "audioWriters" )
++		defaultModules << "MediaKit";
+ #endif
+ 	if (type == "decoders")
+ 		defaultModules << "FFmpeg Decoder";
+-- 
+2.12.2
+
+
+From a0028de97e0bcfbbffb28587f773b0d548e84c2a Mon Sep 17 00:00:00 2001
+From: Khaled Berraoui <khallebal@gmail.com>
+Date: Wed, 14 Jun 2017 17:25:43 +0100
+Subject: Switch to Cmake build
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ebea6b6..5a5b191 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -64,6 +64,12 @@ else()
+     set(DEFAULT_CUVID ON)
+ endif()
+ 
++if(HAIKU)
++	set(DEFAULT_MEDIAKIT ON)
++else()
++	set(DEFAULT_MEDIAKIT OFF)
++endif()
++
+ add_definitions(-D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -DQT_USE_FAST_OPERATOR_PLUS)
+ 
+ if(WIN32)
+@@ -81,7 +87,7 @@ if(USE_QT5 AND NOT Qt5Widgets_FOUND)
+     find_package(Qt5Widgets REQUIRED)
+ endif()
+ 
+-if(NOT WIN32 AND NOT APPLE)
++if(NOT WIN32 AND NOT APPLE AND NOT HAIKU)
+     option(USE_FREEDESKTOP_NOTIFICATIONS "Use Freedesktop notifications" ON)
+     add_feature_info("Freedesktop notifications" USE_FREEDESKTOP_NOTIFICATIONS "Use Freedesktop notifications")
+ endif()
+@@ -110,6 +116,9 @@ add_feature_info(libass USE_LIBASS "Build with libass support")
+ option(USE_INPUTS "Build with Inputs module" ON)
+ add_feature_info(Inputs USE_INPUTS "Build with Inputs module")
+ 
++option(USE_MEDIAKIT "Build with MediaKit module" ON)
++add_feature_info(MediaKit USE_MEDIAKIT "Build with MediaKit module")
++
+ option(USE_MODPLUG "Build with Modplug module" ON)
+ add_feature_info(Modplug USE_MODPLUG "Build with Modplug module")
+ 
+@@ -326,7 +335,7 @@ if(APPLE)
+     set(DEFAULT_INSTALL_RPATH ON)
+ endif()
+ 
+-if(NOT WIN32 AND NOT APPLE)
++if(NOT WIN32 AND NOT APPLE AND NOT HAIKU)
+     # RPATH
+     option(SET_INSTALL_RPATH "Set RPATH for executable after install" ${DEFAULT_INSTALL_RPATH})
+ 
+@@ -339,7 +348,7 @@ if(LANGUAGES)
+     add_subdirectory(lang)
+ endif()
+ 
+-if(WIN32)
++if(WIN32 OR HAIKU)
+     install(FILES AUTHORS ChangeLog LICENSE TODO README.md DESTINATION ${CMAKE_INSTALL_PREFIX})
+ else()
+     install(FILES AUTHORS ChangeLog LICENSE TODO README.md DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/qmplay2")
+diff --git a/lang/CMakeLists.txt b/lang/CMakeLists.txt
+index f5f86be..9b4fcf7 100644
+--- a/lang/CMakeLists.txt
++++ b/lang/CMakeLists.txt
+@@ -21,7 +21,7 @@ endif()
+ 
+ add_custom_target(translations ALL DEPENDS ${QM_FILES})
+ 
+-if(WIN32)
++if(WIN32 OR HAIKU)
+     install(FILES ${QM_FILES} DESTINATION "lang/")
+ else()
+     install(FILES ${QM_FILES} DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/qmplay2/lang")
+diff --git a/src/gui/CMakeLists.txt b/src/gui/CMakeLists.txt
+index 5853dc9..6adc25b 100644
+--- a/src/gui/CMakeLists.txt
++++ b/src/gui/CMakeLists.txt
+@@ -210,7 +210,7 @@ elseif(USE_TAGLIB)
+     target_link_libraries(${PROJECT_NAME} ${TAGLIB_LIBRARIES})
+ endif()
+ 
+-if(WIN32)
++if(WIN32 OR HAIKU)
+     install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/)
+ elseif(APPLE)
+     install(TARGETS ${PROJECT_NAME} BUNDLE DESTINATION ${CMAKE_INSTALL_PREFIX})
+diff --git a/src/modules/CMakeLists.txt b/src/modules/CMakeLists.txt
+index 203c68d..f2f3240 100644
+--- a/src/modules/CMakeLists.txt
++++ b/src/modules/CMakeLists.txt
+@@ -7,6 +7,9 @@ if(WIN32)
+ elseif(APPLE)
+     set(MODULES_INSTALL_PATH "${CMAKE_INSTALL_LIBDIR}/modules")
+     set(QMPLAY2_MODULE SHARED) # otherwise CMake uses ".so" extension
++elseif(HAIKU)
++	set(MODULES_INSTALL_PATH "modules")
++	set(QMPLAY2_MODULE MODULE)
+ else()
+     set(MODULES_INSTALL_PATH "${CMAKE_INSTALL_LIBDIR}/qmplay2/modules")
+     set(QMPLAY2_MODULE MODULE)
+@@ -77,6 +80,10 @@ if(WIN32)
+     add_subdirectory(FileAssociation)
+ endif()
+ 
++if(HAIKU)
++	add_subdirectory(MediaKit)
++endif()
++
+ if(USE_CUVID)
+     add_subdirectory(CUVID)
+ endif()
+diff --git a/src/modules/MediaKit/CMakeLists.txt b/src/modules/MediaKit/CMakeLists.txt
+new file mode 100644
+index 0000000..56232f3
+--- /dev/null
++++ b/src/modules/MediaKit/CMakeLists.txt
+@@ -0,0 +1,63 @@
++cmake_minimum_required(VERSION 2.8.6)
++if(COMMAND cmake_policy)
++    if(POLICY CMP0003)
++        cmake_policy(SET CMP0003 NEW)
++    endif()
++    if(POLICY CMP0020)
++        cmake_policy(SET CMP0020 NEW)
++    endif()
++    if(POLICY CMP0042)
++        cmake_policy(SET CMP0042 NEW)
++    endif()
++    if(POLICY CMP0043)
++        cmake_policy(SET CMP0043 NEW)
++    endif()
++endif()
++project(MediaKit)
++
++set(MediaKit_HDR
++    MediaKit.hpp
++    MediaKitWriter.hpp
++    SndPlayer.hpp
++    RingBuffer.hpp
++)
++
++set(MediaKit_SRC
++    MediaKit.cpp
++    MediaKitWriter.cpp
++    SndPlayer.cpp
++    RingBuffer.cpp
++)
++
++set(MediaKit_RESOURCES
++    icon.qrc
++)
++
++if(USE_QT5)
++    qt5_add_resources(MediaKit_RESOURCES_RCC ${MediaKit_RESOURCES})
++else()
++    qt4_add_resources(MediaKit_RESOURCES_RCC ${MediaKit_RESOURCES})
++endif()
++
++include_directories(../../qmplay2/headers)
++
++add_library(${PROJECT_NAME} ${QMPLAY2_MODULE}
++    ${MediaKit_HDR}
++    ${MediaKit_SRC}
++    ${MediaKit_RESOURCES_RCC}
++)
++
++if(USE_QT5)
++    qt5_use_modules(${PROJECT_NAME} Gui Widgets)
++else()
++    target_link_libraries(${PROJECT_NAME} Qt4::QtCore Qt4::QtGui)
++endif()
++
++add_dependencies(${PROJECT_NAME} libqmplay2)
++target_link_libraries(${PROJECT_NAME}
++    ${qmplay2lib}
++    media
++    be
++)
++
++install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${MODULES_INSTALL_PATH})
+diff --git a/src/qmplay2/CMakeLists.txt b/src/qmplay2/CMakeLists.txt
+index c41de09..36da55d 100644
+--- a/src/qmplay2/CMakeLists.txt
++++ b/src/qmplay2/CMakeLists.txt
+@@ -234,6 +234,9 @@ else()
+     if(USE_LIBASS)
+         list(APPEND LIBQMPLAY2_LIBS ${LIBASS_LIBRARIES})
+     endif()
++    if(USE_MEDIAKIT)
++    	list(APPEND LIBQMPLAY2_LIBS ${LIBMEDIA_LIBRARIES})
++    endif()
+ endif()
+ 
+ target_link_libraries(${PROJECT_NAME} ${LIBQMPLAY2_LIBS})
+-- 
+2.12.2
+

--- a/media-video/qmplay2/patches/qmplay2_x86-17.06.09.patchset
+++ b/media-video/qmplay2/patches/qmplay2_x86-17.06.09.patchset
@@ -1,0 +1,1036 @@
+From 1cdc4c21c4160b89a995eae9bb6b3a43d61c5e41 Mon Sep 17 00:00:00 2001
+From: Gerasim Troeglazov <3dEyes@gmail.com>
+Date: Thu, 15 Jun 2017 01:41:55 +0000
+Subject: Add Haiku support
+
+
+diff --git a/haiku/QMPlay2.rdef b/haiku/QMPlay2.rdef
+new file mode 100644
+index 0000000..e70bab0
+--- /dev/null
++++ b/haiku/QMPlay2.rdef
+@@ -0,0 +1,42 @@
++resource app_signature "application/x-vnd.QMPlay2";
++resource app_flags B_MULTIPLE_LAUNCH;
++resource app_version {
++	major  = 17,
++	middle = 04,
++	minor  = 21,
++
++	/* Application "variety" can be set to one of the following:
++	*	B_APPV_DEVELOPMENT,
++	*	B_APPV_ALPHA,
++	*	B_APPV_BETA,
++	*	B_APPV_GAMMA,
++	*	B_APPV_GOLDEN_MASTER,
++	*	B_APPV_FINAL
++	*/
++	variety = B_APPV_DEVELOPMENT,
++	internal = 0,
++
++	short_info = "QMPlay2",
++	long_info = "QMPlay2 © 2010-2017 Błażej Szczygieł"
++};
++
++resource file_types message {
++	"types" = "video",
++	"types" = "audio"
++};
++
++resource vector_icon array {
++	$"6E63696602012C165AF20314D77803000DB4D0B47BB4D0B47BB5A4B493B717B5"
++	$"6DB659B515BCBFB846C814BDF0C26CBB17C8CEBE53CA3FBF23C99BBE9CCA9ABF"
++	$"6BCA35C053CA92C00FC985C0E0C7E7C196C8ADC12DC276C452B78EC9BFBD01C7"
++	$"06B6C1CA20B523CAD9B601CAA4B4ACCAF9B426CA1EB421CA9DB41FC965B46DC7"
++	$"FBB44EC8B0B561C2E0B4A9B879B57FBD9BB485B770B428B55FB438B66BB41CB4"
++	$"F6B4D0B47BB466B48CB4D0B47B0209B627B6EDB6A3B714B640B838B6A7BACAB6"
++	$"89B97FB6F3BD1FB6E1C1D3B6F0BF7BB6D1C408B623C864B659C633B71AC816B8"
++	$"DBC716B7F4C787BC65C561C369C1D7BFF0C3ADC4D7C11DC7BDBFBFC64EC075C7"
++	$"1DBF3FC5A7BE96C65EBEEFC0EEBC47B790B783BC40B9E3B71CB7480209B627B6"
++	$"EDB640B838B6A3B714B790B783B71CB748BC40B9E3C5A7BE96C0EEBC47C65EBE"
++	$"EFC7BDBFBFC71DBF3FC64EC075C369C1D7C4D7C11DBFF0C3ADB8DBC716BC65C5"
++	$"61B7F4C787B623C864B71AC816B659C633B6E1C1D3B6D1C408B6F0BF7BB6A7BA"
++	$"CAB6F3BD1FB689B97F020A00020001000A01010200"
++};
+diff --git a/src/gui/Main.cpp b/src/gui/Main.cpp
+index a5a2c48..bb81eeb 100644
+--- a/src/gui/Main.cpp
++++ b/src/gui/Main.cpp
+@@ -456,6 +456,9 @@ int main(int argc, char *argv[])
+ 	signal(SIGTERM, signal_handler);
+ 	atexit(exitProcedure);
+ 
++#ifdef Q_OS_HAIKU
++	setenv("HOME", "/boot/home", 1);
++#endif
+ #if (defined(Q_OS_MAC) || defined(Q_OS_WIN)) && (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+ 	QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+ #endif
+@@ -544,7 +547,7 @@ int main(int argc, char *argv[])
+ 	}
+ 	if (!cmakeBuildFound)
+ 	{
+-#if !defined Q_OS_WIN && !defined Q_OS_MAC && !defined Q_OS_ANDROID
++#if !defined Q_OS_WIN && !defined Q_OS_MAC && !defined Q_OS_ANDROID && !defined Q_OS_HAIKU
+ 		sharePath = QCoreApplication::applicationDirPath() + "/../share/qmplay2";
+ 		libPath = QMPlay2CoreClass::getLibDir();
+ 		if (libPath.isEmpty() || !QDir(libPath).exists("qmplay2"))
+diff --git a/src/gui/MainWidget.cpp b/src/gui/MainWidget.cpp
+index 0962259..7ecd6d2 100644
+--- a/src/gui/MainWidget.cpp
++++ b/src/gui/MainWidget.cpp
+@@ -158,7 +158,7 @@ MainWidget::MainWidget(QPair<QStringList, QStringList> &arguments) :
+ 		setIconSize({22, 22});
+ 
+ 	SettingsWidget::InitSettings();
+-#ifndef Q_OS_ANDROID
++#if !defined Q_OS_ANDROID || !defined Q_OS_HAIKU
+ 	settings.init("MainWidget/WidgetsLocked", false);
+ #else
+ 	settings.init("MainWidget/WidgetsLocked", true);
+diff --git a/src/modules/MediaKit/MediaKit.cpp b/src/modules/MediaKit/MediaKit.cpp
+new file mode 100644
+index 0000000..16e99c4
+--- /dev/null
++++ b/src/modules/MediaKit/MediaKit.cpp
+@@ -0,0 +1,65 @@
++#include <MediaKit.hpp>
++#include <MediaKitWriter.hpp>
++
++MediaKit::MediaKit() :
++	Module( "MediaKit" )
++{
++	m_icon = QIcon( ":/MediaKit" );
++
++	init( "WriterEnabled", true );
++	init( "Delay", 0.2 );
++}
++
++QList< MediaKit::Info > MediaKit::getModulesInfo( const bool showDisabled ) const
++{
++	QList< Info > modulesInfo;
++	if ( showDisabled || getBool( "WriterEnabled" ) )
++		modulesInfo += Info( MediaKitWriterName, WRITER, QStringList( "audio" ) );
++	return modulesInfo;
++}
++void *MediaKit::createInstance( const QString &name )
++{
++	if ( name == MediaKitWriterName && getBool( "WriterEnabled" ) )
++		return new MediaKitWriter( *this );
++	return NULL;
++}
++
++MediaKit::SettingsWidget *MediaKit::getSettingsWidget()
++{
++	return new ModuleSettingsWidget( *this );
++}
++
++QMPLAY2_EXPORT_MODULE( MediaKit )
++
++/**/
++
++#include <QDoubleSpinBox>
++#include <QGridLayout>
++#include <QCheckBox>
++#include <QLabel>
++
++ModuleSettingsWidget::ModuleSettingsWidget( Module &module ) :
++	Module::SettingsWidget( module )
++{
++	enabledB = new QCheckBox( tr( "Włączony" ) );
++	enabledB->setChecked( sets().getBool( "WriterEnabled" ) );
++
++	QLabel *delayL = new QLabel( tr( "Opóźnienie" ) + ": " );
++
++	delayB = new QDoubleSpinBox;
++	delayB->setRange( 0.01, 1.0 );
++	delayB->setSingleStep( 0.01 );
++	delayB->setSuffix( " " + tr( "sek" ) );
++	delayB->setValue( sets().getDouble( "Delay" ) );
++
++	QGridLayout *layout = new QGridLayout( this );
++	layout->addWidget( enabledB, 0, 0, 1, 2 );
++	layout->addWidget( delayL, 1, 0, 1, 1 );
++	layout->addWidget( delayB, 1, 1, 1, 1 );
++}
++
++void ModuleSettingsWidget::saveSettings()
++{
++	sets().set( "WriterEnabled", enabledB->isChecked() );
++	sets().set( "Delay", delayB->value() );
++}
+diff --git a/src/modules/MediaKit/MediaKit.hpp b/src/modules/MediaKit/MediaKit.hpp
+new file mode 100644
+index 0000000..16920f6
+--- /dev/null
++++ b/src/modules/MediaKit/MediaKit.hpp
+@@ -0,0 +1,31 @@
++#include <Module.hpp>
++
++class MediaKit : public Module
++{
++public:
++	MediaKit();
++private:
++	QList< Info > getModulesInfo( const bool ) const;
++	void *createInstance( const QString & );
++
++	SettingsWidget *getSettingsWidget();
++};
++
++/**/
++
++#include <QCoreApplication>
++
++class QDoubleSpinBox;
++class QCheckBox;
++
++class ModuleSettingsWidget : public Module::SettingsWidget
++{
++	Q_DECLARE_TR_FUNCTIONS( ModuleSettingsWidget )
++public:
++	ModuleSettingsWidget( Module & );
++private:
++	void saveSettings();
++
++	QCheckBox *enabledB;
++	QDoubleSpinBox *delayB;
++};
+diff --git a/src/modules/MediaKit/MediaKit.png b/src/modules/MediaKit/MediaKit.png
+new file mode 100644
+index 0000000000000000000000000000000000000000..36cb89c5e5200c5b613e4cf005b772df61aef49c
+GIT binary patch
+literal 5396
+zcmV+v73=DWP)<h;3K|Lk000e1NJLTq002M$002M;1^@s6s%dfF000!*Nkl<Zc%1E<
+zd6ZmLoyR}#zE`iRy1J{=omA4@>1<6FprHd1$Uua_7y$_eS%QE%L=ndUbzGUafkzy0
+z5K$OpK;(=98j&Cv0xD}p1ci`D!UV`lmhMivtC#AkuH~(F{<yDRS1-X%!12r(e&^iN
+z^<Lfg>VCh!<^JyP-iCMN9eGFoKa2J^{{5-INx%uf9AG-o2*iOHPz16-C$JUR1Uv)0
+z4)}kA@xEmdz^TAZC=l{6+g{*0V8&Y=(EpYNq<~KVA46#xfD;$A^5ILDFn9KJCQhuS
+zzCKB9Z8bI3Rd}AnvTQ8dp;&b2+@EIC=IuPZW*tvHy}tYk7x)k0TR_j@4D7E>Kojsq
+z;8Q>qz(+1QgAXh{h52o>X_?hX#Lz(-ISj4huQu%3_az;jy{uXLdp`ZSn<^h#jB<}d
+zlD`%Kao|h9SAx%6ckK!;Uj80tAJG(ak$+)GmEc7{QpGi}uRYB@_x*;ifAh}r!&d>f
+zAId=g8U&nyGRqc#?_Pg77hZ5GGpD5(0<Gegl+d5<r)OW9^qvD`_NN(WPgCj}z$+Co
+zlS!&3)l)a4kx4VB(s;ylCO0>r2_qmxfD}CP*dJJS!M~J$|69Pd;~nhVNkAO99{3!<
+z)nB-fPyf@|Oq)6}04zcJNa@qHx0@X=ZDrdN>&b2Z(-^Nx;Z@HCq6oJOt+XZlX2Q{@
+zbNoeTan#9eM9e6lgC=<G`R6%$@yc?yaa+RMMZhfJAz*$g1$W=RlC#fTfUXC?@o{a3
+z?HhNp@mJ5%vteEMpj&l1J=2%ao0?0ywuyA@L^6pQbTdMYX^@B-)ZtKD7+^xCgW5MX
+zl6dhhCd`?_`@eh{lczPJEJ5S7wLj<Ri|#JJdR#H#?I7Tk0Q}@jKXfYBU2_2~GgBa4
+zz{mGIwyxjCpMLUNayvFFI${gxobwU3H5|_$>!y+xItY!Fp%c{w2~#H;(L(~NB05zO
+zotPmoghrK9VB*V9G2!uRxahXeGr74DG#v)|S@VNSIQKi@*i!t3*+GAc;4c8y0JXP&
+z|1z#wxs=J1;vh?aO?qD^Pu#MG|Nhy}u=~4k>dt2S!f*4)30Lya<W{!Ek`&5;O=u)E
+z4MPYtp<(KRs4g%KK}1*05E{A=h)9&ujH9uRUP|X3w=n<AqtJB?qH*TcO~5Fu=b2Xk
+zl}!Ei%>cX=3%D4#56~aH?@G>F)`q6JAYDAyWy@2W*m&o?cs@AhiR?T5YW_6!B)VKd
+zcgZDf```sZQPTno5TFZcOr2`e7}EkG0WpTq&@`y(*v^Gj_t19Qe9#OS=x5*B%b9)!
+zpz?&-z@CGFI9v<309Xa+k3D!5%a$IAh6R);W;6WpN5A8ZUq1qXck=agU3xuTP4gJ^
+zHS(^+@g!LfH4Q+hhJ?^SD1f@qh#5MjA&5tGOkH5=0z;_pgr=HTJCTm3x3lPEsU`+9
+zN^Q?JCRKOwn~exmD!uOQB;XX3*+(8*{g1r=jF!OU^W+Y6^Wyi{klVHqE!Ilp;}77T
+zz8s=)Y)?{fCAKRmdJ@Bz6v{CYK+_ZfnnqM;L<|uU5H$o5QFZ~<gwW754Gr+?8fev@
+zqq;V#-ZfaFA@VXmP&$|e+{!@`4{?a#X8{ib(be~Ug!jL18puJA17!E^<JDVNA$zxC
+zHeN{bE5D)YU8j<a8YCiuWK^d<rc+}Isw0A^p$&IH3F$G0Xb9Cw4{{-0BLrT4yfmqq
+z*S0tyiy#Y7*F<wYEN%nT0&CvE038Yeaa6QV-Tu90oPW+tkU8-C$?x08-v4|A!%1V#
+zz7pfJKO)jF4O7>MM>LYA0zWwsp(d(R6H&n}rO;H6Aji~`9`w;PrF8*lBiMU>`w<}X
+ziiAWQA>h1)VTZ+U2Lb;I%)fMb8!IlIgGLtoEOt6g&o7=J;-&Fte2(4^-GCFX#gh_U
+z(=dca)X<a_n1ZJ2NN5F0okJkX;B7gY1rd_Ku;oFSGi%B$rF~fd-2>pbS>fZy9t@N*
+zPVi>{pHHRWy04x<JX!$1h?mckdH9bQUK%&`NjARk>%>Kj8b<+$>WYAvA*eCI@g-T?
+zCzXhhvwa2)LE4ev2PmW*3XJ|}5_C-)W&R+MzK>f|4}K0b3xs;MsXpv<P!|{v0dZ7r
+z&)v72P0I`o<N(qwQG8+xdcK`P{2U%Q?yD572r1ny4;S#&T&`>Q5sjp;Gb!$qwR8rm
+z3^FB;l<t%Ev?1V9jw*HNLPOUybd6EwF9WWeNKC~eVjv;_#3Et0CJrLwA>d0u%hjK4
+z<Lo8%;Aa5~cT+psfvsr9Jnn72mKUrTsk|FL<oJ?$41^{zb&aSl@FFlNZjiHm`br)X
+zVmbr1r)F!9Fc79HT)?O>eNEFwn7`7#=lkeF1O#|09{{351SAiafF{(Emd{+#f-VL@
+zmhjU#<exX93wSE=ZSJRms-p6{lIvr6mF8=JDZ+s0NkK!xAZvLHSRR>@hvoRBy`b0=
+zfOjigAT<5q_(Sa@C7$gl|3`wQzOS%=_~8=pMIip&Z?@6g=&SkOv*Cqp2n}`{EBS)H
+z0ITFu<Lg+yWKsqAAtDqBQC*`dB1oD#Q)?m&SRTCvm+q3QR4glEL51i+s8;^3;8$wj
+z_B`UnTtI*iC0ji=l;xBThk(hbN)8t;n-oOYBJAox>rLZpZQP_^M0+`-^F3_WSEa0=
+zmE1~aHV{!kL}=7R1&(hpIT2xE-le8cPK^mkNN8|$m4=9FxF{<S49%Jn@O+8qs|A;l
+z?Nj5!2TPeiuJG0fxE!duZsj~?HUs{k(*Da^(KJ}6eSy131`%A6_BB#cquZAheTnT!
+zY<Fbg)}SUTh#7*~C^RMvvb83?1sA*Iv0{qHX>;NnJ0r=Y2{DAG;kqu_e34x}Hh<2T
+z?3A^k_I=;S^*n6XV`i)~$Vh##iU4GW2<SXi0tBjn$;Ic@1*T=g?hF(m&sp4{{he~g
+zuvRNcJE#SY5BL%*Afn*P&>eJPP;CmTB7%lQguLUE%;q?KdWn{%B*|oySWLrnT^!%X
+zwr%WUo`l`ck%b;a)@19%6L5U6JrB!vDA+cq9JLi>;QYA^0DZX-&)!2NU=c9qqsvpw
+zo=IT-7QD6#G*~AtW1VJJ_-cjkdXV;2P)oT!gN`4%gXQ|zo@8oGgc?&PhRvjo7dR$j
+zQ5#L+c^<Z{{8!U7JkO(8ERxM;>FevGr>BQPdplmQgV(YU%W<(?7ss+VX2vsWj2@8L
+z1wii*0oxCifMo#Zystjcz6HH`7z9T<k=u<0q|iv07c*hZsvyEuZlNqfl5>X74inrS
+zc0Y4Jsbm$-lqp!2MX{(%*Rm|6lsJyV;NT$HY?hv$9y&TYXm4+)>(5)LYG}psAaB{!
+zckCo0_5dbioiLBsK4kbC4wZnV0P|Z>;H3i{fS%$N{iCcm;vgj{LE!&#L;@qjIV$bQ
+z&>B2XGH7}9ba$bzyOUH+lp3><LZLt`77M`(Awuov^LhIE`snKFqO-G;&dyG{4jf=Y
+z`!3x2W(p;X%bGR@;{-Cw4Qv<gSr_67HxkA}z*OL<6WgF=ItsjR!vR2tb;gO*XhP-d
+zK3Gzc5@o=?TG5pW3Ee`HF8Sa&6bl7-=0>JO3MBL?<n#Fue5q6-5>b=4<2dB=d9v9o
+z>2#WOI!$+XH(gy_^z`)LbnYfvm7+M1<?OQ`Qop5H(3b{aR~Kwlp71J4ed8wJB!CYu
+zPZ2R3kTw(m&!nUu!voP7#HB_gNK{OzOx%_d%hOaA7tRbaEC?edX<JhN(rTQpZRG3f
+zLhbs#PpMQQ7K@>28d6G1r4qSZj!Y&)e}6yebei7YUIqpR=<Dml$Yv<z^0dCOnONjm
+zAO!<}3L$KIBgFIQ!N4DkfOi4RorMCA1-W{NM0vwF3rv%!?-NC3YeoP#;!8}uk_;J=
+zp@@*AI=8}xdnhH76bc3U`}+Z9_StL}!!Qs+;JPk_LV<ifPbQNYMnpcJ$FeLkwh!4s
+zZuo~af%enG^t^V+>xZZqCjoN+Ce}mfSH%QGbarb;Qf2DIe3hCxK~VF2iS7HizQmJ~
+zxG!;ii6bSp=hN(i<$JK<Asok{P$;15I({(CB@zh?!$8+{JkP^*U5dqGXa%`kj={k}
+za=9GobUGNO$(il1(opw+x*P<8sJ~-B+_x^o^8-{K@aypsFdd-2w&ISPgb3_0rctdM
+zxD}~tIcIl$A3yl)cybge#g4t?Ha$eH;<cXVg^^weMXK-nIF1t%Wm#6J^&#*;q=s9r
+zxO?cjlQ1t?^{l$p+}uoid%FqTk8<tJ;~}6CpthD^dP{>$f@!lSGKsjR<BdT8=pg}R
+zf?QvQ#O&{Wopd@)DwQIa%VFDgXzF@J(q6Uz$8oT2do*x>wk6y!>vigDf{J$mrF{){
+zcf&QS)b09uRS;-zZ;t}E0jG_JfH*)+RRA8qs70D3x<w79HoAyZNeC#H82R1a*PjOn
+zNw6#n%d&_@qodwu1-bkv;ANS68Y`9s8=^kS_l5fWz;o($OG^u&NN8_w2X!vtB;du$
+zSB*tL48Ze(D+xrBxY0UvjB%BbM-qbc*|m9Sm#Pw2DwP`Z{z0W>0lUBaGP>5T#@369
+z`~vp%z|}uh-Qw|~6>v*S3%hph0yvLx5Ksh?mYpV1en+ed>Boq;<0~OXQ02a|*u^5W
+z?;5l3xIkCPC(pl-8B@Nhz?Xmwpo8ndZEJ`6Rk~F<w*XEa`M$9T$O2OWD^y~d=$?+@
+z51|@$rh%Yh6G$ahTGTu^qC=3D72n~GPpuqEzxxOgJoXaYxLSQ~Zf+j-oMD78TSmTf
+zER}Ww6f0NIF%3OxQZF0~p$eV4Hnd5hhxe4`jbPVC1mBrvjOMme-wJkUJ(ZU~vl6Wg
+zJ{OE$hn-#UiGLsJnn)yuJz8N6wTzIl2-phH*;R4JC_=1;X+|#C#tQ&4v_)0fw4mHy
+zVK2;GeE#9UR?@nd-aDUFfmx!Q)KjA`xbTf1L!~DrlgUc0SBf|C##jVw2H3Qv;*Qn{
+zkvKEWzTp5z)ac5hs@oD@1{E9MW9o@Z4h3>3Eh}yyd&kq%*PtT46Tr|w3i!#Ru<FU7
+z{%vh-)YjHwnr29X7e;hO1)Q-6cn09%-+^CV-T6;~p>agj{xJtxF6Wm)`%+bFJWn;p
+z^{8o{!=lf8?+}nL;Odn(v*U`dP!nUw@5^Hn@ZeK$)xQmY?D*r4r>?G!>gsCZ@i>NI
+z;JRV8dQ@FtEIWA}*!$$OOz$`V)0$9uHhY+ss3Mgq(e1^`(8E%I3|R0hh(Jng&qGRy
+z?Rv~O<D-bWMqa=FCem9sjt#tZ2^_PSJr}&f^wbxE>QV&(02(~@dszPE;g4Q&$tBF2
+zH;;}EwJ0cOmzhka+~uY55a0tp1-`N7aky$laMyVl5u3{ywcEJ2?^p#`As+?W3rxQZ
+zT>8GM+_*l8qZZM6^?cI%c2VqZCzsEulDJU?iF$rFa~JQO`(t!-mojyO@@|M4nSjTh
+zg{4;wAM~O{i#Ye(bHk#F5F%V$ZQHi3-0ks^U=MacVg|4SF!sI((;86hi_4JFW&FJT
+z-Mmzs7~mfb-1j^jUk(9xTx{Q`P_nRWhmvJeC|L{?OIRff9GmYLJ2`LmBh)2+t3XFk
+zDOo)Dtd0Tk;8U>tOQQ$8YSk(l8X6cF7@)tupRTSh_V3@%&Ye41yLK(8x?l?<0^z|D
+zy8+bsnuQZ5z-bFpsx;<pLi6GrSyx5ARLdSKjvHv&@jO-2^UA*OQF0uLwu9q(6m50t
+zGhZw*SS*n%Sv1=vt`V<u^R(5xyYYL(%^gEg)f@s2P_W>~zk(Iljvnk?cily6Yb(00
+z4{L^Duwlc7aw>ci@L%J#0DwsZQFG1R@PYTDOwa@THZad+hkFK3rCZogNQN5sg623b
+zCC61|YsaBrIoOUvqEz4l+0H4(D;%46jF_=LoX^7+sURQ%JG<3Xw`!CD!_7C}%)*5W
+zF-;RKD5IB`(Ob4`Vdct|Wren&Qm0|^X8Qs?sD1UPmt798{^4?tYFeW>@i)WZW@bBg
+zFgvlBZ1u_Pc8{TBu!aMr82y&OMk26CdO0SMp-Hqe)!0r`@@XR4meKR4huS0534@*M
+z!K2T^6}Jta=K<!;o5w{LUBuL>QyCl_B#}rEjYcsHgIFwvZQDHhXjlxoZY=Qd<`z(v
+zD}f&Zyt@8+j+(L)@^`Djx~PSSjhdg!e_e*=>vEF}kL2ZF_kzBXA>WU{z8u{41l;(m
+z(F1C2ZKbWPjTtj$(A3mKDwPVSKGQT2Lh#F9{*oJSyb)AEbW!jtqhvgbyY(m|{rex@
+z^%M(Ey^wkHKL$=cSZTFeT%MmjMo(KKxB2~ms3NM0Q({<H+T8;`S_eySgy&ux{%CV^
+zGc#w-q^_<GDJ8D!BBewK5&FFlg6E!lj%%;I7L@6q#TW_Dp%4J-lvNs7`iuLY#)#K5
+z>$o$iZMhh#mw<jOXtRK6KnlDn#hG6ZUKE@JloF6Hs38?mR#GNNgB?Ba!{5UP?|>&?
+z9S*v&v5|&`hA_wXg5089Jn=jaUDwexjTc{hk*|I2YoIj#LEfY!4u^hD@IAoO<%`>H
+z{b!baU=dRr>k+;Ub`c60)iV2`Zy#jSkn4it02D27(%^&R!Oje9>V&mh;l7HzsHLTa
+zcsxFANjp*u!yu7JkVqt`udgSSO3~5L!Rpnk%iu2o9{fvy4(FicB;XsU*kAxGS+an0
+z&soHA$4sXwRZYw<5_K}ftO4|a4szXHWV*ZQ>+7SpH_i4g_}R;_zJ2(Mo12@%GS+y+
+zFbv}HI6??IIy%Zlj{#sg@WgoD@m5ZX&Hz3RtRN_)9)`S%s@uPTs@|H1LPEJ<8qD*c
+z%>Bc>$zI?{c{>hE3)CT`#i-L*^H3*ClBhhc6tqrMHnttLSGS(wJ2vN{s<%;4ZV-t?
+z!g4tb6->vd5)YuJx?4F&wEw>%ZNRe(pF`fP?FGILjNflY$lv<k=Ef3%`Zv1sQ8m04
+yR3*nl%|zQ#*7G><0%H_8-jR3Y9eGE_EB^yvNfC*>uwT*u0000<MNUMnLSTZ?Yewh*
+
+literal 0
+HcmV?d00001
+
+diff --git a/src/modules/MediaKit/MediaKit.pro b/src/modules/MediaKit/MediaKit.pro
+new file mode 100644
+index 0000000..bf0c648
+--- /dev/null
++++ b/src/modules/MediaKit/MediaKit.pro
+@@ -0,0 +1,21 @@
++TEMPLATE = lib
++CONFIG += plugin
++
++QT += widgets
++
++DESTDIR = ../../../app/lib/qmplay2/modules
++
++QMAKE_LIBDIR += ../../../app/lib
++LIBS += -lqmplay2 -lmedia -lbe
++
++OBJECTS_DIR = build/obj
++MOC_DIR = build/moc
++RCC_DIR = build/rcc
++
++RESOURCES += icon.qrc
++
++INCLUDEPATH += . ../../qmplay2/headers
++DEPENDPATH += . ../../qmplay2/headers
++
++HEADERS += MediaKit.hpp MediaKitoWriter.hpp SndPlayer.hpp RingBuffer.hpp
++SOURCES += MediaKit.cpp MediaKitWriter.cpp SndPlayer.cpp RingBuffer.cpp
+diff --git a/src/modules/MediaKit/MediaKitWriter.cpp b/src/modules/MediaKit/MediaKitWriter.cpp
+new file mode 100644
+index 0000000..f8fad50
+--- /dev/null
++++ b/src/modules/MediaKit/MediaKitWriter.cpp
+@@ -0,0 +1,85 @@
++#include <MediaKitWriter.hpp>
++#include <QMPlay2Core.hpp>
++
++MediaKitWriter::MediaKitWriter( Module &module ) :
++	err( false )
++{
++	addParam( "delay" );
++	addParam( "chn" );
++	addParam( "rate" );
++
++	SetModule( module );
++}
++
++bool MediaKitWriter::set()
++{
++	if ( player.delay != sets().getDouble( "Delay" ) )
++	{
++		player.delay = sets().getDouble( "Delay" );
++		return false;
++	}
++	return sets().getBool( "WriterEnabled" );
++}
++
++bool MediaKitWriter::readyWrite() const
++{
++	return !err && player.isOpen();
++}
++
++bool MediaKitWriter::processParams( bool * )
++{
++	bool resetAudio = false;
++
++	uchar chn = getParam( "chn" ).toUInt();
++	if ( player.channels != chn )
++	{
++		resetAudio = true;
++		player.channels = chn;
++	}
++	uint rate = getParam( "rate" ).toUInt();
++	if ( player.sample_rate != rate )
++	{
++		resetAudio = true;
++		player.sample_rate = rate;
++	}
++
++	if ( resetAudio || err )
++	{
++		player.stop();
++		err = !player.start();
++		if ( !err )
++			modParam( "delay", player.delay );
++		else
++			QMPlay2Core.logError( "MediaKitWriter :: " + tr ( "Nie można otworzyć strumienia wyjścia dźwięku" ) );
++	}
++
++	return readyWrite();
++}
++qint64 MediaKitWriter::write( const QByteArray &arr )
++{
++	if ( !arr.size() || !readyWrite() )
++		return 0;
++
++	err = !player.write( arr );
++	if ( err )
++	{
++		QMPlay2Core.logError( "MediaKitWriter :: " + tr ( "Błąd podczas odtwarzania" ) );
++		return 0;
++	}
++
++	return arr.size();
++}
++
++qint64 MediaKitWriter::size() const
++{
++	return -1;
++}
++QString MediaKitWriter::name() const
++{
++	return MediaKitWriterName;
++}
++
++bool MediaKitWriter::open()
++{
++	return player.isOK();
++}
+diff --git a/src/modules/MediaKit/MediaKitWriter.hpp b/src/modules/MediaKit/MediaKitWriter.hpp
+new file mode 100644
+index 0000000..28fa249
+--- /dev/null
++++ b/src/modules/MediaKit/MediaKitWriter.hpp
+@@ -0,0 +1,30 @@
++#include <Writer.hpp>
++#include <SndPlayer.hpp>
++
++#include <QCoreApplication>
++
++class MediaKitWriter : public Writer
++{
++	Q_DECLARE_TR_FUNCTIONS( MediaKitWriter )
++public:
++	MediaKitWriter( Module & );
++private:
++	bool set();
++
++	bool readyWrite() const;
++
++	bool processParams( bool *paramsCorrected );
++	qint64 write( const QByteArray & );
++
++	qint64 size() const;
++	QString name() const;
++
++	bool open();
++
++	/**/
++
++	SndPlayer player;
++	bool err;
++};
++
++#define MediaKitWriterName "MediaKit Writer"
+diff --git a/src/modules/MediaKit/RingBuffer.cpp b/src/modules/MediaKit/RingBuffer.cpp
+new file mode 100644
+index 0000000..915becc
+--- /dev/null
++++ b/src/modules/MediaKit/RingBuffer.cpp
+@@ -0,0 +1,129 @@
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++
++#include "RingBuffer.hpp"
++
++RingBuffer::RingBuffer( int size )
++{
++	 initialized = false;
++     Buffer = new unsigned char[size];
++     if(Buffer!=NULL) {
++     	memset( Buffer, 0, size );
++	    BufferSize = size;     	
++     } else {
++     	BufferSize = 0;
++     }
++     reader = 0;
++     writer = 0;
++     writeBytesAvailable = size;
++     if((locker=create_sem(1,"locker")) >= B_OK) {
++     	initialized = true;
++     } else {
++     	if(Buffer!=NULL) {
++     		delete[] Buffer;     		
++     	}
++     }
++}
++
++RingBuffer::~RingBuffer( )
++{
++	 if(initialized) {
++     	delete[] Buffer;
++     	delete_sem(locker);
++	 }
++}
++
++bool 
++RingBuffer::Empty( void )
++{
++     memset( Buffer, 0, BufferSize );
++     reader = 0;
++     writer = 0;
++     writeBytesAvailable = BufferSize;
++     return true;
++}
++
++int 
++RingBuffer::Read( unsigned char *data, int size )
++{	
++	 acquire_sem(locker);
++	 
++     if( data == 0 || size <= 0 || writeBytesAvailable == BufferSize ) {
++     	 release_sem(locker);
++         return 0;
++     }
++
++     int readBytesAvailable = BufferSize - writeBytesAvailable;
++
++     if( size > readBytesAvailable ) {
++         size = readBytesAvailable;
++     }
++
++     if(size > BufferSize - reader) {
++         int len = BufferSize - reader;
++         memcpy(data, Buffer + reader, len);
++         memcpy(data + len, Buffer, size-len);
++     } else {
++         memcpy(data, Buffer + reader, size);
++     }
++
++     reader = (reader + size) % BufferSize;
++     writeBytesAvailable += size;
++	 
++	 release_sem(locker);
++     return size;
++}
++
++int 
++RingBuffer::Write( unsigned char *data, int size )
++{
++	 acquire_sem(locker);
++	 
++     if( data == 0 || size <= 0 || writeBytesAvailable == 0 ) {
++     	 release_sem(locker);
++         return 0;
++     }
++
++     if( size > writeBytesAvailable ) {
++         size = writeBytesAvailable;
++     }
++
++     if(size > BufferSize - writer) {
++         int len = BufferSize - writer;
++         memcpy(Buffer + writer, data, len);
++         memcpy(Buffer, data+len, size-len);
++     } else {
++         memcpy(Buffer + writer, data, size);
++     }
++
++     writer = (writer + size) % BufferSize;
++     writeBytesAvailable -= size;
++
++	 release_sem(locker);	 
++     return size;
++}
++
++int 
++RingBuffer::GetSize( void )
++{
++     return BufferSize;
++}
++
++int 
++RingBuffer::GetWriteAvailable( void )
++{
++     return writeBytesAvailable;
++}
++
++int 
++RingBuffer::GetReadAvailable( void )
++{
++     return BufferSize - writeBytesAvailable;
++}
++
++status_t 
++RingBuffer::InitCheck( void )
++{
++	return initialized?B_OK:B_ERROR;
++}
+diff --git a/src/modules/MediaKit/RingBuffer.hpp b/src/modules/MediaKit/RingBuffer.hpp
+new file mode 100644
+index 0000000..4715632
+--- /dev/null
++++ b/src/modules/MediaKit/RingBuffer.hpp
+@@ -0,0 +1,31 @@
++#ifndef __RING_BUFFER_H__
++#define __RING_BUFFER_H__
++
++#include <OS.h>
++
++class RingBuffer {
++
++public:
++     RingBuffer(int size);
++     ~RingBuffer();
++     int Read( unsigned char* dataPtr, int numBytes );
++     int Write( unsigned char *dataPtr, int numBytes );
++     
++     bool Empty( void );
++     int GetSize( );
++     int GetWriteAvailable( );
++     int GetReadAvailable( );
++     status_t InitCheck( );
++private:
++     unsigned char *Buffer;
++     int BufferSize;
++     int reader;
++     int writer;
++     int writeBytesAvailable;
++     
++     sem_id locker;
++     
++     bool 	initialized;
++};
++
++#endif
+diff --git a/src/modules/MediaKit/SndPlayer.cpp b/src/modules/MediaKit/SndPlayer.cpp
+new file mode 100644
+index 0000000..ca7ad89
+--- /dev/null
++++ b/src/modules/MediaKit/SndPlayer.cpp
+@@ -0,0 +1,103 @@
++#include <SndPlayer.hpp>
++
++#include <string.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <SoundPlayer.h>
++
++
++static void proc(void *cookie, void *buffer, size_t len, const media_raw_audio_format &format)
++{
++	RingBuffer *ring = (RingBuffer*)cookie;
++	unsigned char* ptr = (unsigned char*)buffer;
++	
++	int readed = ring->Read(ptr,len);
++	
++	if(readed <len)
++		memset(ptr+readed, 0, len - readed);
++}
++
++SndPlayer::SndPlayer()
++{	
++	channels = sample_rate = delay = 0;
++	player = NULL;
++	_isOK = true;	
++}
++
++bool SndPlayer::start()
++{
++	int gSoundBufferSize = 8192 * sizeof(float);
++		
++	media_raw_audio_format form = {
++		sample_rate,
++		channels,
++		media_raw_audio_format::B_AUDIO_FLOAT,
++		B_MEDIA_LITTLE_ENDIAN,
++		gSoundBufferSize
++	};
++	
++	ring = new RingBuffer(gSoundBufferSize * 3);
++	if(ring->InitCheck() != B_OK) {
++		delete ring; ring = 0;
++		return false;
++	}
++			
++	player = new BSoundPlayer(&form, "QMPlay2_BSoundPlayer", proc, NULL, (void*)ring);
++	
++	if(player->InitCheck() != B_OK) {
++		delete player;
++		player = NULL;
++		return false;
++	}
++	
++	player->Start();
++	player->SetHasData(true);	
++
++	_isOK = true;
++
++	return player;
++}
++void SndPlayer::stop()
++{
++	if ( player )
++	{
++		if(player) {
++			player->Stop();
++			delete player;
++			delete ring;
++		}
++	
++		player = NULL;
++		ring = NULL;
++	}	
++}
++
++double SndPlayer::getLatency()
++{
++	double lat = player->Latency() / (ring->GetSize()*4.0);	
++
++	return lat;
++}
++
++bool SndPlayer::write( const QByteArray &arr )
++{
++	int s = arr.size();
++	while ( s > 0 && s % 4 )
++		s--;
++	if ( s <= 0 )
++		return false;
++
++	int len=s;
++
++	unsigned char *src_ptr = (unsigned char *)arr.data();
++	
++	for(;;) {
++			int len2 = ring->Write(src_ptr,len);
++			if(len2 == len)break;
++			len -= len2;
++			src_ptr += len2;
++			snooze(100);
++	}
++		
++	return true;
++}
+diff --git a/src/modules/MediaKit/SndPlayer.hpp b/src/modules/MediaKit/SndPlayer.hpp
+new file mode 100644
+index 0000000..b0ca8c2
+--- /dev/null
++++ b/src/modules/MediaKit/SndPlayer.hpp
+@@ -0,0 +1,49 @@
++#ifndef PULSE_HPP
++#define PULSE_HPP
++
++#include <QByteArray>
++
++#include <SoundPlayer.h>
++
++#include <Window.h>
++#include <View.h>
++#include <TextControl.h>
++
++#include "RingBuffer.hpp"
++
++class SndPlayer
++{
++public:
++	SndPlayer();
++	inline ~SndPlayer()
++	{
++		stop();
++	}
++
++	inline bool isOK() const
++	{
++		return _isOK;
++	}
++	inline bool isOpen() const
++	{
++		return player;
++	}
++
++	bool start();
++	void stop();
++
++	double getLatency();
++
++	bool write( const QByteArray & );
++
++	double delay;
++	uchar channels;
++	uint sample_rate;
++		
++private:
++	bool _isOK;
++	BSoundPlayer *player;
++	RingBuffer *ring;
++};
++
++#endif
+diff --git a/src/modules/MediaKit/icon.qrc b/src/modules/MediaKit/icon.qrc
+new file mode 100644
+index 0000000..24b4ebd
+--- /dev/null
++++ b/src/modules/MediaKit/icon.qrc
+@@ -0,0 +1,3 @@
++<RCC><qresource>
++	<file alias="MediaKit">MediaKit.png</file>
++</qresource></RCC>
+diff --git a/src/qmplay2/QMPlay2Core.cpp b/src/qmplay2/QMPlay2Core.cpp
+index 9506f86..2bb12ee 100644
+--- a/src/qmplay2/QMPlay2Core.cpp
++++ b/src/qmplay2/QMPlay2Core.cpp
+@@ -167,7 +167,7 @@ void QMPlay2CoreClass::init(bool loadModules, bool modulesInSubdirs, const QStri
+ 		settingsDir = QCoreApplication::applicationDirPath() + "/settings/";
+ 	else
+ 	{
+-#if defined(Q_OS_WIN)
++#if defined(Q_OS_WIN) || defined(Q_OS_HAIKU)
+ 		settingsDir = QFileInfo(QSettings(QSettings::IniFormat, QSettings::UserScope, QString()).fileName()).absolutePath() + "/QMPlay2/";
+ #elif defined(Q_OS_MAC)
+ 		settingsDir = Functions::cleanPath(QStandardPaths::standardLocations(QStandardPaths::DataLocation).value(0, settingsDir));
+@@ -363,6 +363,11 @@ QStringList QMPlay2CoreClass::getModules(const QString &type, int typeLen) const
+ #elif defined Q_OS_WIN
+ 	if (type == "videoWriters")
+ 		defaultModules << "OpenGL 2" << "DirectDraw";
++#elif defined Q_OS_HAIKU
++	if ( type == "videoWriters" )
++		defaultModules << "QPainter";
++	else if ( type == "audioWriters" )
++		defaultModules << "MediaKit";
+ #endif
+ 	if (type == "decoders")
+ 		defaultModules << "FFmpeg Decoder";
+-- 
+2.7.0
+
+
+From 986b0ff28404cda9f12fb987e3ab3496b6251f20 Mon Sep 17 00:00:00 2001
+From: Khaled Berraoui <khallebal@gmail.com>
+Date: Thu, 15 Jun 2017 02:12:50 +0000
+Subject: Switch to Cmake build system
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ebea6b6..5a5b191 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -64,6 +64,12 @@ else()
+     set(DEFAULT_CUVID ON)
+ endif()
+ 
++if(HAIKU)
++	set(DEFAULT_MEDIAKIT ON)
++else()
++	set(DEFAULT_MEDIAKIT OFF)
++endif()
++
+ add_definitions(-D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -DQT_USE_FAST_OPERATOR_PLUS)
+ 
+ if(WIN32)
+@@ -81,7 +87,7 @@ if(USE_QT5 AND NOT Qt5Widgets_FOUND)
+     find_package(Qt5Widgets REQUIRED)
+ endif()
+ 
+-if(NOT WIN32 AND NOT APPLE)
++if(NOT WIN32 AND NOT APPLE AND NOT HAIKU)
+     option(USE_FREEDESKTOP_NOTIFICATIONS "Use Freedesktop notifications" ON)
+     add_feature_info("Freedesktop notifications" USE_FREEDESKTOP_NOTIFICATIONS "Use Freedesktop notifications")
+ endif()
+@@ -110,6 +116,9 @@ add_feature_info(libass USE_LIBASS "Build with libass support")
+ option(USE_INPUTS "Build with Inputs module" ON)
+ add_feature_info(Inputs USE_INPUTS "Build with Inputs module")
+ 
++option(USE_MEDIAKIT "Build with MediaKit module" ON)
++add_feature_info(MediaKit USE_MEDIAKIT "Build with MediaKit module")
++
+ option(USE_MODPLUG "Build with Modplug module" ON)
+ add_feature_info(Modplug USE_MODPLUG "Build with Modplug module")
+ 
+@@ -326,7 +335,7 @@ if(APPLE)
+     set(DEFAULT_INSTALL_RPATH ON)
+ endif()
+ 
+-if(NOT WIN32 AND NOT APPLE)
++if(NOT WIN32 AND NOT APPLE AND NOT HAIKU)
+     # RPATH
+     option(SET_INSTALL_RPATH "Set RPATH for executable after install" ${DEFAULT_INSTALL_RPATH})
+ 
+@@ -339,7 +348,7 @@ if(LANGUAGES)
+     add_subdirectory(lang)
+ endif()
+ 
+-if(WIN32)
++if(WIN32 OR HAIKU)
+     install(FILES AUTHORS ChangeLog LICENSE TODO README.md DESTINATION ${CMAKE_INSTALL_PREFIX})
+ else()
+     install(FILES AUTHORS ChangeLog LICENSE TODO README.md DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/qmplay2")
+diff --git a/lang/CMakeLists.txt b/lang/CMakeLists.txt
+index f5f86be..9b4fcf7 100644
+--- a/lang/CMakeLists.txt
++++ b/lang/CMakeLists.txt
+@@ -21,7 +21,7 @@ endif()
+ 
+ add_custom_target(translations ALL DEPENDS ${QM_FILES})
+ 
+-if(WIN32)
++if(WIN32 OR HAIKU)
+     install(FILES ${QM_FILES} DESTINATION "lang/")
+ else()
+     install(FILES ${QM_FILES} DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/qmplay2/lang")
+diff --git a/src/gui/CMakeLists.txt b/src/gui/CMakeLists.txt
+index 5853dc9..6adc25b 100644
+--- a/src/gui/CMakeLists.txt
++++ b/src/gui/CMakeLists.txt
+@@ -210,7 +210,7 @@ elseif(USE_TAGLIB)
+     target_link_libraries(${PROJECT_NAME} ${TAGLIB_LIBRARIES})
+ endif()
+ 
+-if(WIN32)
++if(WIN32 OR HAIKU)
+     install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/)
+ elseif(APPLE)
+     install(TARGETS ${PROJECT_NAME} BUNDLE DESTINATION ${CMAKE_INSTALL_PREFIX})
+diff --git a/src/modules/CMakeLists.txt b/src/modules/CMakeLists.txt
+index 203c68d..f2f3240 100644
+--- a/src/modules/CMakeLists.txt
++++ b/src/modules/CMakeLists.txt
+@@ -7,6 +7,9 @@ if(WIN32)
+ elseif(APPLE)
+     set(MODULES_INSTALL_PATH "${CMAKE_INSTALL_LIBDIR}/modules")
+     set(QMPLAY2_MODULE SHARED) # otherwise CMake uses ".so" extension
++elseif(HAIKU)
++	set(MODULES_INSTALL_PATH "modules")
++	set(QMPLAY2_MODULE MODULE)
+ else()
+     set(MODULES_INSTALL_PATH "${CMAKE_INSTALL_LIBDIR}/qmplay2/modules")
+     set(QMPLAY2_MODULE MODULE)
+@@ -77,6 +80,10 @@ if(WIN32)
+     add_subdirectory(FileAssociation)
+ endif()
+ 
++if(HAIKU)
++	add_subdirectory(MediaKit)
++endif()
++
+ if(USE_CUVID)
+     add_subdirectory(CUVID)
+ endif()
+diff --git a/src/modules/MediaKit/CMakeLists.txt b/src/modules/MediaKit/CMakeLists.txt
+new file mode 100644
+index 0000000..56232f3
+--- /dev/null
++++ b/src/modules/MediaKit/CMakeLists.txt
+@@ -0,0 +1,63 @@
++cmake_minimum_required(VERSION 2.8.6)
++if(COMMAND cmake_policy)
++    if(POLICY CMP0003)
++        cmake_policy(SET CMP0003 NEW)
++    endif()
++    if(POLICY CMP0020)
++        cmake_policy(SET CMP0020 NEW)
++    endif()
++    if(POLICY CMP0042)
++        cmake_policy(SET CMP0042 NEW)
++    endif()
++    if(POLICY CMP0043)
++        cmake_policy(SET CMP0043 NEW)
++    endif()
++endif()
++project(MediaKit)
++
++set(MediaKit_HDR
++    MediaKit.hpp
++    MediaKitWriter.hpp
++    SndPlayer.hpp
++    RingBuffer.hpp
++)
++
++set(MediaKit_SRC
++    MediaKit.cpp
++    MediaKitWriter.cpp
++    SndPlayer.cpp
++    RingBuffer.cpp
++)
++
++set(MediaKit_RESOURCES
++    icon.qrc
++)
++
++if(USE_QT5)
++    qt5_add_resources(MediaKit_RESOURCES_RCC ${MediaKit_RESOURCES})
++else()
++    qt4_add_resources(MediaKit_RESOURCES_RCC ${MediaKit_RESOURCES})
++endif()
++
++include_directories(../../qmplay2/headers)
++
++add_library(${PROJECT_NAME} ${QMPLAY2_MODULE}
++    ${MediaKit_HDR}
++    ${MediaKit_SRC}
++    ${MediaKit_RESOURCES_RCC}
++)
++
++if(USE_QT5)
++    qt5_use_modules(${PROJECT_NAME} Gui Widgets)
++else()
++    target_link_libraries(${PROJECT_NAME} Qt4::QtCore Qt4::QtGui)
++endif()
++
++add_dependencies(${PROJECT_NAME} libqmplay2)
++target_link_libraries(${PROJECT_NAME}
++    ${qmplay2lib}
++    media
++    be
++)
++
++install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${MODULES_INSTALL_PATH})
+diff --git a/src/qmplay2/CMakeLists.txt b/src/qmplay2/CMakeLists.txt
+index c41de09..36da55d 100644
+--- a/src/qmplay2/CMakeLists.txt
++++ b/src/qmplay2/CMakeLists.txt
+@@ -234,6 +234,9 @@ else()
+     if(USE_LIBASS)
+         list(APPEND LIBQMPLAY2_LIBS ${LIBASS_LIBRARIES})
+     endif()
++    if(USE_MEDIAKIT)
++    	list(APPEND LIBQMPLAY2_LIBS ${LIBMEDIA_LIBRARIES})
++    endif()
+ endif()
+ 
+ target_link_libraries(${PROJECT_NAME} ${LIBQMPLAY2_LIBS})
+-- 
+2.7.0
+

--- a/media-video/qmplay2/qmplay2-17.06.09.recipe
+++ b/media-video/qmplay2/qmplay2-17.06.09.recipe
@@ -1,0 +1,116 @@
+SUMMARY="A video and audio player which can play most formats and codecs"
+DESCRIPTION="QMPlay2 is a video and audio player. It can play all formats \
+supported by ffmpeg, libmodplug (including J2B and SFX). It also supports \
+Audio CD, raw files and Rayman 2 music. It contains YouTube and Prostoplee\
+r browser."
+HOMEPAGE="http://zaps166.sourceforge.net"
+COPYRIGHT="2010-2017 Błażej Szczygieł"
+LICENSE="GNU GPL v3"
+REVISION="1"
+SOURCE_URI="https://github.com/zaps166/QMPlay2/releases/download/$portVersion/QMPlay2-src-$portVersion.tar.xz"
+CHECKSUM_SHA256="59279e38ee395a6a66bd2e5cee3287e145b1fe5735ce2634b4a5b11f2d289a92"
+SOURCE_DIR="QMPlay2-src-$portVersion"
+PATCHES="qmplay2-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 x86 ?x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	qmplay2$secondaryArchSuffix = $portVersion
+	app:QMPlay2$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku${secondaryArchSuffix}
+	lib:libQt5Core$secondaryArchSuffix
+	lib:libQt5Gui$secondaryArchSuffix
+	lib:libQt5Widgets$secondaryArchSuffix
+	lib:libQt5Svg$secondaryArchSuffix
+	lib:libvorbis$secondaryArchSuffix
+	lib:libogg$secondaryArchSuffix
+	lib:libtag$secondaryArchSuffix
+	lib:libtag_c$secondaryArchSuffix
+	lib:libass$secondaryArchSuffix
+	lib:libcdio$secondaryArchSuffix
+	lib:libcddb$secondaryArchSuffix
+	lib:libgl$secondaryArchSuffix
+	lib:libtheora$secondaryArchSuffix
+	lib:libvpx$secondaryArchSuffix
+	lib:libmodplug$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	lib:libexpat$secondaryArchSuffix
+	lib:libgraphite2$secondaryArchSuffix # Needed by harfbuzz
+	lib:libharfbuzz$secondaryArchSuffix # Needed by libass
+	lib:libfreetype$secondaryArchSuffix
+	lib:libfontconfig$secondaryArchSuffix
+	lib:libfribidi$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libQt5Core$secondaryArchSuffix
+	devel:libQt5Gui$secondaryArchSuffix
+	devel:libQt5Widgets$secondaryArchSuffix
+	devel:libQt5Svg$secondaryArchSuffix
+	devel:libavutil$secondaryArchSuffix
+	devel:libavcodec$secondaryArchSuffix
+	devel:libavformat$secondaryArchSuffix
+	devel:libavdevice$secondaryArchSuffix
+	devel:libavfilter$secondaryArchSuffix
+	devel:libavresample$secondaryArchSuffix
+	devel:libswscale$secondaryArchSuffix
+	devel:libswresample$secondaryArchSuffix
+	devel:libpostproc$secondaryArchSuffix
+	devel:libvorbis$secondaryArchSuffix
+	devel:libogg$secondaryArchSuffix
+	devel:libtag$secondaryArchSuffix
+	devel:libtag_c$secondaryArchSuffix
+	devel:libass$secondaryArchSuffix
+	devel:libcdio$secondaryArchSuffix
+	devel:libcddb$secondaryArchSuffix
+	devel:libgl$secondaryArchSuffix
+	devel:libtheora$secondaryArchSuffix
+	devel:libvpx$secondaryArchSuffix
+	devel:libmodplug$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	devel:libexpat$secondaryArchSuffix
+	devel:libgraphite2$secondaryArchSuffix # Needed by harfbuzz
+	devel:libharfbuzz$secondaryArchSuffix # Needed by libass
+	devel:libfreetype$secondaryArchSuffix
+	devel:libfontconfig$secondaryArchSuffix
+	devel:libfribidi$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:make
+	cmd:find
+	cmd:xargs
+	cmd:g++$secondaryArchSuffix
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	mkdir -p build
+	cd build
+	cmake .. \
+		-DCMAKE_INSTALL_PREFIX:PATH=$appsDir/QMPlay2 \
+		-DCMAKE_INSTALL_BINDIR:PATH=$appsDir/QMPlay2 \
+		-DUSE_AVRESAMPLE:BOOL=ON \
+		-DUSE_OPENGL2:BOOL=OFF \
+		-DUSE_CUVID:BOOL=ON \
+		-DUSE_PORTAUDIO:BOOL=OFF
+			
+	make $jobArgs
+}
+
+INSTALL()
+{
+	cd build
+	make install
+	rm -R $appsDir/QMPlay2/include
+	
+	addResourcesToBinaries ../haiku/QMPlay2.rdef $appsDir/QMPlay2/QMPlay2
+	addAppDeskbarSymlink $appsDir/QMPlay2/QMPlay2 QMPlay2
+}


### PR DESCRIPTION
For some reason Cmake requires glib2, harfbuzz and fontconfig for libass, and graphite2 for harfbuzz, but glib2 is only required on gcc2h not on pure X86.
youtube doesn't work, but i suspect a bug in our Qt5 port.
built with Qt5.5.1 on pure x86 and 5.6.1 on gcc2h.