### PR TITLE
Arpack: version bump

### DIFF
--- a/sci-libs/arpack/arpack-3.6.3.recipe
+++ b/sci-libs/arpack/arpack-3.6.3.recipe
@@ -21,15 +21,18 @@ COPYRIGHT="1996-2008 Rice University
 LICENSE="BSD (3-clause)"
 REVISION="1"
 SOURCE_URI="https://github.com/opencollab/arpack-ng/archive/$portVersion.tar.gz"
-CHECKSUM_SHA256="673c8202de996fd3127350725eb1818e534db4e79de56d5dcee8c00768db599a"
+CHECKSUM_SHA256="64f3551e5a2f8497399d82af3076b6a33bf1bc95fc46bbcabe66442db366f453"
 SOURCE_DIR="arpack-ng-$portVersion"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
+libVersion="2.0.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
 PROVIDES="
 	arpack$secondaryArchSuffix = $portVersion
-	lib:libarpack$secondaryArchSuffix = 2.0.0 compat >= 2
+	lib:libarpack$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -41,7 +44,7 @@ REQUIRES="
 
 PROVIDES_devel="
 	arpack${secondaryArchSuffix}_devel = $portVersion
-	devel:libarpack$secondaryArchSuffix = 2.0.0 compat >= 2
+	devel:libarpack$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
 	arpack$secondaryArchSuffix == $portVersion base
@@ -62,7 +65,7 @@ BUILD_PREREQUIRES="
 	"
 
 defineDebugInfoPackage arpack$secondaryArchSuffix \
-	$libDir/libarpack.so.2.0.0
+	$libDir/libarpack.so.$libVersion
 
 BUILD()
 {


### PR DESCRIPTION
No breaking changes: https://abi-laboratory.pro/?view=timeline&l=arpack-ng