### PR TITLE
Install fix for gcc2h

### DIFF
--- a/media-video/mplayer/mplayer-1.3.0.recipe
+++ b/media-video/mplayer/mplayer-1.3.0.recipe
@@ -194,5 +194,5 @@ INSTALL()
 		-e "s|@MINOR@|$MINOR|" \
 		$portDir/additional-files/mplayer.rdef.in > mplayer.rdef
 
-	addResourcesToBinaries mplayer.rdef $binDir/mplayer
+	addResourcesToBinaries mplayer.rdef $prefix/bin/mplayer
 }


### PR DESCRIPTION
Binary is in $prefix/bin on secondary arch, instead of $binDir