### PR TITLE
unarr: use upstream source

### DIFF
--- a/app-arch/unarr/unarr-1.0.0.recipe
+++ b/app-arch/unarr/unarr-1.0.0.recipe
@@ -8,58 +8,92 @@ HOMEPAGE="https://github.com/sumatrapdfreader/sumatrapdf/tree/master/ext/unarr"
 COPYRIGHT="The Unarchiver project (https://code.google.com/p/theunarchiver/) \
 Simon Bünzli (zeniko at gmail.com, http://www.zeniko.ch/#SumatraPDF)"
 LICENSE="GNU LGPL v3"
-REVISION="2"
-SOURCE_URI="http://download.opensuse.org/repositories/home:/selmf/xUbuntu_16.04/libunarr_1.0~r188.c4136ab.orig.tar.xz"
-CHECKSUM_SHA256="d799a8f61e2c87c5fb52f01770b11eaaff1e3cb5840ab6852056d15967f664cb"
-SOURCE_DIR="libunarr"
+REVISION="3"
+SOURCE_URI="https://github.com/selmf/unarr/archive/v${portVersion}.tar.gz"
+CHECKSUM_SHA256="ef1610d636641751ca234da7998b3f6b53313c7e526492a6070dd572b99d4685"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	unarr$secondaryArchSuffix = $portVersion
-	cmd:unarr$secondaryArchSuffix = $portVersion
 	lib:libunarr$secondaryArchSuffix = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	lib:libbz2$secondaryArchSuffix
+	lib:liblzma$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
 	"
-
 PROVIDES_devel="
 	unarr${secondaryArchSuffix}_devel = $portVersion
 	devel:libunarr$secondaryArchSuffix = $portVersion
 	"
 REQUIRES_devel="
-	unarr$secondaryArchSuffix == $portVersion base
+	unarr$secondaryArchSuffix == $portVersion
 	"
-
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	devel:libbz2$secondaryArchSuffix
+	devel:liblzma$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
+	cmd:cmake
 	cmd:make
+	cmd:ar$secondaryArchSuffix
+	cmd:ranlib$secondaryArchSuffix
+	cmd:pkg_config$secondaryArchSuffix
 	"
 
 PATCH()
 {
-	sed -e s/-lm//g -i Makefile
+	# fix a small typo in pkg-config.pc.cmake, fixed since in master branch,  but not in latest release yet
+	# to remove at next release bump
+	sed -i 's/@CMAKE_INSTALL_INCLUDEDIR_LIBDIR@/@CMAKE_INSTALL_LIBDIR@/g' pkg-config.pc.cmake
 }
 
 BUILD()
 {
+	rm -rf build
+	mkdir -p build
+	cd build
+
+	# build static library
+	cmake .. \
+		-DCMAKE_BUILD_TYPE:STRING="Release" \
+		-DBUILD_SHARED_LIBS=OFF \
+		-DCMAKE_INSTALL_PREFIX:PATH=$prefix \
+		-DCMAKE_INSTALL_BINDIR:PATH=$relativeBinDir \
+		-DCMAKE_INSTALL_LIBDIR:PATH=$relativeDevelopLibDir \
+		-DCMAKE_INSTALL_INCLUDEDIR:PATH=$relativeIncludeDir
+	make $jobArgs
+
+	# build shared library too
+	cmake .. \
+		-DCMAKE_BUILD_TYPE:STRING="Release" \
+		-DBUILD_SHARED_LIBS=ON \
+		-DCMAKE_INSTALL_PREFIX:PATH=$prefix \
+		-DCMAKE_INSTALL_BINDIR:PATH=$relativeBinDir \
+		-DCMAKE_INSTALL_LIBDIR:PATH=$relativeDevelopLibDir \
+		-DCMAKE_INSTALL_INCLUDEDIR:PATH=$relativeIncludeDir
 	make $jobArgs
 }
 
 INSTALL()
 {
 	mkdir -p $binDir $libDir $includeDir
-	cp build/debug/unarr-test $binDir/unarr
-	cp build/debug/libunarr.a $libDir/libunarr.a
-	cp unarr.h $includeDir/unarr.h
+	cp build/libunarr.a $libDir
+	cp -P build/libunarr.so* $libDir
+	cp unarr.h $includeDir
+
+	mkdir -p $libDir/pkgconfig
+	cp build/libunarr.pc $libDir/pkgconfig/libunarr.pc
 
 	prepareInstalledDevelLib libunarr
+	fixPkgconfig
 	packageEntries devel \
 		$developDir
 }

--- a/app-arch/unarr/unarr-1.0.0.recipe
+++ b/app-arch/unarr/unarr-1.0.0.recipe
@@ -30,7 +30,7 @@ PROVIDES_devel="
 	devel:libunarr$secondaryArchSuffix = $portVersion
 	"
 REQUIRES_devel="
-	unarr$secondaryArchSuffix == $portVersion
+	unarr$secondaryArchSuffix == $portVersion base
 	"
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel


### PR DESCRIPTION
As notified by selmf (thanks!), actual maintener, we were using obsolete source.
Enabled bz2, xz and zip support too.
Add PkgConfig support.
And now both static and shared libraries are availables.

This should fix #1723.