### PR TITLE
mbedtls: add initial recipe for 2.6.0

### DIFF
--- a/net-libs/mbedtls/mbedtls-2.6.0.recipe
+++ b/net-libs/mbedtls/mbedtls-2.6.0.recipe
@@ -1,0 +1,119 @@
+SUMMARY="Open source, portable, easy to use, readable and flexible SSL library"
+DESCRIPTION="mbed TLS (formerly known as PolarSSL) makes it trivially easy for \
+developers to include cryptographic and SSL/TLS capabilities in their (embedded) \
+products, facilitating this functionality with a minimal coding footprint."
+HOMEPAGE="https://tls.mbed.org/"
+COPYRIGHT="2006-2016, ARM Limited"
+LICENSE="Apache v2"
+REVISION="1"
+SOURCE_URI="https://tls.mbed.org/download/mbedtls-$portVersion-apache.tgz"
+CHECKSUM_SHA256="99bc9d4212d3d885eeb96273bcde8ecc649a481404b8d7ea7bb26397c9909687"
+
+ARCHITECTURES="x86_gcc2 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	mbedtls = $portVersion
+	cmd:mbedtls_aescrypt2 = $portVersion
+	cmd:mbedtls_benchmark = $portVersion
+	cmd:mbedtls_cert_app = $portVersion
+	cmd:mbedtls_cert_req = $portVersion
+	cmd:mbedtls_cert_write = $portVersion
+	cmd:mbedtls_crl_app = $portVersion
+	cmd:mbedtls_crypt_and_hash = $portVersion
+	cmd:mbedtls_dh_client = $portVersion
+	cmd:mbedtls_dh_genprime = $portVersion
+	cmd:mbedtls_dh_server = $portVersion
+	cmd:mbedtls_dtls_client = $portVersion
+	cmd:mbedtls_dtls_server = $portVersion
+	cmd:mbedtls_ecdh_curve25519 = $portVersion
+	cmd:mbedtls_ecdsa = $portVersion
+	cmd:mbedtls_gen_entropy = $portVersion
+	cmd:mbedtls_gen_key = $portVersion
+	cmd:mbedtls_gen_random_ctr_drbg = $portVersion
+	cmd:mbedtls_gen_random_havege = $portVersion
+	cmd:mbedtls_generic_sum = $portVersion
+	cmd:mbedtls_hello = $portVersion
+	cmd:mbedtls_key_app = $portVersion
+	cmd:mbedtls_key_app_writer = $portVersion
+	cmd:mbedtls_mini_client = $portVersion
+	cmd:mbedtls_mpi_demo = $portVersion
+	cmd:mbedtls_pem2der = $portVersion
+	cmd:mbedtls_pk_decrypt = $portVersion
+	cmd:mbedtls_pk_encrypt = $portVersion
+	cmd:mbedtls_pk_sign = $portVersion
+	cmd:mbedtls_pk_verify = $portVersion
+	cmd:mbedtls_req_app = $portVersion
+	cmd:mbedtls_rsa_decrypt = $portVersion
+	cmd:mbedtls_rsa_encrypt = $portVersion
+	cmd:mbedtls_rsa_genkey = $portVersion
+	cmd:mbedtls_rsa_sign = $portVersion
+	cmd:mbedtls_rsa_sign_pss = $portVersion
+	cmd:mbedtls_rsa_verify = $portVersion
+	cmd:mbedtls_rsa_verify_pss = $portVersion
+	cmd:mbedtls_selftest = $portVersion
+	cmd:mbedtls_ssl_cert_test = $portVersion
+	cmd:mbedtls_ssl_client1 = $portVersion
+	cmd:mbedtls_ssl_client2 = $portVersion
+	cmd:mbedtls_ssl_fork_server = $portVersion
+	cmd:mbedtls_ssl_mail_client = $portVersion
+	cmd:mbedtls_ssl_server = $portVersion
+	cmd:mbedtls_ssl_server2 = $portVersion
+	cmd:mbedtls_strerror = $portVersion
+	cmd:mbedtls_udp_proxy = $portVersion
+	lib:libmbedcrypto = 0 compat >=0
+	lib:libmbedtls = 10 compat >= 10
+	lib:libmbedx509 = 0 compat >= 0
+	"
+REQUIRES="
+	haiku
+	"
+
+PROVIDES_devel="
+	mbedtls_devel = $portVersion
+	devel:libmbedcrypto = 0 compat >=0
+	devel:libmbedtls = 10 compat >= 10
+	devel:libmbedx509 = 0 compat >=0
+	"
+REQUIRES_devel="
+	mbedtls == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc
+	cmd:make
+	cmd:perl
+	cmd:sed
+	"
+
+PATCH()
+{
+	sed -i \
+		-e "s|/include/mbedtls|/$relativeOldIncludeDir|;"\
+		-e "s|/include|/$relativeOldIncludeDir|;"\
+		-e "s|/bin/|/$relativeBinDir/|;"\
+		-e "s|/bin\$|/$relativeBinDir/|;"\
+		-e "s|/lib\$|/$relativeLibDir/|;"\
+		Makefile
+}
+
+BUILD()
+{
+	# Haiku is unix-like and network functions are in libnetwork
+	make CFLAGS="-Dunix" LDFLAGS="-lnetwork" SHARED=yes WARNING_CFLAGS=
+}
+
+INSTALL()
+{
+	make install SHARED=yes DESTDIR=$prefix
+	prepareInstalledDevelLibs libmbedcrypto libmbedtls libmbedx509
+	packageEntries devel $developDir
+}
+
+TEST()
+{
+	LIBRARY_PATH="$sourceDir/library:$LIBRARY_PATH" make check
+}

--- a/net-libs/mbedtls/mbedtls-2.6.0.recipe
+++ b/net-libs/mbedtls/mbedtls-2.6.0.recipe
@@ -14,7 +14,7 @@ SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	mbedtls$secondaryArchSuffix = $portVersion
-	lib:libmbedcrypto$secondaryArchSuffix = 0 compat >=0
+	lib:libmbedcrypto$secondaryArchSuffix = 0 compat >= 0
 	lib:libmbedtls$secondaryArchSuffix = 10 compat >= 10
 	lib:libmbedx509$secondaryArchSuffix = 0 compat >= 0
 	"
@@ -75,9 +75,9 @@ REQUIRES="
 
 PROVIDES_devel="
 	mbedtls${secondaryArchSuffix}_devel = $portVersion
-	devel:libmbedcrypto$secondaryArchSuffix = 0 compat >=0
+	devel:libmbedcrypto$secondaryArchSuffix = 0 compat >= 0
 	devel:libmbedtls$secondaryArchSuffix = 10 compat >= 10
-	devel:libmbedx509$secondaryArchSuffix = 0 compat >=0
+	devel:libmbedx509$secondaryArchSuffix = 0 compat >= 0
 	"
 REQUIRES_devel="
 	mbedtls$secondaryArchSuffix == $portVersion base
@@ -96,18 +96,31 @@ BUILD_PREREQUIRES="
 PATCH()
 {
 	sed -i \
-		-e "s|/include/mbedtls|/$relativeOldIncludeDir|;"\
-		-e "s|/include|/$relativeOldIncludeDir|;"\
-		-e "s|/bin/|/$relativeBinDir/|;"\
-		-e "s|/bin\$|/$relativeBinDir/|;"\
-		-e "s|/lib\$|/$relativeLibDir/|;"\
+		-e "s|/include/mbedtls|/$relativeOldIncludeDir|;" \
+		-e "s|/include|/$relativeOldIncludeDir|;" \
+		-e "s|/bin/|/$relativeBinDir/|;" \
+		-e "s|/bin\$|/$relativeBinDir/|;" \
+		-e "s|/lib\$|/$relativeLibDir/|;" \
 		Makefile
 }
+
+if [ -n "$secondaryArchSuffix" ]; then
+	maybe_binDir_mbedtls_runtimes=
+else
+	maybe_binDir_mbedtls_runtimes="`echo "$PROVIDES" | sed -n \
+		-e "s|cmd:\([^ ]*\).*|$binDir/\1|p" \
+		`"
+fi
+defineDebugInfoPackage mbedtls$secondaryArchSuffix \
+	$libDir/libmbedcrypto.so.0 \
+	$libDir/libmbedtls.so.10 \
+	$libDir/libmbedx509.so.0 \
+	$maybe_binDir_mbedtls_runtimes
 
 BUILD()
 {
 	# Haiku is unix-like and network functions are in libnetwork
-	make CFLAGS="-Dunix" LDFLAGS="-lnetwork" SHARED=yes WARNING_CFLAGS=
+	make CFLAGS="-Dunix" LDFLAGS="-lnetwork" SHARED=yes WARNING_CFLAGS=""
 }
 
 INSTALL()

--- a/net-libs/mbedtls/mbedtls-2.6.0.recipe
+++ b/net-libs/mbedtls/mbedtls-2.6.0.recipe
@@ -93,17 +93,6 @@ BUILD_PREREQUIRES="
 	cmd:sed
 	"
 
-PATCH()
-{
-	sed -i \
-		-e "s|/include/mbedtls|/$relativeOldIncludeDir|;" \
-		-e "s|/include|/$relativeOldIncludeDir|;" \
-		-e "s|/bin/|/$relativeBinDir/|;" \
-		-e "s|/bin\$|/$relativeBinDir/|;" \
-		-e "s|/lib\$|/$relativeLibDir/|;" \
-		Makefile
-}
-
 if [ -n "$secondaryArchSuffix" ]; then
 	maybe_binDir_mbedtls_runtimes=
 else
@@ -116,6 +105,17 @@ defineDebugInfoPackage mbedtls$secondaryArchSuffix \
 	$libDir/libmbedtls.so.10 \
 	$libDir/libmbedx509.so.0 \
 	$maybe_binDir_mbedtls_runtimes
+
+PATCH()
+{
+	sed -i \
+		-e "s|/include/mbedtls|/$relativeOldIncludeDir|;" \
+		-e "s|/include|/$relativeOldIncludeDir|;" \
+		-e "s|/bin/|/$relativeBinDir/|;" \
+		-e "s|/bin\$|/$relativeBinDir|;" \
+		-e "s|/lib\$|/$relativeLibDir|;" \
+		Makefile
+}
 
 BUILD()
 {
@@ -135,5 +135,5 @@ INSTALL()
 
 TEST()
 {
-	LIBRARY_PATH="$sourceDir/library:$LIBRARY_PATH" make check
+	LIBRARY_PATH="$sourceDir/library${LIBRARY_PATH:+:$LIBRARY_PATH}" make check
 }

--- a/net-libs/mbedtls/mbedtls-2.6.0.recipe
+++ b/net-libs/mbedtls/mbedtls-2.6.0.recipe
@@ -13,77 +13,81 @@ ARCHITECTURES="x86_gcc2 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	mbedtls = $portVersion
-	cmd:mbedtls_aescrypt2 = $portVersion
-	cmd:mbedtls_benchmark = $portVersion
-	cmd:mbedtls_cert_app = $portVersion
-	cmd:mbedtls_cert_req = $portVersion
-	cmd:mbedtls_cert_write = $portVersion
-	cmd:mbedtls_crl_app = $portVersion
-	cmd:mbedtls_crypt_and_hash = $portVersion
-	cmd:mbedtls_dh_client = $portVersion
-	cmd:mbedtls_dh_genprime = $portVersion
-	cmd:mbedtls_dh_server = $portVersion
-	cmd:mbedtls_dtls_client = $portVersion
-	cmd:mbedtls_dtls_server = $portVersion
-	cmd:mbedtls_ecdh_curve25519 = $portVersion
-	cmd:mbedtls_ecdsa = $portVersion
-	cmd:mbedtls_gen_entropy = $portVersion
-	cmd:mbedtls_gen_key = $portVersion
-	cmd:mbedtls_gen_random_ctr_drbg = $portVersion
-	cmd:mbedtls_gen_random_havege = $portVersion
-	cmd:mbedtls_generic_sum = $portVersion
-	cmd:mbedtls_hello = $portVersion
-	cmd:mbedtls_key_app = $portVersion
-	cmd:mbedtls_key_app_writer = $portVersion
-	cmd:mbedtls_mini_client = $portVersion
-	cmd:mbedtls_mpi_demo = $portVersion
-	cmd:mbedtls_pem2der = $portVersion
-	cmd:mbedtls_pk_decrypt = $portVersion
-	cmd:mbedtls_pk_encrypt = $portVersion
-	cmd:mbedtls_pk_sign = $portVersion
-	cmd:mbedtls_pk_verify = $portVersion
-	cmd:mbedtls_req_app = $portVersion
-	cmd:mbedtls_rsa_decrypt = $portVersion
-	cmd:mbedtls_rsa_encrypt = $portVersion
-	cmd:mbedtls_rsa_genkey = $portVersion
-	cmd:mbedtls_rsa_sign = $portVersion
-	cmd:mbedtls_rsa_sign_pss = $portVersion
-	cmd:mbedtls_rsa_verify = $portVersion
-	cmd:mbedtls_rsa_verify_pss = $portVersion
-	cmd:mbedtls_selftest = $portVersion
-	cmd:mbedtls_ssl_cert_test = $portVersion
-	cmd:mbedtls_ssl_client1 = $portVersion
-	cmd:mbedtls_ssl_client2 = $portVersion
-	cmd:mbedtls_ssl_fork_server = $portVersion
-	cmd:mbedtls_ssl_mail_client = $portVersion
-	cmd:mbedtls_ssl_server = $portVersion
-	cmd:mbedtls_ssl_server2 = $portVersion
-	cmd:mbedtls_strerror = $portVersion
-	cmd:mbedtls_udp_proxy = $portVersion
-	lib:libmbedcrypto = 0 compat >=0
-	lib:libmbedtls = 10 compat >= 10
-	lib:libmbedx509 = 0 compat >= 0
+	mbedtls$secondaryArchSuffix = $portVersion
+	lib:libmbedcrypto$secondaryArchSuffix = 0 compat >=0
+	lib:libmbedtls$secondaryArchSuffix = 10 compat >= 10
+	lib:libmbedx509$secondaryArchSuffix = 0 compat >= 0
 	"
+if [ -z "$secondaryArchSuffix" ]; then
+	PROVIDES="$PROVIDES
+		cmd:mbedtls_aescrypt2 = $portVersion
+		cmd:mbedtls_benchmark = $portVersion
+		cmd:mbedtls_cert_app = $portVersion
+		cmd:mbedtls_cert_req = $portVersion
+		cmd:mbedtls_cert_write = $portVersion
+		cmd:mbedtls_crl_app = $portVersion
+		cmd:mbedtls_crypt_and_hash = $portVersion
+		cmd:mbedtls_dh_client = $portVersion
+		cmd:mbedtls_dh_genprime = $portVersion
+		cmd:mbedtls_dh_server = $portVersion
+		cmd:mbedtls_dtls_client = $portVersion
+		cmd:mbedtls_dtls_server = $portVersion
+		cmd:mbedtls_ecdh_curve25519 = $portVersion
+		cmd:mbedtls_ecdsa = $portVersion
+		cmd:mbedtls_gen_entropy = $portVersion
+		cmd:mbedtls_gen_key = $portVersion
+		cmd:mbedtls_gen_random_ctr_drbg = $portVersion
+		cmd:mbedtls_gen_random_havege = $portVersion
+		cmd:mbedtls_generic_sum = $portVersion
+		cmd:mbedtls_hello = $portVersion
+		cmd:mbedtls_key_app = $portVersion
+		cmd:mbedtls_key_app_writer = $portVersion
+		cmd:mbedtls_mini_client = $portVersion
+		cmd:mbedtls_mpi_demo = $portVersion
+		cmd:mbedtls_pem2der = $portVersion
+		cmd:mbedtls_pk_decrypt = $portVersion
+		cmd:mbedtls_pk_encrypt = $portVersion
+		cmd:mbedtls_pk_sign = $portVersion
+		cmd:mbedtls_pk_verify = $portVersion
+		cmd:mbedtls_req_app = $portVersion
+		cmd:mbedtls_rsa_decrypt = $portVersion
+		cmd:mbedtls_rsa_encrypt = $portVersion
+		cmd:mbedtls_rsa_genkey = $portVersion
+		cmd:mbedtls_rsa_sign = $portVersion
+		cmd:mbedtls_rsa_sign_pss = $portVersion
+		cmd:mbedtls_rsa_verify = $portVersion
+		cmd:mbedtls_rsa_verify_pss = $portVersion
+		cmd:mbedtls_selftest = $portVersion
+		cmd:mbedtls_ssl_cert_test = $portVersion
+		cmd:mbedtls_ssl_client1 = $portVersion
+		cmd:mbedtls_ssl_client2 = $portVersion
+		cmd:mbedtls_ssl_fork_server = $portVersion
+		cmd:mbedtls_ssl_mail_client = $portVersion
+		cmd:mbedtls_ssl_server = $portVersion
+		cmd:mbedtls_ssl_server2 = $portVersion
+		cmd:mbedtls_strerror = $portVersion
+		cmd:mbedtls_udp_proxy = $portVersion
+		"
+fi
 REQUIRES="
-	haiku
+	haiku$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
-	mbedtls_devel = $portVersion
-	devel:libmbedcrypto = 0 compat >=0
-	devel:libmbedtls = 10 compat >= 10
-	devel:libmbedx509 = 0 compat >=0
+	mbedtls${secondaryArchSuffix}_devel = $portVersion
+	devel:libmbedcrypto$secondaryArchSuffix = 0 compat >=0
+	devel:libmbedtls$secondaryArchSuffix = 10 compat >= 10
+	devel:libmbedx509$secondaryArchSuffix = 0 compat >=0
 	"
 REQUIRES_devel="
-	mbedtls == $portVersion base
+	mbedtls$secondaryArchSuffix == $portVersion base
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
+	haiku${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
-	cmd:gcc
+	cmd:gcc$secondaryArchSuffix
 	cmd:make
 	cmd:perl
 	cmd:sed
@@ -111,6 +115,9 @@ INSTALL()
 	make install SHARED=yes DESTDIR=$prefix
 	prepareInstalledDevelLibs libmbedcrypto libmbedtls libmbedx509
 	packageEntries devel $developDir
+	if [ -n "$secondaryArchSuffix" ]; then
+		rm -rf $binDir
+	fi
 }
 
 TEST()


### PR DESCRIPTION
mbed TLS (formerly known as PolarSSL) makes it trivially easy for developers to include cryptographic and SSL/TLS capabilities in their (embedded) products, facilitating this functionality with a minimal coding footprint.
