### PR TITLE
reicast_libretro: bump to current git version

### DIFF
--- a/games-emulation/reicast_libretro/reicast_libretro-r6_20180711.recipe
+++ b/games-emulation/reicast_libretro/reicast_libretro-r6_20180711.recipe
@@ -1,13 +1,14 @@
 SUMMARY="A port of Reicast, a SEGA Dreamcast emulator to the libretro API"
-DESCRIPTION="Reicast is a cross-platform SEGA Dreamcast emulator based off \
-NullDC. It can accurately play several games and is in active development."
+DESCRIPTION="Reicast is a cross-platform SEGA Dreamcast, Naomi and AtomisWave \
+emulator based off NullDC. It can accurately play several games and is in \
+active development."
 HOMEPAGE="http://www.reicast.com"
 COPYRIGHT="2013-2018, drk||Raziel, PsyMan, gb_away, the libretro team"
 LICENSE="GNU GPL v2"
 REVISION="1"
-srcGitRev="d4d1c4ecc8943a3eb394982087f2c861ede65f2c"
+srcGitRev="1d966f149becab535a56b2cf415e9ff36e07622e"
 SOURCE_URI="https://github.com/libretro/reicast-emulator/archive/$srcGitRev.tar.gz"
-CHECKSUM_SHA256="4d8b0082efcb870cde354d0402d9adcdc1188dc25b45928a72737e82c4ac96ff"
+CHECKSUM_SHA256="38aa2c7156b12ac38be8c3f497d1d77c92199dab7b1a078594fdc0712f270bec"
 SOURCE_FILENAME="reicast-libretro-${portVersion/_/-}-$srcGitRev.tar.gz"
 SOURCE_DIR="reicast-emulator-$srcGitRev"
 ADDITIONAL_FILES="reicast_libretro.info.in"


### PR DESCRIPTION
There's been a lot of progress made on the Reicast core in the past two months, with SEGA Naomi and Sammy Atomiswave support being added. 