### PR TITLE
dash: bump to 0.5.10.2, add another patch from Gentoo.

### DIFF
--- a/app-shells/dash/dash-0.5.10.2.recipe
+++ b/app-shells/dash/dash-0.5.10.2.recipe
@@ -10,12 +10,17 @@ COPYRIGHT="1989-1994 The Regents of the University of California
 LICENSE="GNU GPL v3"
 REVISION="1"
 SOURCE_URI="http://gondor.apana.org.au/~herbert/dash/files/dash-$portVersion.tar.gz"
-CHECKSUM_SHA256="ad70e0cc3116b424931c392912b3ebdb8053b21f3fd968c782f0b19fd8ae31ab"
+CHECKSUM_SHA256="3c663919dc5c66ec991da14c7cf7e0be8ad00f3db73986a987c118862b5f6071"
 
-SOURCE_FILENAME_2="dash-$portVersion-dumb-echo.patch"
-srcGitRev_2="da222eb668e9d0743688b0bd1608fd0824b1b8b1"
+SOURCE_FILENAME_2="dash-0.5.9.1-format-security.patch"
+srcGitRev_2="12ee15be33783573e73ab0ad27629daf88788121"
 SOURCE_URI_2="https://gitweb.gentoo.org/repo/gentoo.git/plain/app-shells/dash/files/$SOURCE_FILENAME_2?id=$srcGitRev_2#noarchive"
-CHECKSUM_SHA256_2="c55b86a1f827d9fff5892ffd750b632b135fef938f5fedc770dcf26c20c596ce"
+CHECKSUM_SHA256_2="0ce7a1417b4e780f184588e761b4bea5d068c2312b23d954183076edf2f9432d"
+
+SOURCE_FILENAME_3="dash-0.5.10-dumb-echo.patch"
+srcGitRev_3="12ee15be33783573e73ab0ad27629daf88788121"
+SOURCE_URI_3="https://gitweb.gentoo.org/repo/gentoo.git/plain/app-shells/dash/files/$SOURCE_FILENAME_3?id=$srcGitRev_3#noarchive"
+CHECKSUM_SHA256_3="48c275bffa3504a9e8367fef742bb3a8d9c8bf0e221fb75ebcad14fc4d25bf9b"
 
 ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
@@ -56,6 +61,7 @@ defineDebugInfoPackage dash$secondaryArchSuffix \
 PATCH()
 {
 	patch -p1 -i "$sourceDir2"/$SOURCE_FILENAME_2
+	patch -p1 -i "$sourceDir3"/$SOURCE_FILENAME_3
 }
 
 BUILD()


### PR DESCRIPTION
You will need to delete `download/dash-0.5.10-dumb-echo.patch` before building dash `0.5.10.2` if you downloaded it for building `0.5.10`. That's because there was a typo in the patch.