### PR TITLE
dev-db/sqlcipher: new recipe

### DIFF
--- a/dev-db/sqlcipher/patches/sqlcipher-3.4.2.patchset
+++ b/dev-db/sqlcipher/patches/sqlcipher-3.4.2.patchset
@@ -1,0 +1,66 @@
+From 1d3282d6038bc327fea78482a6c991e05d76aab8 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Wed, 10 Jan 2018 17:22:55 +0700
+Subject: crypto: include <sys/mman.h> unless WAL is omitted
+
+crypto_impl.c is included before os_unix.c, which means if an user
+define OMIT_MEMLOCK, <sys/mman.h> won't be included, which is needed for
+WAL
+
+diff --git a/src/crypto_impl.c b/src/crypto_impl.c
+index 1fd35ba..b516386 100644
+--- a/src/crypto_impl.c
++++ b/src/crypto_impl.c
+@@ -40,11 +40,13 @@
+ #include <errno.h>
+ #include <unistd.h>
+ #include <sys/resource.h>
+-#include <sys/mman.h>
+ #elif defined(_WIN32)
+ #include <windows.h>
+ #endif
+ #endif
++#if !defined(SQLITE_OMIT_WAL) && SQLITE_OS_UNIX
++#include <sys/mman.h>
++#endif
+ 
+ /* the default implementation of SQLCipher uses a cipher_ctx
+    to keep track of read / write state separately. The following
+-- 
+2.15.0
+
+
+From ce7e259cd0d8346f481a1d3e88eaafabe764419f Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Wed, 10 Jan 2018 20:47:29 +0700
+Subject: test1: fixes for Haiku
+
+
+diff --git a/src/test1.c b/src/test1.c
+index df7685f..f21be6b 100644
+--- a/src/test1.c
++++ b/src/test1.c
+@@ -6568,10 +6568,16 @@ static int SQLITE_TCLAPI test_getrusage(
+   getrusage(RUSAGE_SELF, &r);
+ 
+   sqlite3_snprintf(sizeof(buf), buf,
+-    "ru_utime=%d.%06d ru_stime=%d.%06d ru_minflt=%d ru_majflt=%d", 
+-    (int)r.ru_utime.tv_sec, (int)r.ru_utime.tv_usec, 
+-    (int)r.ru_stime.tv_sec, (int)r.ru_stime.tv_usec, 
+-    (int)r.ru_minflt, (int)r.ru_majflt
++    "ru_utime=%d.%06d ru_stime=%d.%06d"
++#ifndef __HAIKU__
++    " ru_minflt=%d ru_majflt=%d"
++#endif
++    ,
++    (int)r.ru_utime.tv_sec, (int)r.ru_utime.tv_usec,
++    (int)r.ru_stime.tv_sec, (int)r.ru_stime.tv_usec
++#ifndef __HAIKU__
++    , (int)r.ru_minflt, (int)r.ru_majflt
++#endif
+   );
+   Tcl_SetObjResult(interp, Tcl_NewStringObj(buf, -1));
+   return TCL_OK;
+-- 
+2.15.0
+

--- a/dev-db/sqlcipher/sqlcipher-3.4.2.recipe
+++ b/dev-db/sqlcipher/sqlcipher-3.4.2.recipe
@@ -1,0 +1,91 @@
+SUMMARY="Full Database Encryption for SQLite"
+DESCRIPTION="SQLCipher extends the SQLite database library to add \
+security enhancements that make it more suitable for encrypted \
+local data storage such as on-the-fly encryption, tamper evidence, \
+and key derivation. Based on SQLite, SQLCipher closely tracks SQLite and \
+periodically integrates stable SQLite release features."
+HOMEPAGE="https://www.zetetic.net/sqlcipher"
+COPYRIGHT="2016 ZETETIC LLC"
+LICENSE="BSD (3-clause)"
+REVISION="1"
+SOURCE_URI="https://github.com/sqlcipher/sqlcipher/archive/v$portVersion.tar.gz"
+CHECKSUM_SHA256="69897a5167f34e8a84c7069f1b283aba88cdfa8ec183165c4a5da2c816cfaadb"
+SOURCE_FILENAME="sqlcipher-$portVersion.tar.gz"
+PATCHES="sqlcipher-$portVersion.patchset"
+
+ARCHITECTURES="x86_gcc2 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="0.8.6"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+majorVersion="${portVersion%%.*}"
+tclVersion="8.5"
+
+PROVIDES="
+	sqlcipher$secondaryArchSuffix = $portVersion
+	cmd:sqlcipher$secondaryArchSuffix = $portVersion
+	lib:libsqlcipher$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcrypto$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	sqlcipher${secondaryArchSuffix}_devel = $portVersion
+	devel:libsqlcipher$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	sqlcipher$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libcrypto$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:cmp
+	cmd:diff
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:sed
+	cmd:tclsh$tclVersion
+	"
+
+defineDebugInfoPackage sqlcipher$secondaryArchSuffix \
+	"$binDir/sqlcipher" \
+	"$libDir/libsqlcipher.so.$libVersion"
+
+BUILD()
+{
+	# Keep up-to-date with sqlite
+	CPPFLAGS="-DSQLITE_ENABLE_COLUMN_METADATA=1 \
+		-DSQLITE_ENABLE_UNLOCK_NOTIFY -DSQLITE_ENABLE_DBSTAT_VTAB \
+		-DSQLITE_SECURE_DELETE=1 -DSQLITE_ENABLE_FTS3_PARENTHESIS \
+		-DSQLITE_HAS_CODEC -DOMIT_MEMLOCK" \
+	LIBS="-Wl,--as-needed -lcrypto" \
+	runConfigure ./configure --enable-tempstore --enable-fts3 --enable-fts5 \
+		--enable-rtree --disable-tcl
+
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	rm -f "$libDir"/*.la
+
+	install -d -m 755 "$docDir"
+	install -t "$docDir" -m 644 README.md
+
+	prepareInstalledDevelLib libsqlcipher
+	fixPkgconfig
+	packageEntries devel "$developDir"
+}
+
+TEST()
+{
+	make fastfuzztest
+}


### PR DESCRIPTION
Done as part of GCI 2017

Changes to sqlcipher:
- Fix build when `OMIT_MEMLOCK` is defined but not `SQLITE_OMIT_WAL`
- Fix tests for Haiku

**NOTE:** I permit anyone to upstream my changes without asking. sqlcipher requires it's contributor to sign an CLA, which I don't want to.