### PR TITLE
Add sci-mathematics/msieve

### DIFF
--- a/sci-mathematics/gmp_ecm/gmp_ecm-7.0.4.recipe
+++ b/sci-mathematics/gmp_ecm/gmp_ecm-7.0.4.recipe
@@ -1,0 +1,77 @@
+SUMMARY="Elliptic Curve Method for Integer Factorization"
+DESCRIPTION="C implementation of the Elliptic Curve Method for factorizing integers"
+HOMEPAGE="http://ecm.gforge.inria.fr/"
+COPYRIGHT="2001-2016 GMP-ECM Authors"
+LICENSE="
+	GNU GPL v3
+	GNU LGPL v3
+	"
+REVISION="1"
+SOURCE_URI="https://gforge.inria.fr/frs/download.php/file/36224/ecm-$portVersion.tar.gz"
+CHECKSUM_SHA256="0cf7b3eee8462cc6f98b418b47630e1eb6b3f4f8c3fc1fb005b08e2a1811ba43"
+SOURCE_DIR="ecm-$portVersion"
+
+ARCHITECTURES="!x86_gcc2 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion=1.0.0
+libVersionCompat="$libVersion compat >= 1"
+
+PROVIDES="
+	gmp_ecm$secondaryArchSuffix = $portVersion
+	cmd:ecm$secondaryArchSuffix = $portVersion
+	lib:libecm$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libgmp$secondaryArchSuffix
+	lib:libgomp$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	gmp_ecm${secondaryArchSuffix}_devel = $portVersion
+	devel:libecm$secondaryArchSuffix = $libVersion
+	"
+REQUIRES_devel="
+	haiku${secondaryArchSuffix}_devel
+	gmp_ecm$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libgmp$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:cmp
+	cmd:gcc$secondaryArchSuffix
+	cmd:m4
+	cmd:make
+	"
+
+BUILD()
+{
+	runConfigure ./configure --enable-shared --enable-openmp
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	install -d -m 755 "$docDir"
+	install -t "$docDir" -m 644 AUTHORS NEWS README*
+
+	rm "$libDir"/*.la
+
+	prepareInstalledDevelLib libecm
+
+	packageEntries devel \
+		"$developDir" \
+		"$docDir/NEWS"
+}
+
+TEST()
+{
+	make check
+}

--- a/sci-mathematics/msieve/msieve-1.53.recipe
+++ b/sci-mathematics/msieve/msieve-1.53.recipe
@@ -1,0 +1,72 @@
+SUMMARY="Library for Factoring Large Integers"
+DESCRIPTION="C library implementing a suite of algorithms to factor large integers"
+HOMEPAGE="https://sourceforge.net/projects/msieve/"
+COPYRIGHT="Public Domain"
+LICENSE="Public Domain"
+REVISION="1"
+SOURCE_URI="https://downloads.sourceforge.net/msieve/msieve/Msieve%20v$portVersion/msieve${portVersion/./}_src.tar.gz"
+CHECKSUM_SHA256="c5fcbaaff266a43aa8bca55239d5b087d3e3f138d1a95d75b776c04ce4d93bb4"
+PATCHES="msieve-$portVersion.patchset"
+
+ARCHITECTURES="?x86_gcc2 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	msieve$secondaryArchSuffix = $portVersion
+	cmd:msieve$secondaryArchSuffix
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libecm$secondaryArchSuffix
+	lib:libgmp$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	msieve${secondaryArchSuffix}_devel = $portVersion
+	devel:libmsieve$secondaryArchSuffix
+	"
+REQUIRES_devel="
+	haiku${secondaryArchSuffix}_devel
+	msieve$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libecm$secondaryArchSuffix
+	devel:libgmp$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:sed
+	"
+
+PATCH()
+{
+	# Allow owns CFLAGS, could be useful when doing debug builds
+	sed -e 's/^CFLAGS =/CFLAGS +=/' -i Makefile
+	# Remove -march=native, while this flag provides speedup,
+	# it's not suitable for binary distribution
+	sed -e 's/-march=native//' -i Makefile
+}
+
+BUILD()
+{
+	make $jobArgs all ECM=1 HAIKU=1
+}
+
+INSTALL()
+{
+	install -d -m 755 "$binDir" "$docDir" "$includeDir" "$developLibDir"
+
+	install -t "$binDir" -m 755 msieve
+	install -t "$docDir" -m 644 Changes Readme*
+	install -t "$includeDir" -m 644 include/*
+	install -t "$developLibDir" -m 644 libmsieve.a
+
+	packageEntries devel \
+		"$developDir" \
+		"$docDir/Changes"
+}

--- a/sci-mathematics/msieve/patches/msieve-1.53.patchset
+++ b/sci-mathematics/msieve/patches/msieve-1.53.patchset
@@ -1,0 +1,636 @@
+From f5992c6e1069e230098aed13d160dcf8f9b3b718 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Thu, 7 Dec 2017 20:49:15 +0700
+Subject: use correct types
+
+
+diff --git a/common/driver.c b/common/driver.c
+index ffecfa9..d9344a5 100644
+--- a/common/driver.c
++++ b/common/driver.c
+@@ -174,7 +174,7 @@ void msieve_run(msieve_obj *obj) {
+ 
+ 	status = evaluate_expression(obj->input, &n);
+ 	if (status < 0 || mp_is_zero(&n)) {
+-		printf("error %d converting '%s'\n", status, obj->input);
++		printf("error %"PRId32" converting '%s'\n", status, obj->input);
+ 		obj->flags |= MSIEVE_FLAG_FACTORIZATION_DONE;
+ 		return;
+ 	}
+diff --git a/common/lanczos/lanczos.c b/common/lanczos/lanczos.c
+index b26185a..4852a4a 100644
+--- a/common/lanczos/lanczos.c
++++ b/common/lanczos/lanczos.c
+@@ -1220,9 +1220,9 @@ static uint64 * block_lanczos_core(msieve_obj *obj,
+ 				uint32 eta = elapsed * (max_n - dim_solved) /
+ 						(dim_solved - first_dim_solved);
+ 
+-				fprintf(stderr, "linear algebra completed %u "
+-					"of %u dimensions (%1.1f%%, ETA "
+-					"%dh%2dm)    \r",
++				fprintf(stderr, "linear algebra completed %" PRIu32 " "
++					"of %" PRIu32 " dimensions (%1.1f%%, ETA "
++					"%" PRId32 "h%2" PRId32 "m)    \r",
+ 					dim_solved, max_n, 100.0 * dim_solved / 
+ 					max_n, eta / 3600, (eta % 3600) / 60);
+ 
+diff --git a/common/smallfact/gmp_ecm.c b/common/smallfact/gmp_ecm.c
+index fd1da3b..c3df19d 100644
+--- a/common/smallfact/gmp_ecm.c
++++ b/common/smallfact/gmp_ecm.c
+@@ -306,14 +306,14 @@ uint32 ecm_pp1_pm1(msieve_obj *obj, mp_t *n, mp_t *reduced_n,
+ 
+ 			if (log_rate && j == next_log) {
+ 				next_log += log_rate;
+-				fprintf(stderr, "%u of %u curves\r",
++				fprintf(stderr, "%" PRIu32 " of %" PRIu32 " curves\r",
+ 						j, curr_work->num_ecm_trials);
+ 				fflush(stderr);
+ 			}
+ 		}
+ 
+ 		if (log_rate)
+-			fprintf(stderr, "\ncompleted %u ECM curves\n", j);
++			fprintf(stderr, "\ncompleted %" PRIu32 " ECM curves\n", j);
+ 	}
+ 
+ clean_up:
+diff --git a/demo.c b/demo.c
+index a882732..a49dbb2 100644
+--- a/demo.c
++++ b/demo.c
+@@ -256,7 +256,7 @@ void factor_integer(char *buf, uint32 flags,
+ 			else
+ 				factor_type = "prp";
+ 
+-			printf("%s%d: %s\n", factor_type, 
++			printf("%s%" PRId32 ": %s\n", factor_type, 
+ 					(int32)strlen(factor->number), 
+ 					factor->number);
+ 			factor = factor->next;
+diff --git a/gnfs/fb.c b/gnfs/fb.c
+index afaee24..15b33c2 100644
+--- a/gnfs/fb.c
++++ b/gnfs/fb.c
+@@ -100,7 +100,7 @@ void create_factor_base(msieve_obj *obj,
+ 		if (report_progress && (num_found_r > next_report ||
+ 					num_found_a > next_report)) {
+ 			fprintf(stderr, "factor base: found "
+-					"%u rational and %u "
++					"%" PRIu32 " rational and %" PRIu32 " "
+ 					"algebraic entries\r", 
+ 					num_found_r, num_found_a);
+ 			fflush(stderr);
+@@ -341,13 +341,13 @@ void write_factor_base(msieve_obj *obj, mpz_t n,
+ 		exit(-1);
+ 	}
+ 	fprintf(fp, "\n");
+-	fprintf(fp, "FRNUM %u\n", fb->rfb.num_entries);
+-	fprintf(fp, "FRMAX %u\n", fb->rfb.max_prime);
+-	fprintf(fp, "FANUM %u\n", fb->afb.num_entries);
+-	fprintf(fp, "FAMAX %u\n", fb->afb.max_prime);
++	fprintf(fp, "FRNUM %" PRIu32 "\n", fb->rfb.num_entries);
++	fprintf(fp, "FRMAX %" PRIu32 "\n", fb->rfb.max_prime);
++	fprintf(fp, "FANUM %" PRIu32 "\n", fb->afb.num_entries);
++	fprintf(fp, "FAMAX %" PRIu32 "\n", fb->afb.max_prime);
+ 
+-	fprintf(fp, "SRLPMAX %u\n", params->rfb_lp_size);
+-	fprintf(fp, "SALPMAX %u\n", params->afb_lp_size);
++	fprintf(fp, "SRLPMAX %" PRIu32 "\n", params->rfb_lp_size);
++	fprintf(fp, "SALPMAX %" PRIu32 "\n", params->afb_lp_size);
+ 	fprintf(fp, "SLINE %" PRIu64 "\n", 
+ 			(uint64)(params->sieve_end - params->sieve_begin) / 2);
+ 	fprintf(fp, "\n");
+@@ -355,10 +355,10 @@ void write_factor_base(msieve_obj *obj, mpz_t n,
+ 	i = 0;
+ 	side = &fb->rfb;
+ 	while (i < side->num_entries) {
+-		fprintf(fp, "%u %u", side->entries[i].p, side->entries[i].r);
++		fprintf(fp, "%" PRIu32 " %" PRIu32, side->entries[i].p, side->entries[i].r);
+ 		for (j = i + 1; j < side->num_entries &&
+ 				side->entries[j].p == side->entries[i].p; j++) {
+-			fprintf(fp, " %u", side->entries[j].r);
++			fprintf(fp, " %" PRIu32, side->entries[j].r);
+ 		}
+ 		fprintf(fp, "\n");
+ 		i = j;
+@@ -367,10 +367,10 @@ void write_factor_base(msieve_obj *obj, mpz_t n,
+ 	i = 0;
+ 	side = &fb->afb;
+ 	while (i < side->num_entries) {
+-		fprintf(fp, "%u %u", side->entries[i].p, side->entries[i].r);
++		fprintf(fp, "%" PRIu32" %" PRIu32, side->entries[i].p, side->entries[i].r);
+ 		for (j = i + 1; j < side->num_entries &&
+ 				side->entries[j].p == side->entries[i].p; j++) {
+-			fprintf(fp, " %u", side->entries[j].r);
++			fprintf(fp, " %" PRIu32, side->entries[j].r);
+ 		}
+ 		fprintf(fp, "\n");
+ 		i = j;
+diff --git a/gnfs/filter/duplicate.c b/gnfs/filter/duplicate.c
+index cd50ead..59330c3 100644
+--- a/gnfs/filter/duplicate.c
++++ b/gnfs/filter/duplicate.c
+@@ -379,7 +379,7 @@ uint32 nfs_purge_duplicates(msieve_obj *obj, factor_base_t *fb,
+ 		}
+ 
+ 		if (curr_relation > 0 && (curr_relation % 10000000 == 0)) {
+-			printf("read %uM relations\n", curr_relation / 1000000);
++			printf("read %" PRIu32 "M relations\n", curr_relation / 1000000);
+ 		} /* there are no more errors -6/-11 to see progress */
+ 
+ 		/* relation is good; find the value to which it
+diff --git a/gnfs/poly/poly_param.c b/gnfs/poly/poly_param.c
+index fea29ed..9af0436 100644
+--- a/gnfs/poly/poly_param.c
++++ b/gnfs/poly/poly_param.c
+@@ -237,7 +237,7 @@ void get_poly_params(msieve_obj *obj, mpz_t n,
+ 		break;
+ 
+ 	default:
+-		printf("error: invalid degree %u\n", degree);
++		printf("error: invalid degree %" PRIu32 "\n", degree);
+ 		exit(-1);
+ 	}
+ 
+diff --git a/gnfs/poly/poly_skew.c b/gnfs/poly/poly_skew.c
+index 2656bf9..a27fdbe 100644
+--- a/gnfs/poly/poly_skew.c
++++ b/gnfs/poly/poly_skew.c
+@@ -55,12 +55,12 @@ rootopt_callback(void *extra, uint32 degree,
+ 	poly.combined_score = combined_score;
+ 	poly.skewness = skewness;
+ 
+-	printf("save %le %.4lf %.2lf %le rroots %u\n", size_score,
++	printf("save %le %.4lf %.2lf %le rroots %" PRIu32 "\n", size_score,
+ 			root_score, skewness, combined_score,
+ 			num_real_roots);
+ 
+ 	fprintf(data->all_poly_file, 
+-		"# norm %le alpha %lf e %.3le rroots %u\nskew: %.2lf\n", 
++		"# norm %le alpha %lf e %.3le rroots %" PRIu32 "\nskew: %.2lf\n", 
+ 		size_score, root_score, combined_score, 
+ 		num_real_roots, skewness);
+ 	for (i = 0; i <= degree; i++)
+diff --git a/gnfs/poly/stage1/stage1.c b/gnfs/poly/stage1/stage1.c
+index 9c7d612..7e55fd0 100644
+--- a/gnfs/poly/stage1/stage1.c
++++ b/gnfs/poly/stage1/stage1.c
+@@ -51,7 +51,7 @@ stage1_bounds_update(poly_search_t *poly, poly_coeff_t *c)
+ 		break;
+ 
+ 	default:
+-		printf("error: unexpected poly degree %d\n", degree);
++		printf("error: unexpected poly degree %" PRId32 "\n", degree);
+ 		exit(-1);
+ 	}
+ 
+diff --git a/gnfs/poly/stage1/stage1_sieve_cpu.c b/gnfs/poly/stage1/stage1_sieve_cpu.c
+index c3e93f3..b35d394 100644
+--- a/gnfs/poly/stage1/stage1_sieve_cpu.c
++++ b/gnfs/poly/stage1/stage1_sieve_cpu.c
+@@ -476,7 +476,7 @@ sieve_specialq_64(msieve_obj *obj, poly_search_t *poly,
+ 	num_p = hash_array.num_p;
+ 	num_roots = hash_array.num_roots;
+ #if 1
+-	printf("aprogs: %u entries, %u roots\n", num_p, num_roots);
++	printf("aprogs: %" PRIu32 " entries, %" PRIu32 " roots\n", num_p, num_roots);
+ #endif
+ 
+ 	block_size = (uint64)p_min * p_min;
+@@ -608,7 +608,7 @@ sieve_specialq_64(msieve_obj *obj, poly_search_t *poly,
+ 
+ finished:
+ #if 1
+-	printf("hashtable: %u entries, %5.2lf MB\n", 
++	printf("hashtable: %" PRIu32 " entries, %5.2lf MB\n", 
+ 			(uint32)1 << hashtable_size_log2,
+ 			(double)sizeof(hash_entry_t) *
+ 				((uint32)1 << hashtable_size_log2) / 1048576);
+@@ -712,7 +712,7 @@ sieve_lattice_cpu(msieve_obj *obj, poly_search_t *poly,
+ 					% num_pieces;
+ 
+ 			printf("randomizing rational coefficient: "
+-				"using piece #%u of %u\n",
++				"using piece #%" PRIu32 " of %" PRIu32 "\n",
+ 				piece + 1, num_pieces);
+ 
+ 			special_q_min2 = special_q_min + piece * piece_length;
+diff --git a/gnfs/poly/stage2/optimize_deg6.c b/gnfs/poly/stage2/optimize_deg6.c
+index 018dc17..69ca3c5 100644
+--- a/gnfs/poly/stage2/optimize_deg6.c
++++ b/gnfs/poly/stage2/optimize_deg6.c
+@@ -334,7 +334,7 @@ parse_objective(multi_poly_t *poly, char *objective)
+ 				break;
+ 
+ 			default:
+-				printf("parse error: %u '%s'\n", i, tmp);
++				printf("parse error: %" PRIu32 " '%s'\n", i, tmp);
+ 				exit(-1);
+ 			}
+ 		}
+diff --git a/gnfs/sieve/sieve_line.c b/gnfs/sieve/sieve_line.c
+index 36141ae..e4156ea 100644
+--- a/gnfs/sieve/sieve_line.c
++++ b/gnfs/sieve/sieve_line.c
+@@ -311,8 +311,8 @@ uint32 do_line_sieving(msieve_obj *obj, sieve_param_t *params, mpz_t n,
+ 
+ 		if ((obj->flags & (MSIEVE_FLAG_USE_LOGFILE |
+ 	    		   	  MSIEVE_FLAG_LOG_TO_STDOUT))) {
+-			fprintf(stderr, "b = %u, %u complete / "
+-				"%u batched relations (need %u)\r", 
++			fprintf(stderr, "b = %" PRIu32 ", %" PRIu32 " complete / "
++				"%" PRIu32 " batched relations (need %" PRIu32 ")\r", 
+ 				job.min_b + i, relations_found, 
+ 				job.relation_batch.num_relations,
+ 				max_relations);
+diff --git a/gnfs/sieve/sieve_util.c b/gnfs/sieve/sieve_util.c
+index a81a560..91deea8 100644
+--- a/gnfs/sieve/sieve_util.c
++++ b/gnfs/sieve/sieve_util.c
+@@ -25,36 +25,36 @@ void print_relation(savefile_t *savefile, int64 a, uint32 b,
+ 	char buf[LINE_BUF_SIZE];
+ 	char *tmp = buf;
+ 
+-	tmp += sprintf(buf, "%" PRId64 ",%u", a, b);
++	tmp += sprintf(buf, "%" PRId64 ",%" PRIu32, a, b);
+ 	for (i = 0; i < num_factors_r; i++) {
+ 		if (i == 0)
+-			tmp += sprintf(tmp, ":%x", factors_r[i]);
++			tmp += sprintf(tmp, ":%" PRIx32, factors_r[i]);
+ 		else
+-			tmp += sprintf(tmp, ",%x", factors_r[i]);
++			tmp += sprintf(tmp, ",%" PRIx32, factors_r[i]);
+ 	}
+ 	for (j = 0; j < MAX_LARGE_PRIMES; j++) {
+ 		if (large_prime_r[j] == 1)
+ 			continue;
+ 		if (i == 0)
+-			tmp += sprintf(tmp, ":%x", large_prime_r[j]);
++			tmp += sprintf(tmp, ":%" PRIx32, large_prime_r[j]);
+ 		else
+-			tmp += sprintf(tmp, ",%x", large_prime_r[j]);
++			tmp += sprintf(tmp, ",%" PRIx32, large_prime_r[j]);
+ 		i++;
+ 	}
+ 
+ 	for (i = 0; i < num_factors_a; i++) {
+ 		if (i == 0)
+-			tmp += sprintf(tmp, ":%x", factors_a[i]);
++			tmp += sprintf(tmp, ":%" PRIx32, factors_a[i]);
+ 		else
+-			tmp += sprintf(tmp, ",%x", factors_a[i]);
++			tmp += sprintf(tmp, ",%" PRIx32, factors_a[i]);
+ 	}
+ 	for (j = 0; j < MAX_LARGE_PRIMES; j++) {
+ 		if (large_prime_a[j] == 1)
+ 			continue;
+ 		if (i == 0)
+-			tmp += sprintf(tmp, ":%x", large_prime_a[j]);
++			tmp += sprintf(tmp, ":%" PRIx32, large_prime_a[j]);
+ 		else
+-			tmp += sprintf(tmp, ",%x", large_prime_a[j]);
++			tmp += sprintf(tmp, ",%" PRIx32, large_prime_a[j]);
+ 		i++;
+ 	}
+ 	sprintf(tmp, "\n");
+@@ -168,7 +168,7 @@ void write_last_line(msieve_obj *obj, mpz_t n, uint32 b) {
+ 	}
+ 
+ 	gmp_fprintf(linefile, "N %Zd\n", n);
+-	fprintf(linefile, "%u\n", b);
++	fprintf(linefile, "%" PRIu32 "\n", b);
+ 	fclose(linefile);
+ }
+ 
+@@ -215,7 +215,7 @@ uint32 add_free_relations(msieve_obj *obj,
+ 
+ 				if (num_roots == rat_degree && 
+ 						high_coeff != 0) {
+-					sprintf(buf, "%u,0:\n", p);
++					sprintf(buf, "%" PRIu32 ",0:\n", p);
+ 					savefile_write_line(&obj->savefile, 
+ 								buf);
+ 					num_relations++;
+diff --git a/include/util.h b/include/util.h
+index 5ab7003..8f8f00b 100644
+--- a/include/util.h
++++ b/include/util.h
+@@ -95,15 +95,15 @@ extern "C" {
+ 	#define PRIx64 "I64x"
+ 
+ #else
+-	typedef unsigned char uint8;
+-	typedef unsigned short uint16;
+-	typedef unsigned int uint32;
++	typedef uint8_t uint8;
++	typedef uint16_t uint16;
++	typedef uint32_t uint32;
+ 	typedef uint64_t uint64;
+ 	
+ 	#ifndef RS6K
+-	typedef char int8;
+-	typedef short int16;
+-	typedef int int32;
++	typedef int8_t int8;
++	typedef int16_t int16;
++	typedef int32_t int32;
+ 	typedef int64_t int64;
+ 	#endif
+ #endif
+@@ -163,7 +163,7 @@ extern "C" {
+ static INLINE void * xmalloc(size_t len) {
+ 	void *ptr = malloc(len);
+ 	if (ptr == NULL) {
+-		printf("failed to allocate %u bytes\n", (uint32)len);
++		printf("failed to allocate %" PRIu32 " bytes\n", (uint32)len);
+ 		exit(-1);
+ 	}
+ 	return ptr;
+@@ -172,7 +172,7 @@ static INLINE void * xmalloc(size_t len) {
+ static INLINE void * xcalloc(size_t num, size_t len) {
+ 	void *ptr = calloc(num, len);
+ 	if (ptr == NULL) {
+-		printf("failed to calloc %u bytes\n", (uint32)(num * len));
++		printf("failed to calloc %" PRIu32 " bytes\n", (uint32)(num * len));
+ 		exit(-1);
+ 	}
+ 	return ptr;
+@@ -181,7 +181,7 @@ static INLINE void * xcalloc(size_t num, size_t len) {
+ static INLINE void * xrealloc(void *iptr, size_t len) {
+ 	void *ptr = realloc(iptr, len);
+ 	if (ptr == NULL) {
+-		printf("failed to reallocate %u bytes\n", (uint32)len);
++		printf("failed to reallocate %" PRIu32 " bytes\n", (uint32)len);
+ 		exit(-1);
+ 	}
+ 	return ptr;
+diff --git a/mpqs/poly.c b/mpqs/poly.c
+index 9d6030e..a9f9046 100644
+--- a/mpqs/poly.c
++++ b/mpqs/poly.c
+@@ -526,7 +526,7 @@ void build_base_poly(sieve_conf_t *conf) {
+ 
+ 	i = sprintf(buf, "A");
+ 	for (j = 0; j < conf->num_poly_factors; j++)
+-		i += sprintf(buf + i, " %x", conf->poly_factors[j]);
++		i += sprintf(buf + i, " %" PRIx32, conf->poly_factors[j]);
+ 	i += sprintf(buf + i, "\n");
+ 	savefile_write_line(&obj->savefile, buf);
+ }
+diff --git a/mpqs/relation.c b/mpqs/relation.c
+index 3be9a55..49d4b1d 100644
+--- a/mpqs/relation.c
++++ b/mpqs/relation.c
+@@ -120,19 +120,19 @@ void save_relation(sieve_conf_t *conf, uint32 sieve_offset,
+ 	i = sprintf(buf, "R ");
+ 
+ 	if (sieve_offset & 0x80000000)
+-		i += sprintf(buf + i, "-%x ", sieve_offset & 0x7fffffff);
++		i += sprintf(buf + i, "-%" PRIx32 " ", sieve_offset & 0x7fffffff);
+ 	else
+-		i += sprintf(buf + i, "%x ", sieve_offset & 0x7fffffff);
++		i += sprintf(buf + i, "%" PRIx32 " ", sieve_offset & 0x7fffffff);
+ 	
+-	i += sprintf(buf + i, "%x ", poly_index);
++	i += sprintf(buf + i, "%" PRIx32 " ", poly_index);
+ 
+ 	for (j = 0; j < num_factors; j++)
+-		i += sprintf(buf + i, "%x ", fb_offsets[j]);
++		i += sprintf(buf + i, "%" PRIx32 " ", fb_offsets[j]);
+ 
+ 	if (large_prime1 < large_prime2)
+-		i += sprintf(buf + i, "L %x %x\n", large_prime1, large_prime2);
++		i += sprintf(buf + i, "L %" PRIx32 " %" PRIx32 "\n", large_prime1, large_prime2);
+ 	else
+-		i += sprintf(buf + i, "L %x %x\n", large_prime2, large_prime1);
++		i += sprintf(buf + i, "L %" PRIx32 " %" PRIx32 "\n", large_prime2, large_prime1);
+ 
+ 	savefile_write_line(&conf->obj->savefile, buf);
+ 
+diff --git a/mpqs/sieve.c b/mpqs/sieve.c
+index 2e02567..40cbc36 100644
+--- a/mpqs/sieve.c
++++ b/mpqs/sieve.c
+@@ -617,8 +617,8 @@ static uint32 do_sieving_internal(sieve_conf_t *conf,
+ 
+ 	    	if (obj->flags & (MSIEVE_FLAG_USE_LOGFILE |
+ 	    		   	  MSIEVE_FLAG_LOG_TO_STDOUT)) {
+-			fprintf(stderr, "%u relations (%u full + "
+-				"%u combined from %u partial), need %u\r",
++			fprintf(stderr, "%" PRIu32 " relations (%" PRIu32 " full + "
++				"%" PRIu32 " combined from %" PRIu32 " partial), need %" PRIu32 "\r",
+ 					num_relations,
+ 					conf->num_relations,
+ 					conf->num_cycles +
+-- 
+2.15.0
+
+
+From 35bce1e609b6857e1bbeb860a0964753470793a0 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Thu, 7 Dec 2017 20:50:18 +0700
+Subject: use correct pointer type
+
+
+diff --git a/common/savefile.c b/common/savefile.c
+index 1ea0108..745d667 100644
+--- a/common/savefile.c
++++ b/common/savefile.c
+@@ -152,7 +152,7 @@ void savefile_open(savefile_t *s, uint32 flags) {
+ 			fclose(fp);
+ 		}
+ 		if (s->is_a_FILE) {
+-			s->fp = (gzFile *)fopen(s->name, "a");
++			s->fp = (gzFile)fopen(s->name, "a");
+ 		} else {
+ 			s->fp = gzopen(s->name, "a");
+ 			s->isCompressed = 1;
+diff --git a/include/msieve.h b/include/msieve.h
+index ed91e25..55568eb 100644
+--- a/include/msieve.h
++++ b/include/msieve.h
+@@ -101,7 +101,7 @@ typedef struct {
+ 	uint32 read_size;
+ 	uint32 eof;
+ #else
+-	gzFile *fp;
++	gzFile fp;
+ 	char isCompressed;
+ 	char is_a_FILE;
+ #endif
+-- 
+2.15.0
+
+
+From a82ae58b3179c68389d18f58637d290b36c3e7ac Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Fri, 8 Dec 2017 07:14:51 +0700
+Subject: haiku support
+
+added haiku target
+
+disabled unoptimized assembly (according to waddlesplash)
+
+implemented haiku version of set_idle_priority
+
+diff --git a/Makefile b/Makefile
+index 3d860c0..761eb6a 100644
+--- a/Makefile
++++ b/Makefile
+@@ -15,6 +15,7 @@
+ # override from command line
+ WIN = 0
+ WIN64 = 0
++HAIKU = 0
+ 
+ # gcc with basic optimization (-march flag could
+ # get overridden by architecture-specific builds)
+@@ -41,9 +42,13 @@ ifeq ($(ECM),1)
+ endif
+ ifeq ($(WIN),1)
+ 
++else
++ifeq ($(HAIKU),1)
++
+ else
+ 	LIBS += -ldl
+ endif
++endif
+ ifeq ($(CUDA),1)
+ 
+ ifeq ($(WIN),1)
+@@ -264,6 +269,7 @@ help:
+ 	@echo "make all"
+ 	@echo "add 'WIN=1 if building on windows"
+ 	@echo "add 'WIN64=1 if building on 64-bit windows"
++	@echo "add 'HAIKU=1' if building on haiku"
+ 	@echo "add 'ECM=1' if GMP-ECM is available (enables ECM)"
+ 	@echo "add 'CUDA=1' for Nvidia graphics card support"
+ 	@echo "add 'MPI=1' for parallel processing using MPI"
+diff --git a/common/util.c b/common/util.c
+index 5495921..de7ce84 100644
+--- a/common/util.c
++++ b/common/util.c
+@@ -116,6 +116,16 @@ void set_idle_priority(void) {
+ #if defined(WIN32) || defined(_WIN64)
+ 	SetPriorityClass(GetCurrentProcess(),
+ 			IDLE_PRIORITY_CLASS);
++#elif defined(__HAIKU__)
++	thread_info thinfo;
++	team_id team;
++	int32 thcookie;
++
++	get_thread_info(find_thread(NULL), &thinfo);
++	team = thinfo.team;
++	while (get_next_thread_info(team, &thcookie, &thinfo) == B_OK) {
++		set_thread_priority(thinfo.thread, B_IDLE_PRIORITY);
++	}
+ #else
+ 	nice(100);
+ #endif
+diff --git a/gnfs/ffpoly.c b/gnfs/ffpoly.c
+index 8e638dc..da94c80 100644
+--- a/gnfs/ffpoly.c
++++ b/gnfs/ffpoly.c
+@@ -202,7 +202,7 @@ static INLINE uint32 mul_mac(uint32 a, uint32 b, uint32 c,
+ 
+ #if defined(GCC_ASM32A) && \
+ 	!(defined(__GNUC__) && __GNUC__ < 3 ) && \
+-	defined(NDEBUG)
++	defined(NDEBUG) && !defined(__HAIKU__)
+ 
+ 	uint32 ans;
+ 	ASM_G(
+@@ -288,7 +288,7 @@ static INLINE uint64 sqr_mac(uint32 a, uint32 b, uint64 c,
+ 
+ #if defined(GCC_ASM32A) && \
+ 	!(defined(__GNUC__) && __GNUC__ < 3 ) && \
+-	defined(NDEBUG)
++	defined(NDEBUG) && !defined(__HAIKU__)
+ 
+ 	ASM_G(
+ 	    "movl %1, %%eax               \n\t"
+@@ -387,7 +387,7 @@ static INLINE uint64 sqr_mac0(uint32 a, uint32 b,
+ 
+ #if defined(GCC_ASM32A) && \
+ 	!(defined(__GNUC__) && __GNUC__ < 3 ) && \
+-	defined(NDEBUG)
++	defined(NDEBUG) && !defined(__HAIKU__)
+ 
+ 	ASM_G(
+ 	    "movl %1, %%eax               \n\t"
+diff --git a/include/util.h b/include/util.h
+index 8f8f00b..512f562 100644
+--- a/include/util.h
++++ b/include/util.h
+@@ -23,6 +23,9 @@ $Id: util.h 1005 2016-11-11 15:43:21Z jasonp_sf $
+ 	#include <windows.h>
+ 	#include <process.h>
+ #else
++	#if defined(__HAIKU__)
++		#include <OS.h>
++	#endif
+ 	#include <fcntl.h>
+ 	#include <unistd.h>
+ 	#include <errno.h>
+@@ -76,7 +79,7 @@ extern "C" {
+ 
+ /* basic types  -------------------------------------------------------*/
+ 
+-#ifdef _MSC_VER
++#if defined(_MSC_VER)
+ 
+ 	typedef __int8 int8;
+ 	typedef __int16 int16;
+@@ -94,7 +97,7 @@ extern "C" {
+ 	#define PRIu64 "I64u"
+ 	#define PRIx64 "I64x"
+ 
+-#else
++#elif !defined(__HAIKU__)
+ 	typedef uint8_t uint8;
+ 	typedef uint16_t uint16;
+ 	typedef uint32_t uint32;
+@@ -116,8 +119,10 @@ extern "C" {
+ 
+ /* useful functions ---------------------------------------------------*/
+ 
+-#define MIN(a,b) ((a) < (b)? (a) : (b))
+-#define MAX(a,b) ((a) > (b)? (a) : (b))
++#if !defined(__HAIKU__)
++	#define MIN(a,b) ((a) < (b)? (a) : (b))
++	#define MAX(a,b) ((a) > (b)? (a) : (b))
++#endif
+ 
+ #if defined(_MSC_VER)
+     
+-- 
+2.15.0
+
+
+From 41df8b622271773c3d98762831243746501e87be Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Sat, 9 Dec 2017 08:09:28 +0700
+Subject: remove svn version from demo.c
+
+
+diff --git a/demo.c b/demo.c
+index a49dbb2..1aaa6c5 100644
+--- a/demo.c
++++ b/demo.c
+@@ -81,9 +81,8 @@ void get_random_seeds(uint32 *seed1, uint32 *seed2) {
+ /*--------------------------------------------------------------------*/
+ void print_usage(char *progname) {
+ 
+-	printf("\nMsieve v. %d.%02d (SVN %s)\n", MSIEVE_MAJOR_VERSION, 
+-					MSIEVE_MINOR_VERSION,
+-					MSIEVE_SVN_VERSION);
++	printf("\nMsieve v. %d.%02d\n", MSIEVE_MAJOR_VERSION, 
++					MSIEVE_MINOR_VERSION);
+ 
+ 	printf("\nusage: %s [options] [one_number]\n", progname);
+ 	printf("\nnumbers starting with '0' are treated as octal,\n"
+-- 
+2.15.0
+


### PR DESCRIPTION
Done as part of GCI 2017

Changes to msieve:
- Convert msieve's `printf` format specifiers to their architecture-independent counterpart
- Fixed a small pointer bug: `gzFile*` used instead of `gzFile`
- Add Haiku support:
  - Add `HAIKU` switch to Makefile: disable `-ldl` on set
  - Disable `ffpoly.c` inline assembly (they won't build, and @waddlesplash said they're not *that* optimized anyway)
  - Implemented `set_idle_priority()` for Haiku: set `B_IDLE_PRIORITY` for the calling team