### PR TITLE
youtube-dl: bump to 2018.03.10, add (unusable) TEST().

### DIFF
--- a/net-misc/youtube_dl/youtube_dl-2018.03.10.recipe
+++ b/net-misc/youtube_dl/youtube_dl-2018.03.10.recipe
@@ -10,7 +10,7 @@ COPYRIGHT="2006-2018 youtube-dl contributors"
 LICENSE="Unlicense"
 REVISION="1"
 SOURCE_URI="https://yt-dl.org/downloads/$portVersion/youtube-dl-$portVersion.tar.gz"
-CHECKSUM_SHA256="a8a061d6cd6ee311c079ea26d4edfadbf5fa817f8dc68c7e42e56896212f15f4"
+CHECKSUM_SHA256="4bfadccb19e379ce38f5601c72dacf0ac5e03881230afee6df2152ab42fa75c5"
 SOURCE_DIR="youtube-dl"
 
 ARCHITECTURES="any"
@@ -90,4 +90,10 @@ INSTALL()
 	mv "$prefix"/etc/fish "$dataDir"
 	cd "$prefix"
 	rmdir -p etc share/doc/youtube_dl
+}
+
+TEST()
+{
+	# Will fail because flake8 is not available
+	make offlinetest
 }


### PR DESCRIPTION
"make offlinetest" will fail because flake8 is not available.