### PR TITLE
Godot: X86_64 support

### DIFF
--- a/dev-games/godot/godot-3.0.6.recipe
+++ b/dev-games/godot/godot-3.0.6.recipe
@@ -9,11 +9,10 @@ click to a number of platforms, including the major desktop platforms \
 HOMEPAGE="https://godotengine.org/"
 COPYRIGHT="2007-2018 Juan Linietsky, Ariel Manzur"
 LICENSE="MIT"
-REVISION="2"
-srcGitRev="229d217a51ae9bba3c356331574e8d0b0be7aa95"
-SOURCE_URI="https://github.com/godotengine/godot/archive/$srcGitRev.tar.gz"
-CHECKSUM_SHA256="613b21598d5efce2e145fee309630bb8f60d75a4f8f6a73cebacda3aba703f7d"
-SOURCE_DIR="godot-$srcGitRev"
+REVISION="1"
+SOURCE_URI="https://github.com/godotengine/godot/archive/$portVersion-stable.tar.gz"
+CHECKSUM_SHA256="50431e021ee5ec21002cc23435f530f8fde518c6eb7085c9f7f1027abaae2581"
+SOURCE_DIR="godot-$portVersion-stable"
 PATCHES="godot-3.0.6.patchset"
 
 ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
@@ -29,16 +28,16 @@ REQUIRES="
 	lib:libGL$secondaryArchSuffix
 	lib:libglew$secondaryArchSuffix
 	lib:libGLU$secondaryArchSuffix
-	lib:libmbedtls$secondaryArchSuffix
-	lib:libminiupnpc$secondaryArchSuffix
 	lib:libmpcdec$secondaryArchSuffix
 	lib:libogg$secondaryArchSuffix
 #	lib:libopus$secondaryArchSuffix
 #	lib:libopusfile$secondaryArchSuffix
+	lib:libpcre2_32$secondaryArchSuffix
 	lib:libpng16$secondaryArchSuffix
 #	lib:libspeex$secondaryArchSuffix
 	lib:libtheora$secondaryArchSuffix
 	lib:libvorbis$secondaryArchSuffix
+	lib:libvpx$secondaryArchSuffix
 	lib:libwebp$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
@@ -50,23 +49,24 @@ BUILD_REQUIRES="
 	devel:libGL$secondaryArchSuffix
 	devel:libglew$secondaryArchSuffix
 	devel:libGLU$secondaryArchSuffix
-	devel:libmbedtls$secondaryArchSuffix
-	devel:libminiupnpc$secondaryArchSuffix
 	devel:libmpcdec$secondaryArchSuffix
 	devel:libogg$secondaryArchSuffix
 #	devel:libopus$secondaryArchSuffix
 #	devel:libopusfile$secondaryArchSuffix
+	devel:libpcre2_32$secondaryArchSuffix
 	devel:libpng16$secondaryArchSuffix
+	devel:libssl$secondaryArchSuffix
 #	devel:libspeex$secondaryArchSuffix
 	devel:libtheora$secondaryArchSuffix
 	devel:libvorbis$secondaryArchSuffix
+	devel:libvpx$secondaryArchSuffix
 	devel:libwebp$secondaryArchSuffix >= 7
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	pkgconfig$secondaryArchSuffix
 	cmd:gcc$secondaryArchSuffix
 	cmd:python
+	cmd:pkg_config$secondaryArchSuffix
 	cmd:scons
 	cmd:yasm
 	"
@@ -83,10 +83,10 @@ BUILD()
 		builtin_libtheora=no \
 		builtin_libvorbis=no \
 		builtin_libwebp=no \
-		builtin_libwebsockets=yes \
-		builtin_mbedtls=no \
-		builtin_miniupnpc=no \
 		builtin_zlib=no \
+		builtin_libvpx=no \
+		builtin_openssl=no \
+		builtin_pcre2=no \
 		unix_global_settings_path=`finddir B_USER_SETTINGS_DIRECTORY`/Godot
 		#builtin_speex=no
 		#builtin_opus=no

--- a/dev-games/godot/patches/godot-3.0.6.patchset
+++ b/dev-games/godot/patches/godot-3.0.6.patchset
@@ -1,4 +1,4 @@
-From 2943f1f9af7f7e6a5cd2f1f62287bfc9b1c4c364 Mon Sep 17 00:00:00 2001
+From 385069fe93f95a3e35ef34cf7468b685ba85334b Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Mon, 9 Jul 2018 15:36:13 +0200
 Subject: Fix various things for Godot 3
@@ -36,7 +36,7 @@ index a09403e..b743039 100644
  class AudioDriverMediaKit : public AudioDriver {
  	Mutex *mutex;
 diff --git a/platform/haiku/detect.py b/platform/haiku/detect.py
-index 2959023..20bdf85 100644
+index 7c62654..407272d 100644
 --- a/platform/haiku/detect.py
 +++ b/platform/haiku/detect.py
 @@ -64,6 +64,79 @@ def configure(env):
@@ -650,10 +650,10 @@ index 2fe85cd..0000000
 -
 -#endif /* PLATFORM_HAIKU_POWER_HAIKU_H_ */
 diff --git a/thirdparty/glad/glad.c b/thirdparty/glad/glad.c
-index 8f8b218..8685297 100644
+index f87ec8c..81795c2 100644
 --- a/thirdparty/glad/glad.c
 +++ b/thirdparty/glad/glad.c
-@@ -76,7 +76,7 @@ void close_gl(void) {
+@@ -55,7 +55,7 @@ void close_gl(void) {
  #include <dlfcn.h>
  static void* libGL;
  
@@ -662,7 +662,7 @@ index 8f8b218..8685297 100644
  typedef void* (APIENTRYP PFNGLXGETPROCADDRESSPROC_PRIVATE)(const char*);
  static PFNGLXGETPROCADDRESSPROC_PRIVATE gladGetProcAddressPtr;
  #endif
-@@ -99,7 +99,7 @@ int open_gl(void) {
+@@ -78,7 +78,7 @@ int open_gl(void) {
          libGL = dlopen(NAMES[index], RTLD_NOW | RTLD_GLOBAL);
  
          if(libGL != NULL) {
@@ -671,7 +671,7 @@ index 8f8b218..8685297 100644
              return 1;
  #else
              gladGetProcAddressPtr = (PFNGLXGETPROCADDRESSPROC_PRIVATE)dlsym(libGL,
-@@ -126,7 +126,7 @@ void* get_proc(const char *namez) {
+@@ -105,7 +105,7 @@ void* get_proc(const char *namez) {
      void* result = NULL;
      if(libGL == NULL) return NULL;
  
@@ -680,7 +680,7 @@ index 8f8b218..8685297 100644
      if(gladGetProcAddressPtr != NULL) {
          result = gladGetProcAddressPtr(namez);
      }
-@@ -148,7 +148,7 @@ int gladLoadGL(void) {
+@@ -127,7 +127,7 @@ int gladLoadGL(void) {
      if(open_gl()) {
          status = gladLoadGLLoader(&get_proc);
          close_gl();
@@ -754,10 +754,10 @@ index 3038297..16dc694 100644
  #endif
  
 -- 
-2.16.4
+2.19.1
 
 
-From 4f2f7b002fdacb2fa383765ce536dce1344d15db Mon Sep 17 00:00:00 2001
+From 926594527d46cd77474849bf9148ec086bdbff6b Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Tue, 10 Jul 2018 15:26:41 +0200
 Subject: Update patches for Godot 3.0.6
@@ -766,183 +766,8 @@ Subject: Update patches for Godot 3.0.6
 - libwebsockets cannot use an external version yet and need some
   configuration patches
 
-diff --git a/modules/websocket/SCsub b/modules/websocket/SCsub
-index 15a8877..c0985b3 100644
---- a/modules/websocket/SCsub
-+++ b/modules/websocket/SCsub
-@@ -7,87 +7,88 @@ Import('env_modules')
- 
- env_lws = env_modules.Clone()
- 
--thirdparty_dir = "#thirdparty/libwebsockets/"
--helper_dir = "win32helpers/"
--thirdparty_sources = [
--
--    "core/alloc.c",
--    "core/context.c",
--    "core/libwebsockets.c",
--    "core/output.c",
--    "core/pollfd.c",
--    "core/service.c",
--
--    "event-libs/poll/poll.c",
--
--    "misc/base64-decode.c",
--    "misc/lejp.c",
--    "misc/sha-1.c",
--
--    "roles/h1/ops-h1.c",
--    "roles/http/header.c",
--    "roles/http/client/client.c",
--    "roles/http/client/client-handshake.c",
--    "roles/http/server/fops-zip.c",
--    "roles/http/server/lejp-conf.c",
--    "roles/http/server/parsers.c",
--    "roles/http/server/server.c",
--    "roles/listen/ops-listen.c",
--    "roles/pipe/ops-pipe.c",
--    "roles/raw/ops-raw.c",
--
--    "roles/ws/client-ws.c",
--    "roles/ws/client-parser-ws.c",
--    "roles/ws/ops-ws.c",
--    "roles/ws/server-ws.c",
--
--    "tls/tls.c",
--    "tls/tls-client.c",
--    "tls/tls-server.c",
--
--    "tls/mbedtls/wrapper/library/ssl_cert.c",
--    "tls/mbedtls/wrapper/library/ssl_pkey.c",
--    "tls/mbedtls/wrapper/library/ssl_stack.c",
--    "tls/mbedtls/wrapper/library/ssl_methods.c",
--    "tls/mbedtls/wrapper/library/ssl_lib.c",
--    "tls/mbedtls/wrapper/library/ssl_x509.c",
--    "tls/mbedtls/wrapper/platform/ssl_port.c",
--    "tls/mbedtls/wrapper/platform/ssl_pm.c",
--    "tls/mbedtls/lws-genhash.c",
--    "tls/mbedtls/mbedtls-client.c",
--    "tls/mbedtls/lws-genrsa.c",
--    "tls/mbedtls/ssl.c",
--    "tls/mbedtls/mbedtls-server.c"
--]
--
--if env_lws["platform"] == "android": # Builtin getifaddrs
--    thirdparty_sources += ["misc/getifaddrs.c"]
--
--if env_lws["platform"] == "windows" or env_lws["platform"] == "uwp": # Winsock
--    thirdparty_sources += ["plat/lws-plat-win.c", helper_dir + "getopt.c", helper_dir + "getopt_long.c", helper_dir + "gettimeofday.c"]
--else: # Unix socket
--    thirdparty_sources += ["plat/lws-plat-unix.c"]
--
--
--thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
--
--if env_lws["platform"] == "javascript": # No need to add third party libraries at all
--    pass
--else:
--    env_lws.add_source_files(env.modules_sources, thirdparty_sources)
--    env_lws.Append(CPPPATH=[thirdparty_dir])
--
--    wrapper_includes = ["#thirdparty/libwebsockets/tls/mbedtls/wrapper/include/" + inc for inc in ["internal", "openssl", "platform", ""]]
--    env_lws.Prepend(CPPPATH=wrapper_includes)
--
--    if env['builtin_mbedtls']:
--        mbedtls_includes = "#thirdparty/mbedtls/include"
--        env_lws.Prepend(CPPPATH=[mbedtls_includes])
--
--    if env_lws["platform"] == "windows" or env_lws["platform"] == "uwp":
--        env_lws.Append(CPPPATH=[thirdparty_dir + helper_dir])
--
--    if env_lws["platform"] == "uwp":
--        env_lws.Append(CCFLAGS=["/DLWS_MINGW_SUPPORT"])
-+if env['builtin_libwebsockets']:
-+    thirdparty_dir = "#thirdparty/libwebsockets/"
-+    helper_dir = "win32helpers/"
-+    thirdparty_sources = [
-+
-+        "core/alloc.c",
-+        "core/context.c",
-+        "core/libwebsockets.c",
-+        "core/output.c",
-+        "core/pollfd.c",
-+        "core/service.c",
-+
-+        "event-libs/poll/poll.c",
-+
-+        "misc/base64-decode.c",
-+        "misc/lejp.c",
-+        "misc/sha-1.c",
-+
-+        "roles/h1/ops-h1.c",
-+        "roles/http/header.c",
-+        "roles/http/client/client.c",
-+        "roles/http/client/client-handshake.c",
-+        "roles/http/server/fops-zip.c",
-+        "roles/http/server/lejp-conf.c",
-+        "roles/http/server/parsers.c",
-+        "roles/http/server/server.c",
-+        "roles/listen/ops-listen.c",
-+        "roles/pipe/ops-pipe.c",
-+        "roles/raw/ops-raw.c",
-+
-+        "roles/ws/client-ws.c",
-+        "roles/ws/client-parser-ws.c",
-+        "roles/ws/ops-ws.c",
-+        "roles/ws/server-ws.c",
-+
-+        "tls/tls.c",
-+        "tls/tls-client.c",
-+        "tls/tls-server.c",
-+
-+        "tls/mbedtls/wrapper/library/ssl_cert.c",
-+        "tls/mbedtls/wrapper/library/ssl_pkey.c",
-+        "tls/mbedtls/wrapper/library/ssl_stack.c",
-+        "tls/mbedtls/wrapper/library/ssl_methods.c",
-+        "tls/mbedtls/wrapper/library/ssl_lib.c",
-+        "tls/mbedtls/wrapper/library/ssl_x509.c",
-+        "tls/mbedtls/wrapper/platform/ssl_port.c",
-+        "tls/mbedtls/wrapper/platform/ssl_pm.c",
-+        "tls/mbedtls/lws-genhash.c",
-+        "tls/mbedtls/mbedtls-client.c",
-+        "tls/mbedtls/lws-genrsa.c",
-+        "tls/mbedtls/ssl.c",
-+        "tls/mbedtls/mbedtls-server.c"
-+    ]
-+
-+    if env_lws["platform"] == "android": # Builtin getifaddrs
-+        thirdparty_sources += ["misc/getifaddrs.c"]
-+
-+    if env_lws["platform"] == "windows" or env_lws["platform"] == "uwp": # Winsock
-+        thirdparty_sources += ["plat/lws-plat-win.c", helper_dir + "getopt.c", helper_dir + "getopt_long.c", helper_dir + "gettimeofday.c"]
-+    else: # Unix socket
-+        thirdparty_sources += ["plat/lws-plat-unix.c"]
-+
-+
-+    thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
-+
-+    if env_lws["platform"] == "javascript": # No need to add third party libraries at all
-+        pass
-+    else:
-+        env_lws.add_source_files(env.modules_sources, thirdparty_sources)
-+        env_lws.Append(CPPPATH=[thirdparty_dir])
-+
-+        wrapper_includes = ["#thirdparty/libwebsockets/tls/mbedtls/wrapper/include/" + inc for inc in ["internal", "openssl", "platform", ""]]
-+        env_lws.Prepend(CPPPATH=wrapper_includes)
-+
-+        if env['builtin_mbedtls']:
-+            mbedtls_includes = "#thirdparty/mbedtls/include"
-+            env_lws.Prepend(CPPPATH=[mbedtls_includes])
-+
-+        if env_lws["platform"] == "windows" or env_lws["platform"] == "uwp":
-+            env_lws.Append(CPPPATH=[thirdparty_dir + helper_dir])
-+
-+        if env_lws["platform"] == "uwp":
-+            env_lws.Append(CCFLAGS=["/DLWS_MINGW_SUPPORT"])
- 
- env_lws.add_source_files(env.modules_sources, "*.cpp")
 diff --git a/platform/haiku/detect.py b/platform/haiku/detect.py
-index 20bdf85..e972876 100644
+index 407272d..82a7678 100644
 --- a/platform/haiku/detect.py
 +++ b/platform/haiku/detect.py
 @@ -66,9 +66,6 @@ def configure(env):
@@ -983,32 +808,140 @@ index bbd72df..72c8ee2 100644
  
  #define GLES3_INCLUDE_H "glad/glad.h"
 +#define GLES2_INCLUDE_H "glad/glad.h"
-diff --git a/thirdparty/libwebsockets/lws_config.h b/thirdparty/libwebsockets/lws_config.h
-index 7185a80..e5e15cc 100644
---- a/thirdparty/libwebsockets/lws_config.h
-+++ b/thirdparty/libwebsockets/lws_config.h
-@@ -174,7 +174,7 @@
- #define LWS_HAVE_MALLOC_H
- #endif
+-- 
+2.19.1
+
+
+From bf49887be57aa22c72fd1f92410ccec9c8cf0d14 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
+Date: Tue, 20 Nov 2018 20:32:05 +0100
+Subject: Godot: platform detection patch for AMD64 arch.
+
+
+diff --git a/platform/haiku/detect.py b/platform/haiku/detect.py
+index 82a7678..8546319 100644
+--- a/platform/haiku/detect.py
++++ b/platform/haiku/detect.py
+@@ -61,8 +61,12 @@ def configure(env):
  
--#if !defined(IPHONE_ENABLED) && !defined(OSX_ENABLED)
-+#if !defined(IPHONE_ENABLED) && !defined(OSX_ENABLED) && !defined(__HAIKU__)
- #define LWS_HAVE_PIPE2
- #endif
+     ## Compiler configuration
  
-diff --git a/thirdparty/libwebsockets/lws_config_private.h b/thirdparty/libwebsockets/lws_config_private.h
-index 9d04078..b26d225 100644
---- a/thirdparty/libwebsockets/lws_config_private.h
-+++ b/thirdparty/libwebsockets/lws_config_private.h
-@@ -81,7 +81,7 @@
+-    env["CC"] = "gcc-x86"
+-    env["CXX"] = "g++-x86"
++    if (is64):
++        env["CC"] = "gcc"
++        env["CXX"] = "g++"
++    else:
++        env["CC"] = "gcc-x86"
++        env["CXX"] = "g++-x86"
  
- /* Define to 1 if you have the <sys/prctl.h> header file. */
- #define LWS_HAVE_SYS_PRCTL_H
--#if defined(OSX_ENABLED) || defined(IPHONE_ENABLED) || defined(__FreeBSD__) || defined(__OpenBSD__)
-+#if defined(OSX_ENABLED) || defined(IPHONE_ENABLED) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__HAIKU__)
- #undef LWS_HAVE_SYS_PRCTL_H
- #endif
+     ## Dependencies
  
 -- 
-2.16.4
+2.19.1
+
+
+From a3410b39f738340fed6851fc4fce88189873a47f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
+Date: Tue, 20 Nov 2018 20:39:43 +0100
+Subject: Header location fix for upnpc
+
+
+diff --git a/platform/haiku/detect.py b/platform/haiku/detect.py
+index 8546319..43dcbf3 100644
+--- a/platform/haiku/detect.py
++++ b/platform/haiku/detect.py
+@@ -141,8 +141,11 @@ def configure(env):
+ 
+     if not env['builtin_miniupnpc']:
+         # No pkgconfig file so far, hardcode default paths.
+-        env.Append(CPPPATH=["/system/develop/headers/x86/miniupnpc"])
+         env.Append(LIBS=["miniupnpc"])
++        if (is64):
++            env.Append(CPPPATH=["/system/develop/headers/miniupnpc"])
++        else:
++            env.Append(CPPPATH=["/system/develop/headers/x86/miniupnpc"])
+ 
+     # On Linux wchar_t should be 32-bits
+     # 16-bit library shouldn't be required due to compiler optimisations
+-- 
+2.19.1
+
+
+From ccc76197b2c9a654f4d1dd6b5d3e0d0002cf0307 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
+Date: Wed, 28 Nov 2018 21:28:36 +0100
+Subject: No websockets anymore
+
+
+diff --git a/platform/haiku/detect.py b/platform/haiku/detect.py
+index 43dcbf3..97dbc33 100644
+--- a/platform/haiku/detect.py
++++ b/platform/haiku/detect.py
+@@ -132,9 +132,6 @@ def configure(env):
+         if any(platform.machine() in s for s in list_of_x86):
+             env["x86_libtheora_opt_gcc"] = True
+ 
+-    if not env['builtin_libwebsockets']:
+-        env.ParseConfig('pkg-config libwebsockets --cflags --libs')
+-
+     if not env['builtin_mbedtls']:
+         # mbedTLS does not provide a pkgconfig config yet. See https://github.com/ARMmbed/mbedtls/issues/228
+         env.Append(LIBS=['mbedtls', 'mbedcrypto', 'mbedx509'])
+-- 
+2.19.1
+
+
+From ae99d2744449698a866e87d5800ae47cdb25f2c0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
+Date: Wed, 28 Nov 2018 21:29:54 +0100
+Subject: No mbedtls either
+
+
+diff --git a/platform/haiku/detect.py b/platform/haiku/detect.py
+index 97dbc33..c5d7d95 100644
+--- a/platform/haiku/detect.py
++++ b/platform/haiku/detect.py
+@@ -132,10 +132,6 @@ def configure(env):
+         if any(platform.machine() in s for s in list_of_x86):
+             env["x86_libtheora_opt_gcc"] = True
+ 
+-    if not env['builtin_mbedtls']:
+-        # mbedTLS does not provide a pkgconfig config yet. See https://github.com/ARMmbed/mbedtls/issues/228
+-        env.Append(LIBS=['mbedtls', 'mbedcrypto', 'mbedx509'])
+-
+     if not env['builtin_miniupnpc']:
+         # No pkgconfig file so far, hardcode default paths.
+         env.Append(LIBS=["miniupnpc"])
+-- 
+2.19.1
+
+
+From f8e33bce0c8944bd331c68689e9ed0ae4791bb9d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
+Date: Wed, 28 Nov 2018 21:30:46 +0100
+Subject: No miniupnpc either
+
+
+diff --git a/platform/haiku/detect.py b/platform/haiku/detect.py
+index c5d7d95..210b2e5 100644
+--- a/platform/haiku/detect.py
++++ b/platform/haiku/detect.py
+@@ -132,14 +132,6 @@ def configure(env):
+         if any(platform.machine() in s for s in list_of_x86):
+             env["x86_libtheora_opt_gcc"] = True
+ 
+-    if not env['builtin_miniupnpc']:
+-        # No pkgconfig file so far, hardcode default paths.
+-        env.Append(LIBS=["miniupnpc"])
+-        if (is64):
+-            env.Append(CPPPATH=["/system/develop/headers/miniupnpc"])
+-        else:
+-            env.Append(CPPPATH=["/system/develop/headers/x86/miniupnpc"])
+-
+     # On Linux wchar_t should be 32-bits
+     # 16-bit library shouldn't be required due to compiler optimisations
+     if not env['builtin_pcre2']:
+-- 
+2.19.1
 


### PR DESCRIPTION
fixes #3388

Builds till the end but linking fails:
```[Initial build] /boot/system/develop/tools/bin/../lib/gcc/x86_64-unknown-haiku/7.3.0/../../../../x86_64-unknown-haiku/bin/ld: modules/libmodules.haiku.tools.64.a(subpixel_mmx.haiku.tools.64.o): relocation R_X86_64_PC32 against symbol `vp8_bilinear_filters_x86_8' can not be used when making a shared object; recompile with -fPIC
/boot/system/develop/tools/bin/../lib/gcc/x86_64-unknown-haiku/7.3.0/../../../../x86_64-unknown-haiku/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status```