### PR TITLE
rust: add recipe for rust-1.11.0

### DIFF
--- a/dev-lang/rust/rust-1.11.0.recipe
+++ b/dev-lang/rust/rust-1.11.0.recipe
@@ -1,0 +1,111 @@
+SUMMARY="Modern and safe systems programming language"
+DESCRIPTION="Rust is a systems programming language that runs blazingly fast, prevents almost all crashes*, and eliminates data races."
+HOMEPAGE="http://www.rust-lang.org/"
+LICENSE="MIT"
+COPYRIGHT="2016, The Rust Project Developers"
+srcGitRev="e4511258789ee6cf16b23105cf6d691ef1c4a9ca"
+srcGitRev2="ac3d1cda612edccb6f1da53cbf7716e248405f3b"
+srcGitRev3="f96680f5a059069a320f62568d5afc88db9a7ec0"
+srcGitRev4="4638c60dedfa581fd5fa7c6420d8f32274c9ca0b"
+srcGitRev5="9b1459b6237748b525e0a4ee33f63ee3e1735593"
+srcGitRev6="0bd1123d8236f2587866b786479bef0aef3f6fe9"
+SOURCE_URI="https://github.com/nielx/rust/archive/$srcGitRev.tar.gz"
+SOURCE_URI_2="https://github.com/rust-lang/compiler-rt/archive/$srcGitRev2.tar.gz"
+SOURCE_URI_3="https://github.com/nielx/rust-installer/archive/$srcGitRev3.tar.gz"
+SOURCE_URI_4="https://github.com/rust-lang/hoedown/archive/$srcGitRev4.tar.gz"
+SOURCE_URI_5="https://github.com/nielx/libc/archive/$srcGitRev5.tar.gz"
+SOURCE_URI_6="https://github.com/nielx/llvm/archive/$srcGitRev6.tar.gz"
+SOURCE_FILENAME="rust-$srcGitRev.tar.gz"
+CHECKSUM_SHA256="c3de89137d1af18bfb37cf3a5f2089e0653e5765fe4fa5179830356a6d860f2e"
+CHECKSUM_SHA256_2="b1c6086509231af13ad8293dd98695e0ac17d1a76808e3fdd30c0ac070abe0aa"
+CHECKSUM_SHA256_3="d5f79186cd4b9221c07cf89b3f038aa073674e13ddd35f2e7e22486b8eb16020"
+CHECKSUM_SHA256_4="a5a0a957544a5f8cf08c0b67cb503f294b0e1bb20c65766abf9dc3c683d3b9c5"
+CHECKSUM_SHA256_5="602d0875cd11eaeac39c1c4e4edab26bc6f99cfefebac7a5bd00066c0962faed"
+CHECKSUM_SHA256_6="73bc1a426052e50bdbc3803b579c647db5fe2cae10e17dd102ccaa5a6530e50e"
+SOURCE_DIR="rust-$srcGitRev"
+REVISION="1"
+ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
+SECONDARY_ARCHITECTURES="?x86"
+
+PROVIDES="
+	rust$secondaryArchSuffix = $portVersion
+	cmd:rustc = $portVersion
+	cmd:rustdoc = $portVersion
+	cmd:rust_gdb = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	binutils${secondaryArchSuffix} == 2.26.1_2016_07_22 # version 2.28.1 will crash when building llvm
+	"
+BUILD_PREREQUIRES="
+	cmd:find
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:python
+	cmd:sed
+	cmd:find
+	cmd:grep
+	cmd:file
+	cmd:git
+	cmd:tar
+	cmd:which
+	cmd:rustc == 1.10.0
+	cmd:cmake
+	"
+
+BUILD()
+{
+	rm -rf src/compiler-rt src/llvm src/rust-installer src/liblibc src/rt/hoedown
+	ln -sf /sources-2/compiler-rt-$srcGitRev2 src/compiler-rt
+	ln -sf /sources-3/rust-installer-$srcGitRev3 src/rust-installer
+	ln -sf /sources-4/hoedown-$srcGitRev4 src/rt/hoedown
+	ln -sf /sources-5/libc-$srcGitRev5 src/liblibc
+	ln -sf /sources-6/llvm-$srcGitRev6 src/llvm
+	# Do not use runConfigure: it generates too much noise, and it creates a totally impossible directory structure
+	#runConfigure --omit-dirs "docDir libExecDir dataRootDir includeDir sharedStateDir sbinDir binDir oldIncludeDir" ./configure --disable-jemalloc --build=i686-unknown-haiku --host=i686-unknown-haiku --target=i686-unknown-haiku
+
+	./configure --prefix=$prefix --mandir=$manDir --disable-jemalloc --enable-local-rust --local-rust-root=/boot/system/ --release-channel=stable
+
+	make
+}
+
+INSTALL()
+{
+	make install
+
+	# move documentation to the proper place
+	mkdir -p $developDocDir
+	mv $prefix/share/doc/rust/* $developDocDir
+	rm -rf $prefix/share
+
+	if [ -n "$secondaryArchSuffix" ]; then
+		# move the libs to the x86 subdir
+		mkdir -p $libDir
+		mv $prefix/lib/*.so $libDir
+	fi
+
+	# move the `rustlib` folder to the developLibDirs (as it is a framework of sorts)
+	# do create a link in $prefix/lib as that is where rustc expects things to live
+	mkdir -p $developLibDir
+	mv $prefix/lib/rustlib $developLibDir
+	cd $prefix/lib
+	ln -s ../$relativeDevelopLibDir/rustlib rustlib
+
+	# clean out unneccesary files created by the rust installer
+	rm $developLibDir/rustlib/components
+	rm $developLibDir/rustlib/install.log
+	rm $developLibDir/rustlib/manifest-rust-docs
+	rm $developLibDir/rustlib/manifest-rust-std-*-haiku
+	rm $developLibDir/rustlib/manifest-rustc
+	rm $developLibDir/rustlib/rust-installer-version
+	rm $developLibDir/rustlib/uninstall.sh
+}
+
+TEST()
+{
+	make check
+}


### PR DESCRIPTION
Note that this recipe depends in on an older version of binutils
(2.26.1), as the current version of binutils (version 2.28.1) has ld
crash in linking the libLTO.so library from the bundled llvm. This is,
by the way, the same on the recipe of llvm-3.8.1 in this repository.