### PR TITLE
youtube-dl: add man page, completion data, python subpackages

### DIFF
--- a/net-misc/youtube_dl/licenses/Unlicense
+++ b/net-misc/youtube_dl/licenses/Unlicense
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/net-misc/youtube_dl/youtube_dl-2018.02.08.recipe
+++ b/net-misc/youtube_dl/youtube_dl-2018.02.08.recipe
@@ -5,11 +5,11 @@ of all options.
 Some YouTube videos are served using Adobe's proprietary RTMP protocol, which \
 imposes DRM restrictions and encrypts the connection. youtube-dl is not able \
 to download these videos by itself."
-HOMEPAGE="http://rg3.github.io/youtube-dl/"
+HOMEPAGE="https://rg3.github.io/youtube-dl/"
 COPYRIGHT="2006-2018 Ricardo Garcia Gonzalez"
 LICENSE="Public Domain"
 REVISION="1"
-SOURCE_URI="https://github.com/rg3/youtube-dl/releases/download/$portVersion/youtube-dl-$portVersion.tar.gz"
+SOURCE_URI="https://yt-dl.org/downloads/$portVersion/youtube-dl-$portVersion.tar.gz"
 CHECKSUM_SHA256="af86595a24ea89f1f705e282193ce973f6f6ce1e3e6700ea03ff0974b6aa0547"
 SOURCE_DIR="youtube-dl"
 

--- a/net-misc/youtube_dl/youtube_dl-2018.02.08.recipe
+++ b/net-misc/youtube_dl/youtube_dl-2018.02.08.recipe
@@ -9,9 +9,9 @@ HOMEPAGE="http://rg3.github.io/youtube-dl/"
 COPYRIGHT="2006-2018 Ricardo Garcia Gonzalez"
 LICENSE="Public Domain"
 REVISION="1"
-SOURCE_URI="https://github.com/rg3/youtube-dl/releases/download/$portVersion/youtube-dl#noarchive"
-CHECKSUM_SHA256="157be71476a97dae99a18df5452472e1786f39b3fe2f968dfa0f81c144d81734"
-SOURCE_FILENAME="youtube-dl-$portVersion.py"
+SOURCE_URI="https://github.com/rg3/youtube-dl/releases/download/$portVersion/youtube-dl-$portVersion.tar.gz"
+CHECKSUM_SHA256="af86595a24ea89f1f705e282193ce973f6f6ce1e3e6700ea03ff0974b6aa0547"
+SOURCE_DIR="youtube-dl"
 
 ARCHITECTURES="any"
 
@@ -26,20 +26,18 @@ REQUIRES="
 	"
 
 BUILD_REQUIRES="
+	haiku_devel
 	"
-
 BUILD_PREREQUIRES="
+	cmd:find
+	cmd:make
 	"
-
-BUILD()
-{
-	sed -i 's/\/usr//' youtube-dl-$portVersion.py
-	mv youtube-dl-$portVersion.py youtube-dl
-	chmod a+x youtube-dl
-}
 
 INSTALL()
 {
-	mkdir -p $binDir
-	cp -a youtube-dl $binDir
+	make install PREFIX="$prefix" MANDIR="$manDir" SHAREDIR="$dataDir"
+	install -d "$dataDir"/bash-completion
+	mv "$prefix"/etc/bash_completion.d "$dataDir"/bash-completion/completions
+	mv "$prefix"/etc/fish "$dataDir"
+	rmdir "$prefix"/etc
 }

--- a/net-misc/youtube_dl/youtube_dl-2018.02.11.recipe
+++ b/net-misc/youtube_dl/youtube_dl-2018.02.11.recipe
@@ -6,11 +6,11 @@ Some YouTube videos are served using Adobe's proprietary RTMP protocol, which \
 imposes DRM restrictions and encrypts the connection. youtube-dl is not able \
 to download these videos by itself."
 HOMEPAGE="https://rg3.github.io/youtube-dl/"
-COPYRIGHT="2006-2018 Ricardo Garcia Gonzalez"
-LICENSE="Public Domain"
+COPYRIGHT="2006-2018 youtube-dl contributors"
+LICENSE="Unlicense"
 REVISION="1"
 SOURCE_URI="https://yt-dl.org/downloads/$portVersion/youtube-dl-$portVersion.tar.gz"
-CHECKSUM_SHA256="af86595a24ea89f1f705e282193ce973f6f6ce1e3e6700ea03ff0974b6aa0547"
+CHECKSUM_SHA256="68bfb7a2d182bbdb321a83adf60092797bd65c3c81cc2c4bc1924737af26e37d"
 SOURCE_DIR="youtube-dl"
 
 ARCHITECTURES="any"
@@ -22,7 +22,6 @@ PROVIDES="
 REQUIRES="
 	haiku
 	cmd:python
-	cmd:ffmpeg
 	"
 
 BUILD_REQUIRES="

--- a/net-misc/youtube_dl/youtube_dl-2018.02.11.recipe
+++ b/net-misc/youtube_dl/youtube_dl-2018.02.11.recipe
@@ -32,11 +32,63 @@ BUILD_PREREQUIRES="
 	cmd:make
 	"
 
+PYTHON_PACKAGES=(python python3)
+PYTHON_VERSIONS=(2.7 3.6)
+
+for i in "${!PYTHON_PACKAGES[@]}"; do
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+	eval "\
+		PROVIDES_${pythonPackage}=\"\n\
+			${portName}_$pythonPackage = $portVersion\n\
+			cmd:youtube_dl_$pythonPackage = $portVersion\n\
+			\"; \
+		REQUIRES_$pythonPackage=\"\n\
+			haiku\n\
+			cmd:python$pythonVersion\n\
+			\"\
+		"
+
+	BUILD_REQUIRES="$BUILD_REQUIRES
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES="$BUILD_PREREQUIRES
+		cmd:python$pythonVersion
+		"
+done
+
 INSTALL()
 {
+	for i in "${!PYTHON_PACKAGES[@]}"; do
+		pythonPackage=${PYTHON_PACKAGES[i]}
+		pythonVersion=${PYTHON_VERSIONS[$i]}
+
+		python=python$pythonVersion
+		installLocation="$prefix"/lib/$python/vendor-packages/
+		export PYTHONPATH="$installLocation"
+		rm -rf build
+		mkdir -p "$installLocation"
+		$python setup.py build install --root=/ --prefix="$prefix"
+
+		rm -rf "$prefix"/share/man
+		mv "$binDir"/youtube-dl "$binDir"/youtube-dl-$pythonPackage
+		packageEntries $pythonPackage \
+			"$prefix"/lib/$python \
+			"$binDir"/youtube-dl-$pythonPackage
+	done
+
 	make install PREFIX="$prefix" MANDIR="$manDir" SHAREDIR="$dataDir"
-	install -d "$dataDir"/bash-completion
+	install -d "$dataDir"/bash-completion "$docDir"
+	mv "$prefix"/share/doc/youtube_dl/README.txt "$docDir"
+
+	# We now have two identical files in $prefix/etc/bash_completion.d/
+	# Let's drop "youtube-dl.bash-completion" and keep "youtube-dl".
+	rm -f "$prefix"/etc/bash_completion.d/youtube-dl.bash-completion
+
+	# We need "youtube-dl" in "$dataDir/bash-completion/completions/".
 	mv "$prefix"/etc/bash_completion.d "$dataDir"/bash-completion/completions
+
 	mv "$prefix"/etc/fish "$dataDir"
-	rmdir "$prefix"/etc
+	cd "$prefix"
+	rmdir -p etc share/doc/youtube_dl
 }

--- a/net-misc/youtube_dl/youtube_dl-2018.02.11.recipe
+++ b/net-misc/youtube_dl/youtube_dl-2018.02.11.recipe
@@ -32,8 +32,16 @@ BUILD_PREREQUIRES="
 	cmd:make
 	"
 
-PYTHON_PACKAGES=(python python3)
-PYTHON_VERSIONS=(2.7 3.6)
+case "$targetArchitecture" in
+	x86_gcc2)
+		PYTHON_PACKAGES=(python)
+		PYTHON_VERSIONS=(2.7)
+		;;
+	*)
+		PYTHON_PACKAGES=(python python3)
+		PYTHON_VERSIONS=(2.7 3.6)
+		;;
+esac
 
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}


### PR DESCRIPTION
Changes:

* Bump to 2018.02.11.
* Add man page and bash/fish/zsh completion data.
* Fix/update `LICENSE` & `COPYRIGHT`.
* Drop `cmd:ffmpeg` from `REQUIRES` as ffmpeg is not required but just recommended. youtube-dl only needs ffmpeg if the user downloads DASH video+audio contents and wants these to be combined together.
* Add _python and _python3 subpackages.

Contents:

* `youtube_dl` ships the `youtube-dl` monolithic python2.7 script, as well as the man page and the bash/fish/zsh completion data.
* `youtube_dl_python` ships the `youtube-dl-python` python2.7 script.
* `youtube_dl_python3` ships the `youtube-dl-python3` python3.6 script.

Remarks:    

* The base package, youtube_dl, does not depend on any of the python subpackages.
* The youtube_dl_python and youtube_dl_python3 packages do not depend on the base package.
* All packages may be installed together.
* Each package works independently of the other two.
* youtube-dl-python3 does not work on x86_gcc2 because python3 is not available on x86_gcc2 primary arch and something is preventing youtube-dl-python3 from working correctly with a secondary arch build of python3. So youtube_dl_python3 is not built on x86_gcc2.