### PR TITLE
orcus: bump to 0.13.4, depend on boost >= 1.65.0.

### DIFF
--- a/dev-libs/orcus/orcus-0.13.4.recipe
+++ b/dev-libs/orcus/orcus-0.13.4.recipe
@@ -6,12 +6,14 @@ HOMEPAGE="https://gitlab.com/orcus/orcus"
 COPYRIGHT="Kohei Yoshida et al."
 LICENSE="MPL v2.0"
 REVISION="1"
-SOURCE_URI="http://kohei.us/files/orcus/src/liborcus-$portVersion.tar.gz"
-CHECKSUM_SHA256="62e76de1fd3101e77118732b860354121b40a87bbb1ebfeb8203477fffac16e9"
+SOURCE_URI="https://kohei.us/files/orcus/src/liborcus-$portVersion.tar.xz"
+CHECKSUM_SHA256="b71c4c15febe7dae63406e8023898e3a5cf7fe4ec43b2028dfbbf24e9fe282e4"
 SOURCE_DIR="liborcus-$portVersion"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
+
+boostMinimumVersion=1.65.0
 
 PROVIDES="
 	orcus$secondaryArchSuffix = $portVersion
@@ -36,10 +38,10 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libboost_system$secondaryArchSuffix
-	lib:libboost_filesystem$secondaryArchSuffix
-	lib:libboost_iostreams$secondaryArchSuffix
-	lib:libboost_program_options$secondaryArchSuffix
+	lib:libboost_system$secondaryArchSuffix >= $boostMinimumVersion
+	lib:libboost_filesystem$secondaryArchSuffix >= $boostMinimumVersion
+	lib:libboost_iostreams$secondaryArchSuffix >= $boostMinimumVersion
+	lib:libboost_program_options$secondaryArchSuffix >= $boostMinimumVersion
 	lib:libixion_0.13$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
@@ -63,7 +65,7 @@ BUILD_REQUIRES="
 	devel:libboost_program_options$secondaryArchSuffix
 	devel:libixion_0.13$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
-	devel:mdds$secondaryArchSuffix >= 1.2
+	devel:mdds >= 1.2
 	"
 BUILD_PREREQUIRES="
 	cmd:aclocal


### PR DESCRIPTION
* Lock to the same minimum boost version as LibreOffice.
* Drop `$secondaryArchSuffix` after `devel:mdds` in `BUILD_REQUIRES`.
* Switch `SOURCE_URI` to `tar.xz` & https.