### PR TITLE
Add recipes for libblkmaker and libbase58

### DIFF
--- a/dev-libs/libbase58/libbase58-0.1.4.recipe
+++ b/dev-libs/libbase58/libbase58-0.1.4.recipe
@@ -1,0 +1,68 @@
+SUMMARY="A library for encoding/decoding base58"
+DESCRIPTION="libbase58 provides encoding and decoding for the base58 format, \
+used in Bitcoin addresses."
+HOMEPAGE="https://github.com/bitcoin/libbase58"
+COPYRIGHT="2014-2017 Luke Dashjr"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://github.com/bitcoin/libbase58/archive/v$portVersion.tar.gz"
+CHECKSUM_SHA256="97e8c3387fd4ed90208a8101e658743efbb6e21714e594f0828e6414f92c0b1d"
+
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion=0.0.2
+libVersionCompat="$libVersion compat >= 0"
+
+PROVIDES="
+	libbase58$secondaryArchSuffix = $portVersion
+	lib:libbase58$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	libbase58${secondaryArchSuffix}_devel = $portVersion
+	devel:libbase58$secondaryArchSuffix = $libVersion
+	"
+REQUIRES_devel="
+	libbase58$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoreconf
+	cmd:gcc$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	"
+
+defineDebugInfoPackage libbase58$secondaryArchSuffix \
+	$libDir/libbase58.so.$libVersion
+
+BUILD()
+{
+	./autogen.sh
+	runConfigure ./configure
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+	rm -f $libDir/libbase58.la
+	prepareInstalledDevelLib libbase58
+	fixPkgconfig
+	packageEntries devel \
+		$developDir
+}
+
+TEST()
+{
+	# Test suite is present but currently has no tests.
+	make check
+}

--- a/net-libs/libblkmaker/libblkmaker-0.5.3.recipe
+++ b/net-libs/libblkmaker/libblkmaker-0.5.3.recipe
@@ -1,0 +1,74 @@
+SUMMARY="A library implementing getblocktemplate"
+DESCRIPTION="libblkmaker provides an implementation of getblocktemplate, the \
+current Bitcoin mining protocol."
+HOMEPAGE="https://github.com/bitcoin/libblkmaker"
+COPYRIGHT="2014-2017 Luke Dashjr"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://github.com/bitcoin/libblkmaker/archive/v$portVersion.tar.gz"
+CHECKSUM_SHA256="549193640d4cc7022725754833d9d8a7639c41e1a7d2c5f2588be65857cc0970"
+
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion=6.1.0
+libVersionCompat="$libVersion compat >= 6"
+
+PROVIDES="
+	libblkmaker$secondaryArchSuffix = $portVersion
+	lib:libblkmaker_0.1$secondaryArchSuffix = $libVersionCompat
+	lib:libblkmaker_jansson_0.1$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libbase58$secondaryArchSuffix
+	lib:libjansson$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	libblkmaker${secondaryArchSuffix}_devel = $portVersion
+	devel:libblkmaker_0.1$secondaryArchSuffix = $libVersion
+	devel:libblkmaker_jansson_0.1$secondaryArchSuffix = $libVersion
+	"
+REQUIRES_devel="
+	libblkmaker$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libbase58$secondaryArchSuffix
+	devel:libjansson$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoreconf
+	cmd:gcc$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	./autogen.sh
+	runConfigure ./configure libbase58_LIBS="-lbase58"
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+	rm -f $libDir/libblkmaker*.la
+	prepareInstalledDevelLibs libblkmaker-0.1 libblkmaker_jansson-0.1
+	#mv $includeDir/libblkmaker-0.1/* $includeDir/
+	#rmdir $includeDir/libblkmaker-0.1
+	fixPkgconfig
+	packageEntries devel \
+		$developDir
+}
+
+TEST()
+{
+	# Test suite is present but currently has no tests.
+	make check
+}


### PR DESCRIPTION
Created recipes for libblkmaker and libbase58.
Both required patches to work with gcc2, largely involving moving declarations and replacing variable-sized arrays with malloc/free. 