### PR TITLE
binutils: bump x86 to v2.31.1

### DIFF
--- a/sys-devel/binutils/binutils-2.31.1.recipe
+++ b/sys-devel/binutils/binutils-2.31.1.recipe
@@ -33,9 +33,8 @@ CHECKSUM_SHA256="5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca8
 SOURCE_DIR="binutils-$binutilsVersion"
 PATCHES="binutils-$portVersion.patchset"
 
-# disabled on x86: see https://github.com/haikuports/haikuports/issues/1750
-ARCHITECTURES="!x86_gcc2 ?x86 x86_64 ?arm"
-SECONDARY_ARCHITECTURES="?x86"
+ARCHITECTURES="!x86_gcc2 x86 x86_64 arm"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	binutils$secondaryArchSuffix = $portVersion compat >= 2.23


### PR DESCRIPTION
bump x86 secondary architecture to binutils 2.31.1