### PR TITLE
optipngtranslator: add 2ndary arch

### DIFF
--- a/haiku-apps/optipngtranslator/optipngtranslator-0.0.1.recipe
+++ b/haiku-apps/optipngtranslator/optipngtranslator-0.0.1.recipe
@@ -1,40 +1,38 @@
 SUMMARY="Save optimized PNG files"
-DESCRIPTION="
-The OptiPNGTranslator for Haiku allows you to save images as PNG files which \
-have been optimized by OptiPNG.
-"
+DESCRIPTION="The OptiPNGTranslator allows you to save images as PNG files \
+which have been optimized with the commandline tool optipng.
+It's a translator, therefore the option to save as 'Optimized PNG image' will \
+be available in any native application. You find settings like the \
+optimization level in the DataTranslations preferences. The higher the \
+ level, the longer it takes."
 HOMEPAGE="https://github.com/noryb009/OptiPNGTranslator"
 COPYRIGHT="2013 Luke (noryb009)"
 LICENSE="MIT"
-REVISION="3"
+REVISION="4"
 srcGitRev="8e3996a92d840f3c097cf954e001d4f371265161"
 SOURCE_URI="$HOMEPAGE/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="4bbcb970f42bc13bba1105cce03739601339c3c52f8aec6c16130a9a1834746d"
 SOURCE_DIR="OptiPNGTranslator-$srcGitRev"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
-
-if [ $buildArchitecture = x86_gcc2 ] && \
-		[ $targetArchitecture = x86_gcc2 ]; then
-	optipngSuffix="_x86"
-fi
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	optipngtranslator = $portVersion
-	app:OptiPNGTranslator = $portVersion
+	optipngtranslator$secondaryArchSuffix = $portVersion
+	add_on:OptiPNGTranslator$secondaryArchSuffix = $portVersion
 	"
 REQUIRES="
-	haiku
-	cmd:optipng$optipngSuffix
+	haiku$secondaryArchSuffix
+	cmd:optipng
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
+	haiku${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
 	makefile_engine
 	cmd:as
-	cmd:gcc
+	cmd:gcc$secondaryArchSuffix
 	cmd:make
 	"
 

--- a/haiku-apps/optipngtranslator/optipngtranslator-0.0.1.recipe
+++ b/haiku-apps/optipngtranslator/optipngtranslator-0.0.1.recipe
@@ -12,6 +12,7 @@ REVISION="4"
 srcGitRev="8e3996a92d840f3c097cf954e001d4f371265161"
 SOURCE_URI="$HOMEPAGE/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="4bbcb970f42bc13bba1105cce03739601339c3c52f8aec6c16130a9a1834746d"
+SOURCE_FILENAME="optipngtranslator-$portVersion-$srcGitRev.tar.gz"
 SOURCE_DIR="OptiPNGTranslator-$srcGitRev"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"


### PR DESCRIPTION
* The package was not installable, because it needed
  cmd:optipng_x86 on 32bit Haiku. I removed the check of
  $buildArchitecture and "targetArchitecture and always
  use the plain cmd:optpng.
  optipng is available for all architectures.

Does the optipng recipe need to provide a SECONDARY_ARCHITECTURE as well?

* Add 2ndary architecture so _x86 apps can use the
  _x86 version of the translator.

* Improved description

* Bumped revision