### PR TITLE
app-crypt/codecrypt: add port

### DIFF
--- a/app-crypt/codecrypt/codecrypt-1.8.recipe
+++ b/app-crypt/codecrypt/codecrypt-1.8.recipe
@@ -1,0 +1,54 @@
+SUMMARY="Post-quantum cryptography tool"
+DESCRIPTION="GnuPG-like unix program for encryption and signing that uses only \
+quantum-computer-resistant algorithms"
+HOMEPAGE="http://e-x-a.org/codecrypt"
+COPYRIGHT="2013-2016 Mirek Kratochvil"
+LICENSE="
+	GNU GPL v3
+	GNU LGPL v3
+	"
+REVISION="1"
+SOURCE_URI="http://e-x-a.org/codecrypt/files/codecrypt-$portVersion.tar.gz"
+CHECKSUM_SHA256="3be7c2a548aa336dbac706c3cab2071664d02b11652c16c02a8b4fb5cac6bc88"
+
+ARCHITECTURES="!x86_gcc2 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	codecrypt$secondaryArchSuffix = $portVersion
+	cmd:ccr$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcryptopp$secondaryArchSuffix
+	lib:libfftw3$secondaryArchSuffix
+	lib:libgmp$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libcryptopp$secondaryArchSuffix
+	devel:libfftw3$secondaryArchSuffix
+	devel:libgmp$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:cmp
+	cmd:g++$secondaryArchSuffix
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	CPPFLAGS="-D_BSD_SOURCE" LIBS="-lbsd" runConfigure ./configure
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+	install -d -m 755 "$docDir"
+	install -t "$docDir" -m 644 README
+}

--- a/dev-libs/crypto++/crypto++-5.6.5.recipe
+++ b/dev-libs/crypto++/crypto++-5.6.5.recipe
@@ -14,20 +14,25 @@ The library contains the following algorithms:
 * Elliptic curve cryptography: ECDSA, ECNR, ECIES, ECDH, ECMQV
 * Insecure or obsolescent algorithms: MD2, MD4, MD5
 * And many more other algorithms."
-HOMEPAGE="https://cryptopp.com"
+HOMEPAGE="https://cryptopp.com/"
 COPYRIGHT="2015-2017 Wei Dai"
 LICENSE="Boost v1.0"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://www.cryptopp.com/cryptopp565.zip"
 CHECKSUM_SHA256="a75ef486fe3128008bbb201efee3dcdcffbe791120952910883b26337ec32c34"
 SOURCE_DIR=""
+# Upstream patch, might be obsolete in a later version
+PATCHES="crypto++-$portVersion.patchset"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
+libVersion=$portVersion
+libVersionCompat="$libVersion compat >= ${libVersion%.*}"
+
 PROVIDES="
 	crypto++$secondaryArchSuffix = $portVersion
-	lib:libcryptopp$secondaryArchSuffix = $portVersion compat >= $portVersion
+	lib:libcryptopp$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -35,7 +40,7 @@ REQUIRES="
 
 PROVIDES_devel="
 	crypto++${secondaryArchSuffix}_devel = $portVersion
-	devel:libcryptopp$secondaryArchSuffix = $portVersion compat >= $portVersion
+	devel:libcryptopp$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
 	crypto++$secondaryArchSuffix == $portVersion base
@@ -48,23 +53,38 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld
 	cmd:make
-	cmd:pkg_config$secondaryArchSuffix
 	cmd:nasm
+	cmd:pkg_config$secondaryArchSuffix
 	"
+
+defineDebugInfoPackage crypto++$secondaryArchSuffix \
+	$libDir/libcryptopp.so.$libVersion
 
 BUILD()
 {
-	make shared dynamic static $jobArgs
+	make HAS_SOLIB_VERSION=1 dynamic static $jobArgs
 }
 
 INSTALL()
 {
-	make install PREFIX=$prefix INCLUDEDIR=$includeDir
+	make \
+		HAS_SOLIB_VERSION=1 LDCONF=true \
+		BINDIR=$binDir LIBDIR=$libDir \
+		DATADIR=$dataDir INCLUDEDIR=$includeDir \
+		install
 
-	mv $libDir/libcryptopp.so $libDir/libcryptopp.so.$portVersion
-	ln -s $libDir/libcryptopp.so.$portVersion $libDir/libcryptopp.so
-
+	# Yes, they created the link. But they forgot to install it...
+	ln -s libcryptopp.so.$libVersion \
+		$libDir/libcryptopp.so.${libVersionCompat##* }
 	prepareInstalledDevelLib libcryptopp
+
+	install -d -m 755 $developLibDir/pkgconfig
+	cat > $developLibDir/pkgconfig/libcrypto++.pc << EOF
+Name: libcrypto++
+Description: Class library of cryptographic schemes
+Version: $portVersion
+Libs: -lcryptopp
+EOF
 
 	packageEntries devel \
 		$relativeDevelopDir

--- a/dev-libs/crypto++/patches/crypto++-5.6.5.patchset
+++ b/dev-libs/crypto++/patches/crypto++-5.6.5.patchset
@@ -1,0 +1,25 @@
+From ec1e84e8ecefb81f7a233f047c75446eee9dfb54 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Sat, 16 Dec 2017 15:06:42 +0700
+Subject: Makefile: fix architecture detection
+
+
+diff --git a/GNUmakefile b/GNUmakefile
+index 2a0ff4c..ddd5422 100644
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -15,9 +15,9 @@ LN ?= ln -sf
+ LDCONF ?= /sbin/ldconfig -n
+ UNAME := $(shell uname)
+ 
+-IS_X86 := $(shell uname -m | $(EGREP) -v "x86_64" | $(EGREP) -i -c "i.86|x86|i86")
++IS_X86 := $(shell $(CXX) $(CXXFLAGS) -dumpmachine 2>/dev/null | $(EGREP) -v "64" | $(EGREP) -i -c "i.86|x86|i86")
+ IS_X32 ?= 0
+-IS_X64 := $(shell uname -m | $(EGREP) -i -c "(_64|d64)")
++IS_X64 := $(shell $(CXX) $(CXXFLAGS) -dumpmachine 2>/dev/null | $(EGREP) -i -c "(_64|d64)")
+ IS_PPC := $(shell uname -m | $(EGREP) -i -c "ppc|power")
+ IS_ARM32 := $(shell uname -m | $(EGREP) -i -c "arm")
+ IS_ARM64 := $(shell uname -m | $(EGREP) -i -c "aarch64")
+-- 
+2.15.0
+


### PR DESCRIPTION
Done as part of GCI 2017

Changes to crypto++:
  - Make the build system use more reliable way to detect architecture (this fixes secondary arch, ~~may also fixes x86_gcc2 but untested~~)
  - Package a pkg-config file. This file is needed for codecrypt to build
  - Install the versioned version of crypto++ instead of doing the rename hack