### PR TITLE
libvpx: move the runtimes to a subpackage.

### DIFF
--- a/media-libs/libvpx/libvpx-1.0.0.recipe
+++ b/media-libs/libvpx/libvpx-1.0.0.recipe
@@ -6,12 +6,12 @@ on millions of computers and devices worldwide.
 This distribution of the WebM VP8 Codec SDK includes the following support:
 - WebM VP8 Encoder
 - WebM VP8 Decoder"
-HOMEPAGE="http://www.webmproject.org"
+HOMEPAGE="https://www.webmproject.org/"
 COPYRIGHT="2009-2012 Google Inc.,
 	The Mozilla Foundation and
 	The Xiph.Org Foundation"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="http://webm.googlecode.com/files/libvpx-v1.0.0.tar.bz2"
 CHECKSUM_SHA256="07cedb0a19a44e6d81d75f52eea864f59ef10c6c725cb860431bec6641eafe21"
 SOURCE_DIR="libvpx-v1.0.0"
@@ -20,25 +20,34 @@ PATCHES="libvpx-1.0.0.patchset"
 ARCHITECTURES="x86_gcc2 !x86 !x86_64"
 SECONDARY_ARCHITECTURES="x86_gcc2 !x86"
 
+libVersion="1.0.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+portVersionCompat="$portVersion compat >= ${portVersion%.*}"
+
 PROVIDES="
 	libvpx$secondaryArchSuffix = $portVersion
-	lib:libvpx$secondaryArchSuffix = $portVersion compat >= 1
+	lib:libvpx$secondaryArchSuffix = $libVersionCompat
 	"
-if [ -z "$secondaryArchSuffix" ]; then
-	PROVIDES="$PROVIDES
-		cmd:vp8_scalable_patterns = $portVersion
-		cmd:vpxdec = $portVersion compat >= 1
-		cmd:vpxenc = $portVersion compat >= 1
-		"
-fi
-
 REQUIRES="
 	haiku$secondaryArchSuffix
 	"
 
+if [ -z "$secondaryArchSuffix" ]; then
+PROVIDES_bin="
+	libvpx${secondaryArchSuffix}_bin = $portVersion
+	cmd:vp8_scalable_patterns = $portVersion
+	cmd:vpxdec = $portVersionCompat
+	cmd:vpxenc = $portVersionCompat
+	"
+REQUIRES_bin="
+	haiku$secondaryArchSuffix
+	libvpx$secondaryArchSuffix == $portVersion base
+	"
+fi
+
 PROVIDES_devel="
 	libvpx${secondaryArchSuffix}_devel = $portVersion
-	devel:libvpx$secondaryArchSuffix = $portVersion compat >= 1
+	devel:libvpx$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
 	libvpx$secondaryArchSuffix == $portVersion
@@ -95,5 +104,9 @@ INSTALL()
 	# Remove stuff we don't need in the secondary architecture base package.
 	if [ -n "$secondaryArchSuffix" ]; then
 		rm -rf $prefix/bin
+	else
+		# bin package
+		packageEntries bin \
+			"$binDir"
 	fi
 }

--- a/media-libs/libvpx/libvpx-1.7.0.recipe
+++ b/media-libs/libvpx/libvpx-1.7.0.recipe
@@ -11,7 +11,7 @@ COPYRIGHT="2009-2012 Google Inc.,
 	The Mozilla Foundation and
 	The Xiph.Org Foundation"
 LICENSE="BSD (3-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/webmproject/libvpx/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="1fec931eb5c94279ad219a5b6e0202358e94a93a90cfb1603578c326abfc1238"
 SOURCE_FILENAME="libvpx-$portVersion.tar.gz"
@@ -30,24 +30,37 @@ fi
 
 libVersion="5.0.0"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
-portVersionCompat="$portVersion compat >= ${portVersion%%.*}"
+portVersionCompat="$portVersion compat >= ${portVersion%.*}"
 
 PROVIDES="
 	libvpx$secondaryArchSuffix = $portVersion
-	cmd:vpxdec$commandSuffix = $portVersionCompat
-	cmd:vpxenc$commandSuffix = $portVersionCompat
 	lib:libvpx$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
 	"
 
+PROVIDES_bin="
+	libvpx${secondaryArchSuffix}_bin = $portVersion
+	cmd:vpxdec$commandSuffix = $portVersionCompat
+	cmd:vpxenc$commandSuffix = $portVersionCompat
+	"
+REQUIRES_bin="
+	haiku$secondaryArchSuffix
+	libvpx$secondaryArchSuffix == $portVersion base
+	"
+if [ -n "$secondaryArchSuffix" -a "$commandBinDir" = "$prefix"/bin ]; then
+CONFLICTS_bin="
+	libvpx_bin
+	"
+fi
+
 PROVIDES_devel="
 	libvpx${secondaryArchSuffix}_devel = $portVersion
 	devel:libvpx$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
-	libvpx$secondaryArchSuffix == $portVersion
+	libvpx$secondaryArchSuffix == $portVersion base
 	"
 
 BUILD_REQUIRES="
@@ -102,5 +115,13 @@ INSTALL()
 
 	# devel package
 	packageEntries devel \
-		$developDir
+		"$developDir"
+
+	# bin package
+	packageEntries bin \
+		"$commandBinDir"
+
+	if [ -n "$secondaryArchSuffix" -a "$commandBinDir" != "$prefix"/bin ]; then
+		rmdir "$prefix"/bin
+	fi
 }

--- a/media-libs/libvpx/libvpx3-1.5.0.recipe
+++ b/media-libs/libvpx/libvpx3-1.5.0.recipe
@@ -6,12 +6,12 @@ on millions of computers and devices worldwide.
 This distribution of the WebM VP8 Codec SDK includes the following support:
 - WebM VP8 Encoder
 - WebM VP8 Decoder"
-HOMEPAGE="http://www.webmproject.org"
+HOMEPAGE="https://www.webmproject.org/"
 COPYRIGHT="2009-2012 Google Inc.,
 	The Mozilla Foundation and
 	The Xiph.Org Foundation"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="http://storage.googleapis.com/downloads.webmproject.org/releases/webm/libvpx-$portVersion.tar.bz2"
 CHECKSUM_SHA256="306d67908625675f8e188d37a81fbfafdf5068b09d9aa52702b6fbe601c76797"
 SOURCE_DIR="libvpx-$portVersion"
@@ -20,32 +20,54 @@ PATCHES="libvpx-$portVersion.patchset"
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
 
-PROVIDES="
-	libvpx3$secondaryArchSuffix = $portVersion
-	lib:libvpx$secondaryArchSuffix = 3.0.0 compat >= 3
-	"
-if [ -z "$secondaryArchSuffix" ]; then
-	PROVIDES="$PROVIDES
-		cmd:vp8_scalable_patterns = $portVersion
-		cmd:vpxdec = $portVersion compat >= 1
-		cmd:vpxenc = $portVersion compat >= 1
-		"
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
 fi
 
+libVersion="3.0.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+portVersionCompat="$portVersion compat >= ${portVersion%.*}"
+
+PROVIDES="
+	libvpx3$secondaryArchSuffix = $portVersion
+	lib:libvpx$secondaryArchSuffix = $libVersionCompat
+	"
 REQUIRES="
 	haiku$secondaryArchSuffix
 	"
 
+PROVIDES_bin="
+	libvpx3${secondaryArchSuffix}_bin = $portVersion
+	cmd:vpxdec$commandSuffix = $portVersionCompat
+	cmd:vpxenc$commandSuffix = $portVersionCompat
+	"
+REQUIRES_bin="
+	haiku$secondaryArchSuffix
+	libvpx3$secondaryArchSuffix == $portVersion base
+	"
+CONFLICTS_bin="
+	libvpx${secondaryArchSuffix}_bin
+	"
+if [ -n "$secondaryArchSuffix" -a "$commandBinDir" = "$prefix"/bin ]; then
+CONFLICTS_bin+="
+	libvpx_bin
+	"
+fi
+
 PROVIDES_devel="
 	libvpx3${secondaryArchSuffix}_devel = $portVersion
-	devel:libvpx$secondaryArchSuffix = 3.0.0 compat >= 3
+	devel:libvpx$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
-	libvpx3$secondaryArchSuffix == $portVersion
+	libvpx3$secondaryArchSuffix == $portVersion base
 	"
 CONFLICTS_devel="
 	libvpx${secondaryArchSuffix}_devel
 	"
+
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
@@ -90,12 +112,21 @@ INSTALL()
 	mv $prefix/include/* $includeDir
 	rmdir $prefix/include
 
+	if [ -n "$secondaryArchSuffix" -a "$commandBinDir" != "$prefix/bin" ]; then
+		mkdir -p "$commandBinDir"
+		mv "$prefix"/bin/vpxdec "$commandBinDir"
+		mv "$prefix"/bin/vpxenc "$commandBinDir"
+	fi
+
 	# devel package
 	packageEntries devel \
-		$developDir
+		"$developDir"
 
-	# Remove stuff we don't need in the secondary architecture base package.
-	if [ -n "$secondaryArchSuffix" ]; then
-		rm -rf $prefix/bin
+	# bin package
+	packageEntries bin \
+		"$commandBinDir"
+
+	if [ -n "$secondaryArchSuffix" -a "$commandBinDir" != "$prefix"/bin ]; then
+		rmdir "$prefix"/bin
 	fi
 }


### PR DESCRIPTION
This is required on x86_gcc2 because `cmd:vpx{dec,enc}` are currently provided by both `libvpx-1.0.0` and `libvpx_x86-1.7.0`. Moving these runtimes to a _bin subpackage and adding the appropriate conflicts allows to co-install all the base packages.

Also, for `libvpx3-1.5.0`, don't remove the runtimes on 2nd arch.