### PR TITLE
boehm_gc: bump to 8.0.4

### DIFF
--- a/dev-libs/boehm_gc/boehm_gc-8.0.4.recipe
+++ b/dev-libs/boehm_gc/boehm_gc-8.0.4.recipe
@@ -20,14 +20,14 @@ COPYRIGHT="1988, 1989 Hans-J. Boehm, Alan J. Demers
 LICENSE="Boehm"
 REVISION="1"
 SOURCE_URI="https://github.com/ivmai/bdwgc/releases/download/v$portVersion/gc-$portVersion.tar.gz"
-CHECKSUM_SHA256="6cafac0d9365c2f8604f930aabd471145ac46ab6f771e835e57995964e845082"
+CHECKSUM_SHA256="436a0ddc67b1ac0b0405b61a9675bca9e075c8156f4debd1d06f3a56c7cd289d"
 SOURCE_DIR="gc-$portVersion"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
-libcordVersion=1.3.2
-libgcVersion=1.3.6
+libcordVersion=1.4.0
+libgcVersion=1.4.3
 libcordVersionCompat="$libcordVersion compat >= ${libcordVersion%%.*}"
 libgcVersionCompat="$libgcVersion compat >= ${libgcVersion%%.*}"
 portVersionCompat="$portVersion compat >= ${portVersion%%.*}"
@@ -72,8 +72,7 @@ defineDebugInfoPackage boehm_gc$secondaryArchSuffix \
 BUILD()
 {
 	autoreconf -vfi
-	runConfigure ./configure --enable-large-config \
-		--enable-parallel-mark
+	runConfigure ./configure --enable-large-config
 	make $jobArgs
 }
 


### PR DESCRIPTION
Update from v7.6.12 to v8.0.4
Remove --enable-parallel-mark which is default now