### PR TITLE
vice, bump version

### DIFF
--- a/games-emulation/vice/patches/vice-3.2.patchset
+++ b/games-emulation/vice/patches/vice-3.2.patchset
@@ -1,0 +1,28 @@
+From c798fb22012d5957691f93a65f940dd43ad2f648 Mon Sep 17 00:00:00 2001
+From: begasus <begasus@gmail.com>
+Date: Wed, 27 Jun 2018 07:04:09 +0200
+Subject: Added Haiku paths system
+
+
+diff --git a/src/arch/beos/archdep.c b/src/arch/beos/archdep.c
+index 41a2114..6a91ded 100644
+--- a/src/arch/beos/archdep.c
++++ b/src/arch/beos/archdep.c
+@@ -124,7 +124,14 @@ static char *boot_path = NULL;
+ const char *archdep_boot_path(void)
+ {
+     if (boot_path == NULL) {
++        #ifdef __HAIKU__
++            char haiku_path[B_PATH_NAME_LENGTH];
++            find_directory(B_SYSTEM_SETTINGS_DIRECTORY, 0, true, haiku_path, sizeof(haiku_path)-strlen("/VICE/"));
++            strcat(haiku_path,"/VICE/");
++	    boot_path = haiku_path;
++        #else
+         util_fname_split(argv0, &boot_path, NULL);
++        #endif
+         /* This should not happen, but you never know...  */
+         if (boot_path == NULL) {
+             boot_path = lib_stralloc("./xxx");
+-- 
+2.16.4
+

--- a/games-emulation/vice/vice-3.2.recipe
+++ b/games-emulation/vice/vice-3.2.recipe
@@ -1,0 +1,124 @@
+SUMMARY="An emulator for the Commodore64 computers"
+DESCRIPTION="VICE is a program that runs on a Unix, MS-DOS, Win32, OS/2, \
+BeOS, Haiku, QNX 4.x, QNX 6.x, Amiga, Syllable or Mac OS X machine and \
+executes programs intended for the old 8-bit computers. The current version \
+emulates the C64, the C64DTV, the C128, the VIC20, practically all PET \
+models, the PLUS4 and the CBM-II (aka C610/C510). An extra emulator is \
+provided for C64 expanded with the CMD SuperCPU."
+HOMEPAGE="http://vice-emu.sourceforge.net/"
+COPYRIGHT="1998-2012 Dag Lem
+	1999-2012 Andreas Matthies
+	1999-2012 Martin Pottendorfer
+	2005-2018 Marco van den Heuvel
+	2006-2012 Christian Vogelgsang
+	2007-2018 Fabrizio Gennari
+	2007-2012 Daniel Kahlin
+	2009-2018 Groepaz
+	2009-2012 Ingo Korb
+	2009-2012 Errol Smith
+	2010-2018 Olaf Seibert
+	2011-2018 Marcus Sutton
+	2011-2012 Ulrich Schulz
+	2011-2012 Stefan Haubenthal
+	2011-2012 Thomas Giesel
+	2011-2018 Kajtar Zsolt
+	2012-2012 Benjamin 'BeRo' Rosseaux
+	2016-2018 AreaScout
+	2016-2018 Bas Wissink
+	2017-2018 Michael C. Martin
+	2000-2011 Spiro Trikaliotis
+	1998-2010 Tibor Biczo
+	1998-2010 Andreas Boose
+	2007-2010 M. Kiesel
+	2007-2011 Hannu Nuotio
+	1999-2007 Andreas Dehmel
+	2003-2005 David Hansel
+	2000-2004 Markus Brenner
+	1999-2004 Thomas Bretz
+	1997-2001 Daniel Sladic
+	1996-1999 Ettore Perazzoli
+	1996-1999 Andre Fachat
+	1993-1994, 1997-1999 Teemu Rantanen
+	1993-1996 Jouko Valta"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="https://downloads.sourceforge.net/vice-emu/vice-$portVersion.tar.gz"
+CHECKSUM_SHA256="28d99f5e110720c97ef16d8dd4219cf9a67661d58819835d19378143697ba523"
+PATCHES="vice-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 x86 ?x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+ 	commandSuffix=
+ 	commandBinDir=$prefix/bin
+fi
+
+GLOBAL_WRITABLE_FILES="
+	settings/VICE directory keep-old
+	"
+
+PROVIDES="
+	vice$secondaryArchSuffix = $portVersion
+	cmd:c1541$commandSuffix
+	cmd:cartconv$commandSuffix
+	cmd:vsid$commandSuffix
+	cmd:x128$commandSuffix
+	cmd:x64$commandSuffix
+	cmd:x64dtv$commandSuffix
+	cmd:x64sc$commandSuffix
+	cmd:xcbm2$commandSuffix
+	cmd:xcbm5x0$commandSuffix
+	cmd:xpet$commandSuffix
+	cmd:xplus4$commandSuffix
+	cmd:xscpu64$commandSuffix
+	cmd:xvic$commandSuffix
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libpng16$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:autoheader
+	cmd:automake
+	cmd:bison
+	cmd:find
+	cmd:flex
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:makeinfo
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:xa
+	"
+
+BUILD()
+{
+	./autogen.sh
+	runConfigure --omit-dirs sbinDir ./configure \
+		--sbindir=$commandBinDir
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make bindist
+	mkdir -p $settingsDir/VICE $commandBinDir
+	mv $sourceDir/BeVICE-3.2.x86/x* \
+		$sourceDir/BeVICE-3.2.x86/vsid \
+		$sourceDir/BeVICE-3.2.x86/cartconv \
+		$sourceDir/BeVICE-3.2.x86/c1541 \
+		$commandBinDir/
+	mv $sourceDir/BeVICE-3.2.x86/* $settingsDir/VICE
+}


### PR DESCRIPTION
From their website:
``
This release marks the end of the legacy ports (native Amiga, BeOS/Haiku, OS/2, DOS, Xaw/Gnome2/Gnome3, Cocoa and Windows) ports, and we will be switching to SDL1/2 and *nix/Windows/OSX native GTK3 ports for all future releases.
``