### PR TITLE
Add rust recipes for 1.9.0 and 1.10.0 for both x86_gcc2 and x86_64

### DIFF
--- a/dev-lang/rust/rust-1.10.0.recipe
+++ b/dev-lang/rust/rust-1.10.0.recipe
@@ -1,0 +1,111 @@
+SUMMARY="Modern and safe systems programming language"
+DESCRIPTION="Rust is a systems programming language that runs blazingly fast, prevents almost all crashes*, and eliminates data races."
+HOMEPAGE="http://www.rust-lang.org/"
+LICENSE="MIT"
+COPYRIGHT="2016, The Rust Project Developers"
+srcGitRev="b515c198d30b5d5e18a15bd167949032659f81dc"
+srcGitRev2="57315f7e07d09b6f0341ebbcd50dded6c20d782f"
+srcGitRev3="eee85639922229007a63fc17ba9d1144ef84d53d"
+srcGitRev4="f96680f5a059069a320f62568d5afc88db9a7ec0"
+srcGitRev5="4638c60dedfa581fd5fa7c6420d8f32274c9ca0b"
+srcGitRev6="e1a938af495e2ba7477204fb4f24ccc902605e75"
+SOURCE_URI="https://github.com/nielx/rust/archive/$srcGitRev.tar.gz"
+SOURCE_URI_2="https://github.com/rust-lang/compiler-rt/archive/$srcGitRev2.tar.gz"
+SOURCE_URI_3="https://github.com/nielx/llvm/archive/$srcGitRev3.tar.gz"
+SOURCE_URI_4="https://github.com/nielx/rust-installer/archive/$srcGitRev4.tar.gz"
+SOURCE_URI_5="https://github.com/rust-lang/hoedown/archive/$srcGitRev5.tar.gz"
+SOURCE_URI_6="https://github.com/nielx/libc/archive/$srcGitRev6.tar.gz"
+SOURCE_FILENAME="rust-$srcGitRev.tar.gz"
+CHECKSUM_SHA256="6ce28e18ef4d83d391486df1fb9cc0f59c991de315d8990642b97c23a467d011"
+CHECKSUM_SHA256_2="244e97dbad67f752a4c394407e0929dbf44ed520a2dd9f19ebf86f2919112c3e"
+CHECKSUM_SHA256_3="bd88fcdcb0f4e070765a209e2dd938cc5136eaa374554f6c8057d237d5bd46fc"
+CHECKSUM_SHA256_4="d5f79186cd4b9221c07cf89b3f038aa073674e13ddd35f2e7e22486b8eb16020"
+CHECKSUM_SHA256_5="a5a0a957544a5f8cf08c0b67cb503f294b0e1bb20c65766abf9dc3c683d3b9c5"
+CHECKSUM_SHA256_6="5996751d47d363932fb130dba61257e6ed7efc439bcac0244e4d9768c6b3142f"
+SOURCE_DIR="rust-$srcGitRev"
+REVISION="1"
+ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
+SECONDARY_ARCHITECTURES="?x86"
+
+PROVIDES="
+	rust$secondaryArchSuffix = $portVersion
+	cmd:rustc = $portVersion
+	cmd:rustdoc = $portVersion
+	cmd:rust_gdb = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:find
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:python
+	cmd:sed
+	cmd:find
+	cmd:grep
+	cmd:file
+	cmd:git
+	cmd:tar
+	cmd:which
+	cmd:rustc == 1.9.0
+	"
+
+BUILD()
+{
+	rm -rf src/compiler-rt src/llvm src/rust-installer src/liblibc src/rt/hoedown
+	ln -sf /sources-2/compiler-rt-$srcGitRev2 src/compiler-rt
+	ln -sf /sources-3/llvm-$srcGitRev3 src/llvm
+	ln -sf /sources-4/rust-installer-$srcGitRev4 src/rust-installer
+	ln -sf /sources-5/hoedown-$srcGitRev5 src/rt/hoedown
+	ln -sf /sources-6/libc-$srcGitRev6 src/liblibc
+	# Do not use runConfigure: it generates too much noise, and it creates a totally impossible directory structure
+	#runConfigure --omit-dirs "docDir libExecDir dataRootDir includeDir sharedStateDir sbinDir binDir oldIncludeDir" ./configure --disable-jemalloc --build=i686-unknown-haiku --host=i686-unknown-haiku --target=i686-unknown-haiku
+
+	./configure --prefix=$prefix --mandir=$manDir --disable-jemalloc --enable-local-rust --local-rust-root=/boot/system/ --release-channel=stable
+
+	make
+}
+
+INSTALL()
+{
+	make install
+
+	# move documentation to the proper place
+	mkdir -p $developDocDir
+	mv $prefix/share/doc/rust/* $developDocDir
+	rm -rf $prefix/share
+
+	if [ -n "$secondaryArchSuffix" ]; then
+		# move the libs to the x86 subdir
+		mkdir -p $libDir
+		mv $prefix/lib/*.so $libDir
+	fi
+
+	# move the `rustlib` folder to the developLibDirs (as it is a framework of sorts)
+	# do create a link in $prefix/lib as that is where rustc expects things to live
+	mkdir -p $developLibDir
+	mv $prefix/lib/rustlib $developLibDir
+	cd $prefix/lib
+	ln -s ../$relativeDevelopLibDir/rustlib rustlib
+
+
+	# clean out unneccesary files created by the rust installer
+	rm $developLibDir/rustlib/components
+	rm $developLibDir/rustlib/install.log
+	rm $developLibDir/rustlib/manifest-rust-docs
+	rm $developLibDir/rustlib/manifest-rust-std-*-haiku
+	rm $developLibDir/rustlib/manifest-rustc
+	rm $developLibDir/rustlib/rust-installer-version
+	rm $developLibDir/rustlib/uninstall.sh
+}
+
+TEST()
+{
+	make check
+}
+

--- a/dev-lang/rust/rust-1.9.0.recipe
+++ b/dev-lang/rust/rust-1.9.0.recipe
@@ -1,0 +1,142 @@
+SUMMARY="Modern and safe systems programming language"
+DESCRIPTION="Rust is a systems programming language that runs blazingly fast, prevents almost all crashes*, and eliminates data races."
+HOMEPAGE="http://www.rust-lang.org/"
+LICENSE="MIT"
+COPYRIGHT="2016, The Rust Project Developers"
+srcGitRev="cc71d3af918369b668c9cb9f092e13ed3e34671d"
+srcGitRev2="57315f7e07d09b6f0341ebbcd50dded6c20d782f"
+srcGitRev3="2686d1d16f4bbcb9e6310fc8d48b95ae12eb7643"
+srcGitRev4="f96680f5a059069a320f62568d5afc88db9a7ec0"
+srcGitRev5="4638c60dedfa581fd5fa7c6420d8f32274c9ca0b"
+srcGitRev6="a8510ebfbd9231db7d97b5df95bdaf983e68a04f"
+SOURCE_URI="https://github.com/nielx/rust/archive/$srcGitRev.tar.gz"
+SOURCE_URI_2="https://github.com/rust-lang/compiler-rt/archive/$srcGitRev2.tar.gz"
+SOURCE_URI_3="https://github.com/nielx/llvm/archive/$srcGitRev3.tar.gz"
+SOURCE_URI_4="https://github.com/nielx/rust-installer/archive/$srcGitRev4.tar.gz"
+SOURCE_URI_5="https://github.com/rust-lang/hoedown/archive/$srcGitRev5.tar.gz"
+SOURCE_URI_6="https://github.com/nielx/libc/archive/$srcGitRev6.tar.gz"
+SOURCE_URI_7="http://rust-on-haiku.com/downloads/44#noarchive"
+SOURCE_URI_8="http://rust-on-haiku.com/downloads/46#noarchive"
+SOURCE_FILENAME="rust-$srcGitRev.tar.gz"
+SOURCE_FILENAME_7="rust-stage0-2016-08-07-b71ea1d-haiku-i386-bb4f6267ef13d945bdfaa443a0a007a84c8ce187.tar.bz2"
+SOURCE_FILENAME_8="rust-stage0-haiku-x86_64.tar.bz2"
+CHECKSUM_SHA256="6ef1d52641b0dea7fa89d66e2e442532055f57a6247149d42763f289b004286e"
+CHECKSUM_SHA256_2="244e97dbad67f752a4c394407e0929dbf44ed520a2dd9f19ebf86f2919112c3e"
+CHECKSUM_SHA256_3="2f78ed9c0223335c5a0118897447aeab58b7f87a41ebca1950e760142cd404f7"
+CHECKSUM_SHA256_4="d5f79186cd4b9221c07cf89b3f038aa073674e13ddd35f2e7e22486b8eb16020"
+CHECKSUM_SHA256_5="a5a0a957544a5f8cf08c0b67cb503f294b0e1bb20c65766abf9dc3c683d3b9c5"
+CHECKSUM_SHA256_6="6831b6ca212d531e8f775bc05af573a33d1e7c7b8b0d5e1d4ac056ac2a079141"
+CHECKSUM_SHA256_7="08fd4f697c08ed3da24225643eb8ae1331feb6afe13ada398691c0e2dbdc3b1f"
+CHECKSUM_SHA256_8="357b1d6a1307d2b9a784daf0a71ca1982f040d8539d7d4e1e0443523347445b0"
+SOURCE_DIR="rust-$srcGitRev"
+REVISION="1"
+ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
+SECONDARY_ARCHITECTURES="?x86"
+
+PROVIDES="
+	rust$secondaryArchSuffix = $portVersion
+	cmd:rustc = $portVersion
+	cmd:rustdoc = $portVersion
+	cmd:rust_gdb = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:find
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:python
+	cmd:sed
+	cmd:find
+	cmd:grep
+	cmd:file
+	cmd:git
+	cmd:tar
+	cmd:which
+	"
+
+BUILD()
+{
+	if [ $effectiveTargetArchitecture = x86_64 ]; then
+		# For x86_64 this recipe will unwrap the pre-built binary rustc compiler
+		# This compiler misses all the libraries and can only be used to bootstrap
+		# newer versions of Rust.
+		return
+	fi
+
+	rm -rf src/compiler-rt src/llvm src/rust-installer
+	ln -sf /sources-2/compiler-rt-$srcGitRev2 src/compiler-rt
+	ln -sf /sources-3/llvm-$srcGitRev3 src/llvm
+	ln -sf /sources-4/rust-installer-$srcGitRev4 src/rust-installer
+	rm -r src/rt/hoedown
+	ln -sf /sources-5/hoedown-$srcGitRev5 src/rt/hoedown
+	rm -r src/liblibc
+	ln -sf /sources-6/libc-$srcGitRev6 src/liblibc
+	# Do not use runConfigure: it generates too much noise, and it creates a totally impossible directory structure
+	#runConfigure --omit-dirs "docDir libExecDir dataRootDir includeDir sharedStateDir sbinDir binDir oldIncludeDir" ./configure --disable-jemalloc --build=i686-unknown-haiku --host=i686-unknown-haiku --target=i686-unknown-haiku
+
+	./configure --prefix=$prefix --mandir=$manDir --disable-jemalloc --disable-rpath --release-channel=stable
+
+	# download the stage 0 compiler, and put it in the proper place
+	if [ $effectiveTargetArchitecture = x86_64 ]; then
+		# TODO: update x86_64 port
+		ln -sf /sources-7/rust-stage0-2015-11-13-c386da0-haiku-x86_64-d09b23db0ef31209a1ebc42e54177449db0985ef.tar.bz2 dl/rust-stage0-2015-11-13-c386da0-haiku-x86_64-d09b23db0ef31209a1ebc42e54177449db0985ef.tar.bz2
+	else
+		ln -sf /sources-7/rust-stage0-2016-08-07-b71ea1d-haiku-i386-bb4f6267ef13d945bdfaa443a0a007a84c8ce187.tar.bz2 dl/rust-stage0-2016-08-07-b71ea1d-haiku-i386-bb4f6267ef13d945bdfaa443a0a007a84c8ce187.tar.bz2
+	fi
+	make
+}
+
+INSTALL()
+{
+	if [ $effectiveTargetArchitecture = x86_64 ]; then
+		cd /sources-8
+		tar xvfj rust-stage0-haiku-x86_64.tar.bz2
+		mkdir -p $binDir
+		cp rust-1.9.0-x86_64-distro/bin/rustc $binDir
+		return
+	fi
+
+	make install
+
+	# move documentation to the proper place
+	mkdir -p $developDocDir
+	mv $prefix/share/doc/rust/* $developDocDir
+	rm -rf $prefix/share
+
+	if [ -n "$secondaryArchSuffix" ]; then
+		# move the libs to the x86 subdir
+		mkdir -p $libDir
+		mv $prefix/lib/*.so $libDir
+	fi
+
+	# move the `rustlib` folder to the developLibDirs (as it is a framework of sorts)
+	# do create a link in $prefix/lib as that is where rustc expects things to live
+	mkdir -p $developLibDir
+	mv $prefix/lib/rustlib $developLibDir
+	cd $prefix/lib
+	ln -s ../$relativeDevelopLibDir/rustlib rustlib
+
+	# clean out unneccesary files created by the rust installer
+	rm $developLibDir/rustlib/components
+	rm $developLibDir/rustlib/install.log
+	rm $developLibDir/rustlib/manifest-rust-docs
+	rm $developLibDir/rustlib/manifest-rust-std-i686-unknown-haiku
+	rm $developLibDir/rustlib/manifest-rustc
+	rm $developLibDir/rustlib/rust-installer-version
+	rm $developLibDir/rustlib/uninstall.sh
+}
+
+TEST()
+{
+	if [ $effectiveTargetArchitecture = x86_64 ]; then
+		return
+	fi
+
+	make check
+}


### PR DESCRIPTION
The recipe for 1.9.0 will build the full compiler suite for x86_gcc2,
and it will 'wrap' a binary stage0 compiler for x86_64.
The recipe for 1.10.0 is a complete build.

These recipes don't create the rust_runtime packages. This package
should be recreated at a later point, but we will need to think about
the package naming, as it will be very much possible to have various
runtime libraries running alongside each other.