### PR TITLE
net-p2p/hefur: new recipe

### DIFF
--- a/net-p2p/hefur/hefur-0.6.recipe
+++ b/net-p2p/hefur/hefur-0.6.recipe
@@ -1,0 +1,105 @@
+SUMMARY="A standalone and lightweight BitTorrent tracker"
+DESCRIPTION="Hefur is a standalone C++ BitTorrent tracker.
+
+Features:
+ - support HTTP, HTTPS and UPD announce and scrape
+ - support both IPv4 and IPv6
+ - no database required (everything in memory)
+ - should be efficient
+ - perfect for small setup
+ - info_hash white list based on .torrent in a directory tree
+ - control interface
+ - control program: hefurctl"
+HOMEPAGE="https://github.com/abique/hefur"
+COPYRIGHT="2012 Alexandre Bique"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://github.com/abique/hefur/archive/$portVersion.tar.gz"
+CHECKSUM_SHA256="ce693eb5f0410e47cd1f65906b77c9b0179eb807943119b900a8fa8f630d0d7b"
+SOURCE_FILENAME="hefur-$portVersion.tar.gz"
+PATCHES="hefur-$portVersion.patchset" # Merged upstream
+srcGitRev2="22137aa7f90b0f90bc48172d964deb82d6e4f2f9"
+SOURCE_URI_2="https://github.com/abique/mimosa/archive/$srcGitRev2.tar.gz"
+CHECKSUM_SHA256_2="abe7992fd45d9a458ebc8786de750ebbe6b961076065f4b6f6f7a870d524fc29"
+SOURCE_FILENAME_2="mimosa-$srcGitRev2.tar.gz"
+SOURCE_DIR_2="mimosa-$srcGitRev2"
+PATCHES_2="mimosa-$srcGitRev2.patchset" # Merged upstream
+
+ARCHITECTURES="!x86_gcc2 x86_64"
+SECONDARY_ARCHITECTURES="?x86"
+
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ -z "${ARCHITECTURES##*!$targetArchitecture*}" ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+PROVIDES="
+	hefur$secondaryArchSuffix = $portVersion
+	cmd:hefurctl$commandSuffix = $portVersion
+	cmd:hefurd$commandSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:liblzma$secondaryArchSuffix
+	lib:libgnutls$secondaryArchSuffix
+	lib:libnettle$secondaryArchSuffix
+	lib:libprotobuf$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel >= r1~alpha4_pm_hrev51768-1
+	devel:libarchive$secondaryArchSuffix
+	devel:libgnutls$secondaryArchSuffix
+	devel:liblzma$secondaryArchSuffix
+	devel:libprotobuf$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	docbook_xsl_stylesheets
+	cmd:bison$secondaryArchSuffix
+	cmd:cc$secondaryArchSuffix
+	cmd:cmake
+	cmd:flex
+	cmd:make
+	cmd:protoc$secondaryArchSuffix
+	cmd:xsltproc$secondaryArchSuffix
+	"
+
+TEST_REQUIRES="
+	devel:libgtest$secondaryArchSuffix
+	devel:libgtest_main$secondaryArchSuffix
+	"
+BUILD_REQUIRES+="$TEST_REQUIRES"
+
+BUILD()
+{
+	cp -rt mimosa "$sourceDir2"/*
+
+	cmake . \
+		$cmakeDirArgs \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_CXX_FLAGS="-D_BSD_SOURCE" \
+		-DCMAKE_EXE_LINKER_FLAGS="-lnetwork -lgnu"
+	make $jobArgs
+
+	local systemData="$(finddir B_SYSTEM_DATA_DIRECTORY)"
+	local docBookXsl=(
+		$systemData/xml/docbook/xsl-stylesheets-*/html/docbook.xsl
+		)
+	cd manual
+	xsltproc -o manual.html \
+		"$docBookXsl" \
+		manual.xml
+}
+
+INSTALL()
+{
+	make install
+}
+
+TEST()
+{
+	make check
+}

--- a/net-p2p/hefur/patches/hefur-0.6.patchset
+++ b/net-p2p/hefur/patches/hefur-0.6.patchset
@@ -1,0 +1,83 @@
+From 7fa6d6448c142409058a40617fa0071d6a6053e6 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Tue, 16 Jan 2018 18:45:42 +0700
+Subject: CMakeLists: Use GNUInstallDirs and don't link rt
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f6780e0..63ede58 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -24,17 +24,25 @@ if(HEFUR_CONTROL_INTERFACE)
+   add_definitions(-DHEFUR_CONTROL_INTERFACE)
+ endif()
+ 
++include(GNUInstallDirs)
++
++if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
++  set(RT_LIB "rt")
++else()
++  set(RT_LIB "")
++endif()
++
+ add_subdirectory(mimosa EXCLUDE_FROM_ALL)
+ include_directories(mimosa)
+ add_subdirectory(hefur)
+ 
+ install(
+   DIRECTORY www/
+-  DESTINATION share/hefur/www
++  DESTINATION ${CMAKE_INSTALL_DATADIR}/hefur/www
+   PATTERN bootstrap EXCLUDE
+   PATTERN *.less EXCLUDE
+   PATTERN update-bootstrap.sh EXCLUDE)
+ 
+ install(
+   FILES manual/manual.html
+-  DESTINATION share/doc/hefur/)
+\ No newline at end of file
++  DESTINATION ${CMAKE_INSTALL_DOCDIR}/hefur/)
+diff --git a/hefur/CMakeLists.txt b/hefur/CMakeLists.txt
+index c347e9f..7c11b0d 100644
+--- a/hefur/CMakeLists.txt
++++ b/hefur/CMakeLists.txt
+@@ -15,12 +15,12 @@ if(HEFUR_CONTROL_INTERFACE)
+     mimosa
+     ${GNUTLS_LIBRARY}
+     pthread
+-    rt)
++    ${RT_LIB})
+ 
+   install(TARGETS hefurctl
+-    RUNTIME DESTINATION bin
+-    LIBRARY DESTINATION lib
+-    ARCHIVE DESTINATION lib)
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ 
+   set(HEFURD_CONTROL_SOURCES
+     control-server.cc
+@@ -64,13 +64,13 @@ target_link_libraries(hefurd
+   mimosa
+   ${GNUTLS_LIBRARY}
+   pthread
+-  rt)
++  ${RT_LIB})
+ 
+ install(TARGETS hefurd
+-  RUNTIME DESTINATION bin
+-  LIBRARY DESTINATION lib
+-  ARCHIVE DESTINATION lib
+-  PUBLIC_HEADER DESTINATION include/hefur)
++  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hefur)
+ 
+ install(FILES tracker-controller.hh
+-  DESTINATION include/hefur)
++  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hefur)
+-- 
+2.15.0
+

--- a/net-p2p/hefur/patches/mimosa-22137aa7f90b0f90bc48172d964deb82d6e4f2f9.patchset
+++ b/net-p2p/hefur/patches/mimosa-22137aa7f90b0f90bc48172d964deb82d6e4f2f9.patchset
@@ -1,0 +1,208 @@
+From 09c13139f8ccbf8953394b8ed33f1b312fcedb90 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Mon, 15 Jan 2018 22:08:24 +0700
+Subject: CMakeLists: Use CheckSymbolExists
+
+Replace CheckFunctionExists with CheckSymbolExists. This allows the use
+of macro definitions
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index de8a13e..094454b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -26,34 +26,34 @@ include(cmake/Flex.cmake)
+ include(cmake/Bison.cmake)
+ include(cmake/ProtocMimosa.cmake)
+ 
+-include(CheckFunctionExists)
++include(CheckSymbolExists)
+ 
+-check_function_exists(writev HAS_WRITEV)
++check_symbol_exists(writev sys/uio.h HAS_WRITEV)
+ if(HAS_WRITEV)
+   add_definitions(-DHAS_WRITEV)
+ endif()
+ 
+-check_function_exists(strchrnul HAS_STRCHRNUL)
++check_symbol_exists(strchrnul string.h HAS_STRCHRNUL)
+ if(HAS_STRCHRNUL)
+   add_definitions(-DHAS_STRCHRNUL)
+ endif()
+ 
+-check_function_exists(timegm HAS_TIMEGM)
++check_symbol_exists(timegm time.h HAS_TIMEGM)
+ if(HAS_TIMEGM)
+   add_definitions(-DHAS_TIMEGM)
+ endif()
+ 
+-check_function_exists(sched_setaffinity HAS_SCHED_SETAFFINITY)
++check_symbol_exists(sched_setaffinity sched.h HAS_SCHED_SETAFFINITY)
+ if(HAS_SCHED_SETAFFINITY)
+   add_definitions(-DHAS_SCHED_SETAFFINITY)
+ endif()
+ 
+-check_function_exists(poll HAS_POLL)
++check_symbol_exists(poll poll.h HAS_POLL)
+ if(HAS_POLL)
+   add_definitions(-DHAS_POLL)
+ endif()
+ 
+-check_function_exists(pipe HAS_PIPE)
++check_symbol_exists(pipe unistd.h HAS_PIPE)
+ if(HAS_PIPE)
+   add_definitions(-DHAS_PIPE)
+ endif()
+-- 
+2.15.0
+
+
+From d4d6447d782aefc4ff6e6729d93e0fbfc76af102 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Mon, 15 Jan 2018 22:19:13 +0700
+Subject: flat: Add support for system without mremap(2)
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 094454b..3153277 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -58,4 +58,9 @@ if(HAS_PIPE)
+   add_definitions(-DHAS_PIPE)
+ endif()
+ 
++check_symbol_exists(mremap sys/mman.h HAS_MREMAP)
++if(HAS_MREMAP)
++  add_definitions(-DHAS_MREMAP)
++endif()
++
+ add_subdirectory(mimosa)
+diff --git a/mimosa/flat/flat.cc b/mimosa/flat/flat.cc
+index d1ba086..7e6481a 100644
+--- a/mimosa/flat/flat.cc
++++ b/mimosa/flat/flat.cc
+@@ -1,3 +1,6 @@
++#ifndef HAS_MREMAP
++# include <stdlib.h>
++#endif
+ #include <sys/mman.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
+@@ -96,9 +99,16 @@ namespace mimosa
+       if (size <= mapped_size_)
+         return true;
+ 
+-      void *addr = mremap(base_, mapped_size_, size, MREMAP_MAYMOVE);
++      void *addr;
++#ifdef HAS_MREMAP
++      addr = mremap(base_, mapped_size_, size, MREMAP_MAYMOVE);
+       if (addr == MAP_FAILED)
+         return false;
++#else
++      addr = realloc(base_, size);
++      if (addr == NULL)
++        return false;
++#endif
+ 
+       base_        = (uint8_t*)addr;
+       mapped_size_ = size;
+-- 
+2.15.0
+
+
+From bb9486898e516cc6f5287a33825314cdf5c99627 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Mon, 15 Jan 2018 22:22:21 +0700
+Subject: fs/copy: Use struct stat instead of struct stat64
+
+struct stat64 is Linux-only
+
+diff --git a/mimosa/fs/copy.cc b/mimosa/fs/copy.cc
+index 0b7b657..3fd9904 100644
+--- a/mimosa/fs/copy.cc
++++ b/mimosa/fs/copy.cc
+@@ -11,9 +11,9 @@ namespace mimosa
+     {
+       stream::DirectFdStream srcStream;
+ 
+-      struct ::stat64 st;
++      struct ::stat st;
+ 
+-      if (::stat64(src.c_str(), &st))
++      if (::stat(src.c_str(), &st))
+         return false;
+ 
+       if (!srcStream.open(src.c_str(), O_RDONLY))
+-- 
+2.15.0
+
+
+From c967e1edbea4f4abfa1b0a62a8d6bd5a7e02e584 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Tue, 16 Jan 2018 07:21:23 +0700
+Subject: mimosa: add Haiku support
+
+
+diff --git a/mimosa/compat/uio.hh b/mimosa/compat/uio.hh
+index 3da9531..8d3407b 100644
+--- a/mimosa/compat/uio.hh
++++ b/mimosa/compat/uio.hh
+@@ -3,7 +3,7 @@
+ # include <sys/types.h>
+ # include <cstdint>
+ 
+-# if defined(__unix__) || defined(__APPLE__)
++# if defined(__unix__) || defined(__APPLE__) || defined(__HAIKU__)
+ #  include <sys/uio.h>
+ # else
+ #  define IOV_MAX 128
+diff --git a/mimosa/net/print.hh b/mimosa/net/print.hh
+index de3f2a5..a0c0031 100644
+--- a/mimosa/net/print.hh
++++ b/mimosa/net/print.hh
+@@ -2,8 +2,9 @@
+ 
+ #include <sys/types.h>
+ 
+-#if defined(__unix__) || defined(__APPLE__)
++#if defined(__unix__) || defined(__APPLE__) || defined(__HAIKU__)
+ # include <sys/socket.h>
++# include <netdb.h>
+ #endif
+ 
+ #ifdef __WIN32__
+diff --git a/mimosa/preproc.hh b/mimosa/preproc.hh
+index 6ebb67e..d22c52a 100644
+--- a/mimosa/preproc.hh
++++ b/mimosa/preproc.hh
+@@ -6,7 +6,7 @@
+ #elif defined(__APPLE__)
+ # define MIMOSA_MAC
+ # define MIMOSA_UNIX
+-#elif defined(__unix__)
++#elif defined(__unix__) || defined(__HAIKU__)
+ # define MIMOSA_UNIX
+ #elif defined(__WIN32__)
+ # define MIMOSA_WIN
+diff --git a/mimosa/thread.cc b/mimosa/thread.cc
+index b141ba6..e79c3b8 100644
+--- a/mimosa/thread.cc
++++ b/mimosa/thread.cc
+@@ -88,6 +88,7 @@ namespace mimosa
+   {
+ #ifdef __WIN32__
+ #elif defined(__MACH__)
++#elif defined(__HAIKU__)
+ #else
+     pthread_setname_np(thread_, name.c_str());
+ #endif
+@@ -98,6 +99,7 @@ namespace mimosa
+ #ifdef __MACH__
+     pthread_setname_np(name.c_str());
+ #elif defined(__WIN32__)
++#elif defined(__HAIKU__)
+ #else
+     pthread_setname_np(pthread_self(), name.c_str());
+ #endif
+-- 
+2.15.0
+


### PR DESCRIPTION
The last PR as part of GCI 2017

Changes to hefur:
- Make packaging easier, also fixes linking on Haiku (https://github.com/abique/hefur/pull/26)

Changes to mimosa:
- Make mimosa works on Haiku (https://github.com/abique/mimosa/pull/5)

Requires: [Ticket#13960](https://dev.haiku-os.org/ticket/13960)

Not tested on x86 secondary architecture due to problems compiling Haiku x86_gcc2 :disappointed: 
