### PR TITLE
libvpx: bump to 1.7.0.

### DIFF
--- a/media-libs/libvpx/libvpx-1.7.0.recipe
+++ b/media-libs/libvpx/libvpx-1.7.0.recipe
@@ -6,25 +6,37 @@ on millions of computers and devices worldwide.
 This distribution of the WebM VP8 Codec SDK includes the following support:
 - WebM VP8 Encoder
 - WebM VP8 Decoder"
-HOMEPAGE="http://www.webmproject.org"
+HOMEPAGE="https://www.webmproject.org/"
 COPYRIGHT="2009-2012 Google Inc.,
 	The Mozilla Foundation and
 	The Xiph.Org Foundation"
 LICENSE="BSD (3-clause)"
 REVISION="1"
 SOURCE_URI="https://github.com/webmproject/libvpx/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="cda8bb6f0e4848c018177d3a576fa83ed96d762554d7010fe4cfb9d70c22e588"
+CHECKSUM_SHA256="1fec931eb5c94279ad219a5b6e0202358e94a93a90cfb1603578c326abfc1238"
+SOURCE_FILENAME="libvpx-$portVersion.tar.gz"
 SOURCE_DIR="libvpx-$portVersion"
 PATCHES="libvpx-$portVersion.patchset"
 
 ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
-SECONDARY_ARCHITECTURES="?x86"
+SECONDARY_ARCHITECTURES="x86"
+
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+libVersion="5.0.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+portVersionCompat="$portVersion compat >= ${portVersion%%.*}"
 
 PROVIDES="
 	libvpx$secondaryArchSuffix = $portVersion
-	cmd:vpxdec = $portVersion compat >= 1
-	cmd:vpxenc = $portVersion compat >= 1
-	lib:libvpx$secondaryArchSuffix = 4.1.0 compat >= 4
+	cmd:vpxdec$commandSuffix = $portVersionCompat
+	cmd:vpxenc$commandSuffix = $portVersionCompat
+	lib:libvpx$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -32,13 +44,10 @@ REQUIRES="
 
 PROVIDES_devel="
 	libvpx${secondaryArchSuffix}_devel = $portVersion
-	devel:libvpx$secondaryArchSuffix = 4.1.0 compat >= 4
+	devel:libvpx$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
 	libvpx$secondaryArchSuffix == $portVersion
-	"
-CONFLICTS_devel="
-	libvpx3${secondaryArchSuffix}_devel
 	"
 
 BUILD_REQUIRES="
@@ -84,6 +93,12 @@ INSTALL()
 	mkdir -p $includeDir
 	mv $prefix/include/* $includeDir
 	rmdir $prefix/include
+
+	if [ -n "$secondaryArchSuffix" -a "$commandBinDir" != "$prefix/bin" ]; then
+		mkdir -p "$commandBinDir"
+		mv "$prefix"/bin/vpxdec "$commandBinDir"
+		mv "$prefix"/bin/vpxenc "$commandBinDir"
+	fi
 
 	# devel package
 	packageEntries devel \

--- a/media-libs/libvpx/patches/libvpx-1.7.0.patchset
+++ b/media-libs/libvpx/patches/libvpx-1.7.0.patchset
@@ -5,10 +5,10 @@ Subject: patch for 1.0.0
 
 
 diff --git a/build/make/configure.sh b/build/make/configure.sh
-index 007e020..430c5ed 100644
+index 683b430..7065d31 100644
 --- a/build/make/configure.sh
 +++ b/build/make/configure.sh
-@@ -741,6 +741,9 @@ process_common_toolchain() {
+@@ -776,6 +776,9 @@ process_common_toolchain() {
        *os2*)
          tgt_os=os2
          ;;
@@ -18,7 +18,7 @@ index 007e020..430c5ed 100644
      esac
  
      if [ -n "$tgt_isa" ] && [ -n "$tgt_os" ]; then
-@@ -1228,8 +1231,8 @@ EOF
+@@ -1287,8 +1290,8 @@ EOF
  EOF
        case ${tgt_cc} in
          gcc*)
@@ -29,7 +29,7 @@ index 007e020..430c5ed 100644
            ;;
        esac
  
-@@ -1286,7 +1289,7 @@ EOF
+@@ -1353,7 +1356,7 @@ EOF
            enabled debug && add_asflags -g cv8
            EXE_SFX=.exe
            ;;
@@ -38,7 +38,7 @@ index 007e020..430c5ed 100644
            add_asflags -f elf${bits}
            enabled debug && [ "${AS}" = yasm ] && add_asflags -g dwarf2
            enabled debug && [ "${AS}" = nasm ] && add_asflags -g
-@@ -1398,6 +1401,8 @@ EOF
+@@ -1465,6 +1468,8 @@ EOF
        *-android-gcc)
          # bionic includes basic pthread functionality, obviating -lpthread.
          ;;
@@ -48,13 +48,13 @@ index 007e020..430c5ed 100644
          check_header pthread.h && add_extralibs -lpthread
          ;;
 diff --git a/configure b/configure
-index fb732ac..0d8ff63 100755
+index e5a74c6..d69e665 100755
 --- a/configure
 +++ b/configure
-@@ -125,6 +125,7 @@ all_platforms="${all_platforms} x86-darwin12-gcc"
- all_platforms="${all_platforms} x86-darwin13-gcc"
+@@ -129,6 +129,7 @@ all_platforms="${all_platforms} x86-darwin13-gcc"
  all_platforms="${all_platforms} x86-darwin14-gcc"
  all_platforms="${all_platforms} x86-darwin15-gcc"
+ all_platforms="${all_platforms} x86-darwin16-gcc"
 +all_platforms="${all_platforms} x86-haiku-gcc"
  all_platforms="${all_platforms} x86-iphonesimulator-gcc"
  all_platforms="${all_platforms} x86-linux-gcc"
@@ -87,10 +87,10 @@ Subject: configure: enable shared library building for Haiku
 
 
 diff --git a/configure b/configure
-index 0d8ff63..1575ad7 100755
+index d69e665..bc5539f 100755
 --- a/configure
 +++ b/configure
-@@ -497,7 +497,7 @@ process_detect() {
+@@ -519,7 +519,7 @@ process_detect() {
          # here rather than at option parse time because the target auto-detect
          # magic happens after the command line has been parsed.
          case "${tgt_os}" in
@@ -110,10 +110,10 @@ Subject: libs.mk: no -lm or -lpthread on Haiku
 
 
 diff --git a/libs.mk b/libs.mk
-index 36935bd..fef8cbb 100644
+index a3e2f9d..c147b7c 100644
 --- a/libs.mk
 +++ b/libs.mk
-@@ -269,7 +269,6 @@ LIBS-$(CONFIG_SHARED) += $(BUILD_PFX)$(LIBVPX_SO)\
+@@ -270,7 +270,6 @@ LIBS-$(CONFIG_SHARED) += $(BUILD_PFX)$(LIBVPX_SO)\
                             $(notdir $(LIBVPX_SO_SYMLINKS)) \
                             $(if $(LIBVPX_SO_IMPLIB), $(BUILD_PFX)$(LIBVPX_SO_IMPLIB))
  $(BUILD_PFX)$(LIBVPX_SO): $(LIBVPX_OBJS) $(EXPORT_FILE)
@@ -121,7 +121,7 @@ index 36935bd..fef8cbb 100644
  $(BUILD_PFX)$(LIBVPX_SO): SONAME = libvpx.so.$(SO_VERSION_MAJOR)
  $(BUILD_PFX)$(LIBVPX_SO): EXPORTS_FILE = $(EXPORT_FILE)
  
-@@ -332,11 +331,11 @@ vpx.pc: config.mk libs.mk
+@@ -333,11 +332,11 @@ vpx.pc: config.mk libs.mk
  	$(qexec)echo 'Version: $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)' >> $@
  	$(qexec)echo 'Requires:' >> $@
  	$(qexec)echo 'Conflicts:' >> $@
@@ -136,7 +136,7 @@ index 36935bd..fef8cbb 100644
  endif
  	$(qexec)echo 'Cflags: -I$${includedir}' >> $@
  INSTALL-LIBS-yes += $(LIBSUBDIR)/pkgconfig/vpx.pc
-@@ -506,7 +505,7 @@ TEST_LIBS := lib$(CODEC_LIB)$(CODEC_LIB_SUF) libgtest.a
+@@ -515,7 +514,7 @@ TEST_LIBS := lib$(CODEC_LIB)$(CODEC_LIB_SUF) libgtest.a
  $(LIBVPX_TEST_BIN): $(TEST_LIBS)
  $(eval $(call linkerxx_template,$(LIBVPX_TEST_BIN), \
                $(LIBVPX_TEST_OBJS) \
@@ -145,7 +145,7 @@ index 36935bd..fef8cbb 100644
  
  ifneq ($(strip $(TEST_INTRA_PRED_SPEED_OBJS)),)
  $(TEST_INTRA_PRED_SPEED_OBJS) $(TEST_INTRA_PRED_SPEED_OBJS:.o=.d): CXXFLAGS += $(GTEST_INCLUDES)
-@@ -516,7 +515,7 @@ BINS-yes += $(TEST_INTRA_PRED_SPEED_BIN)
+@@ -525,7 +524,7 @@ BINS-yes += $(TEST_INTRA_PRED_SPEED_BIN)
  $(TEST_INTRA_PRED_SPEED_BIN): $(TEST_LIBS)
  $(eval $(call linkerxx_template,$(TEST_INTRA_PRED_SPEED_BIN), \
                $(TEST_INTRA_PRED_SPEED_OBJS) \
@@ -166,13 +166,13 @@ Subject: x86_64 support
 * configure, amples.mk
 
 diff --git a/configure b/configure
-index 1575ad7..c82c8ec 100755
+index bc5539f..5fff1f2 100755
 --- a/configure
 +++ b/configure
-@@ -144,6 +144,7 @@ all_platforms="${all_platforms} x86_64-darwin12-gcc"
- all_platforms="${all_platforms} x86_64-darwin13-gcc"
+@@ -150,6 +150,7 @@ all_platforms="${all_platforms} x86_64-darwin13-gcc"
  all_platforms="${all_platforms} x86_64-darwin14-gcc"
  all_platforms="${all_platforms} x86_64-darwin15-gcc"
+ all_platforms="${all_platforms} x86_64-darwin16-gcc"
 +all_platforms="${all_platforms} x86_64-haiku-gcc"
  all_platforms="${all_platforms} x86_64-iphonesimulator-gcc"
  all_platforms="${all_platforms} x86_64-linux-gcc"


### PR DESCRIPTION
It is safe to drop `libvpx4-1.6.1` because no package is using it at the moment: `games-fps/eduke32`, `media-libs/{gd,gst_plugins_good}`, `media-video/{ffmpeg,handbrake}` and `sci-visualization/gnuplot` are all using `libvpx3-1.5.0`.

Co-authored-by: @extrowerk