### PR TITLE
dev-lang/nim: update to 0.19.2

### DIFF
--- a/dev-lang/nim/nim-0.19.2_20190103.recipe
+++ b/dev-lang/nim/nim-0.19.2_20190103.recipe
@@ -13,12 +13,18 @@ COPYRIGHT="2006-2018 Andreas Rumpf
 	2017-2018 Nim contributors"
 LICENSE="MIT"
 REVISION="1"
-SOURCE_URI="https://github.com/nim-lang/Nim/archive/v$portVersion/nim-$portVersion.tar.gz"
-CHECKSUM_SHA256="f6a0b1c7bc227db1f7b8efa3bde0c6f23903c9184beebc99ff0094378c28e1ee"
-SOURCE_DIR="Nim-$portVersion"
-SOURCE_URI_2="https://github.com/nim-lang/csources/archive/v$portVersion.tar.gz"
+# TODO: switch to the official source at nim-lang.org for the next version
+csourceVersion="0.19.0"
+srcGitRev="1134f85faa55531a0eb5a3aff8f766299c1add52"
+SOURCE_URI="https://github.com/nim-lang/Nim/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="445ae79a8e1948c1782eac0d8ad43052f5b74bab5997e54e332dea32cb8c9de0"
+SOURCE_FILENAME="nim-$portVersion.tar.gz"
+SOURCE_DIR="Nim-$srcGitRev"
+PATCHES="nim-$portVersion.patchset"
+SOURCE_URI_2="https://github.com/nim-lang/csources/archive/v$csourceVersion.tar.gz"
 CHECKSUM_SHA256_2="68042afae0b24915acac813b52b9ee0a303219e990d3bfa05ca57fb6bbc51578"
-SOURCE_FILENAME_2="nim-csources-$portVersion.tar.gz"
+SOURCE_FILENAME_2="nim-csources-$csourceVersion.tar.gz"
+SOURCE_DIR_2="csources-$csourceVersion"
 ADDITIONAL_FILES="
 	config.nims
 	nim.rdef.in
@@ -28,7 +34,7 @@ ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
 if [ "$targetArchitecture" = "x86_gcc2" ]; then
 	# There is no point in having secondaryArch package except for gcc2.
 	# The compiler can already target different architectures effortlessly.
-	SECONDARY_ARCHITECTURES="?x86"
+	SECONDARY_ARCHITECTURES="x86"
 fi
 
 GLOBAL_WRITABLE_FILES="
@@ -57,8 +63,13 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	"
 
+PROVIDES_doc="
+	nim_doc = $portVersion
+	"
+
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	devel:libpcre$secondaryArchSuffix >= 1
 	"
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
@@ -67,17 +78,15 @@ BUILD_PREREQUIRES="
 TEST_REQUIRES="
 	lib:libcrypto$secondaryArchSuffix
 	lib:libgc$secondaryArchSuffix
-	lib:libpcre$secondaryArchSuffix >= 1
 	"
 
 BUILD()
 {
 	# Bootstrap
-	mkdir -p csources
-	cp -Trud "$sourceDir2/csources-$portVersion" csources
-	cd csources
+	pushd "$sourceDir2"
 	./build.sh
-	cd ..
+	cp bin/nim "$sourceDir/bin/nim"
+	popd
 
 	# Build
 	bin/nim c -d:release koch
@@ -86,11 +95,15 @@ BUILD()
 	bin/nim c -d:release -o:bin/nimsuggest nimsuggest/nimsuggest.nim
 	bin/nim c -d:release -o:bin/nimgrep tools/nimgrep.nim
 	bin/nim c -d:release -o:bin/nimpretty nimpretty/nimpretty.nim
+
+	# Docs
+	./koch docs
 }
 
 INSTALL()
 {
-	install -d -m 755 "$binDir" "$docDir" "$libDir" "$settingsDir"
+	install -d -m 755 "$binDir" "$docDir" "$libDir" "$settingsDir" \
+		"$developDocDir"
 	./koch install "$libDir"
 
 	install -t "$libDir/nim/bin" -m 755 bin/{nimsuggest,nimgrep,nimpretty}
@@ -101,18 +114,19 @@ INSTALL()
 
 	mv -T "$libDir/nim/doc" "$docDir"
 
-	complierPkgDir="$dataDir/nimble/pkgs/compiler-$portVersion"
+	complierPkgDir="$dataDir/nimble/pkgs/compiler-#$srcGitRev"
 	install -d -m 755 "$complierPkgDir"
 	mv -t "$complierPkgDir" "$libDir/nim"/compiler{,.nimble}
 	# Apparantly you need some files in docDir for the compiler sources to work
 	ln -s "$docDir" "$complierPkgDir/doc"
 
 	install -t "$settingsDir/nim" -m 644 "$portDir/additional-files/config.nims"
+	install -t "$developDocDir" -m 644 doc/html/*.html doc/html/*.js
 
 	# Add Haiku resources
-	local MAJOR="$(echo "${portVersion}" | cut -d. -f1)"
-	local MIDDLE="$(echo "${portVersion}" | cut -d. -f2)"
-	local MINOR="$(echo "${portVersion}" | cut -d. -f3)"
+	local MAJOR="$(echo ${portVersion%%_*} | cut -d. -f1)"
+	local MIDDLE="$(echo ${portVersion%%_*} | cut -d. -f2)"
+	local MINOR="$(echo ${portVersion%%_*} | cut -d. -f3)"
 	sed \
 		-e "s|@MAJOR@|$MAJOR|" \
 		-e "s|@MIDDLE@|$MIDDLE|" \
@@ -120,6 +134,8 @@ INSTALL()
 		"$portDir/additional-files/nim.rdef.in" > nim.rdef
 
 	addResourcesToBinaries nim.rdef "$libDir/nim/bin/nim"
+
+	packageEntries _doc "$developDir"
 }
 
 TEST()

--- a/dev-lang/nim/patches/nim-0.19.2_20190103.patchset
+++ b/dev-lang/nim/patches/nim-0.19.2_20190103.patchset
@@ -1,0 +1,24 @@
+From 1f75fa4b9c8b138585f13db094f3642f228c0ece Mon Sep 17 00:00:00 2001
+From: Leorize <leorize+oss@disroot.org>
+Date: Mon, 7 Jan 2019 08:42:27 +0000
+Subject: os.execShellCmd: use WEXITSTATUS to retrieve exit code
+
+According to POSIX, system() shall returns the termination status in the
+format specified by waitpid(), which means WEXITSTATUS should be used to
+retrieve the exit code portably.
+
+This fixes execShellCmd on Haiku.
+
+diff --git a/lib/pure/os.nim b/lib/pure/os.nim
+index 96833056a0..a218121ed1 100644
+--- a/lib/pure/os.nim
++++ b/lib/pure/os.nim
+@@ -1298,7 +1298,7 @@ proc execShellCmd*(command: string): int {.rtl, extern: "nos$1",
+   ## shell involved, use the `execProcess` proc of the `osproc`
+   ## module.
+   when defined(posix):
+-    result = c_system(command) shr 8
++    result = WEXITSTATUS(c_system(command))
+   else:
+     result = c_system(command)
+ 


### PR DESCRIPTION
A slightly newer version was used as it includes the walkDir fix for Haiku.

Documentations are now built and packaged as `_doc` subpackage.

Tested on `x86_64`. I'd assume that a lot of tests will fail on `x86_gcc2`, due to nim-lang/Nim#9138.