### PR TITLE
htmltidy, bump version, fix build

### DIFF
--- a/app-text/htmltidy/tidy57-5.7.0~git.recipe
+++ b/app-text/htmltidy/tidy57-5.7.0~git.recipe
@@ -1,0 +1,90 @@
+SUMMARY="The granddaddy of HTML tools, with support for modern standards"
+DESCRIPTION="Tidy tidies HTML and XML. It can tidy your documents by itself, \
+and developers can easily integrate its features into even more powerful tools."
+HOMEPAGE="http://www.html-tidy.org/"
+COPYRIGHT="1998-2015 World Wide Web Consortium"
+LICENSE="MIT"
+REVISION="1"
+srcGitRev="28be79db50d2ecf6730068167d8ed23987fa8d59"
+SOURCE_URI="https://github.com/htacg/tidy-html5/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="5fddac299a385203e06a2158df3acd68aa83ffd10d5bdf73b9e7f2913dee1a88"
+SOURCE_FILENAME="tidy-html5-$portVersion-$srcGitRev.tar.gz"
+SOURCE_DIR="tidy-html5-$srcGitRev"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion=5.7.0
+libVersionCompat="$libVersion compat >= 5"
+
+PROVIDES="
+	tidy57$secondaryArchSuffix = $portVersion
+	lib:libtidy$secondaryArchSuffix = $libVersionCompat
+	"
+if [ -z "$secondaryArchSuffix" ]; then
+PROVIDES="$PROVIDES
+	cmd:tidy = $portVersion
+	"
+fi
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+CONFLICTS="
+	tidy$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	tidy57${secondaryArchSuffix}_devel = $portVersion
+	devel:libtidy$secondaryArchSuffix = $libVersion
+	devel:libtidys$secondaryArchSuffix
+	"
+REQUIRES_devel="
+	tidy57$secondaryArchSuffix == $portVersion base
+	"
+CONFLICTS_devel="
+	tidy${secondaryArchSuffix}_devel
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:xsltproc$secondaryArchSuffix
+	"
+
+defineDebugInfoPackage tidy57$secondaryArchSuffix \
+	$libDir/libtidy.so.$libVersion
+
+BUILD()
+{
+	cd build/cmake
+
+	cmake ../.. -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_INSTALL_PREFIX:PATH=$prefix \
+		-DLIB_INSTALL_DIR=$libDir \
+		-DINCLUDE_INSTALL_DIR=$includeDir \
+		-DMAN_INSTALL_DIR=$manDir/man1 \
+		-DBIN_INSTALL_DIR=$binDir
+
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make -C build/cmake install
+
+	prepareInstalledDevelLibs libtidy libtidys
+	fixPkgconfig
+
+	if [ -n "$secondaryArchSuffix" ]; then
+		rm -rf $prefix/bin
+		rm -rf $manDir
+	fi
+
+	# devel package
+	packageEntries devel \
+		$developDir
+}


### PR DESCRIPTION
Build for gcc2 is broken due to unbalanced #endif's and parse errors ... 