### PR TITLE
gpgme, no structural changes, recipe cleanup

### DIFF
--- a/app-crypt/gpgme/gpgme-1.9.0.recipe
+++ b/app-crypt/gpgme/gpgme-1.9.0.recipe
@@ -15,12 +15,12 @@ LICENSE="
 	GNU GPL v2
 	GNU LGPL v2.1
 	"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-$portVersion.tar.bz2"
 CHECKSUM_SHA256="1b29fedb8bfad775e70eafac5b0590621683b2d9869db994568e6401f4034ceb"
 PATCHES="gpgme-$portVersion.patchset"
 
-ARCHITECTURES="x86_gcc2 x86 x86 x86_64"
+ARCHITECTURES="!x86_gcc2 x86 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 #TODO: fix gpgme-config hardcoded package paths
@@ -33,7 +33,6 @@ PROVIDES="
 REQUIRES="
 	haiku${secondaryArchSuffix}
 	lib:libgpg_error${secondaryArchSuffix}
-	cmd:gpg
 	lib:libglib_2.0$secondaryArchSuffix
 	lib:libassuan${secondaryArchSuffix}
 	"
@@ -60,7 +59,7 @@ BUILD_PREREQUIRES="
 	cmd:bison
 	cmd:gcc${secondaryArchSuffix}
 	cmd:git
-	cmd:gpg
+	cmd:gpg$secondaryArchSuffix
 	cmd:gpg_error$secondaryArchSuffix
 	cmd:ld${secondaryArchSuffix}
 	cmd:libtoolize


### PR DESCRIPTION
gnupg can't be build for x86_gcc2 (requirement of gpgme)