### PR TITLE
uif2iso: add commandSuffix, rework INSTALL.

### DIFF
--- a/app-cdr/uif2iso/uif2iso-0.1.7c.recipe
+++ b/app-cdr/uif2iso/uif2iso-0.1.7c.recipe
@@ -18,11 +18,18 @@ SOURCE_URI_2="http://httpredir.debian.org/debian/pool/main/u/uif2iso/uif2iso_0.1
 CHECKSUM_SHA256_2="60e91e4a3c7b64d18a144b0e2bc0499c1ab10db3676c099725aca820ff429594"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
+SECONDARY_ARCHITECTURES="x86"
+
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
 
 PROVIDES="
 	uif2iso$secondaryArchSuffix = $portVersion
-	cmd:uif2iso
+	cmd:uif2iso$commandSuffix
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -49,7 +56,7 @@ BUILD()
 
 INSTALL()
 {
-	make -C src install prefix=$prefix DESTDIR=$commandBinDir
+	make -C src install prefix="$prefix" bindir="$commandBinDir"
 	install -d -m 755 $docDir $manDir/man1
 	install -t $docDir -c -m 444 uif2iso.txt README
 	zcat $sourceDir2/uif2iso_0.1.7a-1.diff.gz | patch -p1


### PR DESCRIPTION
Keep `REVISION` unchanged because this is a neutral change for all existing arches. The sole purpose of this change is to make this recipe ready for x86_64/x86 hybrid, as explained in #2690.