### PR TITLE
boehm_gc: disable dependency tracking

### DIFF
--- a/dev-libs/boehm_gc/boehm_gc-7.6.0.recipe
+++ b/dev-libs/boehm_gc/boehm_gc-7.6.0.recipe
@@ -11,7 +11,7 @@ COPYRIGHT="1988, 1989 Hans-J. Boehm, Alan J. Demers
 	1996-1999 Silicon Graphics.
 	1999-2011 Hewlett-Packard Development Company, L.P."
 LICENSE="BOEHM"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://www.hboehm.info/gc/gc_source/gc-$portVersion.tar.gz"
 CHECKSUM_SHA256="a14a28b1129be90e55cd6f71127ffc5594e1091d5d54131528c24cd0c03b7d90"
 SOURCE_DIR="gc-$portVersion"
@@ -61,7 +61,8 @@ BUILD()
 				 --enable-threads=posix \
 	 			 --enable-thread-local-alloc \
 				 --enable-parallel-mark \
-				 --disable-debug
+				 --disable-debug \
+				 --disable-dependency-tracking
 	make $jobArgs
 }
 


### PR DESCRIPTION
Fixes 'depcomp: No such file or directory' build errors in boehm_gc.