### PR TITLE
libpsl: bump to 0.20.1, add tiny gcc2 patch, enable x86_gcc2.

### DIFF
--- a/net-libs/libpsl/libpsl-0.20.1.recipe
+++ b/net-libs/libpsl/libpsl-0.20.1.recipe
@@ -4,13 +4,14 @@ suffixes. libpsl can be used by browsers and other web clients to avoid \
 privacy-leaking \"supercookies\" or \"super domain\" certificates, highlight \
 parts of the domain in a user interface, and sort domain lists by site."
 HOMEPAGE="https://rockdaboot.github.io/libpsl/"
-COPYRIGHT="2014-2017 Tim Rühsen"
+COPYRIGHT="2014-2018 Tim Rühsen"
 LICENSE="libpsl"
 REVISION="1"
 SOURCE_URI="https://github.com/rockdaboot/libpsl/releases/download/libpsl-$portVersion/libpsl-$portVersion.tar.gz"
-CHECKSUM_SHA256="735146b51bbd3dcb6b0f87819c64bf3115f7fb9fa2e3a7fe9966e3346a8abc79"
+CHECKSUM_SHA256="95199613158dd773257ef4feccf1acdf5f791479ab4537bd984ca8598447219f"
+PATCHES="libpsl-$portVersion.patchset"
 
-ARCHITECTURES="?x86_gcc2 x86 x86_64"
+ARCHITECTURES="x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 IDNA=libidn2
@@ -18,7 +19,7 @@ if [ "$effectiveTargetArchitecture" = x86_gcc2 ]; then
 	IDNA=libidn
 fi
 
-libVersion="5.2.0"
+libVersion="5.3.0"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
@@ -50,9 +51,9 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	cmd:aclocal
-	cmd:autoconf
 	cmd:automake
 	cmd:autoheader
+	cmd:autoreconf
 	cmd:autopoint
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
@@ -71,6 +72,7 @@ PATCH()
 
 BUILD()
 {
+	autoreconf
 	runConfigure ./configure --enable-runtime=$IDNA --enable-builtin=$IDNA
 	make $jobArgs LIBS="-lnetwork"
 }

--- a/net-libs/libpsl/patches/libpsl-0.20.1.patchset
+++ b/net-libs/libpsl/patches/libpsl-0.20.1.patchset
@@ -1,0 +1,45 @@
+From b60ef1f09415e86bfb68aec8ca429759b4b4dd0b Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Thu, 15 Mar 2018 18:20:28 +0000
+Subject: tiny gcc2 patch
+
+
+diff --git a/src/psl.c b/src/psl.c
+index 4860ca0..f61de20 100644
+--- a/src/psl.c
++++ b/src/psl.c
+@@ -1059,6 +1059,7 @@ const char *psl_unregistrable_domain(const psl_ctx_t *psl, const char *domain)
+ 	 * To avoid nasty CPU hogging, we limit the lookup to max. 8 domain labels to the right.
+ 	 */
+ 
++	{
+ 	int nlabels = 0;
+ 	const char *p;
+ 	for (p = domain + strlen(domain) - 1; p >= domain; p--) {
+@@ -1067,6 +1068,7 @@ const char *psl_unregistrable_domain(const psl_ctx_t *psl, const char *domain)
+ 			break;
+ 		}
+ 	}
++	}
+ 
+ 	/*
+ 	 *  We check from left to right to catch special PSL entries like 'forgot.his.name':
+@@ -1115,6 +1117,7 @@ const char *psl_registrable_domain(const psl_ctx_t *psl, const char *domain)
+ 	 * To avoid nasty CPU hogging, we limit the lookup to max. 8 domain labels to the right.
+ 	 */
+ 
++	{
+ 	int nlabels = 0;
+ 	for (p = domain + strlen(domain) - 1; p >= domain; p--) {
+ 		if (*p == '.' && ++nlabels > 8) {
+@@ -1122,6 +1125,7 @@ const char *psl_registrable_domain(const psl_ctx_t *psl, const char *domain)
+ 			break;
+ 		}
+ 	}
++	}
+ 
+ 	/*
+ 	 *  We check from left to right to catch special PSL entries like 'forgot.his.name':
+-- 
+2.16.2
+


### PR DESCRIPTION
The tests do not build with gcc2 but psl seems to work fine.