### PR TITLE
TinyXML2: bump version to 6.0.0

### DIFF
--- a/dev-libs/tinyxml2/tinyxml2-6.0.0.recipe
+++ b/dev-libs/tinyxml2/tinyxml2-6.0.0.recipe
@@ -1,0 +1,69 @@
+SUMMARY="A small C++ XML Parser"
+DESCRIPTION="Tinyxml is a simple, OS independent XML parser for the C++ \
+language.
+Timyxml was first created to solve the common text I/O file problem. It \
+parses the XML into a DOM-like tree and is able to read and write XML files.\
+It allows you to create your own document mark-ups or even construct an XML \
+document from scratch with C++ objects."
+HOMEPAGE="http://www.grinninglizard.com/tinyxml2/"
+COPYRIGHT="2011-2017 Lee Thomason"
+LICENSE="Zlib"
+REVISION="1"
+SOURCE_URI="https://github.com/leethomason/tinyxml2/archive/$portVersion.tar.gz"
+CHECKSUM_SHA256="9444ba6322267110b4aca61cbe37d5dcab040344b5c97d0b36c119aa61319b0f"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	tinyxml2$secondaryArchSuffix = $portVersion
+	lib:libtinyxml2$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	tinyxml2${secondaryArchSuffix}_devel = $portVersion
+	devel:libtinyxml2$secondaryArchSuffix = $portVersion
+	"
+REQUIRES_devel="
+	tinyxml2$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	"
+
+BUILD()
+{
+	g++ -fpic -c tinyxml2.cpp
+	g++ -shared -Wl,-soname,libtinyxml2.so -o libtinyxml2.so tinyxml2.o
+}
+
+INSTALL()
+{
+	mkdir -p $libDir
+	# also install shared lib
+	cp -a libtinyxml2.so $libDir
+
+	# move headers
+	mkdir -p $includeDir
+	mv tinyxml2.h $includeDir
+
+	# prepare development lib links
+	prepareInstalledDevelLib libtinyxml2
+
+	# devel package
+	packageEntries devel $developDir
+}
+
+TEST()
+{
+	make test
+}

--- a/dev-libs/tinyxml2/tinyxml2-6.0.0.recipe
+++ b/dev-libs/tinyxml2/tinyxml2-6.0.0.recipe
@@ -52,9 +52,9 @@ INSTALL()
 	# also install shared lib
 	cp -a libtinyxml2.so $libDir
 
-	# move headers
+	# copy headers
 	mkdir -p $includeDir
-	mv tinyxml2.h $includeDir
+	cp tinyxml2.h $includeDir
 
 	# prepare development lib links
 	prepareInstalledDevelLib libtinyxml2


### PR DESCRIPTION
Update recipe to 6.0.0 (Last revision is 2.2.0). There aren't any major modification since using the previous recipe still works. Closes #1814.