### PR TITLE
[WIP] llvm: bump version to 6.0.1 and add tests.

### DIFF
--- a/sys-devel/llvm/llvm-6.0.1.recipe
+++ b/sys-devel/llvm/llvm-6.0.1.recipe
@@ -1,0 +1,494 @@
+SUMMARY="Modular and reuseable compiler and toolchain technologies"
+DESCRIPTION="LLVM is a collection of modular and reuseable compiler and and \
+toolchain technologies.The LLVM compiler system for C and C++ includes the \
+following:
+
+- Front-ends for C, C++, Objective-C, Fortran, etc. based on the GCC 4.2 \
+parsers. They support the ANSI-standard C and C++ languages to the same \
+degree that GCC supports them. Additionally, many GCC extensions are \
+supported.
+- A stable implementation of the LLVM instruction set, which serves as both \
+the online and offline code representation, together with assembly (ASCII) \
+and bytecode (binary) readers and writers, and a verifier.
+- A powerful pass-management system that automatically sequences passes \
+(including analysis, transformation, and code-generation passes) based on \
+their dependences, and pipelines them for efficiency.
+- A wide range of global scalar optimizations.
+- A link-time interprocedural optimization framework with a rich set of \
+analyses and transformations, including sophisticated whole-program pointer \
+analysis, call graph construction, and support for profile-guided optimizations.
+- An easily retargettable code generator, which currently supports X86, \
+X86-64, PowerPC, PowerPC-64, ARM, Thumb, SPARC, Alpha, CellSPU, MIPS, MSP430, \
+SystemZ, and XCore.
+- A Just-In-Time (JIT) code generation system, which currently supports X86, \
+X86-64, ARM, AArch64, Mips, SystemZ, PowerPC, and PowerPC-64.
+- Support for generating DWARF debugging information.
+- A C back-end useful for testing and for generating native code on targets \
+other than the ones listed above.
+- A profiling system similar to gprof.
+- A test framework with a number of benchmark codes and applications.
+- APIs and debugging tools to simplify rapid development of LLVM components."
+HOMEPAGE="https://www.llvm.org/"
+COPYRIGHT="2003-2018 University of Illinois at Urbana-Champaign"
+LICENSE="UIUC"
+REVISION="1"
+SOURCE_URI="https://releases.llvm.org/$portVersion/llvm-$portVersion.src.tar.xz"
+CHECKSUM_SHA256="b6d6c324f9c71494c0ccaf3dac1f16236d970002b42bb24a6c9e1634f7d0f4e2"
+SOURCE_DIR="llvm-$portVersion.src"
+SOURCE_URI_2="https://releases.llvm.org/$portVersion/cfe-$portVersion.src.tar.xz"
+CHECKSUM_SHA256_2="7c243f1485bddfdfedada3cd402ff4792ea82362ff91fbdac2dae67c6026b667"
+SOURCE_DIR_2="cfe-$portVersion.src"
+SOURCE_URI_3="https://releases.llvm.org/$portVersion/clang-tools-extra-$portVersion.src.tar.xz"
+CHECKSUM_SHA256_3="0d2e3727786437574835b75135f9e36f861932a958d8547ced7e13ebdda115f1"
+SOURCE_DIR_3="clang-tools-extra-$portVersion.src"
+SOURCE_URI_4="https://releases.llvm.org/$portVersion/compiler-rt-$portVersion.src.tar.xz"
+CHECKSUM_SHA256_4="f4cd1e15e7d5cb708f9931d4844524e4904867240c306b06a4287b22ac1c99b9"
+SOURCE_DIR_4="compiler-rt-$portVersion.src"
+PATCHES="llvm-$portVersion.patchset"
+PATCHES_2="clang-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 !x86 !x86_64"
+SECONDARY_ARCHITECTURES="!x86"
+
+PROVIDES="
+	llvm$secondaryArchSuffix = $portVersion
+	cmd:bugpoint
+	cmd:find_all_symbols
+	cmd:llc
+	cmd:lli
+	cmd:llvm_ar
+	cmd:llvm_as
+	cmd:llvm_bcanalyzer
+	cmd:llvm_c_test
+	cmd:llvm_cat
+	cmd:llvm_config
+	cmd:llvm_cov
+	cmd:llvm_cvtres
+	cmd:llvm_cxxdump
+	cmd:llvm_cxxfilt
+	cmd:llvm_diff
+	cmd:llvm_dis
+	cmd:llvm_dlltool
+	cmd:llvm_dsymutil
+	cmd:llvm_dwarfdump
+	cmd:llvm_dwp
+	cmd:llvm_extract
+	cmd:llvm_lib
+	cmd:llvm_link
+	cmd:llvm_lto
+	cmd:llvm_lto2
+	cmd:llvm_mc
+	cmd:llvm_mcmarkup
+	cmd:llvm_modextract
+	cmd:llvm_mt
+	cmd:llvm_nm
+	cmd:llvm_objcopy
+	cmd:llvm_objdump
+	cmd:llvm_opt_report
+	cmd:llvm_pdbdump
+	cmd:llvm_pdbutil
+	cmd:llvm_profdata
+	cmd:llvm_ranlib
+	cmd:llvm_rc
+	cmd:llvm_readelf
+	cmd:llvm_readobj
+	cmd:llvm_rtdyld
+	cmd:llvm_size
+	cmd:llvm_split
+	cmd:llvm_stress
+	cmd:llvm_strings
+	cmd:llvm_symbolizer
+	cmd:llvm_tblgen
+	cmd:llvm_xray
+	cmd:obj2yaml
+	cmd:opt
+	cmd:sancov
+	cmd:sanstats
+	cmd:verify_uselistorder
+	cmd:yaml2obj
+	devel:libfindAllSymbols$secondaryArchSuffix
+	devel:libLLVM_6.0.1$secondaryArchSuffix
+	devel:libLLVM_6.0$secondaryArchSuffix
+	devel:libLLVM$secondaryArchSuffix
+	devel:libLLVMAArch64AsmParser$secondaryArchSuffix
+	devel:libLLVMAArch64AsmPrinter$secondaryArchSuffix
+	devel:libLLVMAArch64CodeGen$secondaryArchSuffix
+	devel:libLLVMAArch64Desc$secondaryArchSuffix
+	devel:libLLVMAArch64Disassembler$secondaryArchSuffix
+	devel:libLLVMAArch64Info$secondaryArchSuffix
+	devel:libLLVMAArch64Utils$secondaryArchSuffix
+	devel:libLLVMAMDGPUAsmParser$secondaryArchSuffix
+	devel:libLLVMAMDGPUAsmPrinter$secondaryArchSuffix
+	devel:libLLVMAMDGPUCodeGen$secondaryArchSuffix
+	devel:libLLVMAMDGPUDesc$secondaryArchSuffix
+	devel:libLLVMAMDGPUDisassembler$secondaryArchSuffix
+	devel:libLLVMAMDGPUInfo$secondaryArchSuffix
+	devel:libLLVMAMDGPUUtils$secondaryArchSuffix
+	devel:libLLVMARMAsmParser$secondaryArchSuffix
+	devel:libLLVMARMAsmPrinter$secondaryArchSuffix
+	devel:libLLVMARMCodeGen$secondaryArchSuffix
+	devel:libLLVMARMDesc$secondaryArchSuffix
+	devel:libLLVMARMDisassembler$secondaryArchSuffix
+	devel:libLLVMARMInfo$secondaryArchSuffix
+	devel:libLLVMARMUtils$secondaryArchSuffix
+	devel:libLLVMAnalysis$secondaryArchSuffix
+	devel:libLLVMAsmParser$secondaryArchSuffix
+	devel:libLLVMAsmPrinter$secondaryArchSuffix
+	devel:libLLVMBinaryFormat$secondaryArchSuffix
+	devel:libLLVMBitReader$secondaryArchSuffix
+	devel:libLLVMBitWriter$secondaryArchSuffix
+	devel:libLLVMBPFAsmParser$secondaryArchSuffix
+	devel:libLLVMBPFAsmPrinter$secondaryArchSuffix
+	devel:libLLVMBPFCodeGen$secondaryArchSuffix
+	devel:libLLVMBPFDesc$secondaryArchSuffix
+	devel:libLLVMBPFDisassembler$secondaryArchSuffix
+	devel:libLLVMBPFInfo$secondaryArchSuffix
+	devel:libLLVMCodeGen$secondaryArchSuffix
+	devel:libLLVMCore$secondaryArchSuffix
+	devel:libLLVMCoroutines$secondaryArchSuffix
+	devel:libLLVMCoverage$secondaryArchSuffix
+	devel:libLLVMDebugInfoCodeView$secondaryArchSuffix
+	devel:libLLVMDebugInfoDWARF$secondaryArchSuffix
+	devel:libLLVMDebugInfoMSF$secondaryArchSuffix
+	devel:libLLVMDebugInfoPDB$secondaryArchSuffix
+	devel:libLLVMDemangle$secondaryArchSuffix
+	devel:libLLVMDlltoolDriver$secondaryArchSuffix
+	devel:libLLVMExecutionEngine$secondaryArchSuffix
+	devel:libLLVMFuzzMutate$secondaryArchSuffix
+	devel:libLLVMGlobalISel$secondaryArchSuffix
+	devel:libLLVMHexagonAsmParser$secondaryArchSuffix
+	devel:libLLVMHexagonCodeGen$secondaryArchSuffix
+	devel:libLLVMHexagonDesc$secondaryArchSuffix
+	devel:libLLVMHexagonDisassembler$secondaryArchSuffix
+	devel:libLLVMHexagonInfo$secondaryArchSuffix
+	devel:libLLVMIRReader$secondaryArchSuffix
+	devel:libLLVMInstCombine$secondaryArchSuffix
+	devel:libLLVMInstrumentation$secondaryArchSuffix
+	devel:libLLVMInterpreter$secondaryArchSuffix
+	devel:libLLVMLanaiAsmParser$secondaryArchSuffix
+	devel:libLLVMLanaiAsmPrinter$secondaryArchSuffix
+	devel:libLLVMLanaiCodeGen$secondaryArchSuffix
+	devel:libLLVMLanaiDesc$secondaryArchSuffix
+	devel:libLLVMLanaiDisassembler$secondaryArchSuffix
+	devel:libLLVMLanaiInfo$secondaryArchSuffix
+	devel:libLLVMLanaiInstPrinter$secondaryArchSuffix
+	devel:libLLVMLTO$secondaryArchSuffix
+	devel:libLLVMLibDriver$secondaryArchSuffix
+	devel:libLLVMLineEditor$secondaryArchSuffix
+	devel:libLLVMLinker$secondaryArchSuffix
+	devel:libLLVMMC$secondaryArchSuffix
+	devel:libLLVMMCDisassembler$secondaryArchSuffix
+	devel:libLLVMMCJIT$secondaryArchSuffix
+	devel:libLLVMMCParser$secondaryArchSuffix
+	devel:libLLVMMIRParser$secondaryArchSuffix
+	devel:libLLVMMSP430AsmPrinter$secondaryArchSuffix
+	devel:libLLVMMSP430CodeGen$secondaryArchSuffix
+	devel:libLLVMMSP430Desc$secondaryArchSuffix
+	devel:libLLVMMSP430Info$secondaryArchSuffix
+	devel:libLLVMMipsAsmParser$secondaryArchSuffix
+	devel:libLLVMMipsAsmPrinter$secondaryArchSuffix
+	devel:libLLVMMipsCodeGen$secondaryArchSuffix
+	devel:libLLVMMipsDesc$secondaryArchSuffix
+	devel:libLLVMMipsDisassembler$secondaryArchSuffix
+	devel:libLLVMMipsInfo$secondaryArchSuffix
+	devel:libLLVMNVPTXAsmPrinter$secondaryArchSuffix
+	devel:libLLVMNVPTXCodeGen$secondaryArchSuffix
+	devel:libLLVMNVPTXDesc$secondaryArchSuffix
+	devel:libLLVMNVPTXInfo$secondaryArchSuffix
+	devel:libLLVMObjCARCOpts$secondaryArchSuffix
+	devel:libLLVMObject$secondaryArchSuffix
+	devel:libLLVMObjectYAML$secondaryArchSuffix
+	devel:libLLVMOption$secondaryArchSuffix
+	devel:libLLVMOrcJIT$secondaryArchSuffix
+	devel:libLLVMPasses$secondaryArchSuffix
+	devel:libLLVMPowerPCAsmParser$secondaryArchSuffix
+	devel:libLLVMPowerPCAsmPrinter$secondaryArchSuffix
+	devel:libLLVMPowerPCCodeGen$secondaryArchSuffix
+	devel:libLLVMPowerPCDesc$secondaryArchSuffix
+	devel:libLLVMPowerPCDisassembler$secondaryArchSuffix
+	devel:libLLVMPowerPCInfo$secondaryArchSuffix
+	devel:libLLVMProfileData$secondaryArchSuffix
+	devel:libLLVMRISCVCodeGen$secondaryArchSuffix
+	devel:libLLVMRISCVDesc$secondaryArchSuffix
+	devel:libLLVMRISCVInfo$secondaryArchSuffix
+	devel:libLLVMRuntimeDyld$secondaryArchSuffix
+	devel:libLLVMScalarOpts$secondaryArchSuffix
+	devel:libLLVMSelectionDAG$secondaryArchSuffix
+	devel:libLLVMSparcAsmParser$secondaryArchSuffix
+	devel:libLLVMSparcAsmPrinter$secondaryArchSuffix
+	devel:libLLVMSparcCodeGen$secondaryArchSuffix
+	devel:libLLVMSparcDesc$secondaryArchSuffix
+	devel:libLLVMSparcDisassembler$secondaryArchSuffix
+	devel:libLLVMSparcInfo$secondaryArchSuffix
+	devel:libLLVMSupport$secondaryArchSuffix
+	devel:libLLVMSymbolize$secondaryArchSuffix
+	devel:libLLVMSystemZAsmParser$secondaryArchSuffix
+	devel:libLLVMSystemZAsmPrinter$secondaryArchSuffix
+	devel:libLLVMSystemZCodeGen$secondaryArchSuffix
+	devel:libLLVMSystemZDesc$secondaryArchSuffix
+	devel:libLLVMSystemZDisassembler$secondaryArchSuffix
+	devel:libLLVMSystemZInfo$secondaryArchSuffix
+	devel:libLLVMTableGen$secondaryArchSuffix
+	devel:libLLVMTarget$secondaryArchSuffix
+	devel:libLLVMTransformUtils$secondaryArchSuffix
+	devel:libLLVMVectorize$secondaryArchSuffix
+	devel:libLLVMWindowsManifest$secondaryArchSuffix
+	devel:libLLVMX86AsmParser$secondaryArchSuffix
+	devel:libLLVMX86AsmPrinter$secondaryArchSuffix
+	devel:libLLVMX86CodeGen$secondaryArchSuffix
+	devel:libLLVMX86Desc$secondaryArchSuffix
+	devel:libLLVMX86Disassembler$secondaryArchSuffix
+	devel:libLLVMX86Info$secondaryArchSuffix
+	devel:libLLVMX86Utils$secondaryArchSuffix
+	devel:libLLVMXCoreAsmPrinter$secondaryArchSuffix
+	devel:libLLVMXCoreCodeGen$secondaryArchSuffix
+	devel:libLLVMXCoreDesc$secondaryArchSuffix
+	devel:libLLVMXCoreDisassembler$secondaryArchSuffix
+	devel:libLLVMXCoreInfo$secondaryArchSuffix
+	devel:libLLVMXRay$secondaryArchSuffix
+	devel:libLLVMipo$secondaryArchSuffix
+	devel:libLTO$secondaryArchSuffix
+	lib:BugpointPasses$secondaryArchSuffix
+	lib:LLVMHello$secondaryArchSuffix
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libLLVM_6.0$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_clang="
+	llvm${secondaryArchSuffix}_clang = $portVersion
+	cmd:clang = $portVersion
+	cmd:clangd = $portVersion
+	cmd:clang_6.0 = $portVersion
+	cmd:clang++ = $portVersion
+	cmd:clang_apply_replacements = $portVersion
+	cmd:clang_change_namespace = $portVersion
+	cmd:clang_check = $portVersion
+	cmd:clang_cl = $portVersion
+	cmd:clang_cpp = $portVersion
+	cmd:clang_format = $portVersion
+	cmd:clang_import_test = $portVersion
+	cmd:clang_include_fixer = $portVersion
+	cmd:clang_offload_bundler = $portVersion
+	cmd:clang_query = $portVersion
+	cmd:clang_refactor = $portVersion
+	cmd:clang_rename = $portVersion
+	cmd:clang_reorder_fields = $portVersion
+	cmd:clang_tidy = $portVersion
+	cmd:c_index_test = $portVersion
+	cmd:git_clang_format = $portVersion
+	cmd:modularize = $portVersion
+	lib:libclang$secondaryArchSuffix = $portVersion
+	devel:libclang$secondaryArchSuffix = $portVersion
+	devel:libclangarcmigrate$secondaryArchSuffix = $portVersion
+	devel:libclangast$secondaryArchSuffix = $portVersion
+	devel:libclangastmatchers$secondaryArchSuffix = $portVersion
+	devel:libclanganalysis$secondaryArchSuffix = $portVersion
+	devel:libclangapplyreplacements$secondaryArchSuffix = $portVersion
+	devel:libclangbasic$secondaryArchSuffix = $portVersion
+	devel:libclangchangenamespace$secondaryArchSuffix = $portVersion
+	devel:libclangcodegen$secondaryArchSuffix = $portVersion
+	devel:libclangdaemon$secondaryArchSuffix = $portVersion
+	devel:libclangdriver$secondaryArchSuffix = $portVersion
+	devel:libclangdynamicastmatchers$secondaryArchSuffix = $portVersion
+	devel:libclangedit$secondaryArchSuffix = $portVersion
+	devel:libclangformat$secondaryArchSuffix = $portVersion
+	devel:libclangfrontend$secondaryArchSuffix = $portVersion
+	devel:libclangfrontendtool$secondaryArchSuffix = $portVersion
+	devel:libclangincludefixer$secondaryArchSuffix = $portVersion
+	devel:libclangincludefixerplugin$secondaryArchSuffix = $portVersion
+	devel:libclangindex$secondaryArchSuffix = $portVersion
+	devel:libclanglex$secondaryArchSuffix = $portVersion
+	devel:libclangmove$secondaryArchSuffix = $portVersion
+	devel:libclangparse$secondaryArchSuffix = $portVersion
+	devel:libclangquery$secondaryArchSuffix = $portVersion
+	devel:libclangrename$secondaryArchSuffix = $portVersion
+	devel:libclangreorderfields$secondaryArchSuffix = $portVersion
+	devel:libclangrewrite$secondaryArchSuffix = $portVersion
+	devel:libclangrewritefrontend$secondaryArchSuffix = $portVersion
+	devel:libclangsema$secondaryArchSuffix = $portVersion
+	devel:libclangserialization$secondaryArchSuffix = $portVersion
+	devel:libclangstaticanalyzercheckers$secondaryArchSuffix = $portVersion
+	devel:libclangstaticanalyzercore$secondaryArchSuffix = $portVersion
+	devel:libclangstaticanalyzerfrontend$secondaryArchSuffix = $portVersion
+	devel:libclangtidy$secondaryArchSuffix = $portVersion
+	devel:libclangtidyandroidmodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidyboostmodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidybugpronemodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidycertmodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidycppcoreguidelinesmodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidygooglemodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidyhicppmodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidyllvmmodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidymiscmodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidymodernizemodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidympimodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidyperformancemodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidyplugin$secondaryArchSuffix = $portVersion
+	devel:libclangtidyreadability$secondaryArchSuffix = $portVersion
+	devel:libclangtidyreadabilitymodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidyutils$secondaryArchSuffix = $portVersion
+	devel:libclangtooling$secondaryArchSuffix = $portVersion
+	devel:libclangtoolingastdiff$secondaryArchSuffix = $portVersion
+	devel:libclangtoolingcore$secondaryArchSuffix = $portVersion
+	devel:libclangtoolingrefactor$secondaryArchSuffix = $portVersion
+	"
+REQUIRES_clang="
+	haiku$secondaryArchSuffix
+	lib:libLLVM_6.0$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_clang_analysis="
+	llvm${secondaryArchSuffix}_clang_analysis = $portVersion
+	cmd:c++_analyzer = $portVersion
+	cmd:ccc_analyzer = $portVersion
+	cmd:scan_build = $portVersion
+	cmd:scan_view = $portVersion
+	"
+REQUIRES_clang_analysis="
+	llvm${secondaryArchSuffix}_clang == $portVersion base
+	cmd:python
+	"
+
+PROVIDES_libs="
+	llvm${secondaryArchSuffix}_libs = $portVersion
+	lib:libLLVM_6.0$secondaryArchSuffix
+	lib:libLTO$secondaryArchSuffix
+	"
+REQUIRES_libs="
+	haiku$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:diff
+	cmd:find
+	cmd:gcc$secondaryArchSuffix
+	cmd:grep
+	cmd:groff
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:ninja
+	cmd:python
+	cmd:sed
+	"
+
+BUILD()
+{
+	# Add clang tools
+	mkdir -p tools/clang
+	cp -rd $sourceDir2/* tools/clang/
+
+	# Add clang tools's tool's (really llvm?)
+	mkdir -p tools/clang/tools/extra
+	cp -rd $sourceDir3/* tools/clang/tools/extra
+
+	mkdir -p projects/compiler-rt
+	cp -rd $sourceDir4/* projects/compiler-rt
+
+	local cmakeFlags
+	if [ -n "$secondaryArchSuffix" ]; then
+		cmakeFlags=-DHAIKU_HYBRID_SECONDARY="\"${effectiveTargetArchitecture}\""
+	fi
+
+	mkdir -p build; cd build
+	# Haiku C++ requires rtti in a lot of central system components
+	# such as Mesa
+	cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$prefix \
+		-DCMAKE_SKIP_RPATH=YES $cmakeFlags \
+		-DLLVM_ENABLE_RTTI=ON -DLLVM_LINK_LLVM_DYLIB=YES \
+		-DLLVM_ENABLE_BUILD_TESTS=YES \
+		..
+
+	make $jobArgs PROJ_datadir=$dataDir PROJ_docsdir=$docDir \
+		PROJ_mandir=$manDir PROJ_includedir=$includeDir PROJ_libdir=$libDir
+}
+
+INSTALL()
+{
+	cd build
+
+	mkdir -p $binDir $developDir $dataDir $docDir $includeDir $manDir
+
+	make install PROJ_datadir=$dataDir PROJ_docsdir=$docDir \
+		PROJ_mandir=$manDir PROJ_includedir=$includeDir PROJ_libdir=$libDir
+
+	make -C tools/clang install PROJ_datadir=$dataDir PROJ_docsdir=$docDir \
+		PROJ_mandir=$manDir PROJ_includedir=$includeDir PROJ_libdir=$libDir
+
+	make -C projects/compiler-rt install PROJ_datadir=$dataDir PROJ_docsdir=$docDir \
+		PROJ_mandir=$manDir PROJ_includedir=$includeDir PROJ_libdir=$libDir
+
+	if [ -n $secondaryArchSuffix ]; then
+		mv $prefix/lib $prefix/lib2
+		mkdir -p $libDir
+		mv $prefix/lib2/* $libDir/
+		rmdir $prefix/lib2
+		binDir=$prefix/bin
+	fi
+
+	# You can try and be fancy here parsing each arch in a for loop... but
+	# not all arches contain the same libraries. The inventory for each arch
+	# also changes between releases... so lets KISS.
+	prepareInstalledDevelLibs \
+		libfindAllSymbols \
+		libLLVM* \
+		libLTO	\
+		libclang*
+
+	mv $prefix/include/* $includeDir/
+	mv $prefix/libexec/* $binDir/
+	mv $prefix/share/man/* $manDir/
+	mv $prefix/share/clang $dataDir/
+	mv $prefix/share/opt-viewer $dataDir/
+	mv $prefix/share/scan-build $dataDir/
+	mv $prefix/share/scan-view $dataDir/
+	rmdir $prefix/include $prefix/libexec $prefix/share/man $prefix/share
+
+	sed -i 's|/libexec/|/bin/|' $binDir/scan-build
+	sed -i 's|/share/|/data/|' $binDir/scan-build $binDir/scan-view
+
+	# clang package
+	packageEntries clang \
+		$binDir/c-index-test \
+		$binDir/clang* \
+		$binDir/git-clang-format \
+		$binDir/modularize \
+		$dataDir/clang \
+		$includeDir/clang* \
+		$libDir/libclang* \
+		$libDir/clang \
+		$libDir/cmake/clang \
+		$developLibDir/libclang*
+
+	# analysis package
+	packageEntries clang_analysis \
+		$binDir/scan-build \
+		$binDir/scan-view \
+		$binDir/c++-analyzer \
+		$binDir/ccc-analyzer \
+		$dataDir/scan-build \
+		$dataDir/scan-view \
+		$manDir/man1/scan-build.1
+
+	# libs package
+	packageEntries libs \
+		$libDir/libLLVM* \
+		$libDir/libLTO*
+}
+
+TEST()
+{
+	cd build
+	export LIBRARY_PATH=$LIBRARY_PATH:$sourceDir/build/lib
+	export LIT_ARGS="-v"
+	make check-llvm
+}

--- a/sys-devel/llvm/patches/clang-6.0.1.patchset
+++ b/sys-devel/llvm/patches/clang-6.0.1.patchset
@@ -1,0 +1,174 @@
+From 264717b79e4c1013603826f56fdad9a687b57e67 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
+Date: Mon, 18 Jul 2016 14:13:19 +0200
+Subject: support for secondary arch.
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2eee8e6..1a3b180 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -402,6 +402,10 @@ option(CLANG_ENABLE_PROTO_FUZZER "Build Clang protobuf fuzzer." OFF)
+ if(NOT CLANG_ENABLE_STATIC_ANALYZER AND (CLANG_ENABLE_ARCMT OR CLANG_ANALYZER_BUILD_Z3))
+   message(FATAL_ERROR "Cannot disable static analyzer while enabling ARCMT or Z3")
+ endif()
++if(DEFINED HAIKU_HYBRID_SECONDARY)
++  add_definitions(-DHAIKU_HYBRID_SECONDARY=${HAIKU_HYBRID_SECONDARY})
++endif()
++
+ 
+ if(CLANG_ANALYZER_BUILD_Z3)
+   find_package(Z3 4.5)
+diff --git a/lib/Driver/ToolChains/Haiku.cpp b/lib/Driver/ToolChains/Haiku.cpp
+index 284d269..3a816aa 100644
+--- a/lib/Driver/ToolChains/Haiku.cpp
++++ b/lib/Driver/ToolChains/Haiku.cpp
+@@ -20,6 +20,13 @@ using namespace llvm::opt;
+ Haiku::Haiku(const Driver &D, const llvm::Triple& Triple, const ArgList &Args)
+   : Generic_ELF(D, Triple, Args) {
+ 
++#ifdef HAIKU_HYBRID_SECONDARY
++  getProgramPaths().insert(getProgramPaths().begin(), getDriver().SysRoot
++                           + "/system/bin/" HAIKU_HYBRID_SECONDARY);
++  getFilePaths().clear();
++  getFilePaths().push_back(getDriver().SysRoot + "/system/lib/"
++                           HAIKU_HYBRID_SECONDARY);
++#endif
+ }
+ 
+ std::string Haiku::findLibCxxIncludePath() const {
+@@ -28,6 +35,12 @@ std::string Haiku::findLibCxxIncludePath() const {
+ 
+ void Haiku::addLibStdCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
+                                      llvm::opt::ArgStringList &CC1Args) const {
++#ifdef HAIKU_HYBRID_SECONDARY
++  addLibStdCXXIncludePaths(getDriver().SysRoot, "/system/develop/headers"
++                     HAIKU_HYBRID_SECONDARY "/c++", getTriple().str(), "", "", "",
++                     DriverArgs, CC1Args);
++#else
+   addLibStdCXXIncludePaths(getDriver().SysRoot, "/system/develop/headers/c++",
+-                           getTriple().str(), "", "", "", DriverArgs, CC1Args);
++                     getTriple().str(), "", "", "", DriverArgs, CC1Args);
++#endif
+ }
+diff --git a/lib/Frontend/InitHeaderSearch.cpp b/lib/Frontend/InitHeaderSearch.cpp
+index 8c6face..4c04668 100644
+--- a/lib/Frontend/InitHeaderSearch.cpp
++++ b/lib/Frontend/InitHeaderSearch.cpp
+@@ -233,7 +233,20 @@ void InitHeaderSearch::AddDefaultCIncludePaths(const llvm::Triple &triple,
+   if (HSOpts.UseBuiltinIncludes) {
+     // Ignore the sys root, we *always* look for clang headers relative to
+     // supplied path.
++#ifdef HAIKU_HYBRID_SECONDARY
++    // Remove version from foo/lib/clang/version
++    StringRef Ver = llvm::sys::path::filename(HSOpts.ResourceDir);
++    StringRef NoVer = llvm::sys::path::parent_path(HSOpts.ResourceDir);
++    // Remove clang from foo/lib/clang
++    StringRef Clang = llvm::sys::path::filename(NoVer);
++    SmallString<128> P = llvm::sys::path::parent_path(NoVer);
++
++    // Get foo/include/c++/v1
++    llvm::sys::path::append(P, HAIKU_HYBRID_SECONDARY, Clang, Ver);
++#else
+     SmallString<128> P = StringRef(HSOpts.ResourceDir);
++#endif
++
+     llvm::sys::path::append(P, "include");
+     AddUnmappedPath(P, ExternCSystem, false);
+   }
+@@ -266,7 +279,12 @@ void InitHeaderSearch::AddDefaultCIncludePaths(const llvm::Triple &triple,
+   }
+ 
+   case llvm::Triple::Haiku:
++#ifdef HAIKU_HYBRID_SECONDARY
++    AddPath("/boot/system/non-packaged/develop/headers/" HAIKU_HYBRID_SECONDARY,
++            System, false);
++#else
+     AddPath("/boot/system/non-packaged/develop/headers", System, false);
++#endif
+     AddPath("/boot/system/develop/headers/os", System, false);
+     AddPath("/boot/system/develop/headers/os/app", System, false);
+     AddPath("/boot/system/develop/headers/os/arch", System, false);
+@@ -298,6 +316,13 @@ void InitHeaderSearch::AddDefaultCIncludePaths(const llvm::Triple &triple,
+     AddPath("/boot/system/develop/headers/bsd", System, false);
+     AddPath("/boot/system/develop/headers/glibc", System, false);
+     AddPath("/boot/system/develop/headers/posix", System, false);
++#ifdef HAIKU_HYBRID_SECONDARY
++    AddPath("/boot/system/develop/headers/" HAIKU_HYBRID_SECONDARY, System, false);
++    AddPath("/boot/system/develop/headers/" HAIKU_HYBRID_SECONDARY "/os", System,
++            false);
++    AddPath("/boot/system/develop/headers/" HAIKU_HYBRID_SECONDARY "/os/opengl",
++            System, false);
++#endif
+     AddPath("/boot/system/develop/headers",  System, false);
+     break;
+   case llvm::Triple::RTEMS:
+-- 
+2.16.4
+
+
+From 62248207b775044c44feaf1cce6a4e053898b225 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Thu, 7 Apr 2016 18:30:52 +0000
+Subject: add a test for haiku driver.
+
+* upstream wants a case for libcxx in ToolChains.cpp, so add it.
+
+diff --git a/test/Driver/haiku.c b/test/Driver/haiku.c
+new file mode 100644
+index 0000000..9591739
+--- /dev/null
++++ b/test/Driver/haiku.c
+@@ -0,0 +1,12 @@
++// RUN: %clang -no-canonical-prefixes -target x86_64-unknown-haiku %s -### 2> %t.log
++// RUN: FileCheck --check-prefix=CHECK-X86_64 -input-file %t.log %s
++
++// CHECK-X86_64: clang{{.*}}" "-cc1" "-triple" "x86_64-unknown-haiku"
++// CHECK-X86_64: gcc{{.*}}" "-o" "a.out" "{{.*}}.o"
++
++// RUN: %clang -no-canonical-prefixes -target i586-pc-haiku %s -### 2> %t.log
++// RUN: FileCheck --check-prefix=CHECK-X86 -input-file %t.log %s
++
++// CHECK-X86: clang{{.*}}" "-cc1" "-triple" "i586-pc-haiku"
++// CHECK-X86: gcc{{.*}}" "-o" "a.out" "{{.*}}.o"
++
+-- 
+2.16.4
+
+
+From 958de163bce332047ee7b677eabc478ce0f88ce9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
+Date: Mon, 18 Jul 2016 14:13:19 +0200
+Subject: Enable thread-local storage and disable PIE by default
+
+
+diff --git a/lib/Basic/Targets/OSTargets.h b/lib/Basic/Targets/OSTargets.h
+index 5af6361..790732b 100644
+--- a/lib/Basic/Targets/OSTargets.h
++++ b/lib/Basic/Targets/OSTargets.h
+@@ -260,7 +260,6 @@ public:
+     this->IntPtrType = TargetInfo::SignedLong;
+     this->PtrDiffType = TargetInfo::SignedLong;
+     this->ProcessIDType = TargetInfo::SignedLong;
+-    this->TLSSupported = false;
+   }
+ };
+ 
+diff --git a/lib/Driver/ToolChains/Haiku.h b/lib/Driver/ToolChains/Haiku.h
+index 8b5b48e..ccd851f 100644
+--- a/lib/Driver/ToolChains/Haiku.h
++++ b/lib/Driver/ToolChains/Haiku.h
+@@ -23,9 +23,7 @@ public:
+   Haiku(const Driver &D, const llvm::Triple &Triple,
+           const llvm::opt::ArgList &Args);
+ 
+-  bool isPIEDefault() const override {
+-    return getTriple().getArch() == llvm::Triple::x86_64;
+-  }
++  bool isPIEDefault() const override { return false; }
+ 
+   std::string findLibCxxIncludePath() const override;
+   void addLibStdCxxIncludePaths(
+-- 
+2.16.4
+

--- a/sys-devel/llvm/patches/llvm-6.0.1.patchset
+++ b/sys-devel/llvm/patches/llvm-6.0.1.patchset
@@ -1,0 +1,124 @@
+From d50678784604cce370b98050e5eb2792610c71b9 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Wed, 20 Jan 2016 21:13:28 +0000
+Subject: llvm-config: use /develop/headers instead of /include
+
+* don't provide obj-root and src-root.
+
+diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.cpp
+index 08b096a..739213c 100644
+--- a/tools/llvm-config/llvm-config.cpp
++++ b/tools/llvm-config/llvm-config.cpp
+@@ -332,11 +332,16 @@ int main(int argc, char **argv) {
+         ("-I" + ActiveIncludeDir + " " + "-I" + ActiveObjRoot + "/include");
+   } else {
+     ActivePrefix = CurrentExecPrefix;
++#ifdef __HAIKU__
++    ActiveIncludeDir = ActivePrefix + "/develop/headers";
++    ActiveLibDir = ActivePrefix + "/develop/lib" + LLVM_LIBDIR_SUFFIX;
++#else
+     ActiveIncludeDir = ActivePrefix + "/include";
++    ActiveLibDir = ActivePrefix + "/lib" + LLVM_LIBDIR_SUFFIX;
++#endif
+     SmallString<256> path(StringRef(LLVM_TOOLS_INSTALL_DIR));
+     sys::fs::make_absolute(ActivePrefix, path);
+     ActiveBinDir = path.str();
+-    ActiveLibDir = ActivePrefix + "/lib" + LLVM_LIBDIR_SUFFIX;
+     ActiveCMakeDir = ActiveLibDir + "/cmake/llvm";
+     ActiveIncludeOption = "-I" + ActiveIncludeDir;
+   }
+@@ -556,10 +561,16 @@ int main(int argc, char **argv) {
+         OS << (LLVM_HAS_GLOBAL_ISEL ? "ON" : "OFF") << '\n';
+       } else if (Arg == "--shared-mode") {
+         PrintSharedMode = true;
+-      } else if (Arg == "--obj-root") {
+-        OS << ActivePrefix << '\n';
+-      } else if (Arg == "--src-root") {
+-        OS << LLVM_SRC_ROOT << '\n';
++      } else if (Arg == "--obj-root" || Arg == "--src-root") {
++        if (IsInDevelopmentTree) {
++          if (Arg == "--obj-root")
++            OS << ActivePrefix << '\n';
++          else
++            OS << LLVM_SRC_ROOT << '\n';
++        } else {
++          llvm::errs() << "llvm-config: sources not installed\n";
++          exit(1);
++        }
+       } else if (Arg == "--ignore-libllvm") {
+         LinkDyLib = false;
+         LinkMode = BuiltSharedLibs ? LinkModeShared : LinkModeAuto;
+-- 
+2.16.4
+
+
+From 4e37cee8e89f8a130a42b1db3dfb486770975fae Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Sat, 16 Sep 2017 15:02:46 +0200
+Subject: Haiku doesn't expose whether a FS is local or remote.
+
+
+diff --git a/lib/Support/Unix/Path.inc b/lib/Support/Unix/Path.inc
+index 2ecb973..4fe5bda 100644
+--- a/lib/Support/Unix/Path.inc
++++ b/lib/Support/Unix/Path.inc
+@@ -380,6 +380,9 @@ static bool is_local_impl(struct STATVFS &Vfs) {
+ #elif defined(__CYGWIN__)
+   // Cygwin doesn't expose this information; would need to use Win32 API.
+   return false;
++#elif defined(__HAIKU__)
++  // Haiku doesn't expose this information
++  return false;
+ #elif defined(__sun)
+   // statvfs::f_basetype contains a null-terminated FSType name of the mounted target
+   StringRef fstype(Vfs.f_basetype);
+-- 
+2.16.4
+
+
+From efb68990c8752383520ccb6987a98a10aba076c5 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Sun, 9 Sep 2018 16:11:42 +0100
+Subject: import header dir suffix patch from 3dEyes.
+
+
+diff --git a/tools/llvm-config/llvm-config.cpp b/tools/llvm-config/llvm-config.cpp
+index 739213c..ab7b46c 100644
+--- a/tools/llvm-config/llvm-config.cpp
++++ b/tools/llvm-config/llvm-config.cpp
+@@ -333,7 +333,7 @@ int main(int argc, char **argv) {
+   } else {
+     ActivePrefix = CurrentExecPrefix;
+ #ifdef __HAIKU__
+-    ActiveIncludeDir = ActivePrefix + "/develop/headers";
++    ActiveIncludeDir = ActivePrefix + "/develop/headers" + LLVM_LIBDIR_SUFFIX;
+     ActiveLibDir = ActivePrefix + "/develop/lib" + LLVM_LIBDIR_SUFFIX;
+ #else
+     ActiveIncludeDir = ActivePrefix + "/include";
+-- 
+2.16.4
+
+
+From 6032d781e41b460855fccb25cafeebb5985687c3 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Sun, 9 Sep 2018 16:17:33 +0100
+Subject: llvm: allow llvm gtests to build on Haiku.
+
+
+diff --git a/utils/unittest/googletest/include/gtest/internal/gtest-port.h b/utils/unittest/googletest/include/gtest/internal/gtest-port.h
+index d36e820..e6dbb2d 100644
+--- a/utils/unittest/googletest/include/gtest/internal/gtest-port.h
++++ b/utils/unittest/googletest/include/gtest/internal/gtest-port.h
+@@ -793,7 +793,8 @@ using ::std::tuple_size;
+      (GTEST_OS_MAC && !GTEST_OS_IOS) || \
+      (GTEST_OS_WINDOWS_DESKTOP && _MSC_VER >= 1400) || \
+      GTEST_OS_WINDOWS_MINGW || GTEST_OS_AIX || GTEST_OS_HPUX || \
+-     GTEST_OS_OPENBSD || GTEST_OS_QNX || GTEST_OS_FREEBSD || GTEST_OS_NETBSD)
++     GTEST_OS_OPENBSD || GTEST_OS_QNX || GTEST_OS_FREEBSD || GTEST_OS_NETBSD \
++     || GTEST_OS_HAIKU)
+ # define GTEST_HAS_DEATH_TEST 1
+ #endif
+ 
+-- 
+2.16.4
+


### PR DESCRIPTION
This supersedes PR (#2298) and adds support for running the LLVM test-suite. Tested on hrev52316 x86_64 with 15 tests failing (2 tests timed out) and I posted a [short](https://gist.githubusercontent.com/return/aecfbb3ae1f3470e5816e1e948d5a192/raw/6d52cbd37ea7fd738e88ccc8a51dd75f04acb79e/llvm-6.0.1-tests-haiku-x86_64.txt) and a [verbose summary](https://gist.githubusercontent.com/return/d8bcaa8500d53b47049af99815c18951/raw/0dadd2e113ca69b0173e1eb7d310154a11963627/llvm-6.0.1-tests-haiku-x86_64-long.txt) of them.  

 Please add a 'wip-no-merge' on this. x86 and mesa still remains untested.