### PR TITLE
zstd: bump to 1.3.4, enable x86_gcc2 with a few tiny patches.

### DIFF
--- a/app-arch/zstd/patches/zstd-1.3.4-gcc2.patchset
+++ b/app-arch/zstd/patches/zstd-1.3.4-gcc2.patchset
@@ -1,0 +1,39 @@
+From 829c9878f057c1b1687d443a25e9ffa363162156 Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Wed, 28 Mar 2018 16:51:49 +0000
+Subject: Drop gcc options unknown to gcc2.
+
+
+diff --git a/lib/Makefile b/lib/Makefile
+index 8459970..cb91678 100644
+--- a/lib/Makefile
++++ b/lib/Makefile
+@@ -74,7 +74,7 @@ libzstd.a: $(ZSTD_OBJ)
+ libzstd.a-mt: CPPFLAGS += -DZSTD_MULTITHREAD
+ libzstd.a-mt: libzstd.a
+ 
+-$(LIBZSTD): LDFLAGS += -shared -fPIC -fvisibility=hidden
++$(LIBZSTD): LDFLAGS += -shared -fPIC
+ $(LIBZSTD): $(ZSTD_FILES)
+ 	@echo compiling dynamic library $(LIBVER)
+ ifneq (,$(filter Windows%,$(OS)))
+diff --git a/programs/Makefile b/programs/Makefile
+index 85d1db1..2de1675 100644
+--- a/programs/Makefile
++++ b/programs/Makefile
+@@ -39,10 +39,9 @@ CPPFLAGS+= -I$(ZSTDDIR) -I$(ZSTDDIR)/common -I$(ZSTDDIR)/compress \
+            -I$(ZSTDDIR)/dictBuilder \
+            -DXXH_NAMESPACE=ZSTD_
+ CFLAGS  ?= -O3
+-DEBUGFLAGS+=-Wall -Wextra -Wcast-qual -Wcast-align -Wshadow \
+-            -Wstrict-aliasing=1 -Wswitch-enum -Wdeclaration-after-statement \
++DEBUGFLAGS+=-Wall         -Wcast-qual -Wcast-align -Wshadow \
+             -Wstrict-prototypes -Wundef -Wpointer-arith -Wformat-security \
+-            -Wvla -Wformat=2 -Winit-self -Wfloat-equal -Wwrite-strings \
++                  -Wformat=2                           -Wwrite-strings \
+             -Wredundant-decls
+ CFLAGS  += $(DEBUGFLAGS) $(MOREFLAGS)
+ FLAGS    = $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
+-- 
+2.16.3
+

--- a/app-arch/zstd/patches/zstd-1.3.4.patchset
+++ b/app-arch/zstd/patches/zstd-1.3.4.patchset
@@ -5,10 +5,10 @@ Subject: Haiku patch
 
 
 diff --git a/Makefile b/Makefile
-index c8f0ed4..6a0a1b9 100644
+index 320fc68..144cab6 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -107,7 +107,7 @@ clean:
+@@ -120,7 +120,7 @@ clean:
  #------------------------------------------------------------------------------
  # make install is validated only for Linux, OSX, Hurd and some BSD targets
  #------------------------------------------------------------------------------
@@ -31,10 +31,10 @@ index cdfdc5c..8459970 100644
  DESTDIR     ?=
  # directory variables : GNU conventions prefer lowercase
 diff --git a/programs/Makefile b/programs/Makefile
-index 51888d3..f4dc3aa 100644
+index be666b4..85d1db1 100644
 --- a/programs/Makefile
 +++ b/programs/Makefile
-@@ -243,7 +243,7 @@ preview-man: clean-man man
+@@ -245,7 +245,7 @@ preview-man: clean-man man
  #-----------------------------------------------------------------------------
  # make install is validated only for Linux, OSX, BSD, Hurd and Solaris targets
  #-----------------------------------------------------------------------------
@@ -44,7 +44,7 @@ index 51888d3..f4dc3aa 100644
  .PHONY: list
  list:
 diff --git a/programs/platform.h b/programs/platform.h
-index 81dee23..f415006 100644
+index c86d289..3c11229 100644
 --- a/programs/platform.h
 +++ b/programs/platform.h
 @@ -70,9 +70,10 @@ extern "C" {
@@ -53,7 +53,7 @@ index 81dee23..f415006 100644
  #if !defined(_WIN32) && (defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__)) /* UNIX-like OS */ \
 -   || defined(__midipix__) || defined(__VMS))
 +   || defined(__midipix__) || defined(__VMS) || defined(__HAIKU__))
- #  if (defined(__APPLE__) && defined(__MACH__)) || defined(__SVR4) || defined(_AIX) || defined(__hpux) /* POSIX.1–2001 (SUSv3) conformant */ \
+ #  if (defined(__APPLE__) && defined(__MACH__)) || defined(__SVR4) || defined(_AIX) || defined(__hpux) /* POSIX.1-2001 (SUSv3) conformant */ \
 -     || defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)  /* BSD distros */
 +     || defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)  /* BSD distros */ \
 +     || defined(__HAIKU__)
@@ -61,7 +61,7 @@ index 81dee23..f415006 100644
  #  else
  #    if defined(__linux__) || defined(__linux)
 diff --git a/programs/util.h b/programs/util.h
-index af1fa7f..4123efa 100644
+index 3e69745..3bfd1b9 100644
 --- a/programs/util.h
 +++ b/programs/util.h
 @@ -64,7 +64,7 @@ extern "C" {
@@ -74,5 +74,52 @@ index af1fa7f..4123efa 100644
  #  else
  #    define SET_REALTIME_PRIORITY /* disabled */
 -- 
-2.14.2
+2.16.3
+
+
+From 7ddb411bd22753bfd8b5eb8128943c6bfbfe351e Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Wed, 28 Mar 2018 16:54:54 +0000
+Subject: gcc2: Neutral typo fix in cpu.h to satisfy gcc2.
+
+
+diff --git a/lib/common/cpu.h b/lib/common/cpu.h
+index 4eb48e3..0ede1d1 100644
+--- a/lib/common/cpu.h
++++ b/lib/common/cpu.h
+@@ -73,7 +73,7 @@ MEM_STATIC ZSTD_cpuid_t ZSTD_cpuid(void) {
+           "popl %%ebx\n\t"
+           : "=a"(f1a), "=c"(f1c), "=d"(f1d)
+           : "a"(1)
+-          :);
++          );
+     }
+     if (n >= 7) {
+       __asm__(
+-- 
+2.16.3
+
+
+From aa3415d972fd6392bcda173d73e3da556b26c066 Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Wed, 28 Mar 2018 16:56:02 +0000
+Subject: gcc2: Skip PREFETCH() to avoid undefined ref to __builtin_prefetch
+
+
+diff --git a/lib/decompress/zstd_decompress.c b/lib/decompress/zstd_decompress.c
+index 3ec6a1c..97f289d 100644
+--- a/lib/decompress/zstd_decompress.c
++++ b/lib/decompress/zstd_decompress.c
+@@ -1532,7 +1532,9 @@ ZSTD_decompressSequencesLong_body(
+             seq_t const sequence = ZSTD_decodeSequenceLong(&seqState, isLongOffset);
+             size_t const oneSeqSize = ZSTD_execSequenceLong(op, oend, sequences[(seqNb-ADVANCED_SEQS) & STOSEQ_MASK], &litPtr, litEnd, prefixStart, dictStart, dictEnd);
+             if (ZSTD_isError(oneSeqSize)) return oneSeqSize;
++#if defined(__GNUC__) && (__GNUC__ >= 3)
+             PREFETCH(sequence.match);  /* note : it's safe to invoke PREFETCH() on any memory address, including invalid ones */
++#endif
+             sequences[seqNb&STOSEQ_MASK] = sequence;
+             op += oneSeqSize;
+         }
+-- 
+2.16.3
 

--- a/app-arch/zstd/zstd-1.3.4.recipe
+++ b/app-arch/zstd/zstd-1.3.4.recipe
@@ -8,20 +8,26 @@ compression / speed trade-off, while being backed by a very fast decoder. It \
 also offers a special mode for small data, called dictionary compression, and \
 can create dictionaries from any sample set."
 HOMEPAGE="https://facebook.github.io/zstd/"
-COPYRIGHT="2016-2017 Facebook, Inc."
+COPYRIGHT="2016-2018 Facebook, Inc."
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="https://github.com/facebook/zstd/archive/v$portVersion.tar.gz"
 SOURCE_FILENAME="zstd-$portVersion.tar.gz"
-CHECKSUM_SHA256="a77c47153ee7de02626c5b2a097005786b71688be61e9fb81806a011f90b297b"
+CHECKSUM_SHA256="92e41b6e8dd26bbd46248e8aa1d86f1551bc221a796277ae9362954f26d605a9"
 PATCHES="zstd-$portVersion.patchset"
+if [ "$effectiveTargetArchitecture" = x86_gcc2 ]; then
+PATCHES="$PATCHES
+	zstd-$portVersion-gcc2.patchset
+	"
+fi
 
-ARCHITECTURES="!x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
 commandSuffix=$secondaryArchSuffix
 commandBinDir=$binDir
-if [ "$targetArchitecture" = x86_gcc2 ]; then
+if [ -n "$secondaryArchSuffix" ]; then
+# Comment out this block if you wish to co-install zstd_bin & e.g. zstd_x86_bin.
 	commandSuffix=
 	commandBinDir=$prefix/bin
 fi
@@ -39,7 +45,6 @@ REQUIRES="
 
 PROVIDES_bin="
 	zstd${secondaryArchSuffix}_bin = $portVersion
-	cmd:pzstd$commandSuffix = $portVersion
 	cmd:unzstd$commandSuffix = $portVersion
 	cmd:zstd$commandSuffix = $portVersion
 	cmd:zstdcat$commandSuffix = $portVersion
@@ -47,12 +52,22 @@ PROVIDES_bin="
 	cmd:zstdless$commandSuffix = $portVersion
 	cmd:zstdmt$commandSuffix = $portVersion
 	"
+if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+PROVIDES_bin="$PROVIDES_bin
+	cmd:pzstd$commandSuffix = $portVersion
+	"
+fi
 REQUIRES_bin="
 	haiku$secondaryArchSuffix
 	zstd$secondaryArchSuffix == $portVersion base
 	cmd:grep
 	cmd:less
 	"
+if [ -n "$secondaryArchSuffix" -a "$commandBinDir" = "$prefix"/bin ]; then
+CONFLICTS_bin="
+	zstd_bin
+	"
+fi
 
 PROVIDES_devel="
 	zstd${secondaryArchSuffix}_devel = $portVersion
@@ -71,14 +86,12 @@ BUILD_PREREQUIRES="
 	cmd:sed
 	"
 
-defineDebugInfoPackage zstd$secondaryArchSuffix \
-	$libDir/libzstd.so.$libVersion
-
 BUILD()
 {
 	make PREFIX=$prefix INCLUDEDIR=$includeDir LIBDIR=$libDir $jobArgs
-	make -C contrib/pzstd
-	make -C contrib/gen_html
+	if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+		make -C contrib/pzstd
+	fi
 }
 
 INSTALL()
@@ -86,7 +99,9 @@ INSTALL()
 	mkdir -p $libDir
 	make install PREFIX=$prefix LIBDIR=$libDir INCLUDEDIR=$includeDir \
 		BINDIR=$commandBinDir mandir=$manDir
-	make -C contrib/pzstd install PREFIX=$prefix BINDIR=$commandBinDir
+	if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+		make -C contrib/pzstd install PREFIX="$prefix" BINDIR="$commandBinDir"
+	fi
 
 	prepareInstalledDevelLib libzstd
 	fixPkgconfig


### PR DESCRIPTION
Also drop the debuginfo package since we are not compiling with `-g`.