### PR TITLE
goldendict: fix config path

### DIFF
--- a/app-text/goldendict/patches/goldendict-1.5.0rc2.patchset
+++ b/app-text/goldendict/patches/goldendict-1.5.0rc2.patchset
@@ -1,4 +1,4 @@
-From cc931443433db7d12619cb8371bac8757bad857c Mon Sep 17 00:00:00 2001
+From b7d662630d522150ccf3aaffcb355b9023a74db1 Mon Sep 17 00:00:00 2001
 From: Sergei Reznikov <diver@gelios.net>
 Date: Tue, 8 Aug 2017 11:27:18 +0300
 Subject: Haiku patch
@@ -138,10 +138,10 @@ index cf31e63..91f799e 100644
      // Make hunspells
      {
 -- 
-2.16.4
+2.19.1
 
 
-From afd589bf531c2509c57a0c437ca1fdb4546ff53b Mon Sep 17 00:00:00 2001
+From 11598184c6b085b9803b9004b0a2a6fcf6ca22b5 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Wed, 4 Jul 2018 23:37:22 +1000
 Subject: Fix build for gcc7
@@ -206,5 +206,28 @@ index 0db6909..f467925 100644
  #if ( QT_VERSION >= QT_VERSION_CHECK( 5, 0, 0 ) ) && defined( Q_OS_WIN32 )
  #include <QtWidgets/QStyleFactory>
 -- 
-2.16.4
+2.19.1
+
+
+From 0e39b7226b93c5b919b303db904294c84f5e1295 Mon Sep 17 00:00:00 2001
+From: Nikolay Korotkiy <sikmir@gmail.com>
+Date: Mon, 29 Oct 2018 22:41:18 +0000
+Subject: Fix config path
+
+
+diff --git a/config.cc b/config.cc
+index 9b27b31..4ef5b05 100644
+--- a/config.cc
++++ b/config.cc
+@@ -37,6 +37,8 @@ namespace
+         return result;
+       char const * pathInHome = "GoldenDict";
+       result = QDir::fromNativeSeparators( QString::fromWCharArray( _wgetenv( L"APPDATA" ) ) );
++    #elif defined(Q_OS_HAIKU)
++      char const * pathInHome = "config/settings/Goldendict";
+     #else
+       char const * pathInHome = ".goldendict";
+     #endif
+-- 
+2.19.1
 


### PR DESCRIPTION
Use `~/config/settings/Goldendict` instead of `~/.goldendict`.

[Haiku User Guide / Filesystem layout](https://www.haiku-os.org/docs/userguide/en/filesystem-layout.html):
> **~/config/settings/** This folder contains the settings to all applications and a few  configurations for the system. Some applications manage their settings  in their own subfolders, others simply put their configuration file in  there.
