### PR TITLE
QuteBrowser: add recipe for version 1.0.2

### DIFF
--- a/www-client/qutebrowser/qutebrowser-1.0.2.recipe
+++ b/www-client/qutebrowser/qutebrowser-1.0.2.recipe
@@ -1,0 +1,69 @@
+SUMMARY="A VIM-like web browser"
+DESCRIPTION="QuteBrowser is a keyboard-focused browser with a minimal GUI. \
+It’s based on Python and PyQt5 and free software, licensed under the GPL. \
+It was inspired by other browsers/addons like dwb and Vimperator/Pentadactyl."
+HOMEPAGE="http://qutebrowser.org/"
+COPYRIGHT="2014-2017 Florian Bruhin (The Compiler)"
+LICENSE="GNU GPL v3"
+REVISION="1"
+srcGitRev="378498bbd7767a2277ab6fba9e54899959a7c972"
+SOURCE_URI="https://github.com/qutebrowser/qutebrowser/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="bd09e6ec770836a3b5795bc4efdd3d90ad7afad22ec8f69c2afe91ea53387fd8"
+SOURCE_DIR="qutebrowser-$srcGitRev"
+PYTHON_VERSION="3.6"
+
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	qutebrowser$secondaryArchSuffix = $portVersion
+	cmd:qutebrowser$secondaryArchSuffix = $portVersion
+	cmd:pygmentize$secondaryArchSuffix = $portVersion
+	"
+
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libQt5Core$secondaryArchSuffix
+	lib:libQt5DBus$secondaryArchSuffix
+	lib:libQt5Gui$secondaryArchSuffix
+	lib:libQt5Multimedia$secondaryArchSuffix
+	lib:libQt5Network$secondaryArchSuffix
+	lib:libQt5PrintSupport$secondaryArchSuffix
+	lib:libQt5Qml$secondaryArchSuffix
+	lib:libQt5WebKit$secondaryArchSuffix
+	lib:libQt5WebKitWidgets$secondaryArchSuffix
+	lib:libQt5Widgets$secondaryArchSuffix
+	lib:libQt5XmlPatterns$secondaryArchSuffix
+	lib:libssl$secondaryArchSuffix
+	lib:libyaml_cpp$secondaryArchSuffix >= 0.5
+	cmd:python$PYTHON_VERSION
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	setuptools_python3
+	sip_python3  # >= 4.19
+	devel:libyaml_cpp$secondaryArchSuffix # >= 0.5
+	"
+
+BUILD_PREREQUIRES="
+	cmd:python$PYTHON_VERSION
+	cmd:gcc$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	./setup.py build
+}
+
+INSTALL()
+{
+	# GENERIC: all python_setuptools-based installs need this
+	python=$portPackageLinksDir/cmd~python$PYTHON_VERSION/bin/python3
+	pythonVersion=$($python --version 2>&1 | sed 's/Python //' | head -c3)
+	installLocation=$prefix/lib/python$pythonVersion/vendor-packages/
+	export PYTHONPATH=$installLocation:$PYTHONPATH
+	mkdir -p $installLocation
+
+	$python setup.py build $jobArgs install --prefix $prefix
+}


### PR DESCRIPTION
QuteBrowser is a web browser based on PyQt 5. It is able to use both QtWebKit and QtWebEngine.

On Haiku it uses only QtWebKit, because QtWebEngine is not available.
Minor changes were made by the maintainer for Haiku, based on my tests, so no external patches are required. It is also very actively developed with a large community.