### PR TITLE
util-linux: bump to 2.32, build lib{blkid,fdisk,uuid}.

### DIFF
--- a/sys-apps/util-linux/patches/util_linux-2.32.patchset
+++ b/sys-apps/util-linux/patches/util_linux-2.32.patchset
@@ -131,17 +131,18 @@ From: fbrosson <fbrosson@localhost>
 Date: Tue, 1 May 2018 23:37:15 +0000
 Subject: define {makedev,major,minor} macros in blkidP.h for libblkid
 
+
 diff --git a/libblkid/src/blkidP.h b/libblkid/src/blkidP.h
-index 22c9856..66130a3 100644
+index 22c9856..1a08190 100644
 --- a/libblkid/src/blkidP.h
 +++ b/libblkid/src/blkidP.h
 @@ -341,6 +341,10 @@ UL_DEBUG_DECLARE_MASK(libblkid);
  #define UL_DEBUG_CURRENT_MASK	UL_DEBUG_MASK(libblkid)
  #include "debugobj.h"
  
-+#define makedev(ma, mi) ((dev_t)((ma) << 8) | (mi))
-+#define major(devno) ((devno) >> 8)
-+#define minor(devno) ((devno) & 0xff)
++#define makedev(ma, mi) ((dev_t)(((((unsigned int)(ma)) << 8) & 0xff00) | (mi)))
++#define major(devnum) (((unsigned int)((devnum) & 0xff00) >> 8))
++#define minor(devnum) (unsigned int)((devnum) & 0xffff00ff)
 +
  extern void blkid_debug_dump_dev(blkid_dev dev);
  
@@ -157,16 +158,16 @@ Subject: define {makedev,major,minor} macros in sysfs.h for fdisk
 
 
 diff --git a/include/sysfs.h b/include/sysfs.h
-index 9a72a20..4bca6df 100644
+index 9a72a20..b21ab10 100644
 --- a/include/sysfs.h
 +++ b/include/sysfs.h
 @@ -16,6 +16,10 @@
  #include <inttypes.h>
  #include <dirent.h>
  
-+#define makedev(ma, mi) ((dev_t)((ma) << 8) | (mi))
-+#define major(devno) ((devno) >> 8)
-+#define minor(devno) ((devno) & 0xff)
++#define makedev(ma, mi) ((dev_t)(((((unsigned int)(ma)) << 8) & 0xff00) | (mi)))
++#define major(devnum) (((unsigned int)((devnum) & 0xff00) >> 8))
++#define minor(devnum) (unsigned int)((devnum) & 0xffff00ff)
 +
  struct sysfs_cxt {
  	dev_t	devno;

--- a/sys-apps/util-linux/patches/util_linux-2.32.patchset
+++ b/sys-apps/util-linux/patches/util_linux-2.32.patchset
@@ -1,16 +1,11 @@
 From f9bda2ce44de1d434aee3e985b0ea88d9306434b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
 Date: Tue, 22 Aug 2017 18:43:38 +0200
-Subject: [PATCH] Haiku patches
+Subject: Haiku patches
 
----
- include/c.h        |  4 ++++
- include/ttyutils.h | 36 ++++++++++++++++++++++++++++++++++++
- lib/randutils.c    |  2 ++
- 3 files changed, 42 insertions(+)
 
 diff --git a/include/c.h b/include/c.h
-index b0670dc..8808c32 100644
+index c8bcb37..bf6ff26 100644
 --- a/include/c.h
 +++ b/include/c.h
 @@ -29,6 +29,10 @@
@@ -114,7 +109,7 @@ index a9baab3..961fd49 100644
  }
  
 diff --git a/lib/randutils.c b/lib/randutils.c
-index e1c4059..ac553bf 100644
+index de42795..9e07457 100644
 --- a/lib/randutils.c
 +++ b/lib/randutils.c
 @@ -13,7 +13,9 @@
@@ -129,4 +124,53 @@ index e1c4059..ac553bf 100644
  #include "randutils.h"
 -- 
 2.14.1
+
+
+From e8ab90b9e91df50304e32a77325d2030c1d4aeb6 Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Tue, 1 May 2018 23:37:15 +0000
+Subject: define {makedev,major,minor} macros in blkidP.h for libblkid
+
+diff --git a/libblkid/src/blkidP.h b/libblkid/src/blkidP.h
+index 22c9856..66130a3 100644
+--- a/libblkid/src/blkidP.h
++++ b/libblkid/src/blkidP.h
+@@ -341,6 +341,10 @@ UL_DEBUG_DECLARE_MASK(libblkid);
+ #define UL_DEBUG_CURRENT_MASK	UL_DEBUG_MASK(libblkid)
+ #include "debugobj.h"
+ 
++#define makedev(ma, mi) ((dev_t)((ma) << 8) | (mi))
++#define major(devno) ((devno) >> 8)
++#define minor(devno) ((devno) & 0xff)
++
+ extern void blkid_debug_dump_dev(blkid_dev dev);
+ 
+ 
+-- 
+2.17.0
+
+
+From 8ea31be2a92c3b90417061333da461f1e330e9bb Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Fri, 4 May 2018 21:25:57 +0000
+Subject: define {makedev,major,minor} macros in sysfs.h for fdisk
+
+
+diff --git a/include/sysfs.h b/include/sysfs.h
+index 9a72a20..4bca6df 100644
+--- a/include/sysfs.h
++++ b/include/sysfs.h
+@@ -16,6 +16,10 @@
+ #include <inttypes.h>
+ #include <dirent.h>
+ 
++#define makedev(ma, mi) ((dev_t)((ma) << 8) | (mi))
++#define major(devno) ((devno) >> 8)
++#define minor(devno) ((devno) & 0xff)
++
+ struct sysfs_cxt {
+ 	dev_t	devno;
+ 	int	dir_fd;		/* /sys/block/<name> */
+-- 
+2.17.0
 

--- a/sys-apps/util-linux/util_linux-2.32.recipe
+++ b/sys-apps/util-linux/util_linux-2.32.recipe
@@ -7,8 +7,8 @@ LICENSE="GNU GPL v2
 	BSD (4-clause)
 	Public Domain"
 REVISION="1"
-SOURCE_URI="https://www.kernel.org/pub/linux/utils/util-linux/v2.31/util-linux-$portVersion.tar.xz"
-CHECKSUM_SHA256="1a51b16fa9cd51d26ef9ab52d2f1de12403b810fc8252bf7d478df91b3cddf11"
+SOURCE_URI="https://www.kernel.org/pub/linux/utils/util-linux/v2.32/util-linux-$portVersion.tar.xz"
+CHECKSUM_SHA256="6c7397abc764e32e8159c2e96042874a190303e77adceb4ac5bd502a272a4734"
 SOURCE_DIR="util-linux-$portVersion"
 PATCHES="util_linux-$portVersion.patchset"
 
@@ -23,25 +23,57 @@ if [ "$targetArchitecture" = x86_gcc2 ]; then
 	commandBinDir=$prefix/bin
 fi
 
+util_linuxLibs="libblkid libfdisk libsmartcols libuuid"
+libblkidVersion="1.1.0"
+libfdiskVersion="1.1.0"
+libsmartcolsVersion="1.1.0"
+libuuidVersion="1.3.0"
+portVersionCompat="$portVersion compat >= 2"
+for i in $util_linuxLibs; do
+	eval "${i}VersionCompat=\"\$${i}Version compat >= \${${i}Version%%.*}\""
+done
+
 PROVIDES="
 	util_linux$secondaryArchSuffix = $portVersion compat >= 2
+	cmd:blkid$commandSuffix = $portVersion
 	cmd:cal$commandSuffix = $portVersion
+	cmd:hexdump$commandSuffix = $portVersion
 	cmd:nologin$commandSuffix = $portVersion
 	cmd:rename$commandSuffix = $portVersion
 	cmd:ul$commandSuffix = $portVersion
+	cmd:uuidgen$commandSuffix = $portVersion
+	lib:libblkid$secondaryArchSuffix = $libblkidVersionCompat
+	lib:libfdisk$secondaryArchSuffix = $libfdiskVersionCompat
 	lib:libsmartcols$secondaryArchSuffix = 1.1.0 compat >= 1
-
+	lib:libuuid$secondaryArchSuffix = $libuuidVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libintl$secondaryArchSuffix
-	lib:libncurses$secondaryArchSuffix
+	lib:libncursesw$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
+	"
+
+SUMMARY_fdisk="A random collection of Linux utilities (fdisk)"
+ARCHITECTURES_fdisk="!x86_gcc2 ?x86 ?x86_64"
+SECONDARY_ARCHITECTURES="?x86"
+PROVIDES_fdisk="
+	util_linux${secondaryArchSuffix}_fdisk = $portVersion compat >= 2
+	cmd:fdisk$commandSuffix = $portVersionCompat
+	"
+REQUIRES_fdisk="
+	util_linux$secondaryArchSuffix == $portVersion base
+	haiku$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libncursesw$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
 	util_linux${secondaryArchSuffix}_devel = $portVersion compat >= 2
+	devel:libblkid$secondaryArchSuffix = $libblkidVersionCompat
+	devel:libfdisk$secondaryArchSuffix = $libfdiskVersionCompat
 	devel:libsmartcols$secondaryArchSuffix = 1.1.0 compat >= 1
+	devel:libuuid$secondaryArchSuffix = $libuuidVersionCompat
 	"
 REQUIRES_devel="
 	util_linux$secondaryArchSuffix == $portVersion base
@@ -50,7 +82,7 @@ REQUIRES_devel="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libintl$secondaryArchSuffix
-	devel:libncurses$secondaryArchSuffix
+	devel:libncursesw$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
@@ -64,6 +96,7 @@ BUILD_PREREQUIRES="
 	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
+	cmd:sed
 	"
 
 BUILD()
@@ -80,11 +113,28 @@ BUILD()
 	runConfigure --omit-dirs "binDir sbinDir" ./configure $maybe_x86 \
 		--bindir="$commandBinDir" --sbindir="$commandBinDir" \
 		--disable-all-programs \
+		--disable-libmount \
+		--disable-makedev \
+		--enable-blkid \
 		--enable-cal \
+		--enable-fdisk \
+		--enable-hexdump \
+		--enable-libfdisk \
 		--enable-libsmartcols \
+		--enable-libuuid \
 		--enable-rename \
 		--enable-nologin \
-		--enable-ul
+		--enable-ul \
+		--enable-uuidgen \
+		--without-udev \
+
+	# --disable-all-programs kills several --enable-* switches, so enable them:
+	for i in BLKID FDISK LIBBLKID LIBFDISK HEXDUMP UUIDGEN; do
+		sed -i \
+			-e "/BUILD_${i}_TRUE/ s/\"#\"/\"\"/;" \
+			-e "/BUILD_${i}_FALSE/ s/\"\"/\"#\"/;" \
+			config.status
+	done
 	make
 }
 
@@ -95,16 +145,19 @@ INSTALL()
 	# Cleanup
 	rm -rf $prefix/sbin
 
-	# Remove libtool file
-	rm -f $libDir/libsmartcols.la
+	rm -f "$libDir"/lib*.la
 
-	prepareInstalledDevelLib libsmartcols
+	prepareInstalledDevelLibs $util_linuxLibs
 	fixPkgconfig
 
-	packageEntries devel \
-		$developDir
+	packageEntries fdisk \
+		"$commandBinDir"/fdisk \
+		"$dataDir"/bash-completion/completions/fdisk \
+		"$manDir"/man8/fdisk.8
 
-	rmdir $manDir/man3
+	packageEntries devel \
+		"$developDir" \
+		"$manDir"/man3
 }
 
 TEST()


### PR DESCRIPTION
~Also build blkid, hexdump and uuidgen.~

Also build blkid, fdisk, hexdump and uuidgen, but put fdisk in a subpackage, marked as untested, as the geometry autodetection is not working, so the default values are not useful at all.
fdisk is working fine but it does not know how to inform Haiku that a partition table was modified. Workaround: reboot.
TODO: teach fdisk and partprobe how to talk to Haiku's kernel.