### PR TITLE
simutrans: several updates and bugfixes (incl. for paksets and makeobj)

### DIFF
--- a/games-simulation/simutrans/patches/simutrans-120.3.patchset
+++ b/games-simulation/simutrans/patches/simutrans-120.3.patchset
@@ -1,0 +1,28 @@
+From 9a405cc969daa5702721d833f3c7e7f4dde45d70 Mon Sep 17 00:00:00 2001
+From: none <user@shredder>
+Date: Fri, 4 Jan 2019 23:21:49 +0100
+Subject: Bugfix: add ',' at end of line to re-enable building under Haiku
+
+
+diff --git a/simsys.cc b/simsys.cc
+index a0a5f95..ab7fa44 100644
+--- a/simsys.cc
++++ b/simsys.cc
+@@ -408,12 +408,12 @@ const char *dr_query_fontpath(int which)
+ 		"/boot/system/non-packaged/data/fonts/",
+ 		"/boot/home/config/non-packaged/data/fonts/",
+ 		"~/config/non-packaged/data/fonts/",
+-		"/boot/system/data/fonts/ttfonts/"
++		"/boot/system/data/fonts/ttfonts/",
+ #else
+ 		"~/.fonts/",
+ 		"~/.local/share/fonts/",
+ 		"/usr/share/fonts/truetype/",
+-		"/usr/X11R6/lib/X11/fonts/ttfonts/"
++		"/usr/X11R6/lib/X11/fonts/ttfonts/",
+ 		"/usr/local/sharefonts/truetype/",
+ 		"/usr/share/fonts/",
+ 		"/usr/X11R6/lib/X11/fonts/",
+-- 
+2.19.1
+

--- a/games-simulation/simutrans/patches/simutrans-120.4.1.patchset
+++ b/games-simulation/simutrans/patches/simutrans-120.4.1.patchset
@@ -1,0 +1,22 @@
+From a1714af9856bfd9da1d89713d45eb94c1a9fb2c1 Mon Sep 17 00:00:00 2001
+From: none <user@shredder>
+Date: Fri, 4 Jan 2019 19:45:50 +0100
+Subject: Bugfix: add ',' at end of line to re-enable building under Haiku
+
+
+diff --git a/simsys.cc b/simsys.cc
+index 83a46bc..9e7a939 100644
+--- a/simsys.cc
++++ b/simsys.cc
+@@ -406,7 +406,7 @@ const char *dr_query_fontpath(int which)
+ 		"/boot/system/non-packaged/data/fonts/",
+ 		"/boot/home/config/non-packaged/data/fonts/",
+ 		"~/config/non-packaged/data/fonts/",
+-		"/boot/system/data/fonts/ttfonts/"
++		"/boot/system/data/fonts/ttfonts/",
+ #else
+ 		"~/.fonts/",
+ 		"~/.local/share/fonts/",
+-- 
+2.19.1
+

--- a/games-simulation/simutrans/simutrans-120.3.recipe
+++ b/games-simulation/simutrans/simutrans-120.3.recipe
@@ -1,0 +1,93 @@
+SUMMARY="A transport simulation game"
+DESCRIPTION="Simutrans is a freeware and open-source transportation \
+simulator. Your goal is to establish a successful transport company. \
+Transport passengers, mail and goods by rail, road, ship, and even air. \
+Interconnect districts, cities, public buildings, industries and \
+tourist attractions by building a transport network you always dreamed \
+of."
+HOMEPAGE="http://www.simutrans.com"
+COPYRIGHT="1997-2004 Hj. Malthaner
+	2005-2018 The Simutrans Team"
+LICENSE="Artistic"
+REVISION="1"
+SvnRevision="8504"
+GitRevision="a7b09e3b7af67d14a1602fa4ca809e94172d0db3"
+SOURCE_URI="https://github.com/aburch/simutrans/archive/$GitRevision.tar.gz"
+CHECKSUM_SHA256="4e1f418fe6efbd85af34176b5c75158943d2248c06366e566a2c91a94e4ace79"
+SOURCE_FILENAME="simutrans-$portVersion.tar.gz"
+SOURCE_DIR="simutrans-$GitRevision"
+PATCHES="simutrans-$portVersion.patchset"
+SOURCE_URI_2="https://downloads.sourceforge.net/project/simutrans/simutrans/120-3/simutrans-src-120-3.zip"
+CHECKSUM_SHA256_2="6f68785798688bf956b0d7f5971a8d8fa42d12199011665b07b903164cb3929f"
+SOURCE_FILENAME_2="simutrans-sf-$portVersion.zip"
+SOURCE_DIR_2=""
+
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="?x86"
+
+PROVIDES="
+	simutrans$secondaryArchSuffix = $portVersion
+	app:simutrans$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	simutrans_pakset$secondaryArchSuffix >= 120.3
+	timgmsoundfont
+	lib:libbz2$secondaryArchSuffix
+	lib:libfreetype$secondaryArchSuffix
+	lib:libgl$secondaryArchSuffix
+	lib:libminiupnpc$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
+	lib:libSDL_1.2$secondaryArchSuffix
+	lib:libSDL_mixer_1.2$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libbz2$secondaryArchSuffix
+	devel:libfreetype$secondaryArchSuffix
+	devel:libminiupnpc$secondaryArchSuffix
+	devel:libpng16$secondaryArchSuffix
+	devel:libSDL_1.2$secondaryArchSuffix
+	devel:libSDL_mixer_1.2$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoreconf
+	cmd:g++$secondaryArchSuffix
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:sdl_config$secondaryArchSuffix >= 1.2
+	cmd:strip$secondaryArchSuffix
+	"
+
+GLOBAL_WRITABLE_FILES="
+	non-packaged/$relativeAppsDir/simutrans/config directory keep-old
+	"
+
+BUILD()
+{
+	autoreconf configure.ac
+	export CFLAGS+=-DREVISION=$SvnRevision
+	runConfigure ./configure
+	make $jobArgs
+	strip sim
+}
+
+INSTALL()
+{
+	cp $sourceDir2/simutrans/text/*.tab simutrans/text/
+	cp sim simutrans/simutrans
+	mkdir -p $appsDir/simutrans
+	mkdir -p $prefix/non-packaged/$relativeAppsDir/simutrans/config
+	cp -r  simutrans $appsDir/
+	mv  $appsDir/simutrans/config \
+		$prefix/non-packaged/$relativeAppsDir/simutrans/
+	ln -s $prefix/non-packaged/$relativeAppsDir/simutrans/config \
+		$appsDir/simutrans/config
+
+	addAppDeskbarSymlink $appsDir/simutrans/simutrans "Simutrans"
+}

--- a/games-simulation/simutrans/simutrans-120.4.1.recipe
+++ b/games-simulation/simutrans/simutrans-120.4.1.recipe
@@ -1,0 +1,96 @@
+SUMMARY="A transport simulation game"
+DESCRIPTION="Simutrans is a freeware and open-source transportation \
+simulator. Your goal is to establish a successful transport company. \
+Transport passengers, mail and goods by rail, road, ship, and even air. \
+Interconnect districts, cities, public buildings, industries and \
+tourist attractions by building a transport network you always dreamed \
+of."
+HOMEPAGE="http://www.simutrans.com"
+COPYRIGHT="1997-2004 Hj. Malthaner
+	2005-2018 The Simutrans Team"
+LICENSE="Artistic"
+REVISION="1"
+SvnRevision="8600"
+GitRevision="89498c762ffb8c709167a875b2de836af50f608e"
+SOURCE_URI="https://github.com/aburch/simutrans/archive/$GitRevision.tar.gz"
+CHECKSUM_SHA256="65ae302ca96aeb25e99b70908e814e82fa411e78143da5ae8a6ceb72d7ce8f9b"
+SOURCE_FILENAME="simutrans-$portVersion.tar.gz"
+SOURCE_DIR="simutrans-$GitRevision"
+PATCHES="simutrans-$portVersion.patchset"
+SOURCE_URI_2="https://downloads.sourceforge.net/project/simutrans/simutrans/120-4-1/simutrans-src-120-4-1.zip"
+CHECKSUM_SHA256_2="2cee0d067b3b72fa3a8b4ff31ad2bf5fc77521e7ba8cf9aa10e07e56b7dc877b"
+SOURCE_FILENAME_2="simutrans-sf-$portVersion.zip"
+SOURCE_DIR_2=""
+
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	simutrans$secondaryArchSuffix = $portVersion
+	app:simutrans$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	simutrans_pakset$secondaryArchSuffix >= 120.4
+	timgmsoundfont
+	lib:libbz2$secondaryArchSuffix
+	lib:libfreetype$secondaryArchSuffix
+	lib:libGL$secondaryArchSuffix
+	lib:libltdl$secondaryArchSuffix
+	lib:libminiupnpc$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
+	lib:libSDL2_2.0$secondaryArchSuffix
+	lib:libSDL2_mixer_2.0$secondaryArchSuffix
+	lib:libtxc_dxtn$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libbz2$secondaryArchSuffix
+	devel:libfreetype$secondaryArchSuffix
+	devel:libltdl$secondaryArchSuffix
+	devel:libminiupnpc$secondaryArchSuffix
+	devel:libpng16$secondaryArchSuffix
+	devel:libSDL2_2.0$secondaryArchSuffix
+	devel:libSDL2_mixer_2.0$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoreconf
+	cmd:g++$secondaryArchSuffix
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:sdl2_config$secondaryArchSuffix >= 2.0
+	cmd:strip$secondaryArchSuffix
+	"
+
+GLOBAL_WRITABLE_FILES="
+	non-packaged/$relativeAppsDir/simutrans/config directory keep-old
+	"
+
+BUILD()
+{
+	autoreconf configure.ac
+	export CFLAGS+=-DREVISION=$SvnRevision
+	runConfigure ./configure
+	make $jobArgs
+	strip sim
+}
+
+INSTALL()
+{
+	cp $sourceDir2/simutrans/text/*.tab simutrans/text/
+	cp sim simutrans/simutrans
+	mkdir -p $appsDir/simutrans
+	mkdir -p $prefix/non-packaged/$relativeAppsDir/simutrans/config
+	cp -r  simutrans $appsDir/
+	mv  $appsDir/simutrans/config \
+		$prefix/non-packaged/$relativeAppsDir/simutrans/
+	ln -s $prefix/non-packaged/$relativeAppsDir/simutrans/config \
+		$appsDir/simutrans/config
+
+	addAppDeskbarSymlink $appsDir/simutrans/simutrans "Simutrans"
+}

--- a/games-simulation/simutrans/simutrans-120.4~nightly.recipe
+++ b/games-simulation/simutrans/simutrans-120.4~nightly.recipe
@@ -10,7 +10,7 @@ bugs that will destroy your game, or not even run. They are for bug testing \
 only."
 HOMEPAGE="http://www.simutrans.com"
 COPYRIGHT="1997-2004 Hj. Malthaner
-	2005-2017 The Simutrans Team"
+	2005-2019 The Simutrans Team"
 LICENSE="Artistic"
 REVISION="1"
 SOURCE_URI="svn://servers.simutrans.org/simutrans/trunk"
@@ -30,20 +30,29 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	simutrans_pakset$secondaryArchSuffix >= 120.2
+	simutrans_pakset$secondaryArchSuffix >= 120.4
 	timgmsoundfont
 	lib:libbz2$secondaryArchSuffix
-	lib:libpng$secondaryArchSuffix
-	lib:libsdl$secondaryArchSuffix
-	lib:libsdl_mixer$secondaryArchSuffix
+	lib:libfreetype$secondaryArchSuffix
+	lib:libGL$secondaryArchSuffix
+	lib:libltdl$secondaryArchSuffix
+	lib:libminiupnpc$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
+	lib:libSDL2_2.0$secondaryArchSuffix
+	lib:libSDL2_mixer_2.0$secondaryArchSuffix
+	lib:libtxc_dxtn$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libbz2$secondaryArchSuffix
-	devel:libpng$secondaryArchSuffix
-	devel:libsdl$secondaryArchSuffix
+	devel:libfreetype$secondaryArchSuffix
+	devel:libltdl$secondaryArchSuffix
+	devel:libminiupnpc$secondaryArchSuffix
+	devel:libpng16$secondaryArchSuffix
+	devel:libSDL2_2.0$secondaryArchSuffix
+	devel:libSDL2_mixer_2.0$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
@@ -55,7 +64,7 @@ BUILD_PREREQUIRES="
 	cmd:ld$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:sdl_config$secondaryArchSuffix
+	cmd:sdl2_config$secondaryArchSuffix >= 2.0
 	cmd:strip$secondaryArchSuffix
 	cmd:svn
 	"

--- a/games-simulation/simutrans_pak128/simutrans_pak128-2.8.1.recipe
+++ b/games-simulation/simutrans_pak128/simutrans_pak128-2.8.1.recipe
@@ -8,48 +8,34 @@ When Simutrans could only support 64px size graphics, pak128 already \
 started. First pak to feature a complex economy and have a very wide \
 variety of objects. It contains roughly 7 time more graphics data than \
 pak64 and thus requires by far the largest amount of RAM and \
-processing power of all Simutrans sets.
-Nightly builds are versions only for debugging and testing. They may contain \
-changes which make your savegames unreadable by any official version, or \
-bugs that will destroy your game, or not even run. They are for bug testing \
-only."
+processing power of all Simutrans sets."
 HOMEPAGE="http://www.simutrans.com"
 COPYRIGHT="2004-2007 Tomas Kubes
-	2008-2017 The pak128-Team"
+	2008-2018 The pak128-Team"
 LICENSE="Artistic"
 REVISION="1"
-SOURCE_URI="svn+https://svn.code.sf.net/p/simutrans/code/pak128/"
-SOURCE_FILENAME="simupak_128-$portVersion"
-SOURCE_DIR=""
+SOURCE_URI="https://downloads.sourceforge.net/project/simutrans/pak128/pak128%20for%20ST%20120.4.1%20%282.8.1%2C%20priority%20signals%20%2B%20bugfix%29/pak128.zip"
+CHECKSUM_SHA256="bc17793e9d64c7f56e58bc050f6f8d59cac5deb46b9d90773af8fc0cf2f1017c"
+SOURCE_FILENAME="simupak_128-$portVersion.zip"
+SOURCE_DIR="simutrans"
 
-ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
-SECONDARY_ARCHITECTURES="?x86"
+ARCHITECTURES="any"
+DISABLE_SOURCE_PACKAGE="yes"
 
 GLOBAL_WRITABLE_FILES="
 	non-packaged/$relativeAppsDir/simutrans/pak128/config directory keep-old
 	"
 
 PROVIDES="
-	simutrans_pak128$secondaryArchSuffix = $portVersion
-	simutrans_pakset$secondaryArchSuffix = $portVersion compat >= 120.2
+	simutrans_pak128 = $portVersion
+	simutrans_pakset = 120.4 compat >= 120.4
 	"
-
-BUILD_PREREQUIRES="
-	cmd:makeobj$secondaryArchSuffix == 60.0
-	cmd:python
-	cmd:svn
-	"
-
-BUILD()
-{
-	python ./pakmak.py
-}
 
 INSTALL()
 {
 	mkdir -p $appsDir/simutrans
 	mkdir -p $prefix/non-packaged/$relativeAppsDir/simutrans/pak128/config
-	cp -r simutrans $appsDir/
+	cp -r pak128 $appsDir/simutrans/
 	mv $appsDir/simutrans/pak128/config \
 		$prefix/non-packaged/$relativeAppsDir/simutrans/pak128/
 	ln -s $prefix/non-packaged/$relativeAppsDir/simutrans/pak128/config \

--- a/games-simulation/simutrans_pak128/simutrans_pak128-2.8~nightly.recipe
+++ b/games-simulation/simutrans_pak128/simutrans_pak128-2.8~nightly.recipe
@@ -1,0 +1,57 @@
+SUMMARY="Pakset for Simutrans"
+DESCRIPTION="A 'pakset' is the data set that Simutrans needs to run: \
+it contains all the data for the graphics of individual items (vehicles, \
+roads, railways, buildings, etc.) and all of the balancing information \
+(such as prices, speeds, capacities and so forth) necessary to make \
+the game complete.
+When Simutrans could only support 64px size graphics, pak128 already \
+started. First pak to feature a complex economy and have a very wide \
+variety of objects. It contains roughly 7 time more graphics data than \
+pak64 and thus requires by far the largest amount of RAM and \
+processing power of all Simutrans sets.
+Nightly builds are versions only for debugging and testing. They may contain \
+changes which make your savegames unreadable by any official version, or \
+bugs that will destroy your game, or not even run. They are for bug testing \
+only."
+HOMEPAGE="http://www.simutrans.com"
+COPYRIGHT="2004-2007 Tomas Kubes
+	2008-2018 The pak128-Team"
+LICENSE="Artistic"
+REVISION="1"
+SOURCE_URI="svn+https://svn.code.sf.net/p/simutrans/code/pak128/"
+SOURCE_FILENAME="simupak_128-$portVersion"
+SOURCE_DIR=""
+
+ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
+SECONDARY_ARCHITECTURES="?x86"
+
+GLOBAL_WRITABLE_FILES="
+	non-packaged/$relativeAppsDir/simutrans/pak128/config directory keep-old
+	"
+
+PROVIDES="
+	simutrans_pak128$secondaryArchSuffix = $portVersion
+	simutrans_pakset$secondaryArchSuffix = $portVersion compat >= 120.4
+	"
+
+BUILD_PREREQUIRES="
+	cmd:makeobj$secondaryArchSuffix == 60.2
+	cmd:python
+	cmd:svn
+	"
+
+BUILD()
+{
+	python ./pakmak.py
+}
+
+INSTALL()
+{
+	mkdir -p $appsDir/simutrans
+	mkdir -p $prefix/non-packaged/$relativeAppsDir/simutrans/pak128/config
+	cp -r simutrans $appsDir/
+	mv $appsDir/simutrans/pak128/config \
+		$prefix/non-packaged/$relativeAppsDir/simutrans/pak128/
+	ln -s $prefix/non-packaged/$relativeAppsDir/simutrans/pak128/config \
+		$appsDir/simutrans/pak128/config
+}

--- a/games-simulation/simutrans_pak64/simutrans_pak64-120.3.recipe
+++ b/games-simulation/simutrans_pak64/simutrans_pak64-120.3.recipe
@@ -8,45 +8,28 @@ Pak64 is the main and a base set for Simutrans developed along with \
 Simutrans executable. It always contains the most recent features. It is \
 neatly painted pixel by pixel with motherly care. On the other hand it \
 might look too tiny on high resolution displays. Many artists contributed \
-to this pak set, from the 8 bit age on.
-Nightly builds are versions only for debugging and testing. They may contain \
-changes which make your savegames unreadable by any official version, or \
-bugs that will destroy your game, or not even run. They are for bug testing \
-only."
+to this pak set, from the 8 bit age on."
 HOMEPAGE="http://www.simutrans.com"
 COPYRIGHT="1997-2004 Hj. Malthaner
-	2005-2017 The Simutrans Team"
+	2005-2018 The Simutrans Team"
 LICENSE="Artistic"
-REVISION="2"
-SOURCE_URI="svn+https://svn.code.sf.net/p/simutrans/code/pak64/"
-SOURCE_FILENAME="simupak_64-$portVersion"
+REVISION="1"
+SOURCE_URI="https://downloads.sourceforge.net/project/simutrans/pak64/120-3/simupak64-120-3.zip"
+CHECKSUM_SHA256="332ff947fdddf99e0c9b67d857b1ffd02c91dfea1edc98f4195ec1f1309060f5"
+SOURCE_FILENAME="simupak_64-$portVersion.zip"
 SOURCE_DIR=""
 
-ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
-SECONDARY_ARCHITECTURES="?x86"
+ARCHITECTURES="any"
+DISABLE_SOURCE_PACKAGE="yes"
+
+PROVIDES="
+	simutrans_pak64 = $portVersion
+	simutrans_pakset = $portVersion compat >= 120.3
+	"
 
 GLOBAL_WRITABLE_FILES="
 	non-packaged/$relativeAppsDir/simutrans/pak/config directory keep-old
 	"
-
-PROVIDES="
-	simutrans_pak64$secondaryArchSuffix = $portVersion
-	simutrans_pakset$secondaryArchSuffix = $portVersion compat >= 120.2
-	"
-
-BUILD_PREREQUIRES="
-	cmd:find
-	cmd:make
-	cmd:makeobj$secondaryArchSuffix == 60.0
-	cmd:svn
-	cmd:zip
-	"
-
-BUILD()
-{
-	export MAKEOBJ=makeobj
-	make $jobArgs
-}
 
 INSTALL()
 {

--- a/games-simulation/simutrans_pak64/simutrans_pak64-120.4.1.recipe
+++ b/games-simulation/simutrans_pak64/simutrans_pak64-120.4.1.recipe
@@ -1,0 +1,43 @@
+SUMMARY="Pakset for Simutrans"
+DESCRIPTION="A 'pakset' is the data set that Simutrans needs to run: \
+it contains all the data for the graphics of individual items (vehicles, \
+roads, railways, buildings, etc.) and all of the balancing information \
+(such as prices, speeds, capacities and so forth) necessary to make \
+the game complete.
+Pak64 is the main and a base set for Simutrans developed along with \
+Simutrans executable. It always contains the most recent features. It is \
+neatly painted pixel by pixel with motherly care. On the other hand it \
+might look too tiny on high resolution displays. Many artists contributed \
+to this pak set, from the 8 bit age on."
+HOMEPAGE="http://www.simutrans.com"
+COPYRIGHT="1997-2004 Hj. Malthaner
+	2005-2018 The Simutrans Team"
+LICENSE="Artistic"
+REVISION="1"
+SOURCE_URI="https://downloads.sourceforge.net/project/simutrans/pak64/120-4-1/simupak64-120-4-1.zip"
+CHECKSUM_SHA256="fb46cde683ee1c0d10fb18bb2efc767583f1e9e76776a5f93d46a17d699aa69f"
+SOURCE_FILENAME="simupak_64-$portVersion.zip"
+SOURCE_DIR=""
+
+ARCHITECTURES="any"
+DISABLE_SOURCE_PACKAGE="yes"
+
+PROVIDES="
+	simutrans_pak64 = $portVersion
+	simutrans_pakset = $portVersion compat >= 120.4
+	"
+
+GLOBAL_WRITABLE_FILES="
+	non-packaged/$relativeAppsDir/simutrans/pak/config directory keep-old
+	"
+
+INSTALL()
+{
+	mkdir -p $appsDir/simutrans
+	mkdir -p $prefix/non-packaged/$relativeAppsDir/simutrans/pak/config
+	cp -r simutrans $appsDir/
+	mv $appsDir/simutrans/pak/config \
+		$prefix/non-packaged/$relativeAppsDir/simutrans/pak/
+	ln -s $prefix/non-packaged/$relativeAppsDir/simutrans/pak/config \
+		$appsDir/simutrans/pak/config
+}

--- a/games-simulation/simutrans_pak64/simutrans_pak64-120.4~nightly.recipe
+++ b/games-simulation/simutrans_pak64/simutrans_pak64-120.4~nightly.recipe
@@ -1,0 +1,60 @@
+SUMMARY="Pakset for Simutrans"
+DESCRIPTION="A 'pakset' is the data set that Simutrans needs to run: \
+it contains all the data for the graphics of individual items (vehicles, \
+roads, railways, buildings, etc.) and all of the balancing information \
+(such as prices, speeds, capacities and so forth) necessary to make \
+the game complete.
+Pak64 is the main and a base set for Simutrans developed along with \
+Simutrans executable. It always contains the most recent features. It is \
+neatly painted pixel by pixel with motherly care. On the other hand it \
+might look too tiny on high resolution displays. Many artists contributed \
+to this pak set, from the 8 bit age on.
+Nightly builds are versions only for debugging and testing. They may contain \
+changes which make your savegames unreadable by any official version, or \
+bugs that will destroy your game, or not even run. They are for bug testing \
+only."
+HOMEPAGE="http://www.simutrans.com"
+COPYRIGHT="1997-2004 Hj. Malthaner
+	2005-2018 The Simutrans Team"
+LICENSE="Artistic"
+REVISION="1"
+SOURCE_URI="svn+https://svn.code.sf.net/p/simutrans/code/pak64/"
+SOURCE_FILENAME="simupak_64-$portVersion"
+SOURCE_DIR=""
+
+ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
+SECONDARY_ARCHITECTURES="?x86"
+
+GLOBAL_WRITABLE_FILES="
+	non-packaged/$relativeAppsDir/simutrans/pak/config directory keep-old
+	"
+
+PROVIDES="
+	simutrans_pak64$secondaryArchSuffix = $portVersion
+	simutrans_pakset$secondaryArchSuffix = $portVersion compat >= 120.4
+	"
+
+BUILD_PREREQUIRES="
+	cmd:find
+	cmd:make
+	cmd:makeobj$secondaryArchSuffix == 60.2
+	cmd:svn
+	cmd:zip
+	"
+
+BUILD()
+{
+	export MAKEOBJ=makeobj
+	make $jobArgs
+}
+
+INSTALL()
+{
+	mkdir -p $appsDir/simutrans
+	mkdir -p $prefix/non-packaged/$relativeAppsDir/simutrans/pak/config
+	cp -r simutrans $appsDir/
+	mv $appsDir/simutrans/pak/config \
+		$prefix/non-packaged/$relativeAppsDir/simutrans/pak/
+	ln -s $prefix/non-packaged/$relativeAppsDir/simutrans/pak/config \
+		$appsDir/simutrans/pak/config
+}

--- a/games-util/makeobj/makeobj-60.1.recipe
+++ b/games-util/makeobj/makeobj-60.1.recipe
@@ -5,32 +5,33 @@ Makeobj joins both the image and the data files in a single \
 compressed pak-file that will then be read by the game engine."
 HOMEPAGE="http://www.simutrans.com"
 COPYRIGHT="1997-2004 Hj. Malthaner
-	2005-2017 The Simutrans Team"
+	2005-2018 The Simutrans Team"
 LICENSE="Artistic"
 REVISION="1"
-SOURCE_URI="svn://servers.simutrans.org/simutrans/trunk"
-SOURCE_FILENAME="makeobj-$portVersion"
-SOURCE_DIR=""
+GitRevision="a7b09e3b7af67d14a1602fa4ca809e94172d0db3"
+SOURCE_URI="https://github.com/aburch/simutrans/archive/$GitRevision.tar.gz"
+CHECKSUM_SHA256="4e1f418fe6efbd85af34176b5c75158943d2248c06366e566a2c91a94e4ace79"
+SOURCE_FILENAME="makeobj-$portVersion.tar.gz"
+SOURCE_DIR="simutrans-$GitRevision"
 
-ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
-SECONDARY_ARCHITECTURES="?x86"
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	makeobj$secondaryArchSuffix = $portVersion
-	cmd:makeobj$secondaryArchSuffix = 60.0
+	cmd:makeobj$secondaryArchSuffix = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libbz2$secondaryArchSuffix
-	lib:libpng$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
-
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libbz2$secondaryArchSuffix
-	devel:libpng$secondaryArchSuffix
-	devel:libsdl$secondaryArchSuffix
+	devel:libpng16$secondaryArchSuffix
+	devel:libSDL_1.2$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
@@ -41,9 +42,8 @@ BUILD_PREREQUIRES="
 	cmd:ld$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:sdl_config$secondaryArchSuffix
+	cmd:sdl_config$secondaryArchSuffix >= 1.2
 	cmd:strip$secondaryArchSuffix
-	cmd:svn
 	"
 
 BUILD()

--- a/games-util/makeobj/makeobj-60.2.recipe
+++ b/games-util/makeobj/makeobj-60.2.recipe
@@ -1,0 +1,61 @@
+SUMMARY="Tool for creating Simutrans paksets"
+DESCRIPTION="Makeobj is a tool for graphics/pakset developers \
+and is not needed for playing the game.
+Makeobj joins both the image and the data files in a single \
+compressed pak-file that will then be read by the game engine."
+HOMEPAGE="http://www.simutrans.com"
+COPYRIGHT="1997-2004 Hj. Malthaner
+	2005-2018 The Simutrans Team"
+LICENSE="Artistic"
+REVISION="1"
+GitRevision="27760d73138e1e059611577ccbc75fc9ab82f8d8"
+SOURCE_URI="https://github.com/aburch/simutrans/archive/$GitRevision.tar.gz"
+CHECKSUM_SHA256="084e5eec094f6d96212a8dd616d026caf5916febc58202af1c1f2802cedf8b5d"
+SOURCE_FILENAME="makeobj-$portVersion.tar.gz"
+SOURCE_DIR="simutrans-$GitRevision"
+
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	makeobj$secondaryArchSuffix = $portVersion
+	cmd:makeobj$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libbz2$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libbz2$secondaryArchSuffix
+	devel:libpng16$secondaryArchSuffix
+	devel:libSDL2_2.0$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoreconf
+	cmd:g++$secondaryArchSuffix
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:sdl2_config$secondaryArchSuffix >= 2.0
+	cmd:strip$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	autoreconf configure.ac
+	runConfigure ./configure
+	make makeobj $jobArgs
+	strip makeobj/makeobj
+}
+
+INSTALL()
+{
+	mkdir -p $binDir
+	cp -r makeobj/makeobj $binDir/
+}

--- a/games-util/makeobj/makeobj-60.2~nightly.recipe
+++ b/games-util/makeobj/makeobj-60.2~nightly.recipe
@@ -1,0 +1,61 @@
+SUMMARY="Tool for creating Simutrans paksets"
+DESCRIPTION="Makeobj is a tool for graphics/pakset developers \
+and is not needed for playing the game.
+Makeobj joins both the image and the data files in a single \
+compressed pak-file that will then be read by the game engine."
+HOMEPAGE="http://www.simutrans.com"
+COPYRIGHT="1997-2004 Hj. Malthaner
+	2005-2018 The Simutrans Team"
+LICENSE="Artistic"
+REVISION="1"
+SOURCE_URI="svn://servers.simutrans.org/simutrans/trunk"
+SOURCE_FILENAME="makeobj-$portVersion"
+SOURCE_DIR=""
+
+ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
+SECONDARY_ARCHITECTURES="?x86"
+
+PROVIDES="
+	makeobj$secondaryArchSuffix = $portVersion
+	cmd:makeobj$secondaryArchSuffix = 60.2
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libbz2$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libbz2$secondaryArchSuffix
+	devel:libpng16$secondaryArchSuffix
+	devel:libSDL2_2.0$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoreconf
+	cmd:g++$secondaryArchSuffix
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:sdl2_config$secondaryArchSuffix >= 2.0
+	cmd:strip$secondaryArchSuffix
+	cmd:svn
+	"
+
+BUILD()
+{
+	autoreconf configure.ac
+	runConfigure ./configure
+	make makeobj $jobArgs
+	strip makeobj/makeobj
+}
+
+INSTALL()
+{
+	mkdir -p $binDir
+	cp -r makeobj/makeobj $binDir/
+}

--- a/games-util/makeobj/makeobj-60.2~nightly.recipe
+++ b/games-util/makeobj/makeobj-60.2~nightly.recipe
@@ -41,7 +41,7 @@ BUILD_PREREQUIRES="
 	cmd:ld$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:sdl2_config$secondaryArchSuffix >= 2.0
+	cmd:sdl2_config$secondaryArchSuffix
 	cmd:strip$secondaryArchSuffix
 	cmd:svn
 	"


### PR DESCRIPTION
simutrans: fix compiling under Haiku, update to 120.3 (sdl) / 120.4.1 (sdl2)
pak64: update to 120.3 / 120.4.1
pak128: update to 2.8.1
makeobj: update to 60.1 (sdl) / 60.2 (sdl2)

I had to include patchsets due to a bug in a haiku specific section of the simutrans source code that made it impossible to build newer simutrans versions under haiku. I've opened a thread in the simutrans forum to report the bug. Since the bug (a missing ',' at the end of a line) will probably be fixed in a few days I haven't generated patchsets for the nightly recipes.