### PR TITLE
InternalMIDI: new recipe

### DIFF
--- a/haiku-apps/internalmidi/internalmidi-1.0.recipe
+++ b/haiku-apps/internalmidi/internalmidi-1.0.recipe
@@ -2,16 +2,19 @@ SUMMARY="MIDI Node Creator"
 DESCRIPTION="Creates a MIDI (MidiKit2) node for the internal \
 General MIDI synthesizer of BeOS/Haiku."
 HOMEPAGE="https://github.com/HaikuArchives/InternalMIDI"
-COPYRIGHT="2001-2008 Werner Freytag
-	2009 Haiku"
+COPYRIGHT="
+	2001-2008 Werner Freytag
+	2009 Haiku
+	"
 LICENSE="MIT"
 REVISION="1"
 srcGitRev="a7d0ef0d1cb76ce1ba343f1d6e330007dd57c953"
 SOURCE_URI="https://github.com/HaikuArchives/InternalMIDI/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="19f8a6872ddf0fb4273f748e84cbdd7d06a76a1c23e4ef59482d002b31b36c0f"
+SOURCE_FILENAME="InternalMIDI-$portVersion-$srcGitRev.tar.gz"
 SOURCE_DIR="InternalMIDI-$srcGitRev"
 
-ARCHITECTURES="x86 x86_gcc2 x86_64"
+ARCHITECTURES="x86_gcc2 !x86_64"
 
 PROVIDES="
 	internalmidi = $portVersion

--- a/haiku-apps/internalmidi/internalmidi-1.0.recipe
+++ b/haiku-apps/internalmidi/internalmidi-1.0.recipe
@@ -1,0 +1,43 @@
+SUMMARY="MIDI Node Creator"
+DESCRIPTION="Creates a MIDI (MidiKit2) node for the internal General MIDI synthesizer of BeOS/Haiku."
+HOMEPAGE="https://github.com/HaikuArchives/InternalMIDI"
+COPYRIGHT="2001-2008 Werner Freytag, 2009 Haiku"
+LICENSE="MIT"
+REVISION="1"
+srcGitRev="a7d0ef0d1cb76ce1ba343f1d6e330007dd57c953"
+SOURCE_URI="https://github.com/HaikuArchives/InternalMIDI/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="19f8a6872ddf0fb4273f748e84cbdd7d06a76a1c23e4ef59482d002b31b36c0f"
+SOURCE_DIR="InternalMIDI-$srcGitRev"
+
+ARCHITECTURES="x86 x86_gcc2 x86_64"
+
+PROVIDES="
+	internalmidi = $portVersion
+	app:InternalMIDI = $portVersion
+	"
+REQUIRES="
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	makefile_engine
+	cmd:gcc
+	cmd:make
+	"
+
+BUILD()
+{
+	make BUILDHOME=`finddir B_SYSTEM_DEVELOP_DIRECTORY`
+}
+
+INSTALL()
+{
+	mkdir -p $appsDir
+	make install TARGET_DIR=$appsDir \
+		BUILDHOME=`finddir B_SYSTEM_DEVELOP_DIRECTORY`
+
+	addAppDeskbarSymlink $appsDir/InternalMIDI
+}

--- a/haiku-apps/internalmidi/internalmidi-1.0.recipe
+++ b/haiku-apps/internalmidi/internalmidi-1.0.recipe
@@ -1,7 +1,9 @@
 SUMMARY="MIDI Node Creator"
-DESCRIPTION="Creates a MIDI (MidiKit2) node for the internal General MIDI synthesizer of BeOS/Haiku."
+DESCRIPTION="Creates a MIDI (MidiKit2) node for the internal \
+General MIDI synthesizer of BeOS/Haiku."
 HOMEPAGE="https://github.com/HaikuArchives/InternalMIDI"
-COPYRIGHT="2001-2008 Werner Freytag, 2009 Haiku"
+COPYRIGHT="2001-2008 Werner Freytag
+	2009 Haiku"
 LICENSE="MIT"
 REVISION="1"
 srcGitRev="a7d0ef0d1cb76ce1ba343f1d6e330007dd57c953"


### PR DESCRIPTION
Create recipe for [InternalMIDI](https://github.com/HaikuArchives/InternalMIDI), a MIDI (MidiKit2) node for the internal General MIDI synthesizer of BeOS/Haiku.