### PR TITLE
Rust: add recipe for rust 1.13.0

### DIFF
--- a/dev-lang/rust/patches/rust-1.13.0.patchset
+++ b/dev-lang/rust/patches/rust-1.13.0.patchset
@@ -1,0 +1,101 @@
+From 6383a6c04ef2c915391563de62b01456a6723f87 Mon Sep 17 00:00:00 2001
+From: Niels Sascha Reedijk <niels.reedijk@gmail.com>
+Date: Wed, 20 Sep 2017 18:20:13 +0000
+Subject: Patches for Haiku
+
+
+diff --git a/mk/cfg/i686-unknown-haiku.mk b/mk/cfg/i686-unknown-haiku.mk
+index cbacbff..d1bcc7a 100644
+--- a/mk/cfg/i686-unknown-haiku.mk
++++ b/mk/cfg/i686-unknown-haiku.mk
+@@ -9,7 +9,7 @@ CFG_STATIC_LIB_NAME_i686-unknown-haiku=lib$(1).a
+ CFG_LIB_GLOB_i686-unknown-haiku=lib$(1)-*.so
+ CFG_LIB_DSYM_GLOB_i686-unknown-haiku=lib$(1)-*.dylib.dSYM
+ CFG_CFLAGS_i686-unknown-haiku := -m32 $(CFLAGS)
+-CFG_GCCISH_CFLAGS_i686-unknown-haiku := -Wall -Werror -g -fPIC -m32 $(CFLAGS)
++CFG_GCCISH_CFLAGS_i686-unknown-haiku := -Wall -g -fPIC -m32 $(CFLAGS)
+ CFG_GCCISH_CXXFLAGS_i686-unknown-haiku := -fno-rtti $(CXXFLAGS)
+ CFG_GCCISH_LINK_FLAGS_i686-unknown-haiku := -shared -fPIC -ldl -pthread  -lrt -g -m32
+ CFG_GCCISH_PRE_LIB_FLAGS_i686-unknown-haiku := -Wl,-whole-archive
+diff --git a/mk/cfg/x86_64-unknown-haiku.mk b/mk/cfg/x86_64-unknown-haiku.mk
+index 4c2d888..476327a 100644
+--- a/mk/cfg/x86_64-unknown-haiku.mk
++++ b/mk/cfg/x86_64-unknown-haiku.mk
+@@ -9,7 +9,7 @@ CFG_STATIC_LIB_NAME_x86_64-unknown-haiku=lib$(1).a
+ CFG_LIB_GLOB_x86_64-unknown-haiku=lib$(1)-*.so
+ CFG_LIB_DSYM_GLOB_x86_64-unknown-haiku=lib$(1)-*.dylib.dSYM
+ CFG_CFLAGS_x86_64-unknown-haiku := -m64 $(CFLAGS)
+-CFG_GCCISH_CFLAGS_x86_64-unknown-haiku := -Wall -Werror -g -fPIC -m64 $(CFLAGS)
++CFG_GCCISH_CFLAGS_x86_64-unknown-haiku := -Wall -g -fPIC -m64 $(CFLAGS)
+ CFG_GCCISH_CXXFLAGS_x86_64-unknown-haiku := -fno-rtti $(CXXFLAGS)
+ CFG_GCCISH_LINK_FLAGS_x86_64-unknown-haiku := -shared -fPIC -ldl -pthread -lrt -g -m64
+ CFG_GCCISH_PRE_LIB_FLAGS_x86_64-unknown-haiku := -Wl,-whole-archive
+diff --git a/src/librustc_back/target/haiku_base.rs b/src/librustc_back/target/haiku_base.rs
+index 5e319ba..7f79330 100644
+--- a/src/librustc_back/target/haiku_base.rs
++++ b/src/librustc_back/target/haiku_base.rs
+@@ -16,7 +16,7 @@ pub fn opts() -> TargetOptions {
+         linker: "cc".to_string(),
+         dynamic_linking: true,
+         executables: true,
+-        has_rpath: true,
++        has_rpath: false,
+         linker_is_gnu: true,
+         .. Default::default()
+     }
+diff --git a/src/librustc_back/target/mod.rs b/src/librustc_back/target/mod.rs
+index 0870780..4cabd47 100644
+--- a/src/librustc_back/target/mod.rs
++++ b/src/librustc_back/target/mod.rs
+@@ -166,8 +166,8 @@ supported_targets! {
+     ("x86_64-unknown-netbsd", x86_64_unknown_netbsd),
+     ("x86_64-rumprun-netbsd", x86_64_rumprun_netbsd),
+ 
+-    ("i686_unknown_haiku", i686_unknown_haiku),
+-    ("x86_64_unknown_haiku", x86_64_unknown_haiku),
++    ("i686-unknown-haiku", i686_unknown_haiku),
++    ("x86_64-unknown-haiku", x86_64_unknown_haiku),
+ 
+     ("x86_64-apple-darwin", x86_64_apple_darwin),
+     ("i686-apple-darwin", i686_apple_darwin),
+diff --git a/src/librustc_data_structures/flock.rs b/src/librustc_data_structures/flock.rs
+index 510c9ce..c1546e0 100644
+--- a/src/librustc_data_structures/flock.rs
++++ b/src/librustc_data_structures/flock.rs
+@@ -109,6 +109,7 @@ mod imp {
+             pub l_sysid: libc::c_int,
+         }
+ 
++        pub const F_RDLCK: libc::c_short = 0x0040;
+         pub const F_UNLCK: libc::c_short = 0x0200;
+         pub const F_WRLCK: libc::c_short = 0x0400;
+         pub const F_SETLK: libc::c_int = 0x0080;
+diff --git a/src/librustdoc/lib.rs b/src/librustdoc/lib.rs
+index b6dc755..88e5af9 100644
+--- a/src/librustdoc/lib.rs
++++ b/src/librustdoc/lib.rs
+@@ -98,7 +98,7 @@ struct Output {
+ }
+ 
+ pub fn main() {
+-    const STACK_SIZE: usize = 32_000_000; // 32MB
++    const STACK_SIZE: usize = 16_000_000; // 16MB on Haiku
+     let res = std::thread::Builder::new().stack_size(STACK_SIZE).spawn(move || {
+         let s = env::args().collect::<Vec<_>>();
+         main_args(&s)
+diff --git a/src/libstd/sys/common/net.rs b/src/libstd/sys/common/net.rs
+index 18280e4..609e43e 100644
+--- a/src/libstd/sys/common/net.rs
++++ b/src/libstd/sys/common/net.rs
+@@ -29,7 +29,7 @@ use sys::net::netc::IPV6_JOIN_GROUP as IPV6_ADD_MEMBERSHIP;
+ #[cfg(not(any(target_os = "dragonfly", target_os = "freebsd",
+               target_os = "ios", target_os = "macos",
+               target_os = "openbsd", target_os = "netbsd",
+-              target_os = "solaris", taget_os = "haiku")))]
++              target_os = "solaris", target_os = "haiku")))]
+ use sys::net::netc::IPV6_ADD_MEMBERSHIP;
+ #[cfg(any(target_os = "dragonfly", target_os = "freebsd",
+           target_os = "ios", target_os = "macos",
+-- 
+2.7.0
+

--- a/dev-lang/rust/patches/rust-installer-1.13.0.patchset
+++ b/dev-lang/rust/patches/rust-installer-1.13.0.patchset
@@ -1,0 +1,27 @@
+From fa075bf6c5642960985621370954817e34be8f83 Mon Sep 17 00:00:00 2001
+From: Niels Sascha Reedijk <niels.reedijk@gmail.com>
+Date: Mon, 9 Mar 2015 22:27:02 +0100
+Subject: [PATCH] Haiku: detect OS
+
+---
+ install-template.sh | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/install-template.sh b/install-template.sh
+index dcc1ee0..90afec2 100644
+--- a/install-template.sh
++++ b/install-template.sh
+@@ -364,6 +364,10 @@ get_host_triple() {
+             _ostype=pc-windows-gnu
+             ;;
+ 
++	Haiku*)
++            _ostype=unknown-haiku
++            ;;
++
+ 	*)
+ 	    err "unknown value from uname -s: $_uname_value"
+ 	    ;;
+-- 
+2.7.0
+

--- a/dev-lang/rust/rust-1.13.0.recipe
+++ b/dev-lang/rust/rust-1.13.0.recipe
@@ -1,0 +1,115 @@
+SUMMARY="Modern and safe systems programming language"
+DESCRIPTION="Rust is a systems programming language that runs blazingly fast, prevents almost all crashes*, and eliminates data races."
+HOMEPAGE="http://www.rust-lang.org/"
+LICENSE="MIT"
+COPYRIGHT="2016, The Rust Project Developers"
+srcGitRev="2c6933acc05c61e041be764cb1331f6281993f3f"
+srcGitRev2="ecd2b1f6d689d5afbf5debe8afb3739337323852"
+srcGitRev3="4f994850808a572e2cc8d43f968893c8e942e9bf"
+srcGitRev4="a3736a0a1907cbc8bf619708738815a5fd789c80"
+srcGitRev5="ebeab042e6bb14a447627b57ed9a493e2cc0e095"
+srcGitRev6="ac1c94226e9fa17005ce7e2dd52dd6d1875f3137"
+SOURCE_URI="https://github.com/rust-lang/rust/archive/$srcGitRev.tar.gz"
+SOURCE_URI_2="https://github.com/rust-lang/compiler-rt/archive/$srcGitRev2.tar.gz"
+SOURCE_URI_3="https://github.com/rust-lang/rust-installer/archive/$srcGitRev3.tar.gz"
+SOURCE_URI_4="https://github.com/rust-lang/hoedown/archive/$srcGitRev4.tar.gz"
+SOURCE_URI_5="https://github.com/rust-lang/libc/archive/$srcGitRev5.tar.gz"
+SOURCE_URI_6="https://github.com/rust-lang/llvm/archive/$srcGitRev6.tar.gz"
+SOURCE_FILENAME="rust-$srcGitRev.tar.gz"
+CHECKSUM_SHA256="b17dce437b064a7c7954e4e40a3f1351d3cc33db8efeedbaeeb39e842b77fc8f"
+CHECKSUM_SHA256_2="f9814fd94717dec7ec2c09ecc17fe6ef25c8b2e95ad16ced020e864b3ad763f5"
+CHECKSUM_SHA256_3="dc7240d60a869fa24a68c8734fb7c810c27cca0a6dad52df6279865e4e8e7fae"
+CHECKSUM_SHA256_4="29da85607df523a165c1b01a378f929a0b37b75969119b6ec373d95576978b13"
+CHECKSUM_SHA256_5="b0896666125315cdcd8cdef98c51529047f59a656de78503fa69782d5376beb7"
+CHECKSUM_SHA256_6="57638407e7713018e5cd4c0de29b52e976ddb248db122c13d6ded89f5f3243ce"
+SOURCE_DIR="rust-$srcGitRev"
+PATCHES="rust-$portVersion.patchset"
+PATCHES_3="rust-installer-$portVersion.patchset"
+REVISION="1"
+ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	rust$secondaryArchSuffix = $portVersion
+	cmd:rustc = $portVersion
+	cmd:rustdoc = $portVersion
+	cmd:rust_gdb = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	binutils${secondaryArchSuffix} == 2.26.1_2016_07_22 # version 2.28.1 will crash when building llvm
+	"
+BUILD_PREREQUIRES="
+	cmd:find
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:python
+	cmd:sed
+	cmd:find
+	cmd:grep
+	cmd:file
+	cmd:git
+	cmd:tar
+	cmd:which
+	cmd:rustc == 1.12.1
+	cmd:cmake
+	"
+
+BUILD()
+{
+	rm -rf src/compiler-rt src/llvm src/rust-installer src/liblibc src/rt/hoedown
+	ln -sf /sources-2/compiler-rt-$srcGitRev2 src/compiler-rt
+	ln -sf /sources-3/rust-installer-$srcGitRev3 src/rust-installer
+	ln -sf /sources-4/hoedown-$srcGitRev4 src/rt/hoedown
+	ln -sf /sources-5/libc-$srcGitRev5 src/liblibc
+	ln -sf /sources-6/llvm-$srcGitRev6 src/llvm
+	# Do not use runConfigure: it generates too much noise, and it creates a totally impossible directory structure
+	#runConfigure --omit-dirs "docDir libExecDir dataRootDir includeDir sharedStateDir sbinDir binDir oldIncludeDir" ./configure --disable-jemalloc --build=i686-unknown-haiku --host=i686-unknown-haiku --target=i686-unknown-haiku
+
+	./configure --prefix=$prefix --mandir=$manDir --disable-jemalloc \
+	            --enable-local-rust --local-rust-root=/boot/system/ \
+	            --release-channel=stable
+
+	make
+}
+
+INSTALL()
+{
+	make install
+
+	# move documentation to the proper place
+	mkdir -p $developDocDir
+	mv $prefix/share/doc/rust/* $developDocDir
+	rm -rf $prefix/share
+
+	if [ -n "$secondaryArchSuffix" ]; then
+		# move the libs to the x86 subdir
+		mkdir -p $libDir
+		mv $prefix/lib/*.so $libDir
+	fi
+
+	# move the `rustlib` folder to the developLibDirs (as it is a framework of sorts)
+	# do create a link in $prefix/lib as that is where rustc expects things to live
+	mkdir -p $developLibDir
+	mv $prefix/lib/rustlib $developLibDir
+	cd $prefix/lib
+	ln -s ../$relativeDevelopLibDir/rustlib rustlib
+
+	# clean out unneccesary files created by the rust installer
+	rm $developLibDir/rustlib/components
+	rm $developLibDir/rustlib/install.log
+	rm $developLibDir/rustlib/manifest-rust-docs
+	rm $developLibDir/rustlib/manifest-rust-std-*-haiku
+	rm $developLibDir/rustlib/manifest-rustc
+	rm $developLibDir/rustlib/rust-installer-version
+	rm $developLibDir/rustlib/uninstall.sh
+}
+
+TEST()
+{
+	make check
+}


### PR DESCRIPTION
The difference with the recipes for versions 1.9.0 through 1.12.1 is that
this one is based off the "official" rust sources, after Alexander
von Gluck integrated the existing patches and added some additional of his
own. The recipe uses some additional patches to fix the build system (and
some oversights). The complete patched source tree can be found at
https://github.com/nielx/rust

This can be applied after rust 1.12.1 builds successfully.