### PR TITLE
ragel: Mark as broken on x86_gcc2, drop commandBinDir.

### DIFF
--- a/dev-util/ragel/ragel-7.0.0.10.recipe
+++ b/dev-util/ragel/ragel-7.0.0.10.recipe
@@ -15,13 +15,11 @@ REVISION="1"
 SOURCE_URI="https://www.colm.net/files/ragel/ragel-$portVersion.tar.gz"
 CHECKSUM_SHA256="40562bcac66a22dbea8357a35745bbcb1ab596c262d8691145ee11aafa6f8dec"
 
-ARCHITECTURES="?x86_gcc2 ?x86 x86_64"
-SECONDARY_ARCHITECTURES="?x86"
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
 
-commandBinDir=$binDir
 commandSuffix=$secondaryArchSuffix
 if [ "$targetArchitecture" = x86_gcc2 ]; then
-	commandBinDir=$prefix/bin
 	commandSuffix=
 fi
 
@@ -31,7 +29,7 @@ libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
 	ragel$secondaryArchSuffix = $portVersion
-	cmd:ragel$commandSuffix = $binVersionCompat
+	cmd:ragel$secondaryArchSuffix = $binVersionCompat
 	lib:libfsm$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
@@ -56,7 +54,7 @@ BUILD_PREREQUIRES="
 	cmd:asciidoc
 	cmd:autoreconf
 	cmd:awk
-	cmd:colm
+	cmd:colm$commandSuffix
 	cmd:grep
 	cmd:g++$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
@@ -66,14 +64,12 @@ BUILD_PREREQUIRES="
 	"
 
 defineDebugInfoPackage ragel$secondaryArchSuffix \
-	$commandBinDir/ragel \
+	"$binDir"/ragel \
 	$libDir/libfsm.so.$libVersion
 
 BUILD()
 {
-	autoreconf -i
-	runConfigure --omit-dirs "binDir" ./configure \
-		--bindir=$commandBinDir
+	runConfigure ./configure
 	make $jobArgs
 }
 
@@ -87,4 +83,9 @@ INSTALL()
 	fixPkgconfig
 
 	packageEntries devel $developDir
+}
+
+TEST()
+{
+	make check
 }


### PR DESCRIPTION
Unlike ragel `6.9`, which builds on x86_gcc2 primary arch, `7.0.0.10` `BUILD_REQUIRES` `devel:libcolm` which is not available on x86_gcc2. We therefore need to keep `6.9` for x86_gcc2.

So, in order to allow x86_gcc2 hybrid to be able to activate both `ragel-6.9` and `ragel_x86-7.0.0.10`, we cannot install `cmd:ragel` in `$commandBinDir`; we need to install it in `$binDir`.

Minor change: drop the call to autoreconf as it is not needed.