### PR TITLE
openoriginpackage: update to v1.1.0

### DIFF
--- a/haiku-apps/openoriginpackage/openoriginpackage-1.1.0.recipe
+++ b/haiku-apps/openoriginpackage/openoriginpackage-1.1.0.recipe
@@ -1,15 +1,15 @@
 SUMMARY="A Tracker add-on to find the package a file originates from"
-DESCRIPTION="'Open Origin Package' is a Tracker Add-On that finds the \
+DESCRIPTION="'Open Origin Package' is a Tracker add-on that finds the \
 package(s) of any selected file(s) and opens it in the preferred application.
-By default that is HaikuDepot where you could uninstall the package, or look \
-at its description or the 'Contents' tab to see what other files are part of \
-that package and where they are."
+By default that is HaikuDepot where you can look at its description or the \
+'Contents' tab to see what other files are part of that package and where they \
+are."
 HOMEPAGE="https://github.com/humdingerb/OpenOriginPackage"
 COPYRIGHT="2019 Humdinger"
 LICENSE="MIT"
 REVISION="1"
 SOURCE_URI="$HOMEPAGE/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="69e8bccc0cea461144c9901535a0bd576a1a9d0bf9b386ca8a046298a9a555a7"
+CHECKSUM_SHA256="2afa6edae55b1c371c381ec359a477f3143efc565ad0dfd5095dc6ae1f13720a"
 SOURCE_DIR="OpenOriginPackage-$portVersion"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
@@ -38,5 +38,6 @@ BUILD()
 
 INSTALL()
 {
+	mkdir -p $addOnsDir
 	make install INSTALL_DIR=$addOnsDir/Tracker
 }


### PR DESCRIPTION
Very strange:  
"make" creates the binary "`Open Origin Package`", but in the package, the binary is named "`Open\ Origin\ Package`". The build process hasn't changed since v1.0.0 and the package in HaikuDepot shows the correct name.

@waddlesplash: Can this change of the makefile_engine be the issue?
https://git.haiku-os.org/haiku/commit/?id=f84c53e4acb4c8a9e4dadd4ce165ca3a126114b1
