### PR TITLE
Add recipe for iperf-2.0.9

### DIFF
--- a/net-analyzer/iperf/iperf-2.0.9.recipe
+++ b/net-analyzer/iperf/iperf-2.0.9.recipe
@@ -1,0 +1,50 @@
+SUMMARY="Network bandwidth testing tool"
+DESCRIPTION="iperf2 is the legacy network bandwidth testing tool that support \
+active measurement of bandwidth for protocols such as TCP and UDP and a \
+variety of their parameters"
+HOMEPAGE="https://sourceforge.net/projects/iperf2"
+COPYRIGHT="1999-2007 Board of Trustees of University of Illinois"
+LICENSE="UIUC"
+REVISION="1"
+SOURCE_URI="https://github.com/theunrealgeek/iperf/archive/v${portVersion}.zip"
+SOURCE_FILENAME="iperf-${portVersion}.zip"
+SOURCE_DIR="iperf-${portVersion}"
+CHECKSUM_SHA256="6078ac6b52b543bbd40c4061e2dcd1e12c79cff06e7f67cd7787db9b7dc70e12"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	iperf = $portVersion
+	cmd:iperf = $portVersion
+	"
+REQUIRES="
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc
+	cmd:g++
+	cmd:make
+	cmd:sed
+	cmd:grep
+	cmd:awk
+	"
+
+BUILD()
+{
+	chmod +x ./configure
+	echo "Running configue"
+	runConfigure ./configure
+
+	echo "Building iperf"
+	make $jobArgs
+}
+
+INSTALL()
+{
+	echo "Installing iperf"
+	make install
+}

--- a/net-analyzer/iperf/licenses/UIUC
+++ b/net-analyzer/iperf/licenses/UIUC
@@ -1,0 +1,40 @@
+Copyright (c) 1999-2007, The Board of Trustees of the University of Illinois
+All Rights Reserved.
+
+Iperf performance test
+Mark Gates
+Ajay Tirumala
+Jim Ferguson
+Jon Dugan
+Feng Qin
+Kevin Gibbs
+John Estabrook
+National Laboratory for Applied Network Research 
+National Center for Supercomputing Applications 
+University of Illinois at Urbana-Champaign 
+http://www.ncsa.uiuc.edu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software (Iperf) and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimers.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimers in the documentation and/or
+other materials provided with the distribution.
+
+Neither the names of the University of Illinois, NCSA, nor the names of its
+contributors may be used to endorse or promote products derived from this
+Software without specific prior written permission.  THE SOFTWARE IS PROVIDED
+"AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+AND NONINFRINGEMENT. IN NO EVENT SHALL THE CONTIBUTORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Adding a recipe for iperf v2.0.9. 
iperf is a common network bandwidth testing tool especially for TCP. 

Was pretty easy to port to Haiku!