### PR TITLE
emacs: invalid load-history (CANNOT_DUMP) workaround

### DIFF
--- a/app-editors/emacs/emacs-26.1.recipe
+++ b/app-editors/emacs/emacs-26.1.recipe
@@ -13,7 +13,7 @@ project planner, mail and news reader, debugger interface, calendar, and more.
 HOMEPAGE="https://gnu.org/s/emacs/"
 COPYRIGHT="2001-2018 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="http://www.artfiles.org/gnu.org/emacs/emacs-$portVersion.tar.xz"
 CHECKSUM_SHA256="1cf4fc240cd77c25309d15e18593789c8dbfba5c2b44d8f77c886542300fd32c"
 PATCHES="emacs-$portVersion.patchset"

--- a/app-editors/emacs/patches/emacs-26.1.patchset
+++ b/app-editors/emacs/patches/emacs-26.1.patchset
@@ -1,11 +1,8 @@
-From 382d51023f5e54b5c380ec7edb44cc7ea402c403 Mon Sep 17 00:00:00 2001
+From 9147d8c6da14fbc6241c378b97d6f908c2df1dad Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
 Date: Sun, 28 May 2017 12:53:20 +0200
 Subject: Introduce Haiku as supported platform
 
----
- configure.ac | 4 +++-
- 1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/configure.ac b/configure.ac
 index 256b954..d3926e8 100644
@@ -37,5 +34,30 @@ index 256b954..d3926e8 100644
      ;;
  
 -- 
-2.16.4
+2.19.1
+
+
+From 2049cf47c4f7e7aea12a3fd87e2ddf0e9fed89b1 Mon Sep 17 00:00:00 2001
+From: Peter Kosyh <p.kosyh@gmail.com>
+Date: Sun, 28 Oct 2018 15:30:55 +0300
+Subject: CANNOT_DUMP workaround
+
+
+diff --git a/lisp/loadup.el b/lisp/loadup.el
+index 5ecfae1..355d77e 100644
+--- a/lisp/loadup.el
++++ b/lisp/loadup.el
+@@ -393,7 +393,9 @@ lost after dumping")))
+       (message "Warning: Change in load-path due to site-init will be \
+ lost after dumping")))
+ 
+-(setq current-load-list nil)
++;; See https://github.com/termux/termux-packages/issues/423
++;; https://debbugs.gnu.org/cgi/bugreport.cgi?bug=14120
++;; (setq current-load-list nil)
+ ;; Avoid storing references to build directory in the binary.
+ (setq custom-current-group-alist nil)
+ 
+-- 
+2.19.1
 


### PR DESCRIPTION
Emacs in Hauku builded with CANNOT_DUMP=y.
There is known bug with it: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=14120

The same situation in Termux project (with CANNOT_DUMP=y): https://github.com/termux/termux-packages/issues/423

This bug leads to awful problems, that make emacs almost unusable. For example, you can not install melpa packages and so on...

This patch applies workaround, that is used in Termux project and looks fine.

After that workaround i was able to use melpa packages in emacs and all looks working fine.