### PR TITLE
Rust: add recipe for 1.29.0

### DIFF
--- a/dev-lang/rust/patches/rust-1.29.0.patchset
+++ b/dev-lang/rust/patches/rust-1.29.0.patchset
@@ -1,0 +1,491 @@
+From 7bd3beff1d9d834a3be5c0ba6ee7dd0c25dd6338 Mon Sep 17 00:00:00 2001
+From: Niels Sascha Reedijk <niels.reedijk@gmail.com>
+Date: Sat, 15 Sep 2018 21:03:27 +0200
+Subject: Haiku-specific patches from https://github.com/nielx/rust
+
+
+diff --git a/src/Cargo.lock b/src/Cargo.lock
+index 64f6b71..1386e3b 100644
+--- a/src/Cargo.lock
++++ b/src/Cargo.lock
+@@ -90,7 +90,7 @@ name = "atty"
+ version = "0.2.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -102,7 +102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+  "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -113,7 +113,7 @@ version = "0.1.24"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -136,7 +136,7 @@ dependencies = [
+  "filetime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "petgraph 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -196,7 +196,7 @@ dependencies = [
+  "jobserver 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+  "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libgit2-sys 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "miow 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -243,7 +243,7 @@ dependencies = [
+  "jobserver 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+  "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "lazycell 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libgit2-sys 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "miow 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -425,7 +425,7 @@ name = "commoncrypto-sys"
+ version = "0.2.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -445,7 +445,7 @@ dependencies = [
+  "filetime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+  "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "miow 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -464,7 +464,7 @@ dependencies = [
+  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+  "filetime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "miow 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -487,7 +487,7 @@ version = "0.5.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -496,7 +496,7 @@ version = "0.6.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "core-foundation-sys 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -504,7 +504,7 @@ name = "core-foundation-sys"
+ version = "0.5.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -626,7 +626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "curl-sys 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "openssl-sys 0.9.35 (registry+https://github.com/rust-lang/crates.io-index)",
+  "schannel 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -640,7 +640,7 @@ version = "0.4.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+  "openssl-sys 0.9.35 (registry+https://github.com/rust-lang/crates.io-index)",
+  "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -789,7 +789,7 @@ version = "0.2.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -803,7 +803,7 @@ name = "flate2"
+ version = "1.0.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -834,7 +834,7 @@ name = "fs2"
+ version = "0.4.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -891,7 +891,7 @@ version = "0.7.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libgit2-sys 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -1039,7 +1039,7 @@ name = "isatty"
+ version = "0.1.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -1062,7 +1062,7 @@ name = "jobserver"
+ version = "0.1.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -1133,7 +1133,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.42"
++version = "0.2.43"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+@@ -1144,7 +1144,7 @@ dependencies = [
+  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+  "cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+  "curl-sys 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libssh2-sys 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+  "openssl-sys 0.9.35 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -1157,7 +1157,7 @@ version = "0.2.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+  "openssl-sys 0.9.35 (registry+https://github.com/rust-lang/crates.io-index)",
+  "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -1170,7 +1170,7 @@ version = "1.0.18"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+  "vcpkg 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -1210,7 +1210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+  "filetime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -1277,7 +1277,7 @@ name = "memchr"
+ version = "2.0.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -1285,7 +1285,7 @@ name = "memmap"
+ version = "0.6.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -1308,7 +1308,7 @@ version = "0.1.10"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -1376,7 +1376,7 @@ name = "num_cpus"
+ version = "1.8.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -1393,7 +1393,7 @@ dependencies = [
+  "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "openssl-sys 0.9.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -1416,7 +1416,7 @@ version = "0.9.35"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "openssl-src 110.0.5+1.1.0h (registry+https://github.com/rust-lang/crates.io-index)",
+  "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+  "vcpkg 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -1474,7 +1474,7 @@ name = "parking_lot_core"
+ version = "0.2.14"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -1670,7 +1670,7 @@ version = "0.4.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+@@ -1681,7 +1681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rand_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -1707,7 +1707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -2129,7 +2129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -2202,7 +2202,7 @@ dependencies = [
+  "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
+  "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+  "jobserver 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rustc 0.0.0",
+@@ -2342,7 +2342,7 @@ dependencies = [
+  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "build_helper 0.1.0",
+  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rustc_cratesio_shim 0.0.0",
+ ]
+ 
+@@ -2702,7 +2702,7 @@ version = "0.3.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -2889,7 +2889,7 @@ version = "0.4.16"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "filetime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+  "xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -2899,7 +2899,7 @@ name = "tempfile"
+ version = "3.0.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -2950,7 +2950,7 @@ name = "termion"
+ version = "1.5.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -2994,7 +2994,7 @@ name = "time"
+ version = "0.1.40"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+@@ -3194,7 +3194,7 @@ name = "xattr"
+ version = "0.2.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+ [[package]]
+@@ -3307,7 +3307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ "checksum lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fb497c35d362b6a331cfd94956a07fc2c78a4604cdbee844a81170386b996dd3"
+ "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
+ "checksum lazycell 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d33a48d0365c96081958cc663eef834975cb1e8d8bea3378513fc72bdbf11e50"
+-"checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
++"checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
+ "checksum libgit2-sys 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c9051a4b288ba6f8728e9e52bb2510816946b8bcb2e20259e4d4cdc93b9ecafd"
+ "checksum libssh2-sys 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c628b499e8d1a4f4bd09a95d6cb1f8aeb231b46a9d40959bbd0408f14dd63adf"
+ "checksum libz-sys 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "87f737ad6cc6fd6eefe3d9dc5412f1573865bded441300904d2f42269e140f16"
+diff --git a/src/libstd/sys/unix/thread.rs b/src/libstd/sys/unix/thread.rs
+index e26306c..e794ced 100644
+--- a/src/libstd/sys/unix/thread.rs
++++ b/src/libstd/sys/unix/thread.rs
+@@ -175,8 +175,7 @@ impl Thread {
+         unsafe {
+             let ret = libc::pthread_join(self.id, ptr::null_mut());
+             mem::forget(self);
+-            assert!(ret == 0,
+-                    "failed to join thread: {}", io::Error::from_raw_os_error(ret));
++            debug_assert_eq!(ret, 0);
+         }
+     }
+ 
+diff --git a/src/libstd/sys/windows/c.rs b/src/libstd/sys/windows/c.rs
+index 30aba2f..2507e00 100644
+--- a/src/libstd/sys/windows/c.rs
++++ b/src/libstd/sys/windows/c.rs
+@@ -269,7 +269,6 @@ pub const FILE_END: DWORD = 2;
+ 
+ pub const WAIT_OBJECT_0: DWORD = 0x00000000;
+ pub const WAIT_TIMEOUT: DWORD = 258;
+-pub const WAIT_FAILED: DWORD = 0xFFFFFFFF;
+ 
+ #[cfg(target_env = "msvc")]
+ #[cfg(feature = "backtrace")]
+diff --git a/src/libstd/sys/windows/thread.rs b/src/libstd/sys/windows/thread.rs
+index 44ec872..b3c21d5 100644
+--- a/src/libstd/sys/windows/thread.rs
++++ b/src/libstd/sys/windows/thread.rs
+@@ -66,11 +66,7 @@ impl Thread {
+     }
+ 
+     pub fn join(self) {
+-        let rc = unsafe { c::WaitForSingleObject(self.handle.raw(), c::INFINITE) };
+-        if rc == c::WAIT_FAILED {
+-            panic!("failed to join on thread: {}",
+-                   io::Error::last_os_error());
+-        }
++        unsafe { c::WaitForSingleObject(self.handle.raw(), c::INFINITE); }
+     }
+ 
+     pub fn yield_now() {
+diff --git a/src/libstd/thread/mod.rs b/src/libstd/thread/mod.rs
+index ae804ad..9e919a6 100644
+--- a/src/libstd/thread/mod.rs
++++ b/src/libstd/thread/mod.rs
+@@ -1311,11 +1311,6 @@ impl<T> JoinHandle<T> {
+     /// [`Err`]: ../../std/result/enum.Result.html#variant.Err
+     /// [`panic`]: ../../std/macro.panic.html
+     ///
+-    /// # Panics
+-    ///
+-    /// This function may panic on some platforms if a thread attempts to join
+-    /// itself or otherwise may create a deadlock with joining threads.
+-    ///
+     /// # Examples
+     ///
+     /// ```
+diff --git a/src/llvm/lib/Support/Unix/Path.inc b/src/llvm/lib/Support/Unix/Path.inc
+index b8fea5b..908efd4 100644
+--- a/src/llvm/lib/Support/Unix/Path.inc
++++ b/src/llvm/lib/Support/Unix/Path.inc
+@@ -371,6 +371,9 @@ static bool is_local_impl(struct STATVFS &Vfs) {
+ #elif defined(__Fuchsia__)
+   // Fuchsia doesn't yet support remote filesystem mounts.
+   return true;
++#elif defined(__HAIKU__)
++  // Haiku doesn't expose this information
++  return false;
+ #elif defined(__sun)
+   // statvfs::f_basetype contains a null-terminated FSType name of the mounted target
+   StringRef fstype(Vfs.f_basetype);
+-- 
+2.19.0
+

--- a/dev-lang/rust/rust-1.29.0.recipe
+++ b/dev-lang/rust/rust-1.29.0.recipe
@@ -1,0 +1,168 @@
+SUMMARY="Modern and safe systems programming language"
+DESCRIPTION="Rust is a systems programming language that runs blazingly fast, \
+prevents almost all crashes*, and eliminates data races."
+HOMEPAGE="https://www.rust-lang.org/"
+COPYRIGHT="2018 The Rust Project Developers"
+LICENSE="MIT"
+REVISION="1"
+cargoVersion="0.30.0"
+rlsVersion="0.130.0"
+rustfmtVersion="0.99.1"
+clippyVersion="0.0.212"
+SOURCE_URI="https://static.rust-lang.org/dist/rustc-$portVersion-src.tar.xz"
+CHECKSUM_SHA256="3943da98fb478a336ede7404e42ff76ef6ba4fc2b82012cfccd6b9fc4bd2c191"
+SOURCE_DIR="rustc-$portVersion-src"
+PATCHES="rust-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
+SECONDARY_ARCHITECTURES="?x86"
+
+PROVIDES="
+	rust_bin$secondaryArchSuffix = $portVersion
+	cmd:rustc$secondaryArchSuffix = $portVersion
+	cmd:rustdoc$secondaryArchSuffix = $portVersion
+	cmd:rustfmt$secondaryArchSuffix = $portVersion
+	cmd:rust_gdb$secondaryArchSuffix = $portVersion
+	cmd:rust_lldb$secondaryArchSuffix = $portVersion
+	cmd:cargo$secondaryArchSuffix = $cargoVersion
+	cmd:cargo_clippy$secondaryArchSuffix = $clippyVersion
+	cmd:cargo_fmt$secondaryArchSuffix = $cargoVersion
+	cmd:clippy_driver$secondaryArchSuffix = $clippyVersion
+	cmd:rls$secondaryArchSuffix = $rlsVersion
+	cmd:rustfmt = $rustfmtVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcrypto$secondaryArchSuffix
+	lib:libcurl$secondaryArchSuffix
+	lib:libssl$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libcurl$secondaryArchSuffix
+	devel:libssl$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cargo$secondaryArchSuffix == $cargoVersion
+	cmd:cmake
+	cmd:cmp
+	cmd:file
+	cmd:find
+	cmd:gcc$secondaryArchSuffix
+	cmd:git
+	cmd:grep
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:python
+	cmd:rustc == $portVersion
+	cmd:sed
+	cmd:tar
+	cmd:which
+	cmd:xargs
+	"
+
+relativeInstallDir="develop/tools$secondaryArchSubDir/rust"
+installDir="$prefix/$relativeInstallDir"
+
+BUILD()
+{
+	# write the build configuration
+	tr -d '\t' >config.toml <<- EOL
+		[llvm]
+		targets = "X86"
+		experimental-targets = ""
+
+		[build]
+		cargo = "/$relativeBinDir/cargo"
+		rustc = "/boot/system/bin/rustc"
+		submodules = false
+		extended = true
+		tools = ["cargo", "rls", "rustfmt", "analysis"]
+
+		[install]
+		prefix = "$installdir"
+		libdir = "$installdir/bin/lib"
+		mandir = "$manDir"
+		docdir = "$developDocDir"
+		sysconfdir = "$dataDir"
+
+		[rust]
+		channel = "stable"
+		use-jemalloc = false
+		rpath = false
+		deny-warnings = false
+		dist-src = false
+
+		[dist]
+		src-tarball = false
+EOL
+	# Disable ASLR: compiling stage 1 rustc requires a lot of RAM (about 1.5
+	# GB). Haiku has a per-process limit of 2GB on 32 bit systems. ASLR makes
+	# the available space even smaller. Disabling it will give us the space to
+	# compile Rust
+	export DISABLE_ASLR=1
+
+	# now build rust and cargo
+	./x.py dist
+}
+
+INSTALL()
+{
+	# we will manually invoke the install scripts
+	if [ $effectiveTargetArchitecture = x86 ]; then
+		architecture="i686-unknown-haiku"
+	fi
+	if [ $effectiveTargetArchitecture = x86_64 ]; then
+		architecture="x86_64-unknown-haiku"
+	fi
+
+	# let's install the packages one by one
+	cd $sourceDir/build/tmp/dist/
+	for module in "rust-docs-$srcGitRev-$architecture"     \
+	              "rust-std-$srcGitRev-$architecture"      \
+	              "rustc-$srcGitRev-$architecture"         \
+	              "rust-analysis-$srcGitRev-$architecture" \
+	              "cargo-$cargoVersion-$architecture"      \
+	              "clippy-$clippyVersion-$architecture"    \
+	              "rls-$rlsVersion-$architecture"          \
+	              "rustfmt-$rustfmtVersion-$architecture"
+	do
+		./$module/install.sh                               \
+				--prefix=$installDir                       \
+				--docdir=$developDocDir                    \
+				--mandir=$manDir                           \
+				--sysconfdir=$dataDir                      \
+				--disable-ldconfig
+	done
+
+	# move zsh data to the datadir
+	mv $installDir/share/zsh $dataDir
+	rm -rf $installDir/share
+
+	# clean out unneccesary files created by the rust installer
+	rm $installDir/lib/rustlib/components
+	rm $installDir/lib/rustlib/install.log
+	rm $installDir/lib/rustlib/manifest-*
+	rm $installDir/lib/rustlib/rust-installer-version
+	rm $installDir/lib/rustlib/uninstall.sh
+
+	# link the binaries in $binDir
+	mkdir -p $binDir
+	for f in cargo cargo-clippy cargo-fmt clippy-driver rls rust-gdb \
+	         rust-lldb rustc rustdoc rustfmt; do
+		symlinkRelative -sfn $installDir/bin/$f $binDir
+	done
+
+	# make sure runtime_loader can find the libraries in the lib dir relative
+	# to the binaries
+	symlinkRelative -sfn $installDir/lib $installDir/bin/lib
+}
+
+TEST()
+{
+	./x.py test
+}

--- a/dev-lang/rust_bin/rust_bin-1.29.0.recipe
+++ b/dev-lang/rust_bin/rust_bin-1.29.0.recipe
@@ -1,0 +1,99 @@
+SUMMARY="Modern and safe systems programming language"
+DESCRIPTION="Rust is a systems programming language that runs blazingly fast, \
+prevents almost all crashes*, and eliminates data races."
+HOMEPAGE="https://www.rust-lang.org/"
+COPYRIGHT="2018 The Rust Project Developers"
+LICENSE="MIT"
+REVISION="1"
+
+case "$effectiveTargetArchitecture" in
+	x86)
+SOURCE_URI="http://dl.rust-on-haiku.com/dist/$portVersion/rust-$portVersion-i686-unknown-haiku.tar.xz"
+CHECKSUM_SHA256="b4d40d82bb6c07746b1ca8e407a23e45dd357744ee80217446bc9f25cc5e9eaa"
+SOURCE_DIR="rust-$portVersion-i686-unknown-haiku"
+		;;
+	x86_64)
+SOURCE_URI="http://dl.rust-on-haiku.com/dist/$portVersion/rust-$portVersion-x86_64-unknown-haiku.tar.xz"
+CHECKSUM_SHA256="e8229ee38453978485720e6a8ef84e0474aa5fb9375b3e74ecce655ee742b5f2"
+SOURCE_DIR="rust-$portVersion-x86_64-unknown-haiku"
+		;;
+	*)
+SOURCE_URI="http://dl.rust-on-haiku.com/dist/$portVersion/rustc-$portVersion-src.tar.xz"
+CHECKSUM_SHA256="cec7232a3081f7a29919523490b7045dd9637aee371de4051c4f9348b657f30e"
+SOURCE_DIR="rustc-$portVersion-src"
+		;;
+esac
+
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+DISABLE_SOURCE_PACKAGE=yes
+
+cargoVersion="0.30.0"
+rlsVersion="0.130.0"
+rustfmtVersion="0.99.1"
+clippyVersion="0.0.212"
+
+PROVIDES="
+	rust_bin$secondaryArchSuffix = $portVersion
+	cmd:rustc$secondaryArchSuffix = $portVersion
+	cmd:rustdoc$secondaryArchSuffix = $portVersion
+	cmd:rustfmt$secondaryArchSuffix = $portVersion
+	cmd:rust_gdb$secondaryArchSuffix = $portVersion
+	cmd:rust_lldb$secondaryArchSuffix = $portVersion
+	cmd:cargo$secondaryArchSuffix = $cargoVersion
+	cmd:cargo_clippy$secondaryArchSuffix = $clippyVersion
+	cmd:cargo_fmt$secondaryArchSuffix = $cargoVersion
+	cmd:clippy_driver$secondaryArchSuffix = $clippyVersion
+	cmd:rls$secondaryArchSuffix = $rlsVersion
+	cmd:rustfmt = $rustfmtVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcrypto$secondaryArchSuffix
+	lib:libcurl$secondaryArchSuffix
+	lib:libssh2$secondaryArchSuffix
+	lib:libssl$secondaryArchSuffix
+	"
+CONFLICTS="
+	rust$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+
+relativeInstallDir="develop/tools$secondaryArchSubDir/rust"
+installDir="$prefix/$relativeInstallDir"
+
+
+INSTALL()
+{
+	./install.sh                                   \
+		--prefix=$installDir                       \
+		--docdir=$developDocDir                    \
+		--mandir=$manDir                           \
+		--sysconfdir=$dataDir                      \
+		--disable-ldconfig
+
+	# move zsh data to the datadir
+	mv $installDir/share/zsh $dataDir
+	rm -rf $installDir/share
+
+	# clean out unneccesary files created by the rust installer
+	rm $installDir/lib/rustlib/components
+	rm $installDir/lib/rustlib/install.log
+	rm $installDir/lib/rustlib/manifest-*
+	rm $installDir/lib/rustlib/rust-installer-version
+	rm $installDir/lib/rustlib/uninstall.sh
+
+	# link the binaries in $binDir
+	mkdir -p $binDir
+	for f in cargo cargo-clippy cargo-fmt clippy-driver rls rust-gdb \
+	         rust-lldb rustc rustdoc rustfmt; do
+		symlinkRelative -sfn $installDir/bin/$f $binDir
+	done
+
+	# make sure runtime_loader can find the libraries in the lib dir relative
+	# to the binaries
+	symlinkRelative -sfn $installDir/lib $installDir/bin/lib
+}


### PR DESCRIPTION
This is the recipe for Rust 1.29.0. As always, the binary recipe has been tried and tested, the source recipe is here for reference.