### PR TITLE
fix build for buildbots

### DIFF
--- a/haiku-apps/yab_ide/yab_ide-2.2.8a.recipe
+++ b/haiku-apps/yab_ide/yab_ide-2.2.8a.recipe
@@ -56,7 +56,6 @@ BUILD()
  	cp -r src/* tmp/buildfactory
 	cp -r yab-IDE/BuildFactory/* tmp/buildfactory/
 	cp yab-IDE/src/yab-IDE.yab  tmp/buildfactory/
-	 
 	pushd tmp/buildfactory
 	rm flex.c
 	./yab BuildFactory.yab yab-IDE yab-IDE.yab application/x-vnd.yab-IDE

--- a/haiku-apps/yab_ide/yab_ide-2.2.8a.recipe
+++ b/haiku-apps/yab_ide/yab_ide-2.2.8a.recipe
@@ -9,7 +9,7 @@ HOMEPAGE="http://yab.orgfree.com/"
 COPYRIGHT="2006-2015 Jan Bungeroth
 	2015-2017 Jim Saxton"
 LICENSE="Artistic"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/bbjimmy/YAB/archive/1.7.5.5.tar.gz"
 CHECKSUM_SHA256="ea80d21487c472b7ae11eb4f45bb6dc3468b0e68490a7a1ea2d5c44378dc1853"
 SOURCE_DIR="YAB-1.7.5.5"
@@ -40,7 +40,6 @@ BUILD_PREREQUIRES="
 	cmd:make
 	cmd:mkdepend
 	cmd:perl
-	cmd:yab
 	"
 
 BUILD()
@@ -52,12 +51,15 @@ BUILD()
 	gcc -o yab-compress yab-compress.c -lz
 	popd
 	mkdir -p tmp/buildfactory
-	cp -r src/* tmp/buildfactory
+	mkdir -p tmp/buildfactory/lib
+	cp -r src/libyab.so tmp/buildfactory/lib/libyab.so
+ 	cp -r src/* tmp/buildfactory
 	cp -r yab-IDE/BuildFactory/* tmp/buildfactory/
 	cp yab-IDE/src/yab-IDE.yab  tmp/buildfactory/
+	 
 	pushd tmp/buildfactory
 	rm flex.c
-	BuildFactory.yab yab-IDE yab-IDE.yab application/x-vnd.yab-IDE
+	./yab BuildFactory.yab yab-IDE yab-IDE.yab application/x-vnd.yab-IDE
 	RdefApply parts/YAB-IDE.bf.rdef yab-IDE
 	addattr -t mime BEOS:TYPE application/x-vnd.be-elfexecutable yab-IDE
 	popd


### PR DESCRIPTION
remove cmd:yab from BUILD_PREREQUIRES use the yab built from the source for the build.