### PR TITLE
Recipe for primegen 0.97

### DIFF
--- a/sci-libs/primegen/patches/primegen-0.97.patchset
+++ b/sci-libs/primegen/patches/primegen-0.97.patchset
@@ -1,0 +1,34 @@
+From 7a947552d7374f9e99bdf128a9969ad042e1a6bf Mon Sep 17 00:00:00 2001
+From: Mason X <me@masonx.ca>
+Date: Wed, 29 Nov 2017 18:07:28 +0000
+Subject: [PATCH] Create shared object/library
+
+---
+ make-compile.sh | 2 +-
+ make-makelib.sh | 5 +++--
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/make-compile.sh b/make-compile.sh
+index a1eb501..b0be539 100644
+--- a/make-compile.sh
++++ b/make-compile.sh
+@@ -1 +1 @@
+-echo exec "$CC" -c '${1+"$@"}'
++echo exec "$CC" -c -fPIC '${1+"$@"}'
+diff --git a/make-makelib.sh b/make-makelib.sh
+index d6b7c8c..ed01101 100644
+--- a/make-makelib.sh
++++ b/make-makelib.sh
+@@ -1,6 +1,7 @@
+ echo 'main="$1"; shift'
+-echo 'rm -f "$main"'
+-echo 'ar cr "$main" ${1+"$@"}'
++echo 'rm -f `echo "$main" | cut -f 1 -d '.'`.so "$main"'
++echo 'ar cr "$main" ${1+"$@"}'
++echo 'gcc -shared -o `echo "$main" | cut -f 1 -d '.'`.so ${1+"$@"}'
+ 
+ case "$1" in
+ sunos-5.*) ;;
+-- 
+2.14.2
+

--- a/sci-libs/primegen/primegen-0.97.recipe
+++ b/sci-libs/primegen/primegen-0.97.recipe
@@ -1,0 +1,75 @@
+SUMMARY="Fast C/C++ prime number generator library"
+DESCRIPTION="primegen is a small, fast library to generate prime numbers \
+in order. It generates the 50847534 primes up to 1000000000 in just 8 \
+seconds on a Pentium II-350; it prints them in decimal in just 35 seconds. \
+primegen can generate primes up to 1000000000000000, although it is not \
+optimized for primes past 32 bits. It uses the Sieve of Atkin instead of the \
+traditional Sieve of Eratosthenes."
+HOMEPAGE="https://cr.yp.to/primegen.html"
+COPYRIGHT="1999, D. J. Bernstein"
+LICENSE="Public Domain"
+REVISION="1"
+SOURCE_URI="https://cr.yp.to/primegen/primegen-$portVersion.tar.gz"
+CHECKSUM_SHA256="54285baf8eed9e421ff2220a2112d38cfb20c1ebef6014ef3f0004c22c95f40d"
+PATCHES="primegen-$portVersion.patchset"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	primegen = $portVersion
+	cmd:primegaps = $portVersion
+	cmd:primes = $portVersion
+	cmd:primespeed = $portVersion
+	lib:libprimegen
+	"
+REQUIRES="
+	haiku
+	"
+
+PROVIDES_devel="
+	primegen_devel = $portVersion
+	devel:libprimegen
+	"
+REQUIRES_devel="
+	primegen == $portVersion base
+	"
+
+BUILD_PREREQUIRES="
+	cmd:gcc
+	cmd:make
+	cmd:nroff
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+
+BUILD()
+{
+	make
+}
+
+INSTALL()
+{
+	install -d $binDir $docDir $manDir/man1 $manDir/man3
+	install -d $includeDir/primegen $developLibDir $libDir
+	install -t $binDir primegaps primes primespeed
+	install -t $docDir BLURB README
+	install -t $manDir/man1 primegaps.1 primes.1 primespeed.1
+	install -t $manDir/man3 primegen.3
+	install -t $includeDir/primegen primegen.h uint32.h uint64.h
+	install -T primegen.a $developLibDir/libprimegen.a
+	install -T primegen.so $libDir/libprimegen.so
+	prepareInstalledDevelLib libprimegen
+	fixPkgconfig
+
+	# devel package
+	packageEntries devel \
+		$developDir \
+		$manDir/man3
+}
+
+TEST()
+{
+	[ "$(./primes 1 1000000 | md5sum | cut -d " " -f1)" = c13929ee9d2aea8f83aa076236079e94 ]
+}


### PR DESCRIPTION
primegen is a small, fast library to generate prime numbers in order.

The recipe added primegen to haikuports at `haikuports/sci-libs/primegen/`.

I intentionally chose to create a git repository since there are a large number of patches required... I hope this is OK.

Please let me know if anything is wrong!