### PR TITLE
x11-libs/libXrender: enable x86_gcc2.

### DIFF
--- a/x11-libs/libxrender/libxrender-0.9.10.recipe
+++ b/x11-libs/libxrender/libxrender-0.9.10.recipe
@@ -3,9 +3,9 @@ DESCRIPTION="The Xrender library is designed as a lightweight library \
 interface to the Render extension."
 HOMEPAGE="https://www.x.org/releases/individual/lib/"
 COPYRIGHT="2000 SuSE, Inc
-	2001,2003 Keith Packard"
-LICENSE="MIT (no promotion)"
-REVISION="1"
+	2001-2003 Keith Packard"
+LICENSE="libXrender"
+REVISION="2"
 SOURCE_URI="https://www.x.org/releases/individual/lib/libXrender-$portVersion.tar.bz2"
 CHECKSUM_SHA256="c06d5979f86e64cabbde57c223938db0b939dff49fdb5a793a1d3d0396650949"
 SOURCE_DIR="libXrender-$portVersion"
@@ -13,7 +13,7 @@ SOURCE_DIR="libXrender-$portVersion"
 libVersion=1.3.0
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
-ARCHITECTURES="!x86_gcc2 x86 ?x86_64"
+ARCHITECTURES="x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
@@ -58,13 +58,15 @@ defineDebugInfoPackage libxrender$secondaryArchSuffix \
 BUILD()
 {
 	autoreconf -vfi
-	runConfigure ./configure
+	runConfigure --omit-dirs docDir ./configure --docdir "$developDocDir"
 	make $jobArgs
 }
 
 INSTALL()
 {
 	make install
+	install -d "$docDir"
+	install -t "$docDir" README
 
 	rm -f $libDir/*.la
 

--- a/x11-libs/libxrender/licenses/libXrender
+++ b/x11-libs/libxrender/licenses/libXrender
@@ -1,0 +1,39 @@
+
+Copyright © 2001,2003 Keith Packard
+
+Permission to use, copy, modify, distribute, and sell this software and its
+documentation for any purpose is hereby granted without fee, provided that
+the above copyright notice appear in all copies and that both that
+copyright notice and this permission notice appear in supporting
+documentation, and that the name of Keith Packard not be used in
+advertising or publicity pertaining to distribution of the software without
+specific, written prior permission.  Keith Packard makes no
+representations about the suitability of this software for any purpose.  It
+is provided "as is" without express or implied warranty.
+
+KEITH PACKARD DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+EVENT SHALL KEITH PACKARD BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+Copyright © 2000 SuSE, Inc.
+
+Permission to use, copy, modify, distribute, and sell this software and its
+documentation for any purpose is hereby granted without fee, provided that
+the above copyright notice appear in all copies and that both that
+copyright notice and this permission notice appear in supporting
+documentation, and that the name of SuSE not be used in advertising or
+publicity pertaining to distribution of the software without specific,
+written prior permission.  SuSE makes no representations about the
+suitability of this software for any purpose.  It is provided "as is"
+without express or implied warranty.
+
+SuSE DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING ALL
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT SHALL SuSE
+BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.


### PR DESCRIPTION
* Mark x86_64 as tested.
* Fix `COPYRIGHT` years and `LICENSE`.
* Add the project's `COPYING` file as `licenses/libXrender`.
* Add `README` to `$docDir`.
* Move `libXrender.txt` to `$developDocDir`.