### PR TITLE
FlightGear: new recipe for FlightGear 2018.2.2

### DIFF
--- a/games-simulation/flightgear/flightgear-2018.2.2.recipe
+++ b/games-simulation/flightgear/flightgear-2018.2.2.recipe
@@ -1,4 +1,4 @@
-SUMMARY="The FlightGear Flight Simulator"
+SUMMARY="An Amazing 3D Flight Simulator"
 DESCRIPTION="The goal of the FlightGear project is to create a sophisticated \
 and open flight simulator framework for use in research or academic environments, \
 pilot training, as an industry engineering tool, for DIY-ers to pursue their favorite \
@@ -12,27 +12,29 @@ LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://downloads.sourceforge.net/flightgear/flighgear-$portVersion.tar.bz2"
 CHECKSUM_SHA256="924bcaec4bead47d01638f1033c0ca95c4a3fff65bd43d9c5b171d354b4b28f6"
-
-ARCHITECTURES="!x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="x86"
 ADDITIONAL_FILES="flightgear.rdef.in"
+ 
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+ SECONDARY_ARCHITECTURES="x86"
+fi
 
 PROVIDES="
 	flightgear$secondaryArchSuffix
-	cmd:fgcom$secondaryArchSuffix
-	cmd:fgelev$secondaryArchSuffix
-	cmd:fgfs$secondaryArchSuffix
-	cmd:fgjs$secondaryArchSuffix
-	cmd:fgpanel$secondaryArchSuffix
-	cmd:fgtraffic$secondaryArchSuffix
-	cmd:fgviewer$secondaryArchSuffix
-	cmd:GPSsmooth$secondaryArchSuffix
-	cmd:JSBSim$secondaryArchSuffix
-	cmd:js_demo$secondaryArchSuffix
-	cmd:metar$secondaryArchSuffix
-	cmd:MIDGsmooth$secondaryArchSuffix
-	cmd:UGsmooth$secondaryArchSuffix
-	cmd:yasim$secondaryArchSuffix
+	cmd:fgcom
+	cmd:fgelev
+	cmd:fgfs
+	cmd:fgjs
+	cmd:fgpanel
+	cmd:fgtraffic
+	cmd:fgviewer
+	cmd:GPSsmooth
+	cmd:JSBSim
+	cmd:js_demo
+	cmd:metar
+	cmd:MIDGsmooth
+	cmd:UGsmooth
+	cmd:yasim
 	"
 
 REQUIRES="
@@ -56,7 +58,6 @@ BUILD_REQUIRES="
 	devel:simgear$secondaryArchSuffix
 	devel:sqlite$secondaryArchSuffix
 	"
-
 BUILD_PREREQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	cmd:g++$secondaryArchSuffix
@@ -69,16 +70,18 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	mkdir -p build && cd build
-	cmake .. -DFG_DATA_DIR:STRING="%{_datadir}/flightgear" \
-	-DENABLE_GPSSMOOTH:BOOL=OFF -DENABLE_FGVIEWER:BOOL=OFF \
-	-DENABLE_FGELEV:BOOL=OFF -DENABLE_METAR:BOOL=OFF \
-	-DSYSTEM_SQLITE:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=OFF \
-	-DBUILD_TESTING:BOOL=OFF -DENABLE_TESTS:BOOL=OFF \
-	-DENABLE_JS_DEMO:BOOL=OFF
+	cmake .. \
+		-DFG_DATA_DIR:STRING="%{_datadir}/flightgear" \
+		-DENABLE_GPSSMOOTH:BOOL=OFF -DENABLE_FGVIEWER:BOOL=OFF \
+		-DENABLE_FGELEV:BOOL=OFF -DENABLE_METAR:BOOL=OFF \
+		-DSYSTEM_SQLITE:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=OFF \
+		-DBUILD_TESTING:BOOL=OFF -DENABLE_TESTS:BOOL=OFF \
+		-DENABLE_JS_DEMO:BOOL=OFF
 	make $jobArgs
 }
+
 INSTALL()
 {
 	make -C build install
-  addAppDeskbarSymlink $appsDir/FlightGear
+ 	addAppDeskbarSymlink $appsDir/FlightGear
 }

--- a/games-simulation/flightgear/flightgear-2018.2.2.recipe
+++ b/games-simulation/flightgear/flightgear-2018.2.2.recipe
@@ -40,7 +40,7 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:harfbuzz$secondaryArchSuffix
 	lib:libboost_system$secondaryArchSuffix
-	lib:libgL$secondaryArchSuffix
+	lib:libgl$secondaryArchSuffix
 	lib:libqt5$secondaryArchSuffix
 	lib:plib$secondaryArchSuffix
 	lib:simgearopenal$secondaryArchSuffix
@@ -70,7 +70,7 @@ BUILD()
 {
 	mkdir -p build && cd build
 	cmake .. \
-		-DFG_DATA_DIR:STRING="%{_datadir}/flightgear" \
+		-DFG_DATA_DIR:STRING="/boot/system/data/flightgear" \
 		-DENABLE_GPSSMOOTH:BOOL=OFF -DENABLE_FGVIEWER:BOOL=OFF \
 		-DENABLE_FGELEV:BOOL=OFF -DENABLE_METAR:BOOL=OFF \
 		-DSYSTEM_SQLITE:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=OFF \

--- a/games-simulation/flightgear/flightgear-2018.2.2.recipe
+++ b/games-simulation/flightgear/flightgear-2018.2.2.recipe
@@ -8,7 +8,7 @@ open simulation framework that can be expanded and improved upon by anyone inter
 in contributing."
 HOMEPAGE="https://www.flightgear.org/"
 COPYRIGHT="2002-2018 Curtis Olsen and others"
-LICENSE="GNU LGPLv2.0"
+LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://downloads.sourceforge.net/flightgear/flighgear-$portVersion.tar.bz2"
 CHECKSUM_SHA256="924bcaec4bead47d01638f1033c0ca95c4a3fff65bd43d9c5b171d354b4b28f6"

--- a/games-simulation/flightgear/flightgear-2018.2.2.recipe
+++ b/games-simulation/flightgear/flightgear-2018.2.2.recipe
@@ -82,4 +82,5 @@ BUILD()
 INSTALL()
 {
 	make -C build install
+	addAppDeskbarSymlink $binDir/flightgear FlightGear
 }

--- a/games-simulation/flightgear/flightgear-2018.2.2.recipe
+++ b/games-simulation/flightgear/flightgear-2018.2.2.recipe
@@ -33,8 +33,8 @@ PROVIDES="
 	cmd:MIDGsmooth$secondaryArchSuffix
 	cmd:UGsmooth$secondaryArchSuffix
 	cmd:yasim$secondaryArchSuffix
-	cmd:yasim-proptest$secondaryArchSuffix
 	"
+
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libGL$secondaryArchSuffix
@@ -44,7 +44,7 @@ REQUIRES="
 	lib:simgearopenal$secondaryArchSuffix
 	lib:sqlite$secondaryArchSuffix
 	"
-
+	
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:harfbuzz$secondaryArchSuffix
@@ -56,6 +56,7 @@ BUILD_REQUIRES="
 	devel:simgear$secondaryArchSuffix
 	devel:sqlite$secondaryArchSuffix
 	"
+
 BUILD_PREREQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	cmd:g++$secondaryArchSuffix
@@ -64,6 +65,7 @@ BUILD_PREREQUIRES="
 	cmd:make
 	cmd:cmake >= 3.0
 	"
+
 BUILD()
 {
 	mkdir -p build && cd build
@@ -73,8 +75,6 @@ BUILD()
 	-DSYSTEM_SQLITE:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=OFF \
 	-DBUILD_TESTING:BOOL=OFF -DENABLE_TESTS:BOOL=OFF \
 	-DENABLE_JS_DEMO:BOOL=OFF
-
-	cmake .. -DSIMGEAR_SHARED:BOOL=ON -DENABLE_TESTS:BOOL=OFF
 	make $jobArgs
 }
 INSTALL()

--- a/games-simulation/flightgear/flightgear-2018.2.2.recipe
+++ b/games-simulation/flightgear/flightgear-2018.2.2.recipe
@@ -1,4 +1,4 @@
-SUMMARY="FlightGear Flight Simulator"
+SUMMARY="The FlightGear Flight Simulator"
 DESCRIPTION="The goal of the FlightGear project is to create a sophisticated \
 and open flight simulator framework for use in research or academic environments, \
 pilot training, as an industry engineering tool, for DIY-ers to pursue their favorite \

--- a/games-simulation/flightgear/flightgear-2018.2.2.recipe
+++ b/games-simulation/flightgear/flightgear-2018.2.2.recipe
@@ -82,5 +82,4 @@ BUILD()
 INSTALL()
 {
 	make -C build install
- 	addAppDeskbarSymlink $appsDir/FlightGear
 }

--- a/games-simulation/flightgear/flightgear-2018.2.2.recipe
+++ b/games-simulation/flightgear/flightgear-2018.2.2.recipe
@@ -1,0 +1,84 @@
+SUMMARY="FlightGear Flight Simulator"
+DESCRIPTION="The goal of the FlightGear project is to create a sophisticated \
+and open flight simulator framework for use in research or academic environments, \
+pilot training, as an industry engineering tool, for DIY-ers to pursue their favorite \
+interesting flight simulation idea, and last but certainly not least as a fun, \
+realistic, and challenging desktop flight simulator. We are developing a sophisticated, \
+open simulation framework that can be expanded and improved upon by anyone interested \
+in contributing."
+HOMEPAGE="https://www.flightgear.org/"
+COPYRIGHT="2002-2018 Curtis Olsen and others"
+LICENSE="GNU LGPLv2.0"
+REVISION="1"
+SOURCE_URI="https://downloads.sourceforge.net/flightgear/flighgear-$portVersion.tar.bz2"
+CHECKSUM_SHA256="924bcaec4bead47d01638f1033c0ca95c4a3fff65bd43d9c5b171d354b4b28f6"
+
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+ADDITIONAL_FILES="flightgear.rdef.in"
+
+PROVIDES="
+	flightgear$secondaryArchSuffix
+	cmd:fgcom$secondaryArchSuffix
+	cmd:fgelev$secondaryArchSuffix
+	cmd:fgfs$secondaryArchSuffix
+	cmd:fgjs$secondaryArchSuffix
+	cmd:fgpanel$secondaryArchSuffix
+	cmd:fgtraffic$secondaryArchSuffix
+	cmd:fgviewer$secondaryArchSuffix
+	cmd:GPSsmooth$secondaryArchSuffix
+	cmd:JSBSim$secondaryArchSuffix
+	cmd:js_demo$secondaryArchSuffix
+	cmd:metar$secondaryArchSuffix
+	cmd:MIDGsmooth$secondaryArchSuffix
+	cmd:UGsmooth$secondaryArchSuffix
+	cmd:yasim$secondaryArchSuffix
+	cmd:yasim-proptest$secondaryArchSuffix
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libGL$secondaryArchSuffix
+	lib:libqt5$secondaryArchSuffix
+	lib:boost$secondaryArchSuffix
+	lib:plib$secondaryArchSuffix
+	lib:simgearopenal$secondaryArchSuffix
+	lib:sqlite$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:harfbuzz$secondaryArchSuffix
+	devel:libGL$secondaryArchSuffix
+	devel:libqt5$secondaryArchSuffix
+	devel:plib$secondaryArchSuffix
+	devel:boost$secondaryArchSuffix
+	devel:plib$secondaryArchSuffix
+	devel:simgear$secondaryArchSuffix
+	devel:sqlite$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	cmd:g++$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:make
+	cmd:cmake >= 3.0
+	"
+BUILD()
+{
+	mkdir -p build && cd build
+	cmake .. -DFG_DATA_DIR:STRING="%{_datadir}/flightgear" \
+	-DENABLE_GPSSMOOTH:BOOL=OFF -DENABLE_FGVIEWER:BOOL=OFF \
+	-DENABLE_FGELEV:BOOL=OFF -DENABLE_METAR:BOOL=OFF \
+	-DSYSTEM_SQLITE:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=OFF \
+	-DBUILD_TESTING:BOOL=OFF -DENABLE_TESTS:BOOL=OFF \
+	-DENABLE_JS_DEMO:BOOL=OFF
+
+	cmake .. -DSIMGEAR_SHARED:BOOL=ON -DENABLE_TESTS:BOOL=OFF
+	make $jobArgs
+}
+INSTALL()
+{
+	make -C build install
+  addAppDeskbarSymlink $appsDir/FlightGear
+}

--- a/games-simulation/flightgear/flightgear-2018.2.2.recipe
+++ b/games-simulation/flightgear/flightgear-2018.2.2.recipe
@@ -13,7 +13,7 @@ REVISION="1"
 SOURCE_URI="https://downloads.sourceforge.net/flightgear/flighgear-$portVersion.tar.bz2"
 CHECKSUM_SHA256="924bcaec4bead47d01638f1033c0ca95c4a3fff65bd43d9c5b171d354b4b28f6"
 ADDITIONAL_FILES="flightgear.rdef.in"
- 
+
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 if [ "$targetArchitecture" = x86_gcc2 ]; then
 SECONDARY_ARCHITECTURES="x86"

--- a/games-simulation/flightgear/flightgear-2018.2.2.recipe
+++ b/games-simulation/flightgear/flightgear-2018.2.2.recipe
@@ -40,7 +40,7 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libGL$secondaryArchSuffix
 	lib:libqt5$secondaryArchSuffix
-	lib:boost$secondaryArchSuffix
+	lib:libboost_system$secondaryArchSuffix
 	lib:plib$secondaryArchSuffix
 	lib:simgearopenal$secondaryArchSuffix
 	lib:sqlite$secondaryArchSuffix
@@ -49,10 +49,9 @@ REQUIRES="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:harfbuzz$secondaryArchSuffix
-	devel:libGL$secondaryArchSuffix
+	devel:libboost_system$secondaryArchSuffix
+	devel:libgl$secondaryArchSuffix
 	devel:libqt5$secondaryArchSuffix
-	devel:plib$secondaryArchSuffix
-	devel:boost$secondaryArchSuffix
 	devel:plib$secondaryArchSuffix
 	devel:simgear$secondaryArchSuffix
 	devel:sqlite$secondaryArchSuffix

--- a/games-simulation/flightgear/flightgear-2018.2.2.recipe
+++ b/games-simulation/flightgear/flightgear-2018.2.2.recipe
@@ -44,7 +44,7 @@ REQUIRES="
 	lib:simgearopenal$secondaryArchSuffix
 	lib:sqlite$secondaryArchSuffix
 	"
-	
+
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:harfbuzz$secondaryArchSuffix

--- a/games-simulation/flightgear/flightgear-2018.2.2.recipe
+++ b/games-simulation/flightgear/flightgear-2018.2.2.recipe
@@ -16,7 +16,7 @@ ADDITIONAL_FILES="flightgear.rdef.in"
  
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 if [ "$targetArchitecture" = x86_gcc2 ]; then
- SECONDARY_ARCHITECTURES="x86"
+SECONDARY_ARCHITECTURES="x86"
 fi
 
 PROVIDES="
@@ -36,7 +36,6 @@ PROVIDES="
 	cmd:UGsmooth
 	cmd:yasim
 	"
-
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libGL$secondaryArchSuffix

--- a/games-simulation/flightgear/flightgear-2018.2.2.recipe
+++ b/games-simulation/flightgear/flightgear-2018.2.2.recipe
@@ -38,9 +38,10 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libGL$secondaryArchSuffix
-	lib:libqt5$secondaryArchSuffix
+	lib:harfbuzz$secondaryArchSuffix
 	lib:libboost_system$secondaryArchSuffix
+	lib:libgL$secondaryArchSuffix
+	lib:libqt5$secondaryArchSuffix
 	lib:plib$secondaryArchSuffix
 	lib:simgearopenal$secondaryArchSuffix
 	lib:sqlite$secondaryArchSuffix


### PR DESCRIPTION
FlightGear is an open-source flight simulator.  It supports a variety of popular platforms (Windows, Mac, Linux, etc.) and is developed by skilled volunteers from around the world. 

Version: 2018.2.2
Tested on Haiku R!B1 x86 w/ GCC7
Depends on: SimGear 2018.2.2 (#3187), hicolor-icon-theme
Project: FlightGear Flight Simulator
URL: http://home.flightgear.org/
Tag: work-in-progress