### PR TITLE
libreoffice: add to description

### DIFF
--- a/app-office/libreoffice/libreoffice-6.2.0.0~git.recipe
+++ b/app-office/libreoffice/libreoffice-6.2.0.0~git.recipe
@@ -2,10 +2,20 @@ SUMMARY="A full office productivity suite"
 DESCRIPTION="LibreOffice is a powerful office suite – its clean interface and \
 feature-rich tools help you unleash your creativity and enhance your \
 productivity.
+It's compatible with a wide range of document formats such as MS Word (.doc, \
+.docx), Excel (.xls, .xlsx), PowerPoint (.ppt, .pptx) and Publisher.
+
 LibreOffice includes several applications that make it the most powerful Free \
-and Open Source office suite on the market."
+and Open Source office suite on the market:
+
+- Writer (word processing)
+- Calc (spreadsheets)
+- Impress (presentations)
+- Draw (vector graphics and flowcharts)
+- Base (databases)
+- Math (formula editing)"
 HOMEPAGE="https://www.libreoffice.org/"
-COPYRIGHT="2000-2018 LibreOffice contributors."
+COPYRIGHT="2000-2018 LibreOffice contributors"
 LICENSE="MPL v2.0"
 REVISION="2"
 COMMIT="100b6a229e0ab9888578c138cd38424d16dec608"


### PR DESCRIPTION
LibreOffice deserves a few more lines of description. :)
Taken from their website.

Remove full-stop at the end of COPYRIGHT.