### PR TITLE
tinyxml2, bump version, use cmake for the build

### DIFF
--- a/dev-libs/tinyxml2/tinyxml2-7.0.1.recipe
+++ b/dev-libs/tinyxml2/tinyxml2-7.0.1.recipe
@@ -6,18 +6,21 @@ parses the XML into a DOM-like tree and is able to read and write XML files.\
 It allows you to create your own document mark-ups or even construct an XML \
 document from scratch with C++ objects."
 HOMEPAGE="http://www.grinninglizard.com/tinyxml2/"
-COPYRIGHT="2011-2013 Lee Thomason"
+COPYRIGHT="2011-2018 Lee Thomason"
 LICENSE="Zlib"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://github.com/leethomason/tinyxml2/archive/$portVersion.tar.gz"
-CHECKSUM_SHA256="f891224f32e7a06bf279290619cec80cc8ddc335c13696872195ffb87f5bce67"
+CHECKSUM_SHA256="a381729e32b6c2916a23544c04f342682d38b3f6e6c0cad3c25e900c3a7ef1a6"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
+libVersion="$portVersion"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
 PROVIDES="
 	tinyxml2$secondaryArchSuffix = $portVersion
-	lib:libtinyxml2$secondaryArchSuffix = $portVersion
+	lib:libtinyxml2$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -25,7 +28,7 @@ REQUIRES="
 
 PROVIDES_devel="
 	tinyxml2${secondaryArchSuffix}_devel = $portVersion
-	devel:libtinyxml2$secondaryArchSuffix = $portVersion
+	devel:libtinyxml2$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
 	tinyxml2$secondaryArchSuffix == $portVersion base
@@ -35,6 +38,7 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
+	cmd:cmake
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
 	cmd:make
@@ -42,22 +46,26 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	g++ -fpic -c tinyxml2.cpp
-	g++ -shared -Wl,-soname,libtinyxml2.so -o libtinyxml2.so tinyxml2.o
+	mkdir -p build && cd build
+	cmake -DCMAKE_INSTALL_INCLUDEDIR=$includeDir \
+		-DCMAKE_INSTALL_LIBDIR=$libDir ..
+
+	#this is needed to build xmltest on x86_64
+	if [ $targetArchitecture != x86_gcc2 ]; then
+		sed -i 's,-fPIE,-fPIC,g' CMakeFiles/xmltest.dir/flags.make
+	fi
+
+	make $jobArgs
 }
 
 INSTALL()
 {
-	mkdir -p $libDir
-	# also install shared lib
-	cp -a libtinyxml2.so $libDir
-
-	# move headers
-	mkdir -p $includeDir
-	mv tinyxml2.h $includeDir
+	cd build
+	make install
 
 	# prepare development lib links
 	prepareInstalledDevelLib libtinyxml2
+	fixPkgconfig
 
 	# devel package
 	packageEntries devel $developDir
@@ -65,5 +73,6 @@ INSTALL()
 
 TEST()
 {
-	make test
+	cd build
+	./xmltest
 }


### PR DESCRIPTION
For some reason I haven't been able to figure out, it's using -fPIC to build the library but -fPIE to build xmltest.
on x86_gcc2 (for secondary architecture) this doesn't fail, for x86_64 it fails with -fPIE so that needs to be -fPIC there