### PR TITLE
Update sci-mathematics/amath to 1.8.5

### DIFF
--- a/sci-mathematics/amath/amath-1.8.5.recipe
+++ b/sci-mathematics/amath/amath-1.8.5.recipe
@@ -5,11 +5,11 @@ complex numbers, variables and user defined functions, logarithmic and exponenti
 functions, trigonometric and hyperbolic function and selected mathematical \
 constants and rounding functions."
 HOMEPAGE="https://amath.innolan.net"
-COPYRIGHT="2014-2017 Carsten Sonne Larsen"
+COPYRIGHT="2014-2018 Carsten Sonne Larsen"
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="http://dist2.innolan.net/amath-$portVersion.tar.gz"
-CHECKSUM_SHA256="2bb005c96429eaf6cd61a7e774e4e2fc1cbf89a2137f68ae741cb8691623c574"
+CHECKSUM_SHA256="ed77eb2a367a7462a0d13dc7d2188deb7464f59c166bdc346c3abcd9c0a4e31c"
 
 ARCHITECTURES="x86 x86_gcc2"
 
@@ -44,5 +44,5 @@ INSTALL()
 
 TEST()
 {
-	make test
+	make --test
 }

--- a/sci-mathematics/amath/amath-1.8.5.recipe
+++ b/sci-mathematics/amath/amath-1.8.5.recipe
@@ -4,14 +4,14 @@ IEEE 754 calculations with 15 significant digits, calculations with real and \
 complex numbers, variables and user defined functions, logarithmic and exponential \
 functions, trigonometric and hyperbolic function and selected mathematical \
 constants and rounding functions."
-HOMEPAGE="https://amath.innolan.net"
+HOMEPAGE="https://amath.innolan.net/"
 COPYRIGHT="2014-2018 Carsten Sonne Larsen"
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="http://dist2.innolan.net/amath-$portVersion.tar.gz"
 CHECKSUM_SHA256="ed77eb2a367a7462a0d13dc7d2188deb7464f59c166bdc346c3abcd9c0a4e31c"
 
-ARCHITECTURES="x86 x86_gcc2"
+ARCHITECTURES="x86_gcc2 x86 x86_64"
 
 PROVIDES="
 	amath = $portVersion
@@ -29,9 +29,16 @@ BUILD_PREREQUIRES="
 	cmd:make
 	"
 
+if [ "$effectiveTargetArchitecture" = x86_gcc2 ]; then
+PATCH()
+{
+	sed -i -e 's/^\(gcclib="-lstdc++\)"$/\1.r4"/;' configure
+}
+fi
+
 BUILD()
 {
-	./configure --without-stdc++ LDFLAGS=-lbe
+	./configure LDFLAGS=-lbe
 	make static $jobArgs
 }
 
@@ -44,5 +51,6 @@ INSTALL()
 
 TEST()
 {
-	make --test
+	LIBRARY_PATH="$sourceDir/src/lib:$sourceDir/src/cplex:$sourceDir/src/real:$sourceDir/src/clib${LIBRARY_PATH:+:$LIBRARY_PATH}" \
+	"$sourceDir"/amath --test
 }


### PR DESCRIPTION
Changes since 1.8.3
- Fix build on compilers with broken endian detection.
- Ignore casing in hexadecimal numbers.
