### PR TITLE
Fix FDK-AAC recipe (quotation marks in description)

### DIFF
--- a/media-libs/fdk-aac/fdk_aac-0.1.6.recipe
+++ b/media-libs/fdk-aac/fdk_aac-0.1.6.recipe
@@ -1,7 +1,7 @@
 SUMMARY="Fraunhofer AAC codec library"
-DESCRIPTION="The Fraunhofer FDK AAC Codec Library for Android ("FDK AAC Codec") \
-	is software that implements the MPEG Advanced Audio Coding ("AAC") \
-	encoding and decoding scheme for digital audio."
+DESCRIPTION="The Fraunhofer FDK AAC Codec Library for Android (\"FDK AAC \
+Codec\") is software that implements the MPEG Advanced Audio Coding (\"AAC\") \
+encoding and decoding scheme for digital audio."
 HOMEPAGE="https://sourceforge.net/projects/opencore-amr"
 COPYRIGHT="1995-2012 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V."
 LICENSE="Fraunhofer FDK AAC Codec"


### PR DESCRIPTION
Unescaped quotation marks in the description broke this recipe.