### PR TITLE
Enable LAME 3.100 on x86_gcc2 and x86.

### DIFF
--- a/media-sound/lame/lame-3.100.recipe
+++ b/media-sound/lame/lame-3.100.recipe
@@ -27,8 +27,8 @@ REVISION="1"
 SOURCE_URI="http://downloads.sourceforge.net/project/lame/lame/3.100/lame-$portVersion.tar.gz"
 CHECKSUM_SHA256="ddfe36cab873794038ae2c1210557ad34857a4b6bdc515785d1da9e175b1da1e"
 
-ARCHITECTURES="?x86_gcc2 ?x86 x86_64"
-SECONDARY_ARCHITECTURES="?x86_gcc2 ?x86"
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
 PROVIDES="
 	lame$secondaryArchSuffix = $portVersion compat >= 1


### PR DESCRIPTION
I've tested LAME 3.100 on x86_gcc2_hybrid and it works without any further changes. This PR removes the untested flag from the x86_gcc2 and x86 architectures.

How do you go about deleting outdated build scripts? Should I delete the old LAME 3.99.5 scripts and patches with this PR?