### PR TITLE
BoCA: fix dependencies

### DIFF
--- a/media-libs/boca/boca-1.0~alpha20181201.recipe
+++ b/media-libs/boca/boca-1.0~alpha20181201.recipe
@@ -6,7 +6,7 @@ between applications and their components."
 HOMEPAGE="https://github.com/enzo1982/BoCA"
 COPYRIGHT="2007-2018 Robert Kausch"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/enzo1982/BoCA/releases/download/v1.1-alpha-20181201/freac-cdk-1.1-alpha-20181201.tar.gz"
 CHECKSUM_SHA256="3a6a32d001cda5cf32dc657516aa3dffb16264e5cebc982ba9987a4ffdb03d56"
 SOURCE_DIR="freac-cdk-1.1-alpha-20181201"
@@ -23,6 +23,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	smooth$secondaryArchSuffix >= 0.8.74.0~pre5
 	lib:libsmooth_0.8.74$secondaryArchSuffix >= 0
 	lib:libexpat$secondaryArchSuffix
 	lib:liburiparser$secondaryArchSuffix
@@ -35,11 +36,13 @@ PROVIDES_devel="
 	"
 REQUIRES_devel="
 	boca$secondaryArchSuffix == $portVersion base
+	smooth${secondaryArchSuffix}_devel >= 0.8.74.0~pre5
 	devel:libsmooth_0.8.74$secondaryArchSuffix >= 0
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	smooth${secondaryArchSuffix}_devel >= 0.8.74.0~pre5
 	devel:libsmooth_0.8.74$secondaryArchSuffix
 	devel:libexpat$secondaryArchSuffix
 	devel:liburiparser$secondaryArchSuffix


### PR DESCRIPTION
This declares smooth 0.8.74.0~pre5 as an explicit dependency to fix issues with the previous recipe.

The problem here is that smooth 0.8.74 still is a pre-release and the ~pre5 revision introduced API changes compared to ~pre4. This caused issues with BocA and fre:ac.