### PR TITLE
PecoBeat: new recipe

### DIFF
--- a/haiku-apps/pecobeat/patches/pecobeat-1.0.patchset
+++ b/haiku-apps/pecobeat/patches/pecobeat-1.0.patchset
@@ -1,0 +1,86 @@
+From 9c1d0e4643c20e7a4f93ec6907ba733f6e0b111a Mon Sep 17 00:00:00 2001
+From: nys <33534144+nysnatuss@users.noreply.github.com>
+Date: Fri, 15 Dec 2017 16:24:19 +0000
+Subject: fix include and printf
+
+
+diff --git a/Controls/DrumsetButton.cpp b/Controls/DrumsetButton.cpp
+index 2d898fe..34fdcee 100644
+--- a/Controls/DrumsetButton.cpp
++++ b/Controls/DrumsetButton.cpp
+@@ -10,6 +10,7 @@
+ 
+ #include <iostream>
+ 
++#include <stdio.h>
+ #include <math.h>
+ #include <MessageRunner.h>
+ #include <Window.h>
+diff --git a/Controls/PlayListField.cpp b/Controls/PlayListField.cpp
+index 019dea9..d95c473 100644
+--- a/Controls/PlayListField.cpp
++++ b/Controls/PlayListField.cpp
+@@ -21,7 +21,7 @@
+ #include "App.h"
+ #include "Song.h"
+ 
+-#include "SongWindow/SongToolBar.h"
++#include "../SongWindow/SongToolBar.h"
+ 
+ PlayListField::PlayListField(BRect rect, BMessage *message)
+ 	: BControl(rect, "playlistfield", NULL, message, B_FOLLOW_NONE, B_WILL_DRAW),
+diff --git a/Main/App.cpp b/Main/App.cpp
+index a2ce014..bee38f9 100644
+--- a/Main/App.cpp
++++ b/Main/App.cpp
+@@ -35,7 +35,7 @@
+ #include "Prefs.h"
+ #include "Song.h"
+ 
+-#include "SongWindow/SongWindow.h"
++#include "../SongWindow/SongWindow.h"
+ 
+ #define FILE_MIME "application/x-pecobeat-song"
+ #define APP_MIME "application/x-vnd.pecora-pecobeat"
+diff --git a/SongWindow/SongToolBar.cpp b/SongWindow/SongToolBar.cpp
+index 74f97ff..2cb5ad6 100644
+--- a/SongWindow/SongToolBar.cpp
++++ b/SongWindow/SongToolBar.cpp
+@@ -8,7 +8,7 @@
+  *              Werner Freytag <freytag@gmx.de>
+  */
+ 
+-#include "SongWindow/SongToolBar.h"
++#include "SongToolBar.h"
+ 
+ #include <iostream>
+ 
+diff --git a/SongWindow/SongToolBar.h b/SongWindow/SongToolBar.h
+index f80030a..db1c904 100644
+--- a/SongWindow/SongToolBar.h
++++ b/SongWindow/SongToolBar.h
+@@ -13,7 +13,7 @@
+ 
+ #include <View.h>
+ 
+-#include "SongWindow/SongWindow.h"
++#include "SongWindow.h"
+ 
+ class SongToolBar : public BView {
+ 
+diff --git a/SongWindow/SongWindow.cpp b/SongWindow/SongWindow.cpp
+index 438cbc2..e60e058 100644
+--- a/SongWindow/SongWindow.cpp
++++ b/SongWindow/SongWindow.cpp
+@@ -23,7 +23,7 @@
+ #include "PlayListField.h"
+ #include "Prefs.h"
+ #include "Song.h"
+-#include "SongWindow/SongToolBar.h"
++#include "SongToolBar.h"
+ #include "WindowsMenu.h"
+ 
+ SongWindow::SongWindow( BRect frame )
+-- 
+2.15.0
+

--- a/haiku-apps/pecobeat/pecobeat-1.0.recipe
+++ b/haiku-apps/pecobeat/pecobeat-1.0.recipe
@@ -1,0 +1,46 @@
+SUMMARY="MIDI drum computer"
+DESCRIPTION="PecoBeat is a MIDI drum computer for Haiku."
+HOMEPAGE="https://github.com/HaikuArchives/PecoBeat"
+COPYRIGHT="2001-2008 Werner Freytag
+	2009 Haiku"
+LICENSE="MIT"
+REVISION="1"
+srcGitRev="2f2200f6cc9dc9f7bf736e3f921563bce4753c55"
+SOURCE_URI="https://github.com/HaikuArchives/PecoBeat/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="25687e5637638b834d6ac7f2b69edce70523dc5750da466ce174cf6d4a7f56f0"
+SOURCE_FILENAME="PecoBeat-$srcGitRev.tar.gz"
+SOURCE_DIR="PecoBeat-$srcGitRev"
+PATCHES="pecobeat-1.0.patchset"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	pecobeat = $portVersion
+	app:PecoBeat = $portVersion
+	"
+REQUIRES="
+	haiku
+	internalmidi
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	makefile_engine
+	cmd:gcc
+	cmd:make
+	"
+
+BUILD()
+{
+	make $jobArgs
+}
+
+INSTALL()
+{
+	mkdir -p $appsDir
+	make install TARGET_DIR=$appsDir
+
+	addAppDeskbarSymlink $appsDir/PecoBeat
+}

--- a/haiku-apps/pecobeat/pecobeat-1.0.recipe
+++ b/haiku-apps/pecobeat/pecobeat-1.0.recipe
@@ -2,7 +2,7 @@ SUMMARY="MIDI drum computer"
 DESCRIPTION="PecoBeat is a MIDI drum computer for Haiku."
 HOMEPAGE="https://github.com/HaikuArchives/PecoBeat"
 COPYRIGHT="2001-2008 Werner Freytag
-	2009 Haiku"
+	2009, 2014 Haiku"
 LICENSE="MIT"
 REVISION="1"
 srcGitRev="2f2200f6cc9dc9f7bf736e3f921563bce4753c55"
@@ -12,7 +12,7 @@ SOURCE_FILENAME="PecoBeat-$srcGitRev.tar.gz"
 SOURCE_DIR="PecoBeat-$srcGitRev"
 PATCHES="pecobeat-1.0.patchset"
 
-ARCHITECTURES="x86_gcc2 x86 x86_64"
+ARCHITECTURES="x86_gcc2 ?x86 ?x86_64"
 
 PROVIDES="
 	pecobeat = $portVersion


### PR DESCRIPTION
Added PecoBeat, a MIDI drum computer for Haiku. Completes #539.

I also patched a printf error (not including stdio.h) and some include path errors.