### PR TITLE
dev-libs/libmspack: bump to 0.6alpha, add debuginfo.

### DIFF
--- a/dev-libs/libmspack/libmspack-0.6~alpha.recipe
+++ b/dev-libs/libmspack/libmspack-0.6~alpha.recipe
@@ -13,27 +13,43 @@ version of any particular compressor or decompressor, use the \
 mspack_version() function. The UNIX library interface version is defined as \
 the highest-versioned library component."
 HOMEPAGE="https://www.cabextract.org.uk/libmspack/"
-COPYRIGHT="2000-2015 Stuart Caie"
+COPYRIGHT="2000-2017 Stuart Caie"
 LICENSE="GNU LGPL v2"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="$HOMEPAGE/libmspack-${portVersion/\~/}.tar.gz"
-CHECKSUM_SHA256="8967f275525f5067b364cee43b73e44d0433668c39f9376dfff19f653d1c8110"
+CHECKSUM_SHA256="1edbee82accb28e679ab538f803aab7a5a569e4102ccf1715b462b1bd915f921"
 SOURCE_DIR="libmspack-${portVersion/\~/}"
+
+SOURCE_FILENAME_2="libmspack-${portVersion/\~/_}-fix-tests.patch"
+srcGitRev_2="831379877f8c646c5643dd98305afdb5a6b4ca6c"
+SOURCE_URI_2="https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-libs/libmspack/files/$SOURCE_FILENAME_2?id=$srcGitRev_2#noarchive"
+CHECKSUM_SHA256_2="ab1bbe6b469316c320507f1b13aee36fe06b3732949c52b8e5e0f8dd4c3cf8a1"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
+libVersion="0.1.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
 PROVIDES="
 	libmspack$secondaryArchSuffix = $portVersion
-	lib:libmspack$secondaryArchSuffix = 0.1.0 compat >= 0
+	lib:libmspack$secondaryArchSuffix = $libVersionCompat
 	"
+if [ -z "$secondaryArchSuffix" ]; then
+PROVIDES="$PROVIDES
+	cmd:cabrip = $portVersion
+	cmd:chmextract = $portVersion
+	cmd:msexpand = $portVersion
+	cmd:oabextract = $portVersion
+	"
+fi
 REQUIRES="
 	haiku$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
 	libmspack${secondaryArchSuffix}_devel = $portVersion
-	devel:libmspack$secondaryArchSuffix = 0.1.0 compat >= 0
+	devel:libmspack$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
 	libmspack$secondaryArchSuffix == $portVersion base
@@ -52,7 +68,24 @@ BUILD_PREREQUIRES="
 	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
+	cmd:sed
 	"
+
+debugList=(
+	"$libDir"/libmspack.so.$libVersion
+	)
+if [ -z "$secondaryArchSuffix" ]; then
+	for i in `echo "$PROVIDES" | sed -n -e \
+			"s/^[\t]*cmd:\(.*\)$secondaryArchSuffix =.*/\1/p;"`; do
+		debugList+=("$binDir"/$i)
+	done
+fi
+defineDebugInfoPackage libmspack$secondaryArchSuffix "${debugList[@]}"
+
+PATCH()
+{
+	patch -p1 -i "$sourceDir2"/$SOURCE_FILENAME_2
+}
 
 BUILD()
 {
@@ -74,6 +107,8 @@ INSTALL()
 		cp -r doc/* $developDocDir
 		rm $developDocDir/Doxyfile*
 		rm $developDocDir/Makefile*
+	else
+		rm -rf "$binDir"
 	fi
 
 	rm $libDir/libmspack.la
@@ -88,4 +123,6 @@ INSTALL()
 TEST()
 {
 	make check
+	cd test
+	./cabd_test
 }


### PR DESCRIPTION
* Add `cmd:` entries for the runtimes added in this release.
* Call `cabd_test` in `TEST()`. (`ALL 194 TESTS PASSED.`)
* Add patch from Gentoo to fix `cabd_test`.
* Compute arguments being passed to `defineDebugInfoPackage`.