### PR TITLE
kdiff3: fix whitespace issue in patch to allow hp --no-git-repo

### DIFF
--- a/kde-misc/kdiff3/kdiff3-0.9.98.recipe
+++ b/kde-misc/kdiff3/kdiff3-0.9.98.recipe
@@ -13,10 +13,10 @@ DESCRIPTION="KDiff3 is a diff and merge program that:
 * Automatic merging of version control history ($Log$),
 * and has an intuitive graphical user interface."
 HOMEPAGE="http://kdiff3.sourceforge.net/"
-COPYRIGHT="2002-2015 by Joachim Eibl"
+COPYRIGHT="2002-2014 Joachim Eibl"
 LICENSE="GNU GPL v2"
-REVISION="2"
-SOURCE_URI="http://sourceforge.net/projects/kdiff3/files/kdiff3/$portVersion/kdiff3-$portVersion.tar.gz"
+REVISION="3"
+SOURCE_URI="https://downloads.sourceforge.net/kdiff3/kdiff3-$portVersion.tar.gz"
 CHECKSUM_SHA256="802c1ababa02b403a5dca15955c01592997116a24909745016931537210fd668"
 PATCHES="kdiff3-$portVersion.patchset"
 ADDITIONAL_FILES="kdiff3.rdef.in"
@@ -24,9 +24,16 @@ ADDITIONAL_FILES="kdiff3.rdef.in"
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
 PROVIDES="
 	kdiff3$secondaryArchSuffix = $portVersion
-	cmd:kdiff3$secondaryArchSuffix = $portVersion
+	cmd:kdiff3$commandSuffix = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -41,9 +48,9 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
-	cmd:make
-	cmd:qmake$secondaryArchSuffix >=5.7
 	cmd:g++$secondaryArchSuffix
+	cmd:make
+	cmd:qmake$secondaryArchSuffix >= 5.7
 	"
 
 BUILD()
@@ -56,8 +63,8 @@ BUILD()
 
 INSTALL()
 {
-	mkdir -p $binDir
-	cp -af build/kdiff3 $binDir
+	install -d $commandBinDir
+	install -t $commandBinDir build/kdiff3
 
 	local APP_SIGNATURE="application/x-vnd.qt5-kdiff3"
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
@@ -72,6 +79,6 @@ INSTALL()
 		-e "s|@LONG_INFO@|$LONG_INFO|" \
 		$portDir/additional-files/kdiff3.rdef.in > kdiff3.rdef
 
-	addResourcesToBinaries kdiff3.rdef $binDir/kdiff3
-	addAppDeskbarSymlink $binDir/kdiff3 KDiff3
+	addResourcesToBinaries kdiff3.rdef $commandBinDir/kdiff3
+	addAppDeskbarSymlink $commandBinDir/kdiff3 KDiff3
 }

--- a/kde-misc/kdiff3/patches/kdiff3-0.9.98.patchset
+++ b/kde-misc/kdiff3/patches/kdiff3-0.9.98.patchset
@@ -1,11 +1,11 @@
-From f67abf36fc26fcc9e86c16fef5ef86c89f995378 Mon Sep 17 00:00:00 2001
+From b1e5b43476070d319d12d9f5632b9b6d54810ad8 Mon Sep 17 00:00:00 2001
 From: Bach Nguyen <bach5000@gci.test>
 Date: Tue, 26 Dec 2017 21:45:17 +0000
 Subject: Fix settings dir
 
 
 diff --git a/src-QT4/kreplacements/kreplacements.cpp b/src-QT4/kreplacements/kreplacements.cpp
-index 6564ae8..ebda855 100644
+index 6564ae8..1e648a2 100644
 --- a/src-QT4/kreplacements/kreplacements.cpp
 +++ b/src-QT4/kreplacements/kreplacements.cpp
 @@ -48,6 +48,9 @@
@@ -18,24 +18,20 @@ index 6564ae8..ebda855 100644
  
  static QString s_copyright;
  static QString s_email;
-@@ -419,12 +422,18 @@ QString KStandardDirs::findResource(const QString& resource, const QString& /*ap
-    {
- #if defined(_WIN32) || defined(Q_OS_OS2)
-       QString exePath = QCoreApplication::applicationDirPath();
+@@ -422,9 +425,15 @@ QString KStandardDirs::findResource(const QString& resource, const QString& /*ap
        QString configPath = exePath + "/.kdiff3rc"; // This is useful for portable installations (e.g. on USB-Stick)
        if ( QFile::exists( configPath ) )
           return configPath;
+-#endif
 +#elif defined(__HAIKU__)
 +      char hdir[B_PATH_NAME_LENGTH + B_FILE_NAME_LENGTH];
 +      find_directory(B_USER_SETTINGS_DIRECTORY, -1, false, hdir, sizeof(hdir));
 +      QString settings = hdir;
 +      return settings + "/kdiff3rc";
 +#else
-+	QString home = QDir::homePath();
-+      return home + "/.kdiff3rc";
- #endif
--      QString home = QDir::homePath();
--      return home + "/.kdiff3rc";
+       QString home = QDir::homePath();
+       return home + "/.kdiff3rc";
++#endif
     }
     return QString();
  }


### PR DESCRIPTION
... to work. Previously, it only worked without the `--no-git-repo`.
* Shrink the patch a bit by dropping an unneeded indentation change.
* Use `commandBinDir` & `commandSuffix` to move kdiff3 to `$prefix/bin/`.
* Switch `SOURCE_URI` to https and fix `COPYRIGHT`.