### PR TITLE
lighttpd: fix PROVIDES*, add debuginfo & commandSuffix.

### DIFF
--- a/www-servers/lighttpd/lighttpd-1.4.49.recipe
+++ b/www-servers/lighttpd/lighttpd-1.4.49.recipe
@@ -9,7 +9,7 @@ solution for every server that is suffering load problems."
 HOMEPAGE="https://www.lighttpd.net/"
 COPYRIGHT="2003-2018 lighttpd authors"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-$portVersion.tar.xz"
 CHECKSUM_SHA256="aedf49d7127d9e4c0ea56618e9e945a17674dc46a37ac7990120f87dd939ce09"
 ADDITIONAL_FILES="
@@ -21,60 +21,61 @@ ADDITIONAL_FILES="
 	"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64 ?arm ?ppc"
-SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
+SECONDARY_ARCHITECTURES="x86"
 
-if [ "$targetArchitecture" != x86_gcc2 ]; then
-	commandBinDir=$binDir
-else
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
 	commandBinDir=$prefix/bin
 fi
 
 PROVIDES="
 	lighttpd$secondaryArchSuffix = $portVersion
-	cmd:lighttpd
-	cmd:lighttpd_angel
-	lib:mod_access
-	lib:mod_accesslog
-	lib:mod_alias
-	lib:mod_auth
-	lib:mod_authn_file
-#	lib:mod_authn_gssapi
-	lib:mod_authn_ldap
-#	lib:mod_authn_mysql
-	lib:mod_cgi
-	lib:mod_cml
-	lib:mod_compress
-	lib:mod_deflate
-	lib:mod_dirlisting
-	lib:mod_evasive
-	lib:mod_evhost
-	lib:mod_expire
-	lib:mod_extforward
-	lib:mod_fastcgi
-	lib:mod_flv_streaming
-	lib:mod_indexfile
-	lib:mod_magnet
-#	lib:mod_mysql_vhost
-	lib:mod_openssl
-	lib:mod_proxy
-	lib:mod_redirect
-	lib:mod_rewrite
-	lib:mod_rrdtool
-	lib:mod_scgi
-	lib:mod_secdownload
-	lib:mod_setenv
-	lib:mod_simple_vhost
-	lib:mod_ssi
-	lib:mod_staticfile
-	lib:mod_status
-#	lib:mod_trigger_b4_dl
-	lib:mod_uploadprogress
-	lib:mod_userdir
-	lib:mod_usertrack
-	lib:mod_vhostdb_ldap
-	lib:mod_vhostdb
-	lib:mod_webdav
-	lib:mod_wstunnel
+	cmd:lighttpd$commandSuffix
+	cmd:lighttpd_angel$commandSuffix
+	lib:mod_access$secondaryArchSuffix
+	lib:mod_accesslog$secondaryArchSuffix
+	lib:mod_alias$secondaryArchSuffix
+	lib:mod_auth$secondaryArchSuffix
+	lib:mod_authn_file$secondaryArchSuffix
+#	lib:mod_authn_gssapi$secondaryArchSuffix
+	lib:mod_authn_ldap$secondaryArchSuffix
+#	lib:mod_authn_mysql$secondaryArchSuffix
+	lib:mod_cgi$secondaryArchSuffix
+	lib:mod_cml$secondaryArchSuffix
+	lib:mod_compress$secondaryArchSuffix
+	lib:mod_deflate$secondaryArchSuffix
+	lib:mod_dirlisting$secondaryArchSuffix
+	lib:mod_evasive$secondaryArchSuffix
+	lib:mod_evhost$secondaryArchSuffix
+	lib:mod_expire$secondaryArchSuffix
+	lib:mod_extforward$secondaryArchSuffix
+	lib:mod_fastcgi$secondaryArchSuffix
+	lib:mod_flv_streaming$secondaryArchSuffix
+	lib:mod_indexfile$secondaryArchSuffix
+	lib:mod_magnet$secondaryArchSuffix
+#	lib:mod_mysql_vhost$secondaryArchSuffix
+	lib:mod_openssl$secondaryArchSuffix
+	lib:mod_proxy$secondaryArchSuffix
+	lib:mod_redirect$secondaryArchSuffix
+	lib:mod_rewrite$secondaryArchSuffix
+	lib:mod_rrdtool$secondaryArchSuffix
+	lib:mod_scgi$secondaryArchSuffix
+	lib:mod_secdownload$secondaryArchSuffix
+	lib:mod_setenv$secondaryArchSuffix
+	lib:mod_simple_vhost$secondaryArchSuffix
+	lib:mod_ssi$secondaryArchSuffix
+	lib:mod_staticfile$secondaryArchSuffix
+	lib:mod_status$secondaryArchSuffix
+#	lib:mod_trigger_b4_dl$secondaryArchSuffix
+	lib:mod_uploadprogress$secondaryArchSuffix
+	lib:mod_userdir$secondaryArchSuffix
+	lib:mod_usertrack$secondaryArchSuffix
+	lib:mod_vhostdb_ldap$secondaryArchSuffix
+	lib:mod_vhostdb$secondaryArchSuffix
+	lib:mod_webdav$secondaryArchSuffix
+	lib:mod_wstunnel$secondaryArchSuffix
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -93,7 +94,7 @@ REQUIRES="
 
 PROVIDES_mod_geoip="
 	lighttpd${secondaryArchSuffix}_mod_geoip = $portVersion
-	lib:mod_geoip
+	lib:mod_geoip$secondaryArchSuffix
 	"
 REQUIRES_mod_geoip="
 	haiku$secondaryArchSuffix
@@ -209,6 +210,17 @@ USER_SETTINGS_FILES_mod_geoip="
 POST_INSTALL_SCRIPTS="
 	$relativePostInstallDir/create-lighttpd-directories.sh
 	"
+
+debugList=()
+for i in `echo "$PROVIDES" | sed -e "/^\s*#/ d;" | sed -n -e \
+               "s/^\s*lib:\(mod_.*\)$secondaryArchSuffix/\1/p;"` ; do
+       debugList+=("$libDir"/lighttpd/$i.so)
+done
+defineDebugInfoPackage lighttpd$secondaryArchSuffix \
+	"$commandBinDir"/lighttpd \
+	"$commandBinDir"/lighttpd-angel \
+	"$(getPackagePrefix mod_geoip)"/$relativeLibDir/lighttpd/mod_geoip.so \
+	"${debugList[@]}"
 
 BUILD()
 {

--- a/www-servers/lighttpd/lighttpd-1.4.49.recipe
+++ b/www-servers/lighttpd/lighttpd-1.4.49.recipe
@@ -211,16 +211,16 @@ POST_INSTALL_SCRIPTS="
 	$relativePostInstallDir/create-lighttpd-directories.sh
 	"
 
-debugList=()
+debugList=(
+	"$commandBinDir"/lighttpd
+	"$commandBinDir"/lighttpd-angel
+	"${libDir/lighttpd$secondaryArchSuffix/lighttpd${secondaryArchSuffix}_mod_geoip}"/lighttpd/mod_geoip.so
+	)
 for i in `echo "$PROVIDES" | sed -e "/^\s*#/ d;" | sed -n -e \
                "s/^\s*lib:\(mod_.*\)$secondaryArchSuffix/\1/p;"` ; do
        debugList+=("$libDir"/lighttpd/$i.so)
 done
-defineDebugInfoPackage lighttpd$secondaryArchSuffix \
-	"$commandBinDir"/lighttpd \
-	"$commandBinDir"/lighttpd-angel \
-	"$(getPackagePrefix mod_geoip)"/$relativeLibDir/lighttpd/mod_geoip.so \
-	"${debugList[@]}"
+defineDebugInfoPackage lighttpd$secondaryArchSuffix "${debugList[@]}"
 
 BUILD()
 {


### PR DESCRIPTION
* The `lib:mod_*` in `PROVIDES*` were missing a `$secondaryArchSuffix`.
* Use `"$(getPackagePrefix mod_geoip)"` in `defineDebugInfoPackage`.

* Do not use getPackagePrefix for now, because `getPackagePrefix` makes our scripts on travis-ci.org complain:
```
Checking ports of: lighttpd-1.4.49
lighttpd-1.4.49 [www-servers]
packageEntries: error: "mod_geoip" doesn't seem to be
a valid package suffix.
```
So, instead, use a little hack.