### PR TITLE
LibreOffice: drop --with-theme= and add back --with-distro=...

### DIFF
--- a/app-office/libreoffice/libreoffice-6.2.0.0~git.recipe
+++ b/app-office/libreoffice/libreoffice-6.2.0.0~git.recipe
@@ -202,6 +202,7 @@ BUILD()
 	ln -s core core-$COMMIT; cd core
 
 	runConfigure ./autogen.sh \
+		--with-distro=LibreOfficeHaiku \
 		--enable-qt5 \
 		--enable-release-build \
 		--enable-readonly-installset \
@@ -268,7 +269,6 @@ BUILD()
 		--with-system-poppler \
 		--with-system-redland \
 		--with-system-zlib \
-		--with-theme="breeze sifr" \
 		\
 		--without-doxygen \
 		--without-helppack-integration \


### PR DESCRIPTION
It seems we can't pass `"breeze sifr"` as arguments to `--with-theme` from the recipe, so add back the `--with-distro=LibreOfficeHaiku` and let `autogen.sh` find in `distro-configs/LibreOfficeHaiku.conf` the `--with-theme=breeze sifr` parameter as it did previously.