### PR TITLE
Fixing yaml_cpp checksum

### DIFF
--- a/dev-cpp/yaml_cpp/yaml_cpp-0.5.3.recipe
+++ b/dev-cpp/yaml_cpp/yaml_cpp-0.5.3.recipe
@@ -6,7 +6,7 @@ COPYRIGHT="2008 Jesse Beder"
 LICENSE="MIT"
 REVISION="2"
 SOURCE_URI="https://github.com/jbeder/yaml-cpp/archive/release-$portVersion.tar.gz"
-CHECKSUM_SHA256="ac50a27a201d16dc69a881b80ad39a7be66c4d755eda1f76c3a68781b922af8f"
+CHECKSUM_SHA256="3492d9c1f4319dfd5588f60caed7cec3f030f7984386c11ed4b39f8e3316d763"
 SOURCE_DIR="yaml-cpp-release-$portVersion"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"


### PR DESCRIPTION
I was building yaml_cpp for qutebrowser, and it wouldn't build because of the incorrect checksum in the recipe.