### PR TITLE
libdwarf: bump version

### DIFF
--- a/dev-libs/libdwarf/libdwarf-20170416.recipe
+++ b/dev-libs/libdwarf/libdwarf-20170416.recipe
@@ -1,0 +1,90 @@
+SUMMARY="Libraries to dump and manipulate DWARF data"
+DESCRIPTION="DWARF is a widely used, standardized debugging data format. \
+DWARF was originally designed along with Executable and Linkable Format (ELF),\
+although it is independent of object file formats. The name is a medieval \
+fantasy complement to ELF that has no official meaning, although the \
+backronym 'Debugging With Attributed Record Formats' was later proposed.
+
+The DWARF Debugging Information Format is of interest to programmers working \
+on compilers and debuggers (and anyone interested in reading or writing DWARF \
+information). DWARF uses a data structure called a Debugging Information Entry \
+(DIE) to represent each variable, type, procedure, etc. It was developed by a \
+committee (known as the PLSIG at the time) starting around 1991. Starting \
+around 1991 SGI developed the libdwarf and dwarfdump tools for internal use and \
+as part of SGI IRIX developer tools. Since that time dwarfdump and libdwarf \
+have been shipped (as an executable and archive respectively, not source) with \
+every release of the SGI MIPS/IRIX C compiler. In 1994 (I think the correct \
+year) SGI agreed to open-source libdwarf (and in 1999 to open-source dwarfdump) \
+so anyone could use them.
+"
+HOMEPAGE="http://www.prevanders.net/dwarf.html"
+COPYRIGHT="2000,2002,2004,2005 Silicon Graphics, Inc.
+	2007-2010 David Anderson
+	2007-2010 Sun Microsystems, Inc."
+LICENSE="GNU GPL v2
+	GNU LGPL v2.1"
+REVISION="1"
+SOURCE_URI="https://www.prevanders.net/libdwarf-20170416.tar.gz"
+CHECKSUM_SHA256="d340c395217d78a67bec069f9991130622626a87cdba73131d091cb2f1005d81"
+SOURCE_DIR="dwarf-$portVersion"
+PATCHES="libdwarf-20170416.patchset"
+
+ARCHITECTURES="?x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86_gcc2 x86"
+
+# On x86_gcc2 we don't want to install the commands in bin/<arch>/, but in bin/.
+commandSuffix=$secondaryArchSuffix
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+fi
+
+PROVIDES="
+	libdwarf$secondaryArchSuffix = $portVersion
+	cmd:dwarfdump$commandSuffix = $portVersion
+	lib:libdwarf$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libelf$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	libdwarf${secondaryArchSuffix}_devel = $portVersion
+	devel:libdwarf$secondaryArchSuffix = $portVersion
+	"
+REQUIRES_devel="
+	lib:libdwarf$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libelf$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:gcc$secondaryArchSuffix
+	cmd:grep
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	"
+
+BUILD()
+{
+	cd libdwarf
+	runConfigure ./configure --enable-shared
+	make
+	cd ../dwarfdump
+	LDFLAGS="-L../libdwarf" ./configure $configureDirArgs
+	LIBRARY_PATH=$LIBRARY_PATH:%A/../libdwarf make
+}
+
+INSTALL()
+{
+	cd libdwarf
+	make install bindir=$binDir libdir=$libDir incdir=$includeDir
+	cd ../dwarfdump
+	make install mandir=$manDir
+	packageEntries devel $developDir
+}

--- a/dev-libs/libdwarf/patches/libdwarf-20170416.patchset
+++ b/dev-libs/libdwarf/patches/libdwarf-20170416.patchset
@@ -1,0 +1,82 @@
+From bbe4b9bc3ac315454aefa2922d7ae59fb82a31db Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
+Date: Wed, 21 Jun 2017 12:05:45 +0200
+Subject: LibDWARF: Applying patches
+
+
+diff --git a/dwarfdump/Makefile.in b/dwarfdump/Makefile.in
+index 91e89d1..db16055 100644
+--- a/dwarfdump/Makefile.in
++++ b/dwarfdump/Makefile.in
+@@ -203,9 +203,11 @@ selftest:
+ # will work and leave sensible permissions on the resulting files.
+ # Some adjustment might be required, see README.
+ install: all
+-	$(INSTALL) dwarfdump $(bindir)/dwarfdump
+-	$(INSTALL) $(srcdir)/dwarfdump.conf $(libdir)/dwarfdump.conf
+-	$(INSTALL) $(srcdir)/dwarfdump.1 $(man1dir)/dwarfdump.1
++	install -m 0755 -d $(bindir)
++	install -m 0755 -d $(man1dir)
++	install -m 0755  dwarfdump $(bindir)
++	install -m 0755  dwarfdump.conf $(libdir)
++	install -m 0755  dwarfdump.1 $(man1dir)
+ 
+ uninstall:
+ 	-rm -f $(bindir)/dwarfdump
+diff --git a/libdwarf/Makefile.in b/libdwarf/Makefile.in
+index 6a3fd0e..89943f4 100644
+--- a/libdwarf/Makefile.in
++++ b/libdwarf/Makefile.in
+@@ -226,7 +226,11 @@ clean:
+ 	rm -f *~
+ 
+ install: all
+-	echo "No install provided, see comments in the README"
++	install -m 0755 -d $(incdir)
++	install -m 0755 -d $(libdir)
++	install -m 0755 libdwarf.h $(incdir)
++	install -m 0755 dwarf.h $(incdir)
++	install -m 0755 libdwarf.so $(libdir)
+ 
+ distclean:	clean
+ 	rm -f config.status config.log config.cache config.h
+diff --git a/libdwarf/gennames.c b/libdwarf/gennames.c
+index 0ba2227..8052629 100644
+--- a/libdwarf/gennames.c
++++ b/libdwarf/gennames.c
+@@ -547,8 +547,8 @@ ParseDefinitionsAndWriteOutput(void)
+         /*  errno is cleared here so printing errno after
+             the fgets is showing errno as set by fgets. */
+         char *fgbad = 0;
+-        errno = 0;
+         fgbad = fgets(line_in,sizeof(line_in),f_dwarf_in);
++        errno = 0;
+         if(!fgbad) {
+             if(feof(f_dwarf_in)) {
+                 break;
+-- 
+2.12.2
+
+
+From 849094fe092611f3a885caba9819a85c6b44f6f2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
+Date: Wed, 21 Jun 2017 12:06:12 +0200
+Subject: Hardlinks not supported on BFS
+
+
+diff --git a/libdwarf/Makefile.in b/libdwarf/Makefile.in
+index 89943f4..c536032 100644
+--- a/libdwarf/Makefile.in
++++ b/libdwarf/Makefile.in
+@@ -136,7 +136,7 @@ libdwarf.a: dwarf_names.h dwarf_names.c  $(OBJS) dwarf_names.o
+ 
+ libdwarf.so: dwarf_names.h dwarf_names.c $(OBJS) dwarf_names.o
+ 	$(CC) $(CFLAGS) $(LDFLAGS) -shared $(OBJS) -Wl,-soname=$(SONAME)  dwarf_names.o $(dwfzlib) -o $@
+-	ln libdwarf.so $(SONAME)
++	ln -s libdwarf.so $(SONAME)
+ 
+ nosharedlibrary:
+ 	echo "Not building shared library libdwarf.so"
+-- 
+2.12.2
+


### PR DESCRIPTION
Still broken, help wanted:
Warning: POLICY ERROR: "/packaging/libdwarf/bin/dwarfdump" needs library "libdwarf.so.1", but the package doesn't seem to declare that as a requirement