### PR TITLE
app-emulation/aqemu: fix total/free memory detection

### DIFF
--- a/app-emulation/aqemu/patches/aqemu-0.9.2.patchset
+++ b/app-emulation/aqemu/patches/aqemu-0.9.2.patchset
@@ -1,4 +1,4 @@
-From 0703306f350d2bcc6a3658d8868df86986df58dc Mon Sep 17 00:00:00 2001
+From 44d7e9a4ebb1062d5949f5a5d8e6346ad6cec8e9 Mon Sep 17 00:00:00 2001
 From: Sergei Reznikov <diver@gelios.net>
 Date: Tue, 5 Dec 2017 09:27:36 +0300
 Subject: Fix build on Haiku
@@ -82,6 +82,66 @@ index 40a3c61..ace8799 100644
  		if( QDir(QDir::currentPath() + "\\os_icons").exists() &&
  			QDir(QDir::currentPath() + "\\os_templates").exists() )
  		{
+-- 
+2.15.0
+
+
+From 5ee1bb6c08ba39e6aeb494b14fe1601664ef752f Mon Sep 17 00:00:00 2001
+From: Ho Tuan Kiet <tuankiet65@gmail.com>
+Date: Sun, 24 Dec 2017 07:22:22 +0000
+Subject: Fix total/free memory detection on Haiku
+
+
+diff --git a/src/System_Info.cpp b/src/System_Info.cpp
+index 5e368a5..6108df7 100644
+--- a/src/System_Info.cpp
++++ b/src/System_Info.cpp
+@@ -2595,12 +2595,23 @@ void System_Info::Get_Free_Memory_Size( int &allRAM, int &freeRAM )
+ 	}
+ 	
+ 	// If proc fs not exists
+-/*	struct sysinfo sysInfo;
+-	sysinfo( &sysInfo );
+-	
+-	allRAM = (int)(unsigned long)(sysInfo.totalram * sysInfo.mem_unit) / 1024.0 / 1024.0;
+-	freeRAM  = (int)(unsigned long)((sysInfo.freeram + sysInfo.bufferram) * sysInfo.mem_unit) / 1024.0 / 1024.0;
+-*/}
++	#ifdef Q_OS_HAIKU
++		system_info sysinfo;
++		get_system_info(&sysinfo);
++
++		uint64 tmp;
++		tmp = (sysinfo.max_pages + sysinfo.ignored_pages) * B_PAGE_SIZE;
++		allRAM = (int)(tmp / 1024.0 / 1024.0);
++		
++		freeRAM = (int)(sysinfo.free_memory / 1024.0 / 1024.0);
++	#else
++		struct sysinfo sysInfo;
++		sysinfo( &sysInfo );
++		
++		allRAM = (int)(unsigned long)(sysInfo.totalram * sysInfo.mem_unit) / 1024.0 / 1024.0;
++		freeRAM  = (int)(unsigned long)((sysInfo.freeram + sysInfo.bufferram) * sysInfo.mem_unit) / 1024.0 / 1024.0;
++	#endif
++}
+ 
+ QStringList System_Info::Get_Host_FDD_List()
+ {
+diff --git a/src/System_Info.h b/src/System_Info.h
+index fe325f7..64c0e41 100644
+--- a/src/System_Info.h
++++ b/src/System_Info.h
+@@ -26,6 +26,11 @@
+ #include "Utils.h"
+ #include "VM_Devices.h"
+ 
++#ifdef Q_OS_HAIKU
++// for memory size detection
++#include <OS.h>
++#endif
++
+ class System_Info
+ {
+ 	public:
 -- 
 2.15.0
 


### PR DESCRIPTION
This pull request fixes total/free memory detection on Haiku. AQEMU still haven't worked properly though :/ (as QEMU is still segfaulting)

This pull request fixes #1850.

![virtualbox_haiku x86_64_24_12_2017_14_21_54](https://user-images.githubusercontent.com/1905496/34325065-505dc920-e8b9-11e7-9670-ddf757d26b17.png)
