### PR TITLE
app-arch/lrzip: add port

### DIFF
--- a/app-arch/lrzip/lrzip-0.631.recipe
+++ b/app-arch/lrzip/lrzip-0.631.recipe
@@ -1,0 +1,95 @@
+SUMMARY="Long Range ZIP or Lzma RZIP optimized for compressing large files"
+DESCRIPTION="A compression utility that excels at compressing large files \
+(usually > 10-50 MB). Larger files and/or more free RAM means that the utility \
+will be able to more effectively compress your files \
+(ie: faster / smaller size), especially if the filesize(s) exceed 100 MB. \
+You can either choose to optimise for speed (fast compression / decompression) \
+or size, but not both."
+HOMEPAGE="http://lrzip.kolivas.org/"
+COPYRIGHT="2016 lrzip Authors"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="http://ck.kolivas.org/apps/lrzip/lrzip-$portVersion.tar.bz2"
+CHECKSUM_SHA256="0d11e268d0d72310d6d73a8ce6bb3d85e26de3f34d8a713055f3f25a77226455"
+PATCHES="lrzip-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="0.0.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	lrzip$secondaryArchSuffix = $portVersion
+	cmd:lrunzip = $portVersion
+	cmd:lrz = $portVersion
+	cmd:lrzcat = $portVersion
+	cmd:lrzip = $portVersion
+	cmd:lrztar = $portVersion
+	cmd:lrzuntar = $portVersion
+	lib:liblrzip$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libbz2$secondaryArchSuffix
+	lib:liblzo2$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	lrzip${secondaryArchSuffix}_devel = $portVersion
+	devel:liblrzip$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	lrzip$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libbz2$secondaryArchSuffix
+	devel:liblzo2$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:autoconf
+	cmd:awk
+	cmd:cmp
+	cmd:doxygen
+	cmd:find
+	cmd:g++$secondaryArchSuffix
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:pod2man
+	"
+
+USER_SETTING_FILES="
+	settings/lrzip.conf template $relativeDocDir/lrzip.conf.example
+	"
+
+defineDebugInfoPackage lrzip$secondaryArchSuffix \
+	"$prefix"/bin/lrzip \
+	"$libDir"/liblrzip.so.$libVersion
+
+BUILD()
+{
+	runConfigure --omit-dirs "binDir docDir" ./configure \
+		--bindir="$prefix/bin" --docdir="$developDocDir"
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	install -d -m 755 "$docDir"
+	# There's no need for another version of GPL v2
+	rm "$developDocDir"/COPYING
+
+	mv -t "$docDir" "$developDocDir"/{AUTHORS,lrzip.conf.example,README.md}
+
+	rm -f "$libDir"/*.la
+	fixPkgconfig
+	prepareInstalledDevelLib liblrzip
+	packageEntries devel \
+		"$developDir"
+}

--- a/app-arch/lrzip/patches/lrzip-0.631.patchset
+++ b/app-arch/lrzip/patches/lrzip-0.631.patchset
@@ -1,0 +1,129 @@
+From 8cacb87c909cfaa3b08d443b3bbfa57e1a07bc52 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Fri, 22 Dec 2017 15:21:32 +0700
+Subject: add Haiku support
+
+use find_directory for settings
+
+use int typedefs from SupportDefs instead
+
+use fallback ffsll
+
+diff --git a/lrzip_private.h b/lrzip_private.h
+index 9ac9f47..0d4dfda 100644
+--- a/lrzip_private.h
++++ b/lrzip_private.h
+@@ -78,6 +78,10 @@ void *alloca (size_t);
+ # endif
+ #endif
+ 
++#ifdef __HAIKU__
++#include <SupportDefs.h>
++#endif
++
+ #ifndef MD5_DIGEST_SIZE
+ # define MD5_DIGEST_SIZE 16
+ #endif
+@@ -144,7 +148,7 @@ extern int errno;
+ #define unlikely(x)	__builtin_expect(!!(x), 0)
+ #define __maybe_unused	__attribute__((unused))
+ 
+-#if defined(__MINGW32__) || defined(__CYGWIN__) || defined(ANDROID) || defined(__APPLE__)
++#if defined(__MINGW32__) || defined(__CYGWIN__) || defined(ANDROID) || defined(__APPLE__) || defined(__HAIKU__)
+ # define ffsll __builtin_ffsll
+ #endif
+ 
+diff --git a/util.c b/util.c
+index d79125b..7220c81 100644
+--- a/util.c
++++ b/util.c
+@@ -59,6 +59,11 @@
+ # include <ctype.h>
+ #endif
+ 
++#ifdef __HAIKU__
++#include <FindDirectory.h>
++#include <fs_info.h>
++#endif
++
+ /* Macros for testing parameters */
+ #define isparameter( parmstring, value )	(!strcasecmp( parmstring, value ))
+ #define iscaseparameter( parmvalue, value )	(!strcmp( parmvalue, value ))
+@@ -181,7 +186,13 @@ bool get_rand(rzip_control *control, uchar *buf, int len)
+ bool read_config(rzip_control *control)
+ {
+ 	/* check for lrzip.conf in ., $HOME/.lrzip and /etc/lrzip */
++#ifndef __HAIKU__
+ 	char *HOME, homeconf[255];
++#else
++	dev_t volume;
++	char buffer[B_PATH_NAME_LENGTH];
++	char confpath[B_PATH_NAME_LENGTH + B_FILE_NAME_LENGTH];
++#endif
+ 	char *parametervalue;
+ 	char *parameter;
+ 	char line[255];
+@@ -190,6 +201,7 @@ bool read_config(rzip_control *control)
+ 	fp = fopen("lrzip.conf", "r");
+ 	if (fp)
+ 		fprintf(control->msgout, "Using configuration file ./lrzip.conf\n");
++#ifndef __HAIKU__
+ 	if (fp == NULL) {
+ 		HOME=getenv("HOME");
+ 		if (HOME) {
+@@ -204,6 +216,25 @@ bool read_config(rzip_control *control)
+ 		if (fp)
+ 			fprintf(control->msgout, "Using configuration file /etc/lrzip/lrzip.conf\n");
+ 	}
++#else
++	if (fp == NULL) {
++		volume = dev_for_path("/boot");
++		if (find_directory(B_USER_SETTINGS_DIRECTORY, volume, false, buffer, sizeof(buffer)) == B_OK) {
++			snprintf(confpath, sizeof(confpath), "%s/lrzip/lrzip.conf", buffer);
++			fp = fopen(confpath, "r");
++			if (fp)
++				fprintf(control->msgout, "Using configuration file %s\n", confpath);
++		}
++	}
++	if (fp == NULL) {
++		if (find_directory(B_SYSTEM_SETTINGS_DIRECTORY, volume, false, buffer, sizeof(buffer)) == B_OK) {
++			snprintf(confpath, sizeof(confpath), "%s/lrzip/lrzip.conf", buffer);
++			fp = fopen(confpath, "r");
++			if (fp)
++				fprintf(control->msgout, "Using configuration file %s\n", confpath);
++		}
++	}
++#endif
+ 	if (fp == NULL)
+ 		return true;
+ 
+-- 
+2.15.0
+
+
+From 6a726a45f117ca346cfc676c91bd3d6b557fc0ff Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Fri, 22 Dec 2017 15:36:59 +0700
+Subject: use no-op implementation for setpriority, mlock, munlock
+
+
+diff --git a/lrzip_private.h b/lrzip_private.h
+index 0d4dfda..0369dd5 100644
+--- a/lrzip_private.h
++++ b/lrzip_private.h
+@@ -180,6 +180,12 @@ typedef sem_t cksem_t;
+ # define MD5_RELIABLE (1)
+ #endif
+ 
++#if defined(__HAIKU__)
++# define setpriority(...) 0
++# define mlock(...) 0
++# define munlock(...) 0
++#endif
++
+ #define bswap_32(x) \
+      ((((x) & 0xff000000) >> 24) | (((x) & 0x00ff0000) >>  8) |		      \
+       (((x) & 0x0000ff00) <<  8) | (((x) & 0x000000ff) << 24))
+-- 
+2.15.0
+


### PR DESCRIPTION
Done as part of GCI 2017

~~Currently won't work as haiku lacks these POSIX functions: [`setpriority()`][0], [`mlock()`][1], [`munlock()`][1]~~ Replaced with no-ops

Changes done to lrzip:
- Moved settings folder to the correct location using [`find_directory()`][2]
- Implemented [`setpriority()`][0], [`mlock()`][1], [`munlock()`][1] as no-ops

~~**NOT TESTED**: x86 secondary arch~~

Known issues:
- x86 secondary arch: hang upon compressing data from stdin. This is traced to be an `malloc()` hung up, so high chances that this is an Haiku bug. To reproduce, run: `seq 1 1000 | lrz > testfile.lrz`

[0]: http://pubs.opengroup.org/onlinepubs/9699919799/functions/setpriority.html
[1]: http://pubs.opengroup.org/onlinepubs/9699919799/functions/mlock.html
[2]: https://www.haiku-os.org/docs/api/FindDirectory_8h.html#af95c55d472448ab7af9f32c33aeea71e