### PR TITLE
lame: Enable x86 asm optimizations

### DIFF
--- a/media-sound/lame/lame-3.100.recipe
+++ b/media-sound/lame/lame-3.100.recipe
@@ -23,7 +23,7 @@ files."
 HOMEPAGE="http://lame.sourceforge.net/"
 COPYRIGHT="1998-2012 Mike Cheng et al."
 LICENSE="GNU LGPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://downloads.sourceforge.net/project/lame/lame/3.100/lame-$portVersion.tar.gz"
 CHECKSUM_SHA256="ddfe36cab873794038ae2c1210557ad34857a4b6bdc515785d1da9e175b1da1e"
 
@@ -59,17 +59,18 @@ BUILD_REQUIRES="
 	devel:libncurses$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
+	cmd:find
 	cmd:gcc${secondaryArchSuffix}
 	cmd:ld${secondaryArchSuffix}
 	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
+	cmd:nasm
 	cmd:sed
-	cmd:find
 	"
 
 BUILD()
 {
-	runConfigure ./configure
+	runConfigure ./configure --enable-nasm
 	make $jobArgs
 }
 


### PR DESCRIPTION
This enables x86 asm optimizations for LAME which speeds up the encoder by ~20%.

Unfortunately only for 32 bit architectures. On x86_64 this change has no effect.