### PR TITLE
DeeperPeople: bump revision, support for x86_64

### DIFF
--- a/haiku-apps/deeperpeople/deeperpeople-1.0.0.recipe
+++ b/haiku-apps/deeperpeople/deeperpeople-1.0.0.recipe
@@ -8,6 +8,7 @@ REVISION="2"
 srcGitRev="a20c5ad566d85274c5f9b60e8fab82f9ec165c02"
 SOURCE_URI="$HOMEPAGE/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="405a50294e30004073d650c608115e9a854d887b24fd0d153281791017606a7c"
+SOURCE_FILENAME="$APP-$portVersion-$srcGitRev.tar.gz"
 SOURCE_DIR="$APP-$srcGitRev"
 PATCHES="deeperpeople-$portVersion.patchset"
 

--- a/haiku-apps/deeperpeople/deeperpeople-1.0.0.recipe
+++ b/haiku-apps/deeperpeople/deeperpeople-1.0.0.recipe
@@ -4,13 +4,14 @@ APP="DeeperPeople"
 HOMEPAGE="https://github.com/HaikuArchives/$APP"
 COPYRIGHT="1991-1999 Be Incorporated"
 LICENSE="BSD (3-clause)"
-REVISION="1"
+REVISION="2"
 srcGitRev="a20c5ad566d85274c5f9b60e8fab82f9ec165c02"
 SOURCE_URI="$HOMEPAGE/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="405a50294e30004073d650c608115e9a854d887b24fd0d153281791017606a7c"
 SOURCE_DIR="$APP-$srcGitRev"
+PATCHES="deeperpeople-$portVersion.patchset"
 
-ARCHITECTURES="x86_gcc2 !x86_64"
+ARCHITECTURES="x86_gcc2 x86_64"
 
 PROVIDES="
 	deeperpeople = $portVersion

--- a/haiku-apps/deeperpeople/patches/deeperpeople-1.0.0.patchset
+++ b/haiku-apps/deeperpeople/patches/deeperpeople-1.0.0.patchset
@@ -1,0 +1,30 @@
+From 420ef74582eb373fb5498e205d5cabb4d7fbc417 Mon Sep 17 00:00:00 2001
+From: Bach Nguyen <bach5000@gmail.com>
+Date: Sat, 10 Nov 2018 19:02:07 +0000
+Subject: Fix build
+
+diff --git a/src/Makefile b/src/Makefile
+index c4c5c68..af5cad7 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -55,7 +55,7 @@ RSRCS =
+ #	- 	if your library does not follow the standard library naming scheme,
+ #		you need to specify the path to the library and it's name.
+ #		(e.g. for mylib.a, specify "mylib.a" or "path/mylib.a")
+-LIBS =  be tracker
++LIBS = $(STDCPPLIBS) be tracker
+ 
+ #	Specify additional paths to directories following the standard libXXX.so
+ #	or libXXX.a naming scheme. You can specify full paths or paths relative
+@@ -105,7 +105,7 @@ SYMBOLS :=
+ DEBUGGER := 
+ 
+ #	Specify any additional compiler flags to be used.
+-COMPILER_FLAGS = -Wshadow -Wconversion -Winline -funsigned-bitfields -Wwrite-strings
++COMPILER_FLAGS = -fpermissive -Wshadow -Wconversion -Winline -funsigned-bitfields -Wwrite-strings
+ 
+ #	Specify any additional linker flags to be used.
+ LINKER_FLAGS = 
+-- 
+2.19.0
+


### PR DESCRIPTION
Upstream patch: https://github.com/HaikuArchives/DeeperPeople/pull/3

Saw a task on GCI that says "write a recipe for DeeperPeople" but DeeperPeople already has a recipe! However, I noticed that DeeperPeople is marked broken on 64 bit. This patch should fix the build.