### PR TITLE
LibreOffice: fix build on secondary arch. Minor changes.

### DIFF
--- a/app-office/libreoffice/libreoffice-6.2.0.0~git.recipe
+++ b/app-office/libreoffice/libreoffice-6.2.0.0~git.recipe
@@ -17,7 +17,7 @@ and Open Source office suite on the market:
 HOMEPAGE="https://www.libreoffice.org/"
 COPYRIGHT="2000-2018 LibreOffice contributors"
 LICENSE="MPL v2.0"
-REVISION="2"
+REVISION="3"
 COMMIT="100b6a229e0ab9888578c138cd38424d16dec608"
 SOURCE_URI="https://github.com/LibreOffice/core/archive/$COMMIT.tar.gz"
 CHECKSUM_SHA256="21639e6388bdda4d4aca82e3957e44d6fe1b20fb36e32ec9d64394be84b552c6"
@@ -28,6 +28,13 @@ ADDITIONAL_FILES="libreoffice.rdef.in"
 ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
+commandSuffix=$secondaryArchSuffix
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+fi
+
+boostMinimumVersion=1.65.0
+
 PROVIDES="
 	libreoffice$secondaryArchSuffix = $portVersion
 	app:LibreOffice$secondaryArchSuffix = $portVersion
@@ -35,10 +42,10 @@ PROVIDES="
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libabw_0.1$secondaryArchSuffix
-	lib:libboost_date_time$secondaryArchSuffix
-	lib:libboost_filesystem$secondaryArchSuffix
-	lib:libboost_iostreams$secondaryArchSuffix
-	lib:libboost_locale$secondaryArchSuffix
+	lib:libboost_date_time$secondaryArchSuffix >= $boostMinimumVersion
+	lib:libboost_filesystem$secondaryArchSuffix >= $boostMinimumVersion
+	lib:libboost_iostreams$secondaryArchSuffix >= $boostMinimumVersion
+	lib:libboost_locale$secondaryArchSuffix >= $boostMinimumVersion
 	lib:libcairo$secondaryArchSuffix
 	lib:libcdr_0.1$secondaryArchSuffix
 	lib:libclucene_core$secondaryArchSuffix
@@ -110,6 +117,11 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	glm${secondaryArchSuffix}_devel
 	devel:libabw_0.1$secondaryArchSuffix
+	devel:libboost_date_time$secondaryArchSuffix >= $boostMinimumVersion
+	devel:libboost_filesystem$secondaryArchSuffix >= $boostMinimumVersion
+	devel:libboost_iostreams$secondaryArchSuffix >= $boostMinimumVersion
+	devel:libboost_locale$secondaryArchSuffix >= $boostMinimumVersion
+	devel:libcairo$secondaryArchSuffix
 	devel:libcdr_0.1$secondaryArchSuffix
 	devel:libclucene_contribs_lib$secondaryArchSuffix
 	devel:libclucene_core$secondaryArchSuffix
@@ -178,9 +190,10 @@ BUILD_PREREQUIRES="
 	cmd:python2.7
 	cmd:python3.6
 	cmd:which
-	cmd:xz
+	cmd:xz$commandSuffix
 	cmd:zip
 	"
+
 BUILD()
 {
 	# rename $sourceDir to something shorter, otherwise build fails with
@@ -189,10 +202,79 @@ BUILD()
 	ln -s core core-$COMMIT; cd core
 
 	runConfigure ./autogen.sh \
-		--with-distro=LibreOfficeHaiku \
 		--enable-qt5 \
 		--enable-release-build \
-		--enable-readonly-installset
+		--enable-readonly-installset \
+		--enable-python=no \
+		\
+		--disable-sdremote \
+		--disable-gio \
+		--disable-randr \
+		--disable-gstreamer-0-10 \
+		--disable-cups \
+		--disable-ccache \
+		--disable-postgresql-sdbc \
+		--disable-lotuswordpro \
+		--disable-firebird-sdbc \
+		\
+		--with-vendor="The Document Foundation" \
+		--with-system-libxml \
+		--with-system-neon \
+		--with-system-boost \
+		--with-boost-libdir="`finddir B_SYSTEM_LIB_DIRECTORY`" \
+		--with-system-clucene \
+		--with-system-expat \
+		--with-system-libpng \
+		--with-system-jpeg \
+		--with-system-zlib \
+		--with-system-bzip2 \
+		--with-system-icu \
+		--with-system-openssl \
+		--with-system-curl \
+		--with-system-cppunit \
+		--with-system-hunspell \
+		--with-system-altlinuxhyph \
+		--with-system-lcms2 \
+		--with-system-librevenge \
+		--with-system-libodfgen \
+		--with-system-libwpd \
+		--with-system-libwpg \
+		--with-system-libwps \
+		--with-system-libvisio \
+		--with-system-libcdr \
+		--with-system-libmspub \
+		--with-system-libmwaw \
+		--with-system-libepubgen \
+		--with-system-libetonyek \
+		--with-system-libfreehand \
+		--with-system-libebook \
+		--with-system-libabw \
+		--with-system-libpagemaker \
+		--with-system-libzmf \
+		--with-system-libstaroffice \
+		--with-system-libqxp \
+		--with-system-epoxy \
+		--with-system-clucene \
+		--with-system-mdds \
+		--with-system-glm \
+		--with-system-openldap \
+		--with-system-liblangtag \
+		--with-system-graphite \
+		--with-system-harfbuzz \
+		--with-system-nss \
+		--with-system-lpsolve \
+		--with-system-orcus \
+		--with-system-redland \
+		--with-system-libcmis \
+		--with-system-cairo \
+		--with-system-poppler \
+		--with-theme=breeze sifr \
+		--with-galleries=no \
+		\
+		--without-helppack-integration \
+		--without-java \
+		--without-system-jars \
+		--without-doxygen \
 
 	make $jobArgs build-nocheck
 }

--- a/app-office/libreoffice/libreoffice-6.2.0.0~git.recipe
+++ b/app-office/libreoffice/libreoffice-6.2.0.0~git.recipe
@@ -217,7 +217,7 @@ BUILD()
 		--disable-lotuswordpro \
 		--disable-firebird-sdbc \
 		\
-		--with-vendor="The Document Foundation" \
+		--with-vendor="HaikuPorts" \
 		--with-system-libxml \
 		--with-system-neon \
 		--with-system-boost \

--- a/app-office/libreoffice/libreoffice-6.2.0.0~git.recipe
+++ b/app-office/libreoffice/libreoffice-6.2.0.0~git.recipe
@@ -207,74 +207,73 @@ BUILD()
 		--enable-readonly-installset \
 		--enable-python=no \
 		\
-		--disable-sdremote \
-		--disable-gio \
-		--disable-randr \
-		--disable-gstreamer-0-10 \
-		--disable-cups \
 		--disable-ccache \
-		--disable-postgresql-sdbc \
-		--disable-lotuswordpro \
+		--disable-cups \
 		--disable-firebird-sdbc \
+		--disable-gio \
+		--disable-gstreamer-0-10 \
+		--disable-lotuswordpro \
+		--disable-postgresql-sdbc \
+		--disable-randr \
+		--disable-sdremote \
 		\
+		--with-galleries=no \
 		--with-vendor="HaikuPorts" \
-		--with-system-libxml \
-		--with-system-neon \
 		--with-system-boost \
 		--with-boost-libdir="`finddir B_SYSTEM_LIB_DIRECTORY`" \
-		--with-system-clucene \
-		--with-system-expat \
-		--with-system-libpng \
-		--with-system-jpeg \
-		--with-system-zlib \
-		--with-system-bzip2 \
-		--with-system-icu \
-		--with-system-openssl \
-		--with-system-curl \
-		--with-system-cppunit \
-		--with-system-hunspell \
 		--with-system-altlinuxhyph \
+		--with-system-bzip2 \
+		--with-system-cairo \
+		--with-system-clucene \
+		--with-system-cppunit \
+		--with-system-curl \
+		--with-system-epoxy \
+		--with-system-expat \
+		--with-system-glm \
+		--with-system-graphite \
+		--with-system-harfbuzz \
+		--with-system-hunspell \
+		--with-system-icu \
+		--with-system-jpeg \
 		--with-system-lcms2 \
-		--with-system-librevenge \
-		--with-system-libodfgen \
-		--with-system-libwpd \
-		--with-system-libwpg \
-		--with-system-libwps \
-		--with-system-libvisio \
+		--with-system-libabw \
 		--with-system-libcdr \
-		--with-system-libmspub \
-		--with-system-libmwaw \
+		--with-system-libcmis \
+		--with-system-libebook \
 		--with-system-libepubgen \
 		--with-system-libetonyek \
 		--with-system-libfreehand \
-		--with-system-libebook \
-		--with-system-libabw \
-		--with-system-libpagemaker \
-		--with-system-libzmf \
-		--with-system-libstaroffice \
-		--with-system-libqxp \
-		--with-system-epoxy \
-		--with-system-clucene \
-		--with-system-mdds \
-		--with-system-glm \
-		--with-system-openldap \
 		--with-system-liblangtag \
-		--with-system-graphite \
-		--with-system-harfbuzz \
-		--with-system-nss \
+		--with-system-libmspub \
+		--with-system-libmwaw \
+		--with-system-libodfgen \
+		--with-system-libpagemaker \
+		--with-system-libpng \
+		--with-system-libqxp \
+		--with-system-librevenge \
+		--with-system-libstaroffice \
+		--with-system-libvisio \
+		--with-system-libwpd \
+		--with-system-libwpg \
+		--with-system-libwps \
+		--with-system-libxml \
+		--with-system-libzmf \
 		--with-system-lpsolve \
+		--with-system-mdds \
+		--with-system-neon \
+		--with-system-nss \
+		--with-system-openldap \
+		--with-system-openssl \
 		--with-system-orcus \
-		--with-system-redland \
-		--with-system-libcmis \
-		--with-system-cairo \
 		--with-system-poppler \
+		--with-system-redland \
+		--with-system-zlib \
 		--with-theme=breeze sifr \
-		--with-galleries=no \
 		\
+		--without-doxygen \
 		--without-helppack-integration \
 		--without-java \
 		--without-system-jars \
-		--without-doxygen \
 
 	make $jobArgs build-nocheck
 }


### PR DESCRIPTION
* Depend on `libboost* >= 1.65.0` as suggested by @kallisti5 in #2657.
* Add missing `devel:liboost_*` to `BUILD_REQUIRES`.
* Do not use `--with-distro=LibreOfficeHaiku` but, instead, copy upstream's `distro-configs/LibreOfficeHaiku.conf` to the recipe.
* Add `--with-system-libepubgen` to the config options.