### PR TITLE
Add missing SUMMARY

### DIFF
--- a/dev-db/mysql/mysql-5.0.83.recipe
+++ b/dev-db/mysql/mysql-5.0.83.recipe
@@ -1,5 +1,5 @@
-SUMMARY="Database server."
-DESCRIPTION="A very fast and reliable SQL database server."
+SUMMARY="Database server"
+DESCRIPTION="A very fast and reliable SQL database server"
 HOMEPAGE="https://www.mysql.com"
 SOURCE_URI="http://mirror.provenscaling.com/mysql/community/source/5.0/mysql-5.0.83.tar.gz"
 CHECKSUM_MD5="051392064a1e32cca5c23a593908b10e"

--- a/dev-db/mysql/mysql-5.0.83.recipe
+++ b/dev-db/mysql/mysql-5.0.83.recipe
@@ -1,4 +1,4 @@
-SUMMARY="MySQL database server."
+SUMMARY="Database server."
 DESCRIPTION="A very fast and reliable SQL database server."
 HOMEPAGE="https://www.mysql.com"
 SOURCE_URI="http://mirror.provenscaling.com/mysql/community/source/5.0/mysql-5.0.83.tar.gz"

--- a/dev-db/mysql/mysql-5.0.83.recipe
+++ b/dev-db/mysql/mysql-5.0.83.recipe
@@ -6,7 +6,12 @@ CHECKSUM_MD5="051392064a1e32cca5c23a593908b10e"
 REVISION="1"
 STATUS_HAIKU="untested"
 DEPEND="sys-libs/readline >= 5.2"
-ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+ARCHITECTURES="!x86_gcc2 x86 ?x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+        mysql$secondaryArchSuffix = $portVersion"
 
 BUILD()
 {

--- a/dev-db/mysql/mysql-5.0.83.recipe
+++ b/dev-db/mysql/mysql-5.0.83.recipe
@@ -1,4 +1,5 @@
-DESCRIPTION="SQL database server."
+SUMMARY="MySQL database server."
+DESCRIPTION="A very fast and reliable SQL database server."
 HOMEPAGE="https://www.mysql.com"
 SOURCE_URI="http://mirror.provenscaling.com/mysql/community/source/5.0/mysql-5.0.83.tar.gz"
 CHECKSUM_MD5="051392064a1e32cca5c23a593908b10e"

--- a/dev-db/mysql/mysql-5.0.83.recipe
+++ b/dev-db/mysql/mysql-5.0.83.recipe
@@ -1,4 +1,4 @@
-SUMMARY="Database server"
+SUMMARY="SQL Database server"
 DESCRIPTION="A very fast and reliable SQL database server"
 HOMEPAGE="https://www.mysql.com"
 SOURCE_URI="http://mirror.provenscaling.com/mysql/community/source/5.0/mysql-5.0.83.tar.gz"

--- a/dev-db/mysql/mysql-5.0.83.recipe
+++ b/dev-db/mysql/mysql-5.0.83.recipe
@@ -6,6 +6,7 @@ CHECKSUM_MD5="051392064a1e32cca5c23a593908b10e"
 REVISION="1"
 STATUS_HAIKU="untested"
 DEPEND="sys-libs/readline >= 5.2"
+ARCHITECTURES="x86_gcc2 x86 x86_64"
 
 BUILD()
 {

--- a/dev-python/pychart/pychart-1.39.recipe
+++ b/dev-python/pychart/pychart-1.39.recipe
@@ -1,4 +1,4 @@
-SUMMARY="Library for Python."
+SUMMARY="Library for Python"
 DESCRIPTION="PyChart is a Python library for creating high quality charts"
 HOMEPAGE="http://home.gna.org/pychart"
 SOURCE_URI="http://download.gna.org/pychart/PyChart-1.39.tar.gz"

--- a/dev-python/pychart/pychart-1.39.recipe
+++ b/dev-python/pychart/pychart-1.39.recipe
@@ -1,5 +1,5 @@
-SUMMARY="PyChart library for Python."
-DESCRIPTION="PyChart is a Python library for creating high quality charts."
+SUMMARY="Library for Python."
+DESCRIPTION="PyChart is a Python library for creating high quality charts"
 HOMEPAGE="http://home.gna.org/pychart"
 SOURCE_URI="http://download.gna.org/pychart/PyChart-1.39.tar.gz"
 REVISION="1"

--- a/dev-python/pychart/pychart-1.39.recipe
+++ b/dev-python/pychart/pychart-1.39.recipe
@@ -1,3 +1,4 @@
+SUMMARY="PyChart library for Python."
 DESCRIPTION="PyChart is a Python library for creating high quality charts."
 HOMEPAGE="http://home.gna.org/pychart"
 SOURCE_URI="http://download.gna.org/pychart/PyChart-1.39.tar.gz"

--- a/dev-python/pychart/pychart-1.39_bzr.recipe
+++ b/dev-python/pychart/pychart-1.39_bzr.recipe
@@ -1,5 +1,5 @@
-SUMMARY="PyChart library for Python."
-DESCRIPTION="PyChart is a Python library for creating high quality charts."
+SUMMARY="Library for Python"
+DESCRIPTION="PyChart is a Python library for creating high quality charts"
 HOMEPAGE="http://home.gna.org/pychart"
 SOURCE_URI="bzr+http://download.gna.org/pychart/bzr-archive"
 REVISION="1"

--- a/dev-python/pychart/pychart-1.39_bzr.recipe
+++ b/dev-python/pychart/pychart-1.39_bzr.recipe
@@ -1,3 +1,4 @@
+SUMMARY="PyChart library for Python."
 DESCRIPTION="PyChart is a Python library for creating high quality charts."
 HOMEPAGE="http://home.gna.org/pychart"
 SOURCE_URI="bzr+http://download.gna.org/pychart/bzr-archive"

--- a/dev-python/pydispatcher/pydispatcher-2.0.1.recipe
+++ b/dev-python/pydispatcher/pydispatcher-2.0.1.recipe
@@ -1,5 +1,5 @@
 SUMMARY="PyDispatcher Library"
-DESCRIPTION="Multi-producer-multi-consumer signal dispatching mechanism in python."
+DESCRIPTION="Multi-producer-multi-consumer signal dispatching mechanism in python"
 HOMEPAGE="http://pydispatcher.sourceforge.net/"
 SOURCE_URI="http://downloads.sourceforge.net/project/pydispatcher/pydispatcher/2.0.1/PyDispatcher-2.0.1.tar.gz"
 REVISION="1"

--- a/dev-python/pydispatcher/pydispatcher-2.0.1.recipe
+++ b/dev-python/pydispatcher/pydispatcher-2.0.1.recipe
@@ -1,6 +1,5 @@
-DESCRIPTION="
-Multi-producer-multi-consumer signal dispatching mechanism in python.
-"
+SUMMARY="PyDispatcher Library"
+DESCRIPTION="Multi-producer-multi-consumer signal dispatching mechanism in python."
 HOMEPAGE="http://pydispatcher.sourceforge.net/"
 SOURCE_URI="http://downloads.sourceforge.net/project/pydispatcher/pydispatcher/2.0.1/PyDispatcher-2.0.1.tar.gz"
 REVISION="1"

--- a/dev-python/pyopengl/pyopengl-3.0.1.recipe
+++ b/dev-python/pyopengl/pyopengl-3.0.1.recipe
@@ -1,4 +1,6 @@
-DESCRIPTION="pyopengl - python opengl bindings"
+SUMMARY="OpenGL bindings for Python"
+DESCRIPTION="OpenGL bindings for Python including support for GL extensions, GLU,
+WGL, GLUT, GLE, and Tk."
 HOMEPAGE="http://pyopengl.sourceforge.net"
 SOURCE_URI="http://pypi.python.org/packages/source/P/PyOpenGL/PyOpenGL-3.0.1.tar.gz"
 CHECKSUM_MD5="cdf03284f24279b8d9914bb680a37b5e"

--- a/dev-python/pyxml/pyxml-0.8.4.recipe
+++ b/dev-python/pyxml/pyxml-0.8.4.recipe
@@ -1,4 +1,6 @@
-DESCRIPTION="Python XML package"
+SUMMARY="Python XML Tools"
+DESCRIPTION="The Python/XML distribution contains the basic tools required for
+processing XML data using the Python programming language." 
 HOMEPAGE="http://pyxml.sourceforge.net/topics/index.html"
 SOURCE_URI="http://sourceforge.net/projects/pyxml/files/latest/download?source=files"
 CHECKSUM_MD5="1f7655050cebbb664db976405fdba209"

--- a/dev-python/rdflib/rdflib-3.2.0.recipe
+++ b/dev-python/rdflib/rdflib-3.2.0.recipe
@@ -1,4 +1,5 @@
-DESCRIPTION="Python library for working with RDF"
+SUMMARY="Python library for working with RDF"
+DESCRIPTION="RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information. "
 HOMEPAGE="https://github.com/RDFLib/rdflib"
 SOURCE_URI="http://rdflib.googlecode.com/files/rdflib-3.2.0.tar.gz"
 CHECKSUM_MD5="ab3d3a5f71ebb6fe4fd33539f5d5768e"

--- a/net-libs/libyahoo2/libyahoo2-1.0.1.recipe
+++ b/net-libs/libyahoo2/libyahoo2-1.0.1.recipe
@@ -1,6 +1,5 @@
-DESCRIPTION="
-libyahoo2 - A C library for Yahoo! Messenger.
-"
+SUMMARY="A C library for Yahoo! Messenger."
+DESCRIPTION="libyahoo2 is a C library interface to the new Yahoo! Messenger protocol. It supports major features of the protocol."
 HOMEPAGE="http://libyahoo2.sourceforge.net/"
 SOURCE_URI="http://sourceforge.net/projects/libyahoo2/files/libyahoo2/1.0.1/libyahoo2-1.0.1.tar.bz2/download"
 DEPEND="glib >= 1.2.8"

--- a/sys-apps/hgrep/hgrep-1.0.1.recipe
+++ b/sys-apps/hgrep/hgrep-1.0.1.recipe
@@ -1,4 +1,5 @@
-DESCRIPTION="header grep"
+SUMMARY="A header grep utility"
+DESCRIPTION="Grep headers of newsspool/maildir/mbox style files"
 HOMEPAGE="http://www.ports.haiku-files.org/"
 SOURCE_URI="http://www.ports.haiku-files.org/export/1970/haikuports/trunk/sys-apps/hgrep/hgrep-1.0.1.zip"
 REVISION="1"


### PR DESCRIPTION
On running haikuporter, whilst populating the repository a number of recipes report errors due to missing SUMMARY definitions.  The Wiki states: "The old system did not use SUMMARY. All recipes need a SUMMARY of 70 characters or less".  I notice these packages are also missing from the HaikuDepot GUI tool - I assume due to this issue.

This pull request adds a SUMMARY to the problem recipes:-

games-rpg/freedroid/freedroid-1.0.2.recipe
sys-apps/hgrep
net-libs/libyahoo2
dev-db/mysql
dev-python/pychart, pydispatcher, pyopengl, pyxml, rdflib