### PR TITLE
keepassx: Enable on x86_64 and remove stack protector flag

### DIFF
--- a/app-admin/keepassx/keepassx-2.0a6.recipe
+++ b/app-admin/keepassx/keepassx-2.0a6.recipe
@@ -23,12 +23,12 @@ COPYRIGHT="2010-2012 Felix Geyer
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://github.com/keepassx/keepassx/archive/2.0-alpha6.zip"
-CHECKSUM_SHA256="3e4c2f3c5dd278cd139f4e91351aa3f9b435c8da506f14031edda44566365dc3"
+CHECKSUM_SHA256="dc377d6630bd1ae68191713442ff84ea173710bdfeddf95467b4f64910e030aa"
 SOURCE_DIR="keepassx-2.0-alpha6"
 PATCHES="keepassx-2.0a6.patchset"
 ADDITIONAL_FILES="keepassx.rdef"
 
-ARCHITECTURES="x86"
+ARCHITECTURES="x86 x86_64"
 
 PROVIDES="
 	keepassx = $portVersion

--- a/app-admin/keepassx/patches/keepassx-2.0a6.patchset
+++ b/app-admin/keepassx/patches/keepassx-2.0a6.patchset
@@ -1,4 +1,4 @@
-From 13f3d262fd9c6c0cf9f32f7ec8bef110b0aa71ca Mon Sep 17 00:00:00 2001
+From bb99b77b25d9f4f55cc0eb1050188478213c58e5 Mon Sep 17 00:00:00 2001
 From: Chris Roberts <cpr420@gmail.com>
 Date: Thu, 13 Nov 2014 19:28:44 -0700
 Subject: Add Haiku support
@@ -81,5 +81,28 @@ index eb77d2b..958eacb 100644
      QDBusConnection::sessionBus().send(message);
  #endif
 -- 
-1.8.3.4
+2.13.1
+
+
+From c893391972f22f6440f95b465c9b38a91b96d92e Mon Sep 17 00:00:00 2001
+From: Chris Moore <chris@mooreonline.org>
+Date: Wed, 2 Aug 2017 15:25:01 +0100
+Subject: Remove stack protector flag
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 73763a0..da86a83 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -64,7 +64,7 @@ endmacro(add_gcc_compiler_flags)
+ 
+ add_definitions(-DQT_NO_KEYWORDS -DQT_NO_EXCEPTIONS -DQT_NO_STL -DQT_STRICT_ITERATORS -DQT_NO_CAST_TO_ASCII)
+ 
+-add_gcc_compiler_flags("-fno-common -fstack-protector --param=ssp-buffer-size=4")
++add_gcc_compiler_flags("-fno-common --param=ssp-buffer-size=4")
+ add_gcc_compiler_flags("-Wall -Wextra -Wundef -Wpointer-arith -Wno-long-long")
+ add_gcc_compiler_flags("-Wformat=2 -Wmissing-format-attribute")
+ add_gcc_compiler_flags("-fvisibility=hidden")
+-- 
+2.13.1
 


### PR DESCRIPTION
Built and tested on x86_64 - just needed the stack protector flagged removed (or complains about libssp.so.0 being missing).