### PR TITLE
Added recipe for BeScreenCapture 2.3

### DIFF
--- a/haiku-apps/bescreencapture/bescreencapture-2.3.recipe
+++ b/haiku-apps/bescreencapture/bescreencapture-2.3.recipe
@@ -1,0 +1,72 @@
+SUMMARY="A screen recorder utility"
+DESCRIPTION="BeScreenCapture is a screen recorder utility for Haiku.
+It allows you to record what happens on your screen, then save it \
+to any media format supported in Haiku.
+BeScreenCapture can record either the entire screen, or just a section you \
+select."
+
+SUMMARY_inputfilter="Shortcut handler for BeScreenCapture"
+DESCRIPTION_inputfilter="Input Server Addon for BeScreenCapture. Allows the \
+user to launch BeScreenCapture and start/stop recording using a keyboard \
+combination (CTRL-COMMAND-SHIFT + R)."
+
+HOMEPAGE="https://github.com/jackburton79/bescreencapture/releases"
+COPYRIGHT="2014-2017 Stefano Ceccherini"
+LICENSE="BSD (3-clause)
+	MIT"
+REVISION="1"
+SOURCE_URI="https://github.com/jackburton79/bescreencapture/archive/v${portVersion}.tar.gz"
+CHECKSUM_SHA256="8cc0ce610ba05aa49f53c9acfe8a321aaf3d367a1b1c1f4c79965827a40b092c"
+SOURCE_FILENAME="bescreencapture-${portVersion}.tar.gz"
+SOURCE_DIR="bescreencapture-${portVersion}"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	bescreencapture = $portVersion
+	app:BeScreenCapture = $portVersion
+	"
+REQUIRES="
+	haiku
+	"
+
+PROVIDES_inputfilter="
+	bescreencapture_inputfilter = $portVersion
+	app:BeScreenCaptureInputFilter = $portVersion
+	"
+REQUIRES_inputfilter="
+	haiku
+	bescreencapture == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+
+BUILD_PREREQUIRES="
+	makefile_engine
+	cmd:make
+	cmd:gcc
+	"
+
+BUILD()
+{
+	make OBJ_DIR=objects \
+		BUILDHOME=`finddir B_SYSTEM_DEVELOP_DIRECTORY`
+
+	make -C inputfilter OBJ_DIR=objects \
+		BUILDHOME=`finddir B_SYSTEM_DEVELOP_DIRECTORY`
+}
+
+INSTALL()
+{
+	mkdir -p $appsDir
+	cp -a objects/BeScreenCapture $appsDir
+	mkdir -p $addOnsDir/input_server/filters
+	cp -a inputfilter/objects/BeScreenCaptureInputFilter $addOnsDir/input_server/filters
+
+	packageEntries inputfilter \
+		$addOnsDir/input_server/filters/BeScreenCaptureInputFilter
+
+	addAppDeskbarSymlink $appsDir/BeScreenCapture
+}


### PR DESCRIPTION
Added recipe for BeScreenCapture 2.3.


The list of changes include:

    In selection mode, add an hint to the user via text instructions on the screen
    The selection can be moved after being selected
    Added capture frame settings
    Added clip duration when recording
    If saving a frame fails, the application will now abort and report an error
    Layout change: Moved most settings to the options tab
    Adapted code to be able to use the Shortcuts preflet to control recording

