### PR TITLE
aspell: build for gcc7, filters fix

### DIFF
--- a/app-text/aspell/aspell-0.60.6.1.recipe
+++ b/app-text/aspell/aspell-0.60.6.1.recipe
@@ -9,11 +9,12 @@ dictionary. Aspell will also do its best to respect the current locale \
 setting. Other advantages over Ispell include support for using multiple \
 dictionaries at once and intelligently handling personal dictionaries when \
 more than one Aspell process is open at once."
-HOMEPAGE="http://aspell.net"
+HOMEPAGE="http://aspell.net/"
 COPYRIGHT="2000-2006 Kevin Atkinson"
 LICENSE="GNU LGPL v2"
 REVISION="4"
-SOURCE_URI="https://ftp.gnu.org/gnu/aspell/aspell-$portVersion.tar.gz"
+SOURCE_URI="https://ftpmirror.gnu.org/aspell/aspell-$portVersion.tar.gz
+	https://ftp.gnu.org/gnu/aspell/aspell-$portVersion.tar.gz"
 CHECKSUM_SHA256="f52583a83a63633701c5f71db3dc40aab87b7f76b29723aeb27941eff42df6e1"
 PATCHES="aspell-$portVersion.patchset"
 

--- a/app-text/aspell/aspell-0.60.6.1.recipe
+++ b/app-text/aspell/aspell-0.60.6.1.recipe
@@ -13,7 +13,7 @@ HOMEPAGE="http://aspell.net"
 COPYRIGHT="2000-2006 Kevin Atkinson"
 LICENSE="GNU LGPL v2"
 REVISION="4"
-SOURCE_URI="ftp://ftp.gnu.org/gnu/aspell/aspell-$portVersion.tar.gz"
+SOURCE_URI="https://ftp.gnu.org/gnu/aspell/aspell-$portVersion.tar.gz"
 CHECKSUM_SHA256="f52583a83a63633701c5f71db3dc40aab87b7f76b29723aeb27941eff42df6e1"
 PATCHES="aspell-$portVersion.patchset"
 

--- a/app-text/aspell/aspell-0.60.6.1.recipe
+++ b/app-text/aspell/aspell-0.60.6.1.recipe
@@ -12,9 +12,10 @@ more than one Aspell process is open at once."
 HOMEPAGE="http://aspell.net"
 COPYRIGHT="2000-2006 Kevin Atkinson"
 LICENSE="GNU LGPL v2"
-REVISION="3"
-SOURCE_URI="ftp://ftp.gnu.org/gnu/aspell/aspell-0.60.6.1.tar.gz"
+REVISION="4"
+SOURCE_URI="ftp://ftp.gnu.org/gnu/aspell/aspell-$portVersion.tar.gz"
 CHECKSUM_SHA256="f52583a83a63633701c5f71db3dc40aab87b7f76b29723aeb27941eff42df6e1"
+PATCHES="aspell-$portVersion.patchset"
 
 ARCHITECTURES="x86 x86_gcc2 x86_64"
 SECONDARY_ARCHITECTURES="x86"
@@ -71,9 +72,10 @@ BUILD()
 	libtoolize --force --copy --install
 	aclocal -I m4
 	autoconf
-	automake
+	automake --add-missing
 	runConfigure ./configure \
-		--enable-dict-dir=$dataDir/aspell-0.60
+		--enable-dict-dir=$dataDir/aspell-0.60 \
+		--enable-compile-in-filters
 	make
 }
 

--- a/app-text/aspell/patches/aspell-0.60.6.1.patchset
+++ b/app-text/aspell/patches/aspell-0.60.6.1.patchset
@@ -1,0 +1,35 @@
+From c09a03b927daa852d0f89f6577318716a6f75b42 Mon Sep 17 00:00:00 2001
+From: Peter Kosyh <p.kosyh@gmail.com>
+Date: Sat, 27 Oct 2018 08:25:00 +0300
+Subject: gcc7 compilation fix
+
+
+diff --git a/modules/filter/tex.cpp b/modules/filter/tex.cpp
+index a979539..19ab63c 100644
+--- a/modules/filter/tex.cpp
++++ b/modules/filter/tex.cpp
+@@ -174,7 +174,7 @@ namespace {
+ 
+     if (c == '{') {
+ 
+-      if (top.in_what == Parm || top.in_what == Opt || top.do_check == '\0')
++      if (top.in_what == Parm || top.in_what == Opt || *top.do_check == '\0')
+ 	push_command(Parm);
+ 
+       top.in_what = Parm;
+diff --git a/prog/check_funs.cpp b/prog/check_funs.cpp
+index db54f3d..89ee09d 100644
+--- a/prog/check_funs.cpp
++++ b/prog/check_funs.cpp
+@@ -647,7 +647,7 @@ static void print_truncate(FILE * out, const char * word, int width) {
+     }
+   }
+   if (i == width-1) {
+-    if (word == '\0')
++    if (*word == '\0')
+       put(out,' ');
+     else if (word[len] == '\0')
+       put(out, word, len);
+-- 
+2.19.1
+

--- a/haiku-data/be_book/be_book-2008_10_26.recipe
+++ b/haiku-data/be_book/be_book-2008_10_26.recipe
@@ -1,9 +1,11 @@
 SUMMARY="Documentation for the BeOS API"
-DESCRIPTION="The BeOS API documentation."
+DESCRIPTION="The BeBook details the Application Programming Interface (API) \
+to the BeOS operating system. It's the reference for those who want to \
+familiarize themselves with the BeAPI and Haiku programming in general."
 HOMEPAGE="https://www.haiku-os.org/documents"
 COPYRIGHT="ACCESS Co., Ltd."
 LICENSE="Attribution-NonCommercial-NoDerivs 3.0 Unported"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="http://haiku-files.org/files/data/bebook_20081026.zip"
 CHECKSUM_SHA256="8bd4836744c2542567b95b3b1cacf60333562e178d5cbcf3aa0a69a02d2f7a28"
 SOURCE_DIR="bebook"


### PR DESCRIPTION
This fixes compilation of aspell on current Haiku.

Also, the 	--enable-compile-in-filters was added. This fixes error with default ngroff filter.

See: http://aspell.net/man-html/Loadable-Filter-Notes.html

Now, flyspell-mode is working in emacs.