### PR TITLE
util-linux: fix INSTALL when ALLOW_UNTESTED=no

### DIFF
--- a/sys-apps/util-linux/util_linux-2.32.recipe
+++ b/sys-apps/util-linux/util_linux-2.32.recipe
@@ -6,7 +6,7 @@ LICENSE="GNU GPL v2
 	GNU LGPL v2
 	BSD (4-clause)
 	Public Domain"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://www.kernel.org/pub/linux/utils/util-linux/v2.32/util-linux-$portVersion.tar.xz"
 CHECKSUM_SHA256="6c7397abc764e32e8159c2e96042874a190303e77adceb4ac5bd502a272a4734"
 SOURCE_DIR="util-linux-$portVersion"
@@ -99,18 +99,38 @@ BUILD_PREREQUIRES="
 	cmd:sed
 	"
 
+defineDebugInfoPackage util_linux$secondaryArchSuffix \
+	"$commandBinDir"/blkid \
+	"$commandBinDir"/cal \
+	"$commandBinDir"/hexdump \
+	"$commandBinDir"/nologin \
+	"$commandBinDir"/rename \
+	"$commandBinDir"/ul \
+	"$commandBinDir"/uuidgen \
+	"$libDir"/libblkid.so.$libblkidVersion \
+	"$libDir"/libfdisk.so.$libfdiskVersion \
+	"$libDir"/libsmartcols.so.$libsmartcolsVersion \
+	"$libDir"/libuuid.so.$libuuidVersion \
+
 BUILD()
 {
-	export CFLAGS="-D_BSD_SOURCE -DB_USE_POSITIVE_POSIX_ERRORS"
-	export LDFLAGS="-lnetwork -lbsd -lposix_error_mapper"
+	CPPFLAGS="-D_BSD_SOURCE -DB_USE_POSITIVE_POSIX_ERRORS"
+	LDFLAGS="-Wl,--as-needed -lnetwork -lbsd -lposix_error_mapper"
 
-	./autogen.sh
-	if [ "$effectiveTargetArchitecture" = x86 ]; then
-		maybe_x86="scanf_cv_alloc_modifier=no"
-	else
-		maybe_x86=
+	CPPFLAGS="$CPPFLAGS" LDFLAGS="$LDFLAGS" ./autogen.sh
+
+	# Skip some tests in configure to avoid crashes
+	config_opts="
+		scanf_cv_alloc_modifier=no
+		"
+	if [ "$effectiveTargetArchitecture" = x86_64 ]; then
+		config_opts+="
+			ax_cv_have_tls=no
+			"
 	fi
-	runConfigure --omit-dirs "binDir sbinDir" ./configure $maybe_x86 \
+
+	CPPFLAGS="$CPPFLAGS" LDFLAGS="$LDFLAGS" \
+	runConfigure --omit-dirs "binDir sbinDir" ./configure $config_opts \
 		--bindir="$commandBinDir" --sbindir="$commandBinDir" \
 		--disable-all-programs \
 		--disable-libmount \
@@ -150,7 +170,15 @@ INSTALL()
 	prepareInstalledDevelLibs $util_linuxLibs
 	fixPkgconfig
 
-	packageEntries fdisk \
+	# With the fdisk subpackage being marked as untested, haikuporter does not
+	# create the subdirectory for it in $packagingBaseDir when ALLOW_UNTESTED=no
+	# so we need to skip the call to "packageEntries fdisk ..." in that case.
+	if [ -d "$packagingBaseDir"/util_linux${secondaryArchSuffix}_fdisk ]; then
+		maybe_packageEntries_fdisk="packageEntries fdisk"
+	else
+		maybe_packageEntries_fdisk=rm
+	fi
+	$maybe_packageEntries_fdisk \
 		"$commandBinDir"/fdisk \
 		"$dataDir"/bash-completion/completions/fdisk \
 		"$manDir"/man8/fdisk.8


### PR DESCRIPTION
~util-linux: Do not define `*ARCHITECTURES_fdisk` as their content upsets the build servers.~

util-linux: fix `INSTALL` when `ALLOW_UNTESTED=no`

* While at it, do not export `CFLAGS` and `LDFLAGS`. Instead, pass `CPPFLAGS` and `LDFLAGS` to both `autogen.sh` and `configure`.
* Now that we don't override the project's default `CFLAGS` anymore we can add the debuginfo package.
    
**Warning:** If you call haikuporter after the recipe was last modified and then change `ALLOW_UNTESTED` to `yes`, the `.DependencyInfo` file for the fdisk subpackage will be missing.
Workaround: touch the recipe before calling haikuporter. Of course, this is required only once, that is, if you have recently changed `ALLOW_UNTESTED` to `yes`.