### PR TITLE
mesa: GLView: Don't unconditionally unlock GL context

### DIFF
--- a/sys-libs/mesa/patches/mesa-17.1.7.patchset
+++ b/sys-libs/mesa/patches/mesa-17.1.7.patchset
@@ -1,4 +1,4 @@
-From ec8d0a5d3dffdb41b48d2dd1e83c5a05bad0e95f Mon Sep 17 00:00:00 2001
+From 955e760862127dbc1970faabac4e8f08a85d574f Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Mon, 11 Sep 2017 21:29:14 +0200
 Subject: Haiku patch
@@ -509,10 +509,10 @@ index df907ff..9f21a71 100644
   * APIENTRY to _mesa_* entrypoints will not cause crashes on debug builds, as
   * the initial ESP value is saved in the EBP in the function prologue, then
 -- 
-2.14.2
+2.15.0
 
 
-From 639a31f891f1a419d876004930fe1560440e3d23 Mon Sep 17 00:00:00 2001
+From 0971e523fbbbb450aca91578e6ff72e543d025db Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Michel=20D=C3=A4nzer?= <michel.daenzer@amd.com>
 Date: Wed, 10 May 2017 17:26:07 +0900
 Subject: gallivm: Fix build against LLVM SVN >= r302589
@@ -553,5 +553,32 @@ index 2a388cb..0e4a531 100644
        virtual void *getPointerToNamedFunction(const std::string &Name,
                                                bool AbortOnFailure=true) {
 -- 
-2.14.2
+2.15.0
+
+
+From fdde109692022f95aac2ba282bd87ea2ccd4ef0e Mon Sep 17 00:00:00 2001
+From: Andrew Aldridge <i80and@foxquill.com>
+Date: Wed, 3 Jan 2018 02:12:20 +0000
+Subject: Don't unconditionally unlock GL context
+
+
+diff --git a/src/hgl/GLView.cpp b/src/hgl/GLView.cpp
+index 9ae5b5c..32745fa 100644
+--- a/src/hgl/GLView.cpp
++++ b/src/hgl/GLView.cpp
+@@ -204,9 +204,11 @@ BGLView::AttachedToWindow()
+ #endif
+ 
+ 		// Set default OpenGL viewport:
++		bool isLocked = fDisplayLock.IsLocked();
+ 		LockGL();
+ 		glViewport(0, 0, Bounds().IntegerWidth(), Bounds().IntegerHeight());
+-		UnlockGL();
++		if (!isLocked)
++			UnlockGL();
+ 		fRenderer->FrameResized(Bounds().IntegerWidth(),
+ 			Bounds().IntegerHeight());
+ 
+-- 
+2.15.0
 


### PR DESCRIPTION
Addresses https://dev.haiku-os.org/ticket/13191

I'm not 100% confident this is the right solution; in particular, I don't know what guarantees are desired when dealing with multiple threads. Is `IsLocked()` even the right tool here?