### PR TITLE
libepubgen: bump to 0.1.1, depend on libxml2, add debuginfo.

### DIFF
--- a/app-office/libreoffice/libreoffice-6.2.0.0~git.recipe
+++ b/app-office/libreoffice/libreoffice-6.2.0.0~git.recipe
@@ -7,7 +7,7 @@ and Open Source office suite on the market."
 HOMEPAGE="https://www.libreoffice.org/"
 COPYRIGHT="2000-2018 LibreOffice contributors."
 LICENSE="MPL v2.0"
-REVISION="1"
+REVISION="2"
 COMMIT="100b6a229e0ab9888578c138cd38424d16dec608"
 SOURCE_URI="https://github.com/LibreOffice/core/archive/$COMMIT.tar.gz"
 CHECKSUM_SHA256="21639e6388bdda4d4aca82e3957e44d6fe1b20fb36e32ec9d64394be84b552c6"
@@ -37,6 +37,7 @@ REQUIRES="
 	lib:libcurl$secondaryArchSuffix
 	lib:libe_book_0.1$secondaryArchSuffix
 	lib:libepoxy$secondaryArchSuffix
+	lib:libepubgen_0.1$secondaryArchSuffix
 	lib:libetonyek_0.1$secondaryArchSuffix
 	lib:libexpat$secondaryArchSuffix
 	lib:libexslt$secondaryArchSuffix
@@ -107,7 +108,7 @@ BUILD_REQUIRES="
 	devel:libcurl$secondaryArchSuffix
 	devel:libe_book_0.1$secondaryArchSuffix
 	devel:libepoxy$secondaryArchSuffix
-	devel:libepubgen_0.0$secondaryArchSuffix
+	devel:libepubgen_0.1$secondaryArchSuffix
 	devel:libetonyek_0.1$secondaryArchSuffix
 	devel:libexpat$secondaryArchSuffix
 	devel:libfreehand_0.1$secondaryArchSuffix

--- a/app-text/libepubgen/libepubgen-0.1.1.recipe
+++ b/app-text/libepubgen/libepubgen-0.1.1.recipe
@@ -2,32 +2,35 @@ SUMMARY="EPUB generator for librevenge"
 DESCRIPTION="libepubgen is an EPUB generator for librevenge. It supports \
 librevenge's text document interface and--currently in a very limited \
 way--presentation and vector drawing interfaces."
-HOMEPAGE="https://sourceforge.net/projects/libepubgen"
-COPYRIGHT="2016 David Tardon"
+HOMEPAGE="https://sourceforge.net/projects/libepubgen/"
+COPYRIGHT="2014-2018 David Tardon"
 LICENSE="MPL v2.0"
-REVISION="2"
-SOURCE_URI="https://downloads.sourceforge.net/libepubgen/libepubgen-$portVersion.tar.gz"
-CHECKSUM_SHA256="f646ac47dd4ef8ae8106b8739fdc338033b0b28ff5f6a2ab6db1f1ae44777024"
+REVISION="1"
+SOURCE_URI="https://downloads.sourceforge.net/libepubgen/libepubgen-$portVersion.tar.xz"
+CHECKSUM_SHA256="03e084b994cbeffc8c3dd13303b2cb805f44d8f2c3b79f7690d7e3fc7f6215ad"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
+libVersion=1.0.1
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+portVers="${portVersion%.*}"
+
 PROVIDES="
-	libepubgen$secondaryArchSuffix = $portVersion compat >= 0
-	lib:libepubgen_0.0$secondaryArchSuffix = $portVersion compat >= 0
+	libepubgen$secondaryArchSuffix = $portVersion
+	lib:libepubgen_$portVers$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	lib:libboost_system$secondaryArchSuffix
 	lib:librevenge_0.0$secondaryArchSuffix
 	lib:librevenge_generators_0.0$secondaryArchSuffix
 	lib:librevenge_stream_0.0$secondaryArchSuffix
-	lib:libboost_system$secondaryArchSuffix
-	lib:libcppunit$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
-	libepubgen${secondaryArchSuffix}_devel = $portVersion compat >= 0
-	devel:libepubgen_0.0$secondaryArchSuffix = $portVersion
+	libepubgen${secondaryArchSuffix}_devel = $portVersion
+	devel:libepubgen_$portVers$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
 	libepubgen$secondaryArchSuffix == $portVersion base
@@ -35,11 +38,12 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	devel:libboost_system$secondaryArchSuffix
+	devel:libcppunit$secondaryArchSuffix
 	devel:librevenge_0.0$secondaryArchSuffix
 	devel:librevenge_generators_0.0$secondaryArchSuffix
 	devel:librevenge_stream_0.0$secondaryArchSuffix
-	devel:libboost_system$secondaryArchSuffix
-	devel:libcppunit$secondaryArchSuffix
+	devel:libxml2$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:aclocal
@@ -55,6 +59,9 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
+defineDebugInfoPackage libepubgen$secondaryArchSuffix \
+	"$libDir"/libepubgen-$portVers.so.$libVersion
+
 BUILD()
 {
 	autoreconf -fi
@@ -66,9 +73,9 @@ INSTALL()
 {
 	make install
 
-	rm $libDir/libepubgen-0.0.la
+	rm -f "$libDir"/libepubgen-$portVers.la
 
-	prepareInstalledDevelLib libepubgen-0.0
+	prepareInstalledDevelLib libepubgen-$portVers
 	fixPkgconfig
 	packageEntries devel $developDir
 }


### PR DESCRIPTION
* Drop `lib:libcppunit` from `REQUIRES` as it is not needed.
* `lib:librevenge_{stream,generators}` do not seem to be needed, but we can keep them, since `lib:librevenge` already pulls `librevenge`.
* Add `libxml2` because `libepubgen` now needs it.
* Sort `{BUILD_,}REQUIRES`.
* Switch `SOURCE_URI` to `tar.xz`.