### PR TITLE
app-shells/command_not_found: move profile script

### DIFF
--- a/app-shells/command_not_found/command_not_found-0.0.1~git.recipe
+++ b/app-shells/command_not_found/command_not_found-0.0.1~git.recipe
@@ -5,7 +5,7 @@ It can also check for typos (a feature of zsh)."
 HOMEPAGE="https://github.com/jrabbit/haiku-cnf"
 COPYRIGHT="2011 Jrabbit"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 srcGitRev="db1be8b57dedff781dc68caa46f403d88c5eedb9"
 SOURCE_URI="$HOMEPAGE/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="a1ce4e6c8a7307c0d5c1e65a90b3d2a7ba9d16d9506a70aab1005129333d6121"
@@ -31,8 +31,6 @@ BUILD_PREREQUIRES="
 	cmd:python
 	"
 
-GLOBAL_WRITABLE_FILES="settings/etc/profile.d/command-not-found.sh keep-old"
-
 BUILD()
 {
 	true
@@ -40,11 +38,10 @@ BUILD()
 
 INSTALL()
 {
-	profileDir=$settingsDir/etc/profile.d
-	install -d $binDir $profileDir
+	install -d $binDir $dataDir/profile.d
 	install -m 0755 haiku_cnf.py $binDir/command_not_found
 
-	cat > $profileDir/command-not-found.sh << EOF
+	cat > $dataDir/profile.d/command-not-found.sh << EOF
 command_not_found_handle() {
 	if command -v command_not_found >/dev/null 2>&1; then
 		command_not_found "\$1"


### PR DESCRIPTION
Moved the script to `dataDir`, this will make sure the script is removed after the package is deactivated.

Users may override the handle by placing appropriate files in /etc/profile.d

~~Untested, but should work.~~