### PR TITLE
openssl: allow co-installation of 1.0.2 and 1.1.0.

### DIFF
--- a/dev-libs/openssl/openssl-1.0.2m.recipe
+++ b/dev-libs/openssl/openssl-1.0.2m.recipe
@@ -15,7 +15,7 @@ HOMEPAGE="https://www.openssl.org/"
 COPYRIGHT="1995-1998 Eric Young
 	1998-2017 The OpenSSL Project."
 LICENSE="OpenSSL"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://www.openssl.org/source/openssl-$portVersion.tar.gz"
 CHECKSUM_SHA256="8c6ff15ec6b319b50788f42c7abc2890c08ba5a1cdcd3810eb9092deada37b0f"
 PATCHES="openssl-$portVersion.patchset"
@@ -23,15 +23,20 @@ PATCHES="openssl-$portVersion.patchset"
 ARCHITECTURES="x86_gcc2 x86 x86_64 ?arm ?ppc"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
+libVersion=1.0.0
+cmdSuffix=
+mySuffix=
+altSuffix=11
+
 PROVIDES="
-	openssl$secondaryArchSuffix = $portVersion
-	lib:libcrypto$secondaryArchSuffix = 1.0.0 compat >= 1.0.0
-	lib:libssl$secondaryArchSuffix = 1.0.0 compat >= 1.0.0
+	openssl$mySuffix$secondaryArchSuffix = $portVersion compat >= $libVersion
+	lib:libcrypto$secondaryArchSuffix = $libVersion compat >= $libVersion
+	lib:libssl$secondaryArchSuffix = $libVersion compat >= $libVersion
 	"
 if [ -z "$secondaryArchSuffix" ]; then
 	PROVIDES="$PROVIDES
-		cmd:c_rehash = $portVersion compat >= 1
-		cmd:openssl = $portVersion compat >= 1
+		cmd:c_rehash${cmdSuffix/-/_} = $portVersion compat >= 1
+		cmd:openssl${cmdSuffix/-/_} = $portVersion compat >= 1
 		"
 fi
 
@@ -41,13 +46,33 @@ REQUIRES="
 	ca_root_certificates
 	"
 
+if [ -z "$secondaryArchSuffix" ]; then
+	SUMMARY_man="Manual pages for openssl $portVersion"
+	ARCHITECTURES_man="any"
+	PROVIDES_man="
+		openssl${mySuffix}_man = $portVersion
+		"
+	REQUIRES_man="
+		openssl$mySuffix == $portVersion
+		"
+	SUPPLEMENTS_man="
+		openssl$mySuffix == $portVersion
+		"
+	CONFLICTS_man="
+		openssl${altSuffix}_man
+		"
+fi
+
 PROVIDES_devel="
-	openssl${secondaryArchSuffix}_devel = $portVersion
-	devel:libcrypto${secondaryArchSuffix} = 1.0.0 compat >= 1.0.0
-	devel:libssl${secondaryArchSuffix} = 1.0.0 compat >= 1.0.0
+	openssl$mySuffix${secondaryArchSuffix}_devel = $portVersion
+	devel:libcrypto$secondaryArchSuffix = $libVersion compat >= $libVersion
+	devel:libssl$secondaryArchSuffix = $libVersion compat >= $libVersion
 	"
 REQUIRES_devel="
-	openssl${secondaryArchSuffix} == $portVersion base
+	openssl$mySuffix$secondaryArchSuffix == $portVersion base
+	"
+CONFLICTS_devel="
+	openssl$altSuffix${secondaryArchSuffix}_devel
 	"
 
 BUILD_REQUIRES="
@@ -56,16 +81,21 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	cmd:cmp
-	cmd:gcc${secondaryArchSuffix}
-	cmd:ld${secondaryArchSuffix}
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
 	cmd:make
 	cmd:perl >= 5
 	cmd:sed
 	"
 
-defineDebugInfoPackage openssl$secondaryArchSufix \
-	$libDir/libssl.so.1.0.0 \
-	$libDir/libcrypto.so.1.0.0 \
+if [ -n "$secondaryArchSuffix" ]; then
+	maybe_binDir_runtimes=
+else
+	maybe_binDir_runtimes="
+		$binDir/openssl$cmdSuffix \
+		"
+fi
+defineDebugInfoPackage openssl$mySuffix$secondaryArchSuffix \
 	$libDir/engines/lib4758cca.so \
 	$libDir/engines/libaep.so \
 	$libDir/engines/libatalla.so \
@@ -77,8 +107,10 @@ defineDebugInfoPackage openssl$secondaryArchSufix \
 	$libDir/engines/libnuron.so \
 	$libDir/engines/libpadlock.so \
 	$libDir/engines/libsureware.so \
-	$libDir/engines/libubsec.so
-
+	$libDir/engines/libubsec.so \
+	$libDir/libcrypto.so.$libVersion \
+	$libDir/libssl.so.$libVersion \
+	$maybe_binDir_runtimes
 
 PATCH()
 {
@@ -108,19 +140,30 @@ INSTALL()
 	prepareInstalledDevelLibs libcrypto libssl
 	fixPkgconfig
 
+	if [ -n "$secondaryArchSuffix" ]; then
+		maybe_manDir_man3=
+	else
+		maybe_manDir_man3=$manDir/man3
+	fi
+
 	# devel package
 	packageEntries devel \
 		$developDir \
-		$manDir/man3
+		$maybe_manDir_man3
 
-	# Remove stuff we don't need in the secondary architecture base package,
-	# since we make it depend on the primary package.
+	# Remove stuff we don't need in the secondary architecture base package
 	if [ -n "$secondaryArchSuffix" ]; then
 		rm -rf $prefix/bin
 		rm -rf $dataRootDir/ssl
 		rm -rf $documentationDir
 	else
-		strip $binDir/openssl
+		if [ -n "$cmdSuffix" ]; then
+			mv $binDir/openssl $binDir/openssl$cmdSuffix
+			mv $binDir/c_rehash $binDir/c_rehash$cmdSuffix
+		fi
+		# man package
+		packageEntries man \
+			$manDir
 	fi
 }
 

--- a/dev-libs/openssl/openssl11-1.1.0f.recipe
+++ b/dev-libs/openssl/openssl11-1.1.0f.recipe
@@ -15,24 +15,29 @@ HOMEPAGE="https://www.openssl.org/"
 COPYRIGHT="1995-1998 Eric Young
 	1998-2017 The OpenSSL Project."
 LICENSE="OpenSSL"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://www.openssl.org/source/openssl-$portVersion.tar.gz"
 CHECKSUM_SHA256="12f746f3f2493b2f39da7ecf63d7ee19c6ac9ec6a4fcd8c229da8a522cb12765"
 SOURCE_DIR="openssl-$portVersion"
 PATCHES="openssl-$portVersion.patchset"
 
 ARCHITECTURES="?x86_gcc2 ?x86 ?x86_64 ?arm ?ppc"
-SECONDARY_ARCHITECTURES="?x86_gcc2 ?x86 ?arm ?ppc"
+SECONDARY_ARCHITECTURES="?x86_gcc2 ?x86"
+
+libVersion=1.1
+cmdSuffix="-1.1"
+mySuffix=11
+altSuffix=
 
 PROVIDES="
-	openssl11$secondaryArchSuffix = $portVersion compat >= 1.1.0
-	lib:libcrypto$secondaryArchSuffix = 1.1 compat >= 1.1
-	lib:libssl$secondaryArchSuffix = 1.1 compat >= 1.1
+	openssl$mySuffix$secondaryArchSuffix = $portVersion compat >= 1.1.0
+	lib:libcrypto$secondaryArchSuffix = $libVersion compat >= $libVersion
+	lib:libssl$secondaryArchSuffix = $libVersion compat >= $libVersion
 	"
 if [ -z "$secondaryArchSuffix" ]; then
 	PROVIDES="$PROVIDES
-		cmd:c_rehash = $portVersion compat >= 1
-		cmd:openssl = $portVersion compat >= 1
+		cmd:c_rehash${cmdSuffix/-/_} = $portVersion compat >= 1
+		cmd:openssl${cmdSuffix/-/_} = $portVersion compat >= 1
 		"
 fi
 
@@ -42,13 +47,33 @@ REQUIRES="
 	ca_root_certificates
 	"
 
+if [ -z "$secondaryArchSuffix" ]; then
+	SUMMARY_man="Manual pages for openssl $portVersion"
+	ARCHITECTURES_man="any"
+	PROVIDES_man="
+		openssl${mySuffix}_man = $portVersion
+		"
+	REQUIRES_man="
+		openssl$mySuffix == $portVersion
+		"
+	SUPPLEMENTS_man="
+		openssl$mySuffix == $portVersion
+		"
+	CONFLICTS_man="
+		openssl${altSuffix}_man
+		"
+fi
+
 PROVIDES_devel="
-	openssl11${secondaryArchSuffix}_devel = $portVersion
-	devel:libcrypto${secondaryArchSuffix} = 1.1 compat >= 1.1
-	devel:libssl${secondaryArchSuffix} = 1.1 compat >= 1.1
+	openssl$mySuffix${secondaryArchSuffix}_devel = $portVersion
+	devel:libcrypto$secondaryArchSuffix = $libVersion compat >= $libVersion
+	devel:libssl$secondaryArchSuffix = $libVersion compat >= $libVersion
 	"
 REQUIRES_devel="
-	openssl11${secondaryArchSuffix} == $portVersion base
+	openssl$mySuffix$secondaryArchSuffix == $portVersion base
+	"
+CONFLICTS_devel="
+	openssl$altSuffix${secondaryArchSuffix}_devel
 	"
 
 BUILD_REQUIRES="
@@ -56,19 +81,33 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	cmd:gcc${secondaryArchSuffix}
-	cmd:ld${secondaryArchSuffix}
+	cmd:awk
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
 	cmd:make
 	cmd:perl >= 5
 	cmd:sed
-	cmd:awk
 	"
+
+if [ -n "$secondaryArchSuffix" ]; then
+	maybe_binDir_runtimes=
+else
+	maybe_binDir_runtimes="
+		$binDir/openssl$cmdSuffix \
+		"
+fi
+defineDebugInfoPackage openssl$mySuffix$secondaryArchSuffix \
+	$libDir/engines-1.1/capi.so \
+	$libDir/engines-1.1/padlock.so \
+	$libDir/libcrypto.so.$libVersion \
+	$libDir/libssl.so.$libVersion \
+	$maybe_binDir_runtimes
 
 BUILD()
 {
 	./config --prefix=$prefix --libdir=$relativeLibDir \
 		--openssldir=$dataRootDir/ssl \
-		zlib shared no-asm
+		zlib shared no-asm -g
 	make $jobArgs
 }
 
@@ -84,18 +123,33 @@ INSTALL()
 	prepareInstalledDevelLibs libcrypto libssl
 	fixPkgconfig
 
+	if [ -n "$secondaryArchSuffix" ]; then
+		maybe_docDir_html_man3=
+		maybe_manDir_man3=
+	else
+		maybe_docDir_html_man3=$docDir/html/man3
+		maybe_manDir_man3=$manDir/man3
+	fi
+
 	# devel package
 	packageEntries devel \
 		$developDir \
-		$docDir \
-		$manDir/man3
+		$maybe_docDir_html_man3 \
+		$maybe_manDir_man3
 
-	# Remove stuff we don't need in the secondary architecture base package,
-	# since we make it depend on the primary package.
+	# Remove stuff we don't need in the secondary architecture base package
 	if [ -n "$secondaryArchSuffix" ]; then
 		rm -rf $prefix/bin
 		rm -rf $dataRootDir/ssl
 		rm -rf $documentationDir
+	else
+		if [ -n "$cmdSuffix" ]; then
+			mv $binDir/openssl $binDir/openssl$cmdSuffix
+			mv $binDir/c_rehash $binDir/c_rehash$cmdSuffix
+		fi
+		# man package
+		packageEntries man \
+			$manDir
 	fi
 }
 


### PR DESCRIPTION
* ~~Move `cmd:` items to a new `_bin` sub-package.~~
* ~~Base packages openssl11 and openssl now only ship the libs.~~
* ~~Make `openssl11_{bin,devel}` conflict with `openssl_{bin,devel}`.~~
* ~~Skip installation of `lib{ssl,crypto}.so` symlinks in openssl11.~~

The changes detailed below allow to co-install the base packages of 1.0.2 and 1.1.0 (as well as their debuginfo). The _devel (or _man) packages cannot be co-installed.

* Define a debuginfo package for openssl11.
* Fix typo in call to defineDebugInfoPackage for openssl which was producing an incorrect debuginfo on 2nd arch.
* Also add `cmd:openssl{,-1.1}` to their debuginfo packages.
* Move `$docDir/html/man3` to openssl11_devel.
* Add a **`-1.1`** suffix to each `cmd:{openssl,c_rehash}` for openssl11 to allow the co-installation of 1.0.2 & 1.1.
* Create new `_man` sub-packages for openssl and openssl11 and move all man pages (other than the man3 section) there to avoid overlaps when the 2 base packages are installed.
* Add symetric (openssl vs openssl11) `CONFLICTS` for their `_devel` and `_man` sup-packages. ~~Same thing for `REPLACES`.~~
* openssl{,11}_man REQUIRES and SUPPLEMENTS openssl{,11}.

* Introduce 4 custom variables (after portVersion):

portVersion | 1.0.2* | 1.1.0*
--------------- | ------- | --------
libVersion    | 1.0.0  | 1.1
cmdSuffix    |          | -1.1
mySuffix      |          | 11
altSuffix        | 11     |

These are used inside both recipes at the same places to make it easier to spot the real differences between 1.0.2 & 1.1.0.