### PR TITLE
bash: bump to 4.4.023, avoid hardcoded paths in PATCH().

### DIFF
--- a/app-shells/bash/bash-4.4.023.recipe
+++ b/app-shells/bash/bash-4.4.023.recipe
@@ -8,7 +8,7 @@ LICENSE="GNU GPL v3"
 REVISION="1"
 SOURCE_URI="https://ftpmirror.gnu.org/bash/bash-4.4.tar.gz"
 CHECKSUM_SHA256="d86b3392c1202e8ff5a423b302e6284db7f8f435ea9f39b5b1b20fd3ac36dfcb"
-for i in {001..019}; do
+for i in {001..023}; do
 	eval "SOURCE_URI_$i=\"https://ftpmirror.gnu.org/bash/bash-4.4-patches/bash44-$i#noarchive\""
 done
 CHECKSUM_SHA256_001="3e28d91531752df9a8cb167ad07cc542abaf944de9353fe8c6a535c9f1f17f0f"
@@ -30,6 +30,10 @@ CHECKSUM_SHA256_016="501f91cc89fadced16c73aa8858796651473602c722bb29f86a8ba588d0
 CHECKSUM_SHA256_017="773f90b98768d4662a22470ea8eec5fdd8e3439f370f94638872aaf884bcd270"
 CHECKSUM_SHA256_018="5bc494b42f719a8b0d844b7bd9ad50ebaae560e97f67c833c9e7e9d53981a8cc"
 CHECKSUM_SHA256_019="27170d6edfe8819835407fdc08b401d2e161b1400fe9d0c5317a51104c89c11e"
+CHECKSUM_SHA256_020="1840e2cbf26ba822913662f74037594ed562361485390c52813b38156c99522c"
+CHECKSUM_SHA256_021="bd8f59054a763ec1c64179ad5cb607f558708a317c2bdb22b814e3da456374c1"
+CHECKSUM_SHA256_022="45331f0936e36ab91bfe44b936e33ed8a1b1848fa896e8a1d0f2ef74f297cb79"
+CHECKSUM_SHA256_023="4fec236f3fbd3d0c47b893fdfa9122142a474f6ef66c20ffb6c0f4864dd591b6"
 
 SOURCE_DIR="bash-4.4"
 PATCHES="
@@ -76,9 +80,10 @@ GLOBAL_WRITABLE_FILES="settings/bashrc keep-old"
 
 PATCH()
 {
-	for i in {001..019}; do
+	for i in {001..023}; do
 		echo "Applying patch $i..."
-		sed -e "s/\.\.\/bash-4.4\///" ../../sources-$i/bash44-$i | patch -p0
+		eval f=\$sourceDir$i/bash44-$i
+		sed -e "s|\.\./bash-4.4/||" "$f" | patch -p0
 	done
 	# store bash settings under ~/config/settings
 	find -type f | xargs sed -i -e 's,~/\.,~/config/settings/,g'


### PR DESCRIPTION
Avoid `../../sources-$i/` and, instead, use `\$sourceDir$i/` with `eval`.