### PR TITLE
mcrypt: new recipe

### DIFF
--- a/app-crypt/mcrypt/mcrypt-2.6.8.recipe
+++ b/app-crypt/mcrypt/mcrypt-2.6.8.recipe
@@ -1,3 +1,4 @@
+SUMMARY="Replacements for the old Unix crypt"
 DESCRIPTION="mcrypt is an enhanced replacement for the old crypt command. It \
 allows users to encrypt files or data streams without having to be \
 cryptographers. mcrypt uses libmcrypt, its companion library, which contains \

--- a/app-crypt/mcrypt/mcrypt-2.6.8.recipe
+++ b/app-crypt/mcrypt/mcrypt-2.6.8.recipe
@@ -1,0 +1,51 @@
+SUMMARY="Replacements for the old Unix crypt"
+DESCRIPTION="mcrypt is an enhanced replacement for the old crypt \
+command. mcrypt allows developers to use a wide range of encryption \
+functions without making drastic changes to their code. It contains the \
+actual encryption functions and provides a standardized mechanism for \
+accessing them."
+HOMEPAGE="http://mcrypt.sourceforge.net/"
+COPYRIGHT="1998-2007 Nikos Mavroyanopoulos"
+LICENSE="GNU GPL v3"
+REVISION="1"
+SOURCE_URI="https://downloads.sourceforge.net/mcrypt/mcrypt-$portVersion.tar.gz"
+CHECKSUM_SHA256="5145aa844e54cca89ddab6fb7dd9e5952811d8d787c4f4bf27eb261e6c182098"
+SOURCE_DIR="mcrypt-$portVersion"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	mcrypt = $portVersion
+	cmd:mcrypt = $portVersion
+	cmd:mdecrypt = $portVersion
+	"
+REQUIRES="
+	haiku
+	lib:libmcrypt
+	lib:libmhash
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	devel:libmcrypt
+	devel:libmhash
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoreconf
+	cmd:gcc
+	cmd:libtoolize
+	cmd:make
+	"
+
+BUILD()
+{
+	autoreconf -vfi
+	runConfigure ./configure
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+}

--- a/app-crypt/mcrypt/mcrypt-2.6.8.recipe
+++ b/app-crypt/mcrypt/mcrypt-2.6.8.recipe
@@ -10,7 +10,7 @@ REVISION="1"
 SOURCE_URI="https://downloads.sourceforge.net/mcrypt/mcrypt-$portVersion.tar.gz"
 CHECKSUM_SHA256="5145aa844e54cca89ddab6fb7dd9e5952811d8d787c4f4bf27eb261e6c182098"
 
-ARCHITECTURES="x86_gcc2 x86 x86_64"
+ARCHITECTURES="x86_gcc2 ?x86 x86_64"
 
 PROVIDES="
 	mcrypt = $portVersion

--- a/app-crypt/mcrypt/mcrypt-2.6.8.recipe
+++ b/app-crypt/mcrypt/mcrypt-2.6.8.recipe
@@ -1,8 +1,7 @@
-SUMMARY="Replacements for the old Unix crypt"
-DESCRIPTION="mcrypt is an enhanced replacement for the old crypt \
-command. mcrypt allows developers to use a wide range of encryption \
-functions without making drastic changes to their code. It contains the \
-actual encryption functions and provides a standardized mechanism for \
+DESCRIPTION="mcrypt is an enhanced replacement for the old crypt command. It \
+allows users to encrypt files or data streams without having to be \
+cryptographers. mcrypt uses libmcrypt, its companion library, which contains \
+the actual encryption functions and provides a standardized mechanism for \
 accessing them."
 HOMEPAGE="http://mcrypt.sourceforge.net/"
 COPYRIGHT="1998-2007 Nikos Mavroyanopoulos"
@@ -10,7 +9,6 @@ LICENSE="GNU GPL v3"
 REVISION="1"
 SOURCE_URI="https://downloads.sourceforge.net/mcrypt/mcrypt-$portVersion.tar.gz"
 CHECKSUM_SHA256="5145aa844e54cca89ddab6fb7dd9e5952811d8d787c4f4bf27eb261e6c182098"
-SOURCE_DIR="mcrypt-$portVersion"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
 

--- a/app-crypt/mcrypt/mcrypt-2.6.8.recipe
+++ b/app-crypt/mcrypt/mcrypt-2.6.8.recipe
@@ -1,4 +1,4 @@
-SUMMARY="Replacements for the old Unix crypt"
+SUMMARY="A replacement for the old Unix crypt command"
 DESCRIPTION="mcrypt is an enhanced replacement for the old crypt command. It \
 allows users to encrypt files or data streams without having to be \
 cryptographers. mcrypt uses libmcrypt, its companion library, which contains \

--- a/app-crypt/mcrypt/mcrypt.OptionalPackageDescription
+++ b/app-crypt/mcrypt/mcrypt.OptionalPackageDescription
@@ -1,5 +1,0 @@
-Package:	mcrypt
-Version:		2.6.8
-Copyright:	1998-2007 Nikos Mavroyanopoulos
-License:		GNU GPL v3
-URL:			http://mcrypt.sourceforge.net/


### PR DESCRIPTION
Add recipe for [mcrypt](http://mcrypt.sourceforge.net/), an enhanced replacement for the old crypt command.