### PR TITLE
Poppler: build fix

### DIFF
--- a/app-text/poppler/poppler-0.60.1.recipe
+++ b/app-text/poppler/poppler-0.60.1.recipe
@@ -166,6 +166,7 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
 	cmd:make
+	cmd:perl
 	cmd:pkg_config$secondaryArchSuffix
 	cmd:python2
 	"


### PR DESCRIPTION
It seems perl is required: http://vmpkg.haiku-os.org/master/x86_64/logviewer.html?buildruns/382/builds/2533.log