### PR TITLE
GPXSee: bump to 7.2

### DIFF
--- a/sci-geosciences/gpxsee/additional-files/gpxsee.rdef.in
+++ b/sci-geosciences/gpxsee/additional-files/gpxsee.rdef.in
@@ -26,7 +26,8 @@ resource file_types message {
 	"types" = "application/vnd.nmea.nmea",
 	"types" = "application/vnd.oziexplorer.plt",
 	"types" = "application/vnd.oziexplorer.rte",
-	"types" = "application/vnd.oziexplorer.wpt"
+	"types" = "application/vnd.oziexplorer.wpt",
+	"types" = "application/geo+json"
 };
 
 resource vector_icon {

--- a/sci-geosciences/gpxsee/gpxsee-7.2.recipe
+++ b/sci-geosciences/gpxsee/gpxsee-7.2.recipe
@@ -1,12 +1,12 @@
 SUMMARY="GPS log file viewer and analyzer"
 DESCRIPTION="GPXSee is a Qt-based GPS log file viewer and analyzer that supports \
-GPX, TCX, KML, FIT, IGC, NMEA, SLF, LOC and OziExplorer files."
+all common GPS log file formats."
 HOMEPAGE="https://www.gpxsee.org/"
 COPYRIGHT="2015-2019 Martin Tůma"
 LICENSE="GNU GPL v3"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://github.com/tumic0/gpxsee/archive/$portVersion/GPXSee-$portVersion.tar.gz"
-CHECKSUM_SHA256="4f06fbed10629c0c32e2240cc6b8f34ff3c2f4063f0bdd23e084b74c5fe01ca0"
+CHECKSUM_SHA256="b26350f9ab7890c322c04951d3ae528c66d5cfea07cbb3f0688d83ec82ff6098"
 SOURCE_DIR="GPXSee-$portVersion"
 PATCHES="gpxsee-$portVersion.patchset"
 ADDITIONAL_FILES="
@@ -24,6 +24,7 @@ PROVIDES="
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libGL$secondaryArchSuffix
+	lib:libQt5Concurrent$secondaryArchSuffix
 	lib:libQt5Core$secondaryArchSuffix
 	lib:libQt5Gui$secondaryArchSuffix
 	lib:libQt5Network$secondaryArchSuffix
@@ -35,6 +36,7 @@ REQUIRES="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libGL$secondaryArchSuffix
+	devel:libQt5Concurrent$secondaryArchSuffix
 	devel:libQt5Core$secondaryArchSuffix
 	devel:libQt5Gui$secondaryArchSuffix
 	devel:libQt5Network$secondaryArchSuffix
@@ -66,7 +68,7 @@ INSTALL()
 {
 	mkdir -p $appsDir
 	mkdir -p $dataDir/GPXSee/{maps,csv,translations}
-	cp GPXSee $appsDir/
+	cp gpxsee $appsDir/GPXSee
 	cp -r pkg/maps/* $dataDir/GPXSee/maps
 	cp -r pkg/csv/* $dataDir/GPXSee/csv
 	cp -r lang/*.qm $dataDir/GPXSee/translations

--- a/sci-geosciences/gpxsee/patches/gpxsee-7.2.patchset
+++ b/sci-geosciences/gpxsee/patches/gpxsee-7.2.patchset
@@ -1,16 +1,16 @@
-From f7cf312a742231ce97d2042def45760b84fb4a1a Mon Sep 17 00:00:00 2001
+From fe04f0617bbc82466a473718b1643ea7e0548bf6 Mon Sep 17 00:00:00 2001
 From: Nikolay Korotkiy <sikmir@gmail.com>
-Date: Mon, 7 Jan 2019 22:29:26 +0300
+Date: Tue, 29 Jan 2019 03:17:45 +0300
 Subject: Fix APP_NAME
 
 
 diff --git a/src/GUI/app.cpp b/src/GUI/app.cpp
-index d9573da..f4c29ff 100644
+index 6f62d88..a642ca1 100644
 --- a/src/GUI/app.cpp
 +++ b/src/GUI/app.cpp
 @@ -21,7 +21,7 @@
- App::App(int &argc, char **argv) : QApplication(argc, argv),
-   _argc(argc), _argv(argv)
+ 
+ App::App(int &argc, char **argv) : QApplication(argc, argv)
  {
 -#if defined(Q_OS_WIN32) || defined(Q_OS_MAC)
 +#if defined(Q_OS_WIN32) || defined(Q_OS_MAC) || defined(Q_OS_HAIKU)
@@ -21,17 +21,17 @@ index d9573da..f4c29ff 100644
 2.19.1
 
 
-From 19b8fd90adea3d3d0a7bbcf6da031ffe011da7b2 Mon Sep 17 00:00:00 2001
+From 15b7e94410b3e5e6707e8e252c3ad56df63e80c6 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
-Date: Tue, 29 Jan 2019 18:04:38 +1000
+Date: Tue, 29 Jan 2019 13:24:49 +0300
 Subject: Dirty hack for fix crash on exit
 
 
 diff --git a/src/GUI/app.cpp b/src/GUI/app.cpp
-index f4c29ff..e396d8b 100644
+index a642ca1..250855a 100644
 --- a/src/GUI/app.cpp
 +++ b/src/GUI/app.cpp
-@@ -17,6 +17,9 @@
+@@ -18,6 +18,9 @@
  #include "settings.h"
  #include "app.h"
  
@@ -39,13 +39,12 @@ index f4c29ff..e396d8b 100644
 +#include <sys/types.h>
 +#include <signal.h>
  
- App::App(int &argc, char **argv) : QApplication(argc, argv),
-   _argc(argc), _argv(argv)
-@@ -81,8 +84,9 @@ int App::run()
- 	QStringList args(arguments());
+ App::App(int &argc, char **argv) : QApplication(argc, argv)
+ {
+@@ -82,7 +85,9 @@ int App::run()
  	for (int i = 1; i < args.count(); i++)
  		_gui->openFile(args.at(i));
--
+ 
 -	return exec();
 +	exec();
 +	kill(::getpid(), SIGKILL);


### PR DESCRIPTION
Update to version 7.2.

[Changelog](https://build.opensuse.org/package/view_file/home:tumic:GPXSee/gpxsee/gpxsee.changes):

>   * Added support for DEM data (SRTM HGT files).
>   * Improved look&feel in dark styles.
>   * Added support for polar stereographic projections + Antarctica
>     map.
>   * Added support for GeoJSON files.
>   * Added Spanish localization.