### PR TITLE
hdf5: revbump needed after gcc bump from 5.4.0 to 7.3.0.

### DIFF
--- a/sci-libs/hdf5/hdf5-1.10.1.recipe
+++ b/sci-libs/hdf5/hdf5-1.10.1.recipe
@@ -6,7 +6,7 @@ HOMEPAGE="http://www.hdfgroup.org/HDF5/"
 COPYRIGHT="2011-2016 The HDF Group,
 	The Board of Trustees of the University of Illinois."
 LICENSE="BSD (3-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-$portVersion/src/hdf5-$portVersion.tar.gz"
 CHECKSUM_SHA256="048a9d149fb99aaa1680a712963f5a78e9c43b588d0e79d55e06760ec377c172"
 


### PR DESCRIPTION
hdf5 needs to be rebuilt against `libgfortran.so.4` (from `gcc 7.3.0`) instead of `libgfortran.so.3` (from `gcc 5.4.0`.)