### PR TITLE
Add TEST() to various ports

### DIFF
--- a/app-crypt/qca/qca-2.1.3.recipe
+++ b/app-crypt/qca/qca-2.1.3.recipe
@@ -79,6 +79,7 @@ BUILD()
 		-DQCA_PRIVATE_INCLUDE_INSTALL_DIR=$includeDir \
 		-DQCA_DOC_INSTALL_DIR=$docDir \
 		-DQCA_MAN_INSTALL_DIR=$manDir \
+		-DBUILD_TESTS=1 \
 		-DPKGCONFIG_INSTALL_PREFIX=$developLibDir/pkgconfig
 
 	make $jobArgs
@@ -96,4 +97,9 @@ INSTALL()
 		$developDir \
 		$dataDir/Qt/mkspecs \
 		$libDir/cmake
+}
+
+TEST()
+{
+	QCA_PLUGIN_PATH="$sourceDir/lib/qca" make test
 }

--- a/app-crypt/rhash/rhash-1.3.5.recipe
+++ b/app-crypt/rhash/rhash-1.3.5.recipe
@@ -14,20 +14,20 @@ SOURCE_URI="https://downloads.sourceforge.net/rhash/rhash-$portVersion-src.tar.g
 CHECKSUM_SHA256="98e0688acae29e68c298ffbcdbb0f838864105f9b2bd8857980664435b1f1f2e"
 SOURCE_DIR="RHash-$portVersion"
 
-ARCHITECTURES="?x86_gcc2 ?x86 x86_64"
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
 SECONDARY_ARCHITECTURES="?x86"
 
 PROVIDES="
 	rhash$secondaryArchSuffix = $portVersion
-	cmd:ed2k_link
-	cmd:gost_hash
-	cmd:has160_hash
-	cmd:magnet_link
-	cmd:rhash
-	cmd:sfv_hash
-	cmd:tiger_hash
-	cmd:tth_hash
-	cmd:whirlpool_hash
+	cmd:ed2k_link$secondaryArchSuffix
+	cmd:gost_hash$secondaryArchSuffix
+	cmd:has160_hash$secondaryArchSuffix
+	cmd:magnet_link$secondaryArchSuffix
+	cmd:rhash$secondaryArchSuffix
+	cmd:sfv_hash$secondaryArchSuffix
+	cmd:tiger_hash$secondaryArchSuffix
+	cmd:tth_hash$secondaryArchSuffix
+	cmd:whirlpool_hash$secondaryArchSuffix
 	lib:librhash$secondaryArchSuffix = 0
 	"
 REQUIRES="
@@ -44,7 +44,7 @@ REQUIRES_devel="
 	"
 
 BUILD_REQUIRES="
-	haiku_devel$secondaryArchSuffix
+	haiku${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix

--- a/app-crypt/rhash/rhash-1.3.5.recipe
+++ b/app-crypt/rhash/rhash-1.3.5.recipe
@@ -70,3 +70,10 @@ INSTALL()
 	packageEntries devel \
 		$developDir
 }
+
+TEST()
+{
+	cd tests
+	LIBRARY_PATH="$sourceDir/librhash${LIBRARY_PATH:+:$LIBRARY_PATH}" \
+		./test_rhash.sh --full ../rhash_shared
+}

--- a/app-editors/retext/retext-7.0.1.recipe
+++ b/app-editors/retext/retext-7.0.1.recipe
@@ -34,6 +34,11 @@ BUILD_PREREQUIRES="
 	cmd:lrelease
 	cmd:python3
 	"
+# For TEST()
+BUILD_PREREQUIRES+="
+	markups_python3
+	qthaikuplugins$secondaryArchSuffix
+	"
 
 BUILD()
 {
@@ -54,4 +59,9 @@ INSTALL()
 
 	mkdir -p $(dirname $dataDir)
 	mv $prefix/share $dataDir
+}
+
+TEST()
+{
+	python3 setup.py test
 }

--- a/app-i18n/mozc/mozc-2.20.2677.102.recipe
+++ b/app-i18n/mozc/mozc-2.20.2677.102.recipe
@@ -92,3 +92,10 @@ INSTALL()
 	cp $MozcOutDir/x-vnd.Mozc-InputMethod/* \
 		$dataDir/locale/catalogs/x-vnd.Mozc-InputMethod
 }
+
+TEST()
+{
+	cd src
+	# Some tests fails with job > 1
+	python2 build_mozc.py runtests -c Release --test_jobs 1
+}

--- a/app-text/podofo/podofo-0.9.5.recipe
+++ b/app-text/podofo/podofo-0.9.5.recipe
@@ -67,6 +67,7 @@ REQUIRES_devel="
 	"
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	devel:libcppunit$secondaryArchSuffix
 	devel:libfontconfig$secondaryArchSuffix
 	devel:libfreetype$secondaryArchSuffix
 	devel:libjpeg$secondaryArchSuffix
@@ -92,6 +93,13 @@ PATCH()
 	freetypeDir=$portPackageLinksDir/devel~libfreetype$secondaryArchSuffix/develop/headers$headersDir/freetype2
 	sed -i -e s:/usr/include/freetype2:$freetypeDir: cmake/modules/FindFREETYPE.cmake
 
+	# Taken from Gentoo
+	# Test name: EncodingTest::testDifferencesEncoding
+	# equality assertion failed
+	# - Expected: 1
+	# - Actual  : 0
+	sed -e 's:CPPUNIT_TEST( testDifferencesEncoding ://\0:' \
+		-i test/unit/EncodingTest.h
 }
 
 BUILD()
@@ -99,6 +107,7 @@ BUILD()
 	mkdir -p build; cd build
 	cmake -DCMAKE_INSTALL_PREFIX:PATH=$prefix \
 		-DPODOFO_BUILD_SHARED=1 \
+		-DPODOFO_HAVE_CPPUNIT=1 \
 		..
 	make $jobArgs
 }
@@ -126,4 +135,10 @@ INSTALL()
 	# devel package
 	packageEntries devel \
 		$developDir
+}
+
+TEST()
+{
+	cd build/test/unit
+	./podofo-test --selftest
 }

--- a/dev-lang/spidermonkey/spidermonkey-1.8.5.recipe
+++ b/dev-lang/spidermonkey/spidermonkey-1.8.5.recipe
@@ -11,9 +11,11 @@ SOURCE_DIR="js-$portVersion/"
 PATCHES="spidermonkey-${portVersion}.patchset"
 
 ARCHITECTURES="?x86_gcc2 x86 ?x86_64"
+SECONDARY_ARCHITECTURES="?x86"
 
 PROVIDES="
 	spidermonkey$secondaryArchSuffix = $portVersion compat >= 1.8
+	cmd:js_config$secondaryArchSuffix = $portVersion
 	lib:libmozjs185$secondaryArchSuffix = 1.0.0 compat >= 1
 	"
 REQUIRES="
@@ -34,6 +36,7 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
 	cmd:perl
 	cmd:awk
@@ -41,12 +44,21 @@ BUILD_PREREQUIRES="
 	cmd:xargs
 	cmd:pkg_config$secondaryArchSuffix
 	cmd:sed
+	cmd:zip
 	"
+
+PATCH()
+{
+	cd js/src
+	sed -e 's|${srcdir}/||' -i configure.in
+}
 
 BUILD()
 {
 	cd js/src
-	runConfigure --omit-dirs "libDir docDir dataRootDir" ./configure \
+	libtoolize -fci
+
+	runConfigure --omit-dirs "docDir dataRootDir" ./configure \
 		--disable-tracejit --enable-tests
 	make $jobArgs
 }

--- a/dev-lang/spidermonkey/spidermonkey-1.8.5.recipe
+++ b/dev-lang/spidermonkey/spidermonkey-1.8.5.recipe
@@ -47,7 +47,7 @@ BUILD()
 {
 	cd js/src
 	runConfigure --omit-dirs "libDir docDir dataRootDir" ./configure \
-		--disable-tracejit
+		--disable-tracejit --enable-tests
 	make $jobArgs
 }
 
@@ -65,4 +65,10 @@ INSTALL()
 	packageEntries devel \
 		$developDir
 
+}
+
+TEST()
+{
+	cd js/src/jsapi-tests
+	make check
 }

--- a/dev-lang/tcc/patches/tcc-0.9.26.patchset
+++ b/dev-lang/tcc/patches/tcc-0.9.26.patchset
@@ -1,4 +1,4 @@
-From 33b1dca76db5ab527a0cb441dd70b27c339dafca Mon Sep 17 00:00:00 2001
+From a728c4e0a15d3822cfb283a4764c2d01018a788a Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Sat, 9 Aug 2014 18:44:13 +0200
 Subject: Add Haiku support.
@@ -63,5 +63,123 @@ index 50178a8..c67bebb 100644
  #else
          fp = uc->uc_mcontext.gregs[REG_EBP];
 -- 
-1.8.3.4
+2.7.0
+
+
+From 47578a5c04b702ee055ced9dcd29f5eb7f1b2165 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Sun, 3 Dec 2017 11:51:08 +0700
+Subject: tcc.h: ucontext_t is in <signal.h>
+
+
+diff --git a/tcc.h b/tcc.h
+index 2c2936c..ec75502 100644
+--- a/tcc.h
++++ b/tcc.h
+@@ -43,7 +43,11 @@
+ #ifndef _WIN32
+ # include <unistd.h>
+ # include <sys/time.h>
+-# include <sys/ucontext.h>
++# ifndef __HAIKU__
++#  include <sys/ucontext.h>
++# else
++#  include <signal.h>
++# endif
+ # include <sys/mman.h>
+ # ifndef CONFIG_TCC_STATIC
+ #  include <dlfcn.h>
+-- 
+2.7.0
+
+
+From 99dfbd1a1ea61dd7a2fa6b2a64b4f3cef082d3c2 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Sun, 3 Dec 2017 11:52:06 +0700
+Subject: libtcc: add support for haiku start files
+
+
+diff --git a/libtcc.c b/libtcc.c
+index af0fb7f..e5d12bb 100644
+--- a/libtcc.c
++++ b/libtcc.c
+@@ -1346,8 +1346,15 @@ LIBTCCAPI int tcc_set_output_type(TCCState *s, int output_type)
+     if ((output_type == TCC_OUTPUT_EXE || output_type == TCC_OUTPUT_DLL) &&
+         !s->nostdlib) {
+         if (output_type != TCC_OUTPUT_DLL)
++# ifdef __HAIKU__
++            tcc_add_crt(s, "start_dyn.o");
++# else
+             tcc_add_crt(s, "crt1.o");
++# endif
+         tcc_add_crt(s, "crti.o");
++# ifdef __HAIKU__
++        tcc_add_crt(s, "init_term_dyn.o");
++# endif
+     }
+ #endif
+     return 0;
+-- 
+2.7.0
+
+
+From ddb0f5247fd5d09647154fe15000c2b74112f77e Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Sun, 3 Dec 2017 11:52:50 +0700
+Subject: tccelf: haiku use libroot instead of libc
+
+
+diff --git a/tccelf.c b/tccelf.c
+index 500ea18..bdc4c9c 100644
+--- a/tccelf.c
++++ b/tccelf.c
+@@ -1360,7 +1360,11 @@ ST_FUNC void tcc_add_runtime(TCCState *s1)
+ 
+     /* add libc */
+     if (!s1->nostdlib) {
++#ifdef __HAIKU__
++        tcc_add_library(s1, "root");
++#else
+         tcc_add_library(s1, "c");
++#endif
+ #ifdef CONFIG_USE_LIBGCC
+         tcc_add_file(s1, TCC_LIBGCC);
+ #elif !defined WITHOUT_LIBTCC
+-- 
+2.7.0
+
+
+From a7a81c2967a49730c1d55c54e2d80022aad959ac Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Sun, 3 Dec 2017 17:31:00 +0700
+Subject: libtcc: define Haiku specific macros
+
+
+diff --git a/libtcc.c b/libtcc.c
+index e5d12bb..0660c51 100644
+--- a/libtcc.c
++++ b/libtcc.c
+@@ -930,6 +930,10 @@ LIBTCCAPI TCCState *tcc_new(void)
+     tcc_define_symbol(s, "__i386__", NULL);
+     tcc_define_symbol(s, "__i386", NULL);
+     tcc_define_symbol(s, "i386", NULL);
++# if defined(__HAIKU__)
++    tcc_define_symbol(s, "__INTEL__", NULL);
++    tcc_define_symbol(s, "__X86__", NULL);
++# endif
+ #elif defined(TCC_TARGET_X86_64)
+     tcc_define_symbol(s, "__x86_64__", NULL);
+ #elif defined(TCC_TARGET_ARM)
+@@ -964,6 +968,9 @@ LIBTCCAPI TCCState *tcc_new(void)
+ # if defined(__FreeBSD_kernel__)
+     tcc_define_symbol(s, "__FreeBSD_kernel__", NULL);
+ # endif
++# if defined(__HAIKU__)
++    tcc_define_symbol(s, "__HAIKU__", NULL);
++# endif
+ #endif
+ 
+     /* TinyCC & gcc defines */
+-- 
+2.7.0
 

--- a/dev-lang/tcc/tcc-0.9.26.recipe
+++ b/dev-lang/tcc/tcc-0.9.26.recipe
@@ -21,38 +21,101 @@ SOURCE_URI="http://download.savannah.gnu.org/releases/tinycc/tcc-0.9.26.tar.bz2"
 CHECKSUM_SHA256="521e701ae436c302545c3f973a9c9b7e2694769c71d9be10f70a2460705b6d71"
 PATCHES="tcc-$portVersion.patchset"
 
-ARCHITECTURES="x86_gcc2"
+ARCHITECTURES="x86_gcc2 ?x86_64"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	tcc = $portVersion
-	cmd:arm_eabi_tcc
-	cmd:arm_fpa_ld_tcc
-	cmd:arm_fpa_tcc
-	cmd:arm_vfp_tcc
-	cmd:c67_tcc
-	cmd:i386_win32_tcc
-	cmd:tcc
-	cmd:x86_64_tcc
-	cmd:x86_64_win32_tcc
+	tcc$secondaryArchSuffix = $portVersion
+	cmd:arm_eabi_tcc$secondaryArchSuffix
+	cmd:arm_fpa_ld_tcc$secondaryArchSuffix
+	cmd:arm_fpa_tcc$secondaryArchSuffix
+	cmd:arm_vfp_tcc$secondaryArchSuffix
+	cmd:c67_tcc$secondaryArchSuffix
+	cmd:i386_win32_tcc$secondaryArchSuffix
+	cmd:tcc$secondaryArchSuffix
+	cmd:x86_64_tcc$secondaryArchSuffix
+	cmd:x86_64_win32_tcc$secondaryArchSuffix
 	"
 REQUIRES="
-	haiku
+	haiku$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
-	devel:libtcc
+	devel:libtcc$secondaryArchSuffix
 	"
 REQUIRES_devel="
 	"
 BUILD_PREREQUIRES="
-	haiku_devel
-	cmd:gcc
+	haiku${secondaryArchSuffix}_devel
+	cmd:gcc$secondaryArchSuffix
 	cmd:make
 	"
 
 BUILD()
 {
-	runConfigure ./configure --enable-cross
+	local hybrid
+	# Borrowed from gcc
+	local sysincdir=(
+			  "/boot/system/develop/headers/os"
+			  "/boot/system/develop/headers/os/app"
+			  "/boot/system/develop/headers/os/device"
+			  "/boot/system/develop/headers/os/drivers"
+			  "/boot/system/develop/headers/os/game"
+			  "/boot/system/develop/headers/os/interface"
+			  "/boot/system/develop/headers/os/kernel"
+			  "/boot/system/develop/headers/os/locale"
+			  "/boot/system/develop/headers/os/mail"
+			  "/boot/system/develop/headers/os/media"
+			  "/boot/system/develop/headers/os/midi"
+			  "/boot/system/develop/headers/os/midi2"
+			  "/boot/system/develop/headers/os/net"
+			  "/boot/system/develop/headers/os/opengl"
+			  "/boot/system/develop/headers/os/storage"
+			  "/boot/system/develop/headers/os/support"
+			  "/boot/system/develop/headers/os/translation"
+			  "/boot/system/develop/headers/os/add-ons/graphics"
+			  "/boot/system/develop/headers/os/add-ons/input_server"
+			  "/boot/system/develop/headers/os/add-ons/mail_daemon"
+			  "/boot/system/develop/headers/os/add-ons/registrar"
+			  "/boot/system/develop/headers/os/add-ons/screen_saver"
+			  "/boot/system/develop/headers/os/add-ons/tracker"
+			  "/boot/system/develop/headers/os/be_apps/Deskbar"
+			  "/boot/system/develop/headers/os/be_apps/NetPositive"
+			  "/boot/system/develop/headers/os/be_apps/Tracker"
+			  "/boot/system/develop/headers/3rdparty"
+			  "/boot/system/develop/headers/bsd"
+			  "/boot/system/develop/headers/glibc"
+			  "/boot/system/develop/headers/gnu"
+			  "/boot/system/develop/headers/posix"
+			)
+	if [ -n "$secondaryArchSuffix" ]; then
+		hybrid="${secondaryArchSuffix#_}"
+		sysincdir=("/boot/system/non-packaged/develop/headers/$hybrid"
+			   ${sysincdir[@]}
+			   "/boot/system/develop/headers/$hybrid"
+			   "/boot/system/develop/headers/$hybrid/os"
+			   "/boot/system/develop/headers/$hybrid/os/opengl")
+	else
+		sysincdir=("/boot/system/non-packaged/develop/headers"
+			   ${sysincdir[@]})
+	fi
+
+	sysincdir+=("/boot/system/develop/headers"
+		    # TCC owns include paths, refer to tcc.h
+		    "{B}/include")
+
+	local crtpre=("/boot/system/non-packaged/develop/lib${hybrid:+/$hybrid}"
+		      "/boot/system/develop/lib${hybrid:+/$hybrid}")
+
+	local libdir=(${crtpre[@]}
+		      "/boot/system/non-packaged/lib${hybrid:+/$hybrid}"
+		      "/boot/system/lib${hybrid:+/$hybrid}")
+
+	runConfigure ./configure --enable-cross \
+		--sysincludepaths=$(IFS=:; echo "${sysincdir[*]}") \
+		--libpaths=$(IFS=:; echo "${libdir[*]}") \
+		--crtprefix=$(IFS=:; echo "${crtpre[*]}") \
+		--elfinterp=/system/runtime_loader
 	make $jobArgs
 }
 
@@ -65,5 +128,9 @@ INSTALL()
 
 TEST()
 {
-	make test
+	if [ "$targetArchitecture" == "x86_gcc2" && -z "$secondaryArchSuffix" ]; then
+		echo "Sorry, test doesn't support gcc2"
+	else
+		make test
+	fi
 }

--- a/dev-lang/tcc/tcc-0.9.26.recipe
+++ b/dev-lang/tcc/tcc-0.9.26.recipe
@@ -21,8 +21,8 @@ SOURCE_URI="http://download.savannah.gnu.org/releases/tinycc/tcc-0.9.26.tar.bz2"
 CHECKSUM_SHA256="521e701ae436c302545c3f973a9c9b7e2694769c71d9be10f70a2460705b6d71"
 PATCHES="tcc-$portVersion.patchset"
 
-ARCHITECTURES="x86_gcc2 ?x86_64"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="!x86_gcc2 !x86 !x86_64"
+SECONDARY_ARCHITECTURES="!x86"
 
 PROVIDES="
 	tcc$secondaryArchSuffix = $portVersion

--- a/dev-lang/tcc/tcc-0.9.26.recipe
+++ b/dev-lang/tcc/tcc-0.9.26.recipe
@@ -62,3 +62,8 @@ INSTALL()
 	prepareInstalledDevelLib libtcc
 	packageEntries devel $developDir
 }
+
+TEST()
+{
+	make test
+}

--- a/dev-lang/yasm/yasm-1.3.0.recipe
+++ b/dev-lang/yasm/yasm-1.3.0.recipe
@@ -55,6 +55,10 @@ INSTALL()
 	prepareInstalledDevelLibs libyasm
 }
 
+TEST()
+{
+	make check
+}
 
 DESCRIPTION="
 Yasm is a complete rewrite of the NASM assembler under the “new” BSD License \

--- a/dev-libs/glib/glib2-2.54.2.recipe
+++ b/dev-libs/glib/glib2-2.54.2.recipe
@@ -162,3 +162,8 @@ INSTALL()
 
 	rm $libDir/charset.alias
 }
+
+TEST()
+{
+	make check
+}

--- a/dev-libs/jsoncpp/jsoncpp-1.8.3.recipe
+++ b/dev-libs/jsoncpp/jsoncpp-1.8.3.recipe
@@ -39,7 +39,7 @@ BUILD_PREREQUIRES="
 	cmd:ld$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
-#	cmd:python2
+	cmd:python2
 	"
 
 BUILD()
@@ -49,6 +49,7 @@ BUILD()
 	cmake $cmakeDirArgs \
 		-DCMAKE_BUILD_TYPE='Release' \
 		-DBUILD_SHARED_LIBS:BOOL=ON \
+		-DJSONCPP_WITH_TESTS=ON \
 		..
 	make $jobArgs
 }
@@ -64,4 +65,10 @@ INSTALL()
 	# devel package
 	packageEntries devel \
 		$developDir
+}
+
+TEST()
+{
+	cd build
+	make jsoncpp_check
 }

--- a/dev-libs/libtommath/libtommath-1.0.1.recipe
+++ b/dev-libs/libtommath/libtommath-1.0.1.recipe
@@ -44,7 +44,7 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	make $jobArgs -f makefile.shared IGNORE_SPEED=1 
+	make $jobArgs -f makefile.shared IGNORE_SPEED=1
 }
 
 INSTALL()
@@ -59,4 +59,10 @@ INSTALL()
 	fixPkgconfig
 
 	packageEntries devel $developDir
+}
+
+TEST()
+{
+	make $jobArgs -f makefile.shared IGNORE_SPEED=1 test_standalone
+	./test
 }

--- a/dev-libs/libxslt/libxslt-1.1.32.recipe
+++ b/dev-libs/libxslt/libxslt-1.1.32.recipe
@@ -76,3 +76,8 @@ INSTALL()
 	packageEntries devel \
 		$developDir
 }
+
+TEST()
+{
+	make check
+}

--- a/dev-libs/libyajl/libyajl-2.1.0.recipe
+++ b/dev-libs/libyajl/libyajl-2.1.0.recipe
@@ -42,6 +42,11 @@ BUILD_PREREQUIRES="
 	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
 	"
+# For TEST()
+BUILD_PREREQUIRES+="
+	cmd:which
+	"
+
 
 BUILD()
 {
@@ -74,4 +79,10 @@ INSTALL()
 	# devel package
 	packageEntries devel \
 		$developDir
+}
+
+TEST()
+{
+	cd haiku_build
+	make test test-api
 }

--- a/dev-libs/zziplib/patches/zziplib-0.13.67.patchset
+++ b/dev-libs/zziplib/patches/zziplib-0.13.67.patchset
@@ -1,4 +1,4 @@
-From a41afabc0388d0756d24476498decd7b30c74c41 Mon Sep 17 00:00:00 2001
+From 0d855e50ba9eb0941b3bb646bb73a7759f30bb4f Mon Sep 17 00:00:00 2001
 From: begasus <begasus@gmail.com>
 Date: Sat, 7 Oct 2017 21:03:37 +0200
 Subject: gcc2 fix
@@ -28,5 +28,75 @@ index 69070df..410487a 100644
          {
              continue;
 -- 
-2.7.0
+2.15.0
+
+
+From 889f054b6b75704a88bb55b337f202b085df978a Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Mon, 4 Dec 2017 13:34:19 +0700
+Subject: test: set LIBRARY_PATH instead of LD_LIBRARY_PATH
+
+
+diff --git a/test/Makefile.am b/test/Makefile.am
+index 250651d..d7b31b9 100644
+--- a/test/Makefile.am
++++ b/test/Makefile.am
+@@ -70,7 +70,7 @@ zzshowme$(EXEEXT) : zzipself$(EXEEXT) zzipsetstub$(EXEEXT)
+ 
+ check-sfx : zzshowme$(EXEEXT)
+ 	echo :$@: "./zzshowme readme >readme.out 2>readme.err" 
+-	export LD_LIBRARY_PATH="../zzip/.libs:$$LD_LIBRARY_PATH" \
++	export LIBRARY_PATH="../zzip/.libs:$$LIBRARY_PATH" \
+ 	; ./zzshowme readme >readme.out 2>readme.err ; true
+ 	@ echo 'diff readme.out $(README) || grep "libzzip-" readme.err' \
+ 	; if test -s readme.out ; then diff readme.out $(README) \
+-- 
+2.15.0
+
+
+From c76605c6684a07e9f347553c89cb355e2fc7236d Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Mon, 4 Dec 2017 19:40:23 +0700
+Subject: test: use rpath to direct zzipself to correct libpath
+
+
+diff --git a/test/Makefile.am b/test/Makefile.am
+index d7b31b9..3e61034 100644
+--- a/test/Makefile.am
++++ b/test/Makefile.am
+@@ -54,7 +54,7 @@ check-readme : $(zzcat)  test.zip
+ 
+ noinst_PROGRAMS = zzipself zzipsetstub
+ 
+-zzipself_LDFLAGS = @ZZIPLIB_LDFLAGS@
++zzipself_LDFLAGS = @ZZIPLIB_LDFLAGS@ -Wl,-rpath,\$$ORIGIN/../zzip/.libs
+ zzipself_LDADD = ../zzip/libzzip.la @RESOLVES@ -lz
+ 
+ ../zzip/libzzip.la : @top_srcdir@/zzip/*.c
+-- 
+2.15.0
+
+
+From 3d98c87340448e429516e866b52a3367fe81a5c5 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Wed, 6 Dec 2017 19:14:27 +0700
+Subject: test: split file list with xargs
+
+10000 files on argv, won't work
+
+diff --git a/test/zziptests.py b/test/zziptests.py
+index 6e9df78..26aaaf7 100644
+--- a/test/zziptests.py
++++ b/test/zziptests.py
+@@ -199,7 +199,7 @@ class ZZipTest(unittest.TestCase):
+     filename = os.path.join(tmpdir,"README")
+     filetext = self.readme()
+     self.mkfile(filename, filetext)
+-    shell("{exe} -n README ../{zipfile} ??*.* README".format(**locals()), cwd=tmpdir)
++    shell("printf '%s\n' ??*.* | xargs {exe} -un README ../{zipfile} README".format(**locals()), cwd=tmpdir)
+     self.assertGreater(os.path.getsize(zipfile), 1000000)
+   def test_105_make_test5_zip(self):
+     """ create a test5.zip for later tests using standard 'zip'
+-- 
+2.15.0
 

--- a/dev-libs/zziplib/zziplib-0.13.67.recipe
+++ b/dev-libs/zziplib/zziplib-0.13.67.recipe
@@ -9,9 +9,7 @@ REVISION="2"
 SOURCE_URI="https://github.com/gdraheim/zziplib/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="1278178bdabac832da6bbf161033d890d335a2e38493c5af553ff5ce7b9b0220"
 
-if [ "$effectiveTargetArchitecture" = x86_gcc2 ]; then
-	PATCHES="zziplib-$portVersion.patchset"
-fi
+PATCHES="zziplib-$portVersion.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 ?x86_64"
 SECONDARY_ARCHITECTURES="x86"
@@ -96,4 +94,9 @@ INSTALL()
 
 	packageEntries devel \
 		$developDir
+}
+
+TEST()
+{
+	make check
 }

--- a/dev-python/pyqt/pyqt-5.9.1.recipe
+++ b/dev-python/pyqt/pyqt-5.9.1.recipe
@@ -155,7 +155,7 @@ BUILD()
 		--sip=$portPackageLinksDir/sip_python/bin/python2-sip \
 		--stubsdir=$installLocation/PyQt5 \
 		#--verbose
-		
+
 	make $jobArgs
 
 	cd ${sourceDir}_build3
@@ -176,7 +176,7 @@ BUILD()
 		--sip=$portPackageLinksDir/sip_python3/bin/sip \
 		--stubsdir=$installLocation/PyQt5 \
 		#--verbose
-		
+
 	make $jobArgs
 }
 

--- a/dev-python/pyqt/pyqt-5.9.1.recipe
+++ b/dev-python/pyqt/pyqt-5.9.1.recipe
@@ -60,7 +60,7 @@ PROVIDES_python="
 	"
 REQUIRES_python="
 	pyqt$secondaryArchSuffix == $portVersion base
-	sip_python >= 4.19
+	python_sip >= 4.19
 	cmd:python2
 	$REQUIRES
 	"
@@ -78,7 +78,7 @@ PROVIDES_python3="
 REQUIRES_python3="
 	haiku${secondaryArchSuffix}
 	pyqt$secondaryArchSuffix == $portVersion base
-	sip_python3 >= 4.19
+	python3_sip >= 4.19
 	cmd:python$PYTHON3_VERSION
 	$REQUIRES
 	"
@@ -89,9 +89,9 @@ REPLACES_python3="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	setuptools_python
-	sip_python  # >= 4.19 
+	python_sip  # >= 4.19
 	setuptools_python3
-	sip_python3 # >= 4.19
+	python3_sip # >= 4.19
 	devel:libQt5Bluetooth$secondaryArchSuffix >= 5.7
 	devel:libQt5Core$secondaryArchSuffix >= 5.7
 	devel:libQt5Designer$secondaryArchSuffix >= 5.7

--- a/sys-devel/flex/flex-2.6.4.recipe
+++ b/sys-devel/flex/flex-2.6.4.recipe
@@ -61,3 +61,8 @@ INSTALL()
 	# prepare develop/lib
 	prepareInstalledDevelLibs libfl
 }
+
+TEST()
+{
+	make check
+}


### PR DESCRIPTION
Done as part of GCI 2017

This PR add `TEST()` to various ports, with fixes to a few ports I bumped into while running `TEST()`

# Status
## Tested
- [x] app-crypt/qca (PASS)
- [x] app-crypt/rhash (PASS)
- [x] app-text/podofo (PASS)
- [x] app-editors/retext (PASS)
- [x] app-i18n/mozc (FAIL, see below)
- [x] dev-lang/spidermonkey (FAIL, see below)
- [x] dev-lang/tcc (FAIL, see below)
- [x] dev-lang/yasm (PASS)
- [x] dev-libs/glib2 (FAIL, see below)
- [x] dev-libs/jsoncpp (PASS)
- [x] dev-libs/libtommath (PASS)
- [x] dev-libs/libxslt (PASS)
- [x] dev-libs/libyajl (PASS)
- [x] dev-libs/zziplib (PASS)
- [x] sys-devel/flex (PASS)

## Known issues
- app-editors/retext: tests operate on desktop, users should leave their device unattended during test
- app-i18n/mozc: most passes, following fails: `ipc_test`, `prediction_test`, `renderer_server_test`, `session_server_test`. [Log file](https://ghostbin.com/paste/xwsw8)
- dev-lang/spidermonkey: multiple tests failed, all `SIGSEGV`
- dev-lang/tcc: currently broken on Haiku due to [bug#13847](https://dev.haiku-os.org/ticket/13847)
- dev-libs/glib2:
  - tests won't build on `x86_gcc2`, `gcc2` lacks `-Wstrict-aliasing=2` 
  - most passes, some fails: [log](https://ghostbin.com/paste/47uu9)