### PR TITLE
Added 64 bit build of fastdep and verified it works with Paladin

### DIFF
--- a/dev-util/fastdep/fastdep-0.16.recipe
+++ b/dev-util/fastdep/fastdep-0.16.recipe
@@ -10,7 +10,7 @@ SOURCE_URI="http://ports-space.haiku-files.org/dev-util/source/fastdep-0.16.tar.
 CHECKSUM_SHA256="ce87d5aba71a38ad175c831f4f380498e04c22d75478310299812485b3202abb"
 PATCHES="fastdep-0.16.patch"
 
-ARCHITECTURES="x86 x86_gcc2"
+ARCHITECTURES="x86 x86_gcc2 x86_64"
 
 PROVIDES="
 	fastdep = $portVersion


### PR DESCRIPTION
As above. Thankfully just the target x86_64 was missing, no need to do anything else.