### PR TITLE
Rust: several changes to the 1.15.1 recipe

### DIFF
--- a/dev-lang/rust/rust-1.15.1.recipe
+++ b/dev-lang/rust/rust-1.15.1.recipe
@@ -15,28 +15,50 @@ SOURCE_URI_3="https://github.com/rust-lang/rust-installer/archive/$srcGitRev3.ta
 SOURCE_URI_4="https://github.com/rust-lang/hoedown/archive/$srcGitRev4.tar.gz"
 SOURCE_URI_5="https://github.com/rust-lang/libc/archive/$srcGitRev5.tar.gz"
 SOURCE_URI_6="https://github.com/rust-lang/llvm/archive/$srcGitRev6.tar.gz"
+SOURCE_URI_7="http://rust-on-haiku.com/downloads/76#noarchive"
+SOURCE_URI_8="http://rust-on-haiku.com/downloads/77#noarchive"
 SOURCE_FILENAME="rust-$srcGitRev.tar.gz"
+SOURCE_FILENAME_7="cargo-0.16.0-i686.tar.gz"
+SOURCE_FILENAME_8="cargo-0.16.0-x86_64.tar.gz"
 CHECKSUM_SHA256="c9e880a6eb72e9ec689139844ba82e956aad6d69f11e89114a47fb7858d2cef0"
 CHECKSUM_SHA256_2="7d143e0025eb634de5dd2c4ceff22f632cfa065ebbf213068ccacff124732034"
 CHECKSUM_SHA256_3="dc7240d60a869fa24a68c8734fb7c810c27cca0a6dad52df6279865e4e8e7fae"
 CHECKSUM_SHA256_4="29da85607df523a165c1b01a378f929a0b37b75969119b6ec373d95576978b13"
 CHECKSUM_SHA256_5="17694d9a1e09153237f2ce85f9c5e1d632b97ab9a0f688ba27da31c4fecbc400"
 CHECKSUM_SHA256_6="0414d14ba98eb1659180a00e78d002b50a6494e6b596145d6fb4262cbb76019b"
+CHECKSUM_SHA256_7="d92d38cbcdbb491591348d302fe6d079122e12650de9f0e2e9a5a40e7e2504f1"
+CHECKSUM_SHA256_8="54e9062464dbff4b11b91831520a7ecd7b539742871ed43553b2d6a8cd6b7d35"
 SOURCE_DIR="rust-$srcGitRev"
+SOURCE_DIR_7="cargo-i686"
+SOURCE_DIR_8="cargo-x86_64"
 PATCHES="rust-$portVersion.patchset"
 PATCHES_3="rust-installer-$portVersion.patchset"
-REVISION="1"
+REVISION="2"
 ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
 SECONDARY_ARCHITECTURES="x86"
+
+# It is an explicit choice to not provide cmd:rustc$secondaryArchSuffix
+# The compiler uses relative paths to itself to find libs (in particular
+# the *rlib libraries, which is why those are symlinked in the INSTALL()
+# phase). As rust will never compile with gcc2, this will not conflict
+# with a 'vanilla' package.
+# As for cmd:cargo, cargo does not have any paths hardcoded. Putting the
+# binary in a proper place in a secondary architecture, will remind the user
+# to use 'setarch x86', which is required to have rust call the proper linker.
 
 PROVIDES="
 	rust$secondaryArchSuffix = $portVersion
 	cmd:rustc = $portVersion
 	cmd:rustdoc = $portVersion
 	cmd:rust_gdb = $portVersion
+	cmd:cargo$secondaryArchSuffix = 0.16.0
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	lib:libcrypto$secondaryArchSuffix
+	lib:libcurl$secondaryArchSuffix
+	lib:libssl$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
 	"
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
@@ -107,6 +129,19 @@ INSTALL()
 	rm $developLibDir/rustlib/manifest-rustc
 	rm $developLibDir/rustlib/rust-installer-version
 	rm $developLibDir/rustlib/uninstall.sh
+
+	# install the prebuilt cargo binaries
+	if [ $effectiveTargetArchitecture = x86 ]; then
+		cd /sources-7/cargo-i686
+		tar xvfz $SOURCE_FILENAME_7
+	fi
+	if [ $effectiveTargetArchitecture = x86_64 ]; then
+		cd /sources-8/cargo-x86_64
+		tar xvfz $SOURCE_FILENAME_8
+	fi
+
+	mkdir -p $binDir
+	cp cargo $binDir
 }
 
 TEST()


### PR DESCRIPTION
Bump the version number to version 2.

Add the cargo command to the package. Rust's package management tool is now
included in the package. The rationale for inclusion versus external package
is that the cargo command is closely related to the version of the rustc
compiler, and with the future dependency of the rust build system on cargo
they are closely linked.