### PR TITLE
Add recipe for BeScreenCapture 2.4

### DIFF
--- a/haiku-apps/bescreencapture/bescreencapture-2.4.recipe
+++ b/haiku-apps/bescreencapture/bescreencapture-2.4.recipe
@@ -1,0 +1,73 @@
+SUMMARY="A screen recorder utility"
+DESCRIPTION="BeScreenCapture is a screen recorder utility for Haiku.
+It allows you to record what happens on your screen, then save it \
+to any media format supported in Haiku.
+BeScreenCapture can record either the entire screen, or just a section you \
+select."
+HOMEPAGE="https://github.com/jackburton79/bescreencapture/releases"
+COPYRIGHT="2014-2018 Stefano Ceccherini"
+LICENSE="BSD (3-clause)
+	MIT"
+REVISION="1"
+SOURCE_URI="https://github.com/jackburton79/bescreencapture/archive/v$portVersion.tar.gz"
+CHECKSUM_SHA256="7b4f7bcc5cb09cbe2e5fe0c631eb67a2159d0a3098f9141f9300de96930e57ba"
+SOURCE_FILENAME="bescreencapture-$portVersion.tar.gz"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	bescreencapture = $portVersion
+	app:BeScreenCapture = $portVersion
+	"
+REQUIRES="
+	haiku
+	"
+
+SUMMARY_inputfilter="Shortcut handler for BeScreenCapture"
+DESCRIPTION_inputfilter="Input Server Addon for BeScreenCapture. Allows the \
+user to launch BeScreenCapture and start/stop recording using a keyboard \
+combination (CTRL-COMMAND-SHIFT + R)."
+PROVIDES_inputfilter="
+	bescreencapture_inputfilter = $portVersion
+	app:BeScreenCaptureInputFilter = $portVersion
+	"
+REQUIRES_inputfilter="
+	bescreencapture == $portVersion base
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	makefile_engine
+	cmd:gcc
+	cmd:make
+	"
+
+BUILD()
+{
+	make OBJ_DIR=objects \
+		BUILDHOME=`finddir B_SYSTEM_DEVELOP_DIRECTORY`
+
+	make -C inputfilter OBJ_DIR=objects \
+		BUILDHOME=`finddir B_SYSTEM_DEVELOP_DIRECTORY`
+}
+
+INSTALL()
+{
+	install -m 0755 -d "$appsDir"
+	install -m 0755 -t "$appsDir" objects/BeScreenCapture
+
+	install -m 0755 -d "$addOnsDir"/input_server/filters
+	install -m 0755 -t "$addOnsDir"/input_server/filters \
+		inputfilter/objects/BeScreenCaptureInputFilter
+
+	install -m 0755 -d "$docDir"
+	install -m 0644 -t "$docDir" README.md
+
+	packageEntries inputfilter \
+		$addOnsDir/input_server/filters/BeScreenCaptureInputFilter
+
+	addAppDeskbarSymlink $appsDir/BeScreenCapture
+}


### PR DESCRIPTION
Add recipe for BeScreenCapture 2.4.

- Added pause button.
- Added the option to export the captured frames as bitmaps.
- Fixed a memory leak.
- Fixed wrong recording time string in certain cases.
- Disable nonworking output file formats.
