### PR TITLE
mesa: switch to autoconf.

### DIFF
--- a/sys-libs/mesa/mesa-17.1.7.recipe
+++ b/sys-libs/mesa/mesa-17.1.7.recipe
@@ -6,17 +6,18 @@ providing 3D rendering to Haiku applications."
 HOMEPAGE="http://www.mesa3d.org/"
 COPYRIGHT="1999-2017 Brian Paul"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://mesa.freedesktop.org/archive/mesa-${portVersion}.tar.xz"
 CHECKSUM_SHA256="69f472a874b1122404fa0bd13e2d6bf87eb3b9ad9c21d2f39872a96d83d9e5f5"
+PATCHES="mesa-$portVersion.patchset"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64 ?arm ?ppc"
 SECONDARY_ARCHITECTURES="?x86"
 
 PROVIDES="
 	mesa$secondaryArchSuffix = $portVersion
-	lib:libGL$secondaryArchSuffix
-	lib:libEGL$secondaryArchSuffix
+	lib:libGL$secondaryArchSuffix = 1.0.0 compat >= 1
+	lib:libEGL$secondaryArchSuffix = 1.0.0 compat >= 1
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -26,132 +27,12 @@ REQUIRES="
 
 PROVIDES_devel="
 	mesa${secondaryArchSuffix}_devel = $portVersion
-	devel:libGL$secondaryArchSuffix = $portVersion
-	devel:libEGL$secondaryArchSuffix = $portVersion
+	devel:libGL$secondaryArchSuffix = 1.0.0 compat >= 1
+	devel:libEGL$secondaryArchSuffix = 1.0.0 compat >= 1
 	"
 REQUIRES_devel="
 	mesa$secondaryArchSuffix == $portVersion base
 	"
-
-BUILD_REQUIRES="
-	haiku${secondaryArchSuffix}_devel
-	devel:libz$secondaryArchSuffix
-	"
-BUILD_PREREQUIRES="
-	llvm${secondaryArchSuffix}
-	mako_python
-	cmd:bison
-	cmd:find
-	cmd:flex
-	cmd:gcc$secondaryArchSuffix
-	cmd:ld$secondaryArchSuffix
-	cmd:scons
-	cmd:sed
-	"
-
-BUILD()
-{
-	if [ -n "$secondaryArchSuffix" ]; then
-		export HAIKU_SECONDARY_ARCH="$effectiveTargetArchitecture"
-	fi
-	scons $jobArgs build=release
-	#scons $jobArgs build=debug
-}
-
-INSTALL()
-{
-	mesaBuildDir=build/haiku-$effectiveTargetArchitecture
-
-	mkdir -p $libDir
-	mkdir -p $developLibDir
-
-	# libGL.so makes up the core of our OpenGL kit
-	cp $(find $mesaBuildDir -name 'libGL.so') $libDir
-	symlinkRelative -s $libDir/libGL.so $developLibDir
-	symlinkRelative -s $libDir/libGL.so $libDir/libGL.so.1
-
-	# OpenGL ES
-	cp $(find $mesaBuildDir -name 'libEGL.so.1') $libDir
-	symlinkRelative -s $libDir/libEGL.so.1 $libDir/libEGL.so
-	symlinkRelative -s $libDir/libEGL.so.1 $developLibDir/libEGL.so
-
-	# Our rendering add-ons
-	mkdir -p $addOnsDir/opengl
-	cp $(find $mesaBuildDir -name 'libswpipe.so') \
-		"$addOnsDir/opengl/Software Pipe"
-
-	# Set some nice version info
-	appVersion=${portVersion//\./ }
-	setversion "$libDir/libGL.so" -app $appVersion -long "Haiku OpenGL kit"
-	setversion "$libDir/libEGL.so.1" -app $appVersion -long "Mesa EGL"
-	setversion "$addOnsDir/opengl/Software Pipe" -app $appVersion -long "Gallium LLVM software pipe renderer"
-
-	# OpenGL Kit
-	mkdir -p $includeDir/os/opengl
-	cp ./include/HaikuGL/OpenGLKit.h $includeDir/os/
-	cp ./include/HaikuGL/GLView.h $includeDir/os/opengl/
-	cp ./include/HaikuGL/GLRenderer.h $includeDir/os/opengl/
-
-	# Standard GL headers
-	mkdir -p $includeDir/GL
-	cp ./include/GL/gl.h $includeDir/GL/
-	cp ./include/GL/gl_mangle.h $includeDir/GL/
-	cp ./include/GL/glext.h $includeDir/GL/
-
-	# Create GL symlink in opengl kit
-	symlinkRelative -s $includeDir/GL $includeDir/os/opengl/GL
-
-	# Standard EGL headers
-	mkdir -p $includeDir/EGL
-	cp ./include/EGL/* $includeDir/EGL
-
-	# Create GL symlink in opengl kit
-	symlinkRelative -s $includeDir/EGL $includeDir/os/opengl/EGL
-
-	# KHR headers for EGL
-	mkdir -p $includeDir/KHR
-	cp ./include/KHR/* $includeDir/KHR
-
-	# Create KHR symlink in opengl kit
-	symlinkRelative -s $includeDir/EGL $includeDir/os/opengl/KHR
-
-	mkdir -p $developLibDir/pkgconfig
-	cat > $developLibDir/pkgconfig/gl.pc << EOF
-prefix=${prefix}
-exec_prefix=${prefix}
-libdir=${libDir}
-includedir=${includeDir}
-
-Name: gl
-Description: Mesa OpenGL library
-Version: $portVersion
-Libs: -L${developLibDir} -lGL
-Libs.private: -lm
-EOF
-	cat > $developLibDir/pkgconfig/egl.pc << EOF
-prefix=${prefix}
-exec_prefix=${prefix}
-libdir=${libDir}
-includedir=${includeDir}
-
-Name: egl
-Description: Mesa EGL library
-Version: $portVersion
-Libs: -L${developLibDir} -lEGL
-Libs.private: -lm
-EOF
-	# devel package
-	packageEntries devel \
-		$developDir
-
-	# swpipe renderer package
-	packageEntries swpipe \
-		"$addOnsDir/opengl/Software Pipe"
-}
-
-
-# ===== Gallium OpenGL Add-ons ===============================================
-# ----- swpipe package -------------------------------------------------------
 
 SUMMARY_swpipe="The Mesa LLVM enhanced Gallium software pipe renderer"
 DESCRIPTION_swpipe="This 3D BGLRenderer add-on provides Gallium LLVM \
@@ -170,3 +51,89 @@ REQUIRED_swpipe="
 	mesa$secondaryArchSuffix == $portVersion base
 	lib:libLLVM_4.0$secondaryArchSuffix
 	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libz$secondaryArchSuffix
+	llvm${secondaryArchSuffix}
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:automake
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:which
+	"
+
+BUILD()
+{
+	if [ -n "$secondaryArchSuffix" ]; then
+		export HAIKU_SECONDARY_ARCH="$effectiveTargetArchitecture"
+	fi
+
+	autoreconf -fi
+	runConfigure ./configure \
+		--disable-dri \
+		--disable-glx \
+		--disable-glx-tls \
+		--disable-gbm \
+		--disable-gles1 \
+		--disable-gles2 \
+		--disable-shared-glapi \
+		--with-gallium-drivers=swrast \
+		--with-platforms=haiku
+
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	rm $libDir/lib*.la
+
+	# Our rendering add-ons
+	mkdir -p $addOnsDir/opengl
+	mv $(find $libDir -name 'libswpipe.so') \
+		"$addOnsDir/opengl/Software Pipe"
+	rm -rf $libDir/haiku
+
+	# Set some nice version info
+	appVersion=${portVersion//\./ }
+	setversion "$libDir/libGL.so" -app $appVersion -long "Haiku OpenGL kit"
+	setversion "$libDir/libEGL.so.1" -app $appVersion -long "Mesa EGL"
+	setversion "$addOnsDir/opengl/Software Pipe" -app $appVersion -long "Gallium LLVM software pipe renderer"
+
+	prepareInstalledDevelLibs \
+		libGL libEGL
+	fixPkgconfig
+
+	# for compatibility
+	symlinkRelative -s $libDir/libGL.so.1 $libDir/libGL.so
+
+	# OpenGL Kit
+	mkdir -p $includeDir/os/opengl
+	cp ./include/HaikuGL/OpenGLKit.h $includeDir/os/
+	cp ./include/HaikuGL/GLView.h $includeDir/os/opengl/
+	cp ./include/HaikuGL/GLRenderer.h $includeDir/os/opengl/
+
+	# Create GL symlink in opengl kit
+	symlinkRelative -s $includeDir/GL $includeDir/os/opengl/GL
+	# Create EGL symlink in opengl kit
+	symlinkRelative -s $includeDir/EGL $includeDir/os/opengl/EGL
+	# Create KHR symlink in opengl kit
+	symlinkRelative -s $includeDir/KHR $includeDir/os/opengl/KHR
+
+	# devel package
+	packageEntries devel \
+		$developDir
+
+	# swpipe renderer package
+	packageEntries swpipe \
+		"$addOnsDir/opengl/Software Pipe"
+}
+

--- a/sys-libs/mesa/patches/mesa-17.1.7.patchset
+++ b/sys-libs/mesa/patches/mesa-17.1.7.patchset
@@ -1,0 +1,512 @@
+From 0da7d7fd7c04003ac04b0d31150b3fae2c4cd4d9 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Mon, 11 Sep 2017 21:29:14 +0200
+Subject: Haiku patch
+
+
+diff --git a/configure.ac b/configure.ac
+index fd346c8..0fdfb5b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -272,6 +272,9 @@ case "$host_os" in
+ *-android*)
+     android=yes
+     ;;
++*haiku)
++    haiku=yes
++    ;;
+ linux*|*-gnu*|gnu*|cygwin*)
+     DEFINES="$DEFINES -D_GNU_SOURCE"
+     ;;
+@@ -281,6 +284,7 @@ solaris*)
+ esac
+ 
+ AM_CONDITIONAL(HAVE_ANDROID, test "x$android" = xyes)
++AM_CONDITIONAL(HAVE_HAIKU, test "x$haiku" = xyes)
+ 
+ dnl Add flags for gcc and g++
+ if test "x$GCC" = xyes; then
+@@ -841,12 +845,18 @@ dnl According to the manual when using pthreads, one should add -pthread to
+ dnl both compile and link-time arguments.
+ dnl In practise that should be sufficient for all platforms, since any
+ dnl platforms build with GCC and Clang support the flag.
+-PTHREAD_LIBS="$PTHREAD_LIBS -pthread"
++case "$host_os" in
++haiku*)
++    ;;
++* )
++    PTHREAD_LIBS="$PTHREAD_LIBS -pthread"
++    ;;
++esac
+ 
+ dnl pthread-stubs is mandatory on BSD platforms, due to the nature of the
+ dnl project. Even then there's a notable issue as described in the project README
+ case "$host_os" in
+-linux* | cygwin* | darwin* | solaris* | *-gnu* | gnu*)
++linux* | cygwin* | darwin* | solaris* | *-gnu* | gnu* | haiku*)
+     pthread_stubs_possible="no"
+     ;;
+ * )
+@@ -1490,11 +1500,21 @@ require_dri_shared_libs_and_glapi() {
+     if test "x$enable_dri" != xyes; then
+         # There is only a single backend which won't be build/used otherwise.
+         # XXX: Revisit this as the egl/haiku is a thing.
+-        AC_MSG_ERROR([$1 requires --enable-dri])
++        case "$host_os" in
++        haiku*)
++                ;;
++        *)
++                AC_MSG_ERROR([$1 requires --enable-dri]) ;;
++		esac
+     fi
+ 
+     if test "x$enable_shared_glapi" != xyes; then
+-        AC_MSG_ERROR([$1 requires --enable-shared-glapi])
++        case "$host_os" in
++        haiku*)
++            ;;
++        *)
++            AC_MSG_ERROR([$1 requires --enable-shared-glapi]) ;;
++        esac
+     fi
+ }
+ 
+@@ -1710,6 +1730,10 @@ for plat in $platforms; do
+ 		DEFINES="$DEFINES -DHAVE_ANDROID_PLATFORM"
+ 		;;
+ 
++	haiku)
++		DEFINES="$DEFINES -DHAVE_HAIKU_PLATFORM"
++		;;
++
+ 	*)
+ 		AC_MSG_ERROR([platform '$plat' does not exist])
+ 		;;
+@@ -2769,6 +2793,7 @@ AC_CONFIG_FILES([Makefile
+ 		src/gallium/state_trackers/clover/Makefile
+ 		src/gallium/state_trackers/dri/Makefile
+ 		src/gallium/state_trackers/glx/xlib/Makefile
++		src/gallium/state_trackers/hgl/Makefile
+ 		src/gallium/state_trackers/nine/Makefile
+ 		src/gallium/state_trackers/omx/Makefile
+ 		src/gallium/state_trackers/osmesa/Makefile
+@@ -2779,6 +2804,7 @@ AC_CONFIG_FILES([Makefile
+ 		src/gallium/targets/d3dadapter9/Makefile
+ 		src/gallium/targets/d3dadapter9/d3d.pc
+ 		src/gallium/targets/dri/Makefile
++		src/gallium/targets/haiku-softpipe/Makefile
+ 		src/gallium/targets/libgl-xlib/Makefile
+ 		src/gallium/targets/omx/Makefile
+ 		src/gallium/targets/opencl/Makefile
+@@ -2802,6 +2828,7 @@ AC_CONFIG_FILES([Makefile
+ 		src/gallium/winsys/amdgpu/drm/Makefile
+ 		src/gallium/winsys/svga/drm/Makefile
+ 		src/gallium/winsys/sw/dri/Makefile
++		src/gallium/winsys/sw/hgl/Makefile
+ 		src/gallium/winsys/sw/kms-dri/Makefile
+ 		src/gallium/winsys/sw/null/Makefile
+ 		src/gallium/winsys/sw/wrapper/Makefile
+@@ -2817,6 +2844,8 @@ AC_CONFIG_FILES([Makefile
+ 		src/glx/windows/Makefile
+ 		src/glx/windows/windowsdriproto.pc
+ 		src/gtest/Makefile
++		src/hgl/Makefile
++		src/hgl/gl.pc
+ 		src/intel/Makefile
+ 		src/loader/Makefile
+ 		src/mapi/Makefile
+diff --git a/src/Makefile.am b/src/Makefile.am
+index aa5f8aa..91439df 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -113,6 +113,10 @@ if HAVE_PLATFORM_WAYLAND
+ SUBDIRS += egl/wayland/wayland-egl
+ endif
+ 
++if HAVE_HAIKU
++SUBDIRS += hgl
++endif
++
+ if HAVE_EGL
+ SUBDIRS += egl
+ endif
+diff --git a/src/egl/Makefile.am b/src/egl/Makefile.am
+index 8109038..07c2a16 100644
+--- a/src/egl/Makefile.am
++++ b/src/egl/Makefile.am
+@@ -45,6 +45,7 @@ libEGL_common_la_LIBADD = \
+ 
+ dri2_backend_FILES =
+ dri3_backend_FILES =
++haiku_backend_FILES =
+ 
+ if HAVE_PLATFORM_X11
+ AM_CFLAGS += $(XCB_DRI2_CFLAGS)
+@@ -83,6 +84,22 @@ libEGL_common_la_LIBADD += $(ANDROID_LIBS)
+ dri2_backend_FILES += drivers/dri2/platform_android.c
+ endif
+ 
++if HAVE_HAIKU
++AM_CPPFLAGS = \
++	-I$(top_srcdir)/include \
++	-I$(top_srcdir)/include/HaikuGL \
++	-I$(top_srcdir)/src/egl/main \
++	-I$(top_srcdir)/src/ \
++	-D_EGL_BUILT_IN_DRIVER_HAIKU \
++	-D_EGL_NATIVE_PLATFORM=$(EGL_NATIVE_PLATFORM)
++haiku_backend_FILES += drivers/haiku/egl_haiku.cpp
++libEGL_common_la_LIBADD += $(top_builddir)/src/hgl/libGL.la
++libEGL_common_la_SOURCES += \
++	$(haiku_backend_FILES)
++
++endif
++
++if !HAVE_HAIKU
+ AM_CFLAGS += \
+ 	-I$(top_srcdir)/src/loader \
+ 	-I$(top_srcdir)/src/egl/drivers/dri2 \
+@@ -121,6 +138,8 @@ g_egldispatchstubs.h: $(GLVND_GEN_DEPS)
+ BUILT_SOURCES = g_egldispatchstubs.c g_egldispatchstubs.h
+ CLEANFILES = $(BUILT_SOURCES)
+ 
++endif
++
+ if USE_LIBGLVND
+ AM_CFLAGS += \
+ 	$(GLVND_CFLAGS)
+@@ -177,7 +196,6 @@ TESTS = egl-symbols-check \
+ EXTRA_DIST = \
+ 	$(TESTS) \
+ 	SConscript \
+-	drivers/haiku \
+ 	main/egl.def \
+ 	main/README.txt \
+ 	$(GLVND_GEN_DEPS) \
+diff --git a/src/gallium/Makefile.am b/src/gallium/Makefile.am
+index 38da63b..49b457d 100644
+--- a/src/gallium/Makefile.am
++++ b/src/gallium/Makefile.am
+@@ -110,6 +110,10 @@ if HAVE_DRISW_KMS
+ SUBDIRS += winsys/sw/kms-dri
+ endif
+ 
++if HAVE_HAIKU
++SUBDIRS += winsys/sw/hgl
++endif
++
+ SUBDIRS += winsys/sw/wrapper
+ 
+ ##
+@@ -173,6 +177,10 @@ if HAVE_ST_NINE
+ SUBDIRS += state_trackers/nine targets/d3dadapter9
+ endif
+ 
++if HAVE_HAIKU
++SUBDIRS += state_trackers/hgl targets/haiku-softpipe
++endif
++
+ ##
+ ## Don't forget to bundle the remaining (non autotools) state-trackers/targets
+ ##
+@@ -182,7 +190,6 @@ EXTRA_DIST += \
+ 	state_trackers/README \
+ 	state_trackers/wgl targets/libgl-gdi \
+ 	targets/graw-gdi targets/graw-null  targets/graw-xlib \
+-	state_trackers/hgl targets/haiku-softpipe \
+ 	tools
+ 
+ 
+diff --git a/src/gallium/state_trackers/hgl/Makefile.am b/src/gallium/state_trackers/hgl/Makefile.am
+new file mode 100644
+index 0000000..5b55be8
+--- /dev/null
++++ b/src/gallium/state_trackers/hgl/Makefile.am
+@@ -0,0 +1,39 @@
++# Copyright © 2017 Haiku, Inc. All rights reserved.
++#
++# Permission is hereby granted, free of charge, to any person obtaining a
++# copy of this software and associated documentation files (the "Software"),
++# to deal in the Software without restriction, including without limitation
++# the rights to use, copy, modify, merge, publish, distribute, sublicense,
++# and/or sell copies of the Software, and to permit persons to whom the
++# Software is furnished to do so, subject to the following conditions:
++#
++# The above copyright notice and this permission notice (including the next
++# paragraph) shall be included in all copies or substantial portions of the
++# Software.
++#
++# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++# NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
++# DEALINGS IN THE SOFTWARE.
++
++include Makefile.sources
++include $(top_srcdir)/src/gallium/Automake.inc
++
++
++AM_CPPFLAGS = \
++	-I$(top_srcdir)/src \
++	-I$(top_srcdir)/src/mapi \
++	-I$(top_srcdir)/src/mesa \
++	-I$(top_srcdir)/include/HaikuGL \
++	$(GALLIUM_CFLAGS)
++
++noinst_LTLIBRARIES = libhgl.la
++libhgl_la_LIBADD = -ltranslation
++libhgl_la_SOURCES = $(common_SOURCES)
++
++
++EXTRA_DIST = SConscript
+diff --git a/src/gallium/state_trackers/hgl/Makefile.sources b/src/gallium/state_trackers/hgl/Makefile.sources
+new file mode 100644
+index 0000000..3076ba3
+--- /dev/null
++++ b/src/gallium/state_trackers/hgl/Makefile.sources
+@@ -0,0 +1,3 @@
++common_SOURCES := \
++	hgl.c \
++	bitmap_wrapper.cpp
+diff --git a/src/gallium/targets/haiku-softpipe/Makefile.am b/src/gallium/targets/haiku-softpipe/Makefile.am
+new file mode 100644
+index 0000000..d68050f
+--- /dev/null
++++ b/src/gallium/targets/haiku-softpipe/Makefile.am
+@@ -0,0 +1,68 @@
++include $(top_srcdir)/src/gallium/Automake.inc
++
++AM_CPPFLAGS = \
++		-I$(top_srcdir)/src/mapi \
++		-I$(top_srcdir)/src/mesa \
++		-I$(top_srcdir)/src/mesa/main \
++		-I$(top_srcdir)/include/HaikuGL \
++		-I$(top_srcdir)/src/gallium/include \
++		-I$(top_srcdir)/src/gallium/winsys \
++		-I$(top_srcdir)/src/gallium/state_trackers/hgl \
++		-I/boot/system/develop/headers/private \
++		$(GALLIUM_TARGET_CFLAGS) \
++		$(DEFINES) \
++		-DGALLIUM_SOFTPIPE \
++		-DGALLIUM_RBUG \
++		-DGALLIUM_TRACE
++
++hswpipedir = ${libdir}/haiku
++hswpipe_LTLIBRARIES = libswpipe.la
++
++libswpipe_la_SOURCES = \
++		GalliumContext.cpp \
++		SoftwareRenderer.cpp
++
++libswpipe_la_LDFLAGS = \
++		-shared \
++		-shrext .so \
++		-module \
++		-avoid-version \
++		$(GC_SECTIONS)
++
++libswpipe_la_LIBADD = \
++		$(top_builddir)/src/gallium/winsys/sw/hgl/libswhgl.la \
++		$(top_builddir)/src/gallium/state_trackers/hgl/libhgl.la \
++		$(top_builddir)/src/gallium/drivers/rbug/librbug.la \
++		$(top_builddir)/src/gallium/drivers/trace/libtrace.la \
++		$(top_builddir)/src/gallium/auxiliary/libgallium.la \
++		$(top_builddir)/src/mesa/libmesagallium.la \
++		$(top_builddir)/src/gallium/drivers/softpipe/libsoftpipe.la \
++		$(GALLIUM_COMMON_LIB_DEPS) \
++		-lnetwork
++
++EXTRA_DIST = \
++		SConscript
++
++TARGET_DRIVERS =
++TARGET_CPPFLAGS =
++TARGET_LIB_DEPS =
++
++include $(top_srcdir)/src/gallium/drivers/softpipe/Automake.inc
++include $(top_srcdir)/src/gallium/drivers/llvmpipe/Automake.inc
++include $(top_srcdir)/src/gallium/drivers/swr/Automake.inc
++
++
++if HAVE_GALLIUM_LLVM
++AM_CPPFLAGS += -DGALLIUM_LLVMPIPE
++
++libswpipe_la_LIBADD += $(LLVM_LIBS) \
++	$(top_builddir)/src/gallium/drivers/llvmpipe/libllvmpipe.la
++libswpipe_la_LDFLAGS += $(LLVM_LDFLAGS)
++endif
++
++if HAVE_GALLIUM_SWR
++AM_CPPFLAGS += -DGALLIUM_SWR
++
++libswpipe_la_LIBADD += \
++        $(top_builddir)/src/gallium/drivers/swr/libmesaswr.la
++endif
+diff --git a/src/gallium/targets/haiku-softpipe/SoftwareRenderer.cpp b/src/gallium/targets/haiku-softpipe/SoftwareRenderer.cpp
+index 18cb1ac..4e4888a 100644
+--- a/src/gallium/targets/haiku-softpipe/SoftwareRenderer.cpp
++++ b/src/gallium/targets/haiku-softpipe/SoftwareRenderer.cpp
+@@ -33,6 +33,8 @@
+ 
+ extern const char* color_space_name(color_space space);
+ 
++#undef _EXPORT
++#define _EXPORT __attribute__((__visibility__("default")))
+ 
+ extern "C" _EXPORT BGLRenderer*
+ instantiate_gl_renderer(BGLView *view, ulong opts, BGLDispatcher *dispatcher)
+diff --git a/src/gallium/winsys/sw/hgl/Makefile.am b/src/gallium/winsys/sw/hgl/Makefile.am
+new file mode 100644
+index 0000000..8e5d403
+--- /dev/null
++++ b/src/gallium/winsys/sw/hgl/Makefile.am
+@@ -0,0 +1,34 @@
++# Copyright © 2017 Haiku, Inc. All rights reserved.
++#
++# Permission is hereby granted, free of charge, to any person obtaining a
++# copy of this software and associated documentation files (the "Software"),
++# to deal in the Software without restriction, including without limitation
++# the rights to use, copy, modify, merge, publish, distribute, sublicense,
++# and/or sell copies of the Software, and to permit persons to whom the
++# Software is furnished to do so, subject to the following conditions:
++#
++# The above copyright notice and this permission notice (including the next
++# paragraph) shall be included in all copies or substantial portions of the
++# Software.
++#
++# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++# NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
++# DEALINGS IN THE SOFTWARE.
++
++include Makefile.sources
++include $(top_srcdir)/src/gallium/Automake.inc
++
++AM_CFLAGS = \
++	-I$(top_srcdir)/src/gallium/state_trackers/hgl \
++	$(GALLIUM_WINSYS_CFLAGS)
++
++noinst_LTLIBRARIES = libswhgl.la
++
++libswhgl_la_SOURCES = $(C_SOURCES)
++
++EXTRA_DIST = SConscript
+diff --git a/src/gallium/winsys/sw/hgl/Makefile.sources b/src/gallium/winsys/sw/hgl/Makefile.sources
+new file mode 100644
+index 0000000..52bfc88
+--- /dev/null
++++ b/src/gallium/winsys/sw/hgl/Makefile.sources
+@@ -0,0 +1,3 @@
++C_SOURCES := \
++	hgl_sw_winsys.c \
++	hgl_sw_winsys.h
+diff --git a/src/hgl/Makefile.am b/src/hgl/Makefile.am
+new file mode 100644
+index 0000000..f82602a
+--- /dev/null
++++ b/src/hgl/Makefile.am
+@@ -0,0 +1,50 @@
++# Copyright © 2017 Haiku, Inc. All rights reserved.
++#
++# Permission is hereby granted, free of charge, to any person obtaining a
++# copy of this software and associated documentation files (the "Software"),
++# to deal in the Software without restriction, including without limitation
++# the rights to use, copy, modify, merge, publish, distribute, sublicense,
++# and/or sell copies of the Software, and to permit persons to whom the
++# Software is furnished to do so, subject to the following conditions:
++#
++# The above copyright notice and this permission notice (including the next
++# paragraph) shall be included in all copies or substantial portions of the
++# Software.
++#
++# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
++# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
++# IN THE SOFTWARE.
++
++include Makefile.sources
++
++AM_CPPFLAGS = \
++	-I$(top_srcdir)/src \
++	-I$(top_srcdir)/src/mapi \
++	-I$(top_srcdir)/src/mesa \
++	-I$(top_srcdir)/src/mesa/main \
++	-I$(top_srcdir)/include/ \
++	-I$(top_srcdir)/include/HaikuGL \
++	-I/system/develop/headers/private \
++	-I$(top_builddir)/src/mapi \
++	$(DEFINES)
++
++
++lib_LTLIBRARIES = libGL.la
++
++libGL_la_LIBADD = $(top_builddir)/src/mapi/glapi/libglapi.la -lbe
++libGL_la_SOURCES = $(COMMON_SOURCES)
++libGL_la_LDFLAGS = \
++	-no-undefined \
++	-version-number 1:0 \
++	$(BSYMBOLIC) \
++	$(GC_SECTIONS) \
++	$(LD_NO_UNDEFINED)
++
++pkgconfigdir = $(libdir)/pkgconfig
++pkgconfig_DATA = gl.pc
++
++EXTRA_DIST =
+diff --git a/src/hgl/Makefile.sources b/src/hgl/Makefile.sources
+new file mode 100644
+index 0000000..5df230b
+--- /dev/null
++++ b/src/hgl/Makefile.sources
+@@ -0,0 +1,8 @@
++COMMON_SOURCES := \
++    GLView.cpp \
++    GLRenderer.cpp \
++    GLRendererRoster.cpp \
++    GLRendererRoster.h \
++    GLDispatcher.cpp \
++    GLDispatcher.h
++
+diff --git a/src/hgl/gl.pc.in b/src/hgl/gl.pc.in
+new file mode 100644
+index 0000000..7577bae
+--- /dev/null
++++ b/src/hgl/gl.pc.in
+@@ -0,0 +1,11 @@
++prefix=@prefix@
++exec_prefix=${prefix}
++libdir=@libdir@
++includedir=@includedir@
++
++Name: gl
++Description: Mesa OpenGL library
++Version: @PACKAGE_VERSION@
++Libs: -L${libdir} -lGL
++Libs.private: @GL_PC_LIB_PRIV@
++Cflags: -I${includedir} @GL_PC_CFLAGS@
+diff --git a/src/mapi/glapi/glapi_dispatch.c b/src/mapi/glapi/glapi_dispatch.c
+index df907ff..9f21a71 100644
+--- a/src/mapi/glapi/glapi_dispatch.c
++++ b/src/mapi/glapi/glapi_dispatch.c
+@@ -144,6 +144,9 @@ GL_API void GL_APIENTRY glTexParameterxv (GLenum target, GLenum pname, const GLf
+ GL_API void GL_APIENTRY glTranslatex (GLfixed x, GLfixed y, GLfixed z);
+ GL_API void GL_APIENTRY glPointSizePointerOES (GLenum type, GLsizei stride, const GLvoid *pointer);
+ 
++GL_API void GL_APIENTRY glBlendBarrier (void);
++GL_API void GL_APIENTRY glPrimitiveBoundingBox (GLfloat minX, GLfloat minY, GLfloat minZ, GLfloat minW, GLfloat maxX, GLfloat maxY, GLfloat maxZ, GLfloat maxW);
++
+ /* Enable frame pointer elimination on Windows, otherwise forgetting to add
+  * APIENTRY to _mesa_* entrypoints will not cause crashes on debug builds, as
+  * the initial ESP value is saved in the EBP in the function prologue, then
+-- 
+2.13.1
+


### PR DESCRIPTION
Mesa for Unix platforms is usually built with autoconf instead of scons. This switch should help us to follow build system changes for other platforms more easily, it provides a pkgconfig file for egl, library versioning, etc..
One hack is the use of libglapi for both libGL and libEGL, which is forbidden for the autoconf build system, but was allowed in scons. For the time being I added Haiku as an exception.
This commit is probably not so clean for upstream, I only tested libGL on x86_64. 
Please review.