### PR TITLE
byacc, bump version

### DIFF
--- a/dev-util/byacc/byacc-20180510.recipe
+++ b/dev-util/byacc/byacc-20180510.recipe
@@ -1,0 +1,42 @@
+SUMMARY="Berkeley implementation of Yacc"
+DESCRIPTION="Berkeley Yacc (byacc) is generally conceded to be the best yacc \
+variant available. In contrast to bison, it is written to avoid dependencies \
+upon a particular compiler."
+HOMEPAGE="http://invisible-island.net/byacc/byacc.html"
+COPYRIGHT="2002-2018 by Thomas E. Dickey"
+LICENSE="Public Domain"
+REVISION="1"
+SOURCE_URI="https://invisible-mirror.net/archives/byacc/byacc-$portVersion.tgz"
+CHECKSUM_SHA256="d0940dbffbc7e9c9dd4985c25349c390beede84ae1d9fe86b71c0aa659a6d693"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	byacc = $portVersion
+	cmd:byacc = $portVersion
+	"
+REQUIRES="
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:gcc
+	cmd:ld
+	cmd:make
+	cmd:cmp
+	"
+
+BUILD()
+{
+	runConfigure --omit-dirs docDir ./configure --program-transform=s,^,b,
+	make
+}
+
+INSTALL()
+{
+	make install
+}


### PR DESCRIPTION
Running the tests with "make check" fails, same thing for the older recipe (also checked for x86)