### PR TITLE
scummvm: Removed 'untested' flag after testing with several games on x86_64

### DIFF
--- a/games-engines/scummvm/scummvm-1.9.0.recipe
+++ b/games-engines/scummvm/scummvm-1.9.0.recipe
@@ -12,7 +12,7 @@ SOURCE_URI="http://scummvm.org/frs/scummvm/$portVersion/scummvm-$portVersion.tar
 CHECKSUM_SHA256="2417edcb1ad51ca05a817c58aeee610bc6db5442984e8cf28e8a5fd914e8ae05"
 ADDITIONAL_FILES="scummvm.rdef.in"
 
-ARCHITECTURES="!x86_gcc2 x86 ?x86_64"
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="


### PR DESCRIPTION
I've played through some Full Throttle, Monkey Island 2 and 3 and Indiana Jones games (a bit of each). All seems just as stable as the gcc2 hybrid build.