### PR TITLE
gnupg, remove not installed binaries in the recipe

### DIFF
--- a/app-crypt/gnupg/gnupg-2.1.21.recipe
+++ b/app-crypt/gnupg/gnupg-2.1.21.recipe
@@ -20,11 +20,8 @@ PROVIDES="
 	gnupg$secondaryArchSuffix = $portVersion
 	cmd:addgnupghome$secondaryArchSuffix
 	cmd:applygnupgdefaults$secondaryArchSuffix
-	cmd:dirmngr_client$secondaryArchSuffix
 	cmd:dirmngr$secondaryArchSuffix
-	cmd:gpg$secondaryArchSuffix
-	cmd:gpg_zip$secondaryArchSuffix
-	cmd:gpgsplit$secondaryArchSuffix
+	cmd:dirmngr_client$secondaryArchSuffix
 	cmd:gpg_agent$secondaryArchSuffix
 	cmd:gpg_connect_agent$secondaryArchSuffix
 	cmd:gpg2$secondaryArchSuffix
@@ -34,7 +31,6 @@ PROVIDES="
 	cmd:gpgsm$secondaryArchSuffix
 	cmd:gpgtar$secondaryArchSuffix
 	cmd:gpgv2$secondaryArchSuffix
-	cmd:gpgv$secondaryArchSuffix
 	cmd:kbxutil$secondaryArchSuffix
 	cmd:watchgnupg$secondaryArchSuffix
 	"


### PR DESCRIPTION
Some of the cmd: lines are not installed by default, no need to have them in the recipe (untill further notice) :)