### PR TITLE
python3: fix #2558 'str' has no attribute 'append'

### DIFF
--- a/dev-lang/python/patches/python3_x86-3.6.3.patchset
+++ b/dev-lang/python/patches/python3_x86-3.6.3.patchset
@@ -17,7 +17,7 @@ index d537963..fdbb8f4 100644
                      directory = directory.replace('%A',
                          os.path.dirname(os.path.abspath(sys.argv[0] or os.getcwd())))
  
-+                directory.append("/x86")
++                directory = os.path.join(directory, "x86")
                  if not os.path.isdir(directory):
                      continue
  

--- a/dev-lang/python/python3-3.6.3.recipe
+++ b/dev-lang/python/python3-3.6.3.recipe
@@ -11,7 +11,7 @@ OSI-approved open source license.
 HOMEPAGE="http://www.python.org"
 LICENSE="Python"
 COPYRIGHT="1990-2017, Python Software Foundation"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://www.python.org/ftp/python/$portVersion/Python-$portVersion.tar.xz"
 CHECKSUM_SHA256="cda7d967c9a4bfa52337cdf551bcc5cff026b6ac50a8834e568ce4a794ca81da"
 SOURCE_DIR="Python-$portVersion"


### PR DESCRIPTION
#2558 

append method does not exist for strings in python