### PR TITLE
cppunit, 1.14.0 can't be build with gcc2

### DIFF
--- a/dev-util/cppunit/cppunit-1.14.0.recipe
+++ b/dev-util/cppunit/cppunit-1.14.0.recipe
@@ -10,11 +10,11 @@ COPYRIGHT="2000 Jerome Lacoste
 	2001-2002, 2007-2008 Steve Robbins
 	2012-2013 Harvey Brydon"
 LICENSE="GNU LGPL v2.1"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://dev-www.libreoffice.org/src/cppunit-$portVersion.tar.gz"
 CHECKSUM_SHA256="3d569869d27b48860210c758c4f313082103a5e58219a7669b52bfd29d674780"
 
-ARCHITECTURES="x86 x86_gcc2 x86_64"
+ARCHITECTURES="!x86 x86_gcc2 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 libVersion="0.0.0"
@@ -24,7 +24,7 @@ portVers="${portVersion%.*}"
 
 PROVIDES="
 	cppunit$secondaryArchSuffix = $portVersion
-	cmd:cppunit_config$secondaryArchSuffix = $portVersionCompat
+#	cmd:cppunit_config$secondaryArchSuffix = $portVersionCompat
 	cmd:DllPlugInTester$secondaryArchSuffix = $portVersionCompat
 	lib:libcppunit$secondaryArchSuffix = $libVersionCompat
 	lib:libcppunit_$portVers$secondaryArchSuffix = $libVersionCompat


### PR DESCRIPTION
Also, 1.14.0 uses pkg-config and doesn't provide cmd:cppunit_config anymore