### PR TITLE
mbedtls: bump to 2.10.0, drop debuginfo package.

### DIFF
--- a/net-libs/mbedtls/mbedtls-2.10.0.recipe
+++ b/net-libs/mbedtls/mbedtls-2.10.0.recipe
@@ -7,13 +7,14 @@ COPYRIGHT="2006-2018 ARM Limited"
 LICENSE="Apache v2"
 REVISION="1"
 SOURCE_URI="https://github.com/ARMmbed/mbedtls/archive/mbedtls-$portVersion.tar.gz"
-CHECKSUM_SHA256="c544d5a6ea6cf629a3c2d0653b1e8f3ab0491a852b84d9478403c6a3fb699fe4"
+CHECKSUM_SHA256="ca11a8809d6974ac0f76455b3df5bfd3b5fe973296b4038fdd7a5d7b8a3cd30d"
 SOURCE_DIR="mbedtls-mbedtls-$portVersion"
+PATCHES="mbedtls-$portVersion.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="x86"
+SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
-libcryptoVersion="1"
+libcryptoVersion="2"
 libtlsVersion="10"
 libx509Version="0"
 
@@ -72,6 +73,8 @@ if [ -z "$secondaryArchSuffix" ]; then
 		cmd:mbedtls_ssl_server2 = $portVersion
 		cmd:mbedtls_strerror = $portVersion
 		cmd:mbedtls_udp_proxy = $portVersion
+		cmd:mbedtls_udp_proxy_wrapper.sh = $portVersion
+		cmd:mbedtls_zeroize = $portVersion
 		"
 fi
 REQUIRES="
@@ -98,19 +101,6 @@ BUILD_PREREQUIRES="
 	cmd:sed
 	"
 
-if [ -n "$secondaryArchSuffix" ]; then
-	maybe_binDir_mbedtls_runtimes=
-else
-	maybe_binDir_mbedtls_runtimes="`echo "$PROVIDES" | sed -n \
-		-e "s|cmd:\([^ ]*\).*|$binDir/\1|p" \
-		`"
-fi
-defineDebugInfoPackage mbedtls$secondaryArchSuffix \
-	$libDir/libmbedcrypto.so.$libcryptoVersion \
-	$libDir/libmbedtls.so.$libtlsVersion \
-	$libDir/libmbedx509.so.$libx509Version \
-	$maybe_binDir_mbedtls_runtimes
-
 PATCH()
 {
 	sed -i \
@@ -120,6 +110,13 @@ PATCH()
 		-e "s|/bin\$|/$relativeBinDir|;" \
 		-e "s|/lib\$|/$relativeLibDir|;" \
 		Makefile
+
+	# Several perl scripts have a non portable shebang line. Although none of
+	# them get installed, scripts/config.pl is called at the "post_build" step,
+	# so let's fix them all.
+	find "$sourceDir" -type f -name "*.pl" \
+		-exec grep -q '^#!/usr/bin/perl' {} \; \
+		-exec sed -i -e '1 s|^#!/usr/bin/perl|#!/usr/bin/env perl|' {} \;
 }
 
 BUILD()

--- a/net-libs/mbedtls/patches/mbedtls-2.10.0.patchset
+++ b/net-libs/mbedtls/patches/mbedtls-2.10.0.patchset
@@ -1,0 +1,26 @@
+From 91a6d0d1fbd5cddf91944957f37a5f2e6aadd94e Mon Sep 17 00:00:00 2001
+From: fbrosson <fbrosson@localhost>
+Date: Fri, 8 Jun 2018 04:47:21 +0000
+Subject: fix relative paths in udp_proxy_wrapper.sh
+
+
+diff --git a/programs/test/udp_proxy_wrapper.sh b/programs/test/udp_proxy_wrapper.sh
+index 29033d5..20df981 100755
+--- a/programs/test/udp_proxy_wrapper.sh
++++ b/programs/test/udp_proxy_wrapper.sh
+@@ -4,9 +4,9 @@
+ 
+ set -u
+ 
+-MBEDTLS_BASE="$(dirname -- "$0")/../.."
+-TPXY_BIN="$MBEDTLS_BASE/programs/test/udp_proxy"
+-SRV_BIN="$MBEDTLS_BASE/programs/ssl/ssl_server2"
++MBEDTLS_BASE="$(dirname -- "$0")"
++TPXY_BIN="$MBEDTLS_BASE/mbedtls_udp_proxy"
++SRV_BIN="$MBEDTLS_BASE/mbedtls_ssl_server2"
+ 
+ : ${VERBOSE:=0}
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
* Creating the debuginfo package was not appropriate because `-g` is not being passed to the compiler. Bye `defineDebugInfoPackage`!
* Fix the shebang line of all perl scripts which use `/usr/bin/perl` because one of the scripts is called at the end of the build.
* Add a patchset to fix a wrapper script which assumed incorrect paths for 2 runtimes.