### PR TITLE
libice, bump revision after changes to util-macros and xorgproto

### DIFF
--- a/x11-libs/libice/libice-1.0.9.recipe
+++ b/x11-libs/libice/libice-1.0.9.recipe
@@ -7,7 +7,7 @@ a particular message."
 HOMEPAGE="https://www.x.org/releases/individual/lib/"
 COPYRIGHT="1993, 1998 The Open Group"
 LICENSE="MIT (no promotion)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://www.x.org/releases/individual/lib/libICE-$portVersion.tar.bz2"
 CHECKSUM_SHA256="8f7032f2c1c64352b5423f6b48a8ebdc339cc63064af34d66a6c9aa79759e202"
 SOURCE_DIR="libICE-$portVersion"
@@ -36,11 +36,11 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:xproto$secondaryArchSuffix
-	devel:xtrans$secondaryArchSuffix
+	devel:util_macros
+	devel:xproto
+	devel:xtrans
 	"
 BUILD_PREREQUIRES="
-	devel:util_macros$secondaryArchSuffix
 	cmd:aclocal
 	cmd:autoconf
 	cmd:gcc$secondaryArchSuffix


### PR DESCRIPTION
Should we use "lib:libICE" or "lib:libice" here?