### PR TITLE
bzip2: add debuginfo, install {bunzip2,bzcat} using symlinks

### DIFF
--- a/app-arch/bzip2/bzip2-1.0.6.recipe
+++ b/app-arch/bzip2/bzip2-1.0.6.recipe
@@ -8,9 +8,10 @@ similar to those of GNU Gzip."
 HOMEPAGE="http://www.bzip.org/"
 COPYRIGHT="1996-2010 Julian R Seward"
 LICENSE="bzip2"
-REVISION="6"
+REVISION="7"
 SOURCE_URI="http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz"
 CHECKSUM_SHA256="a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd"
+PATCHES="bzip2-$portVersion.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64 arm"
 SECONDARY_ARCHITECTURES="x86 x86_gcc2"
@@ -52,13 +53,20 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
-	cmd:ar
+	cmd:ar$secondaryArchSuffix
 	cmd:cmp
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
 	cmd:make
 	cmd:sed
 	"
+
+debugList=("$libDir"/libbz2.so.$portVersion)
+if [ -z "$secondaryArchSuffix" ]; then
+	debugList+=("$binDir"/bzip2)
+	debugList+=("$binDir"/bzip2recover)
+fi
+defineDebugInfoPackage bzip2$secondaryArchSuffix "${debugList[@]}"
 
 BUILD()
 {
@@ -105,4 +113,9 @@ INSTALL()
 		rm -rf $prefix/bin
 		rm -rf $manDir
 	fi
+}
+
+TEST()
+{
+	make test
 }

--- a/app-arch/bzip2/patches/bzip2-1.0.6.patchset
+++ b/app-arch/bzip2/patches/bzip2-1.0.6.patchset
@@ -1,0 +1,48 @@
+From d854ab39db1fc88a21f782cf983d7d247dbc4db8 Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Sun, 27 May 2018 13:48:37 +0000
+Subject: install {bunzip2,bzcat} using symlinks.
+
+Also, install {bzcmp,bzegrep,bzfgrep,bzless} using relative symlinks.
+
+diff --git a/Makefile b/Makefile
+index 9754ddf..4ff35ed 100644
+--- a/Makefile
++++ b/Makefile
+@@ -76,12 +76,10 @@ install: bzip2 bzip2recover
+ 	if ( test ! -d $(PREFIX)/man/man1 ) ; then mkdir -p $(PREFIX)/man/man1 ; fi
+ 	if ( test ! -d $(PREFIX)/include ) ; then mkdir -p $(PREFIX)/include ; fi
+ 	cp -f bzip2 $(PREFIX)/bin/bzip2
+-	cp -f bzip2 $(PREFIX)/bin/bunzip2
+-	cp -f bzip2 $(PREFIX)/bin/bzcat
++	ln -s -f bzip2 $(PREFIX)/bin/bunzip2
++	ln -s -f bzip2 $(PREFIX)/bin/bzcat
+ 	cp -f bzip2recover $(PREFIX)/bin/bzip2recover
+ 	chmod a+x $(PREFIX)/bin/bzip2
+-	chmod a+x $(PREFIX)/bin/bunzip2
+-	chmod a+x $(PREFIX)/bin/bzcat
+ 	chmod a+x $(PREFIX)/bin/bzip2recover
+ 	cp -f bzip2.1 $(PREFIX)/man/man1
+ 	chmod a+r $(PREFIX)/man/man1/bzip2.1
+@@ -90,14 +88,14 @@ install: bzip2 bzip2recover
+ 	cp -f libbz2.a $(PREFIX)/lib
+ 	chmod a+r $(PREFIX)/lib/libbz2.a
+ 	cp -f bzgrep $(PREFIX)/bin/bzgrep
+-	ln -s -f $(PREFIX)/bin/bzgrep $(PREFIX)/bin/bzegrep
+-	ln -s -f $(PREFIX)/bin/bzgrep $(PREFIX)/bin/bzfgrep
++	ln -r -s -f $(PREFIX)/bin/bzgrep $(PREFIX)/bin/bzegrep
++	ln -r -s -f $(PREFIX)/bin/bzgrep $(PREFIX)/bin/bzfgrep
+ 	chmod a+x $(PREFIX)/bin/bzgrep
+ 	cp -f bzmore $(PREFIX)/bin/bzmore
+-	ln -s -f $(PREFIX)/bin/bzmore $(PREFIX)/bin/bzless
++	ln -r -s -f $(PREFIX)/bin/bzmore $(PREFIX)/bin/bzless
+ 	chmod a+x $(PREFIX)/bin/bzmore
+ 	cp -f bzdiff $(PREFIX)/bin/bzdiff
+-	ln -s -f $(PREFIX)/bin/bzdiff $(PREFIX)/bin/bzcmp
++	ln -r -s -f $(PREFIX)/bin/bzdiff $(PREFIX)/bin/bzcmp
+ 	chmod a+x $(PREFIX)/bin/bzdiff
+ 	cp -f bzgrep.1 bzmore.1 bzdiff.1 $(PREFIX)/man/man1
+ 	chmod a+r $(PREFIX)/man/man1/bzgrep.1
+-- 
+2.17.0
+


### PR DESCRIPTION
... instead of making copies of bzip2.

Also, install `{bzcmp,bzegrep,bzfgrep,bzless}` using relative symlinks.