### PR TITLE
gobject-introspection, new recipe

### DIFF
--- a/dev-libs/gobject-introspection/gobject_introspection-1.56.1.recipe
+++ b/dev-libs/gobject-introspection/gobject_introspection-1.56.1.recipe
@@ -1,0 +1,120 @@
+SUMMARY="Introspection system for GObject-based libraries"
+DESCRIPTION="GObject introspection is a middleware layer between C libraries \
+(using GObject) and language bindings. The C library can be scanned at \
+compile time and generate a metadata file, in addition to the actual native \
+C library. Then at runtime, language bindings can read this metadata and \
+automatically provide bindings to call into the C library."
+HOMEPAGE="https://wiki.gnome.org/Projects/GObjectIntrospection"
+COPYRIGHT="Colin Walters
+	Johan Dahlin
+	Matthias Clasen (girepository)
+	Jürg Billeter (scanner)"
+LICENSE="GNU LGPL v2
+	GNU GPL v2"
+REVISION="1"
+SOURCE_URI="http://ftp.gnome.org/pub/GNOME/sources/gobject-introspection/${portVersion%.*}/gobject-introspection-$portVersion.tar.xz"
+CHECKSUM_SHA256="5b2875ccff99ff7baab63a34b67f8c920def240e178ff50add809e267d9ea24b"
+SOURCE_DIR="gobject-introspection-$portVersion"
+PATCHES="gobject_introspection-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+# On x86_gcc2 we don't want to install the commands in bin/<arch>/, but in bin/.
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+    commandSuffix=
+    commandBinDir=$prefix/bin
+fi
+
+libVersion="1.0.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	gobject_introspection$secondaryArchSuffix = $portVersion
+	cmd:g_ir_annotation_tool$commandSuffix
+	cmd:g_ir_compiler$commandSuffix
+	cmd:g_ir_generate$commandSuffix
+	cmd:g_ir_inspect$commandSuffix
+	cmd:g_ir_scanner$commandSuffix
+	lib:libgirepository_1.0$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libffi$secondaryArchSuffix
+	lib:libgio_2.0$secondaryArchSuffix
+	lib:libglib_2.0$secondaryArchSuffix
+	lib:libgmodule_2.0$secondaryArchSuffix
+	lib:libgobject_2.0$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libxml2$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	gobject_introspection${secondaryArchSuffix}_devel = $portVersion
+	devel:libgirepository_1.0$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	gobject_introspection$secondaryArchSuffix == $portVersion base
+	devel:libffi$secondaryArchSuffix
+	devel:libglib_2.0$secondaryArchSuffix
+	devel:libpcre$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libffi$secondaryArchSuffix
+	devel:libgio_2.0$secondaryArchSuffix
+	devel:libglib_2.0$secondaryArchSuffix
+	devel:libgmodule_2.0$secondaryArchSuffix
+	devel:libgobject_2.0$secondaryArchSuffix
+	devel:libxml2$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:bison
+	cmd:flex
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:python3
+	cmd:which
+	"
+
+defineDebugInfoPackage gobject_introspection$secondaryArchSuffix \
+	"$libDir"/libgirepository-1.0.so.$libVersion
+
+BUILD()
+{
+	runConfigure --omit-dirs binDir ./autogen.sh \
+		--bindir=$commandBinDir --without-cairo \
+		CPPFLAGS=-I"$portPackageLinksDir/cmd~python3/$relativeIncludeDir/python3.6m/" \
+		PYTHON=python3
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	# remove libtool library files
+	rm -f "$libDir"/lib*.la "$libDir"/gobject-introspection/giscanner/*.la
+
+	prepareInstalledDevelLib libgirepository-1.0
+	fixPkgconfig
+
+	# devel package
+	packageEntries devel \
+		"$developDir"
+}
+
+TEST()
+{
+	# tests fails on Regress-1.0.gir, but as it looks
+	# it is known to fail there (doesn't break the tests)
+	make check
+}

--- a/dev-libs/gobject-introspection/patches/gobject_introspection-1.56.1.patchset
+++ b/dev-libs/gobject-introspection/patches/gobject_introspection-1.56.1.patchset
@@ -1,0 +1,32 @@
+From 84e62005b62c08ef301a391015e64b88a81227f7 Mon Sep 17 00:00:00 2001
+From: begasus <begasus@gmail.com>
+Date: Sat, 12 Aug 2017 20:13:53 +0200
+Subject: use readelf instead of ldd
+
+
+diff --git a/giscanner/shlibs.py b/giscanner/shlibs.py
+index 525bdba..ef560a8 100644
+--- a/giscanner/shlibs.py
++++ b/giscanner/shlibs.py
+@@ -108,7 +108,7 @@ def _resolve_non_libtool(options, binary, libraries):
+         if platform_system == 'Darwin':
+             args.extend(['otool', '-L', binary.args[0]])
+         else:
+-            args.extend(['ldd', binary.args[0]])
++            args.extend(['readelf', '-d', binary.args[0]])
+         proc = subprocess.Popen(args, stdout=subprocess.PIPE)
+         patterns = {}
+         for library in libraries:
+@@ -126,7 +126,7 @@ def _resolve_non_libtool(options, binary, libraries):
+                 m = pattern.search(line)
+                 if m:
+                     del patterns[library]
+-                    shlibs.append(m.group(1))
++                    shlibs.append(m.group(1)[0:-1])
+                     break
+ 
+         if len(patterns) > 0:
+-- 
+2.16.4
+
+


### PR DESCRIPTION
Second try (sorry for the noise) :)
This is still version 1.56.1 as it relies on glib2 (version 2.57.1 atm in haikudepot for secondary architecture), 1.56.1 is the last available version that is in line with glib2's version (there is no 1.57.1, next one is 1.57.2 which needs glib2 2.57.2). Disabled gcc2 as the available version is even older for glib2.