### PR TITLE
fre:ac fix dependencies and bump to 1.1~alpha20181201a

### DIFF
--- a/media-sound/freac/freac-1.1~alpha20181201a.recipe
+++ b/media-sound/freac/freac-1.1~alpha20181201a.recipe
@@ -19,7 +19,7 @@ COPYRIGHT="2001-2018 Robert Kausch"
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://github.com/enzo1982/freac/releases/download/v${portVersion/\~alpha/-alpha-}/freac-${portVersion/\~alpha/-alpha-}.tar.gz"
-CHECKSUM_SHA256="f4baad80bd7f948196fc8e0a80a05c05bf8cb39758c7f9fc7465737a48cff750"
+CHECKSUM_SHA256="7f38c0e5716cd551d8636dddb343f700469217940fc0c1ef4ea43c20c19f2961"
 SOURCE_DIR="freac-${portVersion/\~alpha/-alpha-}"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
@@ -39,6 +39,8 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	boca$secondaryArchSuffix >= 1.0~alpha20181201
+	smooth$secondaryArchSuffix >= 0.8.74.0~pre5
 	cmd:ffmpeg
 	cmd:mpcdec
 	cmd:mpcenc
@@ -67,6 +69,8 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	boca${secondaryArchSuffix}_devel >= 1.0~alpha20181201
+	smooth${secondaryArchSuffix}_devel >= 0.8.74.0~pre5
 	devel:libboca_1.0$secondaryArchSuffix >= 0
 	"
 BUILD_PREREQUIRES="


### PR DESCRIPTION
This bumps the version to the 20181201a hotfix release and declares smooth 0.8.74.0~pre5 and BoCA 1.0~alpha20181201 as explicit dependencies to fix issues with the previous recipe.

The dependency issue here is that smooth 0.8.74 still is a pre-release and the ~pre5 revision introduced API changes compared to ~pre4. This caused issues with BocA and fre:ac.

Once fre:ac 1.1 goes beta it will depend on an API/ABI stable smooth release and BoCA will freeze its API too.