### PR TITLE
check: unsplit check_common.

### DIFF
--- a/dev-libs/check/check-0.11.0.recipe
+++ b/dev-libs/check/check-0.11.0.recipe
@@ -9,7 +9,7 @@ HOMEPAGE="https://libcheck.github.io/check/"
 COPYRIGHT="2001-2015 Arien Malec, Branden Archer, Chris Pickett, Fredrik \
 Hugosson, and Robert Lemmen."
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/libcheck/check/releases/download/$portVersion/check-$portVersion.tar.gz"
 CHECKSUM_SHA256="24f7a48aae6b74755bcbe964ce8bc7240f6ced2141f8d9cf480bc3b3de0d5616"
 PATCHES="check-$portVersion.patch"
@@ -24,16 +24,12 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	check_common
 	cmd:gawk
 	"
-
 if [ -z "$secondaryArchSuffix" ]; then
-	ARCHITECTURES_common="any"
-	PROVIDES_common="
-		check_common = $portVersion
-		"
-	REQUIRES_common=""
+REPLACES="
+	check_common
+	"
 fi
 
 PROVIDES_devel="
@@ -63,14 +59,6 @@ BUILD()
 INSTALL()
 {
 	make install
-
-	if [ -z "$secondaryArchSuffix" ]; then
-		packageEntries common \
-			$dataDir/doc \
-			$documentationDir
-	else
-		rm -rf $dataDir/doc $documentationDir
-	fi
 
 	rm $libDir/libcheck.la
 	prepareInstalledDevelLib libcheck

--- a/dev-libs/check/check-0.9.13.recipe
+++ b/dev-libs/check/check-0.9.13.recipe
@@ -9,7 +9,7 @@ HOMEPAGE="http://check.sourceforge.net/"
 COPYRIGHT="2001-2014 Arien Malec, Branden Archer, Chris Pickett, Fredrik \
 Hugosson, and Robert Lemmen."
 LICENSE="GNU LGPL v2.1"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="http://sourceforge.net/projects/check/files/check/$portVersion/check-$portVersion.tar.gz"
 CHECKSUM_SHA256="ca6589c34f9c60ffd4c3e198ce581e944a9f040ca9352ed54068dd61bebb5cb7"
 
@@ -23,16 +23,12 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	check_common
 	cmd:gawk
 	"
-
 if [ -z "$secondaryArchSuffix" ]; then
-	ARCHITECTURES_common="any"
-	PROVIDES_common="
-		check_common = $portVersion
-		"
-	REQUIRES_common=""
+REPLACES="
+	check_common
+	"
 fi
 
 PROVIDES_devel="
@@ -63,11 +59,7 @@ INSTALL()
 {
 	make install
 
-	if [ -z "$secondaryArchSuffix" ]; then
-		packageEntries common \
-			$dataDir/doc \
-			$documentationDir
-	else
+	if [ -n "$secondaryArchSuffix" ]; then
 		rm -rf $dataDir/doc $documentationDir
 	fi
 

--- a/dev-libs/check/check-0.9.14.recipe
+++ b/dev-libs/check/check-0.9.14.recipe
@@ -23,16 +23,12 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	check_common
 	cmd:gawk
 	"
-
 if [ -z "$secondaryArchSuffix" ]; then
-	ARCHITECTURES_common="any"
-	PROVIDES_common="
-		check_common = $portVersion
-		"
-	REQUIRES_common=""
+REPLACES="
+	check_common
+	"
 fi
 
 PROVIDES_devel="
@@ -63,11 +59,7 @@ INSTALL()
 {
 	make install
 
-	if [ -z "$secondaryArchSuffix" ]; then
-		packageEntries common \
-			$dataDir/doc \
-			$documentationDir
-	else
+	if [ -n "$secondaryArchSuffix" ]; then
 		rm -rf $dataDir/doc $documentationDir
 	fi
 


### PR DESCRIPTION
~Until now, check_86, which builds fine on x86_gcc2, had a runtime dependency on check_common, which is the arch-independent subpackage which can only be built when check is built on x86_gcc2 primary arch.
But since the latter no longuer builds for check 0.11.0, there was no way to obtain check_common on x86_gcc2 and meet check_x86's requirement when installing it.
The workaround for this issue is to simply stop creating the check_common subpackage when building on x86_gcc2. All contents of check_common are now part of check_x86.~

This is required because check 0.11.0 no longer builds on x86_gcc2 primary arch, so the arch-independent check_common could not be built on x86_gcc2, hence preventing the installation of check_x86.