### PR TITLE
v8: add recipe for version 7.4.288.28

### DIFF
--- a/dev-lang/v8/patches/build-7.4.288.28.patch
+++ b/dev-lang/v8/patches/build-7.4.288.28.patch
@@ -1,0 +1,395 @@
+From 0130324ce3ce86cc0612b28a61abbc8e6f1605c9 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Wed, 10 Apr 2019 23:43:08 +0000
+Subject: Haiku support for the Chromium build folder
+
+
+diff --git a/build/build_config.h b/build/build_config.h
+index 4d1ba77f2b..b36d2b34c3 100644
+--- a/build/build_config.h
++++ b/build/build_config.h
+@@ -53,6 +53,8 @@
+ #define OS_FUCHSIA 1
+ #elif defined(__FreeBSD__)
+ #define OS_FREEBSD 1
++#elif defined(__HAIKU__)
++#define OS_HAIKU 1
+ #elif defined(__NetBSD__)
+ #define OS_NETBSD 1
+ #elif defined(__OpenBSD__)
+@@ -80,7 +82,7 @@
+ // For access to standard POSIXish features, use OS_POSIX instead of a
+ // more specific macro.
+ #if defined(OS_AIX) || defined(OS_ANDROID) || defined(OS_ASMJS) ||    \
+-    defined(OS_FREEBSD) || defined(OS_LINUX) || defined(OS_MACOSX) || \
++    defined(OS_FREEBSD) || defined(OS_HAIKU) || defined(OS_LINUX) || defined(OS_MACOSX) || \
+     defined(OS_NACL) || defined(OS_NETBSD) || defined(OS_OPENBSD) ||  \
+     defined(OS_QNX) || defined(OS_SOLARIS)
+ #define OS_POSIX 1
+diff --git a/build/config/BUILDCONFIG.gn b/build/config/BUILDCONFIG.gn
+index 9e843f3c30..0c21df3e4d 100644
+--- a/build/config/BUILDCONFIG.gn
++++ b/build/config/BUILDCONFIG.gn
+@@ -213,7 +213,11 @@ if (host_toolchain == "") {
+     }
+   } else if (host_os == "aix") {
+     host_toolchain = "//build/toolchain/aix:$host_cpu"
+-  } else {
++  }
++   else if (host_os == "haiku") {
++    host_toolchain = "//build/toolchain/haiku:$host_cpu"
++  }
++   else {
+     assert(false, "Unsupported host_os: $host_os")
+   }
+ }
+@@ -233,7 +237,10 @@ if (target_os == "android") {
+   }
+ } else if (target_os == "fuchsia") {
+   _default_toolchain = "//build/toolchain/fuchsia:$target_cpu"
+-} else if (target_os == "ios") {
++} else if (target_os == "haiku") {
++  _default_toolchain = "//build/toolchain/haiku:$target_cpu"
++}
++ else if (target_os == "ios") {
+   _default_toolchain = "//build/toolchain/mac:ios_clang_$target_cpu"
+ } else if (target_os == "mac") {
+   assert(host_os == "mac", "Mac cross-compiles are unsupported.")
+@@ -290,6 +297,7 @@ if (custom_toolchain != "") {
+ is_android = current_os == "android"
+ is_chromeos = current_os == "chromeos"
+ is_fuchsia = current_os == "fuchsia"
++is_haiku = current_os == "haiku"
+ is_ios = current_os == "ios"
+ is_linux = current_os == "chromeos" || current_os == "linux"
+ is_mac = current_os == "mac"
+diff --git a/build/config/clang/BUILD.gn b/build/config/clang/BUILD.gn
+index 960726e1e5..b5e2f2e206 100644
+--- a/build/config/clang/BUILD.gn
++++ b/build/config/clang/BUILD.gn
+@@ -31,6 +31,7 @@ config("find_bad_constructs") {
+ # Enables some extra Clang-specific warnings. Some third-party code won't
+ # compile with these so may want to remove this config.
+ config("extra_warnings") {
++   if (!is_haiku) {
+   cflags = [
+     "-Wheader-hygiene",
+ 
+@@ -39,4 +40,5 @@ config("extra_warnings") {
+ 
+     "-Wtautological-overlap-compare",
+   ]
++   }
+ }
+diff --git a/build/config/clang/clang.gni b/build/config/clang/clang.gni
+index 2c2d76fd4b..9ded4f4cca 100644
+--- a/build/config/clang/clang.gni
++++ b/build/config/clang/clang.gni
+@@ -6,6 +6,9 @@ import("//build/toolchain/toolchain.gni")
+ 
+ default_clang_base_path = "//third_party/llvm-build/Release+Asserts"
+ 
++if(is_haiku){
++  default_clang_base_path = ""
++}
+ declare_args() {
+   # Indicates if the build should use the Chrome-specific plugins for enforcing
+   # coding guidelines, etc. Only used when compiling with Clang.
+diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
+index ca6ff2b138..e66eeac213 100644
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -101,7 +101,7 @@ declare_args() {
+   # So only enable this on linux if use_goma.  Elsewhere, there are no
+   # drawbacks to using it, so always enable it there.
+   strip_absolute_paths_from_debug_symbols =
+-      is_android || is_fuchsia || is_nacl || (is_win && use_lld) ||
++      is_android || is_fuchsia || is_nacl || is_haiku || (is_win && use_lld) ||
+       (use_goma && is_linux)
+ 
+   # Allow projects that wish to stay on C++11 to override Chromium's default.
+@@ -236,6 +236,8 @@ config("compiler") {
+     configs += [ "//build/config/fuchsia:compiler" ]
+   } else if (current_os == "aix") {
+     configs += [ "//build/config/aix:compiler" ]
++  } else if (current_os == "haiku") {
++    configs += [ "//build/config/haiku:compiler" ]
+   }
+ 
+   configs += [
+@@ -359,7 +361,7 @@ config("compiler") {
+ 
+   # Linux/Android/Fuchsia common flags setup.
+   # ---------------------------------
+-  if (is_linux || is_android || is_fuchsia) {
++  if (is_linux || is_android || is_fuchsia || is_haiku) {
+     asmflags += [ "-fPIC" ]
+     cflags += [ "-fPIC" ]
+     ldflags += [ "-fPIC" ]
+@@ -464,7 +466,7 @@ config("compiler") {
+ 
+   # Clang-specific compiler flags setup.
+   # ------------------------------------
+-  if (is_clang) {
++  if (is_clang && !is_haiku) {
+     cflags += [ "-fcolor-diagnostics" ]
+ 
+     # Enable -fmerge-all-constants. This used to be the default in clang
+@@ -1139,7 +1141,7 @@ config("compiler_deterministic") {
+   # Tells the compiler not to use absolute paths when passing the default
+   # paths to the tools it invokes. We don't want this because we don't
+   # really need it and it can mess up the goma cache entries.
+-  if (is_clang && !is_nacl) {
++  if (is_clang && !is_nacl && !is_haiku) {
+     cflags += [ "-no-canonical-prefixes" ]
+   }
+ }
+@@ -1707,7 +1709,7 @@ config("thin_archive") {
+   # Mac and iOS use the mac-specific "libtool" command, not ar, which doesn't
+   # have a "thin archive" mode (it does accept -T, but it means truncating
+   # archive names to 16 characters, which is not what we want).
+-  if ((is_posix && !is_nacl && !is_mac && !is_ios) || is_fuchsia) {
++  if ((is_posix && !is_nacl && !is_mac && !is_ios && !is_haiku) || is_fuchsia) {
+     arflags = [ "-T" ]
+   } else if (is_win && use_lld) {
+     arflags = [ "/llvmlibthin" ]
+diff --git a/build/config/haiku/BUILD.gn b/build/config/haiku/BUILD.gn
+new file mode 100644
+index 0000000000..2e25200459
+--- /dev/null
++++ b/build/config/haiku/BUILD.gn
+@@ -0,0 +1,61 @@
++# Copyright 2017 The Chromium Authors. All rights reserved.
++# Use of this source code is governed by a BSD-style license that can be
++# found in the LICENSE file.
++
++import("//build/config/sanitizers/sanitizers.gni")
++import("//build/toolchain/toolchain.gni")
++
++# This is included by reference in the //build/config/compiler config that
++# is applied to all targets. It is here to separate out the logic.
++
++config("compiler") {
++  # These flags are shared between the C compiler and linker.
++
++  defines = [
++    "__STDC_FORMAT_MACROS",
++  ]
++
++  cflags = [
++    "-Wall",
++    "-Wno-unused-parameter",
++    "-Wmissing-field-initializers",
++    "-Wno-uninitialized",
++    "-O3",
++    "-Wno-unused-local-typedefs",
++    "-Wno-deprecated-declarations",
++    "-fno-delete-null-pointer-checks",
++    "-Wno-comments",
++    "-fomit-frame-pointer",
++    "-g0",
++    "-fvisibility=hidden",
++    "-Wno-strict-overflow",
++    "-Wno-return-type",
++    "-fno-ident",
++    "-fdata-sections",
++    "-ffunction-sections",
++    "-Wno-narrowing",
++    "-fno-exceptions",
++    "-fno-rtti",
++    "-fvisibility-inlines-hidden",
++    "-fstack-protector",
++    "--param=ssp-buffer-size=4",
++    "-fstack-protector",
++    "-Wno-builtin-macro-redefined"
++    # "-Werror"
++    # We need to find a way to fix the TOC warnings if we want to enable this.
++  ]
++
++  cflags_cc = [
++    "-std=gnu++11",
++
++  ]
++
++  ldflags = [
++    "-lroot",
++    "-lstdc++",
++    "-lbsd",
++    "-lssp",
++    "-lnetwork",
++  ]
++
++}
+diff --git a/build/toolchain/gcc_toolchain.gni b/build/toolchain/gcc_toolchain.gni
+index 7326a840dc..e10ba7f9dc 100644
+--- a/build/toolchain/gcc_toolchain.gni
++++ b/build/toolchain/gcc_toolchain.gni
+@@ -448,9 +448,9 @@ template("gcc_toolchain") {
+       command = "$python_path \"$solink_wrapper\" --readelf=\"$readelf\" --nm=\"$nm\" $strip_switch--sofile=\"$unstripped_sofile\" --tocfile=\"$tocfile\"$map_switch --output=\"$sofile\" -- $link_command"
+ 
+       if (target_cpu == "mipsel" && is_component_build && is_android) {
+-        rspfile_content = "-Wl,--start-group -Wl,--whole-archive {{inputs}} {{solibs}} -Wl,--no-whole-archive $solink_libs_section_prefix {{libs}} $solink_libs_section_postfix -Wl,--end-group"
++        rspfile_content = "-Wl,--start-group -Wl,--whole-archive {{inputs}} {{solibs}} -Wl,--no-whole-archive $solink_libs_section_prefix {{libs}} $solink_libs_section_postfix -Wl,--end-group -lssp"
+       } else {
+-        rspfile_content = "-Wl,--whole-archive {{inputs}} {{solibs}} -Wl,--no-whole-archive $solink_libs_section_prefix {{libs}} $solink_libs_section_postfix"
++        rspfile_content = "-Wl,--whole-archive {{inputs}} {{solibs}} -Wl,--no-whole-archive $solink_libs_section_prefix {{libs}} $solink_libs_section_postfix -lssp -lexecinfo"
+       }
+ 
+       description = "SOLINK $sofile"
+@@ -501,13 +501,13 @@ template("gcc_toolchain") {
+         unstripped_sofile = sofile
+       }
+ 
+-      command = "$ld -shared {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" -Wl,-soname=\"$soname\" @\"$rspfile\""
++      command = "$ld -shared {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" -Wl,-soname=\"$soname\" @\"$rspfile\" -lssp"
+ 
+       if (defined(invoker.strip)) {
+         strip_command = "${invoker.strip} -o \"$sofile\" \"$unstripped_sofile\""
+         command += " && " + strip_command
+       }
+-      rspfile_content = "-Wl,--whole-archive {{inputs}} {{solibs}} -Wl,--no-whole-archive $solink_libs_section_prefix {{libs}} $solink_libs_section_postfix"
++      rspfile_content = "-Wl,--whole-archive {{inputs}} {{solibs}} -Wl,--no-whole-archive $solink_libs_section_prefix {{libs}} -lexecinfo $solink_libs_section_postfix"
+ 
+       description = "SOLINK_MODULE $sofile"
+ 
+@@ -567,9 +567,10 @@ template("gcc_toolchain") {
+       end_group_flag = ""
+       if (current_os != "aix") {
+         # the "--start-group .. --end-group" feature isn't available on the aix ld.
+-        start_group_flag = "-Wl,--start-group"
+-        end_group_flag = "-Wl,--end-group "
++        start_group_flag = "-Wl,--start-group -lssp -lexecinfo -lnetwork"
++        end_group_flag = "-Wl,--end-group -lssp -lexecinfo -lnetwork"
+       }
++
+       link_command = "$ld {{ldflags}}${extra_ldflags} -o \"$unstripped_outfile\" $start_group_flag @\"$rspfile\" {{solibs}} $end_group_flag $libs_section_prefix {{libs}} $libs_section_postfix"
+ 
+       strip_switch = ""
+diff --git a/build/toolchain/haiku/BUILD.gn b/build/toolchain/haiku/BUILD.gn
+new file mode 100644
+index 0000000000..0b31eade9f
+--- /dev/null
++++ b/build/toolchain/haiku/BUILD.gn
+@@ -0,0 +1,76 @@
++# Copyright 2017 The Chromium Authors. All rights reserved.
++# Use of this source code is governed by a BSD-style license that can be
++# found in the LICENSE file.
++
++import("//build/toolchain/gcc_toolchain.gni")
++
++
++gcc_toolchain("x86") {
++  cc = "gcc"
++  cxx = "g++"
++
++  readelf = "readelf"
++  nm = "nm"
++  ar = "ar"
++  ld = cxx
++
++  # Output linker map files for binary size analysis.
++  enable_linker_map = true
++
++  is_clang = false
++
++  extra_ldflags="-lroot -lbsd -lnetwork -lssp"
++
++
++  toolchain_args = {
++    current_cpu = "x86"
++    current_os = "haiku"
++    is_clang = false
++  }
++}
++
++gcc_toolchain("x64") {
++  cc = "gcc"
++  cxx = "g++"
++
++  readelf = "readelf"
++  nm = "nm"
++  ar = "ar"
++  ld = cxx
++
++  # Output linker map files for binary size analysis.
++  enable_linker_map = true
++
++  is_clang = false
++
++  extra_ldflags="-lroot -lbsd -lnetwork -lssp"
++
++
++  toolchain_args = {
++    current_cpu = "x64"
++    current_os = "haiku"
++    is_clang = false
++  
++  }
++}
++
++clang_toolchain("clang_x64") {
++  # Output linker map files for binary size analysis.
++  enable_linker_map = true
++  
++  
++  toolchain_args = {
++    current_cpu = "x64"
++    current_os = "haiku"
++  }
++}
++
++clang_toolchain("clang_x86") {
++  # Output linker map files for binary size analysis.
++  enable_linker_map = true
++  
++  toolchain_args = {
++    current_cpu = "x86"
++    current_os = "haiku"
++  }
++}
+diff --git a/third_party/googletest/src/googletest/include/gtest/internal/gtest-port-arch.h b/third_party/googletest/src/googletest/include/gtest/internal/gtest-port-arch.h
+index 779872de6a..aaeff5d9d6 100644
+--- a/third_party/googletest/src/googletest/include/gtest/internal/gtest-port-arch.h
++++ b/third_party/googletest/src/googletest/include/gtest/internal/gtest-port-arch.h
+@@ -79,6 +79,8 @@
+ # define GTEST_OS_FUCHSIA 1
+ #elif defined(__GLIBC__) && defined(__FreeBSD_kernel__)
+ # define GTEST_OS_GNU_KFREEBSD 1
++#elif defined(__HAIKU__)
++# define GTEST_OS_HAIKU 1
+ #elif defined __linux__
+ # define GTEST_OS_LINUX 1
+ # if defined __ANDROID__
+diff --git a/third_party/googletest/src/googletest/include/gtest/internal/gtest-port.h b/third_party/googletest/src/googletest/include/gtest/internal/gtest-port.h
+index 4932947b49..ab430447e1 100644
+--- a/third_party/googletest/src/googletest/include/gtest/internal/gtest-port.h
++++ b/third_party/googletest/src/googletest/include/gtest/internal/gtest-port.h
+@@ -121,6 +121,7 @@
+ //   GTEST_OS_FREEBSD  - FreeBSD
+ //   GTEST_OS_FUCHSIA  - Fuchsia
+ //   GTEST_OS_GNU_KFREEBSD - GNU/kFreeBSD
++//   GTEST_OS_HAIKU    - Haiku
+ //   GTEST_OS_HPUX     - HP-UX
+ //   GTEST_OS_LINUX    - Linux
+ //     GTEST_OS_LINUX_ANDROID - Google Android
+@@ -548,7 +549,7 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
+ #define GTEST_HAS_PTHREAD                                             \
+   (GTEST_OS_LINUX || GTEST_OS_MAC || GTEST_OS_HPUX || GTEST_OS_QNX || \
+    GTEST_OS_FREEBSD || GTEST_OS_NACL || GTEST_OS_NETBSD || GTEST_OS_FUCHSIA || \
+-   GTEST_OS_DRAGONFLY || GTEST_OS_GNU_KFREEBSD || GTEST_OS_OPENBSD)
++   GTEST_OS_DRAGONFLY || GTEST_OS_GNU_KFREEBSD || GTEST_OS_OPENBSD || GTEST_OS_HAIKU)
+ #endif  // GTEST_HAS_PTHREAD
+ 
+ #if GTEST_HAS_PTHREAD
+@@ -608,7 +609,7 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
+      GTEST_OS_WINDOWS_MINGW || GTEST_OS_AIX || GTEST_OS_HPUX || \
+      GTEST_OS_OPENBSD || GTEST_OS_QNX || GTEST_OS_FREEBSD || \
+      GTEST_OS_NETBSD || GTEST_OS_FUCHSIA || GTEST_OS_DRAGONFLY || \
+-     GTEST_OS_GNU_KFREEBSD)
++     GTEST_OS_GNU_KFREEBSD || GTEST_OS_HAIKU)
+ # define GTEST_HAS_DEATH_TEST 1
+ #endif
+ 
+-- 
+2.21.0
+

--- a/dev-lang/v8/patches/v8-7.4.288.28.patchset
+++ b/dev-lang/v8/patches/v8-7.4.288.28.patchset
@@ -1,0 +1,300 @@
+From 4bfe04b667ac9f15961d55291e88e85282b0fe51 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Tue, 12 Feb 2019 12:51:52 +0000
+Subject: Haiku platform support.
+
+
+diff --git a/BUILD.gn b/BUILD.gn
+index d52d806..92ec21c 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -603,7 +603,7 @@ config("toolchain") {
+     }
+   }
+ 
+-  if (is_clang) {
++  if (is_clang && !is_haiku) {
+     cflags += [
+       "-Wmissing-field-initializers",
+ 
+@@ -3228,6 +3228,11 @@ v8_component("v8_libbase") {
+       "src/base/debug/stack_trace_fuchsia.cc",
+       "src/base/platform/platform-fuchsia.cc",
+     ]
++  } else if (is_haiku) {
++    sources += [
++      "src/base/debug/stack_trace_posix.cc",
++      "src/base/platform/platform-haiku.cc",
++    ]
+   } else if (is_mac) {
+     sources += [
+       "src/base/debug/stack_trace_posix.cc",
+@@ -3524,6 +3529,13 @@ if (is_fuchsia && !build_with_chromium) {
+ 
+ group("v8_fuzzers") {
+   testonly = true
++
++  if(host_os == "haiku"){
++    data_deps = []
++  }
++
++  if (host_os != "haiku") {
++
+   data_deps = [
+     ":v8_simple_json_fuzzer",
+     ":v8_simple_multi_return_fuzzer",
+@@ -3535,6 +3547,8 @@ group("v8_fuzzers") {
+     ":v8_simple_wasm_compile_fuzzer",
+     ":v8_simple_wasm_fuzzer",
+   ]
++  }
++
+ }
+ 
+ if (is_component_build) {
+diff --git a/include/v8config.h b/include/v8config.h
+index e30a582..9e65520 100644
+--- a/include/v8config.h
++++ b/include/v8config.h
+@@ -61,6 +61,7 @@
+ //  V8_OS_CYGWIN        - Cygwin
+ //  V8_OS_DRAGONFLYBSD  - DragonFlyBSD
+ //  V8_OS_FREEBSD       - FreeBSD
++//  V8_OS_HAIKU         - Haiku
+ //  V8_OS_FUCHSIA       - Fuchsia
+ //  V8_OS_LINUX         - Linux
+ //  V8_OS_MACOSX        - Mac OS X
+@@ -96,6 +97,9 @@
+ # define V8_OS_BSD 1
+ # define V8_OS_FREEBSD 1
+ # define V8_OS_POSIX 1
++#elif defined(__HAIKU__)
++# define V8_OS_HAIKU 1
++# define V8_OS_POSIX 1
+ #elif defined(__Fuchsia__)
+ # define V8_OS_FUCHSIA 1
+ # define V8_OS_POSIX 1
+diff --git a/src/base/debug/stack_trace_posix.cc b/src/base/debug/stack_trace_posix.cc
+index ed602af..58b3b5d 100644
+--- a/src/base/debug/stack_trace_posix.cc
++++ b/src/base/debug/stack_trace_posix.cc
+@@ -25,14 +25,15 @@
+ #include <string>
+ #include <vector>
+ 
+-#if V8_LIBC_GLIBC || V8_LIBC_BSD || V8_LIBC_UCLIBC || V8_OS_SOLARIS
++#if V8_LIBC_GLIBC || V8_LIBC_BSD || V8_LIBC_UCLIBC || V8_OS_SOLARIS || V8_OS_HAIKU
+ #define HAVE_EXECINFO_H 1
+ #endif
+ 
+-#if HAVE_EXECINFO_H
++#if defined(HAVE_EXECINFO_H)
+ #include <cxxabi.h>
+ #include <execinfo.h>
+ #endif
++
+ #if V8_OS_MACOSX
+ #include <AvailabilityMacros.h>
+ #endif
+diff --git a/src/base/platform/platform-haiku.cc b/src/base/platform/platform-haiku.cc
+new file mode 100644
+index 0000000..86bf945
+--- /dev/null
++++ b/src/base/platform/platform-haiku.cc
+@@ -0,0 +1,48 @@
++// Copyright 2012 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++// Platform-specific code for Haiku goes here. For the POSIX-compatible
++// parts, the implementation is in platform-posix.cc.
++
++#include <pthread.h>
++#include <semaphore.h>
++#include <signal.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <sys/resource.h>
++#include <sys/time.h>
++
++#include <errno.h>
++#include <fcntl.h>  // open
++#include <stdarg.h>
++#include <strings.h>    // index
++#include <sys/mman.h>   // mmap & munmap
++#include <sys/stat.h>   // open
++#include <sys/types.h>  // mmap & munmap
++#include <unistd.h>     // sysconf
++
++#include <cmath>
++
++#undef MAP_TYPE
++
++#include "src/base/macros.h"
++#include "src/base/platform/platform-posix-time.h"
++#include "src/base/platform/platform-posix.h"
++#include "src/base/platform/platform.h"
++
++namespace v8 {
++namespace base {
++
++TimezoneCache* OS::CreateTimezoneCache() {
++  return new PosixDefaultTimezoneCache();
++}
++
++std::vector<OS::SharedLibraryAddress> OS::GetSharedLibraryAddresses() {
++  return std::vector<SharedLibraryAddress>();
++}
++
++void OS::SignalCodeMovingGC() {}
++
++}  // namespace base
++}  // namespace v8
+diff --git a/src/base/platform/platform-posix.cc b/src/base/platform/platform-posix.cc
+index e7edbf5..387290c 100644
+--- a/src/base/platform/platform-posix.cc
++++ b/src/base/platform/platform-posix.cc
+@@ -60,7 +60,7 @@
+ #include <sys/resource.h>
+ #endif
+ 
+-#if !defined(_AIX) && !defined(V8_OS_FUCHSIA)
++#if !defined(_AIX) && !defined(V8_OS_FUCHSIA) && !defined(__HAIKU__)
+ #include <sys/syscall.h>
+ #endif
+ 
+@@ -76,6 +76,14 @@ extern int madvise(caddr_t, size_t, int);
+ #endif
+ #endif
+ 
++#if defined(__HAIKU__)
++extern "C" int posix_madvise(void*, size_t, int);
++#endif
++
++#if defined(__HAIKU__)
++#define MADV_FREE POSIX_MADV_DONTNEED
++#endif
++
+ #ifndef MADV_FREE
+ #define MADV_FREE MADV_DONTNEED
+ #endif
+@@ -127,7 +135,7 @@ int GetProtectionFromMemoryPermission(OS::MemoryPermission access) {
+ int GetFlagsForMemoryPermission(OS::MemoryPermission access) {
+   int flags = MAP_PRIVATE | MAP_ANONYMOUS;
+   if (access == OS::MemoryPermission::kNoAccess) {
+-#if !V8_OS_AIX && !V8_OS_FREEBSD && !V8_OS_QNX
++#if !V8_OS_AIX && !V8_OS_FREEBSD && !V8_OS_QNX && !V8_OS_HAIKU
+     flags |= MAP_NORESERVE;
+ #endif  // !V8_OS_AIX && !V8_OS_FREEBSD && !V8_OS_QNX
+ #if V8_OS_QNX
+@@ -356,6 +364,8 @@ bool OS::DiscardSystemPages(void* address, size_t size) {
+   int ret = madvise(address, size, MADV_FREE_REUSABLE);
+ #elif defined(_AIX) || defined(V8_OS_SOLARIS)
+   int ret = madvise(reinterpret_cast<caddr_t>(address), size, MADV_FREE);
++#elif defined(__HAIKU__)
++  int ret = posix_madvise(address, size, MADV_FREE);
+ #else
+   int ret = madvise(address, size, MADV_FREE);
+ #endif
+@@ -367,6 +377,8 @@ bool OS::DiscardSystemPages(void* address, size_t size) {
+ // imply runtime support.
+ #if defined(_AIX) || defined(V8_OS_SOLARIS)
+     ret = madvise(reinterpret_cast<caddr_t>(address), size, MADV_DONTNEED);
++#elif defined(__HAIKU__)
++    ret = posix_madvise(address, size, MADV_FREE);
+ #else
+     ret = madvise(address, size, MADV_DONTNEED);
+ #endif
+diff --git a/src/libsampler/sampler.cc b/src/libsampler/sampler.cc
+index eb804a7..cd3c2bb 100644
+--- a/src/libsampler/sampler.cc
++++ b/src/libsampler/sampler.cc
+@@ -12,7 +12,7 @@
+ #include <sys/time.h>
+ #include <atomic>
+ 
+-#if !V8_OS_QNX && !V8_OS_AIX
++#if !V8_OS_QNX && !V8_OS_AIX && !V8_OS_HAIKU
+ #include <sys/syscall.h>  // NOLINT
+ #endif
+ 
+@@ -20,7 +20,7 @@
+ #include <mach/mach.h>
+ // OpenBSD doesn't have <ucontext.h>. ucontext_t lives in <signal.h>
+ // and is a typedef for struct sigcontext. There is no uc_mcontext.
+-#elif !V8_OS_OPENBSD
++#elif !V8_OS_OPENBSD && !V8_OS_HAIKU
+ #include <ucontext.h>
+ #endif
+ 
+@@ -469,6 +469,16 @@ void SignalHandler::FillRegisterState(void* context, RegisterState* state) {
+   state->sp = reinterpret_cast<void*>(mcontext.mc_r13);
+   state->fp = reinterpret_cast<void*>(mcontext.mc_r11);
+ #endif  // V8_HOST_ARCH_*
++#elif V8_OS_HAIKU
++#if V8_HOST_ARCH_IA32
++  state->pc = reinterpret_cast<void*>(mcontext.eip);
++  state->sp = reinterpret_cast<void*>(mcontext.esp);
++  state->fp = reinterpret_cast<void*>(mcontext.ebp);
++#elif V8_HOST_ARCH_X64
++  state->pc = reinterpret_cast<void*>(mcontext.rip);
++  state->sp = reinterpret_cast<void*>(mcontext.rsp);
++  state->fp = reinterpret_cast<void*>(mcontext.rbp);
++#endif  // V8_HOST_ARCH_*
+ #elif V8_OS_NETBSD
+ #if V8_HOST_ARCH_IA32
+   state->pc = reinterpret_cast<void*>(mcontext.__gregs[_REG_EIP]);
+diff --git a/test/BUILD.gn b/test/BUILD.gn
+index 70c8b51..073ff09 100644
+--- a/test/BUILD.gn
++++ b/test/BUILD.gn
+@@ -7,6 +7,16 @@ import("../gni/v8.gni")
+ group("gn_all") {
+   testonly = true
+ 
++ # Don't build tests for Haiku yet
++
++  if(host_os != "haiku"){
++    data_deps = []
++  }
++
++  deps = []
++
++  if (host_os != "haiku") {
++
+   data_deps = [
+     "benchmarks:v8_benchmarks",
+     "intl:v8_intl",
+@@ -34,6 +44,8 @@ group("gn_all") {
+       "unittests:unittests",
+     ]
+   }
++ }
++
+ }
+ 
+ ###############################################################################
+diff --git a/tools/mb/mb.py b/tools/mb/mb.py
+index cbb5b5d..3238a7a 100755
+--- a/tools/mb/mb.py
++++ b/tools/mb/mb.py
+@@ -832,12 +832,15 @@ class MetaBuildWrapper(object):
+       subdir, exe = 'linux64', 'gn'
+     elif self.platform == 'darwin':
+       subdir, exe = 'mac', 'gn'
++    elif self.platform == 'haiku1':
++      subdir, exe = 'haiku','gn'
++      gn_path = "/bin/gn"
+     else:
+       subdir, exe = 'win', 'gn.exe'
+ 
+     arch = platform.machine()
+     if (arch.startswith('s390') or arch.startswith('ppc') or
+-        self.platform.startswith('aix')):
++	  self.platform.startswith('aix') or self.platform.startswith('haiku')):
+       # use gn in PATH
+       gn_path = 'gn'
+     else:
+-- 
+2.19.1
+

--- a/dev-lang/v8/v8-7.4.288.28.recipe
+++ b/dev-lang/v8/v8-7.4.288.28.recipe
@@ -1,0 +1,128 @@
+SUMMARY="Google's open source JavaScript engine"
+DESCRIPTION="V8 is Google's open source JavaScript engine. V8 is written in \
+C++ and is used in Google Chrome, the open source browser from Google. V8 \
+implements ECMAScript as specified in ECMA-262, 5th edition, and runs on \
+Windows (XP or newer), Mac OS X (10.5 or newer), and Linux systems that use \
+IA-32, x64, or ARM processors. V8 can run standalone, or can be embedded into \
+any C++ application."
+HOMEPAGE="https://v8.dev/"
+COPYRIGHT="2006-2018 The V8 Project Authors"
+LICENSE="BSD (3-clause)"
+REVISION="1"
+SOURCE_URI="https://github.com/v8/v8/archive/$portVersion.tar.gz"
+SOURCE_DIR="v8-$portVersion"
+CHECKSUM_SHA256="a9b1c74ff2fae728e1c94acf525321669679ef56da9cc4d781c427b26032bbf7"
+srcChromeVersion="74.0.3729.157"
+SOURCE_URI_2="https://gsdview.appspot.com/chromium-browser-official/chromium-$srcChromeVersion-lite.tar.xz"
+CHECKSUM_SHA256_2="d7406d4efba9916000f8a0f087e7eaf443523f264a59a51d2089c4b2e4c66be0"
+SOURCE_DIR_2="chromium-$srcChromeVersion"
+
+PATCHES="v8-$portVersion.patchset"
+PATCHES_2="build-$portVersion.patch"
+
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	SECONDARY_ARCHITECTURES="x86"
+	ARCH=x86
+else
+	ARCH=x64
+fi
+
+# On x86_gcc2 we don't want to install the commands in bin/<arch>/, but in bin/.
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+    commandBinDir=$prefix/bin
+fi
+
+PROVIDES="
+	v8$secondaryArchSuffix = $portVersion
+	cmd:d8$commandSuffix = $portVersion
+	lib:libv8$secondaryArchSuffix = $portVersion
+	lib:libv8_for_testing$secondaryArchSuffix = $portVersion
+	lib:libv8_libbase$secondaryArchSuffix = $portVersion
+	lib:libv8_libplatform$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libexecinfo$secondaryArchSuffix
+	lib:libssp$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	v8${secondaryArchSuffix}_devel = $portVersion
+	devel:libv8$secondaryArchSuffix
+	"
+REQUIRES_devel="
+	v8$secondaryArchSuffix == $portVersion
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	gcc${secondaryArchSuffix}_syslibs
+	gcc${secondaryArchSuffix}_syslibs_devel
+	devel:libgcc$secondaryArchSuffix
+	devel:libexecinfo$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:g++$secondaryArchSuffix
+	cmd:gn
+	cmd:ld$secondaryArchSuffix
+	cmd:ninja
+	cmd:python
+	cmd:which
+	"
+
+BUILD()
+{
+	cd $sourceDir
+
+	mkdir -p base/trace_event/common
+	mkdir -p build
+	mkdir -p buildtools
+	mkdir -p third_party/jinja2
+	mkdir -p third_party/markupsafe
+	mkdir -p tools/clang
+	mkdir -p third_party/googletest/src
+
+	cp -rf /$sourceDir2/base/trace_event/common/* $sourceDir/base/trace_event/common
+	cp -rf /$sourceDir2/build/* $sourceDir/build/
+	cp -rf /$sourceDir2/buildtools/* $sourceDir/buildtools
+	cp -rf /$sourceDir2/third_party/jinja2/* $sourceDir/third_party/jinja2
+	cp -rf /$sourceDir2/third_party/markupsafe/* $sourceDir/third_party/markupsafe
+	cp -rf /$sourceDir2/tools/clang/* $sourceDir/tools/clang
+	cp -rf /$sourceDir2/third_party/googletest/src/* $sourceDir/third_party/googletest/src
+
+	mkdir -p out.gn
+
+	gn gen out.gn/$ARCH.release --args="target_os=\"haiku\" target_cpu=\"$ARCH\"
+        v8_enable_embedded_builtins = false is_debug = false symbol_level=0
+        is_clang=false treat_warnings_as_errors=false use_sysroot=false
+        v8_enable_i18n_support=false is_component_build=true
+        v8_use_snapshot=false"
+
+	LIBRARY_PATH=$LIBRARY_PATH:. ninja -C out.gn/$ARCH.release $jobArgs
+}
+
+INSTALL()
+{
+	mkdir $commandBinDir
+	cp -af out.gn/$ARCH.release/d8 ${commandBinDir}
+	mkdir -p ${includeDir}/v8
+	cp -af include/*  ${includeDir}/v8
+	mkdir -p $libDir
+	cp -af out.gn/$ARCH.release/*.so ${libDir}
+
+	prepareInstalledDevelLibs libv8
+	packageEntries devel $developDir
+}
+
+TEST()
+{
+	export LIBRARY_PATH=$LIBRARY_PATH::./out.gn/$ARCH.release
+
+	python tools/run-tests.py --gn $jobArgs --exit-after-n-failures=0 -p color \
+	--report -v -m release unittests message mkgrokdump fuzzer \
+	preparser wasm-spec-tests webkit cctest mjsunit
+}


### PR DESCRIPTION
This version of V8 is from Chrome 74.0.3729.157 as found in the version information in https://omahaproxy.appspot.com.

V8 requires several dependencies defined in its [DEPS](https://chromium.googlesource.com/v8/v8/+/8a28642518a30b588dda7c417fd820a9f2831fee) file which are cloned in before it builds and this recipe uses these git hashes to build the port.

I previously tried using 'depot_tools' to build it, but it doesn't work reliably for several reasons.
See: https://github.com/haikuports/haikuports/issues/2557#issuecomment-389212503

~Needs [GN](https://github.com/haikuports/haikuports/pull/3306) merged first to build correctly.~

EDIT: GN has been merged into HaikuPorts. It is now possible for the buildbots to build V8.