### PR TITLE
Rust 1.12.1: Specify the buildtools version

### DIFF
--- a/dev-lang/rust/rust-1.12.1.recipe
+++ b/dev-lang/rust/rust-1.12.1.recipe
@@ -38,6 +38,7 @@ REQUIRES="
 	"
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	binutils${secondaryArchSuffix} == 2.26.1_2016_07_22 # version 2.28.1 will crash when building llvm
 	"
 BUILD_PREREQUIRES="
 	cmd:find


### PR DESCRIPTION
In response to the discussion of PR #1668
This fix was actually already employed in the recipe for 1.11.0, so instead of renaming binutils, let's do it again this way. 