### PR TITLE
Recipe for Pin8 (native Chip-8 emulator) added

### DIFF
--- a/games-emulation/pin8/pin8-1.0.recipe
+++ b/games-emulation/pin8/pin8-1.0.recipe
@@ -1,0 +1,49 @@
+SUMMARY="A Chip-8 emulator for Haiku OS"
+
+DESCRIPTION="This is a Chip-8 emulator for Haiku OS. Hence, it allows you to run Chip-8 games and software. Blitz, Blinky and Tetris are some of the numerous games available for this platform. A sample game, a flappy bird clone, is also available in the webpage of this program. \ Pin8 features responsive design, real keyboard compatibility, sound and two running modes."
+
+HOMEPAGE="https://github.com/cnelmortimer/Pin8/blob/master/README.md"
+
+COPYRIGHT="2017 N.C. Cruz"
+
+LICENSE="MIT"
+
+REVISION="1"
+
+srcGitRev="5784af55e8e90d658533cce98492d3d13577460f"
+
+SOURCE_URI="https://github.com/cnelmortimer/Pin8/archive/$srcGitRev.tar.gz"
+
+CHECKSUM_SHA256="4997ae2d06a2346c37a8e9c9831e0d56f6132685b95054450d7f4c72e2ca6e00"
+
+SOURCE_DIR="Pin8-$srcGitRev"
+
+ARCHITECTURES="x86_gcc2 x86 ?x86_64"
+
+PROVIDES="
+	Pin8 = $portVersion
+	app:Pin8 = $portVersion
+	"
+
+REQUIRES="
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	cmd:g++
+	cmd:make
+	cmd:xres
+	"
+	
+BUILD()
+{
+	make	
+}
+
+INSTALL()
+{
+	mkdir -p $appsDir
+	cp -a Pin8 $appsDir
+	addAppDeskbarSymlink $appsDir/Pin8	
+}


### PR DESCRIPTION
Dear repository team,

Please find a recipe to install Pin8, a new native Chip-8 emulator for Haiku written in C++.