### PR TITLE
wget: bump to 1.19.5

### DIFF
--- a/net-misc/wget/patches/wget-1.19.5.patchset
+++ b/net-misc/wget/patches/wget-1.19.5.patchset
@@ -208,45 +208,10 @@ index 6cf4afe9..c92d6338 100644
 -- 
 2.19.1
 
-From ae90369e83a059eeaff85061fa037d52be073008 Mon Sep 17 00:00:00 2001
-From: Crestwave <crest.wave@yahoo.com>
-Date: Sun, 25 Nov 2018 11:30:55 +0000
-Subject: Stop fuzz from compiling.
-
-
-diff --git a/Makefile.am b/Makefile.am
-index e915da6..e1145a1 100644
---- a/Makefile.am
-+++ b/Makefile.am
-@@ -41,7 +41,7 @@ distuninstallcheck_listfiles = find . -type f | \
- ACLOCAL_AMFLAGS = -I m4
- 
- # subdirectories in the distribution
--SUBDIRS = lib src doc po util fuzz tests testenv
-+SUBDIRS = lib src doc po util tests testenv
- 
- EXTRA_DIST = MAILING-LIST \
-              msdos/config.h msdos/Makefile.DJ \
-diff --git a/Makefile.in b/Makefile.in
-index 0f2b0cf..3789c8a 100644
---- a/Makefile.in
-+++ b/Makefile.in
-@@ -1443,7 +1443,7 @@ distuninstallcheck_listfiles = find . -type f | \
- ACLOCAL_AMFLAGS = -I m4
- 
- # subdirectories in the distribution
--SUBDIRS = lib src doc po util fuzz tests testenv
-+SUBDIRS = lib src doc po util tests testenv
- EXTRA_DIST = MAILING-LIST \
-              msdos/config.h msdos/Makefile.DJ \
-              msdos/Makefile.WC ABOUT-NLS \
--- 
-2.19.1
-
 From 8a0312531a0fd8caf678982d91c935de93ae593f Mon Sep 17 00:00:00 2001
 From: Crestwave <crest.wave@yahoo.com>
 Date: Sun, 25 Nov 2018 12:01:08 +0000
-Subject: Also move wget-hsts out of home directory in hsts.c.
+Subject: Also move wget-hsts out of the home directory in hsts.c.
 
 
 diff --git a/src/hsts.c b/src/hsts.c
@@ -281,6 +246,211 @@ index 61ca413..ff2fb49 100644
    if (opt.homedir)
      {
        filename = aprintf ("%s/.wget-hsts-test", opt.homedir);
+-- 
+2.19.1
+
+From e08f854073550e67c64a6b394b92aa2cb12913a0 Mon Sep 17 00:00:00 2001
+From: Crestwave <crest.wave@yahoo.com>
+Date: Sun, 25 Nov 2018 11:15:19 +0000
+Subject: Remove -ldl flag from ld.
+
+
+diff --git a/fuzz/Makefile.am b/fuzz/Makefile.am
+index 2e0b6b9..3db9f10 100644
+--- a/fuzz/Makefile.am
++++ b/fuzz/Makefile.am
+@@ -5,8 +5,7 @@ LDADD = ../lib/libgnu.a \
+  $(GETADDRINFO_LIB) $(HOSTENT_LIB) $(INET_NTOP_LIB) $(INET_PTON_LIB) \
+  $(LIBSOCKET) $(LIB_CLOCK_GETTIME) $(LIB_CRYPTO) $(LIB_GETLOGIN) $(LIB_NANOSLEEP) $(LIB_POLL) \
+  $(LIB_POSIX_SPAWN) $(LIB_PTHREAD_SIGMASK) $(LIB_SELECT) $(LTLIBICONV) $(LTLIBINTL) \
+- $(LTLIBMULTITHREAD) $(LTLIBTHREAD) $(SERVENT_LIB) @INTL_MACOSX_LIBS@ \
+- -ldl
++ $(LTLIBMULTITHREAD) $(LTLIBTHREAD) $(SERVENT_LIB) @INTL_MACOSX_LIBS@
+ 
+ WGET_TESTS = \
+  wget_css_fuzzer$(EXEEXT) \
+diff --git a/fuzz/Makefile.in b/fuzz/Makefile.in
+index e258637..31d70ac 100644
+--- a/fuzz/Makefile.in
++++ b/fuzz/Makefile.in
+@@ -1636,7 +1636,7 @@ LDADD = ../lib/libgnu.a $(GETADDRINFO_LIB) $(HOSTENT_LIB) \
+ 	$(LIB_NANOSLEEP) $(LIB_POLL) $(LIB_POSIX_SPAWN) \
+ 	$(LIB_PTHREAD_SIGMASK) $(LIB_SELECT) $(LTLIBICONV) \
+ 	$(LTLIBINTL) $(LTLIBMULTITHREAD) $(LTLIBTHREAD) $(SERVENT_LIB) \
+-	@INTL_MACOSX_LIBS@ -ldl $(am__append_1)
++	@INTL_MACOSX_LIBS@ $(am__append_1)
+ WGET_TESTS = \
+  wget_css_fuzzer$(EXEEXT) \
+  wget_cookie_fuzzer$(EXEEXT) \
+-- 
+2.19.1
+
+From 49fffacd6c335be3f0dce938f9bc10a44b308d63 Mon Sep 17 00:00:00 2001
+From: Crestwave <crest.wave@yahoo.com>
+Date: Mon, 26 Nov 2018 07:13:07 +0000
+Subject: Fix segmentation violation when executing fuzzers.
+
+
+diff --git a/fuzz/wget_cookie_fuzzer.c b/fuzz/wget_cookie_fuzzer.c
+index 121e2e2..40882f6 100644
+--- a/fuzz/wget_cookie_fuzzer.c
++++ b/fuzz/wget_cookie_fuzzer.c
+@@ -56,6 +56,7 @@ FILE *fopen_wgetrc(const char *pathname, const char *mode)
+ 	return NULL;
+ }
+ 
++#ifndef __HAIKU__
+ #ifdef FUZZING
+ void exit_wget(int status)
+ {
+@@ -65,6 +66,7 @@ void exit(int status)
+ {
+ }
+ #endif
++#endif
+ 
+ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+ {
+diff --git a/fuzz/wget_css_fuzzer.c b/fuzz/wget_css_fuzzer.c
+index bcdeb5e..f7600d4 100644
+--- a/fuzz/wget_css_fuzzer.c
++++ b/fuzz/wget_css_fuzzer.c
+@@ -68,6 +68,7 @@ FILE *fopen_wgetrc(const char *pathname, const char *mode)
+ }
+ 
+ static jmp_buf jmpbuf;
++#ifndef __HAIKU__
+ #ifdef FUZZING
+ void exit_wget(int status)
+ {
+@@ -79,6 +80,7 @@ void exit(int status)
+ 	longjmp(jmpbuf, 1);
+ }
+ #endif
++#endif
+ 
+ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+ {
+diff --git a/fuzz/wget_ftpls_fuzzer.c b/fuzz/wget_ftpls_fuzzer.c
+index 138a549..2c04ed0 100644
+--- a/fuzz/wget_ftpls_fuzzer.c
++++ b/fuzz/wget_ftpls_fuzzer.c
+@@ -59,6 +59,7 @@ FILE *fopen_wgetrc(const char *pathname, const char *mode)
+ 	return NULL;
+ }
+ 
++#ifndef __HAIKU__
+ #ifdef FUZZING
+ void exit_wget(int status)
+ {
+@@ -68,6 +69,7 @@ void exit(int status)
+ {
+ }
+ #endif
++#endif
+ 
+ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+ {
+diff --git a/fuzz/wget_html_fuzzer.c b/fuzz/wget_html_fuzzer.c
+index a6c4fdc..dcb9929 100644
+--- a/fuzz/wget_html_fuzzer.c
++++ b/fuzz/wget_html_fuzzer.c
+@@ -68,6 +68,7 @@ FILE *fopen_wgetrc(const char *pathname, const char *mode)
+ #endif
+ }
+ 
++#ifndef __HAIKU__
+ #ifdef FUZZING
+ void exit_wget(int status)
+ {
+@@ -77,6 +78,7 @@ void exit(int status)
+ {
+ }
+ #endif
++#endif
+ 
+ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+ {
+diff --git a/fuzz/wget_netrc_fuzzer.c b/fuzz/wget_netrc_fuzzer.c
+index 97d472e..9f6abbe 100644
+--- a/fuzz/wget_netrc_fuzzer.c
++++ b/fuzz/wget_netrc_fuzzer.c
+@@ -56,6 +56,7 @@ FILE *fopen_wgetrc(const char *pathname, const char *mode)
+ 	return NULL;
+ }
+ 
++#ifndef __HAIKU__
+ #ifdef FUZZING
+ void exit_wget(int status)
+ {
+@@ -65,6 +66,7 @@ void exit(int status)
+ {
+ }
+ #endif
++#endif
+ 
+ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+ {
+diff --git a/fuzz/wget_options_fuzzer.c b/fuzz/wget_options_fuzzer.c
+index d3dcaff..c62a3e4 100644
+--- a/fuzz/wget_options_fuzzer.c
++++ b/fuzz/wget_options_fuzzer.c
+@@ -61,6 +61,7 @@ FILE *fopen_wgetrc(const char *pathname, const char *mode)
+ }
+ 
+ static jmp_buf jmpbuf;
++#ifndef __HAIKU__
+ #ifdef FUZZING
+ void exit_wget(int status)
+ {
+@@ -72,6 +73,7 @@ void exit(int status)
+ 	longjmp(jmpbuf, 1);
+ }
+ #endif
++#endif
+ 
+ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+ {
+diff --git a/fuzz/wget_robots_fuzzer.c b/fuzz/wget_robots_fuzzer.c
+index e6b3bd1..c284990 100644
+--- a/fuzz/wget_robots_fuzzer.c
++++ b/fuzz/wget_robots_fuzzer.c
+@@ -59,6 +59,7 @@ FILE *fopen_wgetrc(const char *pathname, const char *mode)
+ 	return NULL;
+ }
+ 
++#ifndef __HAIKU__
+ #ifdef FUZZING
+ void exit_wget(int status)
+ {
+@@ -68,6 +69,7 @@ void exit(int status)
+ {
+ }
+ #endif
++#endif
+ 
+ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+ {
+diff --git a/fuzz/wget_url_fuzzer.c b/fuzz/wget_url_fuzzer.c
+index ad05ff8..a0f002e 100644
+--- a/fuzz/wget_url_fuzzer.c
++++ b/fuzz/wget_url_fuzzer.c
+@@ -56,6 +56,7 @@ FILE *fopen_wgetrc(const char *pathname, const char *mode)
+ 	return NULL;
+ }
+ 
++#ifndef __HAIKU__
+ #ifdef FUZZING
+ void exit_wget(int status)
+ {
+@@ -65,6 +66,7 @@ void exit(int status)
+ {
+ }
+ #endif
++#endif
+ 
+ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+ {
 -- 
 2.19.1
 

--- a/net-misc/wget/patches/wget-1.19.5.patchset
+++ b/net-misc/wget/patches/wget-1.19.5.patchset
@@ -208,3 +208,38 @@ index 6cf4afe9..c92d6338 100644
 -- 
 2.19.1
 
+From ae90369e83a059eeaff85061fa037d52be073008 Mon Sep 17 00:00:00 2001
+From: Crestwave <crest.wave@yahoo.com>
+Date: Sun, 25 Nov 2018 11:30:55 +0000
+Subject: Stop fuzz from compiling
+
+
+diff --git a/Makefile.am b/Makefile.am
+index e915da6..e1145a1 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -41,7 +41,7 @@ distuninstallcheck_listfiles = find . -type f | \
+ ACLOCAL_AMFLAGS = -I m4
+ 
+ # subdirectories in the distribution
+-SUBDIRS = lib src doc po util fuzz tests testenv
++SUBDIRS = lib src doc po util tests testenv
+ 
+ EXTRA_DIST = MAILING-LIST \
+              msdos/config.h msdos/Makefile.DJ \
+diff --git a/Makefile.in b/Makefile.in
+index 0f2b0cf..3789c8a 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -1443,7 +1443,7 @@ distuninstallcheck_listfiles = find . -type f | \
+ ACLOCAL_AMFLAGS = -I m4
+ 
+ # subdirectories in the distribution
+-SUBDIRS = lib src doc po util fuzz tests testenv
++SUBDIRS = lib src doc po util tests testenv
+ EXTRA_DIST = MAILING-LIST \
+              msdos/config.h msdos/Makefile.DJ \
+              msdos/Makefile.WC ABOUT-NLS \
+-- 
+2.19.1
+

--- a/net-misc/wget/patches/wget-1.19.5.patchset
+++ b/net-misc/wget/patches/wget-1.19.5.patchset
@@ -5,18 +5,18 @@ Subject: apply wget-1.14.patch
 
 
 diff --git a/configure.ac b/configure.ac
-index d9f0098..33fe5b2 100644
+index e273db9..034b6e2 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -238,6 +238,7 @@ AC_HEADER_STDBOOL
+@@ -254,6 +254,7 @@ AC_HEADER_STDBOOL
  AC_CHECK_HEADERS(unistd.h sys/time.h)
  AC_CHECK_HEADERS(termios.h sys/ioctl.h sys/select.h utime.h sys/utime.h)
- AC_CHECK_HEADERS(stdint.h inttypes.h pwd.h wchar.h)
+ AC_CHECK_HEADERS(stdint.h inttypes.h pwd.h wchar.h dlfcn.h)
 +AC_CHECK_HEADERS(arpa/inet.h)
  
  AC_CHECK_DECLS(h_errno,,,[#include <netdb.h>])
  
-@@ -305,6 +306,9 @@ dnl
+@@ -321,6 +322,9 @@ dnl
  
  PKG_PROG_PKG_CONFIG
  
@@ -27,10 +27,10 @@ index d9f0098..33fe5b2 100644
    PKG_CHECK_MODULES([LIBPSL], libpsl, [
      with_libpsl=yes
 diff --git a/src/config.h.in b/src/config.h.in
-index 5a51490..5ed9f67 100644
+index 3179044..ad657c4 100644
 --- a/src/config.h.in
 +++ b/src/config.h.in
-@@ -944,6 +944,9 @@
+@@ -953,6 +953,9 @@
  /* Define if libcares is available. */
  #undef HAVE_LIBCARES
  
@@ -40,7 +40,7 @@ index 5a51490..5ed9f67 100644
  /* Define to 1 if you have the `dl' library (-ldl). */
  #undef HAVE_LIBDL
  
-@@ -956,6 +959,9 @@
+@@ -965,6 +968,9 @@
  /* Define to 1 if you have the <libintl.h> header file. */
  #undef HAVE_LIBINTL_H
  
@@ -81,7 +81,7 @@ index 042d44d..e33b651 100644
  
  struct url;
 -- 
-2.16.1
+2.19.1
 
 
 From e2eec5007e57bad624765a1985a773520fa1d9ed Mon Sep 17 00:00:00 2001
@@ -91,7 +91,7 @@ Subject: apply and augment wget-1.14-build-fixes.patch
 
 
 diff --git a/src/utils.c b/src/utils.c
-index 6f41fab..aa53484 100644
+index ec55f2e0..0feea1b1 100644
 --- a/src/utils.c
 +++ b/src/utils.c
 @@ -59,7 +59,9 @@ as that of the covered work.  */
@@ -105,7 +105,7 @@ index 6f41fab..aa53484 100644
  #endif
  
 -- 
-2.16.1
+2.19.1
 
 
 From f762289dbee26754a4257f42f15f0ec0e29d21e3 Mon Sep 17 00:00:00 2001
@@ -115,10 +115,10 @@ Subject: Move wget-hsts out of home directory.
 
 
 diff --git a/src/main.c b/src/main.c
-index d19437e..f718f58 100644
+index 81db931..5e08a68 100644
 --- a/src/main.c
 +++ b/src/main.c
-@@ -81,6 +81,10 @@ as that of the covered work.  */
+@@ -87,6 +87,10 @@ as that of the covered work.  */
  # include "vms.h"
  #endif /* __VMS */
  
@@ -129,7 +129,7 @@ index d19437e..f718f58 100644
  #ifndef PATH_SEPARATOR
  # define PATH_SEPARATOR '/'
  #endif
-@@ -172,6 +176,16 @@ get_hsts_database (void)
+@@ -175,6 +179,16 @@ get_hsts_database (void)
    if (opt.hsts_file)
      return xstrdup (opt.hsts_file);
  
@@ -137,17 +137,17 @@ index d19437e..f718f58 100644
 +  {
 +    char buffer[256];
 +    if (find_directory(B_USER_SETTINGS_DIRECTORY, 0, false, buffer, sizeof(buffer)) == B_OK) {
-+      home = aprintf("%s/wget-hsts", buffer);
-+      return home;
++      opt.homedir = aprintf("%s/wget-hsts", buffer);
++      return opt.homedir;
 +    }
 +  }
 +#endif
 +
-   home = home_dir ();
-   if (home)
+   if (opt.homedir)
      {
+       char *dir = aprintf ("%s/.wget-hsts", opt.homedir);
 -- 
-2.16.1
+2.19.1
 
 
 From c2dd748d260ae1ad24ba8d63ff26adfeabdf4ae4 Mon Sep 17 00:00:00 2001
@@ -157,10 +157,10 @@ Subject: gcc2 patch
 
 
 diff --git a/src/init.c b/src/init.c
-index 6807e36..c0f3cf4 100644
+index eb81ab4..af833fa 100644
 --- a/src/init.c
 +++ b/src/init.c
-@@ -893,7 +893,7 @@ setval_internal (int comind, const char *com, const char *val)
+@@ -899,7 +899,7 @@ setval_internal (int comind, const char *com, const char *val)
    assert (0 <= comind && ((size_t) comind) < countof (commands));
  
    if ((unsigned) comind >= countof (commands))
@@ -170,7 +170,8 @@ index 6807e36..c0f3cf4 100644
    DEBUGP (("Setting %s (%s) to %s\n", com, commands[comind].name, val));
    return commands[comind].action (com, val, commands[comind].place);
 -- 
-2.16.1
+2.19.1
+
 
 
 From 93e869f8a6f7f1289e49d23bfd8ea339453d9aec Mon Sep 17 00:00:00 2001
@@ -187,10 +188,10 @@ This allows EINTR detection to work, so no error happens when you
 resize terminal anymore.
 
 diff --git a/src/openssl.c b/src/openssl.c
-index 6af38db..f7f99d5 100644
+index 6cf4afe9..c92d6338 100644
 --- a/src/openssl.c
 +++ b/src/openssl.c
-@@ -387,9 +387,11 @@ static void openssl_read_callback(void *arg)
+@@ -408,9 +408,11 @@ static void openssl_read_callback(void *arg)
    int bufsize = args->bufsize;
    int ret;
  
@@ -205,5 +206,5 @@ index 6af38db..f7f99d5 100644
    args->retval = ret;
  }
 -- 
-2.16.1
+2.19.1
 

--- a/net-misc/wget/patches/wget-1.19.5.patchset
+++ b/net-misc/wget/patches/wget-1.19.5.patchset
@@ -211,7 +211,7 @@ index 6cf4afe9..c92d6338 100644
 From ae90369e83a059eeaff85061fa037d52be073008 Mon Sep 17 00:00:00 2001
 From: Crestwave <crest.wave@yahoo.com>
 Date: Sun, 25 Nov 2018 11:30:55 +0000
-Subject: Stop fuzz from compiling
+Subject: Stop fuzz from compiling.
 
 
 diff --git a/Makefile.am b/Makefile.am
@@ -240,6 +240,47 @@ index 0f2b0cf..3789c8a 100644
  EXTRA_DIST = MAILING-LIST \
               msdos/config.h msdos/Makefile.DJ \
               msdos/Makefile.WC ABOUT-NLS \
+-- 
+2.19.1
+
+From 8a0312531a0fd8caf678982d91c935de93ae593f Mon Sep 17 00:00:00 2001
+From: Crestwave <crest.wave@yahoo.com>
+Date: Sun, 25 Nov 2018 12:01:08 +0000
+Subject: Also move wget-hsts out of home directory in hsts.c.
+
+
+diff --git a/src/hsts.c b/src/hsts.c
+index 61ca413..ff2fb49 100644
+--- a/src/hsts.c
++++ b/src/hsts.c
+@@ -48,6 +48,10 @@ as that of the covered work.  */
+ #include <stdio.h>
+ #include <sys/file.h>
+ 
++#ifdef __HAIKU__
++#include "FindDirectory.h"
++#endif
++
+ struct hsts_store {
+   struct hash_table *table;
+   time_t last_mtime;
+@@ -627,6 +631,16 @@ get_hsts_store_filename (void)
+   char *filename = NULL;
+   FILE *fp = NULL;
+ 
++#ifdef __HAIKU__
++  {
++    char buffer[256];
++    if (find_directory(B_USER_SETTINGS_DIRECTORY, 0, false, buffer, sizeof(buffer)) == B_OK) {
++      opt.homedir = aprintf("%s/wget-hsts", buffer);
++      return opt.homedir;
++    }
++  }
++#endif
++
+   if (opt.homedir)
+     {
+       filename = aprintf ("%s/.wget-hsts-test", opt.homedir);
 -- 
 2.19.1
 

--- a/net-misc/wget/wget-1.19.5.recipe
+++ b/net-misc/wget/wget-1.19.5.recipe
@@ -7,7 +7,7 @@ COPYRIGHT="1996-2018 Free Software Foundation"
 LICENSE="GNU GPL v3"
 REVISION="1"
 SOURCE_URI="https://ftpmirror.gnu.org/wget/wget-$portVersion.tar.gz"
-CHECKSUM_SHA256="93fb96b0f48a20ff5be0d9d9d3c4a986b469cb853131f9d5fe4cc9cecbc8b5b5"
+CHECKSUM_SHA256="b39212abe1a73f2b28f4c6cb223c738559caac91d6e416a6d91d4b9d55c9faee"
 PATCHES="wget-$portVersion.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"


### PR DESCRIPTION
The tests fail to start due to an error when compiling them, but most of them failed on the previous version, anyway. Here's the failure:

```
make  -C ../src libunittest.a
make[4]: Entering directory '/sources/wget-1.19.5/src'
make[4]: Leaving directory '/sources/wget-1.19.5/src'
  CCLD     wget_css_fuzzer
/boot/system/develop/tools/bin/../lib/gcc/x86_64-unknown-haiku/7.3.0/../../../../x86_64-unknown-haiku/bin/ld: cannot find -ldl
collect2: error: ld returned 1 exit status
Makefile:1762: recipe for target 'wget_css_fuzzer' failed
make[3]: *** [wget_css_fuzzer] Error 1
make[3]: Leaving directory '/sources/wget-1.19.5/fuzz'
Makefile:2126: recipe for target 'check-am' failed
make[2]: *** [check-am] Error 2
make[2]: Leaving directory '/sources/wget-1.19.5/fuzz'
Makefile:1501: recipe for target 'check-recursive' failed
make[1]: *** [check-recursive] Error 1
make[1]: Leaving directory '/sources/wget-1.19.5'
Makefile:1796: recipe for target 'check' failed
make: *** [check] Error 2
```

Basic functionality seems to be fine.