### PR TITLE
dev-util/pkgconf: new recipe

### DIFF
--- a/dev-libs/atf/atf-0.21.recipe
+++ b/dev-libs/atf/atf-0.21.recipe
@@ -1,0 +1,112 @@
+SUMMARY="Libraries to write tests in C, C++ and shell"
+DESCRIPTION="ATF, or Automated Testing Framework, is a collection of libraries \
+to write test programs in C, C++ and POSIX shell.
+
+The ATF libraries offer a simple API. The API is orthogonal through \
+the various bindings, allowing developers to quickly learn how to write \
+test programs in different languages.
+
+ATF-based test programs offer a consistent end-user command-line interface to \
+allow both humans and automation to run the tests.
+
+ATF-based test programs rely on an execution engine to be run and \
+this execution engine is not shipped with ATF. Kyua is the engine of choice."
+HOMEPAGE="https://github.com/jmmv/atf"
+COPYRIGHT="2007-2012 The NetBSD Foundation, Inc.
+	2011, 2012, 2014 Google Inc."
+LICENSE="BSD (2-clause)
+	BSD (3-clause)"
+REVISION="1"
+SOURCE_URI="https://github.com/jmmv/atf/releases/download/atf-$portVersion/atf-$portVersion.tar.gz"
+CHECKSUM_SHA256="92bc64180135eea8fe84c91c9f894e678767764f6dbc8482021d4dde09857505"
+PATCHES="atf-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+commandSuffix="$secondaryArchSuffix"
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=""
+fi
+
+libVersion="1.0.0"
+libCppVersion="2.0.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+libCppVersionCompat="$libCppVersion compat >= ${libCppVersion%%.*}"
+
+PROVIDES="
+	atf$secondaryArchSuffix = $portVersion
+	cmd:atf_sh$secondaryArchSuffix = $portVersion
+	lib:libatf_c$secondaryArchSuffix = $libVersionCompat
+	lib:libatf_c++$secondaryArchSuffix = $libCppVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	atf${secondaryArchSuffix}_devel = $portVersion
+	devel:libatf_c$secondaryArchSuffix = $libVersionCompat
+	devel:libatf_c++$secondaryArchSuffix = $libCppVersionCompat
+	"
+REQUIRES_devel="
+	atf$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:autoconf
+	cmd:awk
+	cmd:g++$secondaryArchSuffix
+	cmd:gcc$secondaryArchSuffix
+	cmd:grep
+	cmd:make
+	cmd:sed
+	"
+
+TEST_REQUIRES="
+	cmd:kyua$commandSuffix
+	"
+
+defineDebugInfoPackage atf$secondaryArchSuffix \
+	"$binDir/atf-sh" \
+	"$libDir/libatf-c.so.$libVersion" \
+	"$libDir/libatf-c++.so.$libCppVersion"
+
+BUILD()
+{
+	CPPFLAGS="-D_BSD_SOURCE" LIBS="-Wl,--as-needed -lbsd" \
+	runConfigure --omit-dirs "libExecDir" ./configure \
+		--libexecdir="$libExecDir/atf" \
+		--enable-developer=no
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	rm "$docDir"/{COPYING,README}
+
+	rm -rf "$prefix/tests"
+	rm -f "$libDir"/*.la
+
+	prepareInstalledDevelLibs libatf-c++ libatf-c
+	fixPkgconfig
+	# Turns out their .pc files don't have ${prefix}
+	sed -e "s|\${prefix}|$prefix|g" -i "$developLibDir/pkgconfig"/*.pc
+	sed \
+		-e "s|\${exec_prefix}/bin/atf-sh|$binDir/atf-sh|" \
+		-i "$developLibDir/pkgconfig/atf-sh.pc"
+	packageEntries devel \
+		"$developDir" \
+		"$dataDir/aclocal" \
+		"$manDir/man3"/atf-c*
+}
+
+TEST()
+{
+	CPATH="$PWD" kyua test
+}

--- a/dev-libs/atf/patches/atf-0.21.patchset
+++ b/dev-libs/atf/patches/atf-0.21.patchset
@@ -1,0 +1,129 @@
+From f498f903f70b7b80fe62ff3fb4da4a342758eb47 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Sun, 31 Dec 2017 10:22:49 +0700
+Subject: add Haiku support
+
+
+diff --git a/atf-c++/check_test.cpp b/atf-c++/check_test.cpp
+index 7baf3fa..aa9b9b6 100644
+--- a/atf-c++/check_test.cpp
++++ b/atf-c++/check_test.cpp
+@@ -292,7 +292,11 @@ ATF_TEST_CASE_BODY(exec_exitstatus)
+             do_exec(this, "exit-signal");
+         ATF_REQUIRE(!r->exited());
+         ATF_REQUIRE(r->signaled());
++#if defined(__HAIKU__)
++        ATF_REQUIRE_EQ(r->termsig(), SIGKILLTHR);
++#else
+         ATF_REQUIRE_EQ(r->termsig(), SIGKILL);
++#endif
+     }
+ }
+ 
+diff --git a/atf-c++/detail/fs.cpp b/atf-c++/detail/fs.cpp
+index bcef920..3476608 100644
+--- a/atf-c++/detail/fs.cpp
++++ b/atf-c++/detail/fs.cpp
+@@ -32,7 +32,9 @@
+ extern "C" {
+ #include <sys/param.h>
+ #include <sys/types.h>
++#ifndef __HAIKU__
+ #include <sys/mount.h>
++#endif
+ #include <sys/stat.h>
+ #include <sys/wait.h>
+ #include <dirent.h>
+diff --git a/atf-c/check_test.c b/atf-c/check_test.c
+index adaca64..b84337f 100644
+--- a/atf-c/check_test.c
++++ b/atf-c/check_test.c
+@@ -385,7 +385,11 @@ ATF_TC_BODY(exec_exitstatus, tc)
+         do_exec(tc, "exit-signal", &result);
+         ATF_CHECK(!atf_check_result_exited(&result));
+         ATF_CHECK(atf_check_result_signaled(&result));
++#if defined(__HAIKU__)
++        ATF_CHECK(atf_check_result_termsig(&result) == SIGKILLTHR);
++#else
+         ATF_CHECK(atf_check_result_termsig(&result) == SIGKILL);
++#endif
+         atf_check_result_fini(&result);
+     }
+ }
+diff --git a/atf-c/detail/fs.c b/atf-c/detail/fs.c
+index 5ff7648..4740bbd 100644
+--- a/atf-c/detail/fs.c
++++ b/atf-c/detail/fs.c
+@@ -31,7 +31,9 @@
+ 
+ #include <sys/types.h>
+ #include <sys/param.h>
++#ifndef __HAIKU__
+ #include <sys/mount.h>
++#endif
+ #include <sys/stat.h>
+ #include <sys/wait.h>
+ 
+diff --git a/atf-c/detail/process_test.c b/atf-c/detail/process_test.c
+index 5ae5565..9ce030b 100644
+--- a/atf-c/detail/process_test.c
++++ b/atf-c/detail/process_test.c
+@@ -635,7 +635,11 @@ ATF_TC_BODY(status_signaled, tc)
+         RE(atf_process_status_init(&s, rawstatus));
+         ATF_CHECK(!atf_process_status_exited(&s));
+         ATF_CHECK(atf_process_status_signaled(&s));
++#if defined(__HAIKU__)
++        ATF_CHECK_EQ(atf_process_status_termsig(&s), SIGKILLTHR);
++#else
+         ATF_CHECK_EQ(atf_process_status_termsig(&s), SIGKILL);
++#endif
+         ATF_CHECK(!atf_process_status_coredump(&s));
+         atf_process_status_fini(&s);
+     }
+-- 
+2.15.0
+
+
+From 26850579ebf31b997bbdd3ea2b29db0b85a78494 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Fri, 5 Jan 2018 20:38:11 +0700
+Subject: tests: disable tests that requires atf installed
+
+
+diff --git a/Kyuafile b/Kyuafile
+index a65bb53..d85251d 100644
+--- a/Kyuafile
++++ b/Kyuafile
+@@ -4,5 +4,3 @@ test_suite("atf")
+ 
+ include("atf-c/Kyuafile")
+ include("atf-c++/Kyuafile")
+-include("atf-sh/Kyuafile")
+-include("test-programs/Kyuafile")
+diff --git a/atf-c++/Kyuafile b/atf-c++/Kyuafile
+index 9fd43af..5de8481 100644
+--- a/atf-c++/Kyuafile
++++ b/atf-c++/Kyuafile
+@@ -6,7 +6,6 @@ atf_test_program{name="atf_c++_test"}
+ atf_test_program{name="build_test"}
+ atf_test_program{name="check_test"}
+ atf_test_program{name="macros_test"}
+-atf_test_program{name="pkg_config_test"}
+ atf_test_program{name="tests_test"}
+ atf_test_program{name="utils_test"}
+ 
+diff --git a/atf-c/Kyuafile b/atf-c/Kyuafile
+index 40fdb92..fa471c9 100644
+--- a/atf-c/Kyuafile
++++ b/atf-c/Kyuafile
+@@ -7,7 +7,6 @@ atf_test_program{name="build_test"}
+ atf_test_program{name="check_test"}
+ atf_test_program{name="error_test"}
+ atf_test_program{name="macros_test"}
+-atf_test_program{name="pkg_config_test"}
+ atf_test_program{name="tc_test"}
+ atf_test_program{name="tp_test"}
+ atf_test_program{name="utils_test"}
+-- 
+2.15.0
+

--- a/dev-lua/lutok/lutok-0.4.recipe
+++ b/dev-lua/lutok/lutok-0.4.recipe
@@ -1,0 +1,103 @@
+SUMMARY="A lightweight C++ API library for Lua"
+DESCRIPTION="Lutok provides thin C++ wrappers around the Lua C API to ease the \
+interaction between C++ and Lua. These wrappers make intensive use of RAII to \
+prevent resource leakage, expose C++-friendly data types, report errors by means \
+of exceptions and ensure that the Lua stack is always left untouched in the face \
+of errors. The library also provides a small subset of miscellaneous utility \
+functions built on top of the wrappers.
+
+Lutok focuses on providing a clean and safe C++ interface; the drawback is that \
+it is not suitable for performance-critical environments. In order to implement \
+error-safe C++ wrappers on top of a Lua C binary library, Lutok adds several \
+layers of abstraction and error checking that go against the original spirit of \
+the Lua C API and thus degrade performance."
+HOMEPAGE="https://github.com/jmmv/lutok"
+COPYRIGHT="2011, 2012, 2014 Google Inc"
+LICENSE="BSD (3-clause)"
+REVISION="1"
+SOURCE_URI="https://github.com/jmmv/lutok/releases/download/lutok-$portVersion/lutok-$portVersion.tar.gz"
+CHECKSUM_SHA256="2cec51efa0c8d65ace8b21eaa08384b77abc5087b46e785f78de1c21fb754cd5"
+
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+commandSuffix="$secondaryArchSuffix"
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=""
+fi
+
+libVersion="3.0.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	lutok$secondaryArchSuffix = $portVersion
+	lib:liblutok$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:liblua$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	lutok${secondaryArchSuffix}_devel = $portVersion
+	devel:liblutok$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	lutok$secondaryArchSuffix == $portVersion base
+	devel:liblua$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:liblua$secondaryArchSuffix
+	devel:libatf_c++$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:atf_sh$secondaryArchSuffix
+	cmd:awk
+	cmd:diff
+	cmd:doxygen
+	cmd:g++$secondaryArchSuffix
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:sed
+	"
+
+TEST_REQUIRES="
+	cmd:kyua$commandSuffix
+	"
+
+defineDebugInfoPackage lutok$secondaryArchSuffix \
+	"$libDir/liblutok.so.$libVersion"
+
+BUILD()
+{
+	runConfigure --omit-dirs docDir ./configure \
+		--docdir="$developDocDir" \
+		--enable-developer=no
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	install -d -m 755 "$docDir"
+	mv "$developDocDir/AUTHORS" "$docDir"
+	rm "$developDocDir"/{README,COPYING}
+
+	rm -f "$libDir"/*.la
+	rm -rf "$prefix"/tests
+
+	prepareInstalledDevelLib liblutok
+	fixPkgconfig
+	# Not all .pc file use ${prefix}
+	sed -e "s|\${prefix}|$prefix|g" -i "$developLibDir/pkgconfig/lutok.pc"
+	packageEntries devel "$developDir"
+}
+
+TEST()
+{
+	make check
+}

--- a/dev-util/kyua/kyua-0.13.recipe
+++ b/dev-util/kyua/kyua-0.13.recipe
@@ -1,0 +1,97 @@
+SUMMARY="A testing framework for infrastructure software"
+DESCRIPTION="Kyua is a testing framework for infrastructure software, \
+originally designed to equip BSD-based operating systems with a test suite. \
+This means that Kyua is lightweight and simple, and that Kyua integrates well \
+with various build systems and continuous integration frameworks.
+
+Kyua features an expressive test suite definition language, a safe runtime \
+engine for test suites and a powerful report generation engine.
+
+Kyua is for both developers and users, from the developer applying a simple \
+fix to a library to the system administrator deploying a new release on a \
+production machine.
+
+Kyua is able to execute test programs written with a plethora of testing \
+libraries and languages. The library of choice is ATF, for which Kyua was \
+originally designed, but simple, framework-less test programs and \
+TAP-compliant test programs can also be executed through Kyua."
+HOMEPAGE="https://github.com/jmmv/kyua"
+COPYRIGHT="2010-2015 The Kyua Authors"
+LICENSE="BSD (3-clause)"
+REVISION="1"
+SOURCE_URI="https://github.com/jmmv/kyua/releases/download/kyua-$portVersion/kyua-$portVersion.tar.gz"
+CHECKSUM_SHA256="db6e5d341d5cf7e49e50aa361243e19087a00ba33742b0855d2685c0b8e721d6"
+PATCHES="kyua-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+PROVIDES="
+	kyua$secondaryArchSuffix = $portVersion
+	cmd:kyua$commandSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:liblua$secondaryArchSuffix
+	lib:liblutok$secondaryArchSuffix
+	lib:libsqlite3$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libatf_c++$secondaryArchSuffix
+	devel:liblutok$secondaryArchSuffix
+	devel:libsqlite3$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoreconf
+	cmd:awk
+	cmd:doxygen
+	cmd:g++$secondaryArchSuffix
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:sed
+	"
+
+TEST_REQUIRES="
+	cmd:find
+	cmd:sqlite3
+	"
+
+USER_SETTINGS_FILES="
+	settings/kyua directory
+	settings/kyua/kyua.conf template $dataDir/kyua/examples/kyua.conf"
+
+defineDebugInfoPackage kyua$secondaryArchSuffix \
+	"$commandBinDir/kyua"
+
+BUILD()
+{
+	autoreconf -vfi
+	LIBS="-Wl,--as-needed -lbe" \
+	runConfigure --omit-dirs "binDir settingsDir" ./configure \
+		--bindir=$commandBinDir --enable-developer=no
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	rm -rf "$prefix/tests"
+	rm "$docDir"/{LICENSE,CONTRIBUTING.md}
+}
+
+TEST()
+{
+	make check
+}

--- a/dev-util/kyua/patches/kyua-0.13.patchset
+++ b/dev-util/kyua/patches/kyua-0.13.patchset
@@ -1,0 +1,671 @@
+From 235280aa551819a75c09da858a6451e9260488f7 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Mon, 1 Jan 2018 22:35:07 +0700
+Subject: utils/process/child_test: fix type mismatch
+
+Align pipe_fail with syscall_pipe definition
+
+diff --git a/utils/process/child_test.cpp b/utils/process/child_test.cpp
+index 8996c31..2641716 100644
+--- a/utils/process/child_test.cpp
++++ b/utils/process/child_test.cpp
+@@ -256,7 +256,7 @@ open_fail(const char* path, const int flags, ...) throw()
+ ///
+ /// \return Always -1.
+ template< int Errno >
+-static pid_t
++static int
+ pipe_fail(int* UTILS_UNUSED_PARAM(fildes)) throw()
+ {
+     errno = Errno;
+-- 
+2.16.2
+
+
+From ea5b2176fc2fb7b89a14d39469fc33814506e84f Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Wed, 3 Jan 2018 20:56:21 +0700
+Subject: kyua: use Haiku user directory
+
+This broke a lot of tests that assume kyua will save it's data in
+$HOME/.kyua
+
+diff --git a/cli/common.cpp b/cli/common.cpp
+index 9204082..b937bdd 100644
+--- a/cli/common.cpp
++++ b/cli/common.cpp
+@@ -121,9 +121,9 @@ namespace {
+ static optional< fs::path >
+ get_historical_db(void)
+ {
+-    optional< fs::path > home = utils::get_home();
+-    if (home) {
+-        const fs::path old_db = home.get() / ".kyua/store.db";
++    optional< fs::path > data_dir = utils::get_home_data();
++    if (data_dir) {
++        const fs::path old_db = data_dir.get() / "store.db";
+         if (fs::exists(old_db)) {
+             if (old_db.is_absolute())
+                 return utils::make_optional(old_db);
+diff --git a/cli/config.cpp b/cli/config.cpp
+index 0049103..d35a533 100644
+--- a/cli/config.cpp
++++ b/cli/config.cpp
+@@ -101,9 +101,9 @@ load_config_file(const cmdline::parsed_cmdline& cmdline)
+     } else if (filename.str() != cli::config_option.default_value())
+         return engine::load_config(filename);
+ 
+-    const optional< fs::path > home = utils::get_home();
+-    if (home) {
+-        const fs::path path = home.get() / ".kyua" / config_basename;
++    const optional< fs::path > conf_home = utils::get_home_config();
++    if (conf_home) {
++        const fs::path path = conf_home.get() / config_basename;
+         try {
+             if (fs::exists(path))
+                 return engine::load_config(path);
+diff --git a/cli/main.cpp b/cli/main.cpp
+index 531c252..67820cd 100644
+--- a/cli/main.cpp
++++ b/cli/main.cpp
+@@ -239,10 +239,10 @@ fs::path
+ cli::detail::default_log_name(void)
+ {
+     // Update doc/troubleshooting.texi if you change this algorithm.
+-    const optional< std::string > home(utils::getenv("HOME"));
+-    if (home) {
+-        return logging::generate_log_name(fs::path(home.get()) / ".kyua" /
+-                                          "logs", cmdline::progname());
++    const optional< fs::path > data_home = utils::get_home_data();
++    if (data_home) {
++        return logging::generate_log_name(data_home.get() / "logs",
++                                          cmdline::progname());
+     } else {
+         const optional< std::string > tmpdir(utils::getenv("TMPDIR"));
+         if (tmpdir) {
+diff --git a/store/layout.cpp b/store/layout.cpp
+index 6bc67a8..b5f39d2 100644
+--- a/store/layout.cpp
++++ b/store/layout.cpp
+@@ -228,13 +228,13 @@ layout::new_db_for_migration(const fs::path& root,
+ fs::path
+ layout::query_store_dir(void)
+ {
+-    const optional< fs::path > home = utils::get_home();
+-    if (home) {
+-        const fs::path& home_path = home.get();
+-        if (home_path.is_absolute())
+-            return home_path / ".kyua/store";
++    const optional< fs::path > home_data = utils::get_home_data();
++    if (home_data) {
++        const fs::path& data_path = home_data.get();
++        if (data_path.is_absolute())
++            return data_path / "store";
+         else
+-            return home_path.to_absolute() / ".kyua/store";
++            return data_path.to_absolute() / "store";
+     } else {
+         LW("HOME not defined; creating store database in current "
+            "directory");
+diff --git a/utils/env.cpp b/utils/env.cpp
+index b0d995c..2a495bc 100644
+--- a/utils/env.cpp
++++ b/utils/env.cpp
+@@ -31,6 +31,10 @@
+ #if defined(HAVE_CONFIG_H)
+ #  include "config.h"
+ #endif
++#if defined(__HAIKU__)
++#  include <Path.h>
++#  include <FindDirectory.h>
++#endif
+ 
+ #include <cerrno>
+ #include <cstdlib>
+@@ -139,6 +143,54 @@ utils::get_home(void)
+ }
+ 
+ 
++/// Get the kyua user configuration directory.
++///
++/// \return The directory where kyua user configuration files should be found
++optional< fs::path >
++utils::get_home_config(void)
++{
++#if defined(__HAIKU__)
++    BPath conf_path;
++    if (find_directory(B_USER_SETTINGS_DIRECTORY, &conf_path) == B_OK) {
++        return utils::make_optional(fs::path(conf_path.Path()) / "kyua");
++    } else {
++        return none;
++    }
++#else
++    const optional< fs::path > home = utils::get_home();
++    if (home) {
++        return utils::make_optional(home.get() / ".kyua");
++    } else {
++        return none;
++    }
++#endif
++}
++
++
++/// Get the kyua user data directory.
++///
++/// \return The directory where kyua user data should be saved.
++optional< fs::path >
++utils::get_home_data(void)
++{
++#if defined(__HAIKU__)
++    BPath data_path;
++    if (find_directory(B_USER_VAR_DIRECTORY, &data_path) == B_OK) {
++        return utils::make_optional(fs::path(data_path.Path()) / "kyua");
++    } else {
++        return none;
++    }
++#else
++    const optional< fs::path > home = utils::get_home();
++    if (home) {
++        return utils::make_optional(home.get() / ".kyua");
++    } else {
++        return none;
++    }
++#endif
++}
++
++
+ /// Sets the value of an environment variable.
+ ///
+ /// \param name The name of the environment variable to set.
+diff --git a/utils/env.hpp b/utils/env.hpp
+index 2370ee4..a60ca5e 100644
+--- a/utils/env.hpp
++++ b/utils/env.hpp
+@@ -49,6 +49,8 @@ std::map< std::string, std::string > getallenv(void);
+ optional< std::string > getenv(const std::string&);
+ std::string getenv_with_default(const std::string&, const std::string&);
+ optional< utils::fs::path > get_home(void);
++optional< utils::fs::path > get_home_config(void);
++optional< utils::fs::path > get_home_data(void);
+ void setenv(const std::string&, const std::string&);
+ void unsetenv(const std::string&);
+ 
+-- 
+2.16.2
+
+
+From ea4b248c9731d9c782f2e0dc37e58942bbce00b1 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Wed, 3 Jan 2018 21:05:37 +0700
+Subject: utils/process/operations_test: fixes
+
+This commit allow operations_test to compile on OSes that doesn't
+have WCOREDUMP as this macro is non-standard
+
+diff --git a/utils/process/operations_test.cpp b/utils/process/operations_test.cpp
+index e9c1ebb..708a740 100644
+--- a/utils/process/operations_test.cpp
++++ b/utils/process/operations_test.cpp
+@@ -353,7 +353,9 @@ ATF_TEST_CASE_BODY(terminate_self_with__termsig)
+     ATF_REQUIRE(::wait(&status) != -1);
+     ATF_REQUIRE(WIFSIGNALED(status));
+     ATF_REQUIRE(WTERMSIG(status) == SIGKILL);
++#if defined(WCOREDUMP)
+     ATF_REQUIRE(!WCOREDUMP(status));
++#endif
+ }
+ 
+ 
+@@ -374,7 +376,11 @@ ATF_TEST_CASE_BODY(terminate_self_with__termsig_and_core)
+     ATF_REQUIRE(::wait(&status) != -1);
+     ATF_REQUIRE(WIFSIGNALED(status));
+     ATF_REQUIRE(WTERMSIG(status) == SIGABRT);
++#if defined(WCOREDUMP)
+     ATF_REQUIRE(WCOREDUMP(status));
++#else
++    expect_fail("Platform does not checking for coredump");
++#endif
+ }
+ 
+ 
+-- 
+2.16.2
+
+
+From 9bdf4754429fd3ee72e8309eb02879b1ea94a925 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Thu, 4 Jan 2018 11:54:25 +0700
+Subject: utils/fs/directory: use dirent correctly
+
+
+diff --git a/utils/fs/directory.cpp b/utils/fs/directory.cpp
+index ff7ad5e..c6794e5 100644
+--- a/utils/fs/directory.cpp
++++ b/utils/fs/directory.cpp
+@@ -32,6 +32,7 @@ extern "C" {
+ #include <sys/types.h>
+ 
+ #include <dirent.h>
++#include <unistd.h>
+ }
+ 
+ #include <cerrno>
+@@ -131,7 +132,7 @@ struct utils::fs::detail::directory_iterator::impl : utils::noncopyable {
+     ///
+     /// We need to keep this at the class level so that we can use the
+     /// readdir_r(3) function.
+-    ::dirent _dirent;
++    ::dirent* _dirent;
+ 
+     /// Custom representation of the directory entry.
+     ///
+@@ -141,7 +142,7 @@ struct utils::fs::detail::directory_iterator::impl : utils::noncopyable {
+     std::auto_ptr< directory_entry > _entry;
+ 
+     /// Constructs an iterator pointing to the "end" of the directory.
+-    impl(void) : _path("invalid-directory-entry"), _dirp(NULL)
++    impl(void) : _path("invalid-directory-entry"), _dirp(NULL), _dirent(NULL)
+     {
+     }
+ 
+@@ -160,6 +161,16 @@ struct utils::fs::detail::directory_iterator::impl : utils::noncopyable {
+         }
+         _dirp = dirp;
+ 
++        long name_max = pathconf(_path.c_str(), _PC_NAME_MAX);
++        if (name_max == -1)
++#if defined(NAME_MAX)
++            name_max = NAME_MAX;
++#else
++            name_max = 256; /* Wild guess */
++#endif
++        const size_t length = offsetof(::dirent, d_name) + name_max + 1;
++        _dirent = static_cast< ::dirent* >(operator new(length));
++
+         // Initialize our first directory entry.  Note that this may actually
+         // close the directory we just opened if the directory happens to be
+         // empty -- but directories are never empty because they at least have
+@@ -174,6 +185,8 @@ struct utils::fs::detail::directory_iterator::impl : utils::noncopyable {
+     {
+         if (_dirp != NULL)
+             close();
++        delete _dirent;
++        _dirent = NULL;
+     }
+ 
+     /// Closes the directory and invalidates the iterator.
+@@ -198,7 +211,7 @@ struct utils::fs::detail::directory_iterator::impl : utils::noncopyable {
+     {
+         ::dirent* result;
+ 
+-        if (::readdir_r(_dirp, &_dirent, &result) == -1) {
++        if (::readdir_r(_dirp, _dirent, &result) == -1) {
+             const int original_errno = errno;
+             throw fs::system_error(F("readdir_r(%s) failed") % _path,
+                                    original_errno);
+@@ -207,7 +220,7 @@ struct utils::fs::detail::directory_iterator::impl : utils::noncopyable {
+             _entry.reset(NULL);
+             close();
+         } else {
+-            _entry.reset(new directory_entry(_dirent.d_name));
++            _entry.reset(new directory_entry(_dirent->d_name));
+         }
+     }
+ };
+-- 
+2.16.2
+
+
+From 399fd5c96c4b725019082c6d4dbee8b44ea7e9f2 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Fri, 5 Jan 2018 20:36:11 +0700
+Subject: utils/process/status: use WIFCORED on Haiku
+
+
+diff --git a/utils/process/operations_test.cpp b/utils/process/operations_test.cpp
+index 708a740..7a50bfc 100644
+--- a/utils/process/operations_test.cpp
++++ b/utils/process/operations_test.cpp
+@@ -53,6 +53,9 @@ extern "C" {
+ namespace fs = utils::fs;
+ namespace process = utils::process;
+ 
++#if defined(__HAIKU__)
++#   define WCOREDUMP(x) WIFCORED(x)
++#endif
+ 
+ namespace {
+ 
+diff --git a/utils/process/status.cpp b/utils/process/status.cpp
+index a3cea8e..98605c7 100644
+--- a/utils/process/status.cpp
++++ b/utils/process/status.cpp
+@@ -41,7 +41,9 @@ namespace process = utils::process;
+ using utils::none;
+ using utils::optional;
+ 
+-#if !defined(WCOREDUMP)
++#if defined(__HAIKU__)
++#   define WCOREDUMP(x) WIFCORED(x)
++#elif !defined(WCOREDUMP)
+ #   define WCOREDUMP(x) false
+ #endif
+ 
+-- 
+2.16.2
+
+
+From d2cc0a80c05fe537e4b3c0907eba03010a7e9d99 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Fri, 5 Jan 2018 21:28:14 +0700
+Subject: utils/process/tests: Fix SIGKILL check on Haiku
+
+Haiku would emit SIGKILLTHR for our pids instead (they're thread ids)
+
+diff --git a/utils/process/deadline_killer_test.cpp b/utils/process/deadline_killer_test.cpp
+index 06c8966..f3a620f 100644
+--- a/utils/process/deadline_killer_test.cpp
++++ b/utils/process/deadline_killer_test.cpp
+@@ -78,7 +78,11 @@ ATF_TEST_CASE_BODY(activation)
+     ATF_REQUIRE(killer.fired());
+     ATF_REQUIRE(end - start <= datetime::delta(10, 0));
+     ATF_REQUIRE(status.signaled());
++#if defined(__HAIKU__)
++    ATF_REQUIRE_EQ(SIGKILLTHR, status.termsig());
++#else
+     ATF_REQUIRE_EQ(SIGKILL, status.termsig());
++#endif
+ }
+ 
+ 
+diff --git a/utils/process/operations_test.cpp b/utils/process/operations_test.cpp
+index 7a50bfc..05c7251 100644
+--- a/utils/process/operations_test.cpp
++++ b/utils/process/operations_test.cpp
+@@ -299,7 +299,11 @@ ATF_TEST_CASE_BODY(terminate_group__setpgrp_executed)
+     int status;
+     ATF_REQUIRE(::wait(&status) != -1);
+     ATF_REQUIRE(WIFSIGNALED(status));
++#if defined(__HAIKU__)
++    ATF_REQUIRE(WTERMSIG(status) == SIGKILLTHR);
++#else
+     ATF_REQUIRE(WTERMSIG(status) == SIGKILL);
++#endif
+ }
+ 
+ 
+@@ -320,7 +324,11 @@ ATF_TEST_CASE_BODY(terminate_group__setpgrp_not_executed)
+     int status;
+     ATF_REQUIRE(::wait(&status) != -1);
+     ATF_REQUIRE(WIFSIGNALED(status));
++#if defined(__HAIKU__)
++    ATF_REQUIRE(WTERMSIG(status) == SIGKILLTHR);
++#else
+     ATF_REQUIRE(WTERMSIG(status) == SIGKILL);
++#endif
+ }
+ 
+ 
+@@ -355,7 +363,11 @@ ATF_TEST_CASE_BODY(terminate_self_with__termsig)
+     int status;
+     ATF_REQUIRE(::wait(&status) != -1);
+     ATF_REQUIRE(WIFSIGNALED(status));
++#if defined(__HAIKU__)
++    ATF_REQUIRE(WTERMSIG(status) == SIGKILLTHR);
++#else
+     ATF_REQUIRE(WTERMSIG(status) == SIGKILL);
++#endif
+ #if defined(WCOREDUMP)
+     ATF_REQUIRE(!WCOREDUMP(status));
+ #endif
+diff --git a/utils/process/status_test.cpp b/utils/process/status_test.cpp
+index 5a3e19e..afee938 100644
+--- a/utils/process/status_test.cpp
++++ b/utils/process/status_test.cpp
+@@ -173,7 +173,11 @@ ATF_TEST_CASE_BODY(integration__signaled)
+     const status sigkill = fork_and_wait(child_signal< SIGKILL >);
+     ATF_REQUIRE(!sigkill.exited());
+     ATF_REQUIRE(sigkill.signaled());
++#if defined(__HAIKU__)
++    ATF_REQUIRE_EQ(SIGKILLTHR, sigkill.termsig());
++#else
+     ATF_REQUIRE_EQ(SIGKILL, sigkill.termsig());
++#endif
+     ATF_REQUIRE(!sigkill.coredump());
+ }
+ 
+diff --git a/utils/signals/interrupts_test.cpp b/utils/signals/interrupts_test.cpp
+index ef8758d..a7e9840 100644
+--- a/utils/signals/interrupts_test.cpp
++++ b/utils/signals/interrupts_test.cpp
+@@ -217,10 +217,18 @@ ATF_TEST_CASE_BODY(interrupts_handler__kill_children)
+ 
+     const process::status status1 = child1->wait();
+     ATF_REQUIRE(status1.signaled());
++#if defined(__HAIKU__)
++    ATF_REQUIRE_EQ(SIGKILLTHR, status1.termsig());
++#else
+     ATF_REQUIRE_EQ(SIGKILL, status1.termsig());
++#endif
+     const process::status status2 = child2->wait();
+     ATF_REQUIRE(status2.signaled());
++#if defined(__HAIKU__)
++    ATF_REQUIRE_EQ(SIGKILLTHR, status2.termsig());
++#else
+     ATF_REQUIRE_EQ(SIGKILL, status2.termsig());
++#endif
+ }
+ 
+ 
+-- 
+2.16.2
+
+
+From 6f25c5caa9849d3b7a2e3f958f929395cc147bca Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Fri, 5 Jan 2018 21:33:32 +0700
+Subject: utils/memory: add get_system_info support
+
+
+diff --git a/m4/memory.m4 b/m4/memory.m4
+index 3d9a83a..c829d8f 100644
+--- a/m4/memory.m4
++++ b/m4/memory.m4
+@@ -52,6 +52,11 @@ AC_DEFUN([KYUA_MEMORY], [
+         fi
+     fi
+ 
++    _KYUA_GET_SYSTEM_INFO([have_get_system_info=yes], [have_get_system_info=no])
++    if test "${have_get_system_info}" = yes; then
++        memory_query=get_system_info
++    fi
++
+     if test "${memory_query}" = unknown; then
+         AC_MSG_WARN([Don't know how to query the amount of physical memory])
+         AC_MSG_WARN([The test case's require.memory property will not work])
+@@ -120,3 +125,14 @@ AC_DEFUN([_KYUA_SYSCTL_MIB], [
+         m4_default([$4], [:])
+     fi
+ ])
++
++
++dnl Detects the availability of the get_system_info() function.
++dnl
++dnl \param action_if_found Code to run if the function is found.
++dnl \param action_if_not_found Code to run if the function is not found.
++AC_DEFUN([_KYUA_GET_SYSTEM_INFO], [
++    AC_CHECK_HEADERS([OS.h])
++
++    AC_CHECK_FUNCS([get_system_info], [$1], [$2])
++])
+diff --git a/utils/memory.cpp b/utils/memory.cpp
+index fb5da79..dfa6786 100644
+--- a/utils/memory.cpp
++++ b/utils/memory.cpp
+@@ -44,6 +44,10 @@ extern "C" {
+ #endif
+ }
+ 
++#if defined(HAVE_OS_H)
++#   include <OS.h>
++#endif
++
+ #include <cerrno>
+ #include <cstddef>
+ #include <cstring>
+@@ -73,6 +77,10 @@ static const char* query_type_unknown = "unknown";
+ static const char* query_type_sysctlbyname = "sysctlbyname";
+ 
+ 
++/// Value of query_type when we have to use get_system_info().
++static const char* query_type_get_system_info = "get_system_info";
++
++
+ /// Name of the sysctl MIB with the physical memory as detected by configure.
+ ///
+ /// This should only be used if memory_query_type is 'sysctl'.
+@@ -107,6 +115,37 @@ sysctlbyname(const char* UTILS_UNUSED_PARAM(name),
+ #endif
+ 
+ 
++#if !defined(HAVE_GET_SYSTEM_INFO)
++#if !defined(status_t)
++typedef status_t int;
++#endif
++#if !defined(system_info)
++typedef struct {
++  int64_t max_pages;
++} system_info;
++#endif
++#if !defined(B_PAGE_SIZE)
++#define B_PAGE_SIZE 1
++#endif
++/// Stub for get_system_info() for systems that don't have it.
++///
++/// The whole purpose of this fake function is to allow the caller code to be
++/// compiled on any machine regardless of the presence of get_system_info(). This
++/// will prevent the code from breaking when it is compiled on a machine without
++/// this function.  It also prevents "unused variable" warnings in the caller
++/// code.
++///
++/// \param unused_info Unused.
++///
++/// \return Nothing; this always crashes.
++static status_t
++get_system_info(system_info* UTILS_UNUSED_PARAM(unused_info))
++{
++    UNREACHABLE;
++}
++#endif
++
++
+ }  // anonymous namespace
+ 
+ 
+@@ -154,6 +193,12 @@ utils::physical_memory(void)
+             amount = 0;
+         } else if (std::strcmp(query_type, query_type_sysctlbyname) == 0) {
+             amount = query_sysctl(query_sysctl_mib);
++        } else if (std::strcmp(query_type, query_type_get_system_info) == 0) {
++            system_info info;
++            if (get_system_info(&info) == B_OK)
++                amount = static_cast<int64_t>(info.max_pages * B_PAGE_SIZE);
++            else
++                throw std::runtime_error(F("Failed to get page count with get_system_info()"));
+         } else
+             UNREACHABLE_MSG("Unimplemented memory query type");
+         LI(F("Physical memory as returned by query type '%s': %s") %
+diff --git a/utils/memory_test.cpp b/utils/memory_test.cpp
+index 66750fb..7b76a5c 100644
+--- a/utils/memory_test.cpp
++++ b/utils/memory_test.cpp
+@@ -48,7 +48,8 @@ ATF_TEST_CASE_BODY(physical_memory)
+ 
+     if (std::strcmp(MEMORY_QUERY_TYPE, "unknown") == 0) {
+         ATF_REQUIRE(memory == 0);
+-    } else if (std::strcmp(MEMORY_QUERY_TYPE, "sysctlbyname") == 0) {
++    } else if (std::strcmp(MEMORY_QUERY_TYPE, "sysctlbyname") == 0 ||
++               std::strcmp(MEMORY_QUERY_TYPE, "get_system_info") == 0) {
+         ATF_REQUIRE(memory > 0);
+         ATF_REQUIRE(memory < 100 * units::TB);  // Large enough for now...
+     } else {
+-- 
+2.16.2
+
+
+From 24a103d26f668154b434e4a7c1690927a1447aa5 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Sat, 6 Jan 2018 07:07:31 +0700
+Subject: Kyuafiles: disable tests that depends on HOME
+
+On Haiku we use find_directory for user directories, not $HOME. This
+commit disable tests that depends on $HOME being user directory.
+
+diff --git a/Kyuafile b/Kyuafile
+index e986218..f9d5861 100644
+--- a/Kyuafile
++++ b/Kyuafile
+@@ -12,7 +12,6 @@ end
+ include("drivers/Kyuafile")
+ include("engine/Kyuafile")
+ include("examples/Kyuafile")
+-include("integration/Kyuafile")
+ include("model/Kyuafile")
+ include("store/Kyuafile")
+ include("utils/Kyuafile")
+diff --git a/cli/Kyuafile b/cli/Kyuafile
+index f5b797d..727b653 100644
+--- a/cli/Kyuafile
++++ b/cli/Kyuafile
+@@ -9,6 +9,3 @@ atf_test_program{name="cmd_debug_test"}
+ atf_test_program{name="cmd_help_test"}
+ atf_test_program{name="cmd_list_test"}
+ atf_test_program{name="cmd_test_test"}
+-atf_test_program{name="common_test"}
+-atf_test_program{name="config_test"}
+-atf_test_program{name="main_test"}
+diff --git a/store/Kyuafile b/store/Kyuafile
+index ada2f7c..0f8ad43 100644
+--- a/store/Kyuafile
++++ b/store/Kyuafile
+@@ -4,12 +4,10 @@ test_suite("kyua")
+ 
+ atf_test_program{name="dbtypes_test"}
+ atf_test_program{name="exceptions_test"}
+-atf_test_program{name="layout_test"}
+ atf_test_program{name="metadata_test"}
+ atf_test_program{name="migrate_test"}
+ atf_test_program{name="read_backend_test"}
+ atf_test_program{name="read_transaction_test"}
+-atf_test_program{name="schema_inttest"}
+ atf_test_program{name="transaction_test"}
+ atf_test_program{name="write_backend_test"}
+ atf_test_program{name="write_transaction_test"}
+-- 
+2.16.2
+
+
+From b50332f25345fdd2c0e3c24a5452159b7bbbdf4a Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Sat, 6 Jan 2018 08:49:26 +0700
+Subject: utils/fs/operations_test: disable ENOENT test
+
+This test depends on BSD-specific getcwd(3) extension
+
+diff --git a/utils/fs/operations_test.cpp b/utils/fs/operations_test.cpp
+index f134935..c77ec6b 100644
+--- a/utils/fs/operations_test.cpp
++++ b/utils/fs/operations_test.cpp
+@@ -160,6 +160,9 @@ ATF_TEST_CASE_BODY(current_path__ok)
+ ATF_TEST_CASE_WITHOUT_HEAD(current_path__enoent);
+ ATF_TEST_CASE_BODY(current_path__enoent)
+ {
++#if defined(__HAIKU__)
++    expect_fail("This test depends on BSD-specific behaviour");
++#endif
+     const fs::path previous = fs::current_path();
+     fs::mkdir(fs::path("root"), 0755);
+     ATF_REQUIRE(::chdir("root") != -1);
+-- 
+2.16.2
+

--- a/dev-util/pkgconf/licenses/ISC
+++ b/dev-util/pkgconf/licenses/ISC
@@ -1,0 +1,10 @@
+Copyright (c) 2011, 2012, 2013, 2014, 2015, 2016, 2017
+    pkgconf authors (see AUTHORS file in source directory).
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+This software is provided 'as is' and without any warranty, express or
+implied.  In no event shall the authors be liable for any damages arising
+from the use of this software.

--- a/dev-util/pkgconf/patches/pkgconf-1.4.2.patchset
+++ b/dev-util/pkgconf/patches/pkgconf-1.4.2.patchset
@@ -1,0 +1,164 @@
+From bd82c5be63b1d14acfaa9b35e78531fe2f5ce5bf Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Tue, 3 Apr 2018 12:46:35 +0700
+Subject: libpkgconf: add support for Haiku
+
+client: use BELIBRARIES
+
+On Haiku, BELIBRARIES is the equivalent to LIBRARY_PATH on many other
+systems, while LIBRARY_PATH is instead the LD_LIBRARY_PATH of Haiku.
+
+pkg: bootstrap package search paths with Haiku's find_paths
+
+This commit adds build_default_pkgconfig_path. The function appends
+to the list given the default pkgconfig paths, and will supersede
+get_default_pkgconfig_path
+
+diff --git a/libpkgconf/client.c b/libpkgconf/client.c
+index 811e043..a832e83 100644
+--- a/libpkgconf/client.c
++++ b/libpkgconf/client.c
+@@ -78,7 +78,11 @@ pkgconf_client_init(pkgconf_client_t *client, pkgconf_error_handler_func_t error
+ 	pkgconf_path_build_from_environ("PKG_CONFIG_SYSTEM_INCLUDE_PATH", SYSTEM_INCLUDEDIR, &client->filter_includedirs, false);
+ 
+ 	/* GCC uses these environment variables to define system include paths, so we should check them. */
++#ifdef __HAIKU__
++	pkgconf_path_build_from_environ("BELIBRARIES", NULL, &client->filter_libdirs, false);
++#else
+ 	pkgconf_path_build_from_environ("LIBRARY_PATH", NULL, &client->filter_libdirs, false);
++#endif
+ 	pkgconf_path_build_from_environ("CPATH", NULL, &client->filter_includedirs, false);
+ 	pkgconf_path_build_from_environ("C_INCLUDE_PATH", NULL, &client->filter_includedirs, false);
+ 	pkgconf_path_build_from_environ("CPLUS_INCLUDE_PATH", NULL, &client->filter_includedirs, false);
+diff --git a/libpkgconf/pkg.c b/libpkgconf/pkg.c
+index 0feb4d6..67b52d7 100644
+--- a/libpkgconf/pkg.c
++++ b/libpkgconf/pkg.c
+@@ -49,11 +49,12 @@ str_has_suffix(const char *str, const char *suffix)
+ 	return !strncasecmp(str + str_len - suf_len, suffix, suf_len);
+ }
+ 
+-static inline const char *
+-get_default_pkgconfig_path(char *outbuf, size_t outlen)
++static inline void
++build_default_pkgconfig_path(pkgconf_list_t* dirlist)
+ {
+ #ifdef _WIN32
+ 	char namebuf[MAX_PATH];
++	char outbuf[MAX_PATH];
+ 	char *p;
+ 
+ 	int sizepath = GetModuleFileName(NULL, namebuf, sizeof namebuf);
+@@ -65,24 +66,35 @@ get_default_pkgconfig_path(char *outbuf, size_t outlen)
+ 	}
+ 	p = strrchr(namebuf, '/');
+ 	if (p == NULL)
+-		return PKG_DEFAULT_PATH;
++		pkgconf_path_split(PKG_DEFAULT_PATH, dirlist, true);
+ 
+ 	*p = '\0';
+-	pkgconf_strlcpy(outbuf, namebuf, outlen);
+-	pkgconf_strlcat(outbuf, "/", outlen);
+-	pkgconf_strlcat(outbuf, "../lib/pkgconfig", outlen);
+-	pkgconf_strlcat(outbuf, ";", outlen);
+-	pkgconf_strlcat(outbuf, namebuf, outlen);
+-	pkgconf_strlcat(outbuf, "/", outlen);
+-	pkgconf_strlcat(outbuf, "../share/pkgconfig", outlen);
+-
+-	return outbuf;
++	pkgconf_strlcpy(outbuf, namebuf, sizeof outbuf);
++	pkgconf_strlcat(outbuf, "/", sizeof outbuf);
++	pkgconf_strlcat(outbuf, "../lib/pkgconfig", sizeof outbuf);
++	pkgconf_path_add(outbuf, dirlist, true);
++	pkgconf_strlcpy(outbuf, namebuf, sizeof outbuf);
++	pkgconf_strlcat(outbuf, "/", sizeof outbuf);
++	pkgconf_strlcat(outbuf, "../share/pkgconfig", sizeof outbuf);
++	pkgconf_path_add(outbuf, dirlist, true);
++#elif __HAIKU__
++	char **paths;
++	size_t count;
++	if (find_paths(B_FIND_PATH_DEVELOP_LIB_DIRECTORY, "pkgconfig", &paths, &count) == B_OK) {
++		for (size_t i = 0; i < count; i++)
++			pkgconf_path_add(paths[i], dirlist, true);
++		free(paths);
++		paths = NULL;
++	}
++	if (find_paths(B_FIND_PATH_DATA_DIRECTORY, "pkgconfig", &paths, &count) == B_OK) {
++		for (size_t i = 0; i < count; i++)
++			pkgconf_path_add(paths[i], dirlist, true);
++		free(paths);
++		paths = NULL;
++	}
+ #else
+-	(void) outbuf;
+-	(void) outlen;
++	pkgconf_path_split(PKG_DEFAULT_PATH, dirlist, true);
+ #endif
+-
+-	return PKG_DEFAULT_PATH;
+ }
+ 
+ static const char *
+@@ -117,12 +129,8 @@ pkgconf_pkg_dir_list_build(pkgconf_client_t *client)
+ {
+ 	pkgconf_path_build_from_environ("PKG_CONFIG_PATH", NULL, &client->dir_list, true);
+ 
+-	if (!(client->flags & PKGCONF_PKG_PKGF_ENV_ONLY))
+-	{
+-		char pathbuf[PKGCONF_BUFSIZE];
+-
+-		pkgconf_path_build_from_environ("PKG_CONFIG_LIBDIR", get_default_pkgconfig_path(pathbuf, sizeof pathbuf), &client->dir_list, true);
+-	}
++	if (!(client->flags & PKGCONF_PKG_PKGF_ENV_ONLY) && (pkgconf_path_build_from_environ("PKG_CONFIG_LIBDIR", NULL, &client->dir_list, true)) < 1)
++		build_default_pkgconfig_path(&client->dir_list);
+ }
+ 
+ typedef void (*pkgconf_pkg_parser_keyword_func_t)(const pkgconf_client_t *client, pkgconf_pkg_t *pkg, const char *keyword, const size_t lineno, const ptrdiff_t offset, char *value);
+diff --git a/libpkgconf/stdinc.h b/libpkgconf/stdinc.h
+index 3b90853..ca3a7dc 100644
+--- a/libpkgconf/stdinc.h
++++ b/libpkgconf/stdinc.h
+@@ -53,6 +53,9 @@
+ #else
+ # define PATH_DEV_NULL	"/dev/null"
+ # define SIZE_FMT_SPECIFIER	"%zu"
++# ifdef __HAIKU__
++#  include <FindDirectory.h>
++# endif
+ # include <dirent.h>
+ # include <unistd.h>
+ # include <limits.h>
+diff --git a/tests/regress.sh b/tests/regress.sh
+index 7da53e6..0e505d3 100755
+--- a/tests/regress.sh
++++ b/tests/regress.sh
+@@ -79,7 +79,8 @@ variable_body()
+ 
+ keep_system_libs_body()
+ {
+-	export PKG_CONFIG_PATH="${selfdir}/lib1" LIBRARY_PATH="/test/local/lib"
++	export PKG_CONFIG_PATH="${selfdir}/lib1"
++	eval export "$LIBRARY_PATH_ENV"="/test/local/lib"
+ 	atf_check \
+ 		-o inline:"\n" \
+ 		pkgconf --libs-only-L cflags-libs-only
+diff --git a/tests/test_env.sh.in b/tests/test_env.sh.in
+index 229dd00..17ee1f5 100644
+--- a/tests/test_env.sh.in
++++ b/tests/test_env.sh.in
+@@ -22,10 +22,12 @@ done
+ #--- end kludge ---
+ 
+ selfdir="@abs_top_srcdir@/tests"
++LIBRARY_PATH_ENV="LIBRARY_PATH"
+ PATH_SEP=":"
+ SYSROOT_DIR="${selfdir}/test"
+ case "$(uname -s)" in
+ Msys|CYGWIN*) PATH_SEP=";";;
++Haiku) LIBRARY_PATH_ENV="BELIBRARIES";;
+ esac
+ 
+ prefix="@prefix@"
+-- 
+2.16.2
+

--- a/dev-util/pkgconf/pkgconf-1.4.2.recipe
+++ b/dev-util/pkgconf/pkgconf-1.4.2.recipe
@@ -1,0 +1,107 @@
+SUMMARY="A lightweight pkg-config replacement"
+DESCRIPTION="A program which helps to configure compiler and linker flags for \
+development libraries. It is similar to pkg-config from freedesktop.org."
+HOMEPAGE="http://pkgconf.org/"
+COPYRIGHT="2011-2018 pkgconf authors"
+LICENSE="ISC"
+REVISION="1"
+SOURCE_URI="https://distfiles.dereferenced.org/pkgconf/pkgconf-$portVersion.tar.xz"
+CHECKSUM_SHA256="bab39371d4ab972be1d539a8b10b6cc21f8eafc97f617102e667e82bd32eb234"
+PATCHES="pkgconf-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+commandSuffix="$secondaryArchSuffix"
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=""
+fi
+
+libVersion="3.0.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	pkgconf$secondaryArchSuffix = $portVersion
+	cmd:pkgconf$secondaryArchSuffix = $portVersion
+	lib:libpkgconf$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	pkgconf${secondaryArchSuffix}_devel = $portVersion
+	devel:libpkgconf$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	pkgconf$secondaryArchSuffix == $portVersion base
+	"
+
+SUMMARY_pkgconfig="$SUMMARY (pkg-config compat symlink)"
+DESCRIPTION_pkgconfig="$DESCRIPTION (pkg-config compatibility symlink)"
+
+PROVIDES_pkgconfig="
+	pkgconf${secondaryArchSuffix}_pkgconfig = $portVersion
+	cmd:pkg_config$secondaryArchSuffix = $portVersion
+	"
+REQUIRES_pkgconfig="
+	pkgconf$secondaryArchSuffix == $portVersion base
+	"
+CONFLICTS_pkgconfig="
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:cmp
+	cmd:diff
+	cmd:gcc$secondaryArchSuffix
+	cmd:grep
+	cmd:make
+	cmd:sed
+	"
+
+TEST_REQUIRES="
+	devel:libatf_c$secondaryArchSuffix
+	cmd:kyua$commandSuffix
+	"
+
+defineDebugInfoPackage pkgconf$secondaryArchSuffix \
+	"$binDir/pkgconf" \
+	"$libDir/libpkgconf.so.$libVersion"
+
+BUILD()
+{
+	runConfigure ./configure
+
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	install -d -m 755 "$docDir" "$developDocDir"
+	install -t "$docDir" -m 644 AUTHORS NEWS
+	install -t "$developDocDir" -m 644 doc/*.rst
+
+	ln -s pkgconf "$binDir/pkg-config"
+
+	rm -f "$libDir"/*.la
+
+	prepareInstalledDevelLib libpkgconf
+	fixPkgconfig
+	packageEntries devel \
+		"$developDir" \
+		"$dataDir/aclocal" \
+		"$manDir/man7"
+	packageEntries pkgconfig "$binDir/pkg-config"
+}
+
+TEST()
+{
+	make check
+}


### PR DESCRIPTION
Done as part of GCI 2017

| package | arch | status |
| --- | --- | --- |
| dev-libs/atf | x86_gcc2 | `Test cases: 319 total, 7 skipped, 0 expected failures, 0 broken, 0 failed` |
| dev-libs/atf | x86_64 | `Test cases: 319 total, 7 skipped, 0 expected failures, 0 broken, 0 failed` |
| dev-lua/lutok | x86_gcc2 | `Test cases: 101 total, 4 skipped, 0 expected failures, 0 broken, 0 failed` |
| dev-lua/lutok | x86_64 | `Test cases: 101 total, 4 skipped, 0 expected failures, 0 broken, 0 failed` |
| dev-util/pkgconf | x86_gcc2 | `Test cases: 109 total, 0 skipped, 0 expected failures, 0 broken, 0 failed` |
| dev-util/pkgconf | x86_64 | `Test cases: 109 total, 0 skipped, 0 expected failures, 0 broken, 0 failed` |
| dev-util/kyua | x86_gcc2 | `Test cases: 1215 total, 41 skipped, 4 expected failures,`[`3 broken, 3 failed`][1] |
| dev-util/kyua | x86_64 | `Test cases: 1215 total, 41 skipped, 4 expected failures,`[`3 broken, 3 failed`][2] |

Changes:
- dev-libs/atf:
  - don't include `<sys/mount.h>` on Haiku
  - disable tests that requires atf to be installed
- dev-util/kyua:
  - use `struct dirent` correctly. This prevents segfault on Haiku (thanks @pulkomandy for help)
  - use Haiku user configuration directory (this broke a lot of tests)
  - disable all tests that depends on `$HOME`
  - disable tests that use OS-specific behaviour
  - use `WIFCORED(x)` on Haiku
  - fix tests checking for `SIGKILL` on Haiku
  - implemented memory detection code for Haiku
  - and some misc fixes
- dev-util/pkgconf: swap `LIBRARY_PATH` with `BELIBRARIES` as this appears to be what our gcc [uses][0]

**NOTE:** Some changes to kyua are upstreamable but I won't do so as I don't want to sign their CLA. Feel free to upstream those changes if you wish

Known issues:
- dev-libs/atf: cyclic dependency on kyua due to the lack of `TEST_PREREQUIRES`
- dev-lua/lutok: cyclic dependency on kyua due to the lack of `TEST_PREREQUIRES`
- dev-util/kyua: cyclic dependency on `dev-libs/atf` and `dev-lua/lutok`

Meta issues:
Quoting self on GCI
> I'm having an situation here. ATF-based ports have their tests designed to be run after installation. This means that some of them won't execute correctly (or at all) when not installed. Currently I'm removing all of them from our install image, should I instead move them into an another package? And if we decide to do so, where should we put them? Currently they're in $prefix/tests.

[0]: https://github.com/haikuports/haikuports/blob/99b3c76c3e8178c62044b9f0e0594db0b1ff518c/sys-devel/gcc/patches/gcc-5.4.0_2016_06_04.patchset#L641
[1]: https://0bin.net/paste/vM-brFsQ-t2rWEzg#+2mWGpB8EmqSeobYlnAEjzq8mnJRTL7MO2ZBjWFvNry
[2]: https://0bin.net/paste/vOeuxcCguqWSSd3b#kaKOWBz3IJ9F16y42nuk8ZPCnnGVFRqS2XwngFkehl4
  