### PR TITLE
libusbmuxd: use autoreconf, add debuginfo & commandSuffix.

### DIFF
--- a/app-pda/libusbmuxd/libusbmuxd-1.0.10.recipe
+++ b/app-pda/libusbmuxd/libusbmuxd-1.0.10.recipe
@@ -1,29 +1,33 @@
 SUMMARY="A client library to multiplex connections from and to iOS devices"
 DESCRIPTION="libusbmuxd is a client library to multiplex connections from and \
 to iOS devices by connecting to a socket provided by a usbmuxd daemon."
-HOMEPAGE="http://www.libimobiledevice.org/"
+HOMEPAGE="https://www.libimobiledevice.org/"
 COPYRIGHT="2013-2014 Nikias Bassen
 	2009-2014 Martin Szulecki"
 LICENSE="GNU GPL v2
 	GNU LGPL v2.1"
 REVISION="2"
-SOURCE_URI="http://www.libimobiledevice.org/downloads/libusbmuxd-$portVersion.tar.bz2"
+SOURCE_URI="https://www.libimobiledevice.org/downloads/libusbmuxd-$portVersion.tar.bz2"
 CHECKSUM_SHA256="1aa21391265d2284ac3ccb7cf278126d10d354878589905b35e8102104fec9f2"
 PATCHES="libusbmuxd-$portVersion.patchset"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
+SECONDARY_ARCHITECTURES="x86"
 
-if [ "$targetArchitecture" != x86_gcc2 ]; then
-	commandBinDir=$binDir
-else
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
 	commandBinDir=$prefix/bin
 fi
 
+libVersion="4.0.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
 PROVIDES="
 	libusbmuxd$secondaryArchSuffix = $portVersion compat >= 1
-	lib:libusbmuxd$secondaryArchSuffix = 4.0.0 compat >= 4
-	cmd:iproxy = $portVersion compat >= 1
+	lib:libusbmuxd$secondaryArchSuffix = $libVersionCompat
+	cmd:iproxy$commandSuffix = $portVersion compat >= 1
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -35,7 +39,7 @@ REQUIRES="
 
 PROVIDES_devel="
 	libusbmuxd${secondaryArchSuffix}_devel = $portVersion compat >= 1
-	devel:libusbmuxd$secondaryArchSuffix = 4.0.0 compat >= 4
+	devel:libusbmuxd$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
 	libusbmuxd$secondaryArchSuffix == $portVersion base
@@ -50,8 +54,8 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	cmd:aclocal
-	cmd:autoconf
 	cmd:automake
+	cmd:autoreconf
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
 	cmd:libtoolize$secondaryArchSuffix
@@ -59,12 +63,13 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
+defineDebugInfoPackage libusbmuxd$secondaryArchSuffix \
+	"$commandBinDir"/iproxy \
+	"$libDir"/libusbmuxd.so.$libVersion
+
 BUILD()
 {
-	libtoolize --force --copy --install
-	aclocal -I m4
-	autoconf
-	automake
+	autoreconf
 	runConfigure --omit-dirs binDir ./configure --bindir=$commandBinDir
 	make
 }


### PR DESCRIPTION
* `BUILD` was no longer working. We could have replaced `automake` by `automake --add-missing` but it was easier to switch to `autoreconf`.
* Switch `HOMEPAGE` and `SOURCE_URI` to https.