### PR TITLE
util-linux: bump to 2.31.1, fix policy error in 2nd arch.

### DIFF
--- a/sys-apps/util-linux/patches/util_linux-2.31.1.patchset
+++ b/sys-apps/util-linux/patches/util_linux-2.31.1.patchset
@@ -10,7 +10,7 @@ Subject: [PATCH] Haiku patches
  3 files changed, 42 insertions(+)
 
 diff --git a/include/c.h b/include/c.h
-index a5162b9..d9ffef7 100644
+index b0670dc..8808c32 100644
 --- a/include/c.h
 +++ b/include/c.h
 @@ -29,6 +29,10 @@
@@ -25,10 +25,10 @@ index a5162b9..d9ffef7 100644
   * Compiler-specific stuff
   */
 diff --git a/include/ttyutils.h b/include/ttyutils.h
-index 7278d36..f0d902f 100644
+index a9baab3..961fd49 100644
 --- a/include/ttyutils.h
 +++ b/include/ttyutils.h
-@@ -60,15 +60,23 @@ extern int get_terminal_name(const char **path, const char **name,
+@@ -61,15 +61,23 @@ extern int get_terminal_name(const char **path, const char **name,
  static inline void reset_virtual_console(struct termios *tp, int flags)
  {
  	/* Use defaults of <sys/ttydefaults.h> for base settings */
@@ -52,7 +52,7 @@ index 7278d36..f0d902f 100644
  	}
  
  	/* Sane setting, allow eight bit characters, no carriage return delay
-@@ -114,7 +122,11 @@ static inline void reset_virtual_console(struct termios *tp, int flags)
+@@ -115,7 +123,11 @@ static inline void reset_virtual_console(struct termios *tp, int flags)
  # define FFDLY 0
  #endif
  
@@ -64,7 +64,7 @@ index 7278d36..f0d902f 100644
  	tp->c_iflag &= ~(IGNBRK | INLCR | IGNCR | IXOFF | IUCLC | IXANY | ISTRIP);
  	tp->c_oflag |=  (OPOST | ONLCR | NL0 | CR0 | TAB0 | BS0 | VT0 | FF0);
  	tp->c_oflag &= ~(OLCUC | OCRNL | ONOCR | ONLRET | OFILL | \
-@@ -144,24 +156,48 @@ static inline void reset_virtual_console(struct termios *tp, int flags)
+@@ -145,24 +157,48 @@ static inline void reset_virtual_console(struct termios *tp, int flags)
  	 */
  	tp->c_cc[VTIME]    = 0;
  	tp->c_cc[VMIN]     = 1;
@@ -114,7 +114,7 @@ index 7278d36..f0d902f 100644
  }
  
 diff --git a/lib/randutils.c b/lib/randutils.c
-index 09dd261..cc7ac1f 100644
+index e1c4059..ac553bf 100644
 --- a/lib/randutils.c
 +++ b/lib/randutils.c
 @@ -13,7 +13,9 @@

--- a/sys-apps/util-linux/util_linux-2.31.1.recipe
+++ b/sys-apps/util-linux/util_linux-2.31.1.recipe
@@ -7,18 +7,20 @@ LICENSE="GNU GPL v2
 	BSD (4-clause)
 	Public Domain"
 REVISION="1"
-SOURCE_URI="https://www.kernel.org/pub/linux/utils/util-linux/v2.31/util-linux-$portVersion.tar.gz"
-CHECKSUM_SHA256="d5950e4b2839d00aa3781f439bfada8091bc6ed8180d8262c53b4e4304e2d299"
+SOURCE_URI="https://www.kernel.org/pub/linux/utils/util-linux/v2.31/util-linux-$portVersion.tar.xz"
+CHECKSUM_SHA256="1a51b16fa9cd51d26ef9ab52d2f1de12403b810fc8252bf7d478df91b3cddf11"
 SOURCE_DIR="util-linux-$portVersion"
 PATCHES="util_linux-$portVersion.patchset"
 
-ARCHITECTURES="?x86_gcc2 x86 x86_64"
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 # On x86_gcc2 we don't want to install the commands in bin/<arch>/, but in bin/.
 commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
 if [ "$targetArchitecture" = x86_gcc2 ]; then
 	commandSuffix=
+	commandBinDir=$prefix/bin
 fi
 
 PROVIDES="
@@ -69,8 +71,14 @@ BUILD()
 	export CFLAGS="-D_BSD_SOURCE -DB_USE_POSITIVE_POSIX_ERRORS"
 	export LDFLAGS="-lnetwork -lbsd -lposix_error_mapper"
 
-	autogen.sh
-	runConfigure ./configure \
+	./autogen.sh
+	if [ "$effectiveTargetArchitecture" = x86 ]; then
+		maybe_x86="scanf_cv_alloc_modifier=no"
+	else
+		maybe_x86=
+	fi
+	runConfigure --omit-dirs "binDir sbinDir" ./configure $maybe_x86 \
+		--bindir="$commandBinDir" --sbindir="$commandBinDir" \
 		--disable-all-programs \
 		--enable-cal \
 		--enable-libsmartcols \
@@ -95,6 +103,8 @@ INSTALL()
 
 	packageEntries devel \
 		$developDir
+
+	rmdir $manDir/man3
 }
 
 TEST()


### PR DESCRIPTION
* Use the commandBinDir "trick" to fix the policy error.
* Mark x86_gcc2 as broken because a gcc2 patch would be required.
* ~Drop the call to `autogen.sh`.~ (Package contents are identical.) _[Keeping the call to `autogen.sh` because it might be needed if we ever choose to enable some programs]_
* ~x86 secondary arch builds are hanging on two configure tests which crash. Dropping a paragraph in Makefile.am eliminates these crashes and has no impact on the resulting runtimes.~ _[Thanks @alaviss for the hint on passing "have_scanf_alloc_modifier=no" to configure.]_
* On x86, pass "have_scanf_alloc_modifier=no" to configure to skip a conftest which crashes and makes configure hang.
* Switch to tar.xz.