### PR TITLE
Rust: add recipe for 1.15.1

### DIFF
--- a/dev-lang/rust/patches/rust-1.15.1.patchset
+++ b/dev-lang/rust/patches/rust-1.15.1.patchset
@@ -1,0 +1,116 @@
+From cdf6b56465759702bc9ecbe2a488c47e719a1db6 Mon Sep 17 00:00:00 2001
+From: Niels Sascha Reedijk <niels.reedijk@gmail.com>
+Date: Wed, 20 Sep 2017 07:25:06 +0000
+Subject: [PATCH 1/4] Haiku: remove -Werror from compiler-rt build commands
+
+---
+ mk/cfg/i686-unknown-haiku.mk   | 2 +-
+ mk/cfg/x86_64-unknown-haiku.mk | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/mk/cfg/i686-unknown-haiku.mk b/mk/cfg/i686-unknown-haiku.mk
+index cbacbff..d1bcc7a 100644
+--- a/mk/cfg/i686-unknown-haiku.mk
++++ b/mk/cfg/i686-unknown-haiku.mk
+@@ -9,7 +9,7 @@ CFG_STATIC_LIB_NAME_i686-unknown-haiku=lib$(1).a
+ CFG_LIB_GLOB_i686-unknown-haiku=lib$(1)-*.so
+ CFG_LIB_DSYM_GLOB_i686-unknown-haiku=lib$(1)-*.dylib.dSYM
+ CFG_CFLAGS_i686-unknown-haiku := -m32 $(CFLAGS)
+-CFG_GCCISH_CFLAGS_i686-unknown-haiku := -Wall -Werror -g -fPIC -m32 $(CFLAGS)
++CFG_GCCISH_CFLAGS_i686-unknown-haiku := -Wall -g -fPIC -m32 $(CFLAGS)
+ CFG_GCCISH_CXXFLAGS_i686-unknown-haiku := -fno-rtti $(CXXFLAGS)
+ CFG_GCCISH_LINK_FLAGS_i686-unknown-haiku := -shared -fPIC -ldl -pthread  -lrt -g -m32
+ CFG_GCCISH_PRE_LIB_FLAGS_i686-unknown-haiku := -Wl,-whole-archive
+diff --git a/mk/cfg/x86_64-unknown-haiku.mk b/mk/cfg/x86_64-unknown-haiku.mk
+index 4c2d888..476327a 100644
+--- a/mk/cfg/x86_64-unknown-haiku.mk
++++ b/mk/cfg/x86_64-unknown-haiku.mk
+@@ -9,7 +9,7 @@ CFG_STATIC_LIB_NAME_x86_64-unknown-haiku=lib$(1).a
+ CFG_LIB_GLOB_x86_64-unknown-haiku=lib$(1)-*.so
+ CFG_LIB_DSYM_GLOB_x86_64-unknown-haiku=lib$(1)-*.dylib.dSYM
+ CFG_CFLAGS_x86_64-unknown-haiku := -m64 $(CFLAGS)
+-CFG_GCCISH_CFLAGS_x86_64-unknown-haiku := -Wall -Werror -g -fPIC -m64 $(CFLAGS)
++CFG_GCCISH_CFLAGS_x86_64-unknown-haiku := -Wall -g -fPIC -m64 $(CFLAGS)
+ CFG_GCCISH_CXXFLAGS_x86_64-unknown-haiku := -fno-rtti $(CXXFLAGS)
+ CFG_GCCISH_LINK_FLAGS_x86_64-unknown-haiku := -shared -fPIC -ldl -pthread -lrt -g -m64
+ CFG_GCCISH_PRE_LIB_FLAGS_x86_64-unknown-haiku := -Wl,-whole-archive
+-- 
+2.7.0
+
+
+From 31d4c16ca09f2d8731cb3a2781e7a5308e622b81 Mon Sep 17 00:00:00 2001
+From: Niels Sascha Reedijk <niels.reedijk@gmail.com>
+Date: Wed, 20 Sep 2017 07:26:48 +0000
+Subject: [PATCH 2/4] Haiku: disable rpath as standard option on the compiler
+
+---
+ src/librustc_back/target/haiku_base.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/librustc_back/target/haiku_base.rs b/src/librustc_back/target/haiku_base.rs
+index 5e319ba..7f79330 100644
+--- a/src/librustc_back/target/haiku_base.rs
++++ b/src/librustc_back/target/haiku_base.rs
+@@ -16,7 +16,7 @@ pub fn opts() -> TargetOptions {
+         linker: "cc".to_string(),
+         dynamic_linking: true,
+         executables: true,
+-        has_rpath: true,
++        has_rpath: false,
+         linker_is_gnu: true,
+         .. Default::default()
+     }
+-- 
+2.7.0
+
+
+From 0868d4b686eb87205fc0a1c546e7ec39aa9201df Mon Sep 17 00:00:00 2001
+From: Niels Sascha Reedijk <niels.reedijk@gmail.com>
+Date: Wed, 20 Sep 2017 07:27:38 +0000
+Subject: [PATCH 3/4] Haiku: add missing F_RDLCK constant
+
+---
+ src/librustc_data_structures/flock.rs | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/librustc_data_structures/flock.rs b/src/librustc_data_structures/flock.rs
+index 33d71ba..2211854 100644
+--- a/src/librustc_data_structures/flock.rs
++++ b/src/librustc_data_structures/flock.rs
+@@ -113,6 +113,7 @@ mod imp {
+             pub l_sysid: libc::c_int,
+         }
+ 
++        pub const F_RDLCK: libc::c_short = 0x0040;
+         pub const F_UNLCK: libc::c_short = 0x0200;
+         pub const F_WRLCK: libc::c_short = 0x0400;
+         pub const F_SETLK: libc::c_int = 0x0080;
+-- 
+2.7.0
+
+
+From 0931756a613172ab78adee33975636e4d6beb41d Mon Sep 17 00:00:00 2001
+From: Niels Sascha Reedijk <niels.reedijk@gmail.com>
+Date: Wed, 20 Sep 2017 17:36:59 +0000
+Subject: [PATCH 4/4] Haiku: reduce stack memory to 16MB (max on Haiku)
+
+---
+ src/librustdoc/lib.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/librustdoc/lib.rs b/src/librustdoc/lib.rs
+index 174118d..4517992 100644
+--- a/src/librustdoc/lib.rs
++++ b/src/librustdoc/lib.rs
+@@ -99,7 +99,7 @@ struct Output {
+ }
+ 
+ pub fn main() {
+-    const STACK_SIZE: usize = 32_000_000; // 32MB
++    const STACK_SIZE: usize = 16_000_000; // 16MB on Haiku
+     let res = std::thread::Builder::new().stack_size(STACK_SIZE).spawn(move || {
+         let s = env::args().collect::<Vec<_>>();
+         main_args(&s)
+-- 
+2.7.0
+

--- a/dev-lang/rust/patches/rust-installer-1.15.1.patchset
+++ b/dev-lang/rust/patches/rust-installer-1.15.1.patchset
@@ -1,0 +1,27 @@
+From fa075bf6c5642960985621370954817e34be8f83 Mon Sep 17 00:00:00 2001
+From: Niels Sascha Reedijk <niels.reedijk@gmail.com>
+Date: Mon, 9 Mar 2015 22:27:02 +0100
+Subject: [PATCH] Haiku: detect OS
+
+---
+ install-template.sh | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/install-template.sh b/install-template.sh
+index dcc1ee0..90afec2 100644
+--- a/install-template.sh
++++ b/install-template.sh
+@@ -364,6 +364,10 @@ get_host_triple() {
+             _ostype=pc-windows-gnu
+             ;;
+ 
++	Haiku*)
++            _ostype=unknown-haiku
++            ;;
++
+ 	*)
+ 	    err "unknown value from uname -s: $_uname_value"
+ 	    ;;
+-- 
+2.7.0
+

--- a/dev-lang/rust/rust-1.15.1.recipe
+++ b/dev-lang/rust/rust-1.15.1.recipe
@@ -1,0 +1,115 @@
+SUMMARY="Modern and safe systems programming language"
+DESCRIPTION="Rust is a systems programming language that runs blazingly fast, prevents almost all crashes*, and eliminates data races."
+HOMEPAGE="http://www.rust-lang.org/"
+LICENSE="MIT"
+COPYRIGHT="2017, The Rust Project Developers"
+srcGitRev="1.15.1"
+srcGitRev2="a8fc4c169fac43a5dc204d4fd56ddb1739f8c178"
+srcGitRev3="4f994850808a572e2cc8d43f968893c8e942e9bf"
+srcGitRev4="a3736a0a1907cbc8bf619708738815a5fd789c80"
+srcGitRev5="0ac39c5ccf6a04395b7c40dd62321cb91f63f160"
+srcGitRev6="ceb177eeefa7d67ca29230d2e7e8584f97d4fdad"
+SOURCE_URI="https://github.com/rust-lang/rust/archive/$srcGitRev.tar.gz"
+SOURCE_URI_2="https://github.com/rust-lang/compiler-rt/archive/$srcGitRev2.tar.gz"
+SOURCE_URI_3="https://github.com/rust-lang/rust-installer/archive/$srcGitRev3.tar.gz"
+SOURCE_URI_4="https://github.com/rust-lang/hoedown/archive/$srcGitRev4.tar.gz"
+SOURCE_URI_5="https://github.com/rust-lang/libc/archive/$srcGitRev5.tar.gz"
+SOURCE_URI_6="https://github.com/rust-lang/llvm/archive/$srcGitRev6.tar.gz"
+SOURCE_FILENAME="rust-$srcGitRev.tar.gz"
+CHECKSUM_SHA256="c9e880a6eb72e9ec689139844ba82e956aad6d69f11e89114a47fb7858d2cef0"
+CHECKSUM_SHA256_2="7d143e0025eb634de5dd2c4ceff22f632cfa065ebbf213068ccacff124732034"
+CHECKSUM_SHA256_3="dc7240d60a869fa24a68c8734fb7c810c27cca0a6dad52df6279865e4e8e7fae"
+CHECKSUM_SHA256_4="29da85607df523a165c1b01a378f929a0b37b75969119b6ec373d95576978b13"
+CHECKSUM_SHA256_5="17694d9a1e09153237f2ce85f9c5e1d632b97ab9a0f688ba27da31c4fecbc400"
+CHECKSUM_SHA256_6="0414d14ba98eb1659180a00e78d002b50a6494e6b596145d6fb4262cbb76019b"
+SOURCE_DIR="rust-$srcGitRev"
+PATCHES="rust-$portVersion.patchset"
+PATCHES_3="rust-installer-$portVersion.patchset"
+REVISION="1"
+ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	rust$secondaryArchSuffix = $portVersion
+	cmd:rustc = $portVersion
+	cmd:rustdoc = $portVersion
+	cmd:rust_gdb = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	binutils${secondaryArchSuffix} == 2.26.1_2016_07_22 # version 2.28.1 will crash when building llvm
+	"
+BUILD_PREREQUIRES="
+	cmd:find
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:python2
+	cmd:sed
+	cmd:find
+	cmd:grep
+	cmd:file
+	cmd:git
+	cmd:tar
+	cmd:which
+	cmd:rustc == 1.14.0
+	cmd:cmake
+	"
+
+BUILD()
+{
+	rm -rf src/compiler-rt src/llvm src/rust-installer src/liblibc src/rt/hoedown
+	ln -sf /sources-2/compiler-rt-$srcGitRev2 src/compiler-rt
+	ln -sf /sources-3/rust-installer-$srcGitRev3 src/rust-installer
+	ln -sf /sources-4/hoedown-$srcGitRev4 src/rt/hoedown
+	ln -sf /sources-5/libc-$srcGitRev5 src/liblibc
+	ln -sf /sources-6/llvm-$srcGitRev6 src/llvm
+	# Do not use runConfigure: it generates too much noise, and it creates a totally impossible directory structure
+	#runConfigure --omit-dirs "docDir libExecDir dataRootDir includeDir sharedStateDir sbinDir binDir oldIncludeDir" ./configure --disable-jemalloc --build=i686-unknown-haiku --host=i686-unknown-haiku --target=i686-unknown-haiku
+
+	./configure --prefix=$prefix --mandir=$manDir --disable-jemalloc \
+	            --enable-local-rust --local-rust-root=/boot/system/ \
+	            --disable-rustbuild --release-channel=stable
+
+	make
+}
+
+INSTALL()
+{
+	make install
+
+	# move documentation to the proper place
+	mkdir -p $developDocDir
+	mv $prefix/share/doc/rust/* $developDocDir
+	rm -rf $prefix/share
+
+	if [ -n "$secondaryArchSuffix" ]; then
+		# move the libs to the x86 subdir
+		mkdir -p $libDir
+		mv $prefix/lib/*.so $libDir
+	fi
+
+	# move the `rustlib` folder to the developLibDirs (as it is a framework of sorts)
+	# do create a link in $prefix/lib as that is where rustc expects things to live
+	mkdir -p $developLibDir
+	mv $prefix/lib/rustlib $developLibDir
+	cd $prefix/lib
+	ln -s ../$relativeDevelopLibDir/rustlib rustlib
+
+	# clean out unneccesary files created by the rust installer
+	rm $developLibDir/rustlib/components
+	rm $developLibDir/rustlib/install.log
+	rm $developLibDir/rustlib/manifest-rust-docs
+	rm $developLibDir/rustlib/manifest-rust-std-*-haiku
+	rm $developLibDir/rustlib/manifest-rustc
+	rm $developLibDir/rustlib/rust-installer-version
+	rm $developLibDir/rustlib/uninstall.sh
+}
+
+TEST()
+{
+	make check
+}


### PR DESCRIPTION
The recipe is based on the official github sources, plus patches where
applicable. The tree including patches can be found at
https://github.com/nielx/rust