### PR TITLE
libedit: enable wide-character support

### DIFF
--- a/sys-libs/libedit/libedit-2015_03_21_3.1.recipe
+++ b/sys-libs/libedit/libedit-2015_03_21_3.1.recipe
@@ -10,7 +10,7 @@ COPYRIGHT="1992-2014 The NetBSD Foundation, Inc."
 HOMEPAGE="http://www.thrysoee.dk/editline/"
 SOURCE_URI="http://www.thrysoee.dk/editline/libedit-20150325-3.1.tar.gz"
 CHECKSUM_SHA256="c88a5e4af83c5f40dda8455886ac98923a9c33125699742603a88a0253fcc8c5"
-REVISION="7"
+REVISION="8"
 ARCHITECTURES="x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
@@ -45,7 +45,7 @@ BUILD()
 {
 	mkdir m4
 	autoreconf --force --install
-	runConfigure ./configure
+	runConfigure ./configure --enable-examples=no --enable-widec
 	make $jobArgs
 }
 


### PR DESCRIPTION
This commit enables libedit to be built with support for wide characters. It is also required to support the integrated REPL in swift which uses the el_wgets symbol which was missing in libedit.