### PR TITLE
Armadillo: bump

### DIFF
--- a/sci-libs/armadillo/armadillo-8.600.1.recipe
+++ b/sci-libs/armadillo/armadillo-8.600.1.recipe
@@ -9,9 +9,9 @@ COPYRIGHT="2008-2018 Conrad Sanderson
 	2017-2018 Arroyo Consortium
 	2017-2018 Data61, CSIRO"
 LICENSE="Apache v2"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://downloads.sourceforge.net/arma/armadillo-$portVersion.tar.xz"
-CHECKSUM_SHA256="5f00c735e97fc23c910a225d1b6db9541af76022cc74f9b8b327dfa347926b40"
+CHECKSUM_SHA256="b942d10bbd0b6a30f5bbe63cb7e8820f64227adcf3a2ba4bb1bc785526bb957b"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"

--- a/sci-libs/armadillo/armadillo9-9.200.6.recipe
+++ b/sci-libs/armadillo/armadillo9-9.200.6.recipe
@@ -1,0 +1,105 @@
+SUMMARY="A C++ linear algebra library"
+DESCRIPTION="The library provides efficient classes for vectors, matrices and \
+cubes, as well as 200+ associated functions (eg. contiguous and non-contiguous \
+submatrix views). Various matrix decompositions are provided through \
+integration with LAPACK, or one of its high performance drop-in replacements."
+HOMEPAGE="http://arma.sourceforge.net/"
+COPYRIGHT="2008-2018 Conrad Sanderson
+	2008-2016 National ICT Australia (NICTA)
+	2017-2018 Arroyo Consortium
+	2017-2018 Data61, CSIRO"
+LICENSE="Apache v2"
+REVISION="1"
+SOURCE_URI="https://downloads.sourceforge.net/arma/armadillo-$portVersion.tar.xz"
+CHECKSUM_SHA256="2460dced83e0f7d8340a6fab8065f18635707259edc9bf4cbac325b1b46fa8be"
+SOURCE_DIR="armadillo-$portVersion"
+
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="$portVersion"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	armadillo9$secondaryArchSuffix = $portVersion
+	lib:libarmadillo$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libarpack$secondaryArchSuffix
+	lib:libhdf5$secondaryArchSuffix
+	lib:liblapack$secondaryArchSuffix
+	lib:libopenblas$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	armadillo9${secondaryArchSuffix}_devel = $portVersion
+	devel:libarmadillo$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	armadillo9$secondaryArchSuffix == $portVersion base
+	"
+CONFLICTS_devel="
+	armadillo${secondaryArchSuffix}_devel
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libarpack$secondaryArchSuffix
+	devel:libhdf5$secondaryArchSuffix
+	devel:liblapack$secondaryArchSuffix
+	devel:libopenblas$secondaryArchSuffix
+	devel:libsuperlu$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:g++$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:sed
+	"
+
+defineDebugInfoPackage armadillo9$secondaryArchSuffix \
+	"$libDir"/libarmadillo.so.$libVersion
+
+BUILD()
+{
+	mkdir -p build && cd "$_"
+
+	cmake .. \
+		-DDETECT_HDF5=ON \
+		-DBUILD_SHARED_LIBS=ON \
+		$cmakeDirArgs
+
+	make $jobArgs
+}
+
+INSTALL()
+{
+	cd build
+	make install
+
+	mkdir -p $libDir/cmake/
+	cp -r $dataDir/Armadillo/CMake/. $libDir/cmake/.
+	rm -rf $dataDir/Armadillo/
+
+	prepareInstalledDevelLib libarmadillo
+
+	sed  -i "1i prefix=$prefix" \
+		$libDir/pkgconfig/armadillo.pc
+
+	fixPkgconfig
+
+	packageEntries devel \
+		$developDir \
+		$libDir/cmake
+}
+
+TEST()
+{
+	#make test
+	# Armadillo provides no tests through cmake AFAIK
+	true
+}


### PR DESCRIPTION
8 .x is non-breaking bump, while 9.x contains soname change:
https://abi-laboratory.pro/?view=timeline&l=armadillo