### PR TITLE
aranym-1.0.2 recipe

### DIFF
--- a/app-emulation/aranym/aranym-1.0.2.recipe
+++ b/app-emulation/aranym/aranym-1.0.2.recipe
@@ -1,0 +1,59 @@
+SUMMARY="Atari Running on Any Machine"
+DESCRIPTION="ARAnyM (Atari Running on Any Machine) is a multiplatform virtual \
+machine for running Atari ST/TT/Falcon operating systems and applications."
+HOMEPAGE="http://github.com/aranym/aranym"
+COPYRIGHT="2001-2018 ARAnyM developer team"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="https://github.com/aranym/aranym/archive/ARANYM_${portVersion//./_}.tar.gz"
+CHECKSUM_SHA256="c0935aee14cca55c08e75a94b77dcd69f326ae563ae371b22c7b9d8efd82e24e"
+SOURCE_DIR="aranym-ARANYM_${portVersion//./_}"
+PATCHES="aranym-$portVersion.patch"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	aranym = $portVersion
+	app:aranym = $portVersion
+	cmd:aranym = $portVersion
+	"
+REQUIRES="
+	haiku
+	lib:libsdl
+	lib:libSDL_image_1.2
+	lib:libjpeg
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	devel:libsdl_1.2
+	devel:libSDL_image_1.2
+	devel:libjpeg
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:autoheader
+	cmd:make
+	cmd:gcc
+	cmd:sdl_config
+	"
+
+BUILD()
+{
+	rm -f config.guess config.sub
+	aclocal -I m4
+	autoconf
+	autoheader
+	automake --add-missing --copy || true
+	runConfigure --omit-dirs binDir ./configure --bindir="$appsDir" \
+		--disable-sdl2
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+	mimeset "$appsDir"/aranym
+	addAppDeskbarSymlink "$appsDir"/aranym ARAnyM
+}

--- a/app-emulation/aranym/aranym-999~git.recipe
+++ b/app-emulation/aranym/aranym-999~git.recipe
@@ -1,0 +1,53 @@
+SUMMARY="Atari Running on Any Machine"
+DESCRIPTION="ARAnyM (Atari Running on Any Machine) is a multiplatform virtual \
+machine for running Atari ST/TT/Falcon operating systems and applications."
+HOMEPAGE="http://github.com/aranym/aranym"
+COPYRIGHT="2001-2018 ARAnyM developer team"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="git://github.com/aranym/aranym#HEAD"
+SOURCE_DIR="aranym-master"
+
+ARCHITECTURES="?x86_gcc2 ?x86 ?x86_64"
+
+PROVIDES="
+	aranym = $portVersion
+	app:aranym = $portVersion
+	cmd:aranym = $portVersion
+	"
+REQUIRES="
+	haiku
+	lib:libsdl
+	lib:libSDL_image_1.2
+	lib:libjpeg
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	devel:libsdl_1.2
+	devel:libSDL_image_1.2
+	devel:libjpeg
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:autoheader
+	cmd:make
+	cmd:gcc
+	cmd:sdl_config
+	"
+
+BUILD()
+{
+	NO_CONFIGURE=1 ./autogen.sh
+	runConfigure --omit-dirs binDir ./configure --bindir="$appsDir" \
+		--disable-sdl2
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+	mimeset "$appsDir"/aranym
+	addAppDeskbarSymlink "$appsDir"/aranym ARAnyM
+}

--- a/app-emulation/aranym/patches/aranym-1.0.2.patch
+++ b/app-emulation/aranym/patches/aranym-1.0.2.patch
@@ -1,0 +1,57 @@
+From 2ae489b85228a74d925ac4ff3bc54537172ec9c5 Mon Sep 17 00:00:00 2001
+From: Thorsten Otto <admin@tho-otto.de>
+Date: Fri, 23 Feb 2018 15:09:04 +0100
+Subject: [PATCH] Small fixes for compilation on Haiku
+
+
+diff --git a/src/Makefile.am b/src/Makefile.am
+index bc906a14..589a024e 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -15,7 +15,7 @@
+ datarootdir = @datarootdir@
+ mandir = @mandir@
+ man1dir = $(mandir)/man1
+-docdir = $(prefix)/share/doc
++docdir = @docdir@
+ builddir = @builddir@
+ top_srcdir = @top_srcdir@
+ srcdir = $(top_srcdir)/src
+@@ -267,8 +267,12 @@
+ 	$(BEOS_XRES) -o $(APP) $(APP).rsrc
+ endif
+ ifneq ($(BEOS_SETVERSION),)
++	versfile="$(srcdir)/include/version.h"; \
++	major=`sed -n -e 's/#define[ \\t]*VER_MAJOR[ \\t]*\\([0-9]*\\)/\\1/p' $$versfile`; \
++	minor=`sed -n -e 's/#define[ \\t]*VER_MINOR[ \\t]*\\([0-9]*\\)/\\1/p' $$versfile`; \
++	micro=`sed -n -e 's/#define[ \\t]*VER_MICRO[ \\t]*\\([0-9]*\\)/\\1/p' $$versfile`; \
+ 	$(BEOS_SETVERSION) $(APP) \
+-		-app 0 9 0 d 0 \
++		-app $$major $$minor $$micro d 0 \
+ 		-short "$(APP) $(PACKAGE_VERSION)" \
+ 		-long "$(APP) $(PACKAGE_VERSION)"
+ endif
+diff --git a/src/Unix/beos/clipbrd_beos.cpp b/src/Unix/beos/clipbrd_beos.cpp
+index 9c073cc6..b9dfa64a 100644
+--- a/src/Unix/beos/clipbrd_beos.cpp
++++ b/src/Unix/beos/clipbrd_beos.cpp
+@@ -18,6 +18,7 @@
+     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+ 
++#include "sysdeps.h"
+ #if defined(OS_beos)
+ #include <Clipboard.h>
+ #include <String.h>
+@@ -51,7 +55,7 @@ void write_aclip(char *data, size_t len)
+ char * read_aclip( size_t *len)
+ {
+ 	const char *text;
+-	int32 textLen;
++	ssize_t textLen;
+ 	BMessage *clip = NULL;
+ 	char *data = NULL;
+ 	fprintf(stderr, "%s()\n", __FUNCTION__);
+-- 
+2.16.1
+


### PR DESCRIPTION
I'm not yet very familiar with haiku recipes, so just a few notes:

- the recipe for 1.0.2 contains an invocation of automake. This is just done to get updated config.sub & config.guess because the archive contains old versions that don't recognize haiku. 1.0.2 was based on just autoconf scripts, and does not need automake otherwise

- the aranym-git recipe i used just for testing, because there has been no "official" release since 1.0.2, but the current development version has some important fixes (amongst others the small patch that was needed to make it compile on haiku again). Since it downloads directly from the git repo, it is necessary to activate ALLOW_UNSAFE_SOURCES in haikuports.conf. 