### PR TITLE
dev-libs/protobuf: package the correct library

### DIFF
--- a/dev-libs/protobuf/protobuf-3.3.2.recipe
+++ b/dev-libs/protobuf/protobuf-3.3.2.recipe
@@ -8,7 +8,7 @@ languages – Java, C++, or Python."
 HOMEPAGE="https://github.com/google/protobuf"
 COPYRIGHT="2008-2017 Google"
 LICENSE="Apache v2"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="$HOMEPAGE/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="e53fd5d514169dc80fb38673dc63f4048cebd3e524e49c1663428f89330bda56"
 PATCHES="protobuf-$portVersion.patchset"
@@ -50,7 +50,7 @@ BUILD_PREREQUIRES="
 defineDebugInfoPackage protobuf$secondaryArchSuffix \
 	$libDir/libprotobuf.so.13.0.2 \
 	$libDir/libprotoc.so.13.0.2 \
-	$libDir/libprotobuf_lite.so.13.0.2
+	$libDir/libprotobuf-lite.so.13.0.2
 
 
 BUILD()
@@ -67,7 +67,7 @@ INSTALL()
 
 	rm $libDir/lib*.la
 
-	prepareInstalledDevelLibs libprotobuf_lite libprotobuf libprotoc
+	prepareInstalledDevelLibs libprotobuf-lite libprotobuf libprotoc
 	fixPkgconfig
 	packageEntries devel $developDir
 }


### PR DESCRIPTION
This fixes the following packaging issue:

    mv: cannot stat '/packages/protobuf-3.3.2-5/.self/lib/libprotobuf_lite.*': No such file or directory

or

    objcopy: '/packages/protobuf-3.3.2-5/.self/lib/libprotobuf_lite.so.13.0.2': No such file