### PR TITLE
libsigc++ (3.0): add CONFLICTS_devel.

### DIFF
--- a/dev-libs/libsigc++/libsigc++3-2.99.10.recipe
+++ b/dev-libs/libsigc++/libsigc++3-2.99.10.recipe
@@ -8,7 +8,7 @@ has an ease of use unmatched by other C++ callback libraries."
 HOMEPAGE="http://libsigc.sourceforge.net/"
 COPYRIGHT="2002-2018 The libsigc++ Development Team"
 LICENSE="GNU LGPL v3"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="http://ftp.gnome.org/pub/GNOME/sources/libsigc++/2.99/libsigc++-$portVersion.tar.xz"
 CHECKSUM_SHA256="68cdb00e39d6b913d22b0ac362312447c8b4014146b8efd2a9299d9916c72260"
 SOURCE_DIR="libsigc++-$portVersion"
@@ -23,7 +23,6 @@ PROVIDES="
 	libsigc++3$secondaryArchSuffix = $portVersion
 	lib:libsigc_3.0$secondaryArchSuffix = $libVersionCompat
 	"
-
 REQUIRES="
 	haiku$secondaryArchSuffix
 	"
@@ -32,15 +31,16 @@ PROVIDES_devel="
 	libsigc++3${secondaryArchSuffix}_devel = $portVersion
 	devel:libsigc_3.0$secondaryArchSuffix = $libVersionCompat
 	"
-
 REQUIRES_devel="
 	libsigc++3$secondaryArchSuffix == $portVersion base
+	"
+CONFLICTS_devel="
+	libsigc++${secondaryArchSuffix}_devel
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
-
 BUILD_PREREQUIRES="
 	cmd:autoconf
 	cmd:gcc$secondaryArchSuffix


### PR DESCRIPTION
~These changes will require a revbump for:~

* ~`media-libs/paragui/paragui-1.1.8.recipe` (it needs `lib:libsigc_1.2`)~
* ~`dev-cpp/glibmm/glibmm-2.57.1.recipe` (it needs `lib:libsigc_3.0`)~
* ~`net-p2p/rtorrent/rtorrent-0.9.6.recipe` (it needs `lib:libsigc_2.0`)~