### PR TITLE
dev-libs/GeoIP: bump to 1.6.12, add debuginfo, shrink TEST().

### DIFF
--- a/dev-libs/geoip/geoip-1.6.12.recipe
+++ b/dev-libs/geoip/geoip-1.6.12.recipe
@@ -8,27 +8,30 @@ GeoLiteCity(v6) and GeoIPASNum(v6) free databases for the first time. Call \
 month) to update them later. Another package, geoipupdate, may be used to \
 download GeoLite Legacy, GeoLite2 and GeoIP2 databases from MaxMind."
 HOMEPAGE="https://dev.maxmind.com/geoip/legacy/"
-COPYRIGHT="2002-2016 MaxMind, Inc."
+COPYRIGHT="2002-2018 MaxMind, Inc."
 LICENSE="GNU LGPL v2.1"
 REVISION="1"
 SOURCE_URI="https://github.com/maxmind/geoip-api-c/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="8859cb7c9cb63e77f4aedb40a4622024359b956b251aba46b255acbe190c34e0"
+CHECKSUM_SHA256="99b119f8e21e94f1dfd6d49fbeed29a70df1544896e76cd456f25e397b07d476"
 SOURCE_FILENAME="geoip-api-c-$portVersion.tar.gz"
 SOURCE_DIR="geoip-api-c-$portVersion"
-SOURCE_FILENAME_2="geoipupdate-r5.sh"
-srcGitRev_2="11461b27c10c146db1619bd2b5c9448a4c5e4e0f"
+SOURCE_FILENAME_2="geoipupdate-r6.sh"
+srcGitRev_2="f04629f7a52972218915225be56b063db14569a9"
 SOURCE_URI_2="https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-libs/geoip/files/$SOURCE_FILENAME_2?id=$srcGitRev_2#noarchive"
-CHECKSUM_SHA256_2="4c2b032e280b614ff028e930c9612c27bf4281e189c38e572eecfe36fb5e4cd8"
+CHECKSUM_SHA256_2="daebeb831f1a70e0f926525cc755fc97296dded7d63dd7b267dd7556f12a3f28"
 SOURCE_DIR_2=""
 PATCHES="geoip-$portVersion.patchset"
-PATCHES_2="geoipupdate-r5.patchset"
+PATCHES_2="geoipupdate-r6.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
+libVersion="$portVersion"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
 PROVIDES="
 	geoip$secondaryArchSuffix = $portVersion
-	lib:libGeoIP$secondaryArchSuffix = $portVersion
+	lib:libGeoIP$secondaryArchSuffix = $libVersionCompat
 	"
 if [ -z "$secondaryArchSuffix" ]; then
 	PROVIDES="$PROVIDES
@@ -45,7 +48,7 @@ REQUIRES="
 
 PROVIDES_devel="
 	geoip${secondaryArchSuffix}_devel = $portVersion
-	devel:libGeoIP$secondaryArchSuffix = $portVersion
+	devel:libGeoIP$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
 	geoip$secondaryArchSuffix == $portVersion base
@@ -65,6 +68,9 @@ BUILD_PREREQUIRES="
 	cmd:libtoolize$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
 	"
+
+defineDebugInfoPackage geoip$secondaryArchSuffix \
+	$libDir/libGeoIP.so.$libVersion
 
 BUILD()
 {
@@ -105,11 +111,5 @@ INSTALL()
 
 TEST()
 {
-	mkdir -p "$sourceDir/data"
-	if [ ! -f "$sourceDir/data/GeoIP.dat" ]; then
-		if [ -f /system/cache/GeoIP/GeoIP.dat ]; then
-			cp /system/cache/GeoIP/GeoIP.dat "$sourceDir/data"
-		fi
-	fi
 	make check
 }

--- a/dev-libs/geoip/patches/geoip-1.6.12.patchset
+++ b/dev-libs/geoip/patches/geoip-1.6.12.patchset
@@ -5,7 +5,7 @@ Subject: Search for gethostbyname in libnetwork.
 
 
 diff --git a/configure.ac b/configure.ac
-index a56e744..62dddf8 100644
+index 28d098c..969fed2 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -34,9 +34,33 @@ AC_CHECK_FUNC(vasprintf, AC_DEFINE(HAVE_VASPRINTF))
@@ -46,7 +46,7 @@ index a56e744..62dddf8 100644
  AC_CHECK_FUNC(gethostbyname_r, [
  	AC_DEFINE(HAVE_GETHOSTBYNAME_R)
 -- 
-2.7.0
+2.16.1
 
 
 From 14a2b588782d2883883a448c83d377c2d35f3ee0 Mon Sep 17 00:00:00 2001
@@ -56,19 +56,19 @@ Subject: tiny gcc2 patch for test/test-geoip-invalid-file.c
 
 
 diff --git a/test/test-geoip-invalid-file.c b/test/test-geoip-invalid-file.c
-index 089a770..0564259 100644
+index 10fe246..6d351eb 100644
 --- a/test/test-geoip-invalid-file.c
 +++ b/test/test-geoip-invalid-file.c
-@@ -10,6 +10,7 @@ int main()
+@@ -9,6 +9,7 @@ int main(void) {
          return 1;
      }
  
 +  {
      const char *country = GeoIP_country_code_by_addr(gi, "24.24.24.24");
      if (country != NULL) {
-         fprintf(
-@@ -25,6 +26,7 @@ int main()
-             "Received a non-NULL value on an invalid database from GeoIP_country_code_by_addr_v6\n");
+         fprintf(stderr,
+@@ -24,6 +25,7 @@ int main(void) {
+                 "GeoIP_country_code_by_addr_v6\n");
          return 1;
      }
 +  }
@@ -76,5 +76,5 @@ index 089a770..0564259 100644
      return 0;
  }
 -- 
-2.10.1
+2.16.1
 

--- a/dev-libs/geoip/patches/geoipupdate-r6.patchset
+++ b/dev-libs/geoip/patches/geoipupdate-r6.patchset
@@ -4,10 +4,10 @@ Date: Fri, 25 Mar 2016 10:03:51 +0000
 Subject: Use time stamps, add usage and use trap.
 
 
-diff --git a/geoipupdate-r5.sh b/geoipupdate-r5.sh
-index 484ff7e..da72a2d 100644
---- a/geoipupdate-r5.sh
-+++ b/geoipupdate-r5.sh
+diff --git a/geoipupdate-r6.sh b/geoipupdate-r6.sh
+index 83b5810..aeb1e33 100644
+--- a/geoipupdate-r6.sh
++++ b/geoipupdate-r6.sh
 @@ -13,33 +13,94 @@ DATABASES="
  	asnum/GeoIPASNumv6
  "
@@ -115,5 +115,5 @@ index 484ff7e..da72a2d 100644
  		[ -d "${TMPDIR}" ] && rm -rf $TMPDIR
  	fi
 -- 
-2.7.0
+2.16.1
 


### PR DESCRIPTION
Upstream ships a tiny `GeoIP.dat` since 1.6.10 so we can drop the optional steps in `TEST()`.

There seems to be a bug in curl (7.58.0 or earlier) which did not exist in curl 7.50.3 when the patch for geoipupdate.sh was added.
This happens when the script tries to update an up-to-date GeoIP database file. It looks like curl's `--time-cond` option forgets to instruct `--remote-time` to skip its job if a `304 Not Modified` is received.
If the output file exists then this does not get noticed.
But if this file does not exist then curl complains with an unwanted `Failed to set filetime ... on outfile` warning.
Trying to fix this issue in our script would require to redirect curl's stderr to /dev/null (or creating a temporary (empty) file to make curl happy) but doing so would not be a good idea.
We can live with this warning until curl gets fixed.