### PR TITLE
libgcrypt, bump version

### DIFF
--- a/dev-libs/libgcrypt/libgcrypt-1.8.0.recipe
+++ b/dev-libs/libgcrypt/libgcrypt-1.8.0.recipe
@@ -1,0 +1,85 @@
+SUMMARY="GNU's basic cryptographic library"
+DESCRIPTION="Libgcrypt is a general purpose crypto library based on the code \
+used in GnuPG."
+HOMEPAGE="https://gnupg.org/related_software/libgcrypt/"
+COPYRIGHT="2000-2017 Free Software Foundation, Inc."
+LICENSE="GNU LGPL v3"
+REVISION="1"
+SOURCE_URI="https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-$portVersion.tar.bz2"
+CHECKSUM_SHA256="23e49697b87cc4173b03b4757c8df4314e3149058fa18bdc4f82098f103d891b"
+PATCHES="libgcrypt-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	libgcrypt$secondaryArchSuffix = $portVersion compat >= 1.6
+	lib:libgcrypt$secondaryArchSuffix = 20.2.0 compat >= 20
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libgpg_error$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	libgcrypt${secondaryArchSuffix}_devel = $portVersion compat >= 1.6
+	devel:libgcrypt$secondaryArchSuffix = 20.2.0 compat >= 20
+	cmd:dumpsexp$secondaryArchSuffix = $portVersion compat >= 1.6
+	cmd:libgcrypt_config$secondaryArchSuffix = $portVersion compat >= 1.6
+	cmd:hmac256$secondaryArchSuffix = $portVersion compat >= 1.6
+	cmd:mpicalc$secondaryArchSuffix = 2.0
+	"
+REQUIRES_devel="
+	libgcrypt$secondaryArchSuffix == $portVersion base
+	haiku$secondaryArchSuffix
+	lib:libgpg_error$secondaryArchSuffix
+	devel:libgpg_error$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libgpg_error$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:autoconf
+	cmd:make
+	cmd:gcc$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	autoconf
+	runConfigure ./configure
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	#remove libtool file
+	rm -f $libDir/libgcrypt.la
+
+	prepareInstalledDevelLib libgcrypt
+
+	if [ -z "$secondaryArchSuffix" ]; then
+		maybe_infoDir=$infoDir
+		maybe_manDir=$manDir
+	else
+		maybe_infoDir=
+		maybe_manDir=
+		rm -rf $documentationDir
+	fi
+
+	packageEntries devel \
+		$developDir \
+		$binDir \
+		$dataDir \
+		$maybe_infoDir \
+		$maybe_manDir
+}
+
+TEST()
+{
+	make check
+}

--- a/dev-libs/libgcrypt/patches/libgcrypt-1.8.0.patchset
+++ b/dev-libs/libgcrypt/patches/libgcrypt-1.8.0.patchset
@@ -1,0 +1,44 @@
+From 8f17f183b538b6c5bd20cc69e4dcd34913cd5c3e Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Tue, 5 Aug 2014 16:50:29 +0000
+Subject: haiku patch
+
+
+diff --git a/configure.ac b/configure.ac
+index 487a1bc..aa8bc7a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -763,6 +763,7 @@ fi
+ AC_SEARCH_LIBS(setsockopt, [socket], ,
+ 	[AC_SEARCH_LIBS(setsockopt, [socket], , , [-lnsl])])
+ AC_SEARCH_LIBS(setsockopt, [nsl])
++AC_SEARCH_LIBS(socket, [network])
+ 
+ ##################################
+ #### Checks for header files. ####
+-- 
+2.2.2
+
+
+From 2eb88a459c5386a816e74231bc04b4f8a5b42b1e Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Wed, 6 Aug 2014 22:08:04 +0000
+Subject: gcc2 patch
+
+
+diff --git a/src/hwf-x86.c b/src/hwf-x86.c
+index eeacccb..52fad3c 100644
+--- a/src/hwf-x86.c
++++ b/src/hwf-x86.c
+@@ -103,7 +103,7 @@ get_xgetbv(void)
+   unsigned int t_eax, t_edx;
+ 
+   asm volatile
+-    ("xgetbv\n\t"
++    (".byte 0x0f, 0x01, 0xd0\n\t"
+      : "=a" (t_eax), "=d" (t_edx)
+      : "c" (0)
+     );
+-- 
+2.2.2
+


### PR DESCRIPTION
for x86_gcc2 I'm getting "`__GNUC_PATCHLEVEL__' undeclared", it is to a change in globals.c as far as I could trace it, 1.7.8 still builds ok for x86_gcc2 .... could use some attention :)