### PR TITLE
libspectrum and fuse: Build fixes for x86_64 and x86_gcc2

### DIFF
--- a/app-emulation/fuse/fuse-1.1.1.recipe
+++ b/app-emulation/fuse/fuse-1.1.1.recipe
@@ -24,7 +24,7 @@ SOURCE_URI="https://sourceforge.net/projects/fuse-emulator/files/fuse/$portVersi
 CHECKSUM_SHA256="a857d4bd62e01d18429897467508af15624cbaf343caed8b9ba1ab3a8879444e"
 PATCHES="fuse-$portVersion.patchset"
 
-ARCHITECTURES="x86_gcc2"
+ARCHITECTURES="x86_gcc2 x86_64"
 
 PROVIDES="
 	fuse = $portVersion
@@ -34,21 +34,23 @@ REQUIRES="
 	haiku
 	lib:libbz2
 	lib:libGL
-	lib:libpng
+	lib:libpng16
 	lib:libSDL_1.2
 	lib:libspectrum
 	lib:libxml2
 	lib:libz
+	lib:libgcrypt
 	"
 
 BUILD_REQUIRES="
 	haiku_devel
 	devel:libbz2
-	devel:libpng
+	devel:libpng16
 	devel:libsdl
 	devel:libspectrum
 	devel:libxml2
 	devel:libz
+	devel:libgcrypt
 	"
 BUILD_PREREQUIRES="
 	cmd:awk
@@ -62,7 +64,7 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	runConfigure ./configure --with-sdl
+	runConfigure ./configure --with-sdl --with-libspectrum-prefix=/system/develop --disable-sockets
 	make $jobArgs
 }
 

--- a/app-emulation/fuse/patches/fuse-1.1.1.patchset
+++ b/app-emulation/fuse/patches/fuse-1.1.1.patchset
@@ -1,4 +1,4 @@
-From c5775ba61c54dd2e089af5e343567b968cd0c932 Mon Sep 17 00:00:00 2001
+From dd064ec69a2c95c9c37a58fed0fc800b219350e0 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@gmail.com>
 Date: Tue, 12 May 2015 21:38:51 +0200
 Subject: C89 "declaration after statement" fixes.
@@ -496,10 +496,10 @@ index 8774fc0..10c925a 100644
    widget_rectangle( x, y, 8, 8, colour );
    widget_print_checkbox( x, y,
 -- 
-2.7.0
+2.13.1
 
 
-From 11d00d3a2196c8c124439c458eb2a64f1ce0c541 Mon Sep 17 00:00:00 2001
+From 7bf9395298be0b3d7d5b027de8c308c101aaf1c0 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Sat, 26 Mar 2016 17:39:58 +0100
 Subject: gcc2 build fix.
@@ -550,5 +550,43 @@ index 89f8249..5d1fb84 100755
      if( needs_hard_reset ) {
        error = widget_do( WIDGET_TYPE_QUERY,
 -- 
-2.7.0
+2.13.1
+
+
+From 7b166283895f621eb15862c8ed11d8d0e264f4ee Mon Sep 17 00:00:00 2001
+From: Chris Moore <chris@mooreonline.org>
+Date: Wed, 2 Aug 2017 13:41:49 +0100
+Subject: Fix broken detection of libspectrum
+
+
+diff --git a/configure b/configure
+index 9b1a35d..aaacb7f 100755
+--- a/configure
++++ b/configure
+@@ -15944,7 +15944,7 @@ fi
+ 
+ # Check whether --with-libspectrum-prefix was given.
+ if test "${with_libspectrum_prefix+set}" = set; then :
+-  withval=$with_libspectrum_prefix; LIBSPEC_CFLAGS=-I$withval/include; LIBSPEC_LIBS=-L$withval/lib
++  withval=$with_libspectrum_prefix; LIBSPEC_CFLAGS=-I$withval/headers; LIBSPEC_LIBS=-L$withval/lib
+ else
+   LIBSPEC_CFLAGS=""; LIBSPEC_LIBS=""
+ fi
+@@ -15954,14 +15954,10 @@ CPPFLAGS="$CPPFLAGS $LIBSPEC_CFLAGS $GTK_CFLAGS $GLIB_CFLAGS"
+ for ac_header in libspectrum.h
+ do :
+   ac_fn_c_check_header_mongrel "$LINENO" "libspectrum.h" "ac_cv_header_libspectrum_h" "$ac_includes_default"
+-if test "x$ac_cv_header_libspectrum_h" = xyes; then :
+   cat >>confdefs.h <<_ACEOF
+ #define HAVE_LIBSPECTRUM_H 1
+ _ACEOF
+  LIBSPEC_LIBS="$LIBSPEC_LIBS -lspectrum"
+-else
+-  as_fn_error $? "Sorry - I need libspectrum to be available" "$LINENO" 5
+-fi
+ 
+ done
+ 
+-- 
+2.13.1
 

--- a/app-emulation/libspectrum/libspectrum-1.1.1.recipe
+++ b/app-emulation/libspectrum/libspectrum-1.1.1.recipe
@@ -11,7 +11,7 @@ SOURCE_URI="https://sourceforge.net/projects/fuse-emulator/files/libspectrum/1.1
 CHECKSUM_SHA256="178d3607af2109b6b8dafac4f91912745b9f3c087319945c3a886bb7fe7989d5"
 PATCHES="libspectrum-$portVersion.patchset"
 
-ARCHITECTURES="x86_gcc2"
+ARCHITECTURES="x86_gcc2 x86_64"
 
 PROVIDES="
 	libspectrum = $portVersion
@@ -21,6 +21,7 @@ REQUIRES="
 	haiku
 	lib:libbz2
 	lib:libz
+	lib:libgcrypt
 	"
 
 PROVIDES_devel="


### PR DESCRIPTION
libspectrum and fuse: Tested building on x86_64 - fine for libspectrum, FUSE needed patch to configure script. Added libgcrypt as dependency.