### PR TITLE
cairo, bump version, include glib2

### DIFF
--- a/x11-libs/cairo/cairo-1.14.12.recipe
+++ b/x11-libs/cairo/cairo-1.14.12.recipe
@@ -1,0 +1,112 @@
+SUMMARY="Multi-platform 2D graphics library"
+DESCRIPTION="Cairo is a 2D graphics library with support for multiple output \
+devices. Currently supported output targets include the X Window \
+System (via both Xlib and XCB), quartz, win32, and image buffers, \
+as well as PDF, PostScript, and SVG file output. Experimental backends \
+include OpenGL, BeOS, OS/2, and DirectFB."
+HOMEPAGE="https://www.cairographics.org/"
+COPYRIGHT="2000, 2002, 2004-2007 Keith Packard
+	2002-2003 University of Southern California
+	2004-2010 Red Hat, Inc.
+	2005-2010 Mozilla Corporation
+	2006-2009 Adrian Johnson
+	2007-2009 Chris Wilson
+	2006-2013 Intel Corporation
+	2011 Andrea Canciani
+	2011 Samsung Electronics
+	2010-2011 Linaro Limited
+	2009-2010 Eric Anholt
+	2002-2010 many others"
+LICENSE="GNU LGPL v2.1
+	MPL v1.1"
+REVISION="1"
+SOURCE_URI="https://www.cairographics.org/releases/cairo-$portVersion.tar.xz"
+CHECKSUM_SHA256="8c90f00c500b2299c0a323dd9beead2a00353752b2092ead558139bd67f7bf16"
+PATCHES="cairo-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="2.11400.12"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	cairo$secondaryArchSuffix = $portVersion compat >= 1
+	lib:libcairo$secondaryArchSuffix = $libVersionCompat
+	lib:libcairo_script_interpreter$secondaryArchSuffix = $libVersionCompat
+	lib:libcairo_gobject$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libfontconfig$secondaryArchSuffix
+	lib:libfreetype$secondaryArchSuffix
+	lib:libglib_2.0$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libpixman_1$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	cairo${secondaryArchSuffix}_devel = $portVersion compat >= 1
+	devel:libcairo$secondaryArchSuffix = $libVersionCompat
+	devel:libcairo_script_interpreter$secondaryArchSuffix = $libVersionCompat
+	devel:libcairo_gobject$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	cairo$secondaryArchSuffix == $portVersion base
+	devel:libfontconfig$secondaryArchSuffix
+	devel:libpixman_1$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libfontconfig$secondaryArchSuffix
+	devel:libfreetype$secondaryArchSuffix
+	devel:libglib_2.0$secondaryArchSuffix
+	devel:libpixman_1$secondaryArchSuffix
+	devel:libpng16$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:automake
+	cmd:autoreconf
+	cmd:gcc$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+defineDebugInfoPackage cairo$secondaryArchSuffix \
+	$libDir/libcairo.so.$libVersion \
+	$libDir/libcairo-script-interpreter.so.$libVersion \
+	$libDir/libcairo-gobject.so.$libVersion
+
+BUILD()
+{
+	autoreconf -vfi
+	export CPPFLAGS=-D__BSD_VISIBLE
+	runConfigure ./configure
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	rm $libDir/libcairo*.la
+
+	prepareInstalledDevelLibs libcairo libcairo-script-interpreter libcairo-gobject
+	fixPkgconfig
+
+	packageEntries devel \
+		$developDir \
+		$dataDir
+}
+
+TEST()
+{
+	make check
+}

--- a/x11-libs/cairo/patches/cairo-1.14.12.patchset
+++ b/x11-libs/cairo/patches/cairo-1.14.12.patchset
@@ -1,0 +1,115 @@
+From d3ab2a3466d647faecdadeaea547c1bda5a93186 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Fri, 3 Oct 2014 18:33:08 +0000
+Subject: Haiku patch
+
+
+diff --git a/configure.ac b/configure.ac
+index 2ce1959..c04c05c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -287,6 +287,11 @@ CAIRO_ENABLE_SURFACE_BACKEND(beos, BeOS/Zeta, no, [
+       AC_CHECK_LIB(be,main,beos_LIBS="$beos_LIBS -lbe")
+       AC_CHECK_LIB(zeta,main,beos_LIBS="$beos_LIBS -lzeta")
+       ;;
++    *-*-haiku)
++      beos_LIBS=""
++      AC_CHECK_LIB(be,main,beos_LIBS="$beos_LIBS -lbe")
++      AC_CHECK_LIB(network,main,beos_LIBS="$beos_LIBS -lnetwork")
++      ;;
+     *)
+       use_beos="no (requires a BeOS platform)"
+       ;;
+-- 
+2.16.2
+
+
+From 2d542458c0f099b0c8f27be0f757b523446a0241 Mon Sep 17 00:00:00 2001
+From: Adrien Destugues <pulkomandy@gmail.com>
+Date: Mon, 6 Oct 2014 18:07:36 +0200
+Subject: Add missing include fenv.h.
+
+
+diff --git a/test/cairo-test.c b/test/cairo-test.c
+index a351b01..474f34c 100644
+--- a/test/cairo-test.c
++++ b/test/cairo-test.c
+@@ -40,6 +40,7 @@
+ #include <unistd.h>
+ #endif
+ #include <errno.h>
++#include <fenv.h>
+ #include <string.h>
+ #if HAVE_FCFINI
+ #include <fontconfig/fontconfig.h>
+-- 
+2.16.2
+
+
+From 89a97bd0f86351250740454e9cbdbc5047dac256 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Fri, 21 Nov 2014 22:11:40 +0000
+Subject: link tests against libnetwork.
+
+
+diff --git a/perf/Makefile.am b/perf/Makefile.am
+index 40b35bc..ee150d9 100644
+--- a/perf/Makefile.am
++++ b/perf/Makefile.am
+@@ -11,7 +11,7 @@ AM_CPPFLAGS =					\
+ 	-I$(top_builddir)/src			\
+ 	$(CAIRO_CFLAGS)
+ 
+-AM_LDFLAGS = $(CAIRO_LDFLAGS)
++AM_LDFLAGS = $(CAIRO_LDFLAGS) -lnetwork
+ 
+ SUBDIRS = micro
+ 
+diff --git a/test/Makefile.am b/test/Makefile.am
+index b2fcd27..cf7e4ad 100644
+--- a/test/Makefile.am
++++ b/test/Makefile.am
+@@ -94,7 +94,7 @@ cairo_test_suite_LDADD = 					\
+ 	$(top_builddir)/test/pdiff/libpdiff.la 			\
+         $(top_builddir)/boilerplate/libcairoboilerplate.la	\
+ 	$(top_builddir)/src/libcairo.la 			\
+-	$(CAIRO_LDADD)
++	$(CAIRO_LDADD) -lnetwork
+ cairo_test_suite_DEPENDENCIES = \
+ 	$(top_builddir)/test/pdiff/libpdiff.la 			\
+         $(top_builddir)/boilerplate/libcairoboilerplate.la	\
+@@ -210,7 +210,7 @@ AM_CPPFLAGS =					\
+ 	-I$(top_srcdir)/src			\
+ 	-I$(top_builddir)/src			\
+ 	$(CAIRO_CFLAGS)
+-AM_LDFLAGS = $(CAIRO_LDFLAGS)
++AM_LDFLAGS = $(CAIRO_LDFLAGS) -lnetwork
+ 
+ $(top_builddir)/boilerplate/libcairoboilerplate.la: $(top_builddir)/src/libcairo.la
+ 	cd $(top_builddir)/boilerplate && $(MAKE) $(AM_MAKEFLAGS) libcairoboilerplate.la
+-- 
+2.16.2
+
+
+From 90a3359e8595f473d234b145338ef0fef49011a9 Mon Sep 17 00:00:00 2001
+From: begasus <begasus@gmail.com>
+Date: Sun, 18 Mar 2018 10:41:35 +0100
+Subject: link test against libnetwork.
+
+
+diff --git a/boilerplate/Makefile.am b/boilerplate/Makefile.am
+index 29ad015..de9ae93 100644
+--- a/boilerplate/Makefile.am
++++ b/boilerplate/Makefile.am
+@@ -12,7 +12,7 @@ AM_CPPFLAGS = \
+ 	-I$(top_srcdir)/src \
+ 	$(CAIRO_CFLAGS) \
+ 	$(NULL)
+-AM_LDFLAGS = $(CAIRO_LDFLAGS)
++AM_LDFLAGS = $(CAIRO_LDFLAGS) -lnetwork
+ 
+ if BUILD_CXX
+ cxx_boilerplate_lib = libcairoboilerplate_cxx.la
+-- 
+2.16.2
+


### PR DESCRIPTION
Should be ok, included glib2 to check the ability to test gobject-introspection ... (test on that still fails because it can't find cairo-gobject.h header) ... 