### PR TITLE
gptfdisk: bump to 1.0.4, add support for x86 2nd arch.

### DIFF
--- a/sys-apps/gptfdisk/gptfdisk-1.0.4.recipe
+++ b/sys-apps/gptfdisk/gptfdisk-1.0.4.recipe
@@ -7,14 +7,23 @@ Record (MBR) partition tables, but may also be used on MBR disks to convert \
 them to GPT. The fixparts program repairs certain types of damage to MBR disks \
 and enables changing partition types from primary to logical and vice-versa."
 HOMEPAGE="http://www.rodsbooks.com/gdisk/"
-COPYRIGHT="2013-2017 Rod Smith"
+COPYRIGHT="2013-2018 Rod Smith"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://downloads.sf.net/gptfdisk/gptfdisk-$portVersion.tar.gz"
-CHECKSUM_SHA256="89fd5aec35c409d610a36cb49c65b442058565ed84042f767bba614b8fc91b5c"
+CHECKSUM_SHA256="b663391a6876f19a3cd901d862423a16e2b5ceaa2f4a3b9bb681e64b9c7ba78d"
 PATCHES="gptfdisk-$portVersion.patchset"
 
-ARCHITECTURES="x86_gcc2 x86 x86_64"
+ARCHITECTURES="?x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+# Comment out this block if you wish to co-install gptfdisk & gptfdisk_x86.
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
 
 if [ "$effectiveTargetArchitecture" = x86_gcc2 ]; then
 	libuuidMinimumVersion=1.0.0
@@ -25,37 +34,42 @@ else
 fi
 
 PROVIDES="
-	gptfdisk = $portVersion
-	cmd:cgdisk
-	cmd:fixparts
-	cmd:gdisk
-	cmd:sgdisk
+	gptfdisk$secondaryArchSuffix = $portVersion
+	cmd:cgdisk$commandSuffix = $portVersion
+	cmd:fixparts$commandSuffix = $portVersion
+	cmd:gdisk$commandSuffix = $portVersion
+	cmd:sgdisk$commandSuffix = $portVersion
 	"
 REQUIRES="
-	haiku
-	lib:libuuid >= $libuuidMinimumVersion
-	lib:libncurses
-	lib:libpopt
+	haiku$secondaryArchSuffix
+	lib:libuuid$secondaryArchSuffix >= $libuuidMinimumVersion
+	lib:libncursesw$secondaryArchSuffix
+	lib:libpopt$secondaryArchSuffix
 	"
 if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
 REQUIRES+="
-	lib:libintl
+	lib:libintl$secondaryArchSuffix
+	"
+fi
+if [ -n "$secondaryArchSuffix" -a "$commandBinDir" != "$binDir" ]; then
+CONFLICTS="
+	gptfdisk
 	"
 fi
 
 BUILD_REQUIRES="
-	haiku_devel
-	devel:libuuid >= $libuuidMinimumVersion
-	devel:libncurses
-	devel:libpopt
+	haiku${secondaryArchSuffix}_devel
+	devel:libuuid$secondaryArchSuffix >= $libuuidMinimumVersion
+	devel:libncursesw$secondaryArchSuffix
+	devel:libpopt$secondaryArchSuffix
 	"
 if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
 BUILD_REQUIRES+="
-	devel:libintl
+	devel:libintl$secondaryArchSuffix
 	"
 fi
 BUILD_PREREQUIRES="
-	cmd:g++
+	cmd:g++$secondaryArchSuffix
 	cmd:install
 	cmd:make
 	"
@@ -77,10 +91,10 @@ BUILD()
 
 INSTALL()
 {
-	install -d "$sbinDir" "$docDir" "$manDir"/man8
-	install -t "$sbinDir" -s cgdisk gdisk sgdisk fixparts
-	install -t "$docDir" README
-	install -t "$manDir"/man8 *.8
+	install -m 0755 -d "$commandBinDir" "$docDir" "$manDir"/man8
+	install -m 0755 -t "$commandBinDir" -s cgdisk gdisk sgdisk fixparts
+	install -m 0644 -t "$docDir" README
+	install -m 0644 -t "$manDir"/man8 *.8
 }
 
 TEST()

--- a/sys-apps/gptfdisk/patches/gptfdisk-1.0.4.patchset
+++ b/sys-apps/gptfdisk/patches/gptfdisk-1.0.4.patchset
@@ -18,7 +18,7 @@ index 0bdaba4..d8645b7 100644
  #define stat64 stat
  #endif
 diff --git a/gptcurses.cc b/gptcurses.cc
-index 0e18f8f..8651bdc 100644
+index 3e9b240..9037269 100644
 --- a/gptcurses.cc
 +++ b/gptcurses.cc
 @@ -22,6 +22,7 @@
@@ -30,7 +30,7 @@ index 0e18f8f..8651bdc 100644
  #include "gptcurses.h"
  #include "support.h"
 diff --git a/support.h b/support.h
-index 85324f6..58b00fd 100644
+index 8f976da..745bb57 100644
 --- a/support.h
 +++ b/support.h
 @@ -16,6 +16,10 @@


### PR DESCRIPTION
Although gptfdisk builds on all architectures, it is not passing the tests on x86_gcc2, so let's mark that arch as untested.