### PR TITLE
scrnsaverproto: Add custom LICENSE, install README.

### DIFF
--- a/x11-proto/scrnsaverproto/licenses/scrnsaverproto
+++ b/x11-proto/scrnsaverproto/licenses/scrnsaverproto
@@ -1,0 +1,24 @@
+Copyright (c) 1992  X Consortium
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+X CONSORTIUM BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name of the X Consortium shall not be
+used in advertising or otherwise to promote the sale, use or other dealings
+in this Software without prior written authorization from the X Consortium.
+
+Author:  Keith Packard, MIT X Consortium

--- a/x11-proto/scrnsaverproto/scrnsaverproto-1.2.2.recipe
+++ b/x11-proto/scrnsaverproto/scrnsaverproto-1.2.2.recipe
@@ -3,13 +3,13 @@ DESCRIPTION="This extension defines a protocol to control screensaver features \
 and also to query screensaver info on specific windows."
 HOMEPAGE="http://xorg.freedesktop.org/releases/individual/proto/"
 COPYRIGHT="1992 X Consortium"
-LICENSE="MIT (no promotion)"
-REVISION="2"
-SOURCE_URI="http://xorg.freedesktop.org/releases/individual/proto/scrnsaverproto-$portVersion.tar.gz"
-CHECKSUM_SHA256="d8dee19c52977f65af08fad6aa237bacee11bc5a33e1b9b064e8ac1fd99d6e79"
+LICENSE="scrnsaverproto"
+REVISION="3"
+SOURCE_URI="https://www.x.org/releases/individual/proto/scrnsaverproto-$portVersion.tar.bz2"
+CHECKSUM_SHA256="8bb70a8da164930cceaeb4c74180291660533ad3cc45377b30a795d1b85bcd65"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="x86"
+SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
 PROVIDES="
 	scrnsaverproto$secondaryArchSuffix = $portVersion
@@ -24,9 +24,9 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	devel:util_macros$secondaryArchSuffix
-	cmd:autoconf
-	cmd:libtool
 	cmd:aclocal
+	cmd:automake
+	cmd:autoreconf
 	cmd:make
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
@@ -35,7 +35,6 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	libtoolize --force --copy --install
 	autoreconf -i
 	runConfigure ./configure
 }
@@ -44,4 +43,11 @@ INSTALL()
 {
 	make install
 	fixPkgconfig
+
+	if [ -z "$secondaryArchSuffix" ]; then
+		install -t "$docDir" README
+	else
+		rm -rf "$docDir"
+		rmdir "$libDir"
+	fi
 }


### PR DESCRIPTION
* `SOURCE_URI`: switch to https and to tar.bz2.
* Sort `BUILD_PREREQUIRES`.
* Drop unneeded call to libtoolize.
* Remove empty `$libDir` on secondary arch builds.