### PR TITLE
lemon, revive old bep file

### DIFF
--- a/sys-devel/lemon/lemon-1.0~src.recipe
+++ b/sys-devel/lemon/lemon-1.0~src.recipe
@@ -1,0 +1,62 @@
+SUMMARY="The Lemon LALR(1) Parser Generator"
+DESCRIPTION="The SQL language parser for SQLite is generated using a \
+code-generator program called \"Lemon\". The Lemon program reads a grammar \
+of the input language and emits C-code to implement a parser for that language."
+HOMEPAGE="https://www.sqlite.org/lemon.html"
+COPYRIGHT="Public Domain"
+LICENSE="SQLite"
+REVISION="1"
+SOURCE_URI="https://sqlite.org/src/raw/tool/lemon.c?name=33892e2a243865f73e6c6e7cecce3c6eb4bb95db4a3d9d86d146c8064feb92fd#noarchive"
+SOURCE_FILENAME="lemon.c"
+CHECKSUM_SHA256="573ef688d5a18fc0cfff2a3d6efcfc693e4d059328da631dabbfcdfa742ba6ee"
+SOURCE_URI_2="https://sqlite.org/src/doc/trunk/doc/lemon.html#noarchive"
+SOURCE_FILENAME_2="lemon.html"
+CHECKSUM_SHA256_2="91fdc5a8178c401d6ebf358c661609fbce0c5617e0edb19af4e4f47c29f9ef29"
+SOURCE_URI_3="https://sqlite.org/src/raw/tool/lempar.c?name=bf7db78e7213f1d51516710483eab506fd52bf632c7abfb3e2e9b885c90c03e1#noarchive"
+SOURCE_FILENAME_3="lempar.c"
+CHECKSUM_SHA256_3="16cffecd770fe7c1f5bc576f45471181d5e28f92134d451300c6e2b8356633ad"
+
+SOURCE_DIR=""
+SOURCE_DIR_2=""
+SOURCE_DIR_3=""
+
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+# On x86_gcc2 we don't want to install the commands in bin/<arch>/, but in bin/.
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+PROVIDES="
+	lemon$secondaryArchSuffix = $portVersion
+	cmd:lemon$commandSuffix = 1.0 compat >= 1
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	gcc$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	cp -f $sourceDir2/lemon.html $sourceDir
+	#not sure where this template should be installed (lempar.c)
+	cp -f $sourceDir3/lempar.c $sourceDir
+	gcc lemon.c -o lemon
+}
+
+INSTALL()
+{
+	install -d -m 755 "$prefix/bin" "$prefix/documentation/packages/lemon"
+	install -m 755 -t "$prefix/bin" lemon
+	install -m 644 -t "$prefix/documentation/packages/lemon" lemon.html
+}

--- a/sys-devel/lemon/licenses/SQLite
+++ b/sys-devel/lemon/licenses/SQLite
@@ -1,0 +1,32 @@
+SQLite Copyright
+
+SQLite is in the
+Public Domain
+
+All of the deliverable code in SQLite has been dedicated to the public domain by the authors. All code authors, and representatives of the companies they work for, have signed affidavits dedicating their contributions to the public domain and originals of those signed affidavits are stored in a firesafe at the main offices of Hwaci. Anyone is free to copy, modify, publish, use, compile, sell, or distribute the original SQLite code, either in source code form or as a compiled binary, for any purpose, commercial or non-commercial, and by any means.
+
+The previous paragraph applies to the deliverable code in SQLite - those parts of the SQLite library that you actually bundle and ship with a larger application. Portions of the documentation and some code used as part of the build process might fall under other licenses. The details here are unclear. We do not worry about the licensing of the documentation and build code so much because none of these things are part of the core deliverable SQLite library.
+
+All of the deliverable code in SQLite has been written from scratch. No code has been taken from other projects or from the open internet. Every line of code can be traced back to its original author, and all of those authors have public domain dedications on file. So the SQLite code base is clean and is uncontaminated with licensed code from other projects.
+Obtaining An Explicit License To Use SQLite
+
+Even though SQLite is in the public domain and does not require a license, some users want to obtain a license anyway. Some reasons for obtaining a license include:
+
+    * You are using SQLite in a jurisdiction that does not recognize the public domain.
+    * You are using SQLite in a jurisdiction that does not recognize the right of an author to dedicate their work to the public domain.
+    * You want to hold a tangible legal document as evidence that you have the legal right to use and distribute SQLite.
+    * Your legal department tells you that you have to purchase a license.
+
+If you feel like you really have to purchase a license for SQLite, Hwaci, the company that employs the architect and principal developers of SQLite, will sell you one.
+Contributed Code
+
+In order to keep SQLite completely free and unencumbered by copyright, all new contributors to the SQLite code base are asked to dedicate their contributions to the public domain. If you want to send a patch or enhancement for possible inclusion in the SQLite source tree, please accompany the patch with the following statement:
+
+    The author or authors of this code dedicate any and all copyright interest in this code to the public domain. We make this dedication for the benefit of the public at large and to the detriment of our heirs and successors. We intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this code under copyright law. 
+
+We are not able to accept patches or changes to SQLite that are not accompanied by a statement such as the above. In addition, if you make changes or enhancements as an employee, then a simple statement such as the above is insufficient. You must also send by surface mail a copyright release signed by a company officer. A signed original of the copyright release should be mailed to:
+
+    Hwaci
+    6200 Maple Cove Lane
+    Charlotte, NC 28269
+    USA 


### PR DESCRIPTION
renamed the file to 1.0~src as "lemon -x" reports version 1.0 (comments welcome)
the template lempar.c is included but I'm not sure where it should be installed (yet)