### PR TITLE
mozc: Add libprotobuf as dependent lib

### DIFF
--- a/app-i18n/mozc/mozc-2.23.2785.102.1.recipe
+++ b/app-i18n/mozc/mozc-2.23.2785.102.1.recipe
@@ -4,7 +4,7 @@ This is open source version."
 HOMEPAGE="https://github.com/google/mozc"
 COPYRIGHT="2010-2018 Google Inc."
 LICENSE="BSD (3-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/hanya/mozc/releases/download/v$portVersion/mozc-v$portVersion.tar.bz2"
 CHECKSUM_SHA256="17ce4ee5d6a55678d804890d7e2fa7ffd7f852a9673e3b79671613c9167469f5"
 SOURCE_DIR="mozc"
@@ -24,6 +24,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	lib:libprotobuf$secondaryArchSuffix
 	lib:libQt5Core$secondaryArchSuffix
 	lib:libQt5Gui$secondaryArchSuffix
 	lib:libQt5Widgets$secondaryArchSuffix


### PR DESCRIPTION
lib:libprotobuf is required to run.