### PR TITLE
git: add recipe for 2.17.0 but mark it as untested.

### DIFF
--- a/dev-vcs/git/git-2.17.0.recipe
+++ b/dev-vcs/git/git-2.17.0.recipe
@@ -8,22 +8,22 @@ It outclasses SCM tools like Subversion, CVS, Perforce, and ClearCase with \
 features like cheap local branching, convenient staging areas, and multiple \
 workflows."
 HOMEPAGE="https://git-scm.com/"
-COPYRIGHT="2005-2017 Git Authors (see git web site for list)"
+COPYRIGHT="2005-2018 Git Authors (see git web site for list)"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="1"
 
 SOURCE_URI="https://www.kernel.org/pub/software/scm/git/git-$portVersion.tar.xz"
-CHECKSUM_SHA256="999c90fd7d45066992cdb87dda35bdff6dfc1d01496118ea718dfb866da4045c"
+CHECKSUM_SHA256="e916e5e95e81dbeafa7aac5d719c01108b5c814eb90b746695afa1afedf955c7"
 
 SOURCE_URI_2="https://www.kernel.org/pub/software/scm/git/git-manpages-$portVersion.tar.xz"
-CHECKSUM_SHA256_2="6c6bcf7d53aec8a498a1f5af558ae8f83daf892c3565188ee81ce34f6f022656"
+CHECKSUM_SHA256_2="4bdab1aed88ad7a12a766de8e03047eba5afbba9874c7effa5059e5481943727"
 
 SOURCE_URI_3="https://www.kernel.org/pub/software/scm/git/git-htmldocs-$portVersion.tar.xz"
-CHECKSUM_SHA256_3="0b3ad20f1f98d548f07a19900852e134cfc958d9664af95d04c028cf8d140166"
+CHECKSUM_SHA256_3="66d055e15c2f0034379b4a8c5280762a5dff5b4fc99daefa43404dab2f8fc308"
 
 PATCHES="git-$portVersion.patchset"
 
-ARCHITECTURES="x86_gcc2 x86 x86_64"
+ARCHITECTURES="?x86_gcc2 ?x86 ?x86_64"
 
 PROVIDES="
 	git = $portVersion compat >= 2.3
@@ -97,6 +97,7 @@ REQUIRES_email="
 	"
 REQUIRES_svn="
 	haiku
+	alien_svn
 	git == $portVersion base
 	"
 

--- a/dev-vcs/git/patches/git-2.17.0.patchset
+++ b/dev-vcs/git/patches/git-2.17.0.patchset
@@ -77,10 +77,10 @@ Subject: Ensure config-directory exists before using it.
 
 
 diff --git a/config.c b/config.c
-index c38401a..329727d 100644
+index b0c20e6..859d92b 100644
 --- a/config.c
 +++ b/config.c
-@@ -2453,6 +2453,7 @@ int git_config_set_multivar_in_file_gently(const char *config_filename,
+@@ -2485,6 +2485,7 @@ int git_config_set_multivar_in_file_gently(const char *config_filename,
  	int ret;
  	struct lock_file lock = LOCK_INIT;
  	char *filename_buf = NULL;
@@ -88,7 +88,7 @@ index c38401a..329727d 100644
  	char *contents = NULL;
  	size_t contents_sz;
  
-@@ -2466,6 +2467,12 @@ int git_config_set_multivar_in_file_gently(const char *config_filename,
+@@ -2498,6 +2499,12 @@ int git_config_set_multivar_in_file_gently(const char *config_filename,
  	if (!config_filename)
  		config_filename = filename_buf = git_pathdup("config");
  
@@ -102,7 +102,7 @@ index c38401a..329727d 100644
  	 * The lock serves a purpose in addition to locking: the new
  	 * contents of .git/config will be written into it.
 -- 
-2.14.2
+2.16.3
 
 
 From 66ce1d4e8611573bde7ae110d015c45cc5529adf Mon Sep 17 00:00:00 2001
@@ -111,7 +111,6 @@ Date: Sun, 14 Feb 2016 10:32:12 +0100
 Subject: Move credential cache to the config directory.
 
 Do not clutter the home dir.
-
 
 diff --git a/credential-cache.c b/credential-cache.c
 index 1cccc3a..076f6fa 100644
@@ -137,10 +136,10 @@ Subject: builtin: config: use xdg_config even if it does not exist
 
 
 diff --git a/builtin/config.c b/builtin/config.c
-index d13daee..2342d34 100644
+index 01169dd..5378d33 100644
 --- a/builtin/config.c
 +++ b/builtin/config.c
-@@ -508,22 +508,11 @@ int cmd_config(int argc, const char **argv, const char *prefix)
+@@ -523,22 +523,11 @@ int cmd_config(int argc, const char **argv, const char *prefix)
  		char *user_config = expand_user_path("~/.gitconfig", 0);
  		char *xdg_config = xdg_config_home("config");
  
@@ -168,5 +167,5 @@ index d13daee..2342d34 100644
  	}
  	else if (use_system_config)
 -- 
-2.15.1
+2.16.3
 


### PR DESCRIPTION
~Also comment out the dependency of `git_svn` on the missing `svn_alien` in order to be able to use haikuporter's `--test` feature after it was taught to examine the `TEST_REQUIRES` variable.~