### PR TITLE
app-shells/command_not_found: fix handler

### DIFF
--- a/app-shells/command_not_found/command_not_found-0.0.1~git.recipe
+++ b/app-shells/command_not_found/command_not_found-0.0.1~git.recipe
@@ -5,7 +5,7 @@ It can also check for typos (a feature of zsh)."
 HOMEPAGE="https://github.com/jrabbit/haiku-cnf"
 COPYRIGHT="2011 Jrabbit"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 srcGitRev="db1be8b57dedff781dc68caa46f403d88c5eedb9"
 SOURCE_URI="$HOMEPAGE/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="a1ce4e6c8a7307c0d5c1e65a90b3d2a7ba9d16d9506a70aab1005129333d6121"
@@ -46,7 +46,13 @@ INSTALL()
 
 	cat > $profileDir/command-not-found.sh << EOF
 command_not_found_handle() {
-	command_not_found "$1"
+	if command -v command_not_found >/dev/null 2>&1; then
+		command_not_found "\$1"
+		return "\$?"
+	else
+		echo "\$1: command not found: try pkgman install cmd:\$1"
+		return 127 # bash return code for command not found
+	fi
 }
 EOF
 }


### PR DESCRIPTION
- Properly escaped dollar signs
- Respects command_not_found error code
- Added fallback to avoid deadlock in case command_not_found was
uninstalled

Solves #2760

This is done via a quick web search and is completely untested.