### PR TITLE
x11-libs/libXfixes: add debuginfo package.

### DIFF
--- a/x11-libs/libxfixes/libxfixes-5.0.3.recipe
+++ b/x11-libs/libxfixes/libxfixes-5.0.3.recipe
@@ -3,20 +3,26 @@ DESCRIPTION="X applications have often needed to work around various \
 shortcomings in the core X window system. This extension is designed to \
 provide the minimal server-side support necessary to eliminate problems \
 caused by these workarounds."
-HOMEPAGE="http://xorg.freedesktop.org/releases/individual/lib/"
-COPYRIGHT="2001, 2003 Keith Packard"
-LICENSE="MIT (no promotion)"
-REVISION="1"
+HOMEPAGE="https://www.x.org/wiki/"
+COPYRIGHT="2001-2003 Keith Packard
+	2003 Noah Levitt
+	2006 Oracle and/or its affiliates
+	2011 Red Hat"
+LICENSE="libXfixes"
+REVISION="2"
 SOURCE_URI="https://www.x.org/archive/individual/lib/libXfixes-$portVersion.tar.gz"
 CHECKSUM_SHA256="9ab6c13590658501ce4bd965a8a5d32ba4d8b3bb39a5a5bc9901edffc5666570"
 SOURCE_DIR="libXfixes-$portVersion"
 
-ARCHITECTURES="?x86_gcc2 x86 x86_64"
+ARCHITECTURES="x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
+
+libVersion="3.1.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
 	libxfixes$secondaryArchSuffix = $portVersion
-	lib:libxfixes$secondaryArchSuffix = 3.1.0 compat >= 3
+	lib:libxfixes$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -25,7 +31,7 @@ REQUIRES="
 
 PROVIDES_devel="
 	libxfixes${secondaryArchSuffix}_devel = $portVersion
-	devel:libxfixes$secondaryArchSuffix = 3.1.0 compat >= 3
+	devel:libxfixes$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
 	libxfixes$secondaryArchSuffix == $portVersion base
@@ -42,32 +48,43 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	devel:util_macros$secondaryArchSuffix
-	cmd:autoconf
-	cmd:libtool
 	cmd:aclocal
-	cmd:make
+	cmd:autoconf
+	cmd:automake
+	cmd:autoheader
+	cmd:awk
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	cmd:makeinfo
 	cmd:pkg_config$secondaryArchSuffix
 	"
+
+defineDebugInfoPackage libxfixes$secondaryArchSuffix \
+	$libDir/libXfixes.so.$libVersion
 
 BUILD()
 {
 	libtoolize --force --copy --install
 	autoreconf -i
 	runConfigure ./configure
+	make $jobArgs
 }
 
 INSTALL()
 {
 	make install
+	install -d "$docDir"
+	install -t "$docDir" README
 
-	rm -rf $libDir/libXfixes.la
+	rm -f "$libDir"/libXfixes.la
 
 	fixPkgconfig
 	prepareInstalledDevelLib libXfixes
 
 	# devel package
 	packageEntries devel \
-		$developDir
+		"$developDir" \
+		"$manDir"
 }

--- a/x11-libs/libxfixes/licenses/libXfixes
+++ b/x11-libs/libxfixes/licenses/libXfixes
@@ -1,0 +1,41 @@
+
+Copyright © 2001,2003 Keith Packard
+
+Permission to use, copy, modify, distribute, and sell this software and its
+documentation for any purpose is hereby granted without fee, provided that
+the above copyright notice appear in all copies and that both that
+copyright notice and this permission notice appear in supporting
+documentation, and that the name of Keith Packard not be used in
+advertising or publicity pertaining to distribution of the software without
+specific, written prior permission.  Keith Packard makes no
+representations about the suitability of this software for any purpose.  It
+is provided "as is" without express or implied warranty.
+
+KEITH PACKARD DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+EVENT SHALL KEITH PACKARD BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next
+paragraph) shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
* Mark x86_gcc2 as tested.
* Fix `HOMEPAGE`, `COPYRIGHT`, `LICENSE`.
* Add the project's `COPYING` file as `licenses/libXfixes`.
* Sort `BUILD_PREREQUIRES`, add recommended `cmd:` lines.
* Add missing `make $jobArgs` in `BUILD()` to build before `INSTALL()`.
* Move man3 to devel.
* Add `README`.