### PR TITLE
photograbber, fix recipe, bump version

### DIFF
--- a/haiku-apps/photograbber/patches/photograbber-2.3.patchset
+++ b/haiku-apps/photograbber/patches/photograbber-2.3.patchset
@@ -1,0 +1,19 @@
+From cc394a2ab9628aa84db7f4aa579c7d0dafe95c9f Mon Sep 17 00:00:00 2001
+From: begasus <begasus@gmail.com>
+Date: Wed, 20 Dec 2017 22:26:01 +0100
+Subject: fix path for makefile-engine
+
+
+diff --git a/plugins/bdcpPTP/Makefile b/plugins/bdcpPTP/Makefile
+index b285549..7673980 100644
+--- a/plugins/bdcpPTP/Makefile
++++ b/plugins/bdcpPTP/Makefile
+@@ -47,4 +47,4 @@ APP_MENU=
+ 
+ 
+ ## include the makefile-engine
+-include $(BUILDHOME)/etc/makefile-engine
++include $(shell finddir B_SYSTEM_DEVELOP_DIRECTORY)/etc/makefile-engine
+-- 
+2.15.0
+

--- a/haiku-apps/photograbber/photograbber-2.3.recipe
+++ b/haiku-apps/photograbber/photograbber-2.3.recipe
@@ -11,13 +11,13 @@ cameras. In the future Mass Storage and Bluethooth support may be added."
 HOMEPAGE="https://github.com/HaikuArchives/PhotoGrabber"
 COPYRIGHT="2010 Jan-Rixt Van Hoye (Jixt)"
 LICENSE="MIT"
-REVISION="2"
-commit="d1df3fbe63fca6efb99c00f53515a1b0515ec441"
-SOURCE_URI="https://github.com/HaikuArchives/PhotoGrabber/archive/$commit.tar.gz"
-CHECKSUM_SHA256="05da59c345544ac0e972452f6a86a5d17189d4770717db40b7ea86e0c9ab2326"
-SOURCE_DIR="PhotoGrabber-$commit"
+REVISION="1"
+SOURCE_URI="https://github.com/HaikuArchives/PhotoGrabber/archive/$portVersion.tar.gz"
+CHECKSUM_SHA256="9d83e857b2b1d0424e6e71f8989cb802ab11d26b4feb5d539a10cb9d3a69754a"
+SOURCE_DIR="PhotoGrabber-$portVersion"
+PATCHES="photograbber-$portVersion.patchset"
 
-ARCHITECTURES="x86_gcc2 x86 ?x86_64"
+ARCHITECTURES="x86_gcc2 ?x86_64"
 
 PROVIDES="
 	photograbber = $portVersion
@@ -26,11 +26,13 @@ PROVIDES="
 REQUIRES="
 	haiku
 	lib:libiconv
+	lib:libexif
 	"
 
 BUILD_REQUIRES="
 	haiku_devel
 	devel:libiconv
+	devel:libexif
 	"
 BUILD_PREREQUIRES="
 	cmd:g++
@@ -40,13 +42,14 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	PG.sh
+	mkdir -p dist/plugins
+	make $jobArgs
 }
 
 INSTALL()
 {
-	mkdir -p $appsDir
-	cp -r build/PhotoGrabber $appsDir
+	mkdir -p $appsDir/PhotoGrabber
+	cp -r dist/* $appsDir/PhotoGrabber
 
 	addAppDeskbarSymlink $appsDir/PhotoGrabber/PhotoGrabber
 }


### PR DESCRIPTION
Builds ok for x86_gcc2 x86 and x86_64 (just didn't put in x86 in the recipe) :)