### PR TITLE
libqxp: new recipe

### DIFF
--- a/app-text/libqxp/libqxp-0.0.1.recipe
+++ b/app-text/libqxp/libqxp-0.0.1.recipe
@@ -9,7 +9,7 @@ REVISION="1"
 SOURCE_URI="http://dev-www.libreoffice.org/src/libqxp/libqxp-$portVersion.tar.xz"
 CHECKSUM_SHA256="8c257f6184ff94aefa7c9fa1cfae82083d55a49247266905c71c53e013f95c73"
 
-ARCHITECTURES="x86_gcc2 x86 x86_64"
+ARCHITECTURES="?x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 commandBinDir=$binDir
@@ -20,12 +20,12 @@ then
 	commandSuffix=
 fi
 
-libVersion=0.0.2
+libVersion=0.0.1
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
 	libqxp$secondaryArchSuffix = $portVersion
-	lib:libqxp$secondaryArchSuffix = $libVersionCompat
+	lib:libqxp_0.0$secondaryArchSuffix = $libVersionCompat
 	cmd:qxp2raw$commandSuffix = $portVersion
 	cmd:qxp2svg$commandSuffix = $portVersion
 	cmd:qxp2text$commandSuffix = $portVersion
@@ -34,13 +34,13 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	icu$secondaryArchSuffix
 	lib:libboost_system$secondaryArchSuffix
-	lib:libcppunit$secondaryArchSuffix+
+	lib:libcppunit$secondaryArchSuffix
 	lib:librevenge_0.0$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
 	libqxp${secondaryArchSuffix}_devel = $portVersion
-	devel:libqxp$secondaryArchSuffix = $libVersion
+	devel:libqxp_0.0$secondaryArchSuffix = $libVersion
 	"
 REQUIRES_devel="
 	libqxp$secondaryArchSuffix == $portVersion base
@@ -63,11 +63,12 @@ BUILD_PREREQUIRES="
 	"
 
 defineDebugInfoPackage libqxp$secondaryArchSuffix \
-	$libDir/libqxp.so.$libVersion
+	$libDir/libqxp-0.0.so.$libVersion
 
 BUILD()
 {
-	runConfigure ./configure --bindir=$commandBinDir --without-docs
+	runConfigure --omit-dirs binDir ./configure --bindir=$commandBinDir \
+		--without-docs
 	make $jobArgs
 }
 
@@ -77,7 +78,7 @@ INSTALL()
 
 	rm -f $libDir/*.la
 
-	prepareInstalledDevelLib libqxp
+	prepareInstalledDevelLib libqxp-0.0
 	fixPkgconfig
 
 	packageEntries devel \

--- a/app-text/libqxp/libqxp-0.0.1.recipe
+++ b/app-text/libqxp/libqxp-0.0.1.recipe
@@ -1,0 +1,85 @@
+SUMMARY="Parses the file format of QuarkXPress"
+DESCRIPTION="libqxp is a library that parses the file format of QuarkXPress \
+documents. Currently it only understands documents created by QuarkXPress \
+3.1 to 4.1."
+HOMEPAGE="https://wiki.documentfoundation.org/DLP/Libraries/libqxp"
+COPYRIGHT="2017-2018 David Tardon, Aleksas Pantechovski"
+LICENSE="MPL v2.0"
+REVISION="1"
+SOURCE_URI="http://dev-www.libreoffice.org/src/libqxp/libqxp-$portVersion.tar.xz"
+CHECKSUM_SHA256="8c257f6184ff94aefa7c9fa1cfae82083d55a49247266905c71c53e013f95c73"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+commandBinDir=$binDir
+commandSuffix=$secondaryArchSuffix
+if [ "$targetArchitecture" = x86_gcc2 ]
+then
+	commandBinDir=$prefix/bin
+	commandSuffix=
+fi
+
+libVersion=0.0.2
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	libqxp$secondaryArchSuffix = $portVersion
+	lib:libqxp$secondaryArchSuffix = $libVersionCompat
+	cmd:qxp2raw$commandSuffix = $portVersion
+	cmd:qxp2svg$commandSuffix = $portVersion
+	cmd:qxp2text$commandSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	icu$secondaryArchSuffix
+	lib:libboost_system$secondaryArchSuffix
+	lib:libcppunit$secondaryArchSuffix+
+	lib:librevenge_0.0$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	libqxp${secondaryArchSuffix}_devel = $portVersion
+	devel:libqxp$secondaryArchSuffix = $libVersion
+	"
+REQUIRES_devel="
+	libqxp$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	icu${secondaryArchSuffix}_devel
+	devel:libboost_system$secondaryArchSuffix
+	devel:libcppunit$secondaryArchSuffix
+	devel:librevenge_0.0$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:cmp
+	cmd:diff
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+defineDebugInfoPackage libqxp$secondaryArchSuffix \
+	$libDir/libqxp.so.$libVersion
+
+BUILD()
+{
+	runConfigure ./configure --bindir=$commandBinDir --without-docs
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	rm -f $libDir/*.la
+
+	prepareInstalledDevelLib libqxp
+	fixPkgconfig
+
+	packageEntries devel \
+		$developDir
+}


### PR DESCRIPTION
Create recipe for [libqxp](https://wiki.documentfoundation.org/DLP/Libraries/libqxp), a library that parses the file format of QuarkXPress documents.