### PR TITLE
jigdo: new recipe

### DIFF
--- a/app-misc/jigdo/jigdo-0.7.3.recipe
+++ b/app-misc/jigdo/jigdo-0.7.3.recipe
@@ -12,17 +12,26 @@ SOURCE_URI="http://atterer.org/sites/atterer/files/2009-08/jigdo/jigdo-$portVers
 CHECKSUM_SHA256="875c069abad67ce67d032a9479228acdb37c8162236c0e768369505f264827f0"
 PATCHES="jigdo-$portVersion.patchset"
 
-ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
+
+commandBinDir=$binDir
+commandSuffix=$secondaryArchSuffix
+if [ "$targetArchitecture" = x86_gcc2 ]
+then
+	commandBinDir=$prefix/bin
+	commandSuffix=
+fi
 
 PROVIDES="
 	jigdo$secondaryArchSuffix = $portVersion
-	cmd:jigdo_file$secondaryArchSuffix = $portVersion
-	cmd:jigdo_lite$secondaryArchSuffix = $portVersion
-	cmd:jigdo_mirror$secondaryArchSuffix = $portVersion
+	cmd:jigdo_file$commandSuffix = $portVersion
+	cmd:jigdo_lite$commandSuffix = $portVersion
+	cmd:jigdo_mirror$commandSuffix = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	cmd:wget
 	lib:libbz2$secondaryArchSuffix
 	lib:libdb$secondaryArchSuffix
 	lib:libintl$secondaryArchSuffix
@@ -37,15 +46,19 @@ BUILD_REQUIRES="
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
+	cmd:awk
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:wget$secondaryArchSuffix
 	"
+
+defineDebugInfoPackage jigdo$secondaryArchSuffix \
+	$commandBinDir/jigdo-file
 
 BUILD()
 {
-	runConfigure --omit-dirs "docDir dataRootDir" ./configure
+	runConfigure --omit-dirs "binDir docDir dataRootDir" ./configure \
+		--bindir $commandBinDir --without-gtk
 	make $jobArgs
 }
 

--- a/app-misc/jigdo/jigdo-0.7.3.recipe
+++ b/app-misc/jigdo/jigdo-0.7.3.recipe
@@ -31,7 +31,7 @@ REQUIRES="
 	"
 
 BUILD_REQUIRES="
-	haiku$(secondaryArchSuffix)_devel
+	haiku${secondaryArchSuffix}_devel
 	devel:libbz2$secondaryArchSuffix
 	devel:libdb$secondaryArchSuffix
 	devel:libintl$secondaryArchSuffix

--- a/app-misc/jigdo/jigdo-0.7.3.recipe
+++ b/app-misc/jigdo/jigdo-0.7.3.recipe
@@ -46,7 +46,7 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	./configure --bindir=$binDir --mandir=$manDir --datadir=$dataDir
+	runConfigure --omit-dirs "docDir dataRootDir" ./configure
 	make $jobArgs
 }
 

--- a/app-misc/jigdo/jigdo-0.7.3.recipe
+++ b/app-misc/jigdo/jigdo-0.7.3.recipe
@@ -1,9 +1,9 @@
 SUMMARY="Ease the distribution of files"
-DESCRIPTION="Jigsaw Download, or short jigdo, is a tool designed to \
-ease the distribution of very large files over the internet, for example \
-CD or DVD images. Its aim is to make downloading the images as easy for users \
-as a click on a direct download link in a browser, while avoiding all the \
-problems that server administrators have with hosting such large files."
+DESCRIPTION="Jigsaw Download, or short jigdo, is a tool designed to ease the distribution \
+of very large files over the internet, for example CD or DVD images. Its aim is \
+to make downloading the images as easy for users as a click on a direct \
+download link in a browser, while avoiding all the problems that server \
+administrators have with hosting such large files."
 HOMEPAGE="http://atterer.org/jigdo/"
 COPYRIGHT="2001-2006 Richard Atterer"
 LICENSE="GNU GPL v2"
@@ -12,41 +12,50 @@ SOURCE_URI="http://atterer.org/sites/atterer/files/2009-08/jigdo/jigdo-$portVers
 CHECKSUM_SHA256="875c069abad67ce67d032a9479228acdb37c8162236c0e768369505f264827f0"
 PATCHES="jigdo-$portVersion.patchset"
 
-ARCHITECTURES="x86_gcc2 ?x86 x86_64"
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	jigdo = $portVersion
-	cmd:jigdo = $portVersion
+	jigdo$secondaryArchSuffix = $portVersion
+	cmd:jigdo$secondaryArchSuffix = $portVersion
+	cmd:jigdo_file$secondaryArchSuffix = $portVersion
+	cmd:jigdo_lite$secondaryArchSuffix = $portVersion
+	cmd:jigdo_mirror$secondaryArchSuffix = $portVersion
 	"
 REQUIRES="
-	haiku
-	lib:libbz2
-	lib:libdb
-	lib:libgettextlib
-	lib:libz
+	haiku$secondaryArchSuffix
+	lib:libbz2$secondaryArchSuffix
+	lib:libdb$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
-	devel:libbz2
-	devel:libdb
-	devel:libgettextlib
-	devel:libz
+	haiku$(secondaryArchSuffix)_devel
+	devel:libbz2$secondaryArchSuffix
+	devel:libdb$secondaryArchSuffix
+	devel:libintl$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:gcc
+	cmd:gcc$secondaryArchSuffix
 	cmd:make
-	cmd:pkg_config
-	cmd:wget
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:wget$secondaryArchSuffix
 	"
 
 BUILD()
 {
-	./configure
+	./configure --bindir=$binDir --mandir=$manDir --datadir=$dataDir
 	make $jobArgs
 }
 
 INSTALL()
 {
 	make install
+}
+
+TEST()
+{
+	make test
 }

--- a/app-misc/jigdo/jigdo-0.7.3.recipe
+++ b/app-misc/jigdo/jigdo-0.7.3.recipe
@@ -1,9 +1,9 @@
-SUMMARY="Ease the distribution of files"
-DESCRIPTION="Jigsaw Download, or short jigdo, is a tool designed to ease the distribution \
-of very large files over the internet, for example CD or DVD images. Its aim is \
-to make downloading the images as easy for users as a click on a direct \
-download link in a browser, while avoiding all the problems that server \
-administrators have with hosting such large files."
+SUMMARY="A tool to ease the distribution of very large files"
+DESCRIPTION="Jigsaw Download, or short jigdo, is a tool designed to ease the \
+distribution of very large files over the internet, for example CD or DVD \
+images. Its aim is to make downloading the images as easy for users as a click \
+on a direct download link in a browser, while avoiding all the problems that \
+server administrators have with hosting such large files."
 HOMEPAGE="http://atterer.org/jigdo/"
 COPYRIGHT="2001-2006 Richard Atterer"
 LICENSE="GNU GPL v2"

--- a/app-misc/jigdo/jigdo-0.7.3.recipe
+++ b/app-misc/jigdo/jigdo-0.7.3.recipe
@@ -1,0 +1,52 @@
+SUMMARY="Ease the distribution of files"
+DESCRIPTION="Jigsaw Download, or short jigdo, is a tool designed to \
+ease the distribution of very large files over the internet, for example \
+CD or DVD images. Its aim is to make downloading the images as easy for users \
+as a click on a direct download link in a browser, while avoiding all the \
+problems that server administrators have with hosting such large files."
+HOMEPAGE="http://atterer.org/jigdo/"
+COPYRIGHT="2001-2006 Richard Atterer"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="http://atterer.org/sites/atterer/files/2009-08/jigdo/jigdo-$portVersion.tar.bz2"
+CHECKSUM_SHA256="875c069abad67ce67d032a9479228acdb37c8162236c0e768369505f264827f0"
+PATCHES="jigdo-$portVersion.patchset"
+
+ARCHITECTURES="x86_gcc2 ?x86 x86_64"
+
+PROVIDES="
+	jigdo = $portVersion
+	cmd:jigdo = $portVersion
+	"
+REQUIRES="
+	haiku
+	lib:libbz2
+	lib:libdb
+	lib:libgettextlib
+	lib:libz
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	devel:libbz2
+	devel:libdb
+	devel:libgettextlib
+	devel:libz
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc
+	cmd:make
+	cmd:pkg_config
+	cmd:wget
+	"
+
+BUILD()
+{
+	./configure
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+}

--- a/app-misc/jigdo/jigdo-0.7.3.recipe
+++ b/app-misc/jigdo/jigdo-0.7.3.recipe
@@ -17,7 +17,6 @@ SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	jigdo$secondaryArchSuffix = $portVersion
-	cmd:jigdo$secondaryArchSuffix = $portVersion
 	cmd:jigdo_file$secondaryArchSuffix = $portVersion
 	cmd:jigdo_lite$secondaryArchSuffix = $portVersion
 	cmd:jigdo_mirror$secondaryArchSuffix = $portVersion
@@ -57,5 +56,5 @@ INSTALL()
 
 TEST()
 {
-	make test
+	make check
 }

--- a/app-misc/jigdo/patches/jigdo-0.7.3.patchset
+++ b/app-misc/jigdo/patches/jigdo-0.7.3.patchset
@@ -1,0 +1,58 @@
+From 3226f395702e65af17db4c06348e68d088515ce7 Mon Sep 17 00:00:00 2001
+From: nys <33534144+nysnatuss@users.noreply.github.com>
+Date: Sun, 31 Dec 2017 00:25:20 +0000
+Subject: patch jigdo
+
+
+diff --git a/src/compat.hh b/src/compat.hh
+index 3a7ac9a..17c0887 100644
+--- a/src/compat.hh
++++ b/src/compat.hh
+@@ -20,6 +20,7 @@
+ 
+ #include <string>
+ #include <stdio.h>
++#include <stdlib.h>
+ #include <unistd-jigdo.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
+diff --git a/src/recursedir.cc b/src/recursedir.cc
+index 794ece0..7134510 100644
+--- a/src/recursedir.cc
++++ b/src/recursedir.cc
+@@ -37,6 +37,7 @@
+ #include <sys/types.h>
+ #include <unistd-jigdo.h>
+ 
++#include <cstring>
+ #include <string.hh>
+ //______________________________________________________________________
+ 
+diff --git a/src/util/configfile.cc b/src/util/configfile.cc
+index 3a19cb2..568d70b 100644
+--- a/src/util/configfile.cc
++++ b/src/util/configfile.cc
+@@ -18,6 +18,7 @@
+ 
+ #include <iostream>
+ #include <fstream>
++#include <cstring>
+ 
+ #include <configfile.hh>
+ #include <string.hh>
+diff --git a/src/util/md5sum.hh b/src/util/md5sum.hh
+index 793a5e2..fbfe226 100644
+--- a/src/util/md5sum.hh
++++ b/src/util/md5sum.hh
+@@ -30,7 +30,7 @@
+ 
+ #include <cstdlib>
+ #include <iosfwd>
+-#include <string>
++#include <string.h>
+ 
+ #include <bstream.hh>
+ #include <debug.hh>
+-- 
+2.15.0
+

--- a/app-misc/jigdo/patches/jigdo-0.7.3.patchset
+++ b/app-misc/jigdo/patches/jigdo-0.7.3.patchset
@@ -12,7 +12,7 @@ index 3a7ac9a..17c0887 100644
  
  #include <string>
  #include <stdio.h>
-+#include <stdlib.h>
++#include <cstdlib>
  #include <unistd-jigdo.h>
  #include <sys/stat.h>
  #include <sys/types.h>
@@ -49,7 +49,7 @@ index 793a5e2..fbfe226 100644
  #include <cstdlib>
  #include <iosfwd>
 -#include <string>
-+#include <string.h>
++#include <cstring>
  
  #include <bstream.hh>
  #include <debug.hh>


### PR DESCRIPTION
Creates recipe for [jigdo](http://atterer.org/jigdo/), a tool designed to ease the distribution of very large files over the internet, for example CD or DVD images.