### PR TITLE
simutrans: fix build for gcc2hybrid

### DIFF
--- a/games-simulation/simutrans/simutrans-120.3.recipe
+++ b/games-simulation/simutrans/simutrans-120.3.recipe
@@ -31,7 +31,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	simutrans_pakset$secondaryArchSuffix >= 120.3
+	simutrans_pakset >= 120.3
 	timgmsoundfont
 	lib:libbz2$secondaryArchSuffix
 	lib:libfreetype$secondaryArchSuffix

--- a/games-simulation/simutrans/simutrans-120.4.1.recipe
+++ b/games-simulation/simutrans/simutrans-120.4.1.recipe
@@ -31,7 +31,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	simutrans_pakset$secondaryArchSuffix >= 120.4
+	simutrans_pakset >= 120.4
 	timgmsoundfont
 	lib:libbz2$secondaryArchSuffix
 	lib:libfreetype$secondaryArchSuffix


### PR DESCRIPTION
I forgot to remove the "$secondaryArchSuffix" for the corresponding pakset in the REQUIRES section after switching to platform agnostic "any" paksets for simutrans release recipes. This prevented the buildbots from compiling packages for gcc2hybrid. Nightlies are not affected because they still need to compile platform-specific paksets from source code.