### PR TITLE
bison: bump to 3.0.5, add TEST_REQUIRES.

### DIFF
--- a/sys-devel/bison/bison-3.0.5.recipe
+++ b/sys-devel/bison/bison-3.0.5.recipe
@@ -10,14 +10,15 @@ to work with Bison with no change. Anyone familiar with Yacc should be able to \
 use Bison with little trouble. You need to be fluent in C or C++ programming \
 in order to use Bison."
 HOMEPAGE="http://www.gnu.org/software/bison/bison.html"
-COPYRIGHT="1992-2011 Free Software Foundation, Inc."
+COPYRIGHT="1992-2018 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3"
-REVISION="5"
-SOURCE_URI="http://ftp.gnu.org/gnu/bison/bison-$portVersion.tar.xz"
-CHECKSUM_SHA256="a72428c7917bdf9fa93cb8181c971b6e22834125848cf1d03ce10b1bb0716fe1"
+REVISION="1"
+SOURCE_URI="https://ftpmirror.gnu.org/bison/bison-$portVersion.tar.xz
+	https://ftp.gnu.org/gnu/bison/bison-$portVersion.tar.xz"
+CHECKSUM_SHA256="075cef2e814642e30e10e8155e93022e4a91ca38a65aa1d5467d4e969f97f338"
 PATCHES="bison-${portVersion}.patchset"
 
-ARCHITECTURES="x86_gcc2 x86 x86_64"
+ARCHITECTURES="x86_gcc2 x86 x86_64 ?arm ?ppc"
 SECONDARY_ARCHITECTURES="x86 x86_gcc2"
 
 
@@ -44,9 +45,14 @@ BUILD_PREREQUIRES="
 	cmd:help2man
 	cmd:m4
 	cmd:make
-	cmd:makeinfo
 	cmd:perl
 	cmd:sed
+	"
+
+TEST_REQUIRES="
+	cmd:doxygen
+	cmd:find
+	cmd:g++$secondaryArchSuffix
 	"
 
 defineDebugInfoPackage bison$secondaryArchSuffix \
@@ -54,6 +60,7 @@ defineDebugInfoPackage bison$secondaryArchSuffix \
 
 BUILD()
 {
+	MAKEINFO=true \
 	runConfigure ./configure
 	make $jobArgs
 }

--- a/sys-devel/bison/patches/bison-3.0.5.patchset
+++ b/sys-devel/bison/patches/bison-3.0.5.patchset
@@ -5,7 +5,7 @@ Subject: gcc2 fix
 
 
 diff --git a/src/AnnotationList.c b/src/AnnotationList.c
-index 586ed9b..375001a 100644
+index 4c21d6b..c7b7979 100644
 --- a/src/AnnotationList.c
 +++ b/src/AnnotationList.c
 @@ -230,12 +230,12 @@ AnnotationList__computePredecessorAnnotations (AnnotationList *self, state *s,
@@ -24,7 +24,7 @@ index 586ed9b..375001a 100644
          ContributionIndex ci;
          for (ci = 0; ci < self->inadequacyNode->contributionCount; ++ci)
 diff --git a/src/complain.c b/src/complain.c
-index 22e18cb..4cc2361 100644
+index e39626a..4c4d0d0 100644
 --- a/src/complain.c
 +++ b/src/complain.c
 @@ -104,6 +104,7 @@ ARGMATCH_VERIFY (warnings_args, warnings_types);
@@ -44,7 +44,7 @@ index 22e18cb..4cc2361 100644
      if (value & 1 << b)
        {
 diff --git a/src/getargs.c b/src/getargs.c
-index fa9e3c1..433ff27 100644
+index 5696c35..a245e4c 100644
 --- a/src/getargs.c
 +++ b/src/getargs.c
 @@ -253,6 +253,7 @@ usage (int status)
@@ -64,7 +64,7 @@ index fa9e3c1..433ff27 100644
          /* TRANSLATORS: Replace LANG_CODE in this URL with your language
             code <http://translationproject.org/team/LANG_CODE.html> to
 diff --git a/src/ielr.c b/src/ielr.c
-index 8b28e67..29a2726 100644
+index 4ff03c1..9d389cd 100644
 --- a/src/ielr.c
 +++ b/src/ielr.c
 @@ -1032,9 +1032,9 @@ ielr_split_states (bitsetv follow_kernel_items, bitsetv always_follows,
@@ -79,7 +79,7 @@ index 8b28e67..29a2726 100644
          if (!node->state->consistent)
            {
 diff --git a/src/muscle-tab.c b/src/muscle-tab.c
-index b38598b..4b285fb 100644
+index c14273f..a464f38 100644
 --- a/src/muscle-tab.c
 +++ b/src/muscle-tab.c
 @@ -468,12 +468,13 @@ muscle_percent_variable_update (char const *variable, location variable_loc,
@@ -126,7 +126,7 @@ index b38598b..4b285fb 100644
                      _("invalid value for %%define Boolean variable %s"),
                      quote (variable));
 diff --git a/src/scan-gram.l b/src/scan-gram.l
-index a7e9bc4..18b4426 100644
+index ff5c056..7714285 100644
 --- a/src/scan-gram.l
 +++ b/src/scan-gram.l
 @@ -952,10 +952,11 @@ handle_syncline (char *args, location loc)
@@ -143,7 +143,7 @@ index a7e9bc4..18b4426 100644
  /* Adjust scanner cursor so that any later message does not count
       the characters about to be inserted.  */
 diff --git a/src/symlist.c b/src/symlist.c
-index 109c27c..18e6623 100644
+index a6f0d04..d53dc03 100644
 --- a/src/symlist.c
 +++ b/src/symlist.c
 @@ -120,9 +120,9 @@ symbol_list_prepend (symbol_list *list, symbol_list *node)
@@ -158,7 +158,7 @@ index 109c27c..18e6623 100644
      next = next->next;
    next->next = node;
 diff --git a/src/symtab.c b/src/symtab.c
-index fb025da..93f36b8 100644
+index 75024b1..0cd0fd2 100644
 --- a/src/symtab.c
 +++ b/src/symtab.c
 @@ -1030,8 +1030,9 @@ init_prec_nodes (void)
@@ -173,10 +173,10 @@ index fb025da..93f36b8 100644
        s->succ = 0;
        s->pred = 0;
 diff --git a/src/uniqstr.c b/src/uniqstr.c
-index a4e2db0..9a8e30b 100644
+index bfe1d17..f51e722 100644
 --- a/src/uniqstr.c
 +++ b/src/uniqstr.c
-@@ -63,12 +63,14 @@ uniqstr_vsprintf (char const *format, ...)
+@@ -64,12 +64,14 @@ uniqstr_vsprintf (char const *format, ...)
    length = vsnprintf (NULL, 0, format, args);
    va_end (args);
  


### PR DESCRIPTION
Tests `{430,431,432}` failed with `3.0.4` but are OK with `3.0.5` :)
FWIW, adding the same `TEST_REQUIRES` to `3.0.4` did not help.