### PR TITLE
curl: bump to 7.59.0, depend on lib{brotlidec,idn2,psl}.

### DIFF
--- a/net-misc/curl/curl-7.59.0.recipe
+++ b/net-misc/curl/curl-7.59.0.recipe
@@ -11,7 +11,7 @@ COPYRIGHT="1996-2018 Daniel Stenberg"
 LICENSE="Curl"
 REVISION="1"
 SOURCE_URI="https://curl.haxx.se/download/curl-$portVersion.tar.bz2"
-CHECKSUM_SHA256="1cb081f97807c01e3ed747b6e1c9fee7a01cb10048f1cd0b5f56cfe0209de731"
+CHECKSUM_SHA256="b5920ffd6a8c95585fb95070e0ced38322790cb335c39d0dab852d12e157b5a0"
 ADDITIONAL_FILES="curl.rdef"
 
 ARCHITECTURES="x86_gcc2 ?x86 x86_64 ?arm"
@@ -29,9 +29,16 @@ PROVIDES="
 REQUIRES="
 	haiku$secondaryArchSuffix
 	ca_root_certificates
+	lib:libbrotlidec$secondaryArchSuffix
+	lib:libpsl$secondaryArchSuffix
 	lib:libssl$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
+if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+REQUIRES="$REQUIRES
+	lib:libidn2$secondaryArchSuffix
+	"
+fi
 
 PROVIDES_devel="
 	curl${secondaryArchSuffix}_devel = $portVersion
@@ -46,9 +53,16 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	devel:libbrotlidec$secondaryArchSuffix
+	devel:libpsl$secondaryArchSuffix
 	devel:libssl$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"
+if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+BUILD_REQUIRES="$BUILD_REQUIRES
+	devel:libidn2$secondaryArchSuffix
+	"
+fi
 BUILD_PREREQUIRES="
 	cmd:aclocal
 	cmd:autoconf
@@ -64,12 +78,17 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	cmd:sed
 	"
-if [ "$recipeAction" = TEST ]; then
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
+
+TEST_PREREQUIRES="
 	cmd:id
+	cmd:perl
+	cmd:sftp_server
 	cmd:sshd
 	"
-fi
+# The following line does not work, although it has worked in 2016 and/or 2017.
+if [ "$recipeAction" = TEST ]; then BUILD_PREREQUIRES+="$TEST_PREREQUIRES"; fi
+# Uncomment the following line before the build if you wish to run the tests.
+#BUILD_PREREQUIRES+="$TEST_PREREQUIRES"
 
 defineDebugInfoPackage curl$secondaryArchSuffix \
 	$binDir/curl \
@@ -141,5 +160,6 @@ INSTALL()
 
 TEST()
 {
+	PATH="`finddir B_SYSTEM_LIB_DIRECTORY`/openssh:$PATH" \
 	USER="`id -n -u`" make check
 }

--- a/net-misc/curl/curl-7.59.0.recipe
+++ b/net-misc/curl/curl-7.59.0.recipe
@@ -29,16 +29,9 @@ PROVIDES="
 REQUIRES="
 	haiku$secondaryArchSuffix
 	ca_root_certificates
-	lib:libbrotlidec$secondaryArchSuffix
-	lib:libpsl$secondaryArchSuffix
 	lib:libssl$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
-if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
-REQUIRES="$REQUIRES
-	lib:libidn2$secondaryArchSuffix
-	"
-fi
 
 PROVIDES_devel="
 	curl${secondaryArchSuffix}_devel = $portVersion
@@ -53,16 +46,9 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libbrotlidec$secondaryArchSuffix
-	devel:libpsl$secondaryArchSuffix
 	devel:libssl$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"
-if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
-BUILD_REQUIRES="$BUILD_REQUIRES
-	devel:libidn2$secondaryArchSuffix
-	"
-fi
 BUILD_PREREQUIRES="
 	cmd:aclocal
 	cmd:autoconf


### PR DESCRIPTION
Added comments after the definition of `TEST_PREREQUIRES`. They should be removed if haikuports/haikuporter/issues/151 is implemented.