### PR TITLE
libgee, new recipe

### DIFF
--- a/dev-libs/libgee/libgee-0.20.1.recipe
+++ b/dev-libs/libgee/libgee-0.20.1.recipe
@@ -1,0 +1,92 @@
+SUMMARY="The GObject collection library"
+DESCRIPTION="Libgee is a collection library providing GObject-based \
+interfaces and classes for commonly used data structures."
+HOMEPAGE="https://wiki.gnome.org/Projects/Libgee"
+COPYRIGHT="2007-2018 Jürg Billeter"
+LICENSE="GNU LGPL v2.1"
+REVISION="1"
+SOURCE_URI="https://download.gnome.org/sources/libgee/${portVersion%.*}/libgee-$portVersion.tar.xz"
+CHECKSUM_SHA256="bb2802d29a518e8c6d2992884691f06ccfcc25792a5686178575c7111fea4630"
+
+ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
+SECONDARY_ARCHITECTURES="?x86"
+
+libVersion="2.6.1"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	libgee$secondaryArchSuffix = $portVersion
+	lib:libgee_0.8$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+#	lib:libgirepository_1.0$secondaryArchSuffix
+	lib:libglib_2.0$secondaryArchSuffix
+	lib:libgobject_2.0$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	libgee${secondaryArchSuffix}_devel = $portVersion
+	devel:libgee_0.8$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	libgee$secondaryArchSuffix == $portVersion base
+	devel:libglib_2.0$secondaryArchSuffix
+	devel:libpcre$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+#	devel:libgirepository_1.0$secondaryArchSuffix
+	devel:libglib_2.0$secondaryArchSuffix
+	devel:libgobject_2.0$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:aclocal
+	cmd:autoreconf
+	cmd:cmp
+	cmd:diff
+	cmd:gcc$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:valac
+	cmd:vapigen
+	"
+
+defineDebugInfoPackage libgee$secondaryArchSuffix \
+	"$libDir"/libgee-0.8.so.$libVersion
+
+PATCH()
+{
+	# the patch wont break the build
+	# only applies when you enable gobject-introspection
+	sed -i \
+		-e 's|@INTROSPECTION_GIRDIR@|@datadir@/gir-1.0|g' \
+		-e 's|@INTROSPECTION_TYPELIBDIR@|@libdir@/girepository-1.0|g' \
+		gee/Makefile.am
+}
+
+BUILD()
+{
+	autoreconf -vfi
+	runConfigure ./configure --enable-vala
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	# remove libtool library files
+	rm -f "$libDir"/*.la
+
+	prepareInstalledDevelLib libgee-0.8
+	fixPkgconfig
+
+	# devel package
+	packageEntries devel \
+		"$developDir"
+}


### PR DESCRIPTION
Test has been left out as it fails (described in the issue for creating this recipe https://github.com/haikuports/haikuports/issues/3519)
gobject-introspection not enabled (but builds ok with it, just fails the install for the gir file) as gir is not available in haikuports