### PR TITLE
sys-block/parted: add debuginfo package, mark as untested.

### DIFF
--- a/sys-block/parted/parted-3.2.recipe
+++ b/sys-block/parted/parted-3.2.recipe
@@ -5,13 +5,13 @@ data on hard disks and disk imaging."
 HOMEPAGE="https://www.gnu.org/software/parted/"
 COPYRIGHT="1999-2014 Free Software Foundation Inc."
 LICENSE="GNU GPL v3"
-REVISION="2"
-SOURCE_URI="http://ftp.gnu.org/gnu/parted/parted-$portVersion.tar.xz"
+REVISION="3"
+SOURCE_URI="https://ftpmirror.gnu.org/parted/parted-$portVersion.tar.xz"
 CHECKSUM_SHA256="858b589c22297cacdf437f3baff6f04b333087521ab274f7ab677cb8c6bb78e4"
 PATCHES="parted-$portVersion.patchset"
 
-ARCHITECTURES="!x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="!x86_gcc2 ?x86"
+ARCHITECTURES="!x86_gcc2 ?x86_64"
+SECONDARY_ARCHITECTURES="?x86"
 
 # On x86_gcc2 we don't want to install the commands in bin/<arch>/, but in bin/.
 commandSuffix=$secondaryArchSuffix
@@ -21,12 +21,21 @@ if [ "$targetArchitecture" = x86_gcc2 ]; then
 	commandBinDir=$prefix/bin
 fi
 
+libVersion="2.0.1"
+libFsResizeVersion="0.0.1"
+
+libMajorVersion="${libVersion%%.*}"
+libFsResizeMajorVersion="${libFsResizeVersion%%.*}"
+
+libVersionCompat="$libVersion compat >= $libMajorVersion"
+libFsResizeVersionCompat="$libFsResizeVersion compat >= $libFsResizeMajorVersion"
+
 PROVIDES="
 	parted$secondaryArchSuffix = $portVersion
 	cmd:parted$commandSuffix = $portVersion
 	cmd:partprobe$commandSuffix = $portVersion
-	lib:libparted$secondaryArchSuffix = 2.0.1 compat >= 2
-	lib:libparted_fs_resize$secondaryArchSuffix = 0.0.1 compat >= 0
+	lib:libparted$secondaryArchSuffix = $libVersionCompat
+	lib:libparted_fs_resize$secondaryArchSuffix = $libFsResizeVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -39,8 +48,8 @@ REQUIRES="
 
 PROVIDES_devel="
 	parted${secondaryArchSuffix}_devel = $portVersion
-	devel:libparted$secondaryArchSuffix = 2.0.1 compat >= 2
-	devel:libparted_fs_resize$secondaryArchSuffix = 0.0.1 compat >= 0
+	devel:libparted$secondaryArchSuffix = $libVersionCompat
+	devel:libparted_fs_resize$secondaryArchSuffix = $libFsResizeVersionCompat
 	"
 REQUIRES_devel="
 	parted$secondaryArchSuffix == $portVersion base
@@ -80,6 +89,10 @@ BUILD_PREREQUIRES="
 	cmd:sed
 	"
 
+defineDebugInfoPackage parted$secondaryArchSuffix \
+	"$libDir"/libparted.so.$libVersion \
+	"$libDir"/libparted-fs-resize.so.$libFsResizeVersion
+
 BUILD()
 {
 	autoreconf
@@ -91,6 +104,9 @@ BUILD()
 INSTALL()
 {
 	make install
+
+	rm -f "$libDir"/libparted*.la
+	rm -f "$infoDir"/dir
 
 	prepareInstalledDevelLibs \
 		libparted \


### PR DESCRIPTION
* Mark as untested on all architectures, as parted does not seem to be working correctly on Haiku at the moment.
* Switch `SOURCE_URI` to `ftpmirror.gnu.org`, using https.
* Drop libtool files as well as the unneeded `$infoDir/dir`.