### PR TITLE
Rust: add recipe for 1.28.0

### DIFF
--- a/dev-lang/rust/patches/rust-1.28.0.patchset
+++ b/dev-lang/rust/patches/rust-1.28.0.patchset
@@ -1,0 +1,3901 @@
+From 8c6236ec8e881d1b2a30b3b9d1d500e52fd5bba4 Mon Sep 17 00:00:00 2001
+From: Niels Sascha Reedijk <niels.reedijk@gmail.com>
+Date: Wed, 1 Aug 2018 11:17:42 +0200
+Subject: Haiku: add Haiku-specific patches for Rust 1.28.0
+
+See https://github.com/nielx/rust branch rust-haiku-1.28.0
+
+diff --git a/src/Cargo.lock b/src/Cargo.lock
+index 6f39947..caff7e9 100644
+--- a/src/Cargo.lock
++++ b/src/Cargo.lock
+@@ -95,31 +95,30 @@ name = "atty"
+ version = "0.2.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "backtrace"
+-version = "0.3.6"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
++version = "0.3.9"
++source = "git+https://github.com/alexcrichton/backtrace-rs?rev=01219b0#01219b019d08eae4a7d24e4efcad3e9a74e51a2e"
+ dependencies = [
+- "backtrace-sys 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
++ "backtrace-sys 0.1.23 (git+https://github.com/alexcrichton/backtrace-rs?rev=01219b0)",
+  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "rustc-demangle 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "backtrace-sys"
+-version = "0.1.22"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
++version = "0.1.23"
++source = "git+https://github.com/alexcrichton/backtrace-rs?rev=01219b0#01219b019d08eae4a7d24e4efcad3e9a74e51a2e"
+ dependencies = [
+  "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+- "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+ ]
+ 
+ [[package]]
+@@ -151,7 +150,7 @@ dependencies = [
+  "filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+  "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "petgraph 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -215,7 +214,7 @@ dependencies = [
+  "jobserver 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "libgit2-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "miow 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -396,7 +395,7 @@ name = "commoncrypto-sys"
+ version = "0.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+ ]
+ 
+ [[package]]
+@@ -416,7 +415,7 @@ dependencies = [
+  "filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+  "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "miow 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -435,7 +434,7 @@ dependencies = [
+  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+  "filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+  "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "miow 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "serde 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -462,7 +461,7 @@ version = "0.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "core-foundation-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+ ]
+ 
+ [[package]]
+@@ -536,7 +535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "curl-sys 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "openssl-sys 0.9.28 (registry+https://github.com/rust-lang/crates.io-index)",
+  "schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -550,7 +549,7 @@ version = "0.4.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+  "openssl-sys 0.9.28 (registry+https://github.com/rust-lang/crates.io-index)",
+  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -670,7 +669,7 @@ name = "error-chain"
+ version = "0.11.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "backtrace 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "backtrace 0.3.9 (git+https://github.com/alexcrichton/backtrace-rs?rev=01219b0)",
+ ]
+ 
+ [[package]]
+@@ -685,7 +684,7 @@ name = "failure"
+ version = "0.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "backtrace 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "backtrace 0.3.9 (git+https://github.com/alexcrichton/backtrace-rs?rev=01219b0)",
+  "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -709,7 +708,7 @@ version = "0.1.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -719,7 +718,7 @@ version = "0.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -741,7 +740,7 @@ name = "flate2"
+ version = "1.0.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -772,7 +771,7 @@ name = "fs2"
+ version = "0.4.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -815,7 +814,7 @@ version = "0.7.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "libgit2-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -974,7 +973,7 @@ name = "isatty"
+ version = "0.1.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -997,7 +996,7 @@ name = "jobserver"
+ version = "0.1.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -1067,8 +1066,8 @@ dependencies = [
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.40"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
++version = "0.2.42"
++source = "git+https://github.com/rust-lang/libc?rev=572f142#572f142459f8d42f998a8914f5a8ba3b39f91d18"
+ 
+ [[package]]
+ name = "libgit2-sys"
+@@ -1078,7 +1077,7 @@ dependencies = [
+  "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+  "cmake 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+  "curl-sys 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "libssh2-sys 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+  "openssl-sys 0.9.28 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -1091,7 +1090,7 @@ version = "0.2.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "cmake 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+  "openssl-sys 0.9.28 (registry+https://github.com/rust-lang/crates.io-index)",
+  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -1103,7 +1102,7 @@ version = "1.0.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+  "vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -1143,7 +1142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+  "filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -1210,7 +1209,7 @@ name = "memchr"
+ version = "2.0.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+ ]
+ 
+ [[package]]
+@@ -1232,7 +1231,7 @@ version = "0.1.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+ ]
+ 
+ [[package]]
+@@ -1297,7 +1296,7 @@ name = "num_cpus"
+ version = "1.8.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+ ]
+ 
+ [[package]]
+@@ -1313,7 +1312,7 @@ dependencies = [
+  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "openssl-sys 0.9.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -1328,7 +1327,7 @@ version = "0.9.28"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+  "vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -1380,7 +1379,7 @@ name = "parking_lot_core"
+ version = "0.2.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "smallvec 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -1567,7 +1566,7 @@ version = "0.3.22"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -1577,7 +1576,7 @@ version = "0.4.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -1597,7 +1596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -1777,7 +1776,7 @@ name = "rustc"
+ version = "0.0.0"
+ dependencies = [
+  "arena 0.0.0",
+- "backtrace 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "backtrace 0.3.9 (git+https://github.com/alexcrichton/backtrace-rs?rev=01219b0)",
+  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "chalk-engine 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -1931,7 +1930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -1996,7 +1995,7 @@ dependencies = [
+  "env_logger 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+  "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "jobserver 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rustc 0.0.0",
+@@ -2138,7 +2137,7 @@ dependencies = [
+  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "build_helper 0.1.0",
+  "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "rustc_cratesio_shim 0.0.0",
+ ]
+ 
+@@ -2505,7 +2504,7 @@ version = "0.3.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -2675,7 +2674,7 @@ name = "syntex_errors"
+ version = "0.52.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+  "syntex_pos 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -2697,7 +2696,7 @@ version = "0.52.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+  "syntex_errors 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -2712,7 +2711,7 @@ version = "0.4.15"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "filetime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+  "xattr 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -2731,7 +2730,7 @@ name = "tempfile"
+ version = "3.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -2783,7 +2782,7 @@ name = "termion"
+ version = "1.5.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -2827,7 +2826,7 @@ name = "time"
+ version = "0.1.39"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -3036,7 +3035,7 @@ name = "xattr"
+ version = "0.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)",
+ ]
+ 
+ [[package]]
+@@ -3060,8 +3059,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
+ "checksum assert_cli 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5da59dbd8df54562665b925b427221ceda9b771408cb8a6cbd2125d3b001330b"
+ "checksum atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "af80143d6f7608d746df1520709e5d141c96f240b0e62b0aa41bdfb53374d9d4"
+-"checksum backtrace 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbe525f66f42d207968308ee86bc2dd60aa5fab535b22e616323a173d097d8e"
+-"checksum backtrace-sys 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5fd343a2466c4603f76f38de264bc0526cffc7fa38ba52fb9f13237eccc1ced2"
++"checksum backtrace 0.3.9 (git+https://github.com/alexcrichton/backtrace-rs?rev=01219b0)" = "<none>"
++"checksum backtrace-sys 0.1.23 (git+https://github.com/alexcrichton/backtrace-rs?rev=01219b0)" = "<none>"
+ "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
+ "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
+ "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
+@@ -3142,7 +3141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+ "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
+ "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
+-"checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
++"checksum libc 0.2.42 (git+https://github.com/rust-lang/libc?rev=572f142)" = "<none>"
+ "checksum libgit2-sys 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1ecbd6428006c321c29b6c8a895f0d90152f1cf4fd8faab69fc436a3d9594f63"
+ "checksum libssh2-sys 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0db4ec23611747ef772db1c4d650f8bd762f07b461727ec998f953c614024b75"
+ "checksum libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "87f737ad6cc6fd6eefe3d9dc5412f1573865bded441300904d2f42269e140f16"
+diff --git a/src/Cargo.toml b/src/Cargo.toml
+index 47fbe77..618c3c7 100644
+--- a/src/Cargo.toml
++++ b/src/Cargo.toml
+@@ -69,3 +69,7 @@ cargo = { path = "tools/cargo" }
+ # that we're shipping as well (to ensure that the rustfmt in RLS and the
+ # `rustfmt` executable are the same exact vesion).
+ rustfmt-nightly = { path = "tools/rustfmt" }
++
++[patch.crates-io]
++backtrace = { git = "https://github.com/alexcrichton/backtrace-rs", rev = "01219b0" }
++libc = { git = "https://github.com/rust-lang/libc", rev="572f142" }
+diff --git a/src/bootstrap/lib.rs b/src/bootstrap/lib.rs
+index 6e77413..e9699f6 100644
+--- a/src/bootstrap/lib.rs
++++ b/src/bootstrap/lib.rs
+@@ -177,7 +177,7 @@ mod toolstate;
+ #[cfg(windows)]
+ mod job;
+ 
+-#[cfg(unix)]
++#[cfg(all(unix, not(target_os = "haiku")))]
+ mod job {
+     use libc;
+ 
+@@ -188,7 +188,7 @@ mod job {
+     }
+ }
+ 
+-#[cfg(not(any(unix, windows)))]
++#[cfg(any(target_os = "haiku", not(any(unix, windows))))]
+ mod job {
+     pub unsafe fn setup(_build: &mut ::Build) {
+     }
+diff --git a/src/librustc_driver/lib.rs b/src/librustc_driver/lib.rs
+index dbb6cba..8039dea 100644
+--- a/src/librustc_driver/lib.rs
++++ b/src/librustc_driver/lib.rs
+@@ -1495,7 +1495,7 @@ pub fn in_named_rustc_thread<F, R>(name: String, f: F) -> Result<R, Box<Any + Se
+     // Temporarily have stack size set to 16MB to deal with nom-using crates failing
+     const STACK_SIZE: usize = 16 * 1024 * 1024; // 16MB
+ 
+-    #[cfg(unix)]
++    #[cfg(all(unix,not(target_os = "haiku")))]
+     let spawn_thread = unsafe {
+         // Fetch the current resource limits
+         let mut rlim = libc::rlimit {
+@@ -1527,6 +1527,26 @@ pub fn in_named_rustc_thread<F, R>(name: String, f: F) -> Result<R, Box<Any + Se
+     #[cfg(windows)]
+     let spawn_thread = false;
+ 
++    #[cfg(target_os = "haiku")]
++    let spawn_thread = unsafe {
++        // Haiku does not have setrlimit implemented for the stack size.
++        // By default it does have the 16 MB stack limit, but we check this in
++        // case the minimum STACK_SIZE changes or Haiku's defaults change.
++        let mut rlim = libc::rlimit {
++            rlim_cur: 0,
++            rlim_max: 0,
++        };
++        if libc::getrlimit(libc::RLIMIT_STACK, &mut rlim) != 0 {
++            let err = io::Error::last_os_error();
++            error!("in_rustc_thread: error calling getrlimit: {}", err);
++            true
++        } else if rlim.rlim_cur >= STACK_SIZE {
++            false
++        } else {
++            true
++        }
++    };
++
+     #[cfg(not(any(windows,unix)))]
+     let spawn_thread = true;
+ 
+diff --git a/src/librustc_target/spec/x86_64_unknown_haiku.rs b/src/librustc_target/spec/x86_64_unknown_haiku.rs
+index 1e78461..68fa58b 100644
+--- a/src/librustc_target/spec/x86_64_unknown_haiku.rs
++++ b/src/librustc_target/spec/x86_64_unknown_haiku.rs
+@@ -16,6 +16,8 @@ pub fn target() -> TargetResult {
+     base.max_atomic_width = Some(64);
+     base.pre_link_args.insert(LinkerFlavor::Gcc, vec!["-m64".to_string()]);
+     base.stack_probes = true;
++    // This option is required to build executables on Haiku x86_64
++    base.position_independent_executables = true;
+ 
+     Ok(Target {
+         llvm_target: "x86_64-unknown-haiku".to_string(),
+diff --git a/src/librustdoc/lib.rs b/src/librustdoc/lib.rs
+index 1ade690..54a5a00 100644
+--- a/src/librustdoc/lib.rs
++++ b/src/librustdoc/lib.rs
+@@ -102,10 +102,14 @@ struct Output {
+ }
+ 
+ pub fn main() {
+-    const STACK_SIZE: usize = 32_000_000; // 32MB
++    let thread_stack_size: usize = if cfg!(target_os = "haiku") {
++        16_000_000 // 16MB on Haiku
++    } else {
++        32_000_000 // 32MB on other platforms
++    };
+     rustc_driver::set_sigpipe_handler();
+     env_logger::init();
+-    let res = std::thread::Builder::new().stack_size(STACK_SIZE).spawn(move || {
++    let res = std::thread::Builder::new().stack_size(thread_stack_size).spawn(move || {
+         syntax::with_globals(move || {
+             get_args().map(|args| main_args(&args)).unwrap_or(1)
+         })
+diff --git a/src/libstd/build.rs b/src/libstd/build.rs
+index c001e4e..59789a0 100644
+--- a/src/libstd/build.rs
++++ b/src/libstd/build.rs
+@@ -126,7 +126,8 @@ fn build_libbacktrace(target: &str) -> Result<(), ()> {
+     if !target.contains("apple-ios") &&
+        !target.contains("solaris") &&
+        !target.contains("redox") &&
+-       !target.contains("android") {
++       !target.contains("android") &&
++       !target.contains("haiku") {
+         build.define("HAVE_DL_ITERATE_PHDR", "1");
+     }
+     build.define("_GNU_SOURCE", "1");
+diff --git a/src/libstd/sys/unix/thread.rs b/src/libstd/sys/unix/thread.rs
+index 7fdecc9..ce6bcef 100644
+--- a/src/libstd/sys/unix/thread.rs
++++ b/src/libstd/sys/unix/thread.rs
+@@ -175,8 +175,7 @@ impl Thread {
+         unsafe {
+             let ret = libc::pthread_join(self.id, ptr::null_mut());
+             mem::forget(self);
+-            assert!(ret == 0,
+-                    "failed to join thread: {}", io::Error::from_raw_os_error(ret));
++            debug_assert_eq!(ret, 0);
+         }
+     }
+ 
+diff --git a/src/libstd/sys/windows/c.rs b/src/libstd/sys/windows/c.rs
+index 6d929f2..8a6cba2 100644
+--- a/src/libstd/sys/windows/c.rs
++++ b/src/libstd/sys/windows/c.rs
+@@ -269,7 +269,6 @@ pub const FILE_END: DWORD = 2;
+ 
+ pub const WAIT_OBJECT_0: DWORD = 0x00000000;
+ pub const WAIT_TIMEOUT: DWORD = 258;
+-pub const WAIT_FAILED: DWORD = 0xFFFFFFFF;
+ 
+ #[cfg(target_env = "msvc")]
+ #[cfg(feature = "backtrace")]
+diff --git a/src/libstd/sys/windows/thread.rs b/src/libstd/sys/windows/thread.rs
+index b6f6330..2826975 100644
+--- a/src/libstd/sys/windows/thread.rs
++++ b/src/libstd/sys/windows/thread.rs
+@@ -66,11 +66,7 @@ impl Thread {
+     }
+ 
+     pub fn join(self) {
+-        let rc = unsafe { c::WaitForSingleObject(self.handle.raw(), c::INFINITE) };
+-        if rc == c::WAIT_FAILED {
+-            panic!("failed to join on thread: {}",
+-                   io::Error::last_os_error());
+-        }
++        unsafe { c::WaitForSingleObject(self.handle.raw(), c::INFINITE); }
+     }
+ 
+     pub fn yield_now() {
+diff --git a/src/libstd/thread/mod.rs b/src/libstd/thread/mod.rs
+index 1dacf99..c075342 100644
+--- a/src/libstd/thread/mod.rs
++++ b/src/libstd/thread/mod.rs
+@@ -1300,11 +1300,6 @@ impl<T> JoinHandle<T> {
+     /// [`Err`]: ../../std/result/enum.Result.html#variant.Err
+     /// [`panic`]: ../../std/macro.panic.html
+     ///
+-    /// # Panics
+-    ///
+-    /// This function may panic on some platforms if a thread attempts to join
+-    /// itself or otherwise may create a deadlock with joining threads.
+-    ///
+     /// # Examples
+     ///
+     /// ```
+diff --git a/src/llvm/lib/Support/Unix/Path.inc b/src/llvm/lib/Support/Unix/Path.inc
+index 2ecb973..4fe5bda 100644
+--- a/src/llvm/lib/Support/Unix/Path.inc
++++ b/src/llvm/lib/Support/Unix/Path.inc
+@@ -380,6 +380,9 @@ static bool is_local_impl(struct STATVFS &Vfs) {
+ #elif defined(__CYGWIN__)
+   // Cygwin doesn't expose this information; would need to use Win32 API.
+   return false;
++#elif defined(__HAIKU__)
++  // Haiku doesn't expose this information
++  return false;
+ #elif defined(__sun)
+   // statvfs::f_basetype contains a null-terminated FSType name of the mounted target
+   StringRef fstype(Vfs.f_basetype);
+-- 
+2.16.4
+
+
+From 1eba41b305c22cb39570758367b53c936e57f03e Mon Sep 17 00:00:00 2001
+From: Niels Sascha Reedijk <niels.reedijk@gmail.com>
+Date: Wed, 1 Aug 2018 11:21:44 +0200
+Subject: Move forward liblibc to contain Haiku specific patches
+
+
+diff --git a/src/liblibc/.travis.yml b/src/liblibc/.travis.yml
+index 6acf0a8..da3124d 100644
+--- a/src/liblibc/.travis.yml
++++ b/src/liblibc/.travis.yml
+@@ -21,10 +21,13 @@ env:
+   global:
+     secure: "e2/3QjgRN9atOuSHp22TrYG7QVKcYUWY48Hi9b60w+r1+BhPkTseIJLte7WefRhdXtqpjjUJTooKDhnurFOeHaCT+nmBgiv+FPU893sBl4bhesY4m0vgUJVbNZcs6lTImYekWVb+aqjGdgV/XAgCw7c3kPmrZV0MzGDWL64Xaps="
+ matrix:
++  allow_failures:
++    # FIXME(#987) move back to include once 404 is fixed
++    - env: TARGET=s390x-unknown-linux-gnu
+   include:
+-    # 1.0.0 compat
++    # 1.13.0 compat
+     - env: TARGET=x86_64-unknown-linux-gnu NO_ADD=1
+-      rust: 1.0.0
++      rust: 1.13.0
+       script: rm -f Cargo.lock && cargo build
+       install:
+ 
+diff --git a/src/liblibc/Cargo.lock b/src/liblibc/Cargo.lock
+index 098bedb..5c02a4e 100644
+--- a/src/liblibc/Cargo.lock
++++ b/src/liblibc/Cargo.lock
+@@ -5,25 +5,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "bitflags"
+-version = "1.0.1"
++version = "1.0.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "cc"
+-version = "1.0.8"
++version = "1.0.17"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "cfg-if"
+-version = "0.1.2"
++version = "0.1.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "ctest"
+ version = "0.1.7"
+-source = "git+https://github.com/alexcrichton/ctest#954f493d482a0873866ba335bee75ce2936e5415"
++source = "git+https://github.com/alexcrichton/ctest#482c7f0643942174a802d89ad7d460e89b576ed3"
+ dependencies = [
+- "cc 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+  "syntex_syntax 0.59.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -34,13 +34,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "extprim"
+-version = "1.5.1"
++version = "1.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
++ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -48,7 +49,7 @@ name = "fuchsia-zircon"
+ version = "0.3.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -59,7 +60,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "itoa"
+-version = "0.3.4"
++version = "0.4.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+@@ -73,19 +74,19 @@ dependencies = [
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.39"
++version = "0.2.41"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.40"
++version = "0.2.42"
+ 
+ [[package]]
+ name = "libc-test"
+ version = "0.1.0"
+ dependencies = [
+  "ctest 0.1.7 (git+https://github.com/alexcrichton/ctest)",
+- "libc 0.2.40",
++ "libc 0.2.42",
+ ]
+ 
+ [[package]]
+@@ -101,25 +102,17 @@ name = "log"
+ version = "0.4.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "num-traits"
+-version = "0.1.43"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "num-traits"
+-version = "0.2.2"
++version = "0.2.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "proc-macro2"
+-version = "0.2.3"
++version = "0.4.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -127,10 +120,10 @@ dependencies = [
+ 
+ [[package]]
+ name = "quote"
+-version = "0.4.2"
++version = "0.6.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "proc-macro2 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -139,7 +132,7 @@ version = "0.4.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -166,50 +159,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "serde"
+-version = "1.0.33"
++version = "1.0.64"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "serde_derive 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "serde_derive"
+-version = "1.0.33"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-dependencies = [
+- "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde_derive_internals 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "syn 0.12.14 (registry+https://github.com/rust-lang/crates.io-index)",
+-]
+-
+-[[package]]
+-name = "serde_derive_internals"
+-version = "0.21.0"
++version = "1.0.64"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "syn 0.12.14 (registry+https://github.com/rust-lang/crates.io-index)",
++ "proc-macro2 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
++ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "syn 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "serde_json"
+-version = "1.0.11"
++version = "1.0.19"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+- "num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
++ "itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+ name = "syn"
+-version = "0.12.14"
++version = "0.14.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "proc-macro2 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
++ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -218,9 +200,9 @@ name = "syntex_errors"
+ version = "0.59.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde_derive 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
+  "syntex_pos 0.59.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -231,8 +213,8 @@ name = "syntex_pos"
+ version = "0.59.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "serde 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde_derive 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -241,11 +223,11 @@ version = "0.59.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "extprim 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "extprim 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde_derive 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+- "serde_json 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+  "syntex_errors 0.59.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "syntex_pos 0.59.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -296,32 +278,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [metadata]
+ "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
+-"checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
+-"checksum cc 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "d9324127e719125ec8a16e6e509abc4c641e773621b50aea695af3f005656d61"
+-"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
++"checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
++"checksum cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "49ec142f5768efb5b7622aebc3fdbdbb8950a4b9ba996393cb76ef7466e8747d"
++"checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
+ "checksum ctest 0.1.7 (git+https://github.com/alexcrichton/ctest)" = "<none>"
+ "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
+-"checksum extprim 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb09b6eb24a48a5c57729e4a60980bf538b3662c3bcec04b6c7908d7a0f3d9b9"
++"checksum extprim 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "054bc2552b3f66fa8097e29e47255bfff583c08e737a67cbbb54b817ddaa5206"
+ "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+ "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+-"checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
++"checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
+ "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+-"checksum libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)" = "f54263ad99207254cf58b5f701ecb432c717445ea2ee8af387334bdd1a03fdff"
++"checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"
+ "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
+ "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
+-"checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+-"checksum num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dee092fcdf725aee04dd7da1d21debff559237d49ef1cb3e69bcb8ece44c7364"
+-"checksum proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cd07deb3c6d1d9ff827999c7f9b04cdfd66b1b17ae508e14fe47b620f2282ae0"
+-"checksum quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eca14c727ad12702eb4b6bfb5a232287dcf8385cb8ca83a3eeaf6519c44c408"
++"checksum num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "775393e285254d2f5004596d69bb8bc1149754570dcc08cf30cabeba67955e28"
++"checksum proc-macro2 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1fa93823f53cfd0f5ac117b189aed6cfdfb2cfc0a9d82e956dd7927595ed7d46"
++"checksum quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e44651a0dc4cdd99f71c83b561e221f714912d11af1a4dff0631f923d53af035"
+ "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
+ "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
+ "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+ "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+-"checksum serde 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "4fe95aa0d46f04ce5c3a88bdcd4114ecd6144ed0b2725ebca2f1127744357807"
+-"checksum serde_derive 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "23b163a6ce7e1aa897919f9d8e40bd1f8a6f95342ed57727ae31387a01a7a356"
+-"checksum serde_derive_internals 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "370aa477297975243dc914d0b0e1234927520ec311de507a560fbd1c80f7ab8c"
+-"checksum serde_json 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "fab6c4d75bedcf880711c85e39ebf8ccc70d0eba259899047ec5d7436643ee17"
+-"checksum syn 0.12.14 (registry+https://github.com/rust-lang/crates.io-index)" = "8c5bc2d6ff27891209efa5f63e9de78648d7801f085e4653701a692ce938d6fd"
++"checksum serde 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)" = "fba5be06346c5200249c8c8ca4ccba4a09e8747c71c16e420bd359a0db4d8f91"
++"checksum serde_derive 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)" = "79e4620ba6fbe051fc7506fab6f84205823564d55da18d55b695160fb3479cd8"
++"checksum serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "93aee34bb692dde91e602871bc792dd319e489c7308cdbbe5f27cf27c64280f5"
++"checksum syn 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6dfd71b2be5a58ee30a6f8ea355ba8290d397131c00dfa55c3d34e6e13db5101"
+ "checksum syntex_errors 0.59.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3133289179676c9f5c5b2845bf5a2e127769f4889fcbada43035ef6bd662605e"
+ "checksum syntex_pos 0.59.1 (registry+https://github.com/rust-lang/crates.io-index)" = "30ab669fa003d208c681f874bbc76d91cc3d32550d16b5d9d2087cf477316470"
+ "checksum syntex_syntax 0.59.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03815b9f04d95828770d9c974aa39c6e1f6ef3114eb77a3ce09008a0d15dd142"
+diff --git a/src/liblibc/Cargo.toml b/src/liblibc/Cargo.toml
+index 2ecdcfb..662d0ad 100644
+--- a/src/liblibc/Cargo.toml
++++ b/src/liblibc/Cargo.toml
+@@ -1,7 +1,7 @@
+ [package]
+ 
+ name = "libc"
+-version = "0.2.40"
++version = "0.2.42"
+ authors = ["The Rust Project Developers"]
+ license = "MIT/Apache-2.0"
+ readme = "README.md"
+diff --git a/src/liblibc/README.md b/src/liblibc/README.md
+index 7ba5f84..9afd7b5 100644
+--- a/src/liblibc/README.md
++++ b/src/liblibc/README.md
+@@ -122,41 +122,41 @@ it. If you'd like to get a release out ASAP you can follow these steps:
+ The following platforms are currently tested and have documentation available:
+ 
+ Tested:
+-  * [`i686-pc-windows-msvc`](https://doc.rust-lang.org/libc/i686-pc-windows-msvc/libc/)
+-  * [`x86_64-pc-windows-msvc`](https://doc.rust-lang.org/libc/x86_64-pc-windows-msvc/libc/)
++  * [`i686-pc-windows-msvc`](https://rust-lang.github.io/libc/i686-pc-windows-msvc/libc/)
++  * [`x86_64-pc-windows-msvc`](https://rust-lang.github.io/libc/x86_64-pc-windows-msvc/libc/)
+     (Windows)
+-  * [`i686-pc-windows-gnu`](https://doc.rust-lang.org/libc/i686-pc-windows-gnu/libc/)
+-  * [`x86_64-pc-windows-gnu`](https://doc.rust-lang.org/libc/x86_64-pc-windows-gnu/libc/)
+-  * [`i686-apple-darwin`](https://doc.rust-lang.org/libc/i686-apple-darwin/libc/)
+-  * [`x86_64-apple-darwin`](https://doc.rust-lang.org/libc/x86_64-apple-darwin/libc/)
++  * [`i686-pc-windows-gnu`](https://rust-lang.github.io/libc/i686-pc-windows-gnu/libc/)
++  * [`x86_64-pc-windows-gnu`](https://rust-lang.github.io/libc/x86_64-pc-windows-gnu/libc/)
++  * [`i686-apple-darwin`](https://rust-lang.github.io/libc/i686-apple-darwin/libc/)
++  * [`x86_64-apple-darwin`](https://rust-lang.github.io/libc/x86_64-apple-darwin/libc/)
+     (OSX)
+   * `i386-apple-ios`
+   * `x86_64-apple-ios`
+-  * [`i686-unknown-linux-gnu`](https://doc.rust-lang.org/libc/i686-unknown-linux-gnu/libc/)
+-  * [`x86_64-unknown-linux-gnu`](https://doc.rust-lang.org/libc/x86_64-unknown-linux-gnu/libc/)
++  * [`i686-unknown-linux-gnu`](https://rust-lang.github.io/libc/i686-unknown-linux-gnu/libc/)
++  * [`x86_64-unknown-linux-gnu`](https://rust-lang.github.io/libc/x86_64-unknown-linux-gnu/libc/)
+     (Linux)
+-  * [`x86_64-unknown-linux-musl`](https://doc.rust-lang.org/libc/x86_64-unknown-linux-musl/libc/)
++  * [`x86_64-unknown-linux-musl`](https://rust-lang.github.io/libc/x86_64-unknown-linux-musl/libc/)
+     (Linux MUSL)
+-  * [`aarch64-unknown-linux-gnu`](https://doc.rust-lang.org/libc/aarch64-unknown-linux-gnu/libc/)
++  * [`aarch64-unknown-linux-gnu`](https://rust-lang.github.io/libc/aarch64-unknown-linux-gnu/libc/)
+     (Linux)
+   * `aarch64-unknown-linux-musl`
+     (Linux MUSL)
+-  * [`sparc64-unknown-linux-gnu`](https://doc.rust-lang.org/libc/sparc64-unknown-linux-gnu/libc/)
++  * [`sparc64-unknown-linux-gnu`](https://rust-lang.github.io/libc/sparc64-unknown-linux-gnu/libc/)
+     (Linux)
+-  * [`mips-unknown-linux-gnu`](https://doc.rust-lang.org/libc/mips-unknown-linux-gnu/libc/)
+-  * [`arm-unknown-linux-gnueabihf`](https://doc.rust-lang.org/libc/arm-unknown-linux-gnueabihf/libc/)
+-  * [`arm-linux-androideabi`](https://doc.rust-lang.org/libc/arm-linux-androideabi/libc/)
++  * [`mips-unknown-linux-gnu`](https://rust-lang.github.io/libc/mips-unknown-linux-gnu/libc/)
++  * [`arm-unknown-linux-gnueabihf`](https://rust-lang.github.io/libc/arm-unknown-linux-gnueabihf/libc/)
++  * [`arm-linux-androideabi`](https://rust-lang.github.io/libc/arm-linux-androideabi/libc/)
+     (Android)
+-  * [`x86_64-unknown-freebsd`](https://doc.rust-lang.org/libc/x86_64-unknown-freebsd/libc/)
+-  * [`x86_64-unknown-openbsd`](https://doc.rust-lang.org/libc/x86_64-unknown-openbsd/libc/)
+-  * [`x86_64-rumprun-netbsd`](https://doc.rust-lang.org/libc/x86_64-unknown-netbsd/libc/)
++  * [`x86_64-unknown-freebsd`](https://rust-lang.github.io/libc/x86_64-unknown-freebsd/libc/)
++  * [`x86_64-unknown-openbsd`](https://rust-lang.github.io/libc/x86_64-unknown-openbsd/libc/)
++  * [`x86_64-rumprun-netbsd`](https://rust-lang.github.io/libc/x86_64-unknown-netbsd/libc/)
+ 
+ The following may be supported, but are not guaranteed to always work:
+ 
+   * `i686-unknown-freebsd`
+-  * [`x86_64-unknown-bitrig`](https://doc.rust-lang.org/libc/x86_64-unknown-bitrig/libc/)
+-  * [`x86_64-unknown-dragonfly`](https://doc.rust-lang.org/libc/x86_64-unknown-dragonfly/libc/)
++  * [`x86_64-unknown-bitrig`](https://rust-lang.github.io/libc/x86_64-unknown-bitrig/libc/)
++  * [`x86_64-unknown-dragonfly`](https://rust-lang.github.io/libc/x86_64-unknown-dragonfly/libc/)
+   * `i686-unknown-haiku`
+   * `x86_64-unknown-haiku`
+-  * [`x86_64-unknown-netbsd`](https://doc.rust-lang.org/libc/x86_64-unknown-netbsd/libc/)
+-  * [`x86_64-sun-solaris`](https://doc.rust-lang.org/libc/x86_64-sun-solaris/libc/)
++  * [`x86_64-unknown-netbsd`](https://rust-lang.github.io/libc/x86_64-unknown-netbsd/libc/)
++  * [`x86_64-sun-solaris`](https://rust-lang.github.io/libc/x86_64-sun-solaris/libc/)
+diff --git a/src/liblibc/ci/linux-sparc64.sh b/src/liblibc/ci/linux-sparc64.sh
+index 33a3c46..4452b12 100644
+--- a/src/liblibc/ci/linux-sparc64.sh
++++ b/src/liblibc/ci/linux-sparc64.sh
+@@ -3,7 +3,7 @@ set -ex
+ mkdir -m 777 /qemu
+ cd /qemu
+ 
+-curl -LO https://cdimage.debian.org/cdimage/ports/debian-9.0-sparc64-NETINST-1.iso
++curl -LO https://cdimage.debian.org/cdimage/ports/9.0/sparc64/iso-cd/debian-9.0-sparc64-NETINST-1.iso
+ 7z e debian-9.0-sparc64-NETINST-1.iso boot/initrd.gz
+ 7z e debian-9.0-sparc64-NETINST-1.iso boot/sparc64
+ mv sparc64 kernel
+diff --git a/src/liblibc/ci/style.rs b/src/liblibc/ci/style.rs
+index 32e4ba7..bf31576 100644
+--- a/src/liblibc/ci/style.rs
++++ b/src/liblibc/ci/style.rs
+@@ -127,7 +127,9 @@ fn check_style(file: &str, path: &Path, err: &mut Errors) {
+         if line.contains("extern \"C\"") {
+             err.error(path, i, "use `extern` instead of `extern \"C\"");
+         }
+-        if line.contains("#[cfg(") && !line.contains(" if ") {
++        if line.contains("#[cfg(") && !line.contains(" if ")
++            && !line.contains("target_endian")
++        {
+             if state != State::Structs {
+                 err.error(path, i, "use cfg_if! and submodules \
+                                     instead of #[cfg]");
+diff --git a/src/liblibc/libc-test/build.rs b/src/liblibc/libc-test/build.rs
+index a96bcfd..a39e317 100644
+--- a/src/liblibc/libc-test/build.rs
++++ b/src/liblibc/libc-test/build.rs
+@@ -33,6 +33,8 @@ fn main() {
+         cfg.define("_GNU_SOURCE", None);
+     } else if netbsd {
+         cfg.define("_NETBSD_SOURCE", Some("1"));
++    } else if apple {
++        cfg.define("__APPLE_USE_RFC_3542", None);
+     } else if windows {
+         cfg.define("_WIN32_WINNT", Some("0x8000"));
+     } else if solaris {
+@@ -82,6 +84,7 @@ fn main() {
+             cfg.header("sys/socket.h");
+         }
+         cfg.header("net/if.h");
++        cfg.header("net/route.h");
+         cfg.header("netdb.h");
+         cfg.header("netinet/in.h");
+         cfg.header("netinet/ip.h");
+@@ -132,6 +135,7 @@ fn main() {
+         cfg.header("arpa/inet.h");
+         cfg.header("xlocale.h");
+         cfg.header("utmp.h");
++        cfg.header("ifaddrs.h");
+         if i686 || x86_64 {
+             cfg.header("sys/reg.h");
+         }
+@@ -178,6 +182,7 @@ fn main() {
+         }
+         cfg.header("net/route.h");
+         cfg.header("netinet/if_ether.h");
++        cfg.header("netinet/in.h");
+         cfg.header("sys/proc_info.h");
+         cfg.header("sys/kern_control.h");
+         cfg.header("sys/ipc.h");
+@@ -242,6 +247,7 @@ fn main() {
+         }
+         cfg.header("sys/reboot.h");
+         if !emscripten {
++            cfg.header("linux/sockios.h");
+             cfg.header("linux/netlink.h");
+             cfg.header("linux/genetlink.h");
+             cfg.header("linux/netfilter_ipv4.h");
+@@ -416,7 +422,9 @@ fn main() {
+             // which is absent in glibc, has to be defined.
+             "__timeval" if linux => true,
+ 
+-            // The alignment of this is 4 on 64-bit OSX...
++            // Fixed on stdbuild with repr(packed(4))
++            // Once repr_packed stabilizes we can fix this unconditionally
++            // and remove this check.
+             "kevent" | "shmid_ds" if apple && x86_64 => true,
+ 
+             // This is actually a union, not a struct
+@@ -516,6 +524,9 @@ fn main() {
+             "EVFILT_PROCDESC" | "EVFILT_SENDFILE" | "EVFILT_EMPTY" |
+             "PD_CLOEXEC" | "PD_ALLOWED_AT_FORK" if freebsd => true,
+ 
++            // These constants were added in FreeBSD 12
++            "SF_USER_READAHEAD" if freebsd => true,
++
+             // These OSX constants are removed in Sierra.
+             // https://developer.apple.com/library/content/releasenotes/General/APIDiffsMacOS10_12/Swift/Darwin.html
+             "KERN_KDENABLE_BG_TRACE" if apple => true,
+@@ -526,9 +537,12 @@ fn main() {
+             "KERN_USERMOUNT" |
+             "KERN_ARND" if openbsd => true,
+ 
+-            // These constats were added in OpenBSD 6.2
++            // These constants were added in OpenBSD 6.2
+             "EV_RECEIPT" | "EV_DISPATCH" if openbsd => true,
+ 
++            // These constants were added in OpenBSD 6.3
++            "MAP_STACK" if openbsd => true,
++
+             // These are either unimplemented or optionally built into uClibc
+             "LC_CTYPE_MASK" | "LC_NUMERIC_MASK" | "LC_TIME_MASK" | "LC_COLLATE_MASK" | "LC_MONETARY_MASK" | "LC_MESSAGES_MASK" |
+             "MADV_MERGEABLE" | "MADV_UNMERGEABLE" | "MADV_HWPOISON" | "IPV6_ADD_MEMBERSHIP" | "IPV6_DROP_MEMBERSHIP" | "IPV6_MULTICAST_LOOP" | "IPV6_V6ONLY" |
+diff --git a/src/liblibc/src/dox.rs b/src/liblibc/src/dox.rs
+index 1aea62d..779641b 100644
+--- a/src/liblibc/src/dox.rs
++++ b/src/liblibc/src/dox.rs
+@@ -19,6 +19,16 @@ mod imp {
+         fn clone(&self) -> Option<T> { loop {} }
+     }
+ 
++    impl<T> Copy for *mut T {}
++    impl<T> Clone for *mut T {
++        fn clone(&self) -> *mut T { loop {} }
++    }
++
++    impl<T> Copy for *const T {}
++    impl<T> Clone for *const T {
++        fn clone(&self) -> *const T { loop {} }
++    }
++
+     pub trait Clone {
+         fn clone(&self) -> Self;
+     }
+@@ -58,13 +68,13 @@ mod imp {
+     }
+ 
+     #[lang = "div"]
+-    pub trait Div<RHS> {
++    pub trait Div<RHS=Self> {
+         type Output;
+         fn div(self, rhs: RHS) -> Self::Output;
+     }
+ 
+     #[lang = "shl"]
+-    pub trait Shl<RHS> {
++    pub trait Shl<RHS=Self> {
+         type Output;
+         fn shl(self, rhs: RHS) -> Self::Output;
+     }
+@@ -81,12 +91,39 @@ mod imp {
+         fn sub(self, rhs: RHS) -> Self::Output;
+     }
+ 
++    #[lang = "bitand"]
++    pub trait BitAnd<RHS=Self> {
++        type Output;
++        fn bitand(self, rhs: RHS) -> Self::Output;
++    }
++
++    #[lang = "bitand_assign"]
++    pub trait BitAndAssign<RHS = Self> {
++        fn bitand_assign(&mut self, rhs: RHS);
++    }
++
+     #[lang = "bitor"]
+-    pub trait Bitor<RHS=Self> {
++    pub trait BitOr<RHS=Self> {
+         type Output;
+         fn bitor(self, rhs: RHS) -> Self::Output;
+     }
+ 
++    #[lang = "bitor_assign"]
++    pub trait BitOrAssign<RHS = Self> {
++        fn bitor_assign(&mut self, rhs: RHS);
++    }
++
++    #[lang = "bitxor"]
++    pub trait BitXor<RHS=Self> {
++        type Output;
++        fn bitxor(self, rhs: RHS) -> Self::Output;
++    }
++
++    #[lang = "bitxor_assign"]
++    pub trait BitXorAssign<RHS = Self> {
++        fn bitxor_assign(&mut self, rhs: RHS);
++    }
++
+     #[lang = "neg"]
+     pub trait Neg {
+         type Output;
+@@ -124,10 +161,27 @@ mod imp {
+                 type Output = $i;
+                 fn sub(self, rhs: $i) -> $i { self - rhs }
+             }
+-            impl Bitor for $i {
++            impl BitAnd for $i {
++                type Output = $i;
++                fn bitand(self, rhs: $i) -> $i { self & rhs }
++            }
++            impl BitAndAssign for $i {
++                fn bitand_assign(&mut self, rhs: $i) { *self &= rhs; }
++            }
++            impl BitOr for $i {
+                 type Output = $i;
+                 fn bitor(self, rhs: $i) -> $i { self | rhs }
+             }
++            impl BitOrAssign for $i {
++                fn bitor_assign(&mut self, rhs: $i) { *self |= rhs; }
++            }
++            impl BitXor for $i {
++                type Output = $i;
++                fn bitxor(self, rhs: $i) -> $i { self ^ rhs }
++            }
++            impl BitXorAssign for $i {
++                fn bitxor_assign(&mut self, rhs: $i) { *self ^= rhs; }
++            }
+             impl Neg for $i {
+                 type Output = $i;
+                 fn neg(self) -> $i { -self }
+@@ -140,12 +194,16 @@ mod imp {
+                 type Output = $i;
+                 fn add(self, other: $i) -> $i { self + other }
+             }
++            impl Copy for $i {}
++            impl Clone for $i {
++                fn clone(&self) -> $i { loop {} }
++            }
+         )*)
+     }
+     each_int!(impl_traits);
+ 
+     pub mod mem {
+         pub fn size_of_val<T>(_: &T) -> usize { 4 }
+-        pub fn size_of<T>(_: &T) -> usize { 4 }
++        pub const fn size_of<T>() -> usize { 4 }
+     }
+ }
+diff --git a/src/liblibc/src/fuchsia/mod.rs b/src/liblibc/src/fuchsia/mod.rs
+index 929acaf..0aac985 100644
+--- a/src/liblibc/src/fuchsia/mod.rs
++++ b/src/liblibc/src/fuchsia/mod.rs
+@@ -3796,6 +3796,8 @@ extern {
+     pub fn sched_rr_get_interval(pid: ::pid_t, tp: *mut ::timespec) -> ::c_int;
+     pub fn sem_timedwait(sem: *mut sem_t,
+                          abstime: *const ::timespec) -> ::c_int;
++    pub fn sem_getvalue(sem: *mut sem_t,
++                        sval: *mut ::c_int) -> ::c_int;
+     pub fn sched_setparam(pid: ::pid_t, param: *const ::sched_param) -> ::c_int;
+     pub fn setns(fd: ::c_int, nstype: ::c_int) -> ::c_int;
+     pub fn swapoff(puath: *const ::c_char) -> ::c_int;
+diff --git a/src/liblibc/src/lib.rs b/src/liblibc/src/lib.rs
+index 2555480..489315c 100644
+--- a/src/liblibc/src/lib.rs
++++ b/src/liblibc/src/lib.rs
+@@ -13,81 +13,81 @@
+ #![allow(bad_style, overflowing_literals, improper_ctypes)]
+ #![crate_type = "rlib"]
+ #![crate_name = "libc"]
+-#![cfg_attr(cross_platform_docs, feature(no_core, lang_items))]
++#![cfg_attr(cross_platform_docs, feature(no_core, lang_items, const_fn))]
+ #![cfg_attr(cross_platform_docs, no_core)]
+ #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
+        html_favicon_url = "https://doc.rust-lang.org/favicon.ico")]
+ 
+ #![cfg_attr(all(target_os = "linux", target_arch = "x86_64"), doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-linux-gnu"
++    html_root_url = "https://rust-lang.github.io/libc/x86_64-unknown-linux-gnu"
+ ))]
+ #![cfg_attr(all(target_os = "linux", target_arch = "x86"), doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/i686-unknown-linux-gnu"
++    html_root_url = "https://rust-lang.github.io/libc/i686-unknown-linux-gnu"
+ ))]
+ #![cfg_attr(all(target_os = "linux", target_arch = "arm"), doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/arm-unknown-linux-gnueabihf"
++    html_root_url = "https://rust-lang.github.io/libc/arm-unknown-linux-gnueabihf"
+ ))]
+ #![cfg_attr(all(target_os = "linux", target_arch = "mips"), doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/mips-unknown-linux-gnu"
++    html_root_url = "https://rust-lang.github.io/libc/mips-unknown-linux-gnu"
+ ))]
+ #![cfg_attr(all(target_os = "linux", target_arch = "aarch64"), doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/aarch64-unknown-linux-gnu"
++    html_root_url = "https://rust-lang.github.io/libc/aarch64-unknown-linux-gnu"
+ ))]
+ #![cfg_attr(all(target_os = "linux", target_env = "musl"), doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-linux-musl"
++    html_root_url = "https://rust-lang.github.io/libc/x86_64-unknown-linux-musl"
+ ))]
+ #![cfg_attr(all(target_os = "macos", target_arch = "x86_64"), doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/x86_64-apple-darwin"
++    html_root_url = "https://rust-lang.github.io/libc/x86_64-apple-darwin"
+ ))]
+ #![cfg_attr(all(target_os = "macos", target_arch = "x86"), doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/i686-apple-darwin"
++    html_root_url = "https://rust-lang.github.io/libc/i686-apple-darwin"
+ ))]
+ #![cfg_attr(all(windows, target_arch = "x86_64", target_env = "gnu"), doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/x86_64-pc-windows-gnu"
++    html_root_url = "https://rust-lang.github.io/libc/x86_64-pc-windows-gnu"
+ ))]
+ #![cfg_attr(all(windows, target_arch = "x86", target_env = "gnu"), doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/i686-pc-windows-gnu"
++    html_root_url = "https://rust-lang.github.io/libc/i686-pc-windows-gnu"
+ ))]
+ #![cfg_attr(all(windows, target_arch = "x86_64", target_env = "msvc"), doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/x86_64-pc-windows-msvc"
++    html_root_url = "https://rust-lang.github.io/libc/x86_64-pc-windows-msvc"
+ ))]
+ #![cfg_attr(all(windows, target_arch = "x86", target_env = "msvc"), doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/i686-pc-windows-msvc"
++    html_root_url = "https://rust-lang.github.io/libc/i686-pc-windows-msvc"
+ ))]
+ #![cfg_attr(target_os = "android", doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/arm-linux-androideabi"
++    html_root_url = "https://rust-lang.github.io/libc/arm-linux-androideabi"
+ ))]
+ #![cfg_attr(target_os = "freebsd", doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-freebsd"
++    html_root_url = "https://rust-lang.github.io/libc/x86_64-unknown-freebsd"
+ ))]
+ #![cfg_attr(target_os = "openbsd", doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-openbsd"
++    html_root_url = "https://rust-lang.github.io/libc/x86_64-unknown-openbsd"
+ ))]
+ #![cfg_attr(target_os = "bitrig", doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-bitrig"
++    html_root_url = "https://rust-lang.github.io/libc/x86_64-unknown-bitrig"
+ ))]
+ #![cfg_attr(target_os = "netbsd", doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-netbsd"
++    html_root_url = "https://rust-lang.github.io/libc/x86_64-unknown-netbsd"
+ ))]
+ #![cfg_attr(target_os = "dragonfly", doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/x86_64-unknown-dragonfly"
++    html_root_url = "https://rust-lang.github.io/libc/x86_64-unknown-dragonfly"
+ ))]
+ #![cfg_attr(target_os = "solaris", doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/x86_64-sun-solaris"
++    html_root_url = "https://rust-lang.github.io/libc/x86_64-sun-solaris"
+ ))]
+ #![cfg_attr(all(target_os = "emscripten", target_arch = "asmjs"), doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/asmjs-unknown-emscripten"
++    html_root_url = "https://rust-lang.github.io/libc/asmjs-unknown-emscripten"
+ ))]
+ #![cfg_attr(all(target_os = "emscripten", target_arch = "wasm32"), doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/wasm32-unknown-emscripten"
++    html_root_url = "https://rust-lang.github.io/libc/wasm32-unknown-emscripten"
+ ))]
+ #![cfg_attr(all(target_os = "linux", target_arch = "sparc64"), doc(
+-    html_root_url = "https://doc.rust-lang.org/libc/sparc64-unknown-linux-gnu"
++    html_root_url = "https://rust-lang.github.io/libc/sparc64-unknown-linux-gnu"
+ ))]
+ 
+ // Attributes needed when building as part of the standard library
+ #![cfg_attr(feature = "stdbuild", feature(no_std, staged_api, custom_attribute, cfg_target_vendor))]
+-#![cfg_attr(feature = "stdbuild", feature(link_cfg))]
++#![cfg_attr(feature = "stdbuild", feature(link_cfg, repr_packed))]
+ #![cfg_attr(feature = "stdbuild", no_std)]
+ #![cfg_attr(feature = "stdbuild", staged_api)]
+ #![cfg_attr(feature = "stdbuild", allow(warnings))]
+diff --git a/src/liblibc/src/redox/mod.rs b/src/liblibc/src/redox/mod.rs
+index 82b296f..793fd32 100644
+--- a/src/liblibc/src/redox/mod.rs
++++ b/src/liblibc/src/redox/mod.rs
+@@ -85,7 +85,40 @@ pub const O_SYMLINK: ::c_int =    0x4000_0000;
+ pub const O_NOFOLLOW: ::c_int =   0x8000_0000;
+ pub const O_ACCMODE: ::c_int =    O_RDONLY | O_WRONLY | O_RDWR;
+ 
++pub const SIGHUP:    ::c_int = 1;
++pub const SIGINT:    ::c_int = 2;
++pub const SIGQUIT:   ::c_int = 3;
++pub const SIGILL:    ::c_int = 4;
++pub const SIGTRAP:   ::c_int = 5;
++pub const SIGABRT:   ::c_int = 6;
++pub const SIGBUS:    ::c_int = 7;
++pub const SIGFPE:    ::c_int = 8;
++pub const SIGKILL:   ::c_int = 9;
++pub const SIGUSR1:   ::c_int = 10;
++pub const SIGSEGV:   ::c_int = 11;
++pub const SIGUSR2:   ::c_int = 12;
++pub const SIGPIPE:   ::c_int = 13;
++pub const SIGALRM:   ::c_int = 14;
++pub const SIGTERM:   ::c_int = 15;
++pub const SIGSTKFLT: ::c_int = 16;
++pub const SIGCHLD:   ::c_int = 17;
++pub const SIGCONT:   ::c_int = 18;
++pub const SIGSTOP:   ::c_int = 19;
++pub const SIGTSTP:   ::c_int = 20;
++pub const SIGTTIN:   ::c_int = 21;
++pub const SIGTTOU:   ::c_int = 22;
++pub const SIGURG:    ::c_int = 23;
++pub const SIGXCPU:   ::c_int = 24;
++pub const SIGXFSZ:   ::c_int = 25;
++pub const SIGVTALRM: ::c_int = 26;
++pub const SIGPROF:   ::c_int = 27;
++pub const SIGWINCH:  ::c_int = 28;
++pub const SIGIO:     ::c_int = 29;
++pub const SIGPWR:    ::c_int = 30;
++pub const SIGSYS:    ::c_int = 31;
++
+ extern {
++    pub fn gethostname(name: *mut ::c_char, len: ::size_t) -> ::c_int;
+     pub fn memalign(align: ::size_t, size: ::size_t) -> *mut ::c_void;
+     pub fn read(fd: ::c_int, buf: *mut ::c_void, count: ::size_t)
+                 -> ::ssize_t;
+diff --git a/src/liblibc/src/redox/net.rs b/src/liblibc/src/redox/net.rs
+index 0916916..a545ba4 100644
+--- a/src/liblibc/src/redox/net.rs
++++ b/src/liblibc/src/redox/net.rs
+@@ -107,4 +107,16 @@ extern {
+     pub fn setsockopt(socket: ::c_int, level: ::c_int, name: ::c_int,
+                       value: *const ::c_void,
+                       option_len: socklen_t) -> ::c_int;
++    pub fn getpeername(socket: ::c_int, address: *mut sockaddr,
++                       address_len: *mut socklen_t) -> ::c_int;
++    pub fn sendto(socket: ::c_int, buf: *const ::c_void, len: ::size_t,
++                  flags: ::c_int, addr: *const sockaddr,
++                  addrlen: socklen_t) -> ::ssize_t;
++    pub fn send(socket: ::c_int, buf: *const ::c_void, len: ::size_t,
++                flags: ::c_int) -> ::ssize_t;
++    pub fn recvfrom(socket: ::c_int, buf: *mut ::c_void, len: ::size_t,
++                    flags: ::c_int, addr: *mut ::sockaddr,
++                    addrlen: *mut ::socklen_t) -> ::ssize_t;
++    pub fn recv(socket: ::c_int, buf: *mut ::c_void, len: ::size_t,
++                flags: ::c_int) -> ::ssize_t;
+ }
+diff --git a/src/liblibc/src/unix/bsd/apple/mod.rs b/src/liblibc/src/unix/bsd/apple/mod.rs
+index 9cd5db6..d97eb3f 100644
+--- a/src/liblibc/src/unix/bsd/apple/mod.rs
++++ b/src/liblibc/src/unix/bsd/apple/mod.rs
+@@ -245,7 +245,7 @@ s! {
+         pub f_reserved: [::uint32_t; 8],
+     }
+ 
+-    // FIXME: this should have align 4 but it's got align 8 on 64-bit
++    #[cfg_attr(feature = "stdbuild", repr(packed(4)))]
+     pub struct kevent {
+         pub ident: ::uintptr_t,
+         pub filter: ::int16_t,
+@@ -512,6 +512,17 @@ s! {
+         pub sc_reserved: [::uint32_t; 5],
+     }
+ 
++    pub struct in_pktinfo {
++        pub ipi_ifindex: ::c_uint,
++        pub ipi_spec_dst: ::in_addr,
++        pub ipi_addr: ::in_addr,
++    }
++
++    pub struct in6_pktinfo {
++        pub ipi6_addr: ::in6_addr,
++        pub ipi6_ifindex: ::c_uint,
++    }
++
+     // sys/ipc.h:
+ 
+     pub struct ipc_perm {
+@@ -524,7 +535,7 @@ s! {
+         pub _key: ::key_t,
+     }
+ 
+-    // FIXME: this should have align 4 but it's got align 8 on 64-bit
++    #[cfg_attr(feature = "stdbuild", repr(packed(4)))]
+     pub struct shmid_ds {
+         pub shm_perm: ipc_perm,
+         pub shm_segsz: ::size_t,
+@@ -1503,8 +1514,11 @@ pub const IP_TTL: ::c_int = 4;
+ pub const IP_HDRINCL: ::c_int = 2;
+ pub const IP_ADD_MEMBERSHIP: ::c_int = 12;
+ pub const IP_DROP_MEMBERSHIP: ::c_int = 13;
++pub const IP_PKTINFO: ::c_int = 26;
+ pub const IPV6_JOIN_GROUP: ::c_int = 12;
+ pub const IPV6_LEAVE_GROUP: ::c_int = 13;
++pub const IPV6_PKTINFO: ::c_int = 46;
++pub const IPV6_RECVPKTINFO: ::c_int = 61;
+ 
+ pub const TCP_NODELAY: ::c_int = 0x01;
+ pub const TCP_KEEPALIVE: ::c_int = 0x10;
+diff --git a/src/liblibc/src/unix/bsd/freebsdlike/freebsd/mod.rs b/src/liblibc/src/unix/bsd/freebsdlike/freebsd/mod.rs
+index a2a6d69..def81df 100644
+--- a/src/liblibc/src/unix/bsd/freebsdlike/freebsd/mod.rs
++++ b/src/liblibc/src/unix/bsd/freebsdlike/freebsd/mod.rs
+@@ -168,6 +168,8 @@ pub const SIGSTKSZ: ::size_t = 34816;
+ pub const SF_NODISKIO: ::c_int = 0x00000001;
+ pub const SF_MNOWAIT: ::c_int = 0x00000002;
+ pub const SF_SYNC: ::c_int = 0x00000004;
++pub const SF_USER_READAHEAD: ::c_int = 0x00000008;
++pub const SF_NOCACHE: ::c_int = 0x00000010;
+ pub const O_CLOEXEC: ::c_int = 0x00100000;
+ pub const O_DIRECTORY: ::c_int = 0x00020000;
+ pub const O_EXEC: ::c_int = 0x00040000;
+diff --git a/src/liblibc/src/unix/bsd/freebsdlike/mod.rs b/src/liblibc/src/unix/bsd/freebsdlike/mod.rs
+index b392242..cf3e41b 100644
+--- a/src/liblibc/src/unix/bsd/freebsdlike/mod.rs
++++ b/src/liblibc/src/unix/bsd/freebsdlike/mod.rs
+@@ -175,6 +175,11 @@ s! {
+         pub type_: ::c_ushort,
+         pub prio: ::c_ushort,
+     }
++
++    pub struct in6_pktinfo {
++        pub ipi6_addr: ::in6_addr,
++        pub ipi6_ifindex: ::c_uint,
++    }
+ }
+ 
+ pub const AIO_LISTIO_MAX: ::c_int = 16;
+@@ -635,13 +640,20 @@ pub const SOCK_NONBLOCK: ::c_int = 0x20000000;
+ pub const SOCK_MAXADDRLEN: ::c_int = 255;
+ pub const IP_TTL: ::c_int = 4;
+ pub const IP_HDRINCL: ::c_int = 2;
++pub const IP_RECVDSTADDR: ::c_int = 7;
++pub const IP_SENDSRCADDR: ::c_int = IP_RECVDSTADDR;
+ pub const IP_ADD_MEMBERSHIP: ::c_int = 12;
+ pub const IP_DROP_MEMBERSHIP: ::c_int = 13;
+ pub const IPV6_JOIN_GROUP: ::c_int = 12;
+ pub const IPV6_LEAVE_GROUP: ::c_int = 13;
++pub const IPV6_RECVPKTINFO: ::c_int = 36;
++pub const IPV6_PKTINFO: ::c_int = 46;
++
++pub const TCP_NODELAY:   ::c_int = 1;
++pub const TCP_KEEPIDLE:  ::c_int = 256;
++pub const TCP_KEEPINTVL: ::c_int = 512;
++pub const TCP_KEEPCNT:   ::c_int = 1024;
+ 
+-pub const TCP_NODELAY: ::c_int = 1;
+-pub const TCP_KEEPIDLE: ::c_int = 256;
+ pub const SOL_SOCKET: ::c_int = 0xffff;
+ pub const SO_DEBUG: ::c_int = 0x01;
+ pub const SO_ACCEPTCONN: ::c_int = 0x0002;
+@@ -1172,6 +1184,8 @@ extern {
+     pub fn sethostname(name: *const ::c_char, len: ::c_int) -> ::c_int;
+     pub fn sem_timedwait(sem: *mut sem_t,
+                          abstime: *const ::timespec) -> ::c_int;
++    pub fn sem_getvalue(sem: *mut sem_t,
++                        sval: *mut ::c_int) -> ::c_int;
+     pub fn pthread_mutex_timedlock(lock: *mut pthread_mutex_t,
+                                    abstime: *const ::timespec) -> ::c_int;
+     pub fn pipe2(fds: *mut ::c_int, flags: ::c_int) -> ::c_int;
+diff --git a/src/liblibc/src/unix/bsd/netbsdlike/mod.rs b/src/liblibc/src/unix/bsd/netbsdlike/mod.rs
+index 647e25d..a7c6f96 100644
+--- a/src/liblibc/src/unix/bsd/netbsdlike/mod.rs
++++ b/src/liblibc/src/unix/bsd/netbsdlike/mod.rs
+@@ -35,6 +35,11 @@ s! {
+         pub sin_zero: [::int8_t; 8],
+     }
+ 
++    pub struct in6_pktinfo {
++        pub ipi6_addr: ::in6_addr,
++        pub ipi6_ifindex: ::c_uint,
++    }
++
+     pub struct termios {
+         pub c_iflag: ::tcflag_t,
+         pub c_oflag: ::tcflag_t,
+@@ -177,7 +182,6 @@ pub const SIGSEGV : ::c_int = 11;
+ pub const SIGPIPE : ::c_int = 13;
+ pub const SIGALRM : ::c_int = 14;
+ pub const SIGTERM : ::c_int = 15;
+-pub const SIGSTKSZ : ::size_t = 40960;
+ 
+ pub const PROT_NONE : ::c_int = 0;
+ pub const PROT_READ : ::c_int = 1;
+@@ -413,8 +417,15 @@ pub const IP_TTL: ::c_int = 4;
+ pub const IP_HDRINCL: ::c_int = 2;
+ pub const IP_ADD_MEMBERSHIP: ::c_int = 12;
+ pub const IP_DROP_MEMBERSHIP: ::c_int = 13;
++pub const IPV6_RECVPKTINFO: ::c_int = 36;
++pub const IPV6_PKTINFO: ::c_int = 46;
++
++pub const TCP_NODELAY:    ::c_int = 0x01;
++pub const TCP_KEEPIDLE:   ::c_int = 3;
++pub const TCP_KEEPINTVL:  ::c_int = 5;
++pub const TCP_KEEPCNT:    ::c_int = 6;
++pub const TCP_KEEPINIT:   ::c_int = 7;
+ 
+-pub const TCP_NODELAY: ::c_int = 0x01;
+ pub const SOL_SOCKET: ::c_int = 0xffff;
+ pub const SO_DEBUG: ::c_int = 0x01;
+ pub const SO_ACCEPTCONN: ::c_int = 0x0002;
+@@ -547,6 +558,9 @@ pub const TIOCMBIS: ::c_ulong = 0x8004746c;
+ pub const TIOCMSET: ::c_ulong = 0x8004746d;
+ pub const TIOCSTART: ::c_ulong = 0x2000746e;
+ pub const TIOCSTOP: ::c_ulong = 0x2000746f;
++pub const TIOCSCTTY: ::c_ulong = 0x20007461;
++pub const TIOCGWINSZ: ::c_ulong = 0x40087468;
++pub const TIOCSWINSZ: ::c_ulong = 0x80087467;
+ pub const TIOCM_LE: ::c_int = 0o0001;
+ pub const TIOCM_DTR: ::c_int = 0o0002;
+ pub const TIOCM_RTS: ::c_int = 0o0004;
+@@ -625,6 +639,8 @@ extern {
+                     mode: ::mode_t) -> ::c_int;
+     pub fn sem_timedwait(sem: *mut sem_t,
+                          abstime: *const ::timespec) -> ::c_int;
++    pub fn sem_getvalue(sem: *mut sem_t,
++                        sval: *mut ::c_int) -> ::c_int;
+     pub fn pthread_condattr_setclock(attr: *mut pthread_condattr_t,
+                                      clock_id: ::clockid_t) -> ::c_int;
+     pub fn sethostname(name: *const ::c_char, len: ::size_t) -> ::c_int;
+diff --git a/src/liblibc/src/unix/bsd/netbsdlike/netbsd/mod.rs b/src/liblibc/src/unix/bsd/netbsdlike/netbsd/mod.rs
+index e4c4ea1..01dd188 100644
+--- a/src/liblibc/src/unix/bsd/netbsdlike/netbsd/mod.rs
++++ b/src/liblibc/src/unix/bsd/netbsdlike/netbsd/mod.rs
+@@ -313,6 +313,11 @@ s! {
+         pub sdl_slen: ::uint8_t,
+         pub sdl_data: [::c_char; 12],
+     }
++
++    pub struct in_pktinfo {
++        pub ipi_addr: ::in_addr,
++        pub ipi_ifindex: ::c_uint,
++    }
+ }
+ 
+ pub const AT_FDCWD: ::c_int = -100;
+@@ -371,6 +376,8 @@ pub const F_GETNOSIGPIPE: ::c_int = 13;
+ pub const F_SETNOSIGPIPE: ::c_int = 14;
+ pub const F_MAXFD: ::c_int = 11;
+ 
++pub const IP_PKTINFO: ::c_int = 25;
++pub const IP_RECVPKTINFO: ::c_int = 26;
+ pub const IPV6_JOIN_GROUP: ::c_int = 12;
+ pub const IPV6_LEAVE_GROUP: ::c_int = 13;
+ 
+@@ -947,6 +954,8 @@ pub const CHWFLOW: ::tcflag_t = ::MDMBUF | ::CRTSCTS | ::CDTRCTS;
+ pub const SOCK_CLOEXEC: ::c_int = 0x10000000;
+ pub const SOCK_NONBLOCK: ::c_int = 0x20000000;
+ 
++pub const SIGSTKSZ : ::size_t = 40960;
++
+ // dirfd() is a macro on netbsd to access
+ // the first field of the struct where dirp points to:
+ // http://cvsweb.netbsd.org/bsdweb.cgi/src/include/dirent.h?rev=1.36
+diff --git a/src/liblibc/src/unix/bsd/netbsdlike/openbsdlike/bitrig/mod.rs b/src/liblibc/src/unix/bsd/netbsdlike/openbsdlike/bitrig/mod.rs
+index 7250ef5..5574204 100644
+--- a/src/liblibc/src/unix/bsd/netbsdlike/openbsdlike/bitrig/mod.rs
++++ b/src/liblibc/src/unix/bsd/netbsdlike/openbsdlike/bitrig/mod.rs
+@@ -83,6 +83,8 @@ pub const IFF_LINK1: ::c_int = 0x2000; // per link layer defined bit
+ pub const IFF_LINK2: ::c_int = 0x4000; // per link layer defined bit
+ pub const IFF_MULTICAST: ::c_int = 0x8000; // supports multicast
+ 
++pub const SIGSTKSZ : ::size_t = 40960;
++
+ extern {
+     pub fn nl_langinfo_l(item: ::nl_item, locale: ::locale_t) -> *mut ::c_char;
+     pub fn duplocale(base: ::locale_t) -> ::locale_t;
+diff --git a/src/liblibc/src/unix/bsd/netbsdlike/openbsdlike/mod.rs b/src/liblibc/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
+index 5eece5b..e44bfca 100644
+--- a/src/liblibc/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
++++ b/src/liblibc/src/unix/bsd/netbsdlike/openbsdlike/mod.rs
+@@ -308,6 +308,9 @@ pub const IPPROTO_MAX: ::c_int = 256;
+ /// Divert sockets
+ pub const IPPROTO_DIVERT: ::c_int = 258;
+ 
++pub const IP_RECVDSTADDR: ::c_int = 7;
++pub const IP_SENDSRCADDR: ::c_int = IP_RECVDSTADDR;
++
+ pub const AF_ECMA: ::c_int = 8;
+ pub const AF_ROUTE: ::c_int = 17;
+ pub const AF_ENCAP: ::c_int = 28;
+diff --git a/src/liblibc/src/unix/bsd/netbsdlike/openbsdlike/openbsd/mod.rs b/src/liblibc/src/unix/bsd/netbsdlike/openbsdlike/openbsd/mod.rs
+index c4a6080..cca8a47 100644
+--- a/src/liblibc/src/unix/bsd/netbsdlike/openbsdlike/openbsd/mod.rs
++++ b/src/liblibc/src/unix/bsd/netbsdlike/openbsdlike/openbsd/mod.rs
+@@ -27,6 +27,8 @@ s! {
+     }
+ }
+ 
++pub const MAP_STACK : ::c_int = 0x4000;
++
+ // https://github.com/openbsd/src/blob/master/sys/net/if.h#L187
+ pub const IFF_UP: ::c_int = 0x1; // interface is up
+ pub const IFF_BROADCAST: ::c_int = 0x2; // broadcast address valid
+@@ -45,6 +47,8 @@ pub const IFF_LINK1: ::c_int = 0x2000; // per link layer defined bit
+ pub const IFF_LINK2: ::c_int = 0x4000; // per link layer defined bit
+ pub const IFF_MULTICAST: ::c_int = 0x8000; // supports multicast
+ 
++pub const SIGSTKSZ : ::size_t = 24576;
++
+ extern {
+     pub fn accept4(s: ::c_int, addr: *mut ::sockaddr,
+                    addrlen: *mut ::socklen_t, flags: ::c_int) -> ::c_int;
+diff --git a/src/liblibc/src/unix/haiku/mod.rs b/src/liblibc/src/unix/haiku/mod.rs
+index 9b0252d..fc8a583 100644
+--- a/src/liblibc/src/unix/haiku/mod.rs
++++ b/src/liblibc/src/unix/haiku/mod.rs
+@@ -379,6 +379,7 @@ pub const RLIMIT_CPU: ::c_int = 1;
+ pub const RLIMIT_DATA: ::c_int = 2;
+ pub const RLIMIT_FSIZE: ::c_int = 3;
+ pub const RLIMIT_NOFILE: ::c_int = 4;
++pub const RLIMIT_STACK: ::c_int = 5;
+ pub const RLIMIT_AS: ::c_int = 6;
+ // Haiku specific
+ pub const RLIMIT_NOVMON: ::c_int = 7;
+@@ -386,7 +387,7 @@ pub const RLIMIT_NLIMITS: ::c_int = 8;
+ 
+ pub const RUSAGE_SELF: ::c_int = 0;
+ 
+-pub const RTLD_LAXY: ::c_int = 0;
++pub const RTLD_LAZY: ::c_int = 0;
+ 
+ pub const NCCS: usize = 11;
+ 
+@@ -645,22 +646,43 @@ pub const AF_UNIX: ::c_int = AF_LOCAL;
+ pub const AF_BLUETOOTH: ::c_int = 10;
+ pub const AF_MAX: ::c_int = 11;
+ 
++pub const IP_OPTIONS: ::c_int = 1;
++pub const IP_HDRINCL: ::c_int = 2;
++pub const IP_TOS: ::c_int = 3;
++pub const IP_TTL: ::c_int = 4;
++pub const IP_RECVOPTS: ::c_int = 5;
++pub const IP_RECVRETOPTS: ::c_int = 6;
++pub const IP_RECVDSTADDR: ::c_int = 7;
++pub const IP_RETOPTS: ::c_int = 8;
++pub const IP_MULTICAST_IF: ::c_int = 9;
+ pub const IP_MULTICAST_TTL: ::c_int = 10;
+ pub const IP_MULTICAST_LOOP: ::c_int = 11;
+-pub const IP_TTL: ::c_int = 4;
+-pub const IP_HDRINCL: ::c_int = 2;
+ pub const IP_ADD_MEMBERSHIP: ::c_int = 12;
+ pub const IP_DROP_MEMBERSHIP: ::c_int = 13;
++pub const IP_BLOCK_SOURCE: ::c_int = 14;
++pub const IP_UNBLOCK_SOURCE: ::c_int = 15;
++pub const IP_ADD_SOURCE_MEMBERSHIP: ::c_int = 16;
++pub const IP_DROP_SOURCE_MEMBERSHIP: ::c_int = 17;
+ 
+ pub const TCP_NODELAY: ::c_int = 0x01;
+ pub const TCP_MAXSEG: ::c_int = 0x02;
+ pub const TCP_NOPUSH: ::c_int = 0x04;
+ pub const TCP_NOOPT: ::c_int = 0x08;
+ 
++pub const IPV6_MULTICAST_IF: ::c_int = 24;
++pub const IPV6_MULTICAST_HOPS: ::c_int = 25;
+ pub const IPV6_MULTICAST_LOOP: ::c_int = 26;
++pub const IPV6_UNICAST_HOPS: ::c_int = 27;
+ pub const IPV6_JOIN_GROUP: ::c_int = 28;
+ pub const IPV6_LEAVE_GROUP: ::c_int = 29;
+ pub const IPV6_V6ONLY: ::c_int = 30;
++pub const IPV6_PKTINFO: ::c_int = 31;
++pub const IPV6_RECVPKTINFO: ::c_int = 32;
++pub const IPV6_HOPLIMIT: ::c_int = 33;
++pub const IPV6_REVCHOPLIMIT: ::c_int = 34;
++pub const IPV6_HOPOPTS: ::c_int = 35;
++pub const IPV6_DSTOPTS: ::c_int = 36;
++pub const IPV6_RTHDR: ::c_int = 37;
+ 
+ pub const MSG_OOB: ::c_int = 0x0001;
+ pub const MSG_PEEK: ::c_int = 0x0002;
+@@ -701,7 +723,9 @@ pub const SA_ONESHOT: ::c_int = SA_RESETHAND;
+ 
+ pub const FD_SETSIZE: usize = 1024;
+ 
++pub const RTLD_LOCAL: ::c_int = 0x0;
+ pub const RTLD_NOW: ::c_int = 0x1;
++pub const RTLD_GLOBAL: ::c_int = 0x2;
+ pub const RTLD_DEFAULT: *mut ::c_void = 0isize as *mut ::c_void;
+ 
+ pub const BUFSIZ: ::c_uint = 8192;
+diff --git a/src/liblibc/src/unix/notbsd/android/b32/mod.rs b/src/liblibc/src/unix/notbsd/android/b32/mod.rs
+index 99af6d8..394abe8 100644
+--- a/src/liblibc/src/unix/notbsd/android/b32/mod.rs
++++ b/src/liblibc/src/unix/notbsd/android/b32/mod.rs
+@@ -198,22 +198,6 @@ pub const SIGSTKSZ: ::size_t = 8192;
+ pub const MINSIGSTKSZ: ::size_t = 2048;
+ 
+ extern {
+-    pub fn bind(socket: ::c_int, address: *const ::sockaddr,
+-                address_len: socklen_t) -> ::c_int;
+-
+-    pub fn writev(fd: ::c_int,
+-                  iov: *const ::iovec,
+-                  iovcnt: ::c_int) -> ::ssize_t;
+-    pub fn readv(fd: ::c_int,
+-                 iov: *const ::iovec,
+-                 iovcnt: ::c_int) -> ::ssize_t;
+-
+-    pub fn sendmsg(fd: ::c_int,
+-                   msg: *const ::msghdr,
+-                   flags: ::c_int) -> ::ssize_t;
+-    pub fn recvmsg(fd: ::c_int, msg: *mut ::msghdr, flags: ::c_int)
+-                   -> ::ssize_t;
+-
+     pub fn timegm64(tm: *const ::tm) -> ::time64_t;
+ }
+ 
+diff --git a/src/liblibc/src/unix/notbsd/android/b64/mod.rs b/src/liblibc/src/unix/notbsd/android/b64/mod.rs
+index 4aa6997..fb94334 100644
+--- a/src/liblibc/src/unix/notbsd/android/b64/mod.rs
++++ b/src/liblibc/src/unix/notbsd/android/b64/mod.rs
+@@ -154,31 +154,6 @@ pub const UT_LINESIZE: usize = 32;
+ pub const UT_NAMESIZE: usize = 32;
+ pub const UT_HOSTSIZE: usize = 256;
+ 
+-// Some weirdness in Android
+-extern {
+-    // address_len should be socklen_t, but it is c_int!
+-    pub fn bind(socket: ::c_int, address: *const ::sockaddr,
+-                address_len: ::c_int) -> ::c_int;
+-
+-    // the return type should be ::ssize_t, but it is c_int!
+-    pub fn writev(fd: ::c_int,
+-                  iov: *const ::iovec,
+-                  iovcnt: ::c_int) -> ::c_int;
+-
+-    // the return type should be ::ssize_t, but it is c_int!
+-    pub fn readv(fd: ::c_int,
+-                 iov: *const ::iovec,
+-                 iovcnt: ::c_int) -> ::c_int;
+-
+-    // the return type should be ::ssize_t, but it is c_int!
+-    pub fn sendmsg(fd: ::c_int,
+-                   msg: *const ::msghdr,
+-                   flags: ::c_int) -> ::c_int;
+-
+-    // the return type should be ::ssize_t, but it is c_int!
+-    pub fn recvmsg(fd: ::c_int, msg: *mut ::msghdr, flags: ::c_int) -> ::c_int;
+-}
+-
+ cfg_if! {
+     if #[cfg(target_arch = "x86_64")] {
+         mod x86_64;
+diff --git a/src/liblibc/src/unix/notbsd/android/mod.rs b/src/liblibc/src/unix/notbsd/android/mod.rs
+index 22043fd..53f957d 100644
+--- a/src/liblibc/src/unix/notbsd/android/mod.rs
++++ b/src/liblibc/src/unix/notbsd/android/mod.rs
+@@ -187,47 +187,52 @@ s! {
+     }
+ 
+     pub struct genlmsghdr {
+-        cmd: u8,
+-        version: u8,
+-        reserved: u16,
++        pub cmd: u8,
++        pub version: u8,
++        pub reserved: u16,
+     }
+ 
+     pub struct nlmsghdr {
+-        nlmsg_len: u32,
+-        nlmsg_type: u16,
+-        nlmsg_flags: u16,
+-        nlmsg_seq: u32,
+-        nlmsg_pid: u32,
++        pub nlmsg_len: u32,
++        pub nlmsg_type: u16,
++        pub nlmsg_flags: u16,
++        pub nlmsg_seq: u32,
++        pub nlmsg_pid: u32,
+     }
+ 
+     pub struct nlmsgerr {
+-        error: ::c_int,
+-        msg: nlmsghdr,
++        pub error: ::c_int,
++        pub msg: nlmsghdr,
+     }
+ 
+     pub struct nl_pktinfo {
+-        group: u32,
++        pub group: u32,
+     }
+ 
+     pub struct nl_mmap_req {
+-        nm_block_size: ::c_uint,
+-        nm_block_nr: ::c_uint,
+-        nm_frame_size: ::c_uint,
+-        nm_frame_nr: ::c_uint,
++        pub nm_block_size: ::c_uint,
++        pub nm_block_nr: ::c_uint,
++        pub nm_frame_size: ::c_uint,
++        pub nm_frame_nr: ::c_uint,
+     }
+ 
+     pub struct nl_mmap_hdr {
+-        nm_status: ::c_uint,
+-        nm_len: ::c_uint,
+-        nm_group: u32,
+-        nm_pid: u32,
+-        nm_uid: u32,
+-        nm_gid: u32,
++        pub nm_status: ::c_uint,
++        pub nm_len: ::c_uint,
++        pub nm_group: u32,
++        pub nm_pid: u32,
++        pub nm_uid: u32,
++        pub nm_gid: u32,
+     }
+ 
+     pub struct nlattr {
+-        nla_len: u16,
+-        nla_type: u16,
++        pub nla_len: u16,
++        pub nla_type: u16,
++    }
++
++    pub struct in6_pktinfo {
++        pub ipi6_addr: ::in6_addr,
++        pub ipi6_ifindex: ::c_int,
+     }
+ }
+ 
+@@ -386,6 +391,49 @@ pub const _SC_PHYS_PAGES: ::c_int = 98;
+ pub const _SC_AVPHYS_PAGES: ::c_int = 99;
+ pub const _SC_MONOTONIC_CLOCK: ::c_int = 100;
+ 
++pub const _SC_2_PBS: ::c_int = 101;
++pub const _SC_2_PBS_ACCOUNTING: ::c_int = 102;
++pub const _SC_2_PBS_CHECKPOINT: ::c_int = 103;
++pub const _SC_2_PBS_LOCATE: ::c_int = 104;
++pub const _SC_2_PBS_MESSAGE: ::c_int = 105;
++pub const _SC_2_PBS_TRACK: ::c_int = 106;
++pub const _SC_ADVISORY_INFO: ::c_int = 107;
++pub const _SC_BARRIERS: ::c_int = 108;
++pub const _SC_CLOCK_SELECTION: ::c_int = 109;
++pub const _SC_CPUTIME: ::c_int = 110;
++pub const _SC_HOST_NAME_MAX: ::c_int = 111;
++pub const _SC_IPV6: ::c_int = 112;
++pub const _SC_RAW_SOCKETS: ::c_int = 113;
++pub const _SC_READER_WRITER_LOCKS: ::c_int = 114;
++pub const _SC_REGEXP: ::c_int = 115;
++pub const _SC_SHELL: ::c_int = 116;
++pub const _SC_SPAWN: ::c_int = 117;
++pub const _SC_SPIN_LOCKS: ::c_int = 118;
++pub const _SC_SPORADIC_SERVER: ::c_int = 119;
++pub const _SC_SS_REPL_MAX: ::c_int = 120;
++pub const _SC_SYMLOOP_MAX: ::c_int = 121;
++pub const _SC_THREAD_CPUTIME: ::c_int = 122;
++pub const _SC_THREAD_PROCESS_SHARED: ::c_int = 123;
++pub const _SC_THREAD_ROBUST_PRIO_INHERIT: ::c_int = 124;
++pub const _SC_THREAD_ROBUST_PRIO_PROTECT: ::c_int = 125;
++pub const _SC_THREAD_SPORADIC_SERVER: ::c_int = 126;
++pub const _SC_TIMEOUTS: ::c_int = 127;
++pub const _SC_TRACE: ::c_int = 128;
++pub const _SC_TRACE_EVENT_FILTER: ::c_int = 129;
++pub const _SC_TRACE_EVENT_NAME_MAX: ::c_int = 130;
++pub const _SC_TRACE_INHERIT: ::c_int = 131;
++pub const _SC_TRACE_LOG: ::c_int = 132;
++pub const _SC_TRACE_NAME_MAX: ::c_int = 133;
++pub const _SC_TRACE_SYS_MAX: ::c_int = 134;
++pub const _SC_TRACE_USER_EVENT_MAX: ::c_int = 135;
++pub const _SC_TYPED_MEMORY_OBJECTS: ::c_int = 136;
++pub const _SC_V7_ILP32_OFF32: ::c_int = 137;
++pub const _SC_V7_ILP32_OFFBIG: ::c_int = 138;
++pub const _SC_V7_LP64_OFF64: ::c_int = 139;
++pub const _SC_V7_LPBIG_OFFBIG: ::c_int = 140;
++pub const _SC_XOPEN_STREAMS: ::c_int = 141;
++pub const _SC_XOPEN_UUCP: ::c_int = 142;
++
+ pub const PTHREAD_MUTEX_NORMAL: ::c_int = 0;
+ pub const PTHREAD_MUTEX_RECURSIVE: ::c_int = 1;
+ pub const PTHREAD_MUTEX_ERRORCHECK: ::c_int = 2;
+@@ -1372,6 +1420,44 @@ pub const ETH_P_XDSA: ::c_int = 0x00F8;
+ /* see rust-lang/libc#924 pub const ETH_P_MAP: ::c_int = 0x00F9;*/
+ // end android/platform/bionic/libc/kernel/uapi/linux/if_ether.h
+ 
++pub const SIOCADDRT: ::c_ulong = 0x0000890B;
++pub const SIOCDELRT: ::c_ulong = 0x0000890C;
++pub const SIOCGIFNAME: ::c_ulong = 0x00008910;
++pub const SIOCSIFLINK: ::c_ulong = 0x00008911;
++pub const SIOCGIFCONF: ::c_ulong = 0x00008912;
++pub const SIOCGIFFLAGS: ::c_ulong = 0x00008913;
++pub const SIOCSIFFLAGS: ::c_ulong = 0x00008914;
++pub const SIOCGIFADDR: ::c_ulong = 0x00008915;
++pub const SIOCSIFADDR: ::c_ulong = 0x00008916;
++pub const SIOCGIFDSTADDR: ::c_ulong = 0x00008917;
++pub const SIOCSIFDSTADDR: ::c_ulong = 0x00008918;
++pub const SIOCGIFBRDADDR: ::c_ulong = 0x00008919;
++pub const SIOCSIFBRDADDR: ::c_ulong = 0x0000891A;
++pub const SIOCGIFNETMASK: ::c_ulong = 0x0000891B;
++pub const SIOCSIFNETMASK: ::c_ulong = 0x0000891C;
++pub const SIOCGIFMETRIC: ::c_ulong = 0x0000891D;
++pub const SIOCSIFMETRIC: ::c_ulong = 0x0000891E;
++pub const SIOCGIFMEM: ::c_ulong = 0x0000891F;
++pub const SIOCSIFMEM: ::c_ulong = 0x00008920;
++pub const SIOCGIFMTU: ::c_ulong = 0x00008921;
++pub const SIOCSIFMTU: ::c_ulong = 0x00008922;
++pub const SIOCSIFHWADDR: ::c_ulong = 0x00008924;
++pub const SIOCGIFENCAP: ::c_ulong = 0x00008925;
++pub const SIOCSIFENCAP: ::c_ulong = 0x00008926;
++pub const SIOCGIFHWADDR: ::c_ulong = 0x00008927;
++pub const SIOCGIFSLAVE: ::c_ulong = 0x00008929;
++pub const SIOCSIFSLAVE: ::c_ulong = 0x00008930;
++pub const SIOCADDMULTI: ::c_ulong = 0x00008931;
++pub const SIOCDELMULTI: ::c_ulong = 0x00008932;
++pub const SIOCDARP: ::c_ulong = 0x00008953;
++pub const SIOCGARP: ::c_ulong = 0x00008954;
++pub const SIOCSARP: ::c_ulong = 0x00008955;
++pub const SIOCDRARP: ::c_ulong = 0x00008960;
++pub const SIOCGRARP: ::c_ulong = 0x00008961;
++pub const SIOCSRARP: ::c_ulong = 0x00008962;
++pub const SIOCGIFMAP: ::c_ulong = 0x00008970;
++pub const SIOCSIFMAP: ::c_ulong = 0x00008971;
++
+ f! {
+     pub fn CPU_ZERO(cpuset: &mut cpu_set_t) -> () {
+         for slot in cpuset.__bits.iter_mut() {
+@@ -1495,6 +1581,8 @@ extern {
+     pub fn sched_rr_get_interval(pid: ::pid_t, tp: *mut ::timespec) -> ::c_int;
+     pub fn sem_timedwait(sem: *mut sem_t,
+                          abstime: *const ::timespec) -> ::c_int;
++    pub fn sem_getvalue(sem: *mut sem_t,
++                        sval: *mut ::c_int) -> ::c_int;
+     pub fn sched_setparam(pid: ::pid_t, param: *const ::sched_param) -> ::c_int;
+     pub fn setns(fd: ::c_int, nstype: ::c_int) -> ::c_int;
+     pub fn swapoff(puath: *const ::c_char) -> ::c_int;
+diff --git a/src/liblibc/src/unix/notbsd/emscripten.rs b/src/liblibc/src/unix/notbsd/emscripten.rs
+index 90c056c..0d314ec 100644
+--- a/src/liblibc/src/unix/notbsd/emscripten.rs
++++ b/src/liblibc/src/unix/notbsd/emscripten.rs
+@@ -72,16 +72,6 @@ s! {
+         __unused5: *mut ::c_void,
+     }
+ 
+-    pub struct ifaddrs {
+-        pub ifa_next: *mut ifaddrs,
+-        pub ifa_name: *mut c_char,
+-        pub ifa_flags: ::c_uint,
+-        pub ifa_addr: *mut ::sockaddr,
+-        pub ifa_netmask: *mut ::sockaddr,
+-        pub ifa_ifu: *mut ::sockaddr, // FIXME This should be a union
+-        pub ifa_data: *mut ::c_void
+-    }
+-
+     pub struct pthread_mutex_t {
+         __align: [::c_long; 0],
+         size: [u8; __SIZEOF_PTHREAD_MUTEX_T],
+@@ -1600,8 +1590,6 @@ extern {
+                     mode: ::mode_t) -> ::c_int;
+     pub fn if_nameindex() -> *mut if_nameindex;
+     pub fn if_freenameindex(ptr: *mut if_nameindex);
+-    pub fn getifaddrs(ifap: *mut *mut ::ifaddrs) -> ::c_int;
+-    pub fn freeifaddrs(ifa: *mut ::ifaddrs);
+ 
+     pub fn mremap(addr: *mut ::c_void,
+                   len: ::size_t,
+@@ -1635,21 +1623,6 @@ extern {
+     pub fn mkstemps(template: *mut ::c_char, suffixlen: ::c_int) -> ::c_int;
+     pub fn nl_langinfo(item: ::nl_item) -> *mut ::c_char;
+ 
+-    pub fn bind(socket: ::c_int, address: *const ::sockaddr,
+-                address_len: ::socklen_t) -> ::c_int;
+-
+-    pub fn writev(fd: ::c_int,
+-                  iov: *const ::iovec,
+-                  iovcnt: ::c_int) -> ::ssize_t;
+-    pub fn readv(fd: ::c_int,
+-                 iov: *const ::iovec,
+-                 iovcnt: ::c_int) -> ::ssize_t;
+-
+-    pub fn sendmsg(fd: ::c_int,
+-                   msg: *const ::msghdr,
+-                   flags: ::c_int) -> ::ssize_t;
+-    pub fn recvmsg(fd: ::c_int, msg: *mut ::msghdr, flags: ::c_int)
+-                   -> ::ssize_t;
+     pub fn getdomainname(name: *mut ::c_char, len: ::size_t) -> ::c_int;
+     pub fn setdomainname(name: *const ::c_char, len: ::size_t) -> ::c_int;
+     pub fn sendmmsg(sockfd: ::c_int, msgvec: *mut mmsghdr, vlen: ::c_uint,
+diff --git a/src/liblibc/src/unix/notbsd/linux/mips/mips32.rs b/src/liblibc/src/unix/notbsd/linux/mips/mips32.rs
+index 8fad85b..d9d5035 100644
+--- a/src/liblibc/src/unix/notbsd/linux/mips/mips32.rs
++++ b/src/liblibc/src/unix/notbsd/linux/mips/mips32.rs
+@@ -91,6 +91,22 @@ s! {
+         pub f_spare: [::c_long; 5],
+     }
+ 
++    pub struct statvfs {
++        pub f_bsize: ::c_ulong,
++        pub f_frsize: ::c_ulong,
++        pub f_blocks: ::fsblkcnt_t,
++        pub f_bfree: ::fsblkcnt_t,
++        pub f_bavail: ::fsblkcnt_t,
++        pub f_files: ::fsfilcnt_t,
++        pub f_ffree: ::fsfilcnt_t,
++        pub f_favail: ::fsfilcnt_t,
++        pub f_fsid: ::c_ulong,
++        __f_unused: ::c_int,
++        pub f_flag: ::c_ulong,
++        pub f_namemax: ::c_ulong,
++        __f_spare: [::c_int; 6],
++    }
++
+     pub struct statvfs64 {
+         pub f_bsize: ::c_ulong,
+         pub f_frsize: ::c_ulong,
+@@ -100,11 +116,8 @@ s! {
+         pub f_files: u64,
+         pub f_ffree: u64,
+         pub f_favail: u64,
+-        #[cfg(target_endian = "little")]
+         pub f_fsid: ::c_ulong,
+         __f_unused: ::c_int,
+-        #[cfg(target_endian = "big")]
+-        pub f_fsid: ::c_ulong,
+         pub f_flag: ::c_ulong,
+         pub f_namemax: ::c_ulong,
+         __f_spare: [::c_int; 6],
+@@ -265,6 +278,61 @@ pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 32;
+ pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;
+ pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: usize = 8;
+ 
++#[cfg(target_endian = "little")]
++pub const PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++            0, 0,
++        ],
++    };
++#[cfg(target_endian = "little")]
++pub const PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++            0, 0,
++        ],
++    };
++#[cfg(target_endian = "little")]
++pub const PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++            0, 0,
++        ],
++    };
++#[cfg(target_endian = "big")]
++pub const PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
++            0, 0,
++        ],
++    };
++#[cfg(target_endian = "big")]
++pub const PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0,
++            0, 0,
++        ],
++    };
++#[cfg(target_endian = "big")]
++pub const PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
++            0, 0,
++        ],
++    };
++
+ pub const O_LARGEFILE: ::c_int = 0x2000;
+ 
+ pub const RLIM_INFINITY: ::rlim_t = 0x7fffffff;
+diff --git a/src/liblibc/src/unix/notbsd/linux/mips/mips64.rs b/src/liblibc/src/unix/notbsd/linux/mips/mips64.rs
+index 45b3df8..747b97b 100644
+--- a/src/liblibc/src/unix/notbsd/linux/mips/mips64.rs
++++ b/src/liblibc/src/unix/notbsd/linux/mips/mips64.rs
+@@ -91,6 +91,21 @@ s! {
+         pub f_spare: [::c_long; 5],
+     }
+ 
++    pub struct statvfs {
++        pub f_bsize: ::c_ulong,
++        pub f_frsize: ::c_ulong,
++        pub f_blocks: ::fsblkcnt_t,
++        pub f_bfree: ::fsblkcnt_t,
++        pub f_bavail: ::fsblkcnt_t,
++        pub f_files: ::fsfilcnt_t,
++        pub f_ffree: ::fsfilcnt_t,
++        pub f_favail: ::fsfilcnt_t,
++        pub f_fsid: ::c_ulong,
++        pub f_flag: ::c_ulong,
++        pub f_namemax: ::c_ulong,
++        __f_spare: [::c_int; 6],
++    }
++
+     pub struct statvfs64 {
+         pub f_bsize: ::c_ulong,
+         pub f_frsize: ::c_ulong,
+@@ -247,6 +262,61 @@ pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 40;
+ pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 56;
+ pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: usize = 8;
+ 
++#[cfg(target_endian = "little")]
++pub const PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++#[cfg(target_endian = "little")]
++pub const PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++#[cfg(target_endian = "little")]
++pub const PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++#[cfg(target_endian = "big")]
++pub const PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++#[cfg(target_endian = "big")]
++pub const PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++#[cfg(target_endian = "big")]
++pub const PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++
+ pub const O_LARGEFILE: ::c_int = 0;
+ 
+ pub const RLIM_INFINITY: ::rlim_t = 0xffff_ffff_ffff_ffff;
+diff --git a/src/liblibc/src/unix/notbsd/linux/mips/mod.rs b/src/liblibc/src/unix/notbsd/linux/mips/mod.rs
+index 405a2bd..833a321 100644
+--- a/src/liblibc/src/unix/notbsd/linux/mips/mod.rs
++++ b/src/liblibc/src/unix/notbsd/linux/mips/mod.rs
+@@ -41,41 +41,41 @@ s! {
+     }
+ 
+     pub struct nlmsghdr {
+-        nlmsg_len: u32,
+-        nlmsg_type: u16,
+-        nlmsg_flags: u16,
+-        nlmsg_seq: u32,
+-        nlmsg_pid: u32,
++        pub nlmsg_len: u32,
++        pub nlmsg_type: u16,
++        pub nlmsg_flags: u16,
++        pub nlmsg_seq: u32,
++        pub nlmsg_pid: u32,
+     }
+ 
+     pub struct nlmsgerr {
+-        error: ::c_int,
+-        msg: nlmsghdr,
++        pub error: ::c_int,
++        pub msg: nlmsghdr,
+     }
+ 
+     pub struct nl_pktinfo {
+-        group: u32,
++        pub group: u32,
+     }
+ 
+     pub struct nl_mmap_req {
+-        nm_block_size: ::c_uint,
+-        nm_block_nr: ::c_uint,
+-        nm_frame_size: ::c_uint,
+-        nm_frame_nr: ::c_uint,
++        pub nm_block_size: ::c_uint,
++        pub nm_block_nr: ::c_uint,
++        pub nm_frame_size: ::c_uint,
++        pub nm_frame_nr: ::c_uint,
+     }
+ 
+     pub struct nl_mmap_hdr {
+-        nm_status: ::c_uint,
+-        nm_len: ::c_uint,
+-        nm_group: u32,
+-        nm_pid: u32,
+-        nm_uid: u32,
+-        nm_gid: u32,
++        pub nm_status: ::c_uint,
++        pub nm_len: ::c_uint,
++        pub nm_group: u32,
++        pub nm_pid: u32,
++        pub nm_uid: u32,
++        pub nm_gid: u32,
+     }
+ 
+     pub struct nlattr {
+-        nla_len: u16,
+-        nla_type: u16,
++        pub nla_len: u16,
++        pub nla_type: u16,
+     }
+ }
+ 
+@@ -463,6 +463,7 @@ pub const POLLWRNORM: ::c_short = 0x004;
+ pub const POLLWRBAND: ::c_short = 0x100;
+ 
+ pub const PTHREAD_STACK_MIN: ::size_t = 131072;
++pub const PTHREAD_MUTEX_ADAPTIVE_NP: ::c_int = 3;
+ 
+ pub const ADFS_SUPER_MAGIC: ::c_long = 0x0000adf5;
+ pub const AFFS_SUPER_MAGIC: ::c_long = 0x0000adff;
+diff --git a/src/liblibc/src/unix/notbsd/linux/mod.rs b/src/liblibc/src/unix/notbsd/linux/mod.rs
+index e495dc2..60e0d8e 100644
+--- a/src/liblibc/src/unix/notbsd/linux/mod.rs
++++ b/src/liblibc/src/unix/notbsd/linux/mod.rs
+@@ -71,16 +71,6 @@ s! {
+         __unused5: *mut ::c_void,
+     }
+ 
+-    pub struct ifaddrs {
+-        pub ifa_next: *mut ifaddrs,
+-        pub ifa_name: *mut c_char,
+-        pub ifa_flags: ::c_uint,
+-        pub ifa_addr: *mut ::sockaddr,
+-        pub ifa_netmask: *mut ::sockaddr,
+-        pub ifa_ifu: *mut ::sockaddr, // FIXME This should be a union
+-        pub ifa_data: *mut ::c_void
+-    }
+-
+     pub struct pthread_mutex_t {
+         #[cfg(any(target_arch = "mips",
+                   target_arch = "arm",
+@@ -172,26 +162,6 @@ s! {
+         pub sp_flag: ::c_ulong,
+     }
+ 
+-    pub struct statvfs {
+-        pub f_bsize: ::c_ulong,
+-        pub f_frsize: ::c_ulong,
+-        pub f_blocks: ::fsblkcnt_t,
+-        pub f_bfree: ::fsblkcnt_t,
+-        pub f_bavail: ::fsblkcnt_t,
+-        pub f_files: ::fsfilcnt_t,
+-        pub f_ffree: ::fsfilcnt_t,
+-        pub f_favail: ::fsfilcnt_t,
+-        #[cfg(target_endian = "little")]
+-        pub f_fsid: ::c_ulong,
+-        #[cfg(all(target_pointer_width = "32", not(target_arch = "x86_64")))]
+-        __f_unused: ::c_int,
+-        #[cfg(target_endian = "big")]
+-        pub f_fsid: ::c_ulong,
+-        pub f_flag: ::c_ulong,
+-        pub f_namemax: ::c_ulong,
+-        __f_spare: [::c_int; 6],
+-    }
+-
+     pub struct dqblk {
+         pub dqb_bhardlimit: ::uint64_t,
+         pub dqb_bsoftlimit: ::uint64_t,
+@@ -485,9 +455,14 @@ s! {
+     }
+ 
+     pub struct genlmsghdr {
+-        cmd: u8,
+-        version: u8,
+-        reserved: u16,
++        pub cmd: u8,
++        pub version: u8,
++        pub reserved: u16,
++    }
++
++    pub struct in6_pktinfo {
++        pub ipi6_addr: ::in6_addr,
++        pub ipi6_ifindex: ::c_uint,
+     }
+ }
+ 
+@@ -1394,6 +1369,104 @@ pub const NF_IP6_PRI_SELINUX_LAST: ::c_int = 225;
+ pub const NF_IP6_PRI_CONNTRACK_HELPER: ::c_int = 300;
+ pub const NF_IP6_PRI_LAST: ::c_int = ::INT_MAX;
+ 
++pub const SIOCADDRT: ::c_ulong = 0x0000890B;
++pub const SIOCDELRT: ::c_ulong = 0x0000890C;
++pub const SIOCGIFNAME: ::c_ulong = 0x00008910;
++pub const SIOCSIFLINK: ::c_ulong = 0x00008911;
++pub const SIOCGIFCONF: ::c_ulong = 0x00008912;
++pub const SIOCGIFFLAGS: ::c_ulong = 0x00008913;
++pub const SIOCSIFFLAGS: ::c_ulong = 0x00008914;
++pub const SIOCGIFADDR: ::c_ulong = 0x00008915;
++pub const SIOCSIFADDR: ::c_ulong = 0x00008916;
++pub const SIOCGIFDSTADDR: ::c_ulong = 0x00008917;
++pub const SIOCSIFDSTADDR: ::c_ulong = 0x00008918;
++pub const SIOCGIFBRDADDR: ::c_ulong = 0x00008919;
++pub const SIOCSIFBRDADDR: ::c_ulong = 0x0000891A;
++pub const SIOCGIFNETMASK: ::c_ulong = 0x0000891B;
++pub const SIOCSIFNETMASK: ::c_ulong = 0x0000891C;
++pub const SIOCGIFMETRIC: ::c_ulong = 0x0000891D;
++pub const SIOCSIFMETRIC: ::c_ulong = 0x0000891E;
++pub const SIOCGIFMEM: ::c_ulong = 0x0000891F;
++pub const SIOCSIFMEM: ::c_ulong = 0x00008920;
++pub const SIOCGIFMTU: ::c_ulong = 0x00008921;
++pub const SIOCSIFMTU: ::c_ulong = 0x00008922;
++pub const SIOCSIFHWADDR: ::c_ulong = 0x00008924;
++pub const SIOCGIFENCAP: ::c_ulong = 0x00008925;
++pub const SIOCSIFENCAP: ::c_ulong = 0x00008926;
++pub const SIOCGIFHWADDR: ::c_ulong = 0x00008927;
++pub const SIOCGIFSLAVE: ::c_ulong = 0x00008929;
++pub const SIOCSIFSLAVE: ::c_ulong = 0x00008930;
++pub const SIOCADDMULTI: ::c_ulong = 0x00008931;
++pub const SIOCDELMULTI: ::c_ulong = 0x00008932;
++pub const SIOCDARP: ::c_ulong = 0x00008953;
++pub const SIOCGARP: ::c_ulong = 0x00008954;
++pub const SIOCSARP: ::c_ulong = 0x00008955;
++pub const SIOCDRARP: ::c_ulong = 0x00008960;
++pub const SIOCGRARP: ::c_ulong = 0x00008961;
++pub const SIOCSRARP: ::c_ulong = 0x00008962;
++pub const SIOCGIFMAP: ::c_ulong = 0x00008970;
++pub const SIOCSIFMAP: ::c_ulong = 0x00008971;
++
++pub const IPTOS_TOS_MASK: u8 = 0x1E;
++pub const IPTOS_PREC_MASK: u8 = 0xE0;
++
++pub const RTF_UP: ::c_ushort = 0x0001;
++pub const RTF_GATEWAY: ::c_ushort = 0x0002;
++
++pub const RTF_HOST: ::c_ushort = 0x0004;
++pub const RTF_REINSTATE: ::c_ushort = 0x0008;
++pub const RTF_DYNAMIC: ::c_ushort = 0x0010;
++pub const RTF_MODIFIED: ::c_ushort = 0x0020;
++pub const RTF_MTU: ::c_ushort = 0x0040;
++pub const RTF_MSS: ::c_ushort = RTF_MTU;
++pub const RTF_WINDOW: ::c_ushort = 0x0080;
++pub const RTF_IRTT: ::c_ushort = 0x0100;
++pub const RTF_REJECT: ::c_ushort = 0x0200;
++pub const RTF_STATIC: ::c_ushort = 0x0400;
++pub const RTF_XRESOLVE: ::c_ushort = 0x0800;
++pub const RTF_NOFORWARD: ::c_ushort = 0x1000;
++pub const RTF_THROW: ::c_ushort = 0x2000;
++pub const RTF_NOPMTUDISC: ::c_ushort = 0x4000;
++
++pub const RTF_DEFAULT: u32 = 0x00010000;
++pub const RTF_ALLONLINK: u32 = 0x00020000;
++pub const RTF_ADDRCONF: u32 = 0x00040000;
++pub const RTF_LINKRT: u32 = 0x00100000;
++pub const RTF_NONEXTHOP: u32 = 0x00200000;
++pub const RTF_CACHE: u32 = 0x01000000;
++pub const RTF_FLOW: u32 = 0x02000000;
++pub const RTF_POLICY: u32 = 0x04000000;
++
++pub const RTCF_VALVE: u32 = 0x00200000;
++pub const RTCF_MASQ: u32 = 0x00400000;
++pub const RTCF_NAT: u32 = 0x00800000;
++pub const RTCF_DOREDIRECT: u32 = 0x01000000;
++pub const RTCF_LOG: u32 = 0x02000000;
++pub const RTCF_DIRECTSRC: u32 = 0x04000000;
++
++pub const RTF_LOCAL: u32 = 0x80000000;
++pub const RTF_INTERFACE: u32 = 0x40000000;
++pub const RTF_MULTICAST: u32 = 0x20000000;
++pub const RTF_BROADCAST: u32 = 0x10000000;
++pub const RTF_NAT: u32 = 0x08000000;
++pub const RTF_ADDRCLASSMASK: u32 = 0xF8000000;
++
++pub const RT_CLASS_UNSPEC: u8 = 0;
++pub const RT_CLASS_DEFAULT: u8 = 253;
++pub const RT_CLASS_MAIN: u8 = 254;
++pub const RT_CLASS_LOCAL: u8 = 255;
++pub const RT_CLASS_MAX: u8 = 255;
++
++pub const RTMSG_OVERRUN: u32 = ::NLMSG_OVERRUN as u32;
++pub const RTMSG_NEWDEVICE: u32 = 0x11;
++pub const RTMSG_DELDEVICE: u32 = 0x12;
++pub const RTMSG_NEWROUTE: u32 = 0x21;
++pub const RTMSG_DELROUTE: u32 = 0x22;
++pub const RTMSG_NEWRULE: u32 = 0x31;
++pub const RTMSG_DELRULE: u32 = 0x32;
++pub const RTMSG_CONTROL: u32 = 0x40;
++pub const RTMSG_AR_FAILED: u32 = 0x51;
++
+ f! {
+     pub fn CPU_ZERO(cpuset: &mut cpu_set_t) -> () {
+         for slot in cpuset.bits.iter_mut() {
+@@ -1449,6 +1522,26 @@ f! {
+         dev |= (minor & 0xffffff00) << 12;
+         dev
+     }
++
++    pub fn IPTOS_TOS(tos: u8) -> u8 {
++        tos & IPTOS_TOS_MASK
++    }
++
++    pub fn IPTOS_PREC(tos: u8) -> u8 {
++        tos & IPTOS_PREC_MASK
++    }
++
++    pub fn RT_TOS(tos: u8) -> u8 {
++        tos & ::IPTOS_TOS_MASK
++    }
++
++    pub fn RT_ADDRCLASS(flags: u32) -> u32 {
++        flags >> 23
++    }
++
++    pub fn RT_LOCALADDR(flags: u32) -> bool {
++        (flags & RTF_ADDRCLASSMASK) == (RTF_LOCAL | RTF_INTERFACE)
++    }
+ }
+ 
+ extern {
+@@ -1639,8 +1732,6 @@ extern {
+     pub fn if_freenameindex(ptr: *mut if_nameindex);
+     pub fn sync_file_range(fd: ::c_int, offset: ::off64_t,
+                            nbytes: ::off64_t, flags: ::c_uint) -> ::c_int;
+-    pub fn getifaddrs(ifap: *mut *mut ::ifaddrs) -> ::c_int;
+-    pub fn freeifaddrs(ifa: *mut ::ifaddrs);
+     pub fn mremap(addr: *mut ::c_void,
+                   len: ::size_t,
+                   new_len: ::size_t,
+@@ -1675,21 +1766,6 @@ extern {
+     pub fn futimes(fd: ::c_int, times: *const ::timeval) -> ::c_int;
+     pub fn nl_langinfo(item: ::nl_item) -> *mut ::c_char;
+ 
+-    pub fn bind(socket: ::c_int, address: *const ::sockaddr,
+-                address_len: ::socklen_t) -> ::c_int;
+-
+-    pub fn writev(fd: ::c_int,
+-                  iov: *const ::iovec,
+-                  iovcnt: ::c_int) -> ::ssize_t;
+-    pub fn readv(fd: ::c_int,
+-                 iov: *const ::iovec,
+-                 iovcnt: ::c_int) -> ::ssize_t;
+-
+-    pub fn sendmsg(fd: ::c_int,
+-                   msg: *const ::msghdr,
+-                   flags: ::c_int) -> ::ssize_t;
+-    pub fn recvmsg(fd: ::c_int, msg: *mut ::msghdr, flags: ::c_int)
+-                   -> ::ssize_t;
+     pub fn getdomainname(name: *mut ::c_char, len: ::size_t) -> ::c_int;
+     pub fn setdomainname(name: *const ::c_char, len: ::size_t) -> ::c_int;
+     pub fn vhangup() -> ::c_int;
+@@ -1736,6 +1812,8 @@ extern {
+     pub fn sched_rr_get_interval(pid: ::pid_t, tp: *mut ::timespec) -> ::c_int;
+     pub fn sem_timedwait(sem: *mut sem_t,
+                          abstime: *const ::timespec) -> ::c_int;
++    pub fn sem_getvalue(sem: *mut sem_t,
++                        sval: *mut ::c_int) -> ::c_int;
+     pub fn sched_setparam(pid: ::pid_t, param: *const ::sched_param) -> ::c_int;
+     pub fn setns(fd: ::c_int, nstype: ::c_int) -> ::c_int;
+     pub fn swapoff(puath: *const ::c_char) -> ::c_int;
+@@ -1937,6 +2015,11 @@ extern {
+         fd: ::c_int,
+         newfd: ::c_int,
+     ) -> ::c_int;
++    pub fn fread_unlocked(ptr: *mut ::c_void,
++        size: ::size_t,
++        nobj: ::size_t,
++        stream: *mut ::FILE
++    ) -> ::size_t;
+ }
+ 
+ cfg_if! {
+diff --git a/src/liblibc/src/unix/notbsd/linux/musl/mod.rs b/src/liblibc/src/unix/notbsd/linux/musl/mod.rs
+index 7513aae..9a63d1f 100644
+--- a/src/liblibc/src/unix/notbsd/linux/musl/mod.rs
++++ b/src/liblibc/src/unix/notbsd/linux/musl/mod.rs
+@@ -40,6 +40,26 @@ s! {
+         pub sa_restorer: ::dox::Option<extern fn()>,
+     }
+ 
++    pub struct statvfs {
++        pub f_bsize: ::c_ulong,
++        pub f_frsize: ::c_ulong,
++        pub f_blocks: ::fsblkcnt_t,
++        pub f_bfree: ::fsblkcnt_t,
++        pub f_bavail: ::fsblkcnt_t,
++        pub f_files: ::fsfilcnt_t,
++        pub f_ffree: ::fsfilcnt_t,
++        pub f_favail: ::fsfilcnt_t,
++        #[cfg(target_endian = "little")]
++        pub f_fsid: ::c_ulong,
++        #[cfg(target_pointer_width = "32")]
++        __f_unused: ::c_int,
++        #[cfg(target_endian = "big")]
++        pub f_fsid: ::c_ulong,
++        pub f_flag: ::c_ulong,
++        pub f_namemax: ::c_ulong,
++        __f_spare: [::c_int; 6],
++    }
++
+     pub struct termios {
+         pub c_iflag: ::tcflag_t,
+         pub c_oflag: ::tcflag_t,
+diff --git a/src/liblibc/src/unix/notbsd/linux/other/b32/mod.rs b/src/liblibc/src/unix/notbsd/linux/other/b32/mod.rs
+index 8536353..88a5d6c 100644
+--- a/src/liblibc/src/unix/notbsd/linux/other/b32/mod.rs
++++ b/src/liblibc/src/unix/notbsd/linux/other/b32/mod.rs
+@@ -44,6 +44,22 @@ s! {
+         __unused5: ::c_long,
+     }
+ 
++    pub struct statvfs {
++        pub f_bsize: ::c_ulong,
++        pub f_frsize: ::c_ulong,
++        pub f_blocks: ::fsblkcnt_t,
++        pub f_bfree: ::fsblkcnt_t,
++        pub f_bavail: ::fsblkcnt_t,
++        pub f_files: ::fsfilcnt_t,
++        pub f_ffree: ::fsfilcnt_t,
++        pub f_favail: ::fsfilcnt_t,
++        pub f_fsid: ::c_ulong,
++        __f_unused: ::c_int,
++        pub f_flag: ::c_ulong,
++        pub f_namemax: ::c_ulong,
++        __f_spare: [::c_int; 6],
++    }
++
+     pub struct pthread_attr_t {
+         __size: [u32; 9]
+     }
+@@ -283,6 +299,61 @@ pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 32;
+ pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;
+ pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: usize = 8;
+ 
++#[cfg(target_endian = "little")]
++pub const PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++            0, 0,
++        ],
++    };
++#[cfg(target_endian = "little")]
++pub const PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++            0, 0,
++        ],
++    };
++#[cfg(target_endian = "little")]
++pub const PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++            0, 0,
++        ],
++    };
++#[cfg(target_endian = "big")]
++pub const PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
++            0, 0,
++        ],
++    };
++#[cfg(target_endian = "big")]
++pub const PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0,
++            0, 0,
++        ],
++    };
++#[cfg(target_endian = "big")]
++pub const PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
++            0, 0,
++        ],
++    };
++
+ pub const PTRACE_GETFPREGS: ::c_uint = 14;
+ pub const PTRACE_SETFPREGS: ::c_uint = 15;
+ pub const PTRACE_GETREGS: ::c_uint = 12;
+diff --git a/src/liblibc/src/unix/notbsd/linux/other/b64/aarch64.rs b/src/liblibc/src/unix/notbsd/linux/other/b64/aarch64.rs
+index 80ebe7e..cfa8592 100644
+--- a/src/liblibc/src/unix/notbsd/linux/other/b64/aarch64.rs
++++ b/src/liblibc/src/unix/notbsd/linux/other/b64/aarch64.rs
+@@ -69,6 +69,21 @@ s! {
+         pub f_spare: [::__fsword_t; 4],
+     }
+ 
++    pub struct statvfs {
++        pub f_bsize: ::c_ulong,
++        pub f_frsize: ::c_ulong,
++        pub f_blocks: ::fsblkcnt_t,
++        pub f_bfree: ::fsblkcnt_t,
++        pub f_bavail: ::fsblkcnt_t,
++        pub f_files: ::fsfilcnt_t,
++        pub f_ffree: ::fsfilcnt_t,
++        pub f_favail: ::fsfilcnt_t,
++        pub f_fsid: ::c_ulong,
++        pub f_flag: ::c_ulong,
++        pub f_namemax: ::c_ulong,
++        __f_spare: [::c_int; 6],
++    }
++
+     pub struct statvfs64 {
+         pub f_bsize: ::c_ulong,
+         pub f_frsize: ::c_ulong,
+@@ -371,6 +386,34 @@ pub const __SIZEOF_PTHREAD_CONDATTR_T: usize = 8;
+ pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 48;
+ pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 8;
+ 
++pub const PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++            0, 0, 0, 0,
++        ],
++    };
++pub const PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++            0, 0, 0, 0,
++        ],
++    };
++pub const PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++            0, 0, 0, 0,
++        ],
++    };
++
+ pub const O_DIRECT: ::c_int = 0x10000;
+ pub const O_DIRECTORY: ::c_int = 0x4000;
+ pub const O_NOFOLLOW: ::c_int = 0x8000;
+diff --git a/src/liblibc/src/unix/notbsd/linux/other/b64/not_x32.rs b/src/liblibc/src/unix/notbsd/linux/other/b64/not_x32.rs
+index fb30a31..7f42125 100644
+--- a/src/liblibc/src/unix/notbsd/linux/other/b64/not_x32.rs
++++ b/src/liblibc/src/unix/notbsd/linux/other/b64/not_x32.rs
+@@ -1,9 +1,81 @@
+ pub type c_long = i64;
+ pub type c_ulong = u64;
+ 
++s! {
++    pub struct statvfs {
++        pub f_bsize: ::c_ulong,
++        pub f_frsize: ::c_ulong,
++        pub f_blocks: ::fsblkcnt_t,
++        pub f_bfree: ::fsblkcnt_t,
++        pub f_bavail: ::fsblkcnt_t,
++        pub f_files: ::fsfilcnt_t,
++        pub f_ffree: ::fsfilcnt_t,
++        pub f_favail: ::fsfilcnt_t,
++        pub f_fsid: ::c_ulong,
++        pub f_flag: ::c_ulong,
++        pub f_namemax: ::c_ulong,
++        __f_spare: [::c_int; 6],
++    }
++}
++
+ pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 40;
+ pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 56;
+ 
++#[cfg(target_endian = "little")]
++pub const PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++#[cfg(target_endian = "little")]
++pub const PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++#[cfg(target_endian = "little")]
++pub const PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++#[cfg(target_endian = "big")]
++pub const PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++#[cfg(target_endian = "big")]
++pub const PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++#[cfg(target_endian = "big")]
++pub const PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++
+ // Syscall table
+ 
+ pub const SYS_read: ::c_long = 0;
+diff --git a/src/liblibc/src/unix/notbsd/linux/other/b64/powerpc64.rs b/src/liblibc/src/unix/notbsd/linux/other/b64/powerpc64.rs
+index 65f2fa2..858aa24 100644
+--- a/src/liblibc/src/unix/notbsd/linux/other/b64/powerpc64.rs
++++ b/src/liblibc/src/unix/notbsd/linux/other/b64/powerpc64.rs
+@@ -67,6 +67,21 @@ s! {
+         pub f_spare: [::__fsword_t; 4],
+     }
+ 
++    pub struct statvfs {
++        pub f_bsize: ::c_ulong,
++        pub f_frsize: ::c_ulong,
++        pub f_blocks: ::fsblkcnt_t,
++        pub f_bfree: ::fsblkcnt_t,
++        pub f_bavail: ::fsblkcnt_t,
++        pub f_files: ::fsfilcnt_t,
++        pub f_ffree: ::fsfilcnt_t,
++        pub f_favail: ::fsfilcnt_t,
++        pub f_fsid: ::c_ulong,
++        pub f_flag: ::c_ulong,
++        pub f_namemax: ::c_ulong,
++        __f_spare: [::c_int; 6],
++    }
++
+     pub struct statvfs64 {
+         pub f_bsize: ::c_ulong,
+         pub f_frsize: ::c_ulong,
+@@ -358,6 +373,61 @@ pub const __SIZEOF_PTHREAD_CONDATTR_T: usize = 4;
+ pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 40;
+ pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;
+ 
++#[cfg(target_endian = "little")]
++pub const PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++#[cfg(target_endian = "little")]
++pub const PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++#[cfg(target_endian = "little")]
++pub const PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++#[cfg(target_endian = "big")]
++pub const PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++#[cfg(target_endian = "big")]
++pub const PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++#[cfg(target_endian = "big")]
++pub const PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++
+ pub const O_DIRECTORY: ::c_int = 0x4000;
+ pub const O_NOFOLLOW: ::c_int = 0x8000;
+ pub const O_DIRECT: ::c_int = 0x20000;
+diff --git a/src/liblibc/src/unix/notbsd/linux/other/b64/sparc64.rs b/src/liblibc/src/unix/notbsd/linux/other/b64/sparc64.rs
+index 206a0ce..8deef06 100644
+--- a/src/liblibc/src/unix/notbsd/linux/other/b64/sparc64.rs
++++ b/src/liblibc/src/unix/notbsd/linux/other/b64/sparc64.rs
+@@ -69,6 +69,21 @@ s! {
+         pub f_spare: [::__fsword_t; 4],
+     }
+ 
++    pub struct statvfs {
++        pub f_bsize: ::c_ulong,
++        pub f_frsize: ::c_ulong,
++        pub f_blocks: ::fsblkcnt_t,
++        pub f_bfree: ::fsblkcnt_t,
++        pub f_bavail: ::fsblkcnt_t,
++        pub f_files: ::fsfilcnt_t,
++        pub f_ffree: ::fsfilcnt_t,
++        pub f_favail: ::fsfilcnt_t,
++        pub f_fsid: ::c_ulong,
++        pub f_flag: ::c_ulong,
++        pub f_namemax: ::c_ulong,
++        __f_spare: [::c_int; 6],
++    }
++
+     pub struct statvfs64 {
+         pub f_bsize: ::c_ulong,
+         pub f_frsize: ::c_ulong,
+@@ -243,6 +258,8 @@ pub const SO_DONTROUTE: ::c_int = 16;
+ pub const SO_BROADCAST: ::c_int = 32;
+ pub const SO_SNDBUF: ::c_int = 0x1001;
+ pub const SO_RCVBUF: ::c_int = 0x1002;
++pub const SO_SNDBUFFORCE: ::c_int = 0x100a;
++pub const SO_RCVBUFFORCE: ::c_int = 0x100b;
+ pub const SO_DOMAIN: ::c_int = 0x1029;
+ pub const SO_KEEPALIVE: ::c_int = 8;
+ pub const SO_OOBINLINE: ::c_int = 0x100;
+@@ -332,6 +349,31 @@ pub const __SIZEOF_PTHREAD_CONDATTR_T: usize = 4;
+ pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 40;
+ pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;
+ 
++pub const PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++pub const PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++pub const PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++
+ pub const O_DIRECTORY: ::c_int = 0o200000;
+ pub const O_NOFOLLOW: ::c_int = 0o400000;
+ pub const O_DIRECT: ::c_int = 0x100000;
+@@ -407,6 +449,41 @@ pub const FFDLY:  ::tcflag_t = 0o100000;
+ pub const VTDLY:  ::tcflag_t = 0o040000;
+ pub const XTABS:  ::tcflag_t = 0o014000;
+ 
++pub const B0: ::speed_t = 0o000000;
++pub const B50: ::speed_t = 0o000001;
++pub const B75: ::speed_t = 0o000002;
++pub const B110: ::speed_t = 0o000003;
++pub const B134: ::speed_t = 0o000004;
++pub const B150: ::speed_t = 0o000005;
++pub const B200: ::speed_t = 0o000006;
++pub const B300: ::speed_t = 0o000007;
++pub const B600: ::speed_t = 0o000010;
++pub const B1200: ::speed_t = 0o000011;
++pub const B1800: ::speed_t = 0o000012;
++pub const B2400: ::speed_t = 0o000013;
++pub const B4800: ::speed_t = 0o000014;
++pub const B9600: ::speed_t = 0o000015;
++pub const B19200: ::speed_t = 0o000016;
++pub const B38400: ::speed_t = 0o000017;
++pub const EXTA: ::speed_t = B19200;
++pub const EXTB: ::speed_t = B38400;
++pub const BOTHER: ::speed_t = 0x1000;
++pub const B57600: ::speed_t = 0x1001;
++pub const B115200: ::speed_t = 0x1002;
++pub const B230400: ::speed_t = 0x1003;
++pub const B460800: ::speed_t = 0x1004;
++pub const B76800: ::speed_t = 0x1005;
++pub const B153600: ::speed_t = 0x1006;
++pub const B307200: ::speed_t = 0x1007;
++pub const B614400: ::speed_t = 0x1008;
++pub const B921600: ::speed_t = 0x1009;
++pub const B500000: ::speed_t = 0x100a;
++pub const B576000: ::speed_t = 0x100b;
++pub const B1000000: ::speed_t = 0x100c;
++pub const B1152000: ::speed_t = 0x100d;
++pub const B1500000: ::speed_t = 0x100e;
++pub const B2000000: ::speed_t = 0x100f;
++
+ pub const VEOL: usize = 5;
+ pub const VEOL2: usize = 6;
+ pub const VMIN: usize = 4;
+diff --git a/src/liblibc/src/unix/notbsd/linux/other/b64/x32.rs b/src/liblibc/src/unix/notbsd/linux/other/b64/x32.rs
+index 2e97061..9eb30c8 100644
+--- a/src/liblibc/src/unix/notbsd/linux/other/b64/x32.rs
++++ b/src/liblibc/src/unix/notbsd/linux/other/b64/x32.rs
+@@ -1,9 +1,51 @@
+ pub type c_long = i32;
+ pub type c_ulong = u32;
+ 
++s! {
++    pub struct statvfs {
++        pub f_bsize: ::c_ulong,
++        pub f_frsize: ::c_ulong,
++        pub f_blocks: ::fsblkcnt_t,
++        pub f_bfree: ::fsblkcnt_t,
++        pub f_bavail: ::fsblkcnt_t,
++        pub f_files: ::fsfilcnt_t,
++        pub f_ffree: ::fsfilcnt_t,
++        pub f_favail: ::fsfilcnt_t,
++        pub f_fsid: ::c_ulong,
++        pub f_flag: ::c_ulong,
++        pub f_namemax: ::c_ulong,
++        __f_spare: [::c_int; 6],
++    }
++}
++
+ pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 32;
+ pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 44;
+ 
++pub const PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++pub const PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++pub const PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++
+ // Syscall table
+ 
+ pub const __X32_SYSCALL_BIT: ::c_long = 0x40000000;
+diff --git a/src/liblibc/src/unix/notbsd/linux/other/b64/x86_64.rs b/src/liblibc/src/unix/notbsd/linux/other/b64/x86_64.rs
+index 5689aaa..7596eba 100644
+--- a/src/liblibc/src/unix/notbsd/linux/other/b64/x86_64.rs
++++ b/src/liblibc/src/unix/notbsd/linux/other/b64/x86_64.rs
+@@ -427,6 +427,10 @@ pub const F_SETOWN: ::c_int = 8;
+ pub const F_SETLK: ::c_int = 6;
+ pub const F_SETLKW: ::c_int = 7;
+ 
++pub const F_RDLCK: ::c_int = 0;
++pub const F_WRLCK: ::c_int = 1;
++pub const F_UNLCK: ::c_int = 2;
++
+ pub const SFD_NONBLOCK: ::c_int = 0x0800;
+ 
+ pub const TIOCEXCL: ::c_ulong = 0x540C;
+diff --git a/src/liblibc/src/unix/notbsd/linux/other/mod.rs b/src/liblibc/src/unix/notbsd/linux/other/mod.rs
+index b566a95..6a326dd 100644
+--- a/src/liblibc/src/unix/notbsd/linux/other/mod.rs
++++ b/src/liblibc/src/unix/notbsd/linux/other/mod.rs
+@@ -180,41 +180,62 @@ s! {
+     }
+ 
+     pub struct nlmsghdr {
+-        nlmsg_len: u32,
+-        nlmsg_type: u16,
+-        nlmsg_flags: u16,
+-        nlmsg_seq: u32,
+-        nlmsg_pid: u32,
++        pub nlmsg_len: u32,
++        pub nlmsg_type: u16,
++        pub nlmsg_flags: u16,
++        pub nlmsg_seq: u32,
++        pub nlmsg_pid: u32,
+     }
+ 
+     pub struct nlmsgerr {
+-        error: ::c_int,
+-        msg: nlmsghdr,
++        pub error: ::c_int,
++        pub msg: nlmsghdr,
+     }
+ 
+     pub struct nl_pktinfo {
+-        group: u32,
++        pub group: u32,
+     }
+ 
+     pub struct nl_mmap_req {
+-        nm_block_size: ::c_uint,
+-        nm_block_nr: ::c_uint,
+-        nm_frame_size: ::c_uint,
+-        nm_frame_nr: ::c_uint,
++        pub nm_block_size: ::c_uint,
++        pub nm_block_nr: ::c_uint,
++        pub nm_frame_size: ::c_uint,
++        pub nm_frame_nr: ::c_uint,
+     }
+ 
+     pub struct nl_mmap_hdr {
+-        nm_status: ::c_uint,
+-        nm_len: ::c_uint,
+-        nm_group: u32,
+-        nm_pid: u32,
+-        nm_uid: u32,
+-        nm_gid: u32,
++        pub nm_status: ::c_uint,
++        pub nm_len: ::c_uint,
++        pub nm_group: u32,
++        pub nm_pid: u32,
++        pub nm_uid: u32,
++        pub nm_gid: u32,
+     }
+ 
+     pub struct nlattr {
+-        nla_len: u16,
+-        nla_type: u16,
++        pub nla_len: u16,
++        pub nla_type: u16,
++    }
++
++    pub struct rtentry {
++        pub rt_pad1: ::c_ulong,
++        pub rt_dst: ::sockaddr,
++        pub rt_gateway: ::sockaddr,
++        pub rt_genmask: ::sockaddr,
++        pub rt_flags: ::c_ushort,
++        pub rt_pad2: ::c_short,
++        pub rt_pad3: ::c_ulong,
++        pub rt_tos: ::c_uchar,
++        pub rt_class: ::c_uchar,
++        #[cfg(target_pointer_width = "64")]
++        pub rt_pad4: [::c_short; 3usize],
++        #[cfg(not(target_pointer_width = "64"))]
++        pub rt_pad4: ::c_short,
++        pub rt_metric: ::c_short,
++        pub rt_dev: *mut ::c_char,
++        pub rt_mtu: ::c_ulong,
++        pub rt_window: ::c_ulong,
++        pub rt_irtt: ::c_ushort,
+     }
+ }
+ 
+@@ -813,6 +834,7 @@ cfg_if! {
+         pub const PTHREAD_STACK_MIN: ::size_t = 131072;
+     }
+ }
++pub const PTHREAD_MUTEX_ADAPTIVE_NP: ::c_int = 3;
+ 
+ f! {
+     pub fn NLA_ALIGN(len: ::c_int) -> ::c_int {
+diff --git a/src/liblibc/src/unix/notbsd/linux/s390x.rs b/src/liblibc/src/unix/notbsd/linux/s390x.rs
+index 103abcc..61745a3 100644
+--- a/src/liblibc/src/unix/notbsd/linux/s390x.rs
++++ b/src/liblibc/src/unix/notbsd/linux/s390x.rs
+@@ -153,6 +153,21 @@ s! {
+         f_spare: [::c_uint; 4],
+     }
+ 
++    pub struct statvfs {
++        pub f_bsize: ::c_ulong,
++        pub f_frsize: ::c_ulong,
++        pub f_blocks: ::fsblkcnt_t,
++        pub f_bfree: ::fsblkcnt_t,
++        pub f_bavail: ::fsblkcnt_t,
++        pub f_files: ::fsfilcnt_t,
++        pub f_ffree: ::fsfilcnt_t,
++        pub f_favail: ::fsfilcnt_t,
++        pub f_fsid: ::c_ulong,
++        pub f_flag: ::c_ulong,
++        pub f_namemax: ::c_ulong,
++        __f_spare: [::c_int; 6],
++    }
++
+     pub struct msghdr {
+         pub msg_name: *mut ::c_void,
+         pub msg_namelen: ::socklen_t,
+@@ -356,6 +371,31 @@ pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 40;
+ pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 56;
+ pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: usize = 8;
+ 
++pub const PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++pub const PTHREAD_ERRORCHECK_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++pub const PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP: ::pthread_mutex_t =
++    ::pthread_mutex_t {
++        __align: [],
++        size: [
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0,
++            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++        ],
++    };
++
+ pub const EADDRINUSE: ::c_int = 98;
+ pub const EADDRNOTAVAIL: ::c_int = 99;
+ pub const ECONNABORTED: ::c_int = 103;
+@@ -374,6 +414,7 @@ pub const O_CREAT: ::c_int = 64;
+ pub const O_EXCL: ::c_int = 128;
+ pub const O_NONBLOCK: ::c_int = 2048;
+ pub const PTHREAD_STACK_MIN: ::size_t = 16384;
++pub const PTHREAD_MUTEX_ADAPTIVE_NP: ::c_int = 3;
+ pub const RLIM_INFINITY: ::rlim_t = 0xffffffffffffffff;
+ pub const SA_NOCLDWAIT: ::c_int = 2;
+ pub const SA_ONSTACK: ::c_int = 0x08000000;
+diff --git a/src/liblibc/src/unix/notbsd/mod.rs b/src/liblibc/src/unix/notbsd/mod.rs
+index 92dfad6..2de3ac8 100644
+--- a/src/liblibc/src/unix/notbsd/mod.rs
++++ b/src/liblibc/src/unix/notbsd/mod.rs
+@@ -177,6 +177,35 @@ s! {
+         #[cfg(target_pointer_width = "32")]
+         __unused1: [::c_int; 12]
+     }
++
++    pub struct in_pktinfo {
++        pub ipi_ifindex: ::c_int,
++        pub ipi_spec_dst: ::in_addr,
++        pub ipi_addr: ::in_addr,
++    }
++
++    pub struct ifaddrs {
++        pub ifa_next: *mut ifaddrs,
++        pub ifa_name: *mut c_char,
++        pub ifa_flags: ::c_uint,
++        pub ifa_addr: *mut ::sockaddr,
++        pub ifa_netmask: *mut ::sockaddr,
++        pub ifa_ifu: *mut ::sockaddr, // FIXME This should be a union
++        pub ifa_data: *mut ::c_void
++    }
++
++    pub struct in6_rtmsg {
++        rtmsg_dst: ::in6_addr,
++        rtmsg_src: ::in6_addr,
++        rtmsg_gateway: ::in6_addr,
++        rtmsg_type: u32,
++        rtmsg_dst_len: u16,
++        rtmsg_src_len: u16,
++        rtmsg_metric: u32,
++        rtmsg_info: ::c_ulong,
++        rtmsg_flags: u32,
++        rtmsg_ifindex: ::c_int,
++    }
+ }
+ 
+ // intentionally not public, only used for fd_set
+@@ -573,6 +602,7 @@ pub const IP_MULTICAST_TTL: ::c_int = 33;
+ pub const IP_MULTICAST_LOOP: ::c_int = 34;
+ pub const IP_TTL: ::c_int = 2;
+ pub const IP_HDRINCL: ::c_int = 3;
++pub const IP_PKTINFO: ::c_int = 8;
+ pub const IP_ADD_MEMBERSHIP: ::c_int = 35;
+ pub const IP_DROP_MEMBERSHIP: ::c_int = 36;
+ pub const IP_TRANSPARENT: ::c_int = 19;
+@@ -583,6 +613,8 @@ pub const IPV6_MULTICAST_LOOP: ::c_int = 19;
+ pub const IPV6_ADD_MEMBERSHIP: ::c_int = 20;
+ pub const IPV6_DROP_MEMBERSHIP: ::c_int = 21;
+ pub const IPV6_V6ONLY: ::c_int = 26;
++pub const IPV6_RECVPKTINFO: ::c_int = 49;
++pub const IPV6_PKTINFO: ::c_int = 50;
+ 
+ pub const TCP_NODELAY: ::c_int = 1;
+ pub const TCP_MAXSEG: ::c_int = 2;
+@@ -805,6 +837,52 @@ pub const POLLNVAL: ::c_short = 0x20;
+ pub const POLLRDNORM: ::c_short = 0x040;
+ pub const POLLRDBAND: ::c_short = 0x080;
+ 
++pub const IPTOS_LOWDELAY: u8 = 0x10;
++pub const IPTOS_THROUGHPUT: u8 = 0x08;
++pub const IPTOS_RELIABILITY: u8 = 0x04;
++pub const IPTOS_MINCOST: u8 = 0x02;
++
++pub const IPTOS_PREC_NETCONTROL: u8 = 0xe0;
++pub const IPTOS_PREC_INTERNETCONTROL: u8 = 0xc0;
++pub const IPTOS_PREC_CRITIC_ECP: u8 = 0xa0;
++pub const IPTOS_PREC_FLASHOVERRIDE: u8 = 0x80;
++pub const IPTOS_PREC_FLASH: u8 = 0x60;
++pub const IPTOS_PREC_IMMEDIATE: u8 = 0x40;
++pub const IPTOS_PREC_PRIORITY: u8 = 0x20;
++pub const IPTOS_PREC_ROUTINE: u8 = 0x00;
++
++pub const IPOPT_COPY: u8 = 0x80;
++pub const IPOPT_CLASS_MASK: u8 = 0x60;
++pub const IPOPT_NUMBER_MASK: u8 = 0x1f;
++
++pub const IPOPT_CONTROL: u8 = 0x00;
++pub const IPOPT_RESERVED1: u8 = 0x20;
++pub const IPOPT_MEASUREMENT: u8 = 0x40;
++pub const IPOPT_RESERVED2: u8 = 0x60;
++pub const IPOPT_END: u8 = (0 |IPOPT_CONTROL);
++pub const IPOPT_NOOP: u8 = (1 |IPOPT_CONTROL);
++pub const IPOPT_SEC: u8 = (2 |IPOPT_CONTROL|IPOPT_COPY);
++pub const IPOPT_LSRR: u8 = (3 |IPOPT_CONTROL|IPOPT_COPY);
++pub const IPOPT_TIMESTAMP: u8 = (4 |IPOPT_MEASUREMENT);
++pub const IPOPT_RR: u8 = (7 |IPOPT_CONTROL);
++pub const IPOPT_SID: u8 = (8 |IPOPT_CONTROL|IPOPT_COPY);
++pub const IPOPT_SSRR: u8 = (9 |IPOPT_CONTROL|IPOPT_COPY);
++pub const IPOPT_RA: u8 = (20|IPOPT_CONTROL|IPOPT_COPY);
++pub const IPVERSION: u8 = 4;
++pub const MAXTTL: u8 = 255;
++pub const IPDEFTTL: u8 = 64;
++pub const IPOPT_OPTVAL: u8 = 0;
++pub const IPOPT_OLEN: u8 = 1;
++pub const IPOPT_OFFSET: u8 = 2;
++pub const IPOPT_MINOFF: u8 = 4;
++pub const MAX_IPOPTLEN: u8 = 40;
++pub const IPOPT_NOP: u8 = IPOPT_NOOP;
++pub const IPOPT_EOL: u8 = IPOPT_END;
++pub const IPOPT_TS: u8 = IPOPT_TIMESTAMP;
++pub const IPOPT_TS_TSONLY: u8 = 0;
++pub const IPOPT_TS_TSANDADDR: u8 = 1;
++pub const IPOPT_TS_PRESPEC: u8 = 3;
++
+ f! {
+     pub fn FD_CLR(fd: ::c_int, set: *mut fd_set) -> () {
+         let fd = fd as usize;
+@@ -867,6 +945,18 @@ f! {
+     pub fn QCMD(cmd: ::c_int, type_: ::c_int) -> ::c_int {
+         (cmd << 8) | (type_ & 0x00ff)
+     }
++
++    pub fn IPOPT_COPIED(o: u8) -> u8 {
++        o & IPOPT_COPY
++    }
++
++    pub fn IPOPT_CLASS(o: u8) -> u8 {
++        o & IPOPT_CLASS_MASK
++    }
++
++    pub fn IPOPT_NUMBER(o: u8) -> u8 {
++        o & IPOPT_NUMBER_MASK
++    }
+ }
+ 
+ extern {
+@@ -994,6 +1084,23 @@ extern {
+     pub fn fexecve(fd: ::c_int, argv: *const *const ::c_char,
+                    envp: *const *const ::c_char)
+                    -> ::c_int;
++    pub fn getifaddrs(ifap: *mut *mut ::ifaddrs) -> ::c_int;
++    pub fn freeifaddrs(ifa: *mut ::ifaddrs);
++    pub fn bind(socket: ::c_int, address: *const ::sockaddr,
++                address_len: ::socklen_t) -> ::c_int;
++
++    pub fn writev(fd: ::c_int,
++                  iov: *const ::iovec,
++                  iovcnt: ::c_int) -> ::ssize_t;
++    pub fn readv(fd: ::c_int,
++                 iov: *const ::iovec,
++                 iovcnt: ::c_int) -> ::ssize_t;
++
++    pub fn sendmsg(fd: ::c_int,
++                   msg: *const ::msghdr,
++                   flags: ::c_int) -> ::ssize_t;
++    pub fn recvmsg(fd: ::c_int, msg: *mut ::msghdr, flags: ::c_int)
++                   -> ::ssize_t;
+ }
+ 
+ cfg_if! {
+diff --git a/src/liblibc/src/unix/solaris/mod.rs b/src/liblibc/src/unix/solaris/mod.rs
+index 5f8abde..aecc611 100644
+--- a/src/liblibc/src/unix/solaris/mod.rs
++++ b/src/liblibc/src/unix/solaris/mod.rs
+@@ -1316,6 +1316,8 @@ extern {
+                                      clock_id: ::clockid_t) -> ::c_int;
+     pub fn sem_timedwait(sem: *mut sem_t,
+                          abstime: *const ::timespec) -> ::c_int;
++    pub fn sem_getvalue(sem: *mut sem_t,
++                        sval: *mut ::c_int) -> ::c_int;
+     pub fn pthread_mutex_timedlock(lock: *mut pthread_mutex_t,
+                                    abstime: *const ::timespec) -> ::c_int;
+     pub fn waitid(idtype: idtype_t, id: id_t, infop: *mut ::siginfo_t,
+diff --git a/src/liblibc/src/unix/uclibc/mips/mips32.rs b/src/liblibc/src/unix/uclibc/mips/mips32.rs
+index 70d26e7..7ad547c 100644
+--- a/src/liblibc/src/unix/uclibc/mips/mips32.rs
++++ b/src/liblibc/src/unix/uclibc/mips/mips32.rs
+@@ -66,7 +66,7 @@ s! {
+     }
+ 
+     pub struct sigaction {
+-        pub sa_flags: ::c_int,
++        pub sa_flags: ::c_uint,
+         pub sa_sigaction: ::sighandler_t,
+         pub sa_mask: sigset_t,
+         _restorer: *mut ::c_void,
+@@ -238,7 +238,372 @@ pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;
+ 
+ pub const RLIM_INFINITY: ::rlim_t = 0x7fffffff;
+ 
+-pub const SYS_gettid: ::c_long = 4222;   // Valid for O32
++pub const SYS_syscall: ::c_long = 4000 + 0;
++pub const SYS_exit: ::c_long = 4000 + 1;
++pub const SYS_fork: ::c_long = 4000 + 2;
++pub const SYS_read: ::c_long = 4000 + 3;
++pub const SYS_write: ::c_long = 4000 + 4;
++pub const SYS_open: ::c_long = 4000 + 5;
++pub const SYS_close: ::c_long = 4000 + 6;
++pub const SYS_waitpid: ::c_long = 4000 + 7;
++pub const SYS_creat: ::c_long = 4000 + 8;
++pub const SYS_link: ::c_long = 4000 + 9;
++pub const SYS_unlink: ::c_long = 4000 +  10;
++pub const SYS_execve: ::c_long = 4000 +  11;
++pub const SYS_chdir: ::c_long = 4000 +  12;
++pub const SYS_time: ::c_long = 4000 +  13;
++pub const SYS_mknod: ::c_long = 4000 +  14;
++pub const SYS_chmod: ::c_long = 4000 +  15;
++pub const SYS_lchown: ::c_long = 4000 +  16;
++pub const SYS_break: ::c_long = 4000 +  17;
++pub const SYS_unused18: ::c_long = 4000 +  18;
++pub const SYS_lseek: ::c_long = 4000 +  19;
++pub const SYS_getpid: ::c_long = 4000 +  20;
++pub const SYS_mount: ::c_long = 4000 +  21;
++pub const SYS_umount: ::c_long = 4000 +  22;
++pub const SYS_setuid: ::c_long = 4000 +  23;
++pub const SYS_getuid: ::c_long = 4000 +  24;
++pub const SYS_stime: ::c_long = 4000 +  25;
++pub const SYS_ptrace: ::c_long = 4000 +  26;
++pub const SYS_alarm: ::c_long = 4000 +  27;
++pub const SYS_unused28: ::c_long = 4000 +  28;
++pub const SYS_pause: ::c_long = 4000 +  29;
++pub const SYS_utime: ::c_long = 4000 +  30;
++pub const SYS_stty: ::c_long = 4000 +  31;
++pub const SYS_gtty: ::c_long = 4000 +  32;
++pub const SYS_access: ::c_long = 4000 +  33;
++pub const SYS_nice: ::c_long = 4000 +  34;
++pub const SYS_ftime: ::c_long = 4000 +  35;
++pub const SYS_sync: ::c_long = 4000 +  36;
++pub const SYS_kill: ::c_long = 4000 +  37;
++pub const SYS_rename: ::c_long = 4000 +  38;
++pub const SYS_mkdir: ::c_long = 4000 +  39;
++pub const SYS_rmdir: ::c_long = 4000 +  40;
++pub const SYS_dup: ::c_long = 4000 +  41;
++pub const SYS_pipe: ::c_long = 4000 +  42;
++pub const SYS_times: ::c_long = 4000 +  43;
++pub const SYS_prof: ::c_long = 4000 +  44;
++pub const SYS_brk: ::c_long = 4000 +  45;
++pub const SYS_setgid: ::c_long = 4000 +  46;
++pub const SYS_getgid: ::c_long = 4000 +  47;
++pub const SYS_signal: ::c_long = 4000 +  48;
++pub const SYS_geteuid: ::c_long = 4000 +  49;
++pub const SYS_getegid: ::c_long = 4000 +  50;
++pub const SYS_acct: ::c_long = 4000 +  51;
++pub const SYS_umount2: ::c_long = 4000 +  52;
++pub const SYS_lock: ::c_long = 4000 +  53;
++pub const SYS_ioctl: ::c_long = 4000 +  54;
++pub const SYS_fcntl: ::c_long = 4000 +  55;
++pub const SYS_mpx: ::c_long = 4000 +  56;
++pub const SYS_setpgid: ::c_long = 4000 +  57;
++pub const SYS_ulimit: ::c_long = 4000 +  58;
++pub const SYS_unused59: ::c_long = 4000 +  59;
++pub const SYS_umask: ::c_long = 4000 +  60;
++pub const SYS_chroot: ::c_long = 4000 +  61;
++pub const SYS_ustat: ::c_long = 4000 +  62;
++pub const SYS_dup2: ::c_long = 4000 +  63;
++pub const SYS_getppid: ::c_long = 4000 +  64;
++pub const SYS_getpgrp: ::c_long = 4000 +  65;
++pub const SYS_setsid: ::c_long = 4000 +  66;
++pub const SYS_sigaction: ::c_long = 4000 +  67;
++pub const SYS_sgetmask: ::c_long = 4000 +  68;
++pub const SYS_ssetmask: ::c_long = 4000 +  69;
++pub const SYS_setreuid: ::c_long = 4000 +  70;
++pub const SYS_setregid: ::c_long = 4000 +  71;
++pub const SYS_sigsuspend: ::c_long = 4000 +  72;
++pub const SYS_sigpending: ::c_long = 4000 +  73;
++pub const SYS_sethostname: ::c_long = 4000 +  74;
++pub const SYS_setrlimit: ::c_long = 4000 +  75;
++pub const SYS_getrlimit: ::c_long = 4000 +  76;
++pub const SYS_getrusage: ::c_long = 4000 +  77;
++pub const SYS_gettimeofday: ::c_long = 4000 +  78;
++pub const SYS_settimeofday: ::c_long = 4000 +  79;
++pub const SYS_getgroups: ::c_long = 4000 +  80;
++pub const SYS_setgroups: ::c_long = 4000 +  81;
++pub const SYS_reserved82: ::c_long = 4000 +  82;
++pub const SYS_symlink: ::c_long = 4000 +  83;
++pub const SYS_unused84: ::c_long = 4000 +  84;
++pub const SYS_readlink: ::c_long = 4000 +  85;
++pub const SYS_uselib: ::c_long = 4000 +  86;
++pub const SYS_swapon: ::c_long = 4000 +  87;
++pub const SYS_reboot: ::c_long = 4000 +  88;
++pub const SYS_readdir: ::c_long = 4000 +  89;
++pub const SYS_mmap: ::c_long = 4000 +  90;
++pub const SYS_munmap: ::c_long = 4000 +  91;
++pub const SYS_truncate: ::c_long = 4000 +  92;
++pub const SYS_ftruncate: ::c_long = 4000 +  93;
++pub const SYS_fchmod: ::c_long = 4000 +  94;
++pub const SYS_fchown: ::c_long = 4000 +  95;
++pub const SYS_getpriority: ::c_long = 4000 +  96;
++pub const SYS_setpriority: ::c_long = 4000 +  97;
++pub const SYS_profil: ::c_long = 4000 +  98;
++pub const SYS_statfs: ::c_long = 4000 +  99;
++pub const SYS_fstatfs: ::c_long = 4000 + 100;
++pub const SYS_ioperm: ::c_long = 4000 + 101;
++pub const SYS_socketcall: ::c_long = 4000 + 102;
++pub const SYS_syslog: ::c_long = 4000 + 103;
++pub const SYS_setitimer: ::c_long = 4000 + 104;
++pub const SYS_getitimer: ::c_long = 4000 + 105;
++pub const SYS_stat: ::c_long = 4000 + 106;
++pub const SYS_lstat: ::c_long = 4000 + 107;
++pub const SYS_fstat: ::c_long = 4000 + 108;
++pub const SYS_unused109: ::c_long = 4000 + 109;
++pub const SYS_iopl: ::c_long = 4000 + 110;
++pub const SYS_vhangup: ::c_long = 4000 + 111;
++pub const SYS_idle: ::c_long = 4000 + 112;
++pub const SYS_vm86: ::c_long = 4000 + 113;
++pub const SYS_wait4: ::c_long = 4000 + 114;
++pub const SYS_swapoff: ::c_long = 4000 + 115;
++pub const SYS_sysinfo: ::c_long = 4000 + 116;
++pub const SYS_ipc: ::c_long = 4000 + 117;
++pub const SYS_fsync: ::c_long = 4000 + 118;
++pub const SYS_sigreturn: ::c_long = 4000 + 119;
++pub const SYS_clone: ::c_long = 4000 + 120;
++pub const SYS_setdomainname: ::c_long = 4000 + 121;
++pub const SYS_uname: ::c_long = 4000 + 122;
++pub const SYS_modify_ldt: ::c_long = 4000 + 123;
++pub const SYS_adjtimex: ::c_long = 4000 + 124;
++pub const SYS_mprotect: ::c_long = 4000 + 125;
++pub const SYS_sigprocmask: ::c_long = 4000 + 126;
++pub const SYS_create_module: ::c_long = 4000 + 127;
++pub const SYS_init_module: ::c_long = 4000 + 128;
++pub const SYS_delete_module: ::c_long = 4000 + 129;
++pub const SYS_get_kernel_syms: ::c_long = 4000 + 130;
++pub const SYS_quotactl: ::c_long = 4000 + 131;
++pub const SYS_getpgid: ::c_long = 4000 + 132;
++pub const SYS_fchdir: ::c_long = 4000 + 133;
++pub const SYS_bdflush: ::c_long = 4000 + 134;
++pub const SYS_sysfs: ::c_long = 4000 + 135;
++pub const SYS_personality: ::c_long = 4000 + 136;
++pub const SYS_afs_syscall: ::c_long = 4000 + 137;
++pub const SYS_setfsuid: ::c_long = 4000 + 138;
++pub const SYS_setfsgid: ::c_long = 4000 + 139;
++pub const SYS__llseek: ::c_long = 4000 + 140;
++pub const SYS_getdents: ::c_long = 4000 + 141;
++pub const SYS__newselect: ::c_long = 4000 + 142;
++pub const SYS_flock: ::c_long = 4000 + 143;
++pub const SYS_msync: ::c_long = 4000 + 144;
++pub const SYS_readv: ::c_long = 4000 + 145;
++pub const SYS_writev: ::c_long = 4000 + 146;
++pub const SYS_cacheflush: ::c_long = 4000 + 147;
++pub const SYS_cachectl: ::c_long = 4000 + 148;
++pub const SYS_sysmips: ::c_long = 4000 + 149;
++pub const SYS_unused150: ::c_long = 4000 + 150;
++pub const SYS_getsid: ::c_long = 4000 + 151;
++pub const SYS_fdatasync: ::c_long = 4000 + 152;
++pub const SYS__sysctl: ::c_long = 4000 + 153;
++pub const SYS_mlock: ::c_long = 4000 + 154;
++pub const SYS_munlock: ::c_long = 4000 + 155;
++pub const SYS_mlockall: ::c_long = 4000 + 156;
++pub const SYS_munlockall: ::c_long = 4000 + 157;
++pub const SYS_sched_setparam: ::c_long = 4000 + 158;
++pub const SYS_sched_getparam: ::c_long = 4000 + 159;
++pub const SYS_sched_setscheduler: ::c_long = 4000 + 160;
++pub const SYS_sched_getscheduler: ::c_long = 4000 + 161;
++pub const SYS_sched_yield: ::c_long = 4000 + 162;
++pub const SYS_sched_get_priority_max: ::c_long = 4000 + 163;
++pub const SYS_sched_get_priority_min: ::c_long = 4000 + 164;
++pub const SYS_sched_rr_get_interval: ::c_long = 4000 + 165;
++pub const SYS_nanosleep: ::c_long = 4000 + 166;
++pub const SYS_mremap: ::c_long = 4000 + 167;
++pub const SYS_accept: ::c_long = 4000 + 168;
++pub const SYS_bind: ::c_long = 4000 + 169;
++pub const SYS_connect: ::c_long = 4000 + 170;
++pub const SYS_getpeername: ::c_long = 4000 + 171;
++pub const SYS_getsockname: ::c_long = 4000 + 172;
++pub const SYS_getsockopt: ::c_long = 4000 + 173;
++pub const SYS_listen: ::c_long = 4000 + 174;
++pub const SYS_recv: ::c_long = 4000 + 175;
++pub const SYS_recvfrom: ::c_long = 4000 + 176;
++pub const SYS_recvmsg: ::c_long = 4000 + 177;
++pub const SYS_send: ::c_long = 4000 + 178;
++pub const SYS_sendmsg: ::c_long = 4000 + 179;
++pub const SYS_sendto: ::c_long = 4000 + 180;
++pub const SYS_setsockopt: ::c_long = 4000 + 181;
++pub const SYS_shutdown: ::c_long = 4000 + 182;
++pub const SYS_socket: ::c_long = 4000 + 183;
++pub const SYS_socketpair: ::c_long = 4000 + 184;
++pub const SYS_setresuid: ::c_long = 4000 + 185;
++pub const SYS_getresuid: ::c_long = 4000 + 186;
++pub const SYS_query_module: ::c_long = 4000 + 187;
++pub const SYS_poll: ::c_long = 4000 + 188;
++pub const SYS_nfsservctl: ::c_long = 4000 + 189;
++pub const SYS_setresgid: ::c_long = 4000 + 190;
++pub const SYS_getresgid: ::c_long = 4000 + 191;
++pub const SYS_prctl: ::c_long = 4000 + 192;
++pub const SYS_rt_sigreturn: ::c_long = 4000 + 193;
++pub const SYS_rt_sigaction: ::c_long = 4000 + 194;
++pub const SYS_rt_sigprocmask: ::c_long = 4000 + 195;
++pub const SYS_rt_sigpending: ::c_long = 4000 + 196;
++pub const SYS_rt_sigtimedwait: ::c_long = 4000 + 197;
++pub const SYS_rt_sigqueueinfo: ::c_long = 4000 + 198;
++pub const SYS_rt_sigsuspend: ::c_long = 4000 + 199;
++pub const SYS_pread64: ::c_long = 4000 + 200;
++pub const SYS_pwrite64: ::c_long = 4000 + 201;
++pub const SYS_chown: ::c_long = 4000 + 202;
++pub const SYS_getcwd: ::c_long = 4000 + 203;
++pub const SYS_capget: ::c_long = 4000 + 204;
++pub const SYS_capset: ::c_long = 4000 + 205;
++pub const SYS_sigaltstack: ::c_long = 4000 + 206;
++pub const SYS_sendfile: ::c_long = 4000 + 207;
++pub const SYS_getpmsg: ::c_long = 4000 + 208;
++pub const SYS_putpmsg: ::c_long = 4000 + 209;
++pub const SYS_mmap2: ::c_long = 4000 + 210;
++pub const SYS_truncate64: ::c_long = 4000 + 211;
++pub const SYS_ftruncate64: ::c_long = 4000 + 212;
++pub const SYS_stat64: ::c_long = 4000 + 213;
++pub const SYS_lstat64: ::c_long = 4000 + 214;
++pub const SYS_fstat64: ::c_long = 4000 + 215;
++pub const SYS_pivot_root: ::c_long = 4000 + 216;
++pub const SYS_mincore: ::c_long = 4000 + 217;
++pub const SYS_madvise: ::c_long = 4000 + 218;
++pub const SYS_getdents64: ::c_long = 4000 + 219;
++pub const SYS_fcntl64: ::c_long = 4000 + 220;
++pub const SYS_reserved221: ::c_long = 4000 + 221;
++pub const SYS_gettid: ::c_long = 4000 + 222;
++pub const SYS_readahead: ::c_long = 4000 + 223;
++pub const SYS_setxattr: ::c_long = 4000 + 224;
++pub const SYS_lsetxattr: ::c_long = 4000 + 225;
++pub const SYS_fsetxattr: ::c_long = 4000 + 226;
++pub const SYS_getxattr: ::c_long = 4000 + 227;
++pub const SYS_lgetxattr: ::c_long = 4000 + 228;
++pub const SYS_fgetxattr: ::c_long = 4000 + 229;
++pub const SYS_listxattr: ::c_long = 4000 + 230;
++pub const SYS_llistxattr: ::c_long = 4000 + 231;
++pub const SYS_flistxattr: ::c_long = 4000 + 232;
++pub const SYS_removexattr: ::c_long = 4000 + 233;
++pub const SYS_lremovexattr: ::c_long = 4000 + 234;
++pub const SYS_fremovexattr: ::c_long = 4000 + 235;
++pub const SYS_tkill: ::c_long = 4000 + 236;
++pub const SYS_sendfile64: ::c_long = 4000 + 237;
++pub const SYS_futex: ::c_long = 4000 + 238;
++pub const SYS_sched_setaffinity: ::c_long = 4000 + 239;
++pub const SYS_sched_getaffinity: ::c_long = 4000 + 240;
++pub const SYS_io_setup: ::c_long = 4000 + 241;
++pub const SYS_io_destroy: ::c_long = 4000 + 242;
++pub const SYS_io_getevents: ::c_long = 4000 + 243;
++pub const SYS_io_submit: ::c_long = 4000 + 244;
++pub const SYS_io_cancel: ::c_long = 4000 + 245;
++pub const SYS_exit_group: ::c_long = 4000 + 246;
++pub const SYS_lookup_dcookie: ::c_long = 4000 + 247;
++pub const SYS_epoll_create: ::c_long = 4000 + 248;
++pub const SYS_epoll_ctl: ::c_long = 4000 + 249;
++pub const SYS_epoll_wait: ::c_long = 4000 + 250;
++pub const SYS_remap_file_pages: ::c_long = 4000 + 251;
++pub const SYS_set_tid_address: ::c_long = 4000 + 252;
++pub const SYS_restart_syscall: ::c_long = 4000 + 253;
++pub const SYS_fadvise64: ::c_long = 4000 + 254;
++pub const SYS_statfs64: ::c_long = 4000 + 255;
++pub const SYS_fstatfs64: ::c_long = 4000 + 256;
++pub const SYS_timer_create: ::c_long = 4000 + 257;
++pub const SYS_timer_settime: ::c_long = 4000 + 258;
++pub const SYS_timer_gettime: ::c_long = 4000 + 259;
++pub const SYS_timer_getoverrun: ::c_long = 4000 + 260;
++pub const SYS_timer_delete: ::c_long = 4000 + 261;
++pub const SYS_clock_settime: ::c_long = 4000 + 262;
++pub const SYS_clock_gettime: ::c_long = 4000 + 263;
++pub const SYS_clock_getres: ::c_long = 4000 + 264;
++pub const SYS_clock_nanosleep: ::c_long = 4000 + 265;
++pub const SYS_tgkill: ::c_long = 4000 + 266;
++pub const SYS_utimes: ::c_long = 4000 + 267;
++pub const SYS_mbind: ::c_long = 4000 + 268;
++pub const SYS_get_mempolicy: ::c_long = 4000 + 269;
++pub const SYS_set_mempolicy: ::c_long = 4000 + 270;
++pub const SYS_mq_open: ::c_long = 4000 + 271;
++pub const SYS_mq_unlink: ::c_long = 4000 + 272;
++pub const SYS_mq_timedsend: ::c_long = 4000 + 273;
++pub const SYS_mq_timedreceive: ::c_long = 4000 + 274;
++pub const SYS_mq_notify: ::c_long = 4000 + 275;
++pub const SYS_mq_getsetattr: ::c_long = 4000 + 276;
++pub const SYS_vserver: ::c_long = 4000 + 277;
++pub const SYS_waitid: ::c_long = 4000 + 278;
++/* pub const SYS_sys_setaltroot: ::c_long = 4000 + 279; */
++pub const SYS_add_key: ::c_long = 4000 + 280;
++pub const SYS_request_key: ::c_long = 4000 + 281;
++pub const SYS_keyctl: ::c_long = 4000 + 282;
++pub const SYS_set_thread_area: ::c_long = 4000 + 283;
++pub const SYS_inotify_init: ::c_long = 4000 + 284;
++pub const SYS_inotify_add_watch: ::c_long = 4000 + 285;
++pub const SYS_inotify_rm_watch: ::c_long = 4000 + 286;
++pub const SYS_migrate_pages: ::c_long = 4000 + 287;
++pub const SYS_openat: ::c_long = 4000 + 288;
++pub const SYS_mkdirat: ::c_long = 4000 + 289;
++pub const SYS_mknodat: ::c_long = 4000 + 290;
++pub const SYS_fchownat: ::c_long = 4000 + 291;
++pub const SYS_futimesat: ::c_long = 4000 + 292;
++pub const SYS_fstatat64: ::c_long = 4000 + 293;
++pub const SYS_unlinkat: ::c_long = 4000 + 294;
++pub const SYS_renameat: ::c_long = 4000 + 295;
++pub const SYS_linkat: ::c_long = 4000 + 296;
++pub const SYS_symlinkat: ::c_long = 4000 + 297;
++pub const SYS_readlinkat: ::c_long = 4000 + 298;
++pub const SYS_fchmodat: ::c_long = 4000 + 299;
++pub const SYS_faccessat: ::c_long = 4000 + 300;
++pub const SYS_pselect6: ::c_long = 4000 + 301;
++pub const SYS_ppoll: ::c_long = 4000 + 302;
++pub const SYS_unshare: ::c_long = 4000 + 303;
++pub const SYS_splice: ::c_long = 4000 + 304;
++pub const SYS_sync_file_range: ::c_long = 4000 + 305;
++pub const SYS_tee: ::c_long = 4000 + 306;
++pub const SYS_vmsplice: ::c_long = 4000 + 307;
++pub const SYS_move_pages: ::c_long = 4000 + 308;
++pub const SYS_set_robust_list: ::c_long = 4000 + 309;
++pub const SYS_get_robust_list: ::c_long = 4000 + 310;
++pub const SYS_kexec_load: ::c_long = 4000 + 311;
++pub const SYS_getcpu: ::c_long = 4000 + 312;
++pub const SYS_epoll_pwait: ::c_long = 4000 + 313;
++pub const SYS_ioprio_set: ::c_long = 4000 + 314;
++pub const SYS_ioprio_get: ::c_long = 4000 + 315;
++pub const SYS_utimensat: ::c_long = 4000 + 316;
++pub const SYS_signalfd: ::c_long = 4000 + 317;
++pub const SYS_timerfd: ::c_long = 4000 + 318;
++pub const SYS_eventfd: ::c_long = 4000 + 319;
++pub const SYS_fallocate: ::c_long = 4000 + 320;
++pub const SYS_timerfd_create: ::c_long = 4000 + 321;
++pub const SYS_timerfd_gettime: ::c_long = 4000 + 322;
++pub const SYS_timerfd_settime: ::c_long = 4000 + 323;
++pub const SYS_signalfd4: ::c_long = 4000 + 324;
++pub const SYS_eventfd2: ::c_long = 4000 + 325;
++pub const SYS_epoll_create1: ::c_long = 4000 + 326;
++pub const SYS_dup3: ::c_long = 4000 + 327;
++pub const SYS_pipe2: ::c_long = 4000 + 328;
++pub const SYS_inotify_init1: ::c_long = 4000 + 329;
++pub const SYS_preadv: ::c_long = 4000 + 330;
++pub const SYS_pwritev: ::c_long = 4000 + 331;
++pub const SYS_rt_tgsigqueueinfo: ::c_long = 4000 + 332;
++pub const SYS_perf_event_open: ::c_long = 4000 + 333;
++pub const SYS_accept4: ::c_long = 4000 + 334;
++pub const SYS_recvmmsg: ::c_long = 4000 + 335;
++pub const SYS_fanotify_init: ::c_long = 4000 + 336;
++pub const SYS_fanotify_mark: ::c_long = 4000 + 337;
++pub const SYS_prlimit64: ::c_long = 4000 + 338;
++pub const SYS_name_to_handle_at: ::c_long = 4000 + 339;
++pub const SYS_open_by_handle_at: ::c_long = 4000 + 340;
++pub const SYS_clock_adjtime: ::c_long = 4000 + 341;
++pub const SYS_syncfs: ::c_long = 4000 + 342;
++pub const SYS_sendmmsg: ::c_long = 4000 + 343;
++pub const SYS_setns: ::c_long = 4000 + 344;
++pub const SYS_process_vm_readv: ::c_long = 4000 + 345;
++pub const SYS_process_vm_writev: ::c_long = 4000 + 346;
++pub const SYS_kcmp: ::c_long = 4000 + 347;
++pub const SYS_finit_module: ::c_long = 4000 + 348;
++pub const SYS_sched_setattr: ::c_long = 4000 + 349;
++pub const SYS_sched_getattr: ::c_long = 4000 + 350;
++pub const SYS_renameat2: ::c_long = 4000 + 351;
++pub const SYS_seccomp: ::c_long = 4000 + 352;
++pub const SYS_getrandom: ::c_long = 4000 + 353;
++pub const SYS_memfd_create: ::c_long = 4000 + 354;
++pub const SYS_bpf: ::c_long = 4000 + 355;
++pub const SYS_execveat: ::c_long = 4000 + 356;
++pub const SYS_userfaultfd: ::c_long = 4000 + 357;
++pub const SYS_membarrier: ::c_long = 4000 + 358;
++pub const SYS_mlock2: ::c_long = 4000 + 359;
++pub const SYS_copy_file_range: ::c_long = 4000 + 360;
++pub const SYS_preadv2: ::c_long = 4000 + 361;
++pub const SYS_pwritev2: ::c_long = 4000 + 362;
++pub const SYS_pkey_mprotect: ::c_long = 4000 + 363;
++pub const SYS_pkey_alloc: ::c_long = 4000 + 364;
++pub const SYS_pkey_free: ::c_long = 4000 + 365;
+ 
+ #[link(name = "util")]
+ extern {
+diff --git a/src/liblibc/src/unix/uclibc/mod.rs b/src/liblibc/src/unix/uclibc/mod.rs
+index 34eddda..49f7792 100644
+--- a/src/liblibc/src/unix/uclibc/mod.rs
++++ b/src/liblibc/src/unix/uclibc/mod.rs
+@@ -1328,6 +1328,9 @@ pub const PR_GET_TID_ADDRESS: ::c_int = 40;
+ pub const PR_SET_THP_DISABLE: ::c_int = 41;
+ pub const PR_GET_THP_DISABLE: ::c_int = 42;
+ 
++pub const GRND_NONBLOCK: ::c_uint = 0x0001;
++pub const GRND_RANDOM: ::c_uint = 0x0002;
++
+ pub const ABDAY_1: ::nl_item = 0x300;
+ pub const ABDAY_2: ::nl_item = 0x301;
+ pub const ABDAY_3: ::nl_item = 0x302;
+@@ -1634,6 +1637,8 @@ extern {
+     pub fn unshare(flags: ::c_int) -> ::c_int;
+     pub fn sem_timedwait(sem: *mut sem_t,
+                          abstime: *const ::timespec) -> ::c_int;
++    pub fn sem_getvalue(sem: *mut sem_t,
++                        sval: *mut ::c_int) -> ::c_int;
+     pub fn accept4(fd: ::c_int, addr: *mut ::sockaddr, len: *mut ::socklen_t,
+                    flg: ::c_int) -> ::c_int;
+     pub fn pthread_mutex_timedlock(lock: *mut pthread_mutex_t,
+-- 
+2.16.4
+

--- a/dev-lang/rust/rust-1.28.0.recipe
+++ b/dev-lang/rust/rust-1.28.0.recipe
@@ -1,0 +1,168 @@
+SUMMARY="Modern and safe systems programming language"
+DESCRIPTION="Rust is a systems programming language that runs blazingly fast, \
+prevents almost all crashes*, and eliminates data races."
+HOMEPAGE="https://www.rust-lang.org/"
+COPYRIGHT="2018 The Rust Project Developers"
+LICENSE="MIT"
+REVISION="1"
+
+SOURCE_URI="https://static.rust-lang.org/dist/rustc-$portVersion-src.tar.xz"
+CHECKSUM_SHA256="8a899afd4b502b4ebff5cfc82cba77a8cb37113b5e6018f15c09545936081848"
+SOURCE_DIR="rustc-$portVersion-src"
+PATCHES="rust-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
+SECONDARY_ARCHITECTURES="?x86"
+
+cargoVersion="0.29.0"
+rlsVersion="0.128.0"
+rustfmtVersion="0.8.2"
+
+PROVIDES="
+	rust$secondaryArchSuffix = $portVersion
+	cmd:rustc = $portVersion
+	cmd:rustdoc = $portVersion
+	cmd:rust_gdb = $portVersion
+	cmd:rust_lldb = $portVersion
+	cmd:cargo$secondaryArchSuffix = $cargoVersion
+	cmd:cargo_fmt = $cargoVersion
+	cmd:rls = $rlsVersion
+	cmd:rustfmt = $rustfmtVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcrypto$secondaryArchSuffix
+	lib:libcurl$secondaryArchSuffix
+	lib:libssl$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libcurl$secondaryArchSuffix
+	devel:libssl$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cargo$secondaryArchSuffix == $cargoVersion
+	cmd:cmake
+	cmd:cmp
+	cmd:file
+	cmd:find
+	cmd:git
+	cmd:gcc$secondaryArchSuffix
+	cmd:grep
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:python
+	cmd:rustc == $portVersion
+	cmd:sed
+	cmd:tar
+	cmd:which
+	cmd:xargs
+	"
+
+BUILD()
+{
+	# write the build configuration
+	tr -d '\t' >config.toml <<- EOL
+		[llvm]
+		targets = "X86"
+		experimental-targets = ""
+
+		[build]
+		cargo = "/$relativeBinDir/cargo"
+		rustc = "/boot/system/bin/rustc"
+		submodules = false
+		extended = true
+		tools = ["cargo", "rls", "rustfmt", "analysis"]
+
+		[install]
+		prefix = "$prefix"
+		libdir = "$relativeLibDir"
+		mandir = "$relativeManDir"
+		docdir = "$relativeDevelopDocDir"
+		sysconfdir = "$relativeDataDir"
+
+		[rust]
+		channel = "stable"
+		use-jemalloc = false
+		rpath = false
+		deny-warnings = false
+		dist-src = false
+
+		[dist]
+		src-tarball = false
+EOL
+	# Disable ASLR: compiling stage 1 rustc requires a lot of RAM (about 1.5
+	# GB). Haiku has a per-process limit of 2GB on 32 bit systems. ASLR makes
+	# the available space even smaller. Disabling it will give us the space to
+	# compile Rust
+	export DISABLE_ASLR=1
+
+	# now build rust and cargo
+	./x.py dist
+}
+
+INSTALL()
+{
+	# we will manually invoke the install scripts
+	if [ $effectiveTargetArchitecture = x86 ]; then
+		architecture="i686-unknown-haiku"
+	fi
+	if [ $effectiveTargetArchitecture = x86_64 ]; then
+		architecture="x86_64-unknown-haiku"
+	fi
+
+	# let's install the packages one by one
+	cd $sourceDir/build/tmp/dist/
+	for module in "rust-docs-$srcGitRev-$architecture"     \
+	              "rust-std-$srcGitRev-$architecture"      \
+	              "rustc-$srcGitRev-$architecture"         \
+	              "rust-analysis-$srcGitRev-$architecture" \
+	              "cargo-$cargoVersion-$architecture"      \
+	              "rls-$rlsVersion-$architecture"          \
+	              "rustfmt-$rustfmtVersion-$architecture"
+	do
+		./$module/install.sh                               \
+				--prefix=$prefix                           \
+				--docdir=$developDocDir                    \
+				--libdir=$libDir                           \
+				--mandir=$manDir                           \
+				--sysconfdir=$dataDir                      \
+				--disable-ldconfig
+	done
+
+	# move the cargo and binaries (in case of a secondary arch)
+	if [ -n "$secondaryArchSuffix" ]; then
+		mkdir -p $binDir
+		mv $prefix/bin/cargo $binDir/cargo
+	fi
+
+	# remove zsh data, it is not used on Haiku anyway
+	rm -rf $prefix/share
+
+	# move the `rustlib` folder to the developLibDirs (as it is a framework of sorts)
+	# do create a link in $prefix/lib as that is where rustc expects things to live
+	# Note; this actually seems to be a bug in the Rust build system. The path
+	# to rustlib is hardcoded in the rustc binary, but it does allow it to be
+	# set to libdir_relative (see config.rs in the bootstrap tool). This variable
+	# is only set when the configure script is used to generate the config, not
+	# with config.toml
+	mkdir -p $developLibDir
+	mv $libDir/rustlib $developLibDir
+	ln -r -s $developLibDir/rustlib $prefix/lib/rustlib
+
+	# clean out unneccesary files created by the rust installer
+	rm $developLibDir/rustlib/components
+	rm $developLibDir/rustlib/install.log
+	rm $developLibDir/rustlib/manifest-*
+	rm $developLibDir/rustlib/rust-installer-version
+	rm $developLibDir/rustlib/uninstall.sh
+}
+
+TEST()
+{
+	./x.py test
+}

--- a/dev-lang/rust_bin/rust_bin-1.28.0.recipe
+++ b/dev-lang/rust_bin/rust_bin-1.28.0.recipe
@@ -1,0 +1,98 @@
+SUMMARY="Modern and safe systems programming language"
+DESCRIPTION="Rust is a systems programming language that runs blazingly fast, \
+prevents almost all crashes*, and eliminates data races."
+HOMEPAGE="https://www.rust-lang.org/"
+COPYRIGHT="2018 The Rust Project Developers"
+LICENSE="MIT"
+REVISION="1"
+
+case "$effectiveTargetArchitecture" in
+	x86)
+SOURCE_URI="http://dl.rust-on-haiku.com/dist/$portVersion/rust-$portVersion-i686-unknown-haiku.tar.xz"
+CHECKSUM_SHA256="f7dd24059a6cc7375d1547c0e915c226ff52bff123c57e5e79e680ee0d90ce49"
+SOURCE_DIR="rust-$portVersion-i686-unknown-haiku"
+		;;
+	x86_64)
+SOURCE_URI="http://dl.rust-on-haiku.com/dist/$portVersion/rust-$portVersion-x86_64-unknown-haiku.tar.xz"
+CHECKSUM_SHA256="e26c564611ad920dcfad0c96bb86782afe29a684107afca908461ae09634b428"
+SOURCE_DIR="rust-$portVersion-x86_64-unknown-haiku"
+		;;
+	*)
+SOURCE_URI="http://dl.rust-on-haiku.com/dist/$portVersion/rustc-$portVersion-src.tar.xz"
+CHECKSUM_SHA256="f180eab88ea3139765bff9499ecbdb12d67a4f0b5fcbf86829f30b0a9a58fd8f"
+SOURCE_DIR="rustc-$portVersion-src"
+		;;
+esac
+
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+DISABLE_SOURCE_PACKAGE=yes
+
+cargoVersion="0.29.0"
+rlsVersion="0.128.0"
+rustfmtVersion="0.8.2"
+
+PROVIDES="
+	rust_bin$secondaryArchSuffix = $portVersion
+	cmd:rustc = $portVersion
+	cmd:rustdoc = $portVersion
+	cmd:rust_gdb = $portVersion
+	cmd:rust_lldb = $portVersion
+	cmd:cargo$secondaryArchSuffix = $cargoVersion
+	cmd:cargo_fmt = $cargoVersion
+	cmd:rls = $rlsVersion
+	cmd:rustfmt = $rustfmtVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcrypto$secondaryArchSuffix
+	lib:libcurl$secondaryArchSuffix
+	lib:libssl$secondaryArchSuffix
+	lib:libssh2$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+CONFLICTS="
+	rust$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+
+INSTALL()
+{
+	./install.sh                                   \
+		--prefix=$prefix                           \
+		--docdir=$developDocDir                    \
+		--libdir=$libDir                           \
+		--mandir=$manDir                           \
+		--sysconfdir=$dataDir                      \
+		--disable-ldconfig
+
+	# move the cargo and binaries (in case of a secondary arch)
+	if [ -n "$secondaryArchSuffix" ]; then
+		mkdir -p $binDir
+		mv $prefix/bin/cargo $binDir/cargo
+	fi
+
+	# remove zsh data, it is not used on Haiku anyway
+	rm -rf $prefix/share
+
+	# move the `rustlib` folder to the developLibDirs (as it is a framework of sorts)
+	# do create a link in $prefix/lib as that is where rustc expects things to live
+	# Note; this actually seems to be a bug in the Rust build system. The path
+	# to rustlib is hardcoded in the rustc binary, but it does allow it to be
+	# set to libdir_relative (see config.rs in the bootstrap tool). This variable
+	# is only set when the configure script is used to generate the config, not
+	# with config.toml
+	mkdir -p $developLibDir
+	mv $libDir/rustlib $developLibDir
+	ln -r -s $developLibDir/rustlib $prefix/lib/rustlib
+
+	# clean out unneccesary files created by the rust installer
+	rm $developLibDir/rustlib/components
+	rm $developLibDir/rustlib/install.log
+	rm $developLibDir/rustlib/manifest-*
+	rm $developLibDir/rustlib/rust-installer-version
+	rm $developLibDir/rustlib/uninstall.sh
+}


### PR DESCRIPTION
The source based version is now based on the official source tarball.