### PR TITLE
app-crypt/johntheripper: add port

### DIFF
--- a/app-crypt/johntheripper/johntheripper-1.8.0.recipe
+++ b/app-crypt/johntheripper/johntheripper-1.8.0.recipe
@@ -1,0 +1,188 @@
+SUMMARY="A fast password cracker"
+DESCRIPTION="A fast password cracker, currently available for many flavors of \
+Unix, Windows, DOS, and OpenVMS. Its primary purpose is to detect weak Unix \
+passwords. Besides several crypt(3) password hash types most commonly found on \
+various Unix systems, supported out of the box are Windows LM hashes, plus \
+lots of other hashes and ciphers in the community-enhanced version."
+HOMEPAGE="http://www.openwall.com/john"
+COPYRIGHT="1996-2013 Solar Designer
+	2014 John the Ripper '-jumbo' authors"
+LICENSE="GNU GPL v2
+	John the Ripper"
+REVISION="1"
+jumboVersion="1"
+SOURCE_URI="http://www.openwall.com/john/j/john-$portVersion-jumbo-$jumboVersion.tar.xz"
+CHECKSUM_SHA256="bac93d025995a051f055adbd7ce2f1975676cac6c74a6c7a3ee4cfdd9c160923"
+SOURCE_DIR="john-$portVersion-jumbo-$jumboVersion"
+# Upstream patches, can be dropped in the next version
+PATCHES="johntheripper-$portVersion-upstreamed.patchset
+	johntheripper-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	johntheripper$secondaryArchSuffix = $portVersion
+	cmd:john = $portVersion
+	"
+
+bins=(calc_stat cprepair genmkvpwd luks2john mkvcalcproba raw2dyna
+	tgtsnarf uaf2john wpapcap2john)
+syms=(base64conv dmg2john gpg2john hccap2john keepass2john keychain2john
+	keyring2john keystore2john kwallet2john pfx2john putty2john pwsafe2john
+	racf2john rar2john ssh2john truecrypt_volume2john unafs undrop unique
+	unshadow zip2john)
+
+for b in ${bins[@]} ${syms[@]}
+do
+	PROVIDES+="
+		cmd:$b = $portVersion
+		"
+done
+
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcrypto$secondaryArchSuffix
+	lib:libgmp$secondaryArchSuffix
+	lib:libgomp$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libcrypto$secondaryArchSuffix
+	devel:libgmp$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:find
+	cmd:gcc$secondaryArchSuffix
+	cmd:grep
+	cmd:make
+	cmd:sed
+	"
+
+GLOBAL_WRITABLE_FILES="
+	settings/john/john.conf auto-merge
+	"
+USER_SETTINGS_FILES="
+	settings/john directory
+	settings/john/john.local.conf template $docDir/john.local.conf.example
+	"
+
+# Instruction sets for fallback chain
+instr=(ssse3 sse4.1 avx xop)
+# SSE2 is enabled by default for x86_64, but not for x86.
+# To check for enabled instruction set, run:
+# gcc -dM -E -x c /dev/null | grep -E "(MMX|SSE|AVX|XOP)"
+if [ "$effectiveTargetArchitecture" != "x86_64" ]; then
+	instr=(sse2 ${instr[@]})
+fi
+
+BUILD()
+{
+	local constantSettingsDir="$(finddir B_SYSTEM_SETTINGS_DIRECTORY)"
+	cat > haiku.config << EOF
+		#define CFG_FULL_NAME "$constantSettingsDir/john/john.conf"
+		#define CFG_ALT_NAME "$constantSettingsDir/john/john.ini"
+		#define CFG_PRIVATE_FULL_NAME "~config/john/john.conf"
+		#define CFG_PRIVATE_ALT_NAME "~config/john/john.ini"
+		#define CPU_FALLBACK 1
+		#define JOHN_SYSTEMWIDE 1
+		#define JOHN_SYSTEMWIDE_EXEC "$libExecDir/john"
+		#define JOHN_SYSTEMWIDE_HOME "$dataDir/john"
+		#define JOHN_PRIVATE_HOME "~data/john"
+EOF
+	local cfgFlags="--disable-native-tests --enable-openmp"
+
+	# TODO: somehow quote PWD without autotools acting up
+	export CFLAGS="-O2 -pipe -iquote $PWD -include haiku.config"
+	export LIBS="-Wl,--as-needed -lnetwork" # Need libnetwork for tgtsnarf
+
+	cd src
+	runConfigure ./configure $cfgFlags
+	make clean
+	make $jobArgs
+
+	for i in ${instr[@]}
+	do
+		mv ../run/john{,-non-$i}
+		CFLAGS="$CFLAGS -m$i" \
+			runConfigure ./configure $cfgFlags
+		make clean
+		make $jobArgs
+	done
+}
+
+INSTALL()
+{
+	install -d -m 755 "$dataDir/bash-completion/completions" \
+		"$dataDir/zsh/site-functions" \
+		"$dataDir/john" "$docDir" "$libExecDir/john" "$settingsDir/john" \
+		"$prefix/bin"
+
+	# configs
+	local constantSettingsDir="$(finddir B_SYSTEM_SETTINGS_DIRECTORY)"
+	sed run/john.conf > "$settingsDir/john/john.conf" \
+		-e "s|\$JOHN/john.local.conf|$constantSettingsDir/john/john.local.conf|g"
+
+	install -m 644 run/john.local.conf "$docDir/john.local.conf.example"
+	install -t "$dataDir/john" -m 644 run/*.conf
+	rm "$dataDir/john/"john{,.local}.conf
+
+	# docs
+	install -t "$docDir" -m 644 doc/*
+
+	# remove stuff that only devs need
+	rm "$docDir/"{AddressSanitizer-HOWTO.txt,INSTALL*}
+
+	# licenses
+	rm "$docDir/COPYING" # no need for another GPL v2 copy
+	rm "$docDir/"LICENSE{,.mpi} # john's mpi is licensed under the same terms
+	rm "$docDir/SIPcrack-LICENSE" # we don't have this installed
+
+	# completions
+	install -m 644 run/john.bash_completion \
+		"$dataDir/bash-completion/completions/john"
+	install -m 644 run/john.zsh_completion "$dataDir/zsh/site-functions/_john"
+
+	# bins
+	install -t "$prefix/bin" -m 755 run/john
+	install -t "$libExecDir/john" -m 755 run/john-non-*
+	for b in ${bins[@]}
+	do
+		install -t "$prefix/bin" -m 755 run/$b
+	done
+
+	# scripts
+	install -t "$libExecDir/john" -m 755 run/*.{pl,py,rb} run/benchmark-unify \
+		run/mailer run/makechr run/relbench
+
+	# data
+	install -t "$dataDir/john" -m 644 run/*.chr run/*.lst run/dictionary* \
+		run/stats
+
+	for s in ${syms[@]}
+	do
+		ln -s john "$prefix/bin/$s"
+	done
+}
+
+TEST()
+{
+	cd run
+
+	if ./john 2>&1 | grep -q execv; then
+		# Fallback chain
+		for (( i=${#instr[@]} - 1; i >= 0; i-- ))
+		do
+			if ! ./john-non-${instr[i]} 2>&1 | grep -q execv; then
+				./john-non-${instr[i]} --make_check
+				break
+			fi
+		done
+	else
+		./john --make_check
+	fi
+}

--- a/app-crypt/johntheripper/licenses/John the Ripper
+++ b/app-crypt/johntheripper/licenses/John the Ripper
@@ -1,0 +1,61 @@
+	John the Ripper copyright and license.
+
+John the Ripper password cracker,
+Copyright (c) 1996-2013 by Solar Designer.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+As a special exception to the GNU General Public License terms,
+permission is hereby granted to link the code of this program, with or
+without modification, with any version of the OpenSSL library and/or any
+version of unRAR, and to distribute such linked combinations.  You must
+obey the GNU GPL in all respects for all of the code used other than
+OpenSSL and unRAR.  If you modify this program, you may extend this
+exception to your version of the program, but you are not obligated to
+do so.  (In other words, you may release your derived work under pure
+GNU GPL version 2 or later as published by the FSF.)
+
+(This exception from the GNU GPL is not required for the core tree of
+John the Ripper, but arguably it is required for -jumbo.)
+
+
+	Relaxed terms for certain components.
+
+In addition or alternatively to the license above, many components are
+available to you under more relaxed terms (most commonly under cut-down
+BSD license) as specified in the corresponding source files.
+
+Furthermore, as the copyright holder for the bcrypt (Blowfish-based
+password hashing) implementation found in John the Ripper, I have placed
+a derived version of this implementation in the public domain.  This
+derived version may be obtained at:
+
+	http://www.openwall.com/crypt/
+
+The intent is to provide modern password hashing for your servers and
+your software (where the GPL restrictions could be a problem).
+
+
+	Commercial licensing.
+
+Commercial licenses (non-GPL) are available upon request.
+
+
+	Copyright holder contact information.
+
+For the core John the Ripper tree:
+
+Alexander Peslyak aka Solar Designer <solar at openwall.com>
+
+(There are additional copyright holders for "community enhanced" -jumbo
+versions of John the Ripper.)
+
+$Owl: Owl/packages/john/john/doc/LICENSE,v 1.16 2013/05/30 00:42:06 solar Exp $

--- a/app-crypt/johntheripper/patches/johntheripper-1.8.0-upstreamed.patchset
+++ b/app-crypt/johntheripper/patches/johntheripper-1.8.0-upstreamed.patchset
@@ -1,0 +1,119 @@
+From 10525817cb0192c749ed6a1b98c3bdc627d61765 Mon Sep 17 00:00:00 2001
+From: Solar <solar@openwall.com>
+Date: Thu, 18 Dec 2014 21:24:01 +0100
+Subject: Fix a bug in truecrypt for non-x86 archs. Closes #912.
+
+
+diff --git a/src/truecrypt_fmt_plug.c b/src/truecrypt_fmt_plug.c
+index 1c95c39..8cef85e 100644
+--- a/src/truecrypt_fmt_plug.c
++++ b/src/truecrypt_fmt_plug.c
+@@ -310,8 +310,8 @@ static int crypt_all(int *pcount, struct db_salt *salt)
+ 			pbkdf2_sha512_sse((const unsigned char **)pin, lens, psalt->salt, 64, psalt->num_iterations, &(x.poutc), sizeof(key), 0);
+ 		}
+ #else
+-		if (is_sha512)
+-			pbkdf2_sha512((const unsigned char*)key_buffer[i], strlen(key_buffer[i]), psalt->salt, 64, num_iterations, key, sizeof(key), 0);
++		if (psalt->hash_type == IS_SHA512)
++			pbkdf2_sha512((const unsigned char*)key_buffer[i], strlen((char*)key_buffer[i]), psalt->salt, 64, psalt->num_iterations, key, sizeof(key), 0);
+ #endif
+ 		else if (psalt->hash_type == IS_RIPEMD160)
+ 			pbkdf2_ripemd160(key_buffer[i], strlen((char*)(key_buffer[i])), psalt->salt, 64, psalt->num_iterations, key, sizeof(key), 0);
+-- 
+2.15.0
+
+
+From ef31fea6ee020e40857c52ab5310003b6fc7844f Mon Sep 17 00:00:00 2001
+From: magnum <john.magnum@hushmail.com>
+Date: Wed, 13 May 2015 12:05:00 +0200
+Subject: Add another solution to #1093. This make it possible to build using
+ gcc 5 without --std=gnu89 (although I kept the latter for now). See also
+ #1250.
+
+
+diff --git a/src/DES_bs_b.c b/src/DES_bs_b.c
+index e97c4de..0a48ff2 100644
+--- a/src/DES_bs_b.c
++++ b/src/DES_bs_b.c
+@@ -1247,6 +1247,9 @@ static MAYBE_INLINE void DES_bs_finalize_keys(void)
+ #endif
+ 
+ #if DES_bs_mt
++#if __GNUC__ >= 5
++extern
++#endif
+ MAYBE_INLINE void DES_bs_set_salt_for_thread(int t, unsigned int salt)
+ #else
+ void DES_bs_set_salt(ARCH_WORD salt)
+diff --git a/src/MD5_std.c b/src/MD5_std.c
+index 40bf79e..842eb38 100644
+--- a/src/MD5_std.c
++++ b/src/MD5_std.c
+@@ -490,9 +490,15 @@ extern void MD5_body(MD5_word x[15], MD5_word out[4]);
+ #if MD5_std_mt
+ #define MD5_body(x, out) \
+ 	MD5_body_for_thread(t, x, out)
++#if __GNUC__ >= 5
++extern
++#endif
+ MAYBE_INLINE_BODY void MD5_body_for_thread(int t,
+ 	MD5_word x[15], MD5_word out[4])
+ #else
++#if __GNUC__ >= 5
++extern
++#endif
+ MAYBE_INLINE_BODY void MD5_body(MD5_word x[15], MD5_word out[4])
+ #endif
+ {
+@@ -589,10 +595,16 @@ MAYBE_INLINE_BODY void MD5_body(MD5_word x[15], MD5_word out[4])
+ #if MD5_std_mt
+ #define MD5_body(x0, x1, out0, out1) \
+ 	MD5_body_for_thread(t, x0, x1, out0, out1)
++#if __GNUC__ >= 5
++extern
++#endif
+ MAYBE_INLINE_BODY void MD5_body_for_thread(int t,
+ 	MD5_word x0[15], MD5_word x1[15],
+ 	MD5_word out0[4], MD5_word out1[4])
+ #else
++#if __GNUC__ >= 5
++extern
++#endif
+ MAYBE_INLINE_BODY void MD5_body(MD5_word x0[15], MD5_word x1[15],
+ 	MD5_word out0[4], MD5_word out1[4])
+ #endif
+-- 
+2.15.0
+
+
+From db958159908e72908c5d366883ca19159eae7bb7 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Sat, 23 Dec 2017 11:25:01 +0700
+Subject: idle: add Haiku support
+
+
+diff --git a/src/idle.c b/src/idle.c
+index 1515833..225dfae 100644
+--- a/src/idle.c
++++ b/src/idle.c
+@@ -35,7 +35,7 @@ static int use_yield = 0;
+ extern int nice(int);
+ #endif
+ 
+-#ifdef __BEOS__
++#if defined(__BEOS__) || defined(__HAIKU__)
+ #include <OS.h>
+ #endif
+ 
+@@ -78,7 +78,7 @@ void idle_init(struct fmt_main *format)
+ #if defined(__MINGW32__) || defined (_MSC_VER)
+ 	SetPriorityClass(GetCurrentProcess(), IDLE_PRIORITY_CLASS);
+ 	SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_IDLE);
+-#elif defined(__BEOS__)
++#elif defined(__BEOS__) || defined(__HAIKU__)
+ 	set_thread_priority(getpid(), 1);
+ #else
+ /*
+-- 
+2.15.0
+

--- a/app-crypt/johntheripper/patches/johntheripper-1.8.0.patchset
+++ b/app-crypt/johntheripper/patches/johntheripper-1.8.0.patchset
@@ -1,0 +1,198 @@
+From e70ffaaaa9542949d6a371b9755914d1a093b28b Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Sun, 24 Dec 2017 19:41:43 +0700
+Subject: path: add expansion for "~config" and "~data"
+
+This commit enable the ability to dynamically expand user configuration
+folder and user data folder for Haiku.
+
+This could also be further extended to support XDG Base Directory
+Specification.
+
+diff --git a/src/path.c b/src/path.c
+index 14f6310..444ecb8 100644
+--- a/src/path.c
++++ b/src/path.c
+@@ -31,9 +31,16 @@ static int john_home_lengthex;
+ #include <pwd.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
++#ifdef __HAIKU__
++#include <FindDirectory.h>
++#endif
+ 
+ static char *user_home_path = NULL;
+ static int user_home_length;
++static char *user_config_path = NULL;
++static int user_config_length;
++static char *user_data_path = NULL;
++static int user_data_length;
+ #endif
+ 
+ #include "memdbg.h"
+@@ -66,6 +73,26 @@ void path_init(char **argv)
+ 	memcpy(user_home_path, pw->pw_dir, user_home_length - 1);
+ 	user_home_path[user_home_length - 1] = '/';
+ 
++	if (user_config_path) return;
++#ifdef __HAIKU__
++	user_config_path = mem_alloc(PATH_BUFFER_SIZE);
++	if (find_directory(B_USER_SETTINGS_DIRECTORY, (dev_t)-1, false,
++			user_config_path, PATH_BUFFER_SIZE) != B_OK)
++		return;
++	user_config_length = strlen(user_config_path) + 1;
++	user_config_path[user_config_length - 1] = '/';
++#endif
++
++	if (user_data_path) return;
++#ifdef __HAIKU__
++	user_data_path = mem_alloc(PATH_BUFFER_SIZE);
++	if (find_directory(B_USER_VAR_DIRECTORY, (dev_t)-1, false,
++			user_data_path, PATH_BUFFER_SIZE) != B_OK)
++		return;
++	user_data_length = strlen(user_data_path) + 1;
++	user_data_path[user_data_length - 1] = '/';
++#endif
++
+ #ifdef JOHN_PRIVATE_HOME
+ 	private = path_expand(JOHN_PRIVATE_HOME);
+ 	if (mkdir(private, S_IRUSR | S_IWUSR | S_IXUSR)) {
+@@ -166,6 +193,24 @@ char *path_expand(char *name)
+ 		}
+ 		return name + 2;
+ 	}
++	if (!strncmp(name, "~config/", 8)) {
++		if (user_config_path &&
++		    user_config_length + strlen(name) - 8 < PATH_BUFFER_SIZE) {
++			strnzcpy(&user_config_path[user_config_length], &name[8],
++				PATH_BUFFER_SIZE - user_config_length);
++			return user_config_path;
++		}
++		return name + 8;
++	}
++	if (!strncmp(name, "~data/", 6)) {
++		if (user_data_path &&
++		    user_data_length + strlen(name) - 6 < PATH_BUFFER_SIZE) {
++			strnzcpy(&user_data_path[user_data_length], &name[6],
++				PATH_BUFFER_SIZE - user_data_length);
++			return user_data_path;
++		}
++		return name + 6;
++	}
+ #endif
+ 
+ 	return name;
+@@ -200,6 +245,8 @@ void path_done(void)
+ 	MEM_FREE(john_home_path);
+ #if JOHN_SYSTEMWIDE
+ 	MEM_FREE(user_home_path);
++	MEM_FREE(user_config_path);
++	MEM_FREE(user_data_path);
+ #endif
+ 	if (john_home_pathex)
+ 		MEM_FREE(john_home_pathex);
+diff --git a/src/path.h b/src/path.h
+index eeb4b04..9b64e80 100644
+--- a/src/path.h
++++ b/src/path.h
+@@ -21,7 +21,7 @@
+ extern void path_init(char **argv);
+ 
+ /*
+- * Expands "$JOHN/" and "~/" in a path name.
++ * Expands "$JOHN/", "~/", "~config/" and "~data/" in a path name.
+  * The returned buffer might be overwritten with subsequent calls.
+  */
+ extern char *path_expand(char *name);
+-- 
+2.15.0
+
+
+From a531b588f256bb4a4f559ffc23e861ca31b9e556 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Sun, 24 Dec 2017 20:17:07 +0700
+Subject: params: allow changing various paths
+
+
+diff --git a/src/params.h b/src/params.h
+index 29e6509..bd1ee50 100644
+--- a/src/params.h
++++ b/src/params.h
+@@ -90,8 +90,10 @@
+ #ifndef JOHN_SYSTEMWIDE_HOME
+ #define JOHN_SYSTEMWIDE_HOME		"/usr/share/john"
+ #endif
++#ifndef JOHN_PRIVATE_HOME
+ #define JOHN_PRIVATE_HOME		"~/.john"
+ #endif
++#endif
+ 
+ #ifndef OMP_FALLBACK
+ #define OMP_FALLBACK			0
+@@ -140,11 +142,19 @@
+ /*
+  * File names.
+  */
++#ifndef CFG_FULL_NAME
+ #define CFG_FULL_NAME			"$JOHN/john.conf"
++#endif
++#ifndef CFG_ALT_NAME
+ #define CFG_ALT_NAME			"$JOHN/john.ini"
++#endif
+ #if JOHN_SYSTEMWIDE
++#ifndef CFG_PRIVATE_FULL_NAME
+ #define CFG_PRIVATE_FULL_NAME		JOHN_PRIVATE_HOME "/john.conf"
++#endif
++#ifndef CFG_PRIVATE_ALT_NAME
+ #define CFG_PRIVATE_ALT_NAME		JOHN_PRIVATE_HOME "/john.ini"
++#endif
+ #define POT_NAME			JOHN_PRIVATE_HOME "/john.pot"
+ #define SEC_POT_NAME			JOHN_PRIVATE_HOME "/secure.pot"
+ #define LOG_NAME			JOHN_PRIVATE_HOME "/john.log"
+-- 
+2.15.0
+
+
+From 58dc5c82ea65bc7ca176b52c2729560bb6be90b6 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Wed, 27 Dec 2017 12:00:07 +0700
+Subject: x86-64: disable SIMD code path for NT fmt on Haiku
+
+
+diff --git a/src/x86-64.S b/src/x86-64.S
+index 80cce05..9905794 100644
+--- a/src/x86-64.S
++++ b/src/x86-64.S
+@@ -1672,6 +1672,7 @@ CPU_detect_fail:
+ 	ret
+ #endif
+ 
++#ifdef NT_X86_64
+ /* The following was written by Alain Espinosa <alainesp at gmail.com> in 2007.
+  * No copyright is claimed, and the software is hereby placed in the public domain.
+  * In case this attempt to disclaim copyright and place the software in the
+@@ -2029,6 +2030,7 @@ nt_crypt_all_8859_1_x86_64:
+ 	xchgq %r8,%rax
+ 	EPILOGUE
+ 	ret
++#endif
+ 
+ #if defined(__ELF__) && defined(__linux__)
+ .section .note.GNU-stack,"",@progbits
+diff --git a/src/x86-64.h b/src/x86-64.h
+index 12dc07a..6696ac0 100644
+--- a/src/x86-64.h
++++ b/src/x86-64.h
+@@ -314,7 +314,9 @@
+ #define MMX_TYPE			" SSE2"
+ #define MMX_COEF			4
+ 
++#ifndef __HAIKU__
+ #define NT_X86_64
++#endif
+ 
+ #define MMX_COEF_SHA256 4
+ #define MMX_COEF_SHA512 2
+-- 
+2.15.0
+


### PR DESCRIPTION
Done as part of GCI 2017

Changes done to JtR:
- Apply upstream patch to fix non-SSE compilation on x86 and gcc 5 compilation on x86_64 (thanks @bach5000 for the pointer)
- Use set_thread_priority for Haiku (upstreamed)
- Disable SIMD codepath for NT format plugin on Haiku x86_64 as the associated assembly is not PIC-compatible
- Make JtR expand "~config", "~data" to user home settings folder and var folder
- Allow changes to default paths on compile time

Known issues:
~~- JtR [won't build](https://0bin.net/paste/fHQN9wP2nozRpSco#jkq10zu3BVsSuxiHLkXjQX52qlwSiYathG9K3oLbMBh) on x86_64. I would appreciate help on this as I'm stuck now~~

Updates:
~~- JtR **still** won't build, except with 1 less issue now, updated log above~~