### PR TITLE
Terrarium: new recipe

### DIFF
--- a/games-action/terrarium/terrarium-0.1.8.recipe
+++ b/games-action/terrarium/terrarium-0.1.8.recipe
@@ -1,0 +1,57 @@
+SUMMARY="Open source Terraria clone"
+DESCRIPTION="Terrarium is a free and open source Terraria clone game, possibly with some new features."
+HOMEPAGE="https://github.com/hydren/terrarium"
+COPYRIGHT="hydren"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="https://github.com/hydren/terrarium/releases/download/$portVersion/terrarium-$portVersion-source.tar.gz"
+CHECKSUM_SHA256="83a4dbd88da1c3b93fd8e1ebeeee973114ba4a473bbd25f32f56fd55801100d6"
+SOURCE_DIR="terrarium-$portVersion"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	terrarium = $portVersion
+	app:terrarium = $portVersion
+	"
+REQUIRES="
+	haiku
+	lib:libbox2d
+	lib:libSDL2_2.0
+	lib:libSDL2_mixer_2.0
+	lib:libSDL2_image_2.0
+	lib:libSDL2_ttf_2.0
+	lib:libsdl2_gfx_1.0
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	devel:libbox2d
+	devel:libSDL2_2.0
+	devel:libSDL2_mixer_2.0
+	devel:libSDL2_image_2.0
+	devel:libSDL2_ttf_2.0
+	devel:libsdl2_gfx
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc
+	cmd:make
+	cmd:which
+	"
+
+BUILD()
+{
+	cp -r build/linux-gcc-sdl2.0-release/ .
+	cd linux-gcc-sdl2.0-release
+	runConfigure ./configure.sh
+	make $jobArgs
+}
+
+INSTALL()
+{
+	mkdir -p $appsDir
+	cp terrarium $appsDir/Terrarium
+	cp -r resources $appsDir/Terrarium/resources/
+
+	addAppDeskbarSymlink $appsDir/terrarium Terrarium
+}

--- a/games-action/terrarium/terrarium-0.1.8.recipe
+++ b/games-action/terrarium/terrarium-0.1.8.recipe
@@ -1,5 +1,6 @@
 SUMMARY="Open source Terraria clone"
-DESCRIPTION="Terrarium is a free and open source Terraria clone game, possibly with some new features."
+DESCRIPTION="Terrarium is a free and open source Terraria clone game, \
+possibly with some new features."
 HOMEPAGE="https://github.com/hydren/terrarium"
 COPYRIGHT="hydren"
 LICENSE="GNU GPL v2"
@@ -49,9 +50,9 @@ BUILD()
 
 INSTALL()
 {
-	mkdir -p $appsDir
-	cp terrarium $appsDir/Terrarium
+	mkdir -p $appsDir/Terrarium
+	cp terrarium $appsDir/Terrarium/Terrarium
 	cp -r resources $appsDir/Terrarium/resources/
 
-	addAppDeskbarSymlink $appsDir/terrarium Terrarium
+	addAppDeskbarSymlink $appsDir/Terrarium/Terrarium
 }


### PR DESCRIPTION
Added [Terrarium](https://github.com/hydren/terrarium)'s recipe, a free and open source Terraria clone game. The recipe is based on the [building instructions](https://github.com/hydren/terrarium/blob/master/BUILDING.md) from the repo and uses SDL2.

Please correct any mistakes in the recipe, thanks!