### PR TITLE
Add recipe for BeScreenCapture 2.3.3

### DIFF
--- a/haiku-apps/bescreencapture/bescreencapture-2.3.3.recipe
+++ b/haiku-apps/bescreencapture/bescreencapture-2.3.3.recipe
@@ -1,0 +1,76 @@
+SUMMARY="A screen recorder utility"
+DESCRIPTION="BeScreenCapture is a screen recorder utility for Haiku.
+It allows you to record what happens on your screen, then save it \
+to any media format supported in Haiku.
+BeScreenCapture can record either the entire screen, or just a section you \
+select."
+
+SUMMARY_inputfilter="Shortcut handler for BeScreenCapture"
+DESCRIPTION_inputfilter="Input Server Addon for BeScreenCapture. Allows the \
+user to launch BeScreenCapture and start/stop recording using a keyboard \
+combination (CTRL-COMMAND-SHIFT + R)."
+
+HOMEPAGE="https://github.com/jackburton79/bescreencapture/releases"
+COPYRIGHT="2014-2018 Stefano Ceccherini"
+LICENSE="BSD (3-clause)
+	MIT"
+REVISION="1"
+SOURCE_URI="https://github.com/jackburton79/bescreencapture/archive/v$portVersion.tar.gz"
+CHECKSUM_SHA256="4efaebffb6e90e6cf497e7dc1439048fd5be576e75db9578b1189208c2ceeaac"
+SOURCE_FILENAME="bescreencapture-$portVersion.tar.gz"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	bescreencapture = $portVersion
+	app:BeScreenCapture = $portVersion
+	"
+REQUIRES="
+	haiku
+	"
+
+PROVIDES_inputfilter="
+	bescreencapture_inputfilter = $portVersion
+	app:BeScreenCaptureInputFilter = $portVersion
+	"
+REQUIRES_inputfilter="
+	haiku
+	bescreencapture == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+
+BUILD_PREREQUIRES="
+	makefile_engine
+	cmd:make
+	cmd:gcc
+	"
+
+BUILD()
+{
+	make OBJ_DIR=objects \
+		BUILDHOME=`finddir B_SYSTEM_DEVELOP_DIRECTORY`
+
+	make -C inputfilter OBJ_DIR=objects \
+		BUILDHOME=`finddir B_SYSTEM_DEVELOP_DIRECTORY`
+}
+
+INSTALL()
+{
+	install -m 0755 -d "$appsDir"
+	install -m 0755 -t "$appsDir" objects/BeScreenCapture
+
+	install -m 0755 -d "$addOnsDir"/input_server/filters
+	install -m 0755 -t "$addOnsDir"/input_server/filters \
+		inputfilter/objects/BeScreenCaptureInputFilter
+
+	install -m 0755 -d "$docDir"
+	install -m 0644 -t "$docDir" README.md
+
+	packageEntries inputfilter \
+		$addOnsDir/input_server/filters/BeScreenCaptureInputFilter
+
+	addAppDeskbarSymlink $appsDir/BeScreenCapture
+}


### PR DESCRIPTION
Update BeScreenCapture to version 2.3.3.
- Fix build with recent compilers.
- Fix unstoppable capture thread on full-disk conditions.
- Disable controls when recording to avoid possible problems.
- Improved error messages.
- Improved drawing of the deskbar replicant.

