### PR TITLE
Testing untested recipes for x86_64

### DIFF
--- a/app-text/antiword/antiword-0.37.recipe
+++ b/app-text/antiword/antiword-0.37.recipe
@@ -12,7 +12,7 @@ REVISION="1"
 LICENSE="GNU GPL v2"
 COPYRIGHT="1998-2005 A.J. van Os"
 
-ARCHITECTURES="x86_gcc2 ?x86 ?x86_64"
+ARCHITECTURES="x86_gcc2 ?x86 x86_64"
 
 PROVIDES="
 	antiword = $portVersion

--- a/games-arcade/alienblaster/alienblaster-1.1.0.recipe
+++ b/games-arcade/alienblaster/alienblaster-1.1.0.recipe
@@ -10,7 +10,7 @@ CHECKSUM_SHA256="c4081548c05acdd92df4d721c556f6f2c18a60e2bf5c513cb18690ad9d76998
 SOURCE_DIR="alienblaster"
 PATCHES="alienblaster-1.1.0.patch"
 
-ARCHITECTURES="x86_gcc2 ?x86 ?x86_64"
+ARCHITECTURES="x86_gcc2 ?x86 x86_64"
 
 PROVIDES="
 	alienBlaster = $portVersion

--- a/games-puzzle/lpairs/lpairs-1.0.4.recipe
+++ b/games-puzzle/lpairs/lpairs-1.0.4.recipe
@@ -10,7 +10,7 @@ SOURCE_URI="http://sourceforge.net/projects/lgames/files/lpairs/lpairs-1.0.4.tar
 CHECKSUM_SHA256="350237a51a5de6b2a557af687b4f16678056a0e8d8d96d7e395f6629481462c5"
 PATCHES="lpairs-1.0.4.patchset"
 
-ARCHITECTURES="x86_gcc2 ?x86 ?x86_64"
+ARCHITECTURES="x86_gcc2 ?x86 !x86_64"
 
 PROVIDES="
 	lpairs = $portVersion

--- a/haiku-apps/bdhcalc/bdhcalc-1.1.recipe
+++ b/haiku-apps/bdhcalc/bdhcalc-1.1.recipe
@@ -10,7 +10,7 @@ LICENSE="Zlib"
 REVISION="1"
 SOURCE_URI="git://github.com/HaikuArchives/BDH-Calc.git#6a3433a5fb558f592dd246b400221f2223770e75"
 
-ARCHITECTURES="x86 x86_gcc2 ?x86_64"
+ARCHITECTURES="x86 x86_gcc2 !x86_64"
 
 PROVIDES="
 	bdhcalc = $portVersion

--- a/haiku-apps/helios/helios-1.7.2.recipe
+++ b/haiku-apps/helios/helios-1.7.2.recipe
@@ -7,7 +7,7 @@ REVISION="1"
 SOURCE_URI="git+https://github.com/HaikuArchives/Helios.git#ffbbca7"
 CHECKSUM_SHA256="ce82ede4fd218d3f0c7e30cafc061d2a377e473dbc88512a61e286f21ae51925"
 
-ARCHITECTURES="x86_gcc2 ?x86 ?x86_64"
+ARCHITECTURES="x86_gcc2 ?x86 !x86_64"
 
 PROVIDES="
 	helios = $portVersion

--- a/haiku-apps/ppviewer/ppviewer-1.0.0.recipe
+++ b/haiku-apps/ppviewer/ppviewer-1.0.0.recipe
@@ -8,7 +8,7 @@ LICENSE="MIT"
 REVISION="1"
 SOURCE_URI="git+https://github.com/HaikuArchives/PPViewer#ce572506ca6e69c888898abf5b958701e068122b"
 
-ARCHITECTURES="x86_gcc2 x86 ?x86_64"
+ARCHITECTURES="x86_gcc2 x86 !x86_64"
 
 PROVIDES="
 	ppviewer = $portVersion


### PR DESCRIPTION
I have tested 6 _x86_64_ untested recipes (?x86_64). Here's the result:
1. [haiku-apps/helios-1.7.2](https://github.com/haikuports/haikuports/blob/master/haiku-apps/helios/helios-1.7.2.recipe) - [Failed](https://github.com/haikuports/haikuports/issues/1979)
2. [haiku-apps/ppviewer-1.0.0](https://github.com/haikuports/haikuports/blob/master/haiku-apps/ppviewer/ppviewer-1.0.0.recipe) - [Failed](https://github.com/haikuports/haikuports/issues/1980)
3. [app-text/antiword-0.37](https://github.com/haikuports/haikuports/blob/master/app-text/antiword/antiword-0.37.recipe) - [Success](https://pastebin.com/639Vb6HG)
4. [games-arcade/alienblaster-1.1.0](https://github.com/haikuports/haikuports/blob/master/games-arcade/alienblaster/alienblaster-1.1.0.recipe) - [Success](https://pastebin.com/VkjDpTCX)
5. [haiku-apps/bdhcalc-1.1.recipe](https://github.com/haikuports/haikuports/blob/master/haiku-apps/bdhcalc/bdhcalc-1.1.recipe) - [Failed](https://github.com/haikuports/haikuports/issues/1982)
6. [games-puzzle/lpairs-1.0.4](https://github.com/haikuports/haikuports/blob/master/games-puzzle/lpairs/lpairs-1.0.4.recipe) - [Failed](https://github.com/haikuports/haikuports/issues/1983)