### PR TITLE
chocolate-doom: Enable x86_64 after testing

### DIFF
--- a/games-fps/chocolate-doom/chocolate_doom-2.2.1.recipe
+++ b/games-fps/chocolate-doom/chocolate_doom-2.2.1.recipe
@@ -13,7 +13,7 @@ SOURCE_URI="http://www.chocolate-doom.org/downloads/$portVersion/chocolate-doom-
 CHECKSUM_SHA256="ad11e2871667c6fa0658abf2dcba0cd9b26fbd651ee8df55adfdc18ad8fd674a"
 SOURCE_DIR="chocolate-doom-$portVersion"
 
-ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="


### PR DESCRIPTION
Tested with Doom 1 and 2 WADs - works just the same as gcc2 hybrid