### PR TITLE
unrtf, lcms, libopenmpt, mpg321, dvdauthor: add commandSuffix.

### DIFF
--- a/app-text/unrtf/unrtf-0.21.9.recipe
+++ b/app-text/unrtf/unrtf-0.21.9.recipe
@@ -10,17 +10,18 @@ SOURCE_URI="https://www.gnu.org/software/unrtf/unrtf-$portVersion.tar.gz"
 CHECKSUM_SHA256="22a37826f96d754e335fb69f8036c068c00dd01ee9edd9461a36df0085fb8ddd"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
+SECONDARY_ARCHITECTURES="x86"
 
-if [ "$targetArchitecture" != x86_gcc2 ]; then
-	commandBinDir=$binDir
-else
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
 	commandBinDir=$prefix/bin
 fi
 
 PROVIDES="
 	unrtf$secondaryArchSuffix = $portVersion
-	cmd:unrtf = $portVersion
+	cmd:unrtf$commandSuffix = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix

--- a/media-libs/lcms/lcms-2.9.recipe
+++ b/media-libs/lcms/lcms-2.9.recipe
@@ -14,22 +14,23 @@ CHECKSUM_SHA256="48c6fdf98396fa245ed86e622028caf49b96fa22f3e5734f853f806fbc8e7d2
 SOURCE_DIR="lcms2-$portVersion"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
+SECONDARY_ARCHITECTURES="x86"
 
-if [ "$targetArchitecture" != x86_gcc2 ]; then
-	commandBinDir=$binDir
-else
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
 	commandBinDir=$prefix/bin
 fi
 
 PROVIDES="
 	lcms$secondaryArchSuffix = $portVersion compat >= 2
 	lib:liblcms2$secondaryArchSuffix = 2.0.8 compat >= 2
-	cmd:jpgicc
-	cmd:linkicc
-	cmd:psicc
-	cmd:tificc
-	cmd:transicc
+	cmd:jpgicc$commandSuffix
+	cmd:linkicc$commandSuffix
+	cmd:psicc$commandSuffix
+	cmd:tificc$commandSuffix
+	cmd:transicc$commandSuffix
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix

--- a/media-sound/libopenmpt/libopenmpt-0.2.7386~beta20.3.recipe
+++ b/media-sound/libopenmpt/libopenmpt-0.2.7386~beta20.3.recipe
@@ -11,18 +11,19 @@ CHECKSUM_SHA256="a6a7e6da1ae66e1cf46985ee92c182e50652d71b96135e9fa6048e132d84475
 SOURCE_DIR="libopenmpt-${portVersion%~*}-autotools"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
+SECONDARY_ARCHITECTURES="x86"
 
-if [ "$targetArchitecture" != x86_gcc2 ]; then
-	commandBinDir=$binDir
-else
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
 	commandBinDir=$prefix/bin
 fi
 
 PROVIDES="
 	libopenmpt$secondaryArchSuffix = $portVersion
 	lib:libopenmpt$secondaryArchSuffix = 0.0.20 compat >= 0
-	cmd:openmpt123 = $portVersion
+	cmd:openmpt123$commandSuffix = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix

--- a/media-sound/mpg321/mpg321-0.3.2.recipe
+++ b/media-sound/mpg321/mpg321-0.3.2.recipe
@@ -13,17 +13,18 @@ SOURCE_DIR="mpg321-$portVersion-orig"
 PATCHES="mpg321-$portVersion.patchset"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
+SECONDARY_ARCHITECTURES="x86"
 
-if [ "$targetArchitecture" != x86_gcc2 ]; then
-	commandBinDir=$binDir
-else
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
 	commandBinDir=$prefix/bin
 fi
 
 PROVIDES="
 	mpg321$secondaryArchSuffix = $portVersion
-	cmd:mpg321 = $portVersion
+	cmd:mpg321$commandSuffix = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix

--- a/media-video/dvdauthor/dvdauthor-0.7.2.recipe
+++ b/media-video/dvdauthor/dvdauthor-0.7.2.recipe
@@ -10,22 +10,23 @@ CHECKSUM_SHA256="3020a92de9f78eb36f48b6f22d5a001c47107826634a785a62dfcd080f612eb
 SOURCE_DIR="dvdauthor"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
+SECONDARY_ARCHITECTURES="x86"
 
-if [ "$targetArchitecture" != x86_gcc2 ]; then
-	commandBinDir=$binDir
-else
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
 	commandBinDir=$prefix/bin
 fi
 
 PROVIDES="
 	dvdauthor$secondaryArchSuffix = $portVersion
-	cmd:dvdauthor = $portVersion
-	cmd:dvddirdel = $portVersion
-	cmd:dvdunauthor = $portVersion
-	cmd:mpeg2desc = $portVersion
-	cmd:spumux = $portVersion
-	cmd:spuunmux = $portVersion
+	cmd:dvdauthor$commandSuffix = $portVersion
+	cmd:dvddirdel$commandSuffix = $portVersion
+	cmd:dvdunauthor$commandSuffix = $portVersion
+	cmd:mpeg2desc$commandSuffix = $portVersion
+	cmd:spumux$commandSuffix = $portVersion
+	cmd:spuunmux$commandSuffix = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix


### PR DESCRIPTION
Adding `commandSuffix` is neutral for all architectures, except for x86 secondary arch on a x86_64/x86 hybrid system, which is not yet available, so we can keep `REVISION` unchanged.