### PR TITLE
wordgrinder, fix build

### DIFF
--- a/app-text/wordgrinder/wordgrinder-0.7.1.recipe
+++ b/app-text/wordgrinder/wordgrinder-0.7.1.recipe
@@ -1,9 +1,9 @@
 SUMMARY="A simple, Unicode-aware word processor that runs on the console"
 DESCRIPTION="WordGrinder is designed to get out of your way and let you write; \
-it does very little, but what it does it does it well. It supports basic paragraph \
-styles, basic character styles, basic screen markup, a menu interface that means you \
-don't have to remember complex key sequences, HTML import and export, and some other \
-useful features."
+it does very little, but what it does it does it well. It supports basic \
+paragraph styles, basic character styles, basic screen markup, a menu \
+interface that means you don't have to remember complex key sequences, HTML \
+import and export, and some other useful features."
 HOMEPAGE="http://cowlark.com/wordgrinder/"
 COPYRIGHT="2007-2017 David Given"
 LICENSE="MIT"
@@ -11,40 +11,58 @@ REVISION="1"
 SOURCE_URI="https://github.com/davidgiven/wordgrinder/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="54085af7963e1f67342bc0b1b20d1ccc75494f2e23d401b601cf3089acea747c"
 
-ARCHITECTURES="!x86_gcc2 !x86_64"
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+commandBinDir=$binDir
+commandSuffix=$secondaryArchSuffix
+if [ "$targetArchitecture" = x86_gcc2 ]
+then
+	commandBinDir=$prefix/bin
+	commandSuffix=
+fi
 
 PROVIDES="
-	wordgrinder = $portVersion
-	cmd:WordGrinder = $portVersion
+	wordgrinder$secondaryArchSuffix = $portVersion
+	cmd:wordgrinder$commandSuffix = $portVersion
 	"
 REQUIRES="
-	haiku
-	lib:libncurses
-	lib:liblua
-	lib:libz
+	haiku$secondaryArchSuffix
+#	lib:libfreetype$secondaryArchSuffix
+	lib:liblua$secondaryArchSuffix >= 5.3
+	lib:libncurses$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
-	devel:libncurses
-	devel:liblua
-	devel:libz
+	haiku${secondaryArchSuffix}_devel
+#	devel:libfreetype$secondaryArchSuffix
+	devel:liblua$secondaryArchSuffix >= 5.3
+	devel:libncurses$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:g++
+	cmd:cc$secondaryArchSuffix
 	cmd:make
 	cmd:ninja
-	cmd:pkg_config
+	cmd:pkg_config$secondaryArchSuffix
 	"
+
+defineDebugInfoPackage wordgrinder$secondaryArchSuffix \
+	$commandBinDir/wordgrinder
 
 BUILD()
 {
-	make OBJDIR=$sourceDir/build PREFIX=$prefix BINDIR=$binDir \
-		DOCDIR=$docDir MANDIR=$manDir
+	make PREFIX=$prefix BINDIR=$commandBinDir DOCDIR=$docDir \
+		MANDIR=$manDir HOME="`finddir B_USER_DIRECTORY`" \
+		LUA_PACKAGE=lua
 }
 
 INSTALL()
 {
-	make install OBJDIR=$sourceDir/build PREFIX=$prefix BINDIR=$binDir \
-		DOCDIR=$docDir MANDIR=$manDir
+	make install PREFIX=$prefix BINDIR=$commandBinDir DOCDIR=$docDir \
+		MANDIR=$manDir HOME="`finddir B_USER_DIRECTORY`" \
+		LUA_PACKAGE=lua
+	mv $docDir/wordgrinder/README.wg $docDir
+	rmdir $docDir/wordgrinder
 }


### PR DESCRIPTION
help needed ... I need to manually switch of some ninja settings, but it is only created after make in the OBJDIR directory ... 
build all: phony bin/wordgrinder.1 bin/wordgrinder-lua-curses-release-stripped  test-lua-curses-debug

Needs to be replaced by:
build all: phony bin/wordgrinder.1 bin/wordgrinder-lua-curses-release-stripped

Just can't find out where it takes the settings from ... 

After removing test-lua-curses-debug, the build works ok ... 