### PR TITLE
app-crypt/minisign: add port

### DIFF
--- a/app-crypt/minisign/licenses/ISC
+++ b/app-crypt/minisign/licenses/ISC
@@ -1,0 +1,18 @@
+ISC LICENSE.
+
+/*
+ * Copyright (c) 2015-2016
+ * Frank Denis <j at pureftpd dot org>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */

--- a/app-crypt/minisign/minisign-0.7.recipe
+++ b/app-crypt/minisign/minisign-0.7.recipe
@@ -1,0 +1,49 @@
+SUMMARY="A dead simple tool to sign files and verify digital signatures"
+DESCRIPTION="Minisign is a dead simple tool to sign files and verify signatures.
+It is portable, lightweight, and uses the highly secure Ed25519 public-key \
+signature system"
+HOMEPAGE="https://jedisct1.github.io/minisign"
+COPYRIGHT="2015-2016 Frank Denis"
+LICENSE="ISC"
+REVISION="1"
+SOURCE_URI="https://github.com/jedisct1/minisign/archive/$portVersion.tar.gz"
+CHECKSUM_SHA256="0c9f25ae647b6ba38cf7e6aea1da4e8fb20e1bc64ef0c679da737a38c8ad43ef"
+# NOTE: This patch is upstreamed. It could be drop once a new version come out
+PATCHES="minisign-$portVersion.patchset"
+
+ARCHITECTURES="x86_gcc2 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	minisign$secondaryArchSuffix = $portVersion
+	cmd:minisign$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libsodium$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libsodium$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	"
+
+BUILD()
+{
+	cmake . -DCMAKE_BUILD_TYPE=Release
+
+	make $jobArgs
+}
+
+INSTALL()
+{
+	install -d -m 755 "$binDir" "$docDir" "$manDir/man1"
+	install -t "$binDir" -m 755 minisign
+	install -t "$docDir" -m 644 README.md
+	install -t "$manDir/man1" -m 644 share/man/man1/minisign.1
+}

--- a/app-crypt/minisign/patches/minisign-0.7.patchset
+++ b/app-crypt/minisign/patches/minisign-0.7.patchset
@@ -1,0 +1,79 @@
+From 1a98e0ece40e6e4b2a26f899804cccbffef1aea6 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Sun, 17 Dec 2017 17:51:40 +0700
+Subject: Add Haiku support
+
+
+diff --git a/src/get_line.c b/src/get_line.c
+index 8db6765..3030f78 100644
+--- a/src/get_line.c
++++ b/src/get_line.c
+@@ -1,5 +1,5 @@
+ 
+-#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
++#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__HAIKU__)
+ # include <sys/types.h>
+ #endif
+ 
+@@ -9,7 +9,7 @@
+ #include <stdio.h>
+ #include <string.h>
+ 
+-#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
++#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__HAIKU__)
+ # include <fcntl.h>
+ # include <poll.h>
+ # include <termios.h>
+@@ -33,7 +33,7 @@ disable_echo(void)
+     fflush(stdout);
+     fflush(stderr);
+ 
+-# if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
++# if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__HAIKU__)
+     {
+         struct termios p;
+ 
+@@ -60,7 +60,7 @@ enable_echo(void)
+     fflush(stdout);
+     fflush(stderr);
+ 
+-# if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
++# if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__HAIKU__)
+     {
+         struct termios p;
+ 
+diff --git a/src/helpers.c b/src/helpers.c
+index dbe46df..1f59d2e 100644
+--- a/src/helpers.c
++++ b/src/helpers.c
+@@ -1,7 +1,7 @@
+ 
+-#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
++#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__HAIKU__)
+ # include <sys/types.h>
+-# include <sys/fcntl.h>
++# include <fcntl.h>
+ # include <sys/stat.h>
+ #elif defined(_WIN32)
+ # include <direct.h>
+@@ -184,7 +184,7 @@ file_basename(const char *file)
+ FILE *
+ fopen_create_useronly(const char *file)
+ {
+-#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
++#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__HAIKU__)
+     int fd;
+ 
+     if ((fd = open(file, O_CREAT | O_TRUNC | O_WRONLY,
+@@ -209,7 +209,7 @@ basedir_create_useronly(const char *file)
+     if (basename != dir) {
+         dir[basename - dir - 1] = 0;
+     }
+-#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
++#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__HAIKU__)
+     if (*dir == 0 || mkdir(dir, 0700) == 0 || errno == EEXIST) {
+         ret = 0;
+     }
+-- 
+2.15.0
+


### PR DESCRIPTION
Done as part of GCI 2017

Changes to minisign (upstreamed at jedisct1/minisign#36):
- Use unix codepath for Haiku