### PR TITLE
sys-devel/gcc: add -Bsymbolic to link spec

### DIFF
--- a/sys-devel/gcc/gcc-7.3.0_2018_05_01.recipe
+++ b/sys-devel/gcc/gcc-7.3.0_2018_05_01.recipe
@@ -5,7 +5,7 @@ HOMEPAGE="https://gcc.gnu.org/"
 COPYRIGHT="1988-2018 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3
 	GNU LGPL v3"
-REVISION="4"
+REVISION="5"
 gccVersion="${portVersion%%_*}"
 SOURCE_URI="https://ftpmirror.gnu.org/gcc/gcc-$gccVersion/gcc-$gccVersion.tar.xz
 	https://ftp.gnu.org/gnu/gcc/gcc-$gccVersion/gcc-$gccVersion.tar.xz"

--- a/sys-devel/gcc/patches/gcc-7.3.0_2018_05_01.patchset
+++ b/sys-devel/gcc/patches/gcc-7.3.0_2018_05_01.patchset
@@ -1,4 +1,4 @@
-From f079b889ac15702289eb126d1abba202061c7412 Mon Sep 17 00:00:00 2001
+From 81bc05f5417923350d2091d616348e3c4a117bf1 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Sun, 19 Jul 2015 18:55:34 +0200
 Subject: Haiku patch
@@ -8,7 +8,7 @@ diff --git a/compile b/compile
 old mode 100755
 new mode 100644
 diff --git a/config.rpath b/config.rpath
-index 4dea759..5bcc5be 100755
+index 4dea75957..5bcc5be17 100755
 --- a/config.rpath
 +++ b/config.rpath
 @@ -161,6 +161,8 @@ if test "$with_gnu_ld" = yes; then
@@ -21,7 +21,7 @@ index 4dea759..5bcc5be 100755
        if $LD -v 2>&1 | egrep 'BFD 2\.8' > /dev/null; then
          ld_shlibs=no
 diff --git a/config/acx.m4 b/config/acx.m4
-index aa1d34b..6eb6480 100644
+index aa1d34b2b..6eb648015 100644
 --- a/config/acx.m4
 +++ b/config/acx.m4
 @@ -428,24 +428,30 @@ dnl for the parameter format "cmp file1 file2 skip1 skip2" which is
@@ -71,7 +71,7 @@ index aa1d34b..6eb6480 100644
  do_compare="$gcc_cv_prog_cmp_skip"
  AC_SUBST(do_compare)
 diff --git a/configure.ac b/configure.ac
-index 1237749..cd4182c 100644
+index 123774992..cd4182c9f 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -420,6 +420,9 @@ case "${host}" in
@@ -124,7 +124,7 @@ index 1237749..cd4182c 100644
      # Remove unsupported stuff on all kaOS configurations.
      noconfigdirs="$noconfigdirs target-libgloss"
 diff --git a/gcc/Makefile.in b/gcc/Makefile.in
-index f675e07..9e99dc4 100644
+index f675e073e..9e99dc43c 100644
 --- a/gcc/Makefile.in
 +++ b/gcc/Makefile.in
 @@ -105,6 +105,8 @@ build_objdir := $(toplevel_builddir)/$(build_subdir)
@@ -168,7 +168,7 @@ index f675e07..9e99dc4 100644
  cppbuiltin.o: $(BASEVER)
  
 diff --git a/gcc/config.gcc b/gcc/config.gcc
-index 6e75bd4..1caee9f 100644
+index 6e75bd45f..1caee9f3b 100644
 --- a/gcc/config.gcc
 +++ b/gcc/config.gcc
 @@ -716,6 +716,19 @@ case ${target} in
@@ -262,7 +262,7 @@ index 6e75bd4..1caee9f 100644
  	tm_file="rs6000/biarch64.h ${tm_file} dbxelf.h elfos.h freebsd-spec.h newlib-stdint.h rs6000/sysv4.h rs6000/e500.h rs6000/rtems.h rtems.h"
  	extra_options="${extra_options} rs6000/sysv4.opt rs6000/linux64.opt"
 diff --git a/gcc/config.host b/gcc/config.host
-index 6b28f30..72ebc4f 100644
+index 6b28f3033..72ebc4f1a 100644
 --- a/gcc/config.host
 +++ b/gcc/config.host
 @@ -107,7 +107,7 @@ case ${host} in
@@ -290,7 +290,7 @@ index 6b28f30..72ebc4f 100644
        ;;
 diff --git a/gcc/config/arm/haiku.h b/gcc/config/arm/haiku.h
 new file mode 100644
-index 0000000..f0c0d63
+index 000000000..f0c0d6326
 --- /dev/null
 +++ b/gcc/config/arm/haiku.h
 @@ -0,0 +1,80 @@
@@ -376,7 +376,7 @@ index 0000000..f0c0d63
 +
 diff --git a/gcc/config/arm/t-haiku b/gcc/config/arm/t-haiku
 new file mode 100644
-index 0000000..3f7f488
+index 000000000..3f7f488fe
 --- /dev/null
 +++ b/gcc/config/arm/t-haiku
 @@ -0,0 +1,21 @@
@@ -403,7 +403,7 @@ index 0000000..3f7f488
 +#TARGET_LIBGCC2_CFLAGS = 
 diff --git a/gcc/config/haiku-stdint.h b/gcc/config/haiku-stdint.h
 new file mode 100644
-index 0000000..8f702d0
+index 000000000..8f702d0c7
 --- /dev/null
 +++ b/gcc/config/haiku-stdint.h
 @@ -0,0 +1,55 @@
@@ -464,7 +464,7 @@ index 0000000..8f702d0
 +#define UINTPTR_TYPE "long unsigned int"
 diff --git a/gcc/config/haiku.h b/gcc/config/haiku.h
 new file mode 100644
-index 0000000..8e9f101
+index 000000000..8e9f10134
 --- /dev/null
 +++ b/gcc/config/haiku.h
 @@ -0,0 +1,214 @@
@@ -684,7 +684,7 @@ index 0000000..8e9f101
 +#define USE_TM_CLONE_REGISTRY 0
 diff --git a/gcc/config/i386/haiku.h b/gcc/config/i386/haiku.h
 new file mode 100644
-index 0000000..3379e19
+index 000000000..3379e19f5
 --- /dev/null
 +++ b/gcc/config/i386/haiku.h
 @@ -0,0 +1,77 @@
@@ -767,7 +767,7 @@ index 0000000..3379e19
 +#endif
 diff --git a/gcc/config/i386/haiku64.h b/gcc/config/i386/haiku64.h
 new file mode 100644
-index 0000000..76ba48e
+index 000000000..76ba48e9e
 --- /dev/null
 +++ b/gcc/config/i386/haiku64.h
 @@ -0,0 +1,135 @@
@@ -911,7 +911,7 @@ old mode 100644
 new mode 100755
 diff --git a/gcc/config/i386/t-haiku64 b/gcc/config/i386/t-haiku64
 new file mode 100644
-index 0000000..9c8f8e6
+index 000000000..9c8f8e62e
 --- /dev/null
 +++ b/gcc/config/i386/t-haiku64
 @@ -0,0 +1,16 @@
@@ -939,7 +939,7 @@ old mode 100644
 new mode 100755
 diff --git a/gcc/config/m68k/haiku.h b/gcc/config/m68k/haiku.h
 new file mode 100644
-index 0000000..358c19f
+index 000000000..358c19f5c
 --- /dev/null
 +++ b/gcc/config/m68k/haiku.h
 @@ -0,0 +1,268 @@
@@ -1213,7 +1213,7 @@ index 0000000..358c19f
 +}
 diff --git a/gcc/config/mips/haiku.h b/gcc/config/mips/haiku.h
 new file mode 100644
-index 0000000..f6d2efb
+index 000000000..f6d2efb97
 --- /dev/null
 +++ b/gcc/config/mips/haiku.h
 @@ -0,0 +1,44 @@
@@ -1263,7 +1263,7 @@ index 0000000..f6d2efb
 +
 diff --git a/gcc/config/rs6000/haiku.h b/gcc/config/rs6000/haiku.h
 new file mode 100644
-index 0000000..4dff89e
+index 000000000..4dff89e5c
 --- /dev/null
 +++ b/gcc/config/rs6000/haiku.h
 @@ -0,0 +1,56 @@
@@ -1325,7 +1325,7 @@ index 0000000..4dff89e
 +#define LINK_SPEC "%{!o*:-o %b} -m elf32ppchaiku %{!r:-shared} %{nostart:-e 0} %{shared:-e 0} %{!shared: %{!nostart: -no-undefined}}"
 diff --git a/gcc/config/t-haiku b/gcc/config/t-haiku
 new file mode 100644
-index 0000000..587d1fb
+index 000000000..587d1fb01
 --- /dev/null
 +++ b/gcc/config/t-haiku
 @@ -0,0 +1,4 @@
@@ -1335,7 +1335,7 @@ index 0000000..587d1fb
 +LIMITS_H_TEST = [ -f $(SYSTEM_HEADER_DIR)/posix/limits.h ]
 \ No newline at end of file
 diff --git a/gcc/configure.ac b/gcc/configure.ac
-index 2b52da3..acf8701 100644
+index 2b52da3bb..acf8701ac 100644
 --- a/gcc/configure.ac
 +++ b/gcc/configure.ac
 @@ -771,6 +771,15 @@ fi
@@ -1381,7 +1381,7 @@ index 2b52da3..acf8701 100644
      target_thread_file=${enable_threads}
      ;;
 diff --git a/gcc/ginclude/stdarg.h b/gcc/ginclude/stdarg.h
-index aa248be..57a3ab0 100644
+index aa248be5d..57a3ab081 100644
 --- a/gcc/ginclude/stdarg.h
 +++ b/gcc/ginclude/stdarg.h
 @@ -94,7 +94,7 @@ typedef __gnuc_va_list va_list;
@@ -1394,7 +1394,7 @@ index aa248be..57a3ab0 100644
  typedef __gnuc_va_list va_list;
  #endif /* not __va_list__ */
 diff --git a/gcc/ginclude/stddef.h b/gcc/ginclude/stddef.h
-index 872f451..3522e12 100644
+index 872f451ca..3522e1269 100644
 --- a/gcc/ginclude/stddef.h
 +++ b/gcc/ginclude/stddef.h
 @@ -167,7 +167,7 @@ typedef __PTRDIFF_TYPE__ ptrdiff_t;
@@ -1443,7 +1443,7 @@ index 872f451..3522e12 100644
  #define _WCHAR_T
  #define _T_WCHAR_
 diff --git a/include/filenames.h b/include/filenames.h
-index 5a2a055..ca8dd20 100644
+index 5a2a0552e..ca8dd20c7 100644
 --- a/include/filenames.h
 +++ b/include/filenames.h
 @@ -44,9 +44,11 @@ extern "C" {
@@ -1459,7 +1459,7 @@ index 5a2a055..ca8dd20 100644
  #  define HAS_DRIVE_SPEC(f) (0)
  #  define IS_DIR_SEPARATOR(c) IS_UNIX_DIR_SEPARATOR (c)
 diff --git a/libatomic/configure.ac b/libatomic/configure.ac
-index 023f172..1814d0c 100644
+index 023f1727b..1814d0c1c 100644
 --- a/libatomic/configure.ac
 +++ b/libatomic/configure.ac
 @@ -199,21 +199,27 @@ LIBAT_WORDSIZE
@@ -1500,7 +1500,7 @@ index 023f172..1814d0c 100644
    ;;
  esac
 diff --git a/libatomic/configure.tgt b/libatomic/configure.tgt
-index b8af3ab..93b3d4e 100644
+index b8af3ab25..93b3d4e47 100644
 --- a/libatomic/configure.tgt
 +++ b/libatomic/configure.tgt
 @@ -117,7 +117,7 @@ case "${target}" in
@@ -1513,7 +1513,7 @@ index b8af3ab..93b3d4e 100644
  	config_path="${config_path} posix"
  	;;
 diff --git a/libgcc/Makefile.in b/libgcc/Makefile.in
-index a1a392d..3fea2da 100644
+index a1a392de8..3fea2daf9 100644
 --- a/libgcc/Makefile.in
 +++ b/libgcc/Makefile.in
 @@ -394,10 +394,16 @@ ifeq ($(enable_shared),yes)
@@ -1534,7 +1534,7 @@ index a1a392d..3fea2da 100644
  ifneq (,$(vis_hide))
  
 diff --git a/libgcc/config.host b/libgcc/config.host
-index 8beb492..b0ec388 100644
+index 8beb492b5..b0ec388bb 100644
 --- a/libgcc/config.host
 +++ b/libgcc/config.host
 @@ -231,6 +231,14 @@ case ${host} in
@@ -1610,7 +1610,7 @@ old mode 100644
 new mode 100755
 diff --git a/libgcc/config/t-haiku b/libgcc/config/t-haiku
 new file mode 100644
-index 0000000..b4fff2d
+index 000000000..b4fff2d8f
 --- /dev/null
 +++ b/libgcc/config/t-haiku
 @@ -0,0 +1,3 @@
@@ -1618,7 +1618,7 @@ index 0000000..b4fff2d
 +LIB2ADDEH = $(srcdir)/unwind-dw2.c $(srcdir)/unwind-dw2-fde.c \
 +  $(srcdir)/unwind-sjlj.c $(srcdir)/unwind-c.c
 diff --git a/libgcc/crtstuff.c b/libgcc/crtstuff.c
-index 52ed6d3..a0a25c2 100644
+index 52ed6d39c..a0a25c29d 100644
 --- a/libgcc/crtstuff.c
 +++ b/libgcc/crtstuff.c
 @@ -108,7 +108,9 @@ call_ ## FUNC (void)					\
@@ -1632,7 +1632,7 @@ index 52ed6d3..a0a25c2 100644
     But it doesn't use PT_GNU_EH_FRAME ELF segment currently.  */
  # if !defined(__UCLIBC__) \
 diff --git a/libgomp/configure.ac b/libgomp/configure.ac
-index a42d4f0..17bc715 100644
+index a42d4f08b..17bc71584 100644
 --- a/libgomp/configure.ac
 +++ b/libgomp/configure.ac
 @@ -188,21 +188,27 @@ case "$host" in
@@ -1670,7 +1670,7 @@ index a42d4f0..17bc715 100644
  if test x$libgomp_use_pthreads != xno; then
 diff --git a/libstdc++-v3/config/os/haiku/ctype_base.h b/libstdc++-v3/config/os/haiku/ctype_base.h
 new file mode 100644
-index 0000000..e762aaa
+index 000000000..e762aaa43
 --- /dev/null
 +++ b/libstdc++-v3/config/os/haiku/ctype_base.h
 @@ -0,0 +1,61 @@
@@ -1737,7 +1737,7 @@ index 0000000..e762aaa
 +} // namespace
 diff --git a/libstdc++-v3/config/os/haiku/ctype_configure_char.cc b/libstdc++-v3/config/os/haiku/ctype_configure_char.cc
 new file mode 100644
-index 0000000..35e6b80
+index 000000000..35e6b80f0
 --- /dev/null
 +++ b/libstdc++-v3/config/os/haiku/ctype_configure_char.cc
 @@ -0,0 +1,99 @@
@@ -1842,7 +1842,7 @@ index 0000000..35e6b80
 +} // namespace
 diff --git a/libstdc++-v3/config/os/haiku/ctype_inline.h b/libstdc++-v3/config/os/haiku/ctype_inline.h
 new file mode 100644
-index 0000000..5b5cc56
+index 000000000..5b5cc5693
 --- /dev/null
 +++ b/libstdc++-v3/config/os/haiku/ctype_inline.h
 @@ -0,0 +1,173 @@
@@ -2021,7 +2021,7 @@ index 0000000..5b5cc56
 +} // namespace
 diff --git a/libstdc++-v3/config/os/haiku/error_constants.h b/libstdc++-v3/config/os/haiku/error_constants.h
 new file mode 100644
-index 0000000..fa6d889
+index 000000000..fa6d88919
 --- /dev/null
 +++ b/libstdc++-v3/config/os/haiku/error_constants.h
 @@ -0,0 +1,178 @@
@@ -2205,7 +2205,7 @@ index 0000000..fa6d889
 +#endif
 diff --git a/libstdc++-v3/config/os/haiku/os_defines.h b/libstdc++-v3/config/os/haiku/os_defines.h
 new file mode 100644
-index 0000000..4674f7b
+index 000000000..4674f7b66
 --- /dev/null
 +++ b/libstdc++-v3/config/os/haiku/os_defines.h
 @@ -0,0 +1,45 @@
@@ -2255,7 +2255,7 @@ index 0000000..4674f7b
 +
 +#endif
 diff --git a/libstdc++-v3/configure.host b/libstdc++-v3/configure.host
-index caea9de..00b70da 100644
+index caea9de9c..00b70daf2 100644
 --- a/libstdc++-v3/configure.host
 +++ b/libstdc++-v3/configure.host
 @@ -270,6 +270,9 @@ case "${host_os}" in
@@ -2269,7 +2269,7 @@ index caea9de..00b70da 100644
      os_include_dir="os/hpux"
      ;;
 diff --git a/libstdc++-v3/crossconfig.m4 b/libstdc++-v3/crossconfig.m4
-index 77c9828..f989e01 100644
+index 77c9828fe..f989e01ae 100644
 --- a/libstdc++-v3/crossconfig.m4
 +++ b/libstdc++-v3/crossconfig.m4
 @@ -140,6 +140,46 @@ case "${host}" in
@@ -2320,7 +2320,7 @@ index 77c9828..f989e01 100644
      SECTION_FLAGS='-ffunction-sections -fdata-sections'
      AC_SUBST(SECTION_FLAGS)
 diff --git a/libstdc++-v3/libsupc++/tinfo.cc b/libstdc++-v3/libsupc++/tinfo.cc
-index 04d101f..f765d9a 100644
+index 04d101f5c..f765d9aac 100644
 --- a/libstdc++-v3/libsupc++/tinfo.cc
 +++ b/libstdc++-v3/libsupc++/tinfo.cc
 @@ -30,6 +30,15 @@ std::type_info::
@@ -2340,7 +2340,7 @@ index 04d101f..f765d9a 100644
  
  // We can't rely on common symbols being shared between shared objects.
 diff --git a/libtool.m4 b/libtool.m4
-index 24d13f3..94d96d9 100644
+index 24d13f344..94d96d9ea 100644
 --- a/libtool.m4
 +++ b/libtool.m4
 @@ -1137,7 +1137,7 @@ fi
@@ -2400,17 +2400,17 @@ index 24d13f3..94d96d9 100644
  
      hpux*)
 -- 
-2.16.4
+2.19.1
 
 
-From 8b403a6f08ef13c725e1185fcc218876a45e1e9e Mon Sep 17 00:00:00 2001
+From 735bf1ef8fb1464a7e31cf01ef4a25d7d687e414 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 12 May 2017 23:49:00 +0200
 Subject: Haiku: regenerate configure.
 
 
 diff --git a/configure b/configure
-index 32a3863..4ff544f 100755
+index 32a38633a..4ff544fc5 100755
 --- a/configure
 +++ b/configure
 @@ -3054,6 +3054,9 @@ case "${host}" in
@@ -2509,7 +2509,7 @@ index 32a3863..4ff544f 100755
  fi
  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $gcc_cv_prog_cmp_skip" >&5
 diff --git a/gcc/configure b/gcc/configure
-index 043a62b..487601c 100755
+index 043a62b0d..487601c95 100755
 --- a/gcc/configure
 +++ b/gcc/configure
 @@ -747,6 +747,7 @@ LDEXP_LIB
@@ -2668,7 +2668,7 @@ index 043a62b..487601c 100755
  
  hpux9* | hpux10* | hpux11*)
 diff --git a/libatomic/configure b/libatomic/configure
-index c05fc9d..c86a824 100755
+index c05fc9d11..c86a824cd 100755
 --- a/libatomic/configure
 +++ b/libatomic/configure
 @@ -8206,8 +8206,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
@@ -2811,7 +2811,7 @@ index c05fc9d..c86a824 100755
      conftest$ac_exeext conftest.$ac_ext
    CFLAGS="$save_CFLAGS $XPCFLAGS"
 diff --git a/libgomp/configure b/libgomp/configure
-index b7e9f40..0a7fdb7 100755
+index b7e9f40b8..0a7fdb792 100755
 --- a/libgomp/configure
 +++ b/libgomp/configure
 @@ -8246,8 +8246,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
@@ -2937,7 +2937,7 @@ index b7e9f40..0a7fdb7 100755
      conftest$ac_exeext conftest.$ac_ext
  esac
 diff --git a/libstdc++-v3/configure b/libstdc++-v3/configure
-index e70fdd6..1a8cd2d 100755
+index e70fdd642..1a8cd2de1 100755
 --- a/libstdc++-v3/configure
 +++ b/libstdc++-v3/configure
 @@ -8665,8 +8665,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
@@ -3171,17 +3171,17 @@ index e70fdd6..1a8cd2d 100755
      SECTION_FLAGS='-ffunction-sections -fdata-sections'
  
 -- 
-2.16.4
+2.19.1
 
 
-From d8fcd673a6b0e84ade0a6fb5ecb2a43d65ee2ac0 Mon Sep 17 00:00:00 2001
+From 36ecc0aba54fad21e66f2554f199b037fb6c6531 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Mon, 27 Jul 2015 16:32:32 +0200
 Subject: Haiku: disable -fno-PIE as this fails on x86_64.
 
 
 diff --git a/gcc/Makefile.in b/gcc/Makefile.in
-index 9e99dc4..d2ae898 100644
+index 9e99dc43c..d2ae8985e 100644
 --- a/gcc/Makefile.in
 +++ b/gcc/Makefile.in
 @@ -265,7 +265,7 @@ NO_PIE_CFLAGS = @NO_PIE_CFLAGS@
@@ -3207,17 +3207,17 @@ index 9e99dc4..d2ae898 100644
  # Native compiler that we use.  This may be C++ some day.
  COMPILER_FOR_BUILD = $(CXX_FOR_BUILD)
 -- 
-2.16.4
+2.19.1
 
 
-From 777289c81992ddbb4b07f7fcb5351b30e5bf7cb3 Mon Sep 17 00:00:00 2001
+From 2f2ea43d69dfcc664eae68fecb7273564f079b4b Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Thu, 5 May 2016 09:03:06 +0000
 Subject: fix for libstdc++/69506
 
 
 diff --git a/libstdc++-v3/config/os/haiku/os_defines.h b/libstdc++-v3/config/os/haiku/os_defines.h
-index 4674f7b..02c8693 100644
+index 4674f7b66..02c869321 100644
 --- a/libstdc++-v3/config/os/haiku/os_defines.h
 +++ b/libstdc++-v3/config/os/haiku/os_defines.h
 @@ -42,4 +42,7 @@
@@ -3229,17 +3229,17 @@ index 4674f7b..02c8693 100644
 +
  #endif
 -- 
-2.16.4
+2.19.1
 
 
-From 602125c2cc1a3797cc51d9117474e43e2aba7142 Mon Sep 17 00:00:00 2001
+From 13e1d32e0cb1075344fbc404f67dcbfc45d1dcc4 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Thu, 5 May 2016 15:52:08 +0000
 Subject: rename x86_elf_aligned_common.
 
 
 diff --git a/gcc/config/i386/haiku64.h b/gcc/config/i386/haiku64.h
-index 76ba48e..e2fa55a 100644
+index 76ba48e9e..e2fa55a34 100644
 --- a/gcc/config/i386/haiku64.h
 +++ b/gcc/config/i386/haiku64.h
 @@ -112,9 +112,9 @@ Boston, MA 02111-1307, USA.  */
@@ -3256,17 +3256,17 @@ index 76ba48e..e2fa55a 100644
  
  /* i386 System V Release 4 uses DWARF debugging info.
 -- 
-2.16.4
+2.19.1
 
 
-From 2d840327dc8f00d11355cc7502eb098fc9f88d6d Mon Sep 17 00:00:00 2001
+From e5a32cc732fc6f2052bbcb8a5feeb24011eff0ac Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
 Date: Wed, 2 May 2018 08:37:20 +0200
 Subject: Enable libstdcxx_filesystem_ts for Haiku
 
 
 diff --git a/libstdc++-v3/acinclude.m4 b/libstdc++-v3/acinclude.m4
-index 805148d..e94dc11 100644
+index 805148d3b..e94dc11e9 100644
 --- a/libstdc++-v3/acinclude.m4
 +++ b/libstdc++-v3/acinclude.m4
 @@ -4297,6 +4297,9 @@ AC_DEFUN([GLIBCXX_ENABLE_FILESYSTEM_TS], [
@@ -3280,10 +3280,10 @@ index 805148d..e94dc11 100644
          enable_libstdcxx_filesystem_ts=no
          ;;
 -- 
-2.16.4
+2.19.1
 
 
-From b39fc5be3ead2242fe3294ac3e6986fa62f85f4f Mon Sep 17 00:00:00 2001
+From a38c9a8a1c65503aa1d5b5ec140fa7a2696ba412 Mon Sep 17 00:00:00 2001
 From: Jessica Hamilton <jessica.l.hamilton@gmail.com>
 Date: Mon, 16 Jul 2018 12:31:18 +0000
 Subject: gcc: fix build configuration for libgcc.
@@ -3292,7 +3292,7 @@ Subject: gcc: fix build configuration for libgcc.
   which is needed for gfortran to produce working binaries.
 
 diff --git a/libgcc/config.host b/libgcc/config.host
-index b0ec388..a3e4543 100644
+index b0ec388bb..a3e4543a2 100644
 --- a/libgcc/config.host
 +++ b/libgcc/config.host
 @@ -236,7 +236,7 @@ case ${host} in
@@ -3305,10 +3305,10 @@ index b0ec388..a3e4543 100644
    ;;
  *-*-linux* | frv-*-*linux* | *-*-kfreebsd*-gnu | *-*-gnu* | *-*-kopensolaris*-gnu)
 -- 
-2.16.4
+2.19.1
 
 
-From 942069228a6ff7b59e0c8e1b900dcb951cda137a Mon Sep 17 00:00:00 2001
+From 4ecc4ada18719e039c00f7513e9bf9f8f35c7701 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Sun, 14 Oct 2018 21:29:42 +0200
 Subject: Backport fix for std::is_trivially_constructible
@@ -3316,7 +3316,7 @@ Subject: Backport fix for std::is_trivially_constructible
 https://github.com/gcc-mirror/gcc/commit/57b9683f0ce55a410c567fcb2dc365a2cc848d6a
 
 diff --git a/gcc/cp/method.c b/gcc/cp/method.c
-index c7b6758..19e5b08 100644
+index c7b675899..19e5b08f6 100644
 --- a/gcc/cp/method.c
 +++ b/gcc/cp/method.c
 @@ -1165,6 +1165,7 @@ constructible_expr (tree to, tree from)
@@ -3328,5 +3328,63 @@ index c7b6758..19e5b08 100644
  	to = cp_build_reference_type (to, /*rval*/false);
        tree ob = build_stub_object (to);
 -- 
-2.16.4
+2.19.1
+
+
+From 8e8521493340940bd874f096cda3d0d5cb9bd541 Mon Sep 17 00:00:00 2001
+From: Leorize <alaviss@users.noreply.github.com>
+Date: Fri, 16 Nov 2018 16:20:56 +0700
+Subject: haiku: add -Bsymbolic to linkspec
+
+
+diff --git a/gcc/config/arm/haiku.h b/gcc/config/arm/haiku.h
+index f0c0d6326..22e0a09d7 100644
+--- a/gcc/config/arm/haiku.h
++++ b/gcc/config/arm/haiku.h
+@@ -75,6 +75,6 @@
+ /* If ELF is the default format, we should not use /lib/elf.  */
+ 
+ #undef	LINK_SPEC
+-#define LINK_SPEC "%{!o*:-o %b} -m armelf %{!r:-shared} %{nostart:-e 0} %{shared:-e 0} %{!shared: %{!nostart: -no-undefined}}\
++#define LINK_SPEC "%{!o*:-o %b} -m armelf %{!r:-shared} %{nostart|shared:-e 0} %{shared:-Bsymbolic} %{!shared: %{!nostart: -no-undefined}}\
+   %{mbig-endian:-EB} %{mlittle-endian:-EL} -X"
+ 
+diff --git a/gcc/config/i386/haiku.h b/gcc/config/i386/haiku.h
+index 3379e19f5..48c253c69 100644
+--- a/gcc/config/i386/haiku.h
++++ b/gcc/config/i386/haiku.h
+@@ -53,7 +53,7 @@ Boston, MA 02111-1307, USA.  */
+ /* If ELF is the default format, we should not use /lib/elf.  */
+ 
+ #undef	LINK_SPEC
+-#define LINK_SPEC "-m elf_i386_haiku %{!r:-shared} %{nostart:-e 0} %{shared:-e 0} %{!shared: %{!nostart: -no-undefined}}"
++#define LINK_SPEC "-m elf_i386_haiku %{!r:-shared} %{nostart|shared:-e 0} %{shared:-Bsymbolic} %{!shared: %{!nostart: -no-undefined}}"
+ 
+ /* A C statement (sans semicolon) to output to the stdio stream
+    FILE the assembler definition of uninitialized global DECL named
+diff --git a/gcc/config/i386/haiku64.h b/gcc/config/i386/haiku64.h
+index e2fa55a34..10db05a12 100644
+--- a/gcc/config/i386/haiku64.h
++++ b/gcc/config/i386/haiku64.h
+@@ -65,7 +65,7 @@ Boston, MA 02111-1307, USA.  */
+ 
+ #undef	LINK_SPEC
+ #define LINK_SPEC "%{" SPEC_64 ":-m elf_x86_64_haiku} %{" SPEC_32 ":-m elf_i386_haiku} \
+-	%{!r:-shared} %{nostart:-e 0} %{shared:-e 0} %{!shared: %{!nostart: -no-undefined}}"
++	%{!r:-shared} %{nostart|shared:-e 0} %{shared:-Bsymbolic} %{!shared: %{!nostart: -no-undefined}}"
+ 
+ /* A C statement (sans semicolon) to output to the stdio stream
+    FILE the assembler definition of uninitialized global DECL named
+diff --git a/gcc/config/rs6000/haiku.h b/gcc/config/rs6000/haiku.h
+index 4dff89e5c..dbb80d588 100644
+--- a/gcc/config/rs6000/haiku.h
++++ b/gcc/config/rs6000/haiku.h
+@@ -53,4 +53,4 @@ Boston, MA 02111-1307, USA.  */
+ /* If ELF is the default format, we should not use /lib/elf.  */
+ 
+ #undef	LINK_SPEC
+-#define LINK_SPEC "%{!o*:-o %b} -m elf32ppchaiku %{!r:-shared} %{nostart:-e 0} %{shared:-e 0} %{!shared: %{!nostart: -no-undefined}}"
++#define LINK_SPEC "%{!o*:-o %b} -m elf32ppchaiku %{!r:-shared} %{nostart|shared:-e 0} %{shared:-Bsymbolic} %{!shared: %{!nostart: -no-undefined}}"
+-- 
+2.19.1
 


### PR DESCRIPTION
This fixes an issue shown on IRC by @waddlesplash. This is highly experimental and completely untested.

Also, I've noticed that [gcc2's linkspec][0] is vastly different than that of gcc7, is there any reason in particular? I could try to sync up the linkspecs, but as mentioned in #3319, `-pie` by default will break TLS.

[0]: https://github.com/haiku/buildtools/blob/0c77ecec1fb2c5679db724046edea2c0a7bf62e2/legacy/gcc/gcc/config/i386/haiku.h#L188