### PR TITLE
zstd: bump to 1.3.3, add debuginfo, drop HTML manual.

### DIFF
--- a/app-arch/zstd/patches/zstd-1.3.3.patchset
+++ b/app-arch/zstd/patches/zstd-1.3.3.patchset
@@ -5,10 +5,10 @@ Subject: Haiku patch
 
 
 diff --git a/Makefile b/Makefile
-index 2805c8a..b14f2c6 100644
+index c8f0ed4..6a0a1b9 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -104,7 +104,7 @@ clean:
+@@ -107,7 +107,7 @@ clean:
  #------------------------------------------------------------------------------
  # make install is validated only for Linux, OSX, Hurd and some BSD targets
  #------------------------------------------------------------------------------
@@ -31,7 +31,7 @@ index cdfdc5c..8459970 100644
  DESTDIR     ?=
  # directory variables : GNU conventions prefer lowercase
 diff --git a/programs/Makefile b/programs/Makefile
-index cbb67e9..0f4bb6e 100644
+index 51888d3..f4dc3aa 100644
 --- a/programs/Makefile
 +++ b/programs/Makefile
 @@ -243,7 +243,7 @@ preview-man: clean-man man
@@ -44,7 +44,7 @@ index cbb67e9..0f4bb6e 100644
  .PHONY: list
  list:
 diff --git a/programs/platform.h b/programs/platform.h
-index a4d7850..bd78b8a 100644
+index 81dee23..f415006 100644
 --- a/programs/platform.h
 +++ b/programs/platform.h
 @@ -70,9 +70,10 @@ extern "C" {
@@ -61,13 +61,13 @@ index a4d7850..bd78b8a 100644
  #  else
  #    if defined(__linux__) || defined(__linux)
 diff --git a/programs/util.h b/programs/util.h
-index c8be5f5..0ac585a 100644
+index af1fa7f..4123efa 100644
 --- a/programs/util.h
 +++ b/programs/util.h
-@@ -65,7 +65,7 @@ extern "C" {
+@@ -64,7 +64,7 @@ extern "C" {
+ #elif PLATFORM_POSIX_VERSION >= 0 /* Unix-like operating system */
  #  include <unistd.h>
  #  include <sys/resource.h> /* setpriority */
- #  include <time.h>         /* clock_t, nanosleep, clock, CLOCKS_PER_SEC */
 -#  if defined(PRIO_PROCESS)
 +#  if defined(PRIO_PROCESS) && !defined(__HAIKU__)
  #    define SET_REALTIME_PRIORITY setpriority(PRIO_PROCESS, 0, -20)

--- a/app-arch/zstd/zstd-1.3.3.recipe
+++ b/app-arch/zstd/zstd-1.3.3.recipe
@@ -10,10 +10,10 @@ can create dictionaries from any sample set."
 HOMEPAGE="https://facebook.github.io/zstd/"
 COPYRIGHT="2016-2017 Facebook, Inc."
 LICENSE="BSD (2-clause)"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://github.com/facebook/zstd/archive/v$portVersion.tar.gz"
 SOURCE_FILENAME="zstd-$portVersion.tar.gz"
-CHECKSUM_SHA256="ac5054a3c64e6510bc1ae890d05e3d271cc33ceebc9d06ac9f08105766d2798a"
+CHECKSUM_SHA256="a77c47153ee7de02626c5b2a097005786b71688be61e9fb81806a011f90b297b"
 PATCHES="zstd-$portVersion.patchset"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
@@ -26,9 +26,12 @@ if [ "$targetArchitecture" = x86_gcc2 ]; then
 	commandBinDir=$prefix/bin
 fi
 
+libVersion="$portVersion"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
 PROVIDES="
 	zstd$secondaryArchSuffix = $portVersion
-	lib:libzstd$secondaryArchSuffix = $portVersion compat >= 1
+	lib:libzstd$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -36,7 +39,6 @@ REQUIRES="
 
 PROVIDES_bin="
 	zstd${secondaryArchSuffix}_bin = $portVersion
-	cmd:gzstd$commandSuffix = $portVersion
 	cmd:pzstd$commandSuffix = $portVersion
 	cmd:unzstd$commandSuffix = $portVersion
 	cmd:zstd$commandSuffix = $portVersion
@@ -54,7 +56,7 @@ REQUIRES_bin="
 
 PROVIDES_devel="
 	zstd${secondaryArchSuffix}_devel = $portVersion
-	devel:libzstd$secondaryArchSuffix = $portVersion compat >= 1
+	devel:libzstd$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
 	zstd$secondaryArchSuffix == $portVersion base
@@ -69,19 +71,21 @@ BUILD_PREREQUIRES="
 	cmd:sed
 	"
 
+defineDebugInfoPackage zstd$secondaryArchSuffix \
+	$libDir/libzstd.so.$libVersion
+
 BUILD()
 {
 	make PREFIX=$prefix INCLUDEDIR=$includeDir LIBDIR=$libDir $jobArgs
 	make -C contrib/pzstd
 	make -C contrib/gen_html
-	contrib/gen_html/gen_html $portVersion lib/zstd.h zstd_manual.html
 }
 
 INSTALL()
 {
 	mkdir -p $libDir
 	make install PREFIX=$prefix LIBDIR=$libDir INCLUDEDIR=$includeDir \
-		BINDIR=$commandBinDir MANDIR=$manDir/man1
+		BINDIR=$commandBinDir mandir=$manDir
 	make -C contrib/pzstd install PREFIX=$prefix BINDIR=$commandBinDir
 
 	prepareInstalledDevelLib libzstd
@@ -97,7 +101,7 @@ INSTALL()
 	rmdir $manDir
 
 	install -d $docDir
-	install -t $docDir -m 444 LICENSE zstd_manual.html
+	install -t $docDir -m 444 LICENSE
 }
 
 TEST()


### PR DESCRIPTION
Also remove `cmd:gzstd` from `PROVIDES_bin` as it no longer exists.