### PR TITLE
rubberband: bump to 1.8.2, add debuginfo.

### DIFF
--- a/media-libs/rubberband/patches/rubberband-1.8.2.patchset
+++ b/media-libs/rubberband/patches/rubberband-1.8.2.patchset
@@ -5,23 +5,23 @@ Subject: Haiku patch
 
 
 diff --git a/Makefile.in b/Makefile.in
-index 413d075..d92019f 100644
+index 3a70a71..722e7bf 100644
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -2,7 +2,7 @@
- CXX		:= @CXX@
- CXXFLAGS	:= -DHAVE_LIBSAMPLERATE -DHAVE_FFTW3 -DFFTW_DOUBLE_ONLY -DNO_THREAD_CHECKS -DUSE_PTHREADS -DNO_TIMING -DNDEBUG @CXXFLAGS@ @SRC_CFLAGS@ @SNDFILE_CFLAGS@ @FFTW_CFLAGS@ @Vamp_CFLAGS@ -Irubberband -I. -Isrc $(OPTFLAGS)
+@@ -4,7 +4,7 @@ CXX		:= @CXX@
+ CC		:= @CC@
+ CXXFLAGS	:= -DHAVE_LIBSAMPLERATE -DHAVE_FFTW3 -DFFTW_DOUBLE_ONLY -DNO_THREAD_CHECKS -DUSE_PTHREADS -DNO_TIMING -DNDEBUG -I. -Isrc -Irubberband @CXXFLAGS@ @SRC_CFLAGS@ @SNDFILE_CFLAGS@ @FFTW_CFLAGS@ @Vamp_CFLAGS@ $(OPTFLAGS)
  CFLAGS		:= @CFLAGS@ $(OPTFLAGS)
 -LDFLAGS		:= @LDFLAGS@ -lpthread $(LDFLAGS)
 +LDFLAGS		:= @LDFLAGS@ @LIBPTHREAD@ $(LDFLAGS)
  
- LIBRARY_LIBS		:= @SRC_LIBS@ @FFTW_LIBS@ 
- PROGRAM_LIBS		:= @SNDFILE_LIBS@ $(LIBRARY_LIBS)
+ JNI_CXXFLAGS	:= -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux
+ JAVAC		:= $(JAVA_HOME)/bin/javac
 diff --git a/configure.ac b/configure.ac
-index 1339294..1dadebd 100644
+index eef571b..e275071 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -6,6 +6,10 @@ AC_PROG_CXX
+@@ -7,6 +7,10 @@ AC_PROG_CC
  AC_HEADER_STDC
  AC_C_BIGENDIAN
  
@@ -33,10 +33,10 @@ index 1339294..1dadebd 100644
  AC_SUBST(SRC_CFLAGS)
  AC_SUBST(SRC_LIBS)
 diff --git a/src/system/sysutils.h b/src/system/sysutils.h
-index 371736b..1c66999 100644
+index b63c640..c80d47d 100644
 --- a/src/system/sysutils.h
 +++ b/src/system/sysutils.h
-@@ -135,9 +135,15 @@ extern void system_memorybarrier();
+@@ -130,9 +130,15 @@ extern void system_memorybarrier();
  #include <dlfcn.h>
  #include <stdio.h>
  

--- a/media-libs/rubberband/rubberband-1.8.2.recipe
+++ b/media-libs/rubberband/rubberband-1.8.2.recipe
@@ -3,26 +3,32 @@ DESCRIPTION="Rubber Band is a library and utility program that permits \
 changing the tempo and pitch of an audio recording independently of one \
 another."
 HOMEPAGE="https://www.breakfastquay.com/rubberband/"
-COPYRIGHT="2007-2012 Particular Programs Ltd"
+COPYRIGHT="2007-2018 Particular Programs Ltd"
 LICENSE="GNU GPL v2"
-REVISION="4"
-SOURCE_URI="http://code.breakfastquay.com/attachments/download/34/rubberband-$portVersion.tar.bz2"
-CHECKSUM_SHA256="ff0c63b0b5ce41f937a8a3bc560f27918c5fe0b90c6bc1cb70829b86ada82b75"
+REVISION="1"
+SOURCE_URI="https://breakfastquay.com/files/releases/rubberband-$portVersion.tar.bz2"
+CHECKSUM_SHA256="86bed06b7115b64441d32ae53634fcc0539a50b9b648ef87443f936782f6c3ca"
 PATCHES="rubberband-$portVersion.patchset"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
-if [ "$targetArchitecture" != x86_gcc2 ]; then
-	commandBinDir=$binDir
-else
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+relativeCommandBinDir=$relativeBinDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
 	commandBinDir=$prefix/bin
+	relativeCommandBinDir=bin
 fi
+
+libVersion="2.1.1"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
 	rubberband$secondaryArchSuffix = $portVersion
-	cmd:rubberband
-	lib:librubberband$secondaryArchSuffix = 2.1.0 compat >= 2
+	cmd:rubberband$commandSuffix = $portVersion
+	lib:librubberband$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -34,7 +40,7 @@ REQUIRES="
 
 PROVIDES_devel="
 	rubberband${secondaryArchSuffix}_devel = $portVersion
-	devel:librubberband$secondaryArchSuffix = 2.1.0 compat >= 2
+	devel:librubberband$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
 	rubberband$secondaryArchSuffix == $portVersion base
@@ -59,12 +65,22 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
+defineDebugInfoPackage rubberband$secondaryArchSuffix \
+	"$commandBinDir"/rubberband \
+	"$libDir"/librubberband.so.$libVersion \
+	"$libDir"/ladspa/ladspa-rubberband.so \
+	"$libDir"/vamp/vamp-rubberband.so \
+
 PATCH()
 {
+	# Don't try to install $(JNI_TARGET) if it was not built.
+	# (It can't be built without javac.)
 	sed -i \
-		-e "/^INSTALL_INCDIR/ s|\(@prefix@/\)include/|\1$relativeIncludeDir/|;" \
-		-e "/^INSTALL_LRDFDIR/ s|\(@prefix@/\)share/|\1$relativeDataDir/|;" \
-		-e "/^INSTALL_/ s|\(@prefix@/\)lib|\1$relativeLibDir|;" \
+		-e "s/cp -f \(\$(JNI_TARGET)\) \$(DESTDIR).*/@[ -f \1 ] \&\& & || true/;" \
+		-e "/^INSTALL_BINDIR/ s|\(\$(PREFIX)/\)bin$|\1$relativeCommandBinDir|;" \
+		-e "/^INSTALL_INCDIR/ s|\(\$(PREFIX)/\)include/|\1$relativeIncludeDir/|;" \
+		-e "/^INSTALL_LRDFDIR/ s|\(\$(PREFIX)/\)share/|\1$relativeDataDir/|;" \
+		-e "/^INSTALL_/ s|\(\$(PREFIX)/\)lib|\1$relativeLibDir|;" \
 		Makefile.in
 }
 


### PR DESCRIPTION
* Add `commandSuffix` and `relativeCommandBinDir`.
* Update the `sed` command in `PATCH()`, mostly `s/@prefix@/$(PREFIX)/`, and also make `make install` check if `librubberband-jni.so` exists before trying to install it. (We need `javac` to build it.)