### PR TITLE
llvm6/7: enable float128 support in clang.

### DIFF
--- a/sys-devel/llvm/llvm6-6.0.1.recipe
+++ b/sys-devel/llvm/llvm6-6.0.1.recipe
@@ -31,7 +31,7 @@ other than the ones listed above.
 HOMEPAGE="https://www.llvm.org/"
 COPYRIGHT="2003-2018 University of Illinois at Urbana-Champaign"
 LICENSE="UIUC"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://releases.llvm.org/$portVersion/llvm-$portVersion.src.tar.xz"
 CHECKSUM_SHA256="b6d6c324f9c71494c0ccaf3dac1f16236d970002b42bb24a6c9e1634f7d0f4e2"
 SOURCE_DIR="llvm-$portVersion.src"

--- a/sys-devel/llvm/llvm7-7.0.0.recipe
+++ b/sys-devel/llvm/llvm7-7.0.0.recipe
@@ -31,7 +31,7 @@ other than the ones listed above.
 HOMEPAGE="https://www.llvm.org/"
 COPYRIGHT="2003-2018 University of Illinois at Urbana-Champaign"
 LICENSE="UIUC"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://releases.llvm.org/$portVersion/llvm-$portVersion.src.tar.xz"
 CHECKSUM_SHA256="8bc1f844e6cbde1b652c19c1edebc1864456fd9c78b8c1bea038e51b363fe222"
 SOURCE_DIR="llvm-$portVersion.src"

--- a/sys-devel/llvm/patches/clang-6.0.1.patchset
+++ b/sys-devel/llvm/patches/clang-6.0.1.patchset
@@ -1,4 +1,4 @@
-From 264717b79e4c1013603826f56fdad9a687b57e67 Mon Sep 17 00:00:00 2001
+From 2224160e6b72457a3b386f412831f48c21710bf3 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Mon, 18 Jul 2016 14:13:19 +0200
 Subject: support for secondary arch.
@@ -104,10 +104,10 @@ index 8c6face..4c04668 100644
      break;
    case llvm::Triple::RTEMS:
 -- 
-2.16.4
+2.19.1
 
 
-From 62248207b775044c44feaf1cce6a4e053898b225 Mon Sep 17 00:00:00 2001
+From 01c867dbd8530f5531532cba7d07f1e3e47f38c5 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Thu, 7 Apr 2016 18:30:52 +0000
 Subject: add a test for haiku driver.
@@ -133,10 +133,10 @@ index 0000000..9591739
 +// CHECK-X86: gcc{{.*}}" "-o" "a.out" "{{.*}}.o"
 +
 -- 
-2.16.4
+2.19.1
 
 
-From 958de163bce332047ee7b677eabc478ce0f88ce9 Mon Sep 17 00:00:00 2001
+From c889c9ad0249e680afd209729ee87259f78f59c3 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Mon, 18 Jul 2016 14:13:19 +0200
 Subject: Enable thread-local storage and disable PIE by default
@@ -170,5 +170,60 @@ index 8b5b48e..ccd851f 100644
    std::string findLibCxxIncludePath() const override;
    void addLibStdCxxIncludePaths(
 -- 
-2.16.4
+2.19.1
+
+
+From 90022e621a8d44fd7f3d865f34568cb2c9213ad5 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Wed, 24 Oct 2018 10:47:00 +0100
+Subject: clang: Enable float128 support in clang with tests.
+
+
+diff --git a/lib/Basic/Targets/OSTargets.h b/lib/Basic/Targets/OSTargets.h
+index 790732b..11692b6 100644
+--- a/lib/Basic/Targets/OSTargets.h
++++ b/lib/Basic/Targets/OSTargets.h
+@@ -251,6 +251,10 @@ protected:
+     Builder.defineMacro("__HAIKU__");
+     Builder.defineMacro("__ELF__");
+     DefineStd(Builder, "unix", Opts);
++    if (this->HasFloat128) {
++      Builder.defineMacro("__FLOAT128__");
++      Builder.defineMacro("_GLIBCXX_USE_FLOAT128");
++    }
+   }
+ 
+ public:
+@@ -260,6 +264,14 @@ public:
+     this->IntPtrType = TargetInfo::SignedLong;
+     this->PtrDiffType = TargetInfo::SignedLong;
+     this->ProcessIDType = TargetInfo::SignedLong;
++    switch (Triple.getArch()) {
++    default:
++      break;
++    case llvm::Triple::x86:
++    case llvm::Triple::x86_64:
++      this->HasFloat128 = true;
++      break;
++    }
+   }
+ };
+ 
+diff --git a/test/CodeGenCXX/float128-declarations.cpp b/test/CodeGenCXX/float128-declarations.cpp
+index f1db8f4..11a49c9 100644
+--- a/test/CodeGenCXX/float128-declarations.cpp
++++ b/test/CodeGenCXX/float128-declarations.cpp
+@@ -12,6 +12,10 @@
+ // RUN:   %s -o - | FileCheck %s -check-prefix=CHECK-X86
+ // RUN: %clang_cc1 -emit-llvm -triple amd64-pc-openbsd -std=c++11 \
+ // RUN:   %s -o - | FileCheck %s -check-prefix=CHECK-X86
++// RUN: %clang_cc1 -emit-llvm -triple i586-pc-haiku -std=c++11 \
++// RUN:   %s -o - | FileCheck %s -check-prefix=CHECK-X86
++// RUN: %clang_cc1 -emit-llvm -triple x86_64-unknown-haiku -std=c++11 \
++// RUN:   %s -o - | FileCheck %s -check-prefix=CHECK-X86
+ //
+ /*  Various contexts where type __float128 can appear. The different check
+     prefixes are due to different mangling on X86 and different calling
+-- 
+2.19.1
 

--- a/sys-devel/llvm/patches/clang-7.0.0.patchset
+++ b/sys-devel/llvm/patches/clang-7.0.0.patchset
@@ -1,4 +1,4 @@
-From cea5db5c03ce27efcb71fda034bd07bfc0229d97 Mon Sep 17 00:00:00 2001
+From d6de87bba8dd243cdf649785f709363462de1d51 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Mon, 18 Jul 2016 14:13:19 +0200
 Subject: support for secondary arch.
@@ -104,10 +104,10 @@ index 8a70404..c80c3da 100644
      break;
    case llvm::Triple::RTEMS:
 -- 
-2.19.0
+2.19.1
 
 
-From 1688fb113225cef84ec6a44da26c7c38e5bdd6dd Mon Sep 17 00:00:00 2001
+From c23d8bc4ba199a2ee2171407a164889af480a911 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Thu, 7 Apr 2016 18:30:52 +0000
 Subject: add a test for haiku driver.
@@ -133,10 +133,10 @@ index 0000000..9591739
 +// CHECK-X86: gcc{{.*}}" "-o" "a.out" "{{.*}}.o"
 +
 -- 
-2.19.0
+2.19.1
 
 
-From 325461add9d4e93f029cbabf4fad6156cd62f2ae Mon Sep 17 00:00:00 2001
+From 8ce6ce6dfde5419b126572cc07d0b05a642a55c2 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Mon, 18 Jul 2016 14:13:19 +0200
 Subject: Enable thread-local storage and disable PIE by default
@@ -170,5 +170,60 @@ index a12a48e..9f6eb52 100644
    void addLibCxxIncludePaths(
        const llvm::opt::ArgList &DriverArgs,
 -- 
-2.19.0
+2.19.1
+
+
+From 970c902cea0d3b31148586ef6901f781c0b3e880 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Sat, 20 Oct 2018 23:45:16 +0100
+Subject: clang: Enable float128 support in clang with tests.
+
+
+diff --git a/lib/Basic/Targets/OSTargets.h b/lib/Basic/Targets/OSTargets.h
+index d373382..0033560 100644
+--- a/lib/Basic/Targets/OSTargets.h
++++ b/lib/Basic/Targets/OSTargets.h
+@@ -257,6 +257,10 @@ protected:
+     Builder.defineMacro("__HAIKU__");
+     Builder.defineMacro("__ELF__");
+     DefineStd(Builder, "unix", Opts);
++    if (this->HasFloat128) {
++      Builder.defineMacro("__FLOAT128__");
++      Builder.defineMacro("_GLIBCXX_USE_FLOAT128");
++    }
+   }
+ 
+ public:
+@@ -266,6 +270,14 @@ public:
+     this->IntPtrType = TargetInfo::SignedLong;
+     this->PtrDiffType = TargetInfo::SignedLong;
+     this->ProcessIDType = TargetInfo::SignedLong;
++    switch (Triple.getArch()) {
++    default:
++      break;
++    case llvm::Triple::x86:
++    case llvm::Triple::x86_64:
++      this->HasFloat128 = true;
++      break;
++    }
+   }
+ };
+ 
+diff --git a/test/CodeGenCXX/float128-declarations.cpp b/test/CodeGenCXX/float128-declarations.cpp
+index 07e73b2..c5a8c52 100644
+--- a/test/CodeGenCXX/float128-declarations.cpp
++++ b/test/CodeGenCXX/float128-declarations.cpp
+@@ -16,6 +16,10 @@
+ // RUN:   %s -o - | FileCheck %s -check-prefix=CHECK-X86
+ // RUN: %clang_cc1 -emit-llvm -triple x86_64-pc-solaris2.11 -std=c++11 \
+ // RUN:   %s -o - | FileCheck %s -check-prefix=CHECK-X86
++// RUN: %clang_cc1 -emit-llvm -triple i586-pc-haiku -std=c++11 \
++// RUN:   %s -o - | FileCheck %s -check-prefix=CHECK-X86
++// RUN: %clang_cc1 -emit-llvm -triple x86_64-unknown-haiku -std=c++11 \
++// RUN:   %s -o - | FileCheck %s -check-prefix=CHECK-X86
+ //
+ /*  Various contexts where type __float128 can appear. The different check
+     prefixes are due to different mangling on X86 and different calling
+-- 
+2.19.1
 


### PR DESCRIPTION
This patch is required to build a dependency of swift-lang when built with LLVM 6 and higher, and enables support for float128 in the compiler. Tested on Haiku x86_64, untested on x86.