### PR TITLE
iasl: bump to 20180508, build the acpitests in TEST.

### DIFF
--- a/sys-power/iasl/iasl-20180508.recipe
+++ b/sys-power/iasl/iasl-20180508.recipe
@@ -3,23 +3,28 @@ DESCRIPTION="The ACPI Component Architecture (ACPICA) project provides an \
 operating system (OS)-independent reference implementation of the Advanced \
 Configuration and Power Interface Specification (ACPI)."
 HOMEPAGE="https://acpica.org/"
-COPYRIGHT="2000-2017 Intel Corp."
-LICENSE="
-	Intel (ACPICA)
+COPYRIGHT="2000-2018 Intel Corp."
+LICENSE="Intel (ACPICA)
 	GNU GPL v2
 	BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="https://acpica.org/sites/acpica/files/acpica-unix-$portVersion.tar.gz"
-CHECKSUM_SHA256="1287c3d75c7956680dbb7e90151caef0255797eb29e18dd55588d713ada97d14"
+CHECKSUM_SHA256="2b81e45cb9cc5116e9bbb39f8822ff90ec44f9f2bf6fa87243e2cd7376c5f4d8"
 SOURCE_DIR="acpica-unix-$portVersion"
+
+SOURCE_URI_2="https://acpica.org/sites/acpica/files/acpitests-unix-$portVersion.tar.gz"
+CHECKSUM_SHA256_2="0b89b982e4158f59846b557fe93acb8fbd1a4b6fdb2d8a3eaa3f6792c3105b52"
+SOURCE_DIR_2="acpitests-unix-$portVersion"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 # On x86_gcc2 we don't want to install the commands in bin/<arch>/, but in bin/.
 commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
 if [ "$targetArchitecture" = x86_gcc2 ]; then
 	commandSuffix=
+	commandBinDir=$prefix/bin
 fi
 
 PROVIDES="
@@ -44,20 +49,14 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	cmd:bison
 	cmd:flex
-	cmd:make
 	cmd:gcc$secondaryArchSuffix
+	cmd:make
 	"
 
-defineDebugInfoPackage iasl$secondaryArchSuffix \
-	$binDir/acpibin \
-	$binDir/acpidump \
-	$binDir/acpiexamples \
-	$binDir/acpiexec \
-	$binDir/acpihelp \
-	$binDir/acpinames \
-	$binDir/acpisrc \
-	$binDir/acpixtract \
-	$binDir/iasl
+TEST_REQUIRES="
+	cmd:awk
+	cmd:find
+	"
 
 PATCH()
 {
@@ -71,5 +70,19 @@ BUILD()
 
 INSTALL()
 {
-	make PREFIX=$prefix install
+	make PREFIX="$prefix" INSTALLDIR="$commandBinDir" install
+}
+
+TEST()
+{
+	export ASL="$sourceDir"/generate/unix/bin/iasl
+	cd "$sourceDir2"/tests/aslts
+	make install
+
+	export acpiexec="$sourceDir"/generate/unix/bin/acpiexec
+	export acpibin="$sourceDir"/generate/unix/bin/acpibin
+	export ASLTSDIR="$sourceDir2"/tests/aslts
+	PATH="$sourceDir/generate/unix/bin:$PATH"
+	cd "$ASLTSDIR"/bin
+	./Do 1
 }


### PR DESCRIPTION
* Drop unneeded `debuginfo`.
* Use `commandBinDir` as it is now recommended for recipes using `commandSuffix`.