### PR TITLE
ZSH: install fix

### DIFF
--- a/app-shells/zsh/zsh-5.6.2.recipe
+++ b/app-shells/zsh/zsh-5.6.2.recipe
@@ -64,6 +64,7 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	cmd:autoreconf
 	cmd:awk
+	cmd:col
 	cmd:find
 	cmd:gcc
 	cmd:grep


### PR DESCRIPTION
Help generation requires cmd:col.
Interestingly the current util_linux package (2.33) not available in the depot, only an earlier version (2.32) which doesn't provides cmd:col. The 2.33 builds just fine, this i'm a bit puzzled.