### PR TITLE
libexecinfo: fix broken symlink in devel package.

### DIFF
--- a/sys-libs/libexecinfo/libexecinfo-1.1.recipe
+++ b/sys-libs/libexecinfo/libexecinfo-1.1.recipe
@@ -5,7 +5,7 @@ platforms, however it can be used at any platform which has a GCC compiler."
 HOMEPAGE="http://www.freshports.org/devel/libexecinfo"
 COPYRIGHT="2003-2014 Maxim Sobolev"
 LICENSE="BSD (2-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="http://ftp.freebsd.org/pub/FreeBSD/ports/local-distfiles/itetcu/libexecinfo-1.1.tar.bz2"
 CHECKSUM_SHA256="c9a21913e7fdac8ef6b33250b167aa1fc0a7b8a175145e26913a4c19d8a59b1f"
 PATCHES="libexecinfo-$portVersion.patchset"
@@ -52,8 +52,8 @@ INSTALL()
 	mkdir -p $includeDir
 
 	cp libexecinfo.a $libDir
-	cp libexecinfo.so $libDir/libexecinfo.so.1.1
-	ln -s $libDir/libexecinfo.so.1.1 $libDir/libexecinfo.so
+	cp libexecinfo.so $libDir
+	ln -s $libDir/libexecinfo.so $libDir/libexecinfo.so.1.1
 	cp execinfo.h $includeDir
 
 	prepareInstalledDevelLibs libexecinfo


### PR DESCRIPTION
The devel package of libexecinfo_1.1-3 seemed to still install with a broken symlink and some packages that search for 'libexecinfo.so' will fail to do so. This commit fixes this issue.