### PR TITLE
pycharm_community: remove bundled jre.

### DIFF
--- a/dev-util/pycharm-community/pycharm_community_bin-2018.3.2.recipe
+++ b/dev-util/pycharm-community/pycharm_community_bin-2018.3.2.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="PyCharm is a Python IDE for professional developers by JetBrains"
 HOMEPAGE="https://www.jetbrains.com/pycharm/"
 COPYRIGHT="2018 JetBrains s.r.o."
 LICENSE="Apache v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://download.jetbrains.com/python/pycharm-community-$portVersion.tar.gz#noarchive"
 CHECKSUM_SHA256="8eedae360aaf3e0480171d43a12db66f0623b5a7cc1cf239e98e8d9aed272aaa"
 ADDITIONAL_FILES="PyCharm_Logo.hvif"
@@ -29,6 +29,8 @@ INSTALL()
 	mkdir -p $appsDir
 	tar xvf pycharm-community-$portVersion.tar.gz -C $appsDir
 	mv $appsDir/pycharm-community-$portVersion $appsDir/pycharm
+
+	rm -rf $appsDir/pycharm/jre64
 
 	cat << EOF > $appsDir/pycharm/pycharm.sh
 #!/bin/sh -l


### PR DESCRIPTION
The bundled JRE runs only on Linux and is not required to run PyCharm. So it can be safely removed.