### PR TITLE
util-linux: move cmd:cal to a subpackage.

### DIFF
--- a/sys-apps/util-linux/util_linux-2.32.recipe
+++ b/sys-apps/util-linux/util_linux-2.32.recipe
@@ -6,7 +6,7 @@ LICENSE="GNU GPL v2
 	GNU LGPL v2
 	BSD (4-clause)
 	Public Domain"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://www.kernel.org/pub/linux/utils/util-linux/v2.32/util-linux-$portVersion.tar.xz"
 CHECKSUM_SHA256="6c7397abc764e32e8159c2e96042874a190303e77adceb4ac5bd502a272a4734"
 SOURCE_DIR="util-linux-$portVersion"
@@ -36,7 +36,6 @@ done
 PROVIDES="
 	util_linux$secondaryArchSuffix = $portVersion compat >= 2
 	cmd:blkid$commandSuffix = $portVersion
-	cmd:cal$commandSuffix = $portVersion
 	cmd:hexdump$commandSuffix = $portVersion
 	cmd:nologin$commandSuffix = $portVersion
 	cmd:rename$commandSuffix = $portVersion
@@ -53,6 +52,22 @@ REQUIRES="
 	lib:libncursesw$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
+
+SUMMARY_cal="A random collection of Linux utilities (cal)"
+PROVIDES_cal="
+	util_linux${secondaryArchSuffix}_cal = $portVersion compat >= 2
+	cmd:cal$commandSuffix = $portVersion
+	"
+REQUIRES_cal="
+	haiku$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libncursesw$secondaryArchSuffix
+	"
+if [ -z "$commandSuffix" ]; then
+CONFLICTS_cal="
+	cmd:cal
+	"
+fi
 
 SUMMARY_fdisk="A random collection of Linux utilities (fdisk)"
 ARCHITECTURES_fdisk="!x86_gcc2 ?x86 ?x86_64"
@@ -101,7 +116,7 @@ BUILD_PREREQUIRES="
 
 defineDebugInfoPackage util_linux$secondaryArchSuffix \
 	"$commandBinDir"/blkid \
-	"$commandBinDir"/cal \
+	"${commandBinDir/util_linux$secondaryArchSuffix/util_linux${secondaryArchSuffix}_cal}"/cal \
 	"$commandBinDir"/hexdump \
 	"$commandBinDir"/nologin \
 	"$commandBinDir"/rename \
@@ -169,6 +184,11 @@ INSTALL()
 
 	prepareInstalledDevelLibs $util_linuxLibs
 	fixPkgconfig
+
+	packageEntries cal \
+		"$commandBinDir"/cal \
+		"$dataDir"/bash-completion/completions/cal \
+		"$manDir"/man1/cal.1
 
 	# With the fdisk subpackage being marked as untested, haikuporter does not
 	# create the subdirectory for it in $packagingBaseDir when ALLOW_UNTESTED=no


### PR DESCRIPTION
This will allow HaikuPorts users to choose which package they want for the `cal` command, since both `cal` and `util_linux_cal` provide it.