### PR TITLE
golang: Update patchset to enable bootstrapping.

### DIFF
--- a/dev-lang/golang/golang-1.4.3.recipe
+++ b/dev-lang/golang/golang-1.4.3.recipe
@@ -12,7 +12,7 @@ interpreted language."
 HOMEPAGE="https://golang.org/go"
 COPYRIGHT="2009-2018 The Go Authors"
 LICENSE="BSD (3-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://dl.google.com/go/go$portVersion.src.tar.gz"
 CHECKSUM_SHA256="9947fc705b0b841b5938c48b22dc33e9647ec0752bae66e50278df4f23f64959"
 SOURCE_DIR="go"
@@ -20,6 +20,10 @@ PATCHES="golang-$portVersion.patchset"
 
 ARCHITECTURES="!x86_gcc2 !x86 ?x86_64"
 SECONDARY_ARCHITECTURES="!x86"
+
+GLOBAL_WRITABLE_FILES="
+	non-packaged/lib/go directory keep-old
+	"
 
 PROVIDES="
 	golang$secondaryArchSuffix = $portVersion
@@ -50,7 +54,7 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	echo "$portVersion" > VERSION
-	export GOROOT_FINAL=/system/$relativeDevelopLibDir/go
+	export GOROOT_FINAL=$prefix/non-packaged/lib/go/
 	cd src
 	DISABLE_ASLR=1 ./make.bash
 	cd ..
@@ -60,10 +64,10 @@ BUILD()
 
 INSTALL()
 {
-	mkdir -p $developLibDir/go/
-	cp -r src pkg doc $developLibDir/go/
+	mkdir -p $prefix/non-packaged/lib/go/
+	cp -r src pkg doc $prefix/non-packaged/lib/go/
 	mkdir -p $binDir
-	cp bin/* $binDir/
+	cp bin/* $binDir
 }
 
 TEST()

--- a/dev-lang/golang/patches/golang-1.4.3.patchset
+++ b/dev-lang/golang/patches/golang-1.4.3.patchset
@@ -1,21 +1,9 @@
-From 709601cc4136cb49e4a6f3f1b2b90058b698d396 Mon Sep 17 00:00:00 2001
+From 4b3acaf327dcb3d5b6ffe35f4f82a4b8a8af9cb9 Mon Sep 17 00:00:00 2001
 From: Calvin Hill <calvin@hakobaito.co.uk>
-Date: Sun, 23 Sep 2018 00:55:04 +0100
-Subject: cmd/ld: Port cmd and ld to build on Haiku x86_64.
+Date: Mon, 29 Oct 2018 22:59:38 +0000
+Subject: cmd: build for Haiku amd64.
 
 
-diff --git a/include/link.h b/include/link.h
-index 05e117c..50c8120 100644
---- a/include/link.h
-+++ b/include/link.h
-@@ -495,6 +495,7 @@ enum {
- 	Hdragonfly,
- 	Helf,
- 	Hfreebsd,
-+	Hhaiku,
- 	Hlinux,
- 	Hnacl,
- 	Hnetbsd,
 diff --git a/src/cmd/5l/asm.c b/src/cmd/5l/asm.c
 index 9c1c04e..7af74ea 100644
 --- a/src/cmd/5l/asm.c
@@ -29,7 +17,7 @@ index 9c1c04e..7af74ea 100644
  char netbsddynld[] = "/libexec/ld.elf_so";
  char dragonflydynld[] = "XXX";
 diff --git a/src/cmd/6l/asm.c b/src/cmd/6l/asm.c
-index 18b5aa3..3936b83 100644
+index 18b5aa3..18b27cf 100644
 --- a/src/cmd/6l/asm.c
 +++ b/src/cmd/6l/asm.c
 @@ -41,6 +41,7 @@
@@ -57,22 +45,22 @@ index 18b5aa3..3936b83 100644
  		} else
  			return -1;
  		break;
-@@ -678,6 +687,7 @@ asmb(void)
+@@ -674,6 +683,7 @@ asmb(void)
+ 		break;
+ 	case Hlinux:
+ 	case Hfreebsd:
++	case Hhaiku:
+ 	case Hnetbsd:
  	case Hopenbsd:
  	case Hdragonfly:
- 	case Hsolaris:
-+	case Hhaiku:
- 		debug['8'] = 1;	/* 64-bit addresses */
- 		break;
- 	case Hnacl:
-@@ -710,6 +720,7 @@ asmb(void)
- 		case Hdragonfly:
- 		case Hsolaris:
- 		case Hnacl:
-+		case Hhaiku:
- 			symo = segdata.fileoff+segdata.filelen;
- 			symo = rnd(symo, INITRND);
+@@ -705,6 +715,7 @@ asmb(void)
  			break;
+ 		case Hlinux:
+ 		case Hfreebsd:
++		case Hhaiku:
+ 		case Hnetbsd:
+ 		case Hopenbsd:
+ 		case Hdragonfly:
 @@ -787,6 +798,7 @@ asmb(void)
  		break;
  	case Hlinux:
@@ -198,30 +186,6 @@ index 523ba37..bb954fc 100644
  		flag_largemodel = 1;
  
  	setexp();
-diff --git a/src/cmd/go/build.go b/src/cmd/go/build.go
-index 1dd4314..d13d0a7 100644
---- a/src/cmd/go/build.go
-+++ b/src/cmd/go/build.go
-@@ -2118,6 +2118,10 @@ func (b *builder) ccompilerCmd(envvar, defcmd, objdir string) []string {
- 		a = append(a, "-fno-common")
- 	}
- 
-+	if goos == "haiku" {
-+		a = append(a, "-Wl, -Bsymbolic")
-+	}
-+
- 	return a
- }
- 
-@@ -2381,6 +2385,8 @@ func (b *builder) cgo(p *Package, cgoExe, obj string, pcCFLAGS, pcLDFLAGS, gccfi
- 	switch goos {
- 	case "android", "dragonfly", "linux", "netbsd":
- 		ldflags = append(ldflags, "-Wl,--build-id=none")
-+	case "haiku":
-+		ldflags = append(ldflags, "-fPIC")
- 	}
- 
- 	if err := b.gccld(p, ofile, ldflags, gccObjs); err != nil {
 diff --git a/src/cmd/go/signal_unix.go b/src/cmd/go/signal_unix.go
 index e86cd46..9e2fe0e 100644
 --- a/src/cmd/go/signal_unix.go
@@ -276,7 +240,7 @@ index 6184754..d8168a3 100644
  		sect->align = PtrSize;
  		sect->vaddr = 0;
 diff --git a/src/cmd/ld/elf.c b/src/cmd/ld/elf.c
-index 3196961..e4d1489 100644
+index 3196961..b34a227 100644
 --- a/src/cmd/ld/elf.c
 +++ b/src/cmd/ld/elf.c
 @@ -911,7 +911,7 @@ doelf(void)
@@ -316,15 +280,6 @@ index 3196961..e4d1489 100644
  		sh = elfshname(".tbss");
  		sh->type = SHT_NOBITS;
  		sh->addralign = RegSize;
-@@ -1484,6 +1487,8 @@ elfobj:
- 		eh->ident[EI_OSABI] = ELFOSABI_OPENBSD;
- 	else if(HEADTYPE == Hdragonfly)
- 		eh->ident[EI_OSABI] = ELFOSABI_NONE;
-+	else if(HEADTYPE == Hhaiku)
-+		eh->ident[EI_OSABI] = ELFOSABI_NONE;
- 	if(elf64)
- 		eh->ident[EI_CLASS] = ELFCLASS64;
- 	else
 diff --git a/src/cmd/ld/elf.h b/src/cmd/ld/elf.h
 index e84d996..3796967 100644
 --- a/src/cmd/ld/elf.h
@@ -338,7 +293,7 @@ index e84d996..3796967 100644
  extern char openbsddynld[];
  extern char dragonflydynld[];
 diff --git a/src/cmd/ld/lib.c b/src/cmd/ld/lib.c
-index f889aba..6e68e6d 100644
+index f889aba..abfd4b7 100644
 --- a/src/cmd/ld/lib.c
 +++ b/src/cmd/ld/lib.c
 @@ -208,7 +208,9 @@ loadlib(void)
@@ -361,17 +316,7 @@ index f889aba..6e68e6d 100644
  		debug['d'] = 1;
  	
  	importcycles();
-@@ -609,6 +611,9 @@ hostlink(void)
- 		argv[argc++] = "-Wl,-no_pie,-pagezero_size,4000000";
- 	if(HEADTYPE == Hopenbsd)
- 		argv[argc++] = "-Wl,-nopie";
-+
-+	if(HEADTYPE == Hhaiku)
-+		argv[argc++] = "-fPIC";
- 	
- 	if(iself && AssumeGoldLinker)
- 		argv[argc++] = "-Wl,--rosegment";
-@@ -622,10 +627,13 @@ hostlink(void)
+@@ -622,6 +624,9 @@ hostlink(void)
  	
  	if(rpath)
  		argv[argc++] = smprint("-Wl,-rpath,%s", rpath);
@@ -381,11 +326,6 @@ index f889aba..6e68e6d 100644
  
  	// Force global symbols to be exported for dlopen, etc.
  	if(iself)
--		argv[argc++] = "-rdynamic";
-+		// argv[argc++] = "-rdynamic";
- 
- 	if(strstr(argv[0], "clang") != nil)
- 		argv[argc++] = "-Qunused-arguments";
 diff --git a/src/cmd/ld/pobj.c b/src/cmd/ld/pobj.c
 index 63460df..4e8152e 100644
 --- a/src/cmd/ld/pobj.c
@@ -413,39 +353,15 @@ index 156270c..53e9160 100644
  		if(s->sect == nil) {
  			ctxt->cursym = nil;
 -- 
-2.19.0
+2.19.1
 
 
-From 1aa9823a966a0e04513fe2293d55046e516a7d4a Mon Sep 17 00:00:00 2001
+From 3da5197df7c37a612a066acde216bef71406a033 Mon Sep 17 00:00:00 2001
 From: Calvin Hill <calvin@hakobaito.co.uk>
-Date: Sun, 23 Sep 2018 00:55:40 +0100
-Subject: lib9/liblink: Add Haiku to the syslist and build lib9 and liblink.
+Date: Mon, 29 Oct 2018 23:01:38 +0000
+Subject: lib9: get lib9 building
 
 
-diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index b74595e..61641e4 100644
---- a/src/go/build/deps_test.go
-+++ b/src/go/build/deps_test.go
-@@ -361,7 +361,7 @@ func allowed(pkg string) map[string]bool {
- }
- 
- var bools = []bool{false, true}
--var geese = []string{"android", "darwin", "dragonfly", "freebsd", "linux", "nacl", "netbsd", "openbsd", "plan9", "solaris", "windows"}
-+var geese = []string{"android", "darwin", "dragonfly", "freebsd", "haiku", "linux", "nacl", "netbsd", "openbsd", "plan9", "solaris", "windows"}
- var goarches = []string{"386", "amd64", "arm"}
- 
- type osPkg struct {
-diff --git a/src/go/build/syslist.go b/src/go/build/syslist.go
-index 965f873..4d5906f 100644
---- a/src/go/build/syslist.go
-+++ b/src/go/build/syslist.go
-@@ -4,5 +4,5 @@
- 
- package build
- 
--const goosList = "android darwin dragonfly freebsd linux nacl netbsd openbsd plan9 solaris windows "
-+const goosList = "android darwin dragonfly haiku freebsd linux nacl netbsd openbsd plan9 solaris windows "
- const goarchList = "386 amd64 amd64p32 arm "
 diff --git a/src/lib9/run_unix.c b/src/lib9/run_unix.c
 index 1acaefe..6c32872 100644
 --- a/src/lib9/run_unix.c
@@ -460,7 +376,7 @@ index 1acaefe..6c32872 100644
  #include <u.h>
  #include <errno.h>
 diff --git a/src/lib9/tempdir_unix.c b/src/lib9/tempdir_unix.c
-index 269d538..8fda14e 100644
+index 269d538..f4fa6dc 100644
 --- a/src/lib9/tempdir_unix.c
 +++ b/src/lib9/tempdir_unix.c
 @@ -2,7 +2,7 @@
@@ -472,19 +388,29 @@ index 269d538..8fda14e 100644
  
  #include <u.h>
  #include <dirent.h>
-@@ -17,7 +17,11 @@ mktempdir(void)
+@@ -17,8 +17,11 @@ mktempdir(void)
  	
  	tmp = getenv("TMPDIR");
  	if(tmp == nil || strlen(tmp) == 0)
--		tmp = "/var/tmp";
 +#ifdef __HAIKU__
-+	tmp = "/boot/system/cache/tmp";
++		tmp = "/tmp";
 +#else
-+	tmp = "/var/tmp";
-+#endif
- 	p = smprint("%s/go-link-XXXXXX", tmp);
+ 		tmp = "/var/tmp";
+-	p = smprint("%s/go-link-XXXXXX", tmp);
++#endif	p = smprint("%s/go-link-XXXXXX", tmp);
  	if(mkdtemp(p) == nil)
  		return nil;
+ 	return p;
+-- 
+2.19.1
+
+
+From ac70c1ca0c29b6c4d7380c6785dcf6adca297fa3 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Mon, 29 Oct 2018 23:04:06 +0000
+Subject: liblink: get liblink building on Haiku
+
+
 diff --git a/src/liblink/asm6.c b/src/liblink/asm6.c
 index 428eb94..44c0ec1 100644
 --- a/src/liblink/asm6.c
@@ -535,7 +461,7 @@ index 2acfd2f..2d699b7 100644
  	case Hwindows:
  		return 0;
 diff --git a/src/liblink/sym.c b/src/liblink/sym.c
-index bd85518..6e9aead 100644
+index bd85518..acda518 100644
 --- a/src/liblink/sym.c
 +++ b/src/liblink/sym.c
 @@ -48,6 +48,7 @@ static struct {
@@ -546,29 +472,73 @@ index bd85518..6e9aead 100644
  	{"freebsd",	Hfreebsd},
  	{"linux",	Hlinux},
  	{"nacl",		Hnacl},
-@@ -130,6 +131,13 @@ linknew(LinkArch *arch)
+@@ -130,6 +131,12 @@ linknew(LinkArch *arch)
  	case Hplan9:
  	case Hwindows:
  		break;
-+	case Hhaiku:
-+ 		/* FIXME */
-+		// // on 64-bit we use the last two regular TLS slots
-+		 if(ctxt->arch->thechar == '6') {
-+		 	ctxt->tlsoffset = (64 - 2) * 8;
-+		 }
++	case Hhaiku: /* FIXME */
++		// on 64-bit we use the last two regular TLS slots
++		if(ctxt->arch->thechar == '6') {
++			ctxt->tlsoffset = (64 - 2) * 8;
++		}
 +		break;
  	case Hlinux:
  	case Hfreebsd:
  	case Hnetbsd:
 -- 
-2.19.0
+2.19.1
 
 
-From 91c5e8374435ecf60f410d90688acaff69b29e93 Mon Sep 17 00:00:00 2001
+From ba8a8ba6eb058d84bc0923fdbe884dfed44a3b65 Mon Sep 17 00:00:00 2001
 From: Calvin Hill <calvin@hakobaito.co.uk>
-Date: Sun, 23 Sep 2018 00:56:26 +0100
-Subject: runtime: Add early Haiku x86_64 support. Derived mostly from Solaris
- port.
+Date: Mon, 29 Oct 2018 23:04:58 +0000
+Subject: go: Add strings to syslist for Haiku
+
+
+diff --git a/include/link.h b/include/link.h
+index 05e117c..50c8120 100644
+--- a/include/link.h
++++ b/include/link.h
+@@ -495,6 +495,7 @@ enum {
+ 	Hdragonfly,
+ 	Helf,
+ 	Hfreebsd,
++	Hhaiku,
+ 	Hlinux,
+ 	Hnacl,
+ 	Hnetbsd,
+diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
+index b74595e..61641e4 100644
+--- a/src/go/build/deps_test.go
++++ b/src/go/build/deps_test.go
+@@ -361,7 +361,7 @@ func allowed(pkg string) map[string]bool {
+ }
+ 
+ var bools = []bool{false, true}
+-var geese = []string{"android", "darwin", "dragonfly", "freebsd", "linux", "nacl", "netbsd", "openbsd", "plan9", "solaris", "windows"}
++var geese = []string{"android", "darwin", "dragonfly", "freebsd", "haiku", "linux", "nacl", "netbsd", "openbsd", "plan9", "solaris", "windows"}
+ var goarches = []string{"386", "amd64", "arm"}
+ 
+ type osPkg struct {
+diff --git a/src/go/build/syslist.go b/src/go/build/syslist.go
+index 965f873..4d5906f 100644
+--- a/src/go/build/syslist.go
++++ b/src/go/build/syslist.go
+@@ -4,5 +4,5 @@
+ 
+ package build
+ 
+-const goosList = "android darwin dragonfly freebsd linux nacl netbsd openbsd plan9 solaris windows "
++const goosList = "android darwin dragonfly haiku freebsd linux nacl netbsd openbsd plan9 solaris windows "
+ const goarchList = "386 amd64 amd64p32 arm "
+-- 
+2.19.1
+
+
+From 182ec679bfe70d93bb48378acbcf5c123c98c230 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Mon, 29 Oct 2018 23:06:29 +0000
+Subject: runtime: Add initial Haiku definitions to relevant packages
 
 
 diff --git a/src/runtime/asm_amd64.s b/src/runtime/asm_amd64.s
@@ -598,6 +568,191 @@ index 7fd9146..5e58db5 100644
  		gothrow("cgocall unavailable")
  	}
  
+diff --git a/src/runtime/env_posix.go b/src/runtime/env_posix.go
+index dd57872..ef9c294 100644
+--- a/src/runtime/env_posix.go
++++ b/src/runtime/env_posix.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris windows
++// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris windows
+ 
+ package runtime
+ 
+diff --git a/src/runtime/lock_sema.go b/src/runtime/lock_sema.go
+index d136b82..0604f13 100644
+--- a/src/runtime/lock_sema.go
++++ b/src/runtime/lock_sema.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin nacl netbsd openbsd plan9 solaris windows
++// +build darwin haiku nacl netbsd openbsd plan9 solaris windows
+ 
+ package runtime
+ 
+@@ -200,7 +200,9 @@ func notetsleep_internal(n *note, ns int64, gp *g, deadline int64) bool {
+ 	for {
+ 		// Registered.  Sleep.
+ 		gp.m.blocked = true
+-		if semasleep(ns) >= 0 {
++		// HACK for Haiku support.
++		if semasleep(deadline) >= 0 {
++			//if semasleep(ns) >= 0 {
+ 			gp.m.blocked = false
+ 			// Acquired semaphore, semawakeup unregistered us.
+ 			// Done.
+diff --git a/src/runtime/mheap.c b/src/runtime/mheap.c
+index bb203d5..67de821 100644
+--- a/src/runtime/mheap.c
++++ b/src/runtime/mheap.c
+@@ -608,6 +608,8 @@ scavengelist(MSpan *list, uint64 now, uint64 limit)
+ void
+ runtime·MHeap_Scavenge(int32 k, uint64 now, uint64 limit)
+ {
++	//HACK: Disable GC for Haiku
++	/*
+ 	uint32 i;
+ 	uintptr sumreleased;
+ 	MHeap *h;
+@@ -629,6 +631,7 @@ runtime·MHeap_Scavenge(int32 k, uint64 now, uint64 limit)
+ 			k, mstats.heap_inuse>>20, mstats.heap_idle>>20, mstats.heap_sys>>20,
+ 			mstats.heap_released>>20, (mstats.heap_sys - mstats.heap_released)>>20);
+ 	}
++	*/
+ }
+ 
+ void
+diff --git a/src/runtime/pprof/pprof_test.go b/src/runtime/pprof/pprof_test.go
+index 8677cb3..3da28f9 100644
+--- a/src/runtime/pprof/pprof_test.go
++++ b/src/runtime/pprof/pprof_test.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build !nacl
++// +build !haiku !nacl
+ 
+ package pprof_test
+ 
+diff --git a/src/runtime/proc.c b/src/runtime/proc.c
+index 8462c4b..d8377ac 100644
+--- a/src/runtime/proc.c
++++ b/src/runtime/proc.c
+@@ -902,7 +902,7 @@ runtime·allocm(P *p)
+ 
+ 	// In case of cgo or Solaris, pthread_create will make us a stack.
+ 	// Windows and Plan 9 will layout sched stack on OS stack.
+-	if(runtime·iscgo || Solaris || Windows || Plan9)
++	if(runtime·iscgo || Haiku || Solaris || Windows || Plan9)
+ 		mp->g0 = runtime·malg(-1);
+ 	else
+ 		mp->g0 = runtime·malg(8192);
+diff --git a/src/runtime/runtime.c b/src/runtime/runtime.c
+index c823691..25408c3 100644
+--- a/src/runtime/runtime.c
++++ b/src/runtime/runtime.c
+@@ -80,6 +80,7 @@ runtime·args(int32 c, uint8 **v)
+ 		runtime·sysargs(c, v);
+ }
+ 
++int32 runtime·ishaiku;
+ int32 runtime·isplan9;
+ int32 runtime·issolaris;
+ int32 runtime·iswindows;
+diff --git a/src/runtime/runtime.h b/src/runtime/runtime.h
+index 177a128..c24d5d9 100644
+--- a/src/runtime/runtime.h
++++ b/src/runtime/runtime.h
+@@ -392,6 +392,19 @@ struct	M
+ 		uintptr v[6];
+ 	} scratch;
+ #endif
++#ifdef GOOS_haiku
++	int32*	perrno; 	// pointer to TLS errno
++	// these are here because they are too large to be on the stack
++	// of low-level NOSPLIT functions.
++	LibCall	libcall;
++	struct MTs {
++		int64	tv_sec;
++		int64	tv_nsec;
++	} ts;
++	struct MScratch {
++		uintptr v[6];
++	} scratch;
++#endif
+ #ifdef GOOS_plan9
+ 	int8*	notesig;
+ 	byte*	errstr;
+@@ -559,6 +572,15 @@ enum {
+    Solaris = 0
+ };
+ #endif
++#ifdef GOOS_haiku
++enum {
++   Haiku = 1
++};
++#else
++enum {
++   Haiku = 0
++};
++#endif
+ #ifdef GOOS_plan9
+ enum {
+    Plan9 = 1
+diff --git a/src/runtime/signal_amd64x.c b/src/runtime/signal_amd64x.c
+index feb4afc..26d0680 100644
+--- a/src/runtime/signal_amd64x.c
++++ b/src/runtime/signal_amd64x.c
+@@ -3,7 +3,7 @@
+ // license that can be found in the LICENSE file.
+ 
+ // +build amd64 amd64p32
+-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris
+ 
+ #include "runtime.h"
+ #include "defs_GOOS_GOARCH.h"
+diff --git a/src/runtime/signal_unix.go b/src/runtime/signal_unix.go
+index ba77b6e..f75eb92 100644
+--- a/src/runtime/signal_unix.go
++++ b/src/runtime/signal_unix.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
+ 
+ package runtime
+ 
+diff --git a/src/runtime/sigpanic_unix.go b/src/runtime/sigpanic_unix.go
+index 6807985..5cd9a2a 100644
+--- a/src/runtime/sigpanic_unix.go
++++ b/src/runtime/sigpanic_unix.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
+ 
+ package runtime
+ 
+-- 
+2.19.1
+
+
+From a08b9cba21ee1a00629e8808c0b117ab60922207 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Mon, 29 Oct 2018 23:07:50 +0000
+Subject: runtime: Add Haiku specific patches for building runtime
+
+
 diff --git a/src/runtime/defs_haiku.go b/src/runtime/defs_haiku.go
 new file mode 100644
 index 0000000..d0ea4fe
@@ -1014,43 +1169,6 @@ index 0000000..fd4f2bf
 +
 +
 +#pragma pack off
-diff --git a/src/runtime/env_posix.go b/src/runtime/env_posix.go
-index dd57872..ef9c294 100644
---- a/src/runtime/env_posix.go
-+++ b/src/runtime/env_posix.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris windows
-+// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris windows
- 
- package runtime
- 
-diff --git a/src/runtime/lock_sema.go b/src/runtime/lock_sema.go
-index d136b82..0604f13 100644
---- a/src/runtime/lock_sema.go
-+++ b/src/runtime/lock_sema.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin nacl netbsd openbsd plan9 solaris windows
-+// +build darwin haiku nacl netbsd openbsd plan9 solaris windows
- 
- package runtime
- 
-@@ -200,7 +200,9 @@ func notetsleep_internal(n *note, ns int64, gp *g, deadline int64) bool {
- 	for {
- 		// Registered.  Sleep.
- 		gp.m.blocked = true
--		if semasleep(ns) >= 0 {
-+		// HACK for Haiku support.
-+		if semasleep(deadline) >= 0 {
-+			//if semasleep(ns) >= 0 {
- 			gp.m.blocked = false
- 			// Acquired semaphore, semawakeup unregistered us.
- 			// Done.
 diff --git a/src/runtime/mem_haiku.c b/src/runtime/mem_haiku.c
 new file mode 100644
 index 0000000..0d59b5d
@@ -1217,75 +1335,12 @@ index 0000000..0d59b5d
 +	if(p != v)
 +		runtime·throw("runtime: cannot map pages in arena address space");
 +}
-diff --git a/src/runtime/mheap.c b/src/runtime/mheap.c
-index bb203d5..67de821 100644
---- a/src/runtime/mheap.c
-+++ b/src/runtime/mheap.c
-@@ -608,6 +608,8 @@ scavengelist(MSpan *list, uint64 now, uint64 limit)
- void
- runtime·MHeap_Scavenge(int32 k, uint64 now, uint64 limit)
- {
-+	//HACK: Disable GC for Haiku
-+	/*
- 	uint32 i;
- 	uintptr sumreleased;
- 	MHeap *h;
-@@ -629,6 +631,7 @@ runtime·MHeap_Scavenge(int32 k, uint64 now, uint64 limit)
- 			k, mstats.heap_inuse>>20, mstats.heap_idle>>20, mstats.heap_sys>>20,
- 			mstats.heap_released>>20, (mstats.heap_sys - mstats.heap_released)>>20);
- 	}
-+	*/
- }
- 
- void
-diff --git a/src/runtime/netpoll.go b/src/runtime/netpoll.go
-index 3456e02..1b69e8a 100644
---- a/src/runtime/netpoll.go
-+++ b/src/runtime/netpoll.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris windows
-+// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris windows
- 
- package runtime
- 
-diff --git a/src/runtime/netpoll_haiku.go b/src/runtime/netpoll_haiku.go
-new file mode 100644
-index 0000000..e003d8e
---- /dev/null
-+++ b/src/runtime/netpoll_haiku.go
-@@ -0,0 +1,23 @@
-+// Copyright 2013 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+package runtime
-+
-+func netpollinit() {
-+}
-+
-+func netpollopen(fd uintptr, pd *pollDesc) int32 {
-+	return 0
-+}
-+
-+func netpollclose(fd uintptr) int32 {
-+	return 0
-+}
-+
-+func netpollarm(pd *pollDesc, mode int) {
-+}
-+
-+func netpoll(block bool) *g {
-+	return nil
-+}
 diff --git a/src/runtime/os_haiku.c b/src/runtime/os_haiku.c
 new file mode 100644
-index 0000000..3180fa5
+index 0000000..188c0ea
 --- /dev/null
 +++ b/src/runtime/os_haiku.c
-@@ -0,0 +1,595 @@
+@@ -0,0 +1,583 @@
 +// Copyright 2011 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -1668,42 +1723,36 @@ index 0000000..3180fa5
 +		runtime·throw("sem_post");
 +}
 +
-+#pragma textflag NOSPLIT
 +int32
 +runtime·close(int32 fd)
 +{
 +	return runtime·sysvicall1(FUNC(libc·close), (uintptr)fd);
 +}
 +
-+#pragma textflag NOSPLIT
 +void
 +runtime·exit(int32 r)
 +{
 +	runtime·sysvicall1(FUNC(libc·exit), (uintptr)r);
 +}
 +
-+#pragma textflag NOSPLIT
 +/* int32 */ void
 +runtime·getcontext(Ucontext* context)
 +{
 +	runtime·sysvicall1(FUNC(libc·getcontext), (uintptr)context);
 +}
 +
-+#pragma textflag NOSPLIT
 +int32
 +runtime·getrlimit(int32 res, Rlimit* rlp)
 +{
 +	return runtime·sysvicall2(FUNC(libc·getrlimit), (uintptr)res, (uintptr)rlp);
 +}
 +
-+#pragma textflag NOSPLIT
 +uint8*
 +runtime·mmap(byte* addr, uintptr len, int32 prot, int32 flags, int32 fildes, uint32 off)
 +{
 +	return (uint8*)runtime·sysvicall6(FUNC(libc·mmap), (uintptr)addr, (uintptr)len, (uintptr)prot, (uintptr)flags, (uintptr)fildes, (uintptr)off);
 +}
 +
-+#pragma textflag NOSPLIT
 +void
 +runtime·munmap(byte* addr, uintptr len)
 +{
@@ -1726,7 +1775,6 @@ index 0000000..3180fa5
 +	return (m->libcall.r1 * 1000000000LL) + m->libcall.r2;
 +}
 +
-+// #pragma textflag NOSPLIT
 +// void
 +// time·now(int64 sec, int32 usec)
 +// {
@@ -1739,7 +1787,6 @@ index 0000000..3180fa5
 +// 	FLUSH(&usec);
 +// }
 +
-+#pragma textflag NOSPLIT
 +int32
 +runtime·open(int8* path, int32 oflag, int32 mode)
 +{
@@ -1788,7 +1835,6 @@ index 0000000..3180fa5
 +	runtime·sysvicall1(FUNC(libc·raise), (uintptr)sig);
 +}
 +
-+#pragma textflag NOSPLIT
 +int32
 +runtime·read(int32 fd, void* buf, int32 nbyte)
 +{
@@ -1846,21 +1892,18 @@ index 0000000..3180fa5
 +	return runtime·sysvicall1(FUNC(libc·sysconf), (uintptr)name);
 +}
 +
-+#pragma textflag NOSPLIT
 +void
 +runtime·usleep(uint32 us)
 +{
 +	runtime·sysvicall1(FUNC(libc·usleep), (uintptr)us);
 +}
 +
-+#pragma textflag NOSPLIT
 +int32
 +runtime·write(uintptr fd, void* buf, int32 nbyte)
 +{
 +	return runtime·sysvicall3(FUNC(libc·write), (uintptr)fd, (uintptr)buf, (uintptr)nbyte);
 +}
 +
-+#pragma textflag NOSPLIT
 +void
 +runtime·osyield(void)
 +{
@@ -2040,35 +2083,9 @@ index 0000000..b611b13
 +uintptr	runtime·sysvicall6(uintptr fn, uintptr a1, uintptr a2, uintptr a3, uintptr a4, uintptr a5, uintptr a6);
 +void	runtime·asmsysvicall6(void *c);
 +void	runtime·miniterrno(void *fn);
-diff --git a/src/runtime/pprof/pprof_test.go b/src/runtime/pprof/pprof_test.go
-index 8677cb3..3da28f9 100644
---- a/src/runtime/pprof/pprof_test.go
-+++ b/src/runtime/pprof/pprof_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build !nacl
-+// +build !haiku !nacl
- 
- package pprof_test
- 
-diff --git a/src/runtime/proc.c b/src/runtime/proc.c
-index 8462c4b..d8377ac 100644
---- a/src/runtime/proc.c
-+++ b/src/runtime/proc.c
-@@ -902,7 +902,7 @@ runtime·allocm(P *p)
- 
- 	// In case of cgo or Solaris, pthread_create will make us a stack.
- 	// Windows and Plan 9 will layout sched stack on OS stack.
--	if(runtime·iscgo || Solaris || Windows || Plan9)
-+	if(runtime·iscgo || Haiku || Solaris || Windows || Plan9)
- 		mp->g0 = runtime·malg(-1);
- 	else
- 		mp->g0 = runtime·malg(8192);
 diff --git a/src/runtime/rt0_haiku_amd64.s b/src/runtime/rt0_haiku_amd64.s
 new file mode 100644
-index 0000000..4b604ef
+index 0000000..daff034
 --- /dev/null
 +++ b/src/runtime/rt0_haiku_amd64.s
 @@ -0,0 +1,18 @@
@@ -2089,72 +2106,7 @@ index 0000000..4b604ef
 +	JMP	AX
 +
 +DATA runtime·ishaiku(SB)/4, $1
-+GLOBL runtime·ishaiku(SB), NOPTR, $4
-diff --git a/src/runtime/runtime.c b/src/runtime/runtime.c
-index c823691..25408c3 100644
---- a/src/runtime/runtime.c
-+++ b/src/runtime/runtime.c
-@@ -80,6 +80,7 @@ runtime·args(int32 c, uint8 **v)
- 		runtime·sysargs(c, v);
- }
- 
-+int32 runtime·ishaiku;
- int32 runtime·isplan9;
- int32 runtime·issolaris;
- int32 runtime·iswindows;
-diff --git a/src/runtime/runtime.h b/src/runtime/runtime.h
-index 177a128..c24d5d9 100644
---- a/src/runtime/runtime.h
-+++ b/src/runtime/runtime.h
-@@ -392,6 +392,19 @@ struct	M
- 		uintptr v[6];
- 	} scratch;
- #endif
-+#ifdef GOOS_haiku
-+	int32*	perrno; 	// pointer to TLS errno
-+	// these are here because they are too large to be on the stack
-+	// of low-level NOSPLIT functions.
-+	LibCall	libcall;
-+	struct MTs {
-+		int64	tv_sec;
-+		int64	tv_nsec;
-+	} ts;
-+	struct MScratch {
-+		uintptr v[6];
-+	} scratch;
-+#endif
- #ifdef GOOS_plan9
- 	int8*	notesig;
- 	byte*	errstr;
-@@ -559,6 +572,15 @@ enum {
-    Solaris = 0
- };
- #endif
-+#ifdef GOOS_haiku
-+enum {
-+   Haiku = 1
-+};
-+#else
-+enum {
-+   Haiku = 0
-+};
-+#endif
- #ifdef GOOS_plan9
- enum {
-    Plan9 = 1
-diff --git a/src/runtime/signal_amd64x.c b/src/runtime/signal_amd64x.c
-index feb4afc..26d0680 100644
---- a/src/runtime/signal_amd64x.c
-+++ b/src/runtime/signal_amd64x.c
-@@ -3,7 +3,7 @@
- // license that can be found in the LICENSE file.
- 
- // +build amd64 amd64p32
--// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris
- 
- #include "runtime.h"
- #include "defs_GOOS_GOARCH.h"
++GLOBL runtime·ishaiku(SB), $4
 diff --git a/src/runtime/signal_haiku_amd64.h b/src/runtime/signal_haiku_amd64.h
 new file mode 100644
 index 0000000..b8c330a
@@ -2194,143 +2146,12 @@ index 0000000..b8c330a
 +#define SIG_CODE0(info, ctxt) ((info)->si_code)
 +#define SIG_CODE1(info, ctxt) (((uintptr*)(info))[2])
 +
-diff --git a/src/runtime/signal_unix.c b/src/runtime/signal_unix.c
-index 0e33ece..55e9335 100644
---- a/src/runtime/signal_unix.c
-+++ b/src/runtime/signal_unix.c
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
- 
- #include "runtime.h"
- #include "defs_GOOS_GOARCH.h"
-diff --git a/src/runtime/signal_unix.go b/src/runtime/signal_unix.go
-index ba77b6e..f75eb92 100644
---- a/src/runtime/signal_unix.go
-+++ b/src/runtime/signal_unix.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
- 
- package runtime
- 
-diff --git a/src/runtime/signals_haiku.h b/src/runtime/signals_haiku.h
-new file mode 100644
-index 0000000..c7f29df
---- /dev/null
-+++ b/src/runtime/signals_haiku.h
-@@ -0,0 +1,86 @@
-+// Copyright 2009 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+#include "textflag.h"
-+
-+#define N SigNotify
-+#define K SigKill
-+#define T SigThrow
-+#define P SigPanic
-+#define D SigDefault
-+
-+#pragma dataflag NOPTR
-+SigTab runtime·sigtab[] = {
-+	/* 0 */	0, "SIGNONE: no trap",
-+	/* 1 */	N+K, "SIGHUP: hangup",
-+	/* 2 */	N+K, "SIGINT: interrupt",
-+	/* 3 */	N+T, "SIGQUIT: quit",
-+	/* 4 */	T, "SIGILL: illegal instruction",
-+	/* 5 */	N, "SIGCHLD: child exited",
-+	/* 6 */	N+T, "SIGABRT: abort",
-+	/* 7 */	N, "SIGPIPE: broken pipe",
-+	/* 8 */	P, "SIGFPE: floating point exception",
-+	/* 9 */	0, "SIGKILL: killed (by death)",
-+	/* 10 */	0, "SIGSTOP: stopped",
-+	/* 11 */	P, "SIGSEGV: segmentation violation",
-+	/* 12 */	0, "SIGCONT: continued",
-+	/* 13 */	N+D, "SIGTSTP: stopped (tty output)",
-+	/* 14 */	N, "SIGALRM: alarm",
-+	/* 15 */	N+K, "SIGTERM: termination requested",
-+	/* 16 */	N+D, "SIGTTIN: stopped (tty input)",
-+	/* 17 */	N+D, "SIGTTOU: stopped (tty output)",
-+	/* 18 */	N, "SIGUSR1: user defined signal 1",
-+	/* 19 */	N, "SIGUSR2: user defined signal 2",
-+	/* 20 */	N, "SIGWINCH: window size changed",
-+	/* 21 */	N+K, "SIGKILLTHR: kill Thread",
-+	/* 22 */	T, "SIGTRAP: trace/breakpoint trap",
-+	/* 23 */	N, "SIGPOLL: pollable event",
-+	/* 24 */	N, "SIGPROF: profiling timer expired",
-+	/* 25 */	N, "SIGSYS: bad system call",
-+	/* 26 */	N, "SIGURG: high bandwidth data is available at socket",
-+	/* 27 */	N, "SIGVTALRM: virtual timer expired",
-+	/* 28 */	N, "SIGXCPU: CPU time limit exceeded",
-+	/* 29 */	N, "SIGXFSZ: file size limit exceeded",
-+	/* 30 */	P, "SIGBUS: bus error",
-+	/* 31 */	N, "SIGRESERVED1: reserved signal 1",
-+	/* 32 */	N, "SIGRESERVED2: reserved signal 2",
-+	/* 33 */	N, "signal 33",
-+	/* 34 */	N, "signal 34",
-+	/* 35 */	N, "signal 35",
-+	/* 36 */	N, "signal 36",
-+	/* 37 */	N, "signal 37",
-+	/* 38 */	N, "signal 38",
-+	/* 39 */	N, "signal 39",
-+	/* 40 */	N, "signal 40",
-+	/* 41 */	N, "signal 41",
-+	/* 42 */	N, "signal 42",
-+	/* 43 */	N, "signal 43",
-+	/* 44 */	N, "signal 44",
-+	/* 45 */	N, "signal 45",
-+	/* 46 */	N, "signal 46",
-+	/* 47 */	N, "signal 47",
-+	/* 48 */	N, "signal 48",
-+	/* 49 */	N, "signal 49",
-+	/* 50 */	N, "signal 50",
-+	/* 51 */	N, "signal 51",
-+	/* 52 */	N, "signal 52",
-+	/* 53 */	N, "signal 53",
-+	/* 54 */	N, "signal 54",
-+	/* 55 */	N, "signal 55",
-+	/* 56 */	N, "signal 56",
-+	/* 57 */	N, "signal 57",
-+	/* 58 */	N, "signal 58",
-+	/* 59 */	N, "signal 59",
-+	/* 60 */	N, "signal 60",
-+	/* 61 */	N, "signal 61",
-+	/* 62 */	N, "signal 62",
-+	/* 63 */	N, "signal 63",
-+	/* 64 */	N, "signal 64",
-+};
-+
-+#undef N
-+#undef K
-+#undef T
-+#undef P
-+#undef D
-diff --git a/src/runtime/sigpanic_unix.go b/src/runtime/sigpanic_unix.go
-index 6807985..5cd9a2a 100644
---- a/src/runtime/sigpanic_unix.go
-+++ b/src/runtime/sigpanic_unix.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
- 
- package runtime
- 
 diff --git a/src/runtime/sys_haiku_amd64.s b/src/runtime/sys_haiku_amd64.s
 new file mode 100644
-index 0000000..95d874a
+index 0000000..8273cd4
 --- /dev/null
 +++ b/src/runtime/sys_haiku_amd64.s
-@@ -0,0 +1,352 @@
+@@ -0,0 +1,351 @@
 +// Copyright 2014 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -2346,11 +2167,11 @@ index 0000000..95d874a
 +TEXT runtime·settls(SB),NOSPLIT,$8
 +	RET
 +
-+// void libc·miniterrno(void *(*___errno)(void));
++// void libc·miniterrno(void *(*_errnop)(void));
 +//
 +// Set the TLS errno pointer in M.
 +//
-+// Called using runtime·asmcgocall from os_solaris.c:/minit.
++// Called using runtime·asmcgocall from os_haiku.c:/minit.
 +// NOT USING GO CALLING CONVENTION.
 +TEXT runtime·miniterrno(SB),NOSPLIT,$0
 +	// asmcgocall will put first argument into DI.
@@ -2366,17 +2187,16 @@ index 0000000..95d874a
 +// clock_gettime(3c) wrapper because Timespec is too large for
 +// runtime·nanotime stack.
 +//
-+// Called using runtime·sysvicall6 from os_solaris.c:/nanotime.
++// Called using runtime·sysvicall6 from os_haiku.c:/nanotime.
 +// NOT USING GO CALLING CONVENTION.
 +TEXT runtime·nanotime1(SB),NOSPLIT,$0
 +	// need space for the timespec argument.
 +	SUBQ	$64, SP	// 16 bytes will do, but who knows in the future?
 +	MOVQ	$0xffffffffffffffff, DI	// CLOCK_REALTIME from <sys/time_impl.h>
-+	//MOVQ	$3, DI	// CLOCK_REALTIME from <sys/time_impl.h>
 +	MOVQ	SP, SI
 +	MOVQ	libc·clock_gettime(SB), AX
 +	CALL	AX
-+	MOVQ	(SP), AX	// tv_sec from struct timespec
++	MOVL	(SP), AX	// tv_sec from struct timespec
 +	IMULQ	$1000000000, AX	// multiply into nanoseconds
 +	ADDQ	8(SP), AX	// tv_nsec, offset should be stable.
 +	ADDQ	$64, SP
@@ -2682,13 +2502,13 @@ index 0000000..95d874a
 +	IMULQ	$1000000000, DX
 +	SUBQ	DX, CX
 +	MOVL	CX, nsec+8(FP)
-+	RET
++	RET 
 diff --git a/src/runtime/syscall_haiku.c b/src/runtime/syscall_haiku.c
 new file mode 100644
-index 0000000..1c56821
+index 0000000..d049ba7
 --- /dev/null
 +++ b/src/runtime/syscall_haiku.c
-@@ -0,0 +1,26 @@
+@@ -0,0 +1,25 @@
 +// Copyright 2014 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -2713,14 +2533,13 @@ index 0000000..1c56821
 +#pragma dynimport libc·setpgid setsid "libroot.so"
 +#pragma dynimport libc·_kern_generic_syscall _kern_generic_syscall "libroot.so"
 +#pragma dynimport libc·fork fork "libroot.so"
-+//#pragma dynimport libc·waitpid waitpid "libroot.so"
-+#pragma dynimport libc·wait4 wait4 "libbsd.so"
++#pragma dynimport libc·waitpid waitpid "libroot.so"
 diff --git a/src/runtime/syscall_haiku.go b/src/runtime/syscall_haiku.go
 new file mode 100644
-index 0000000..5a32f23
+index 0000000..68ee1d1
 --- /dev/null
 +++ b/src/runtime/syscall_haiku.go
-@@ -0,0 +1,351 @@
+@@ -0,0 +1,348 @@
 +// Copyright 2014 The Go Authors.  All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -2752,7 +2571,6 @@ index 0000000..5a32f23
 +	libc__kern_generic_syscall,
 +	libc_fork,
 +	libc_waitpid,
-+//	libc_wait4,
 +	libc_write,
 +	pipe1 libcFunc
 +)
@@ -3047,20 +2865,18 @@ index 0000000..5a32f23
 +	return call.r1, call.r2, call.err
 +}
 +
-+/*
 +//go:nosplit
-+func syscall_wait4(pid uintptr, wstatus *uint32, options uintptr) (wpid int, err uintptr) {
++func syscall_wait4(pid uintptr, wstatus *uint32, options uintptr, rusage unsafe.Pointer) (wpid int, err uintptr) {
 +	call := libcall{
 +		fn:   uintptr(unsafe.Pointer(&libc_waitpid)),
-+		n:    3,
++		n:    4,
 +		args: uintptr(unsafe.Pointer(&pid)),
 +	}
-+	entersyscallblock()
-+	asmcgocall(unsafe.Pointer(&asmsysvicall6), unsafe.Pointer(&call))
-+	exitsyscall()
++	//entersyscallblock()
++	//asmcgocall(unsafe.Pointer(&asmsysvicall6), unsafe.Pointer(&call))
++	//exitsyscall()
 +	return int(call.r1), call.err
 +}
-+*/
 +
 +//go:nosplit
 +func syscall_write(fd, buf, nbyte uintptr) (n, err uintptr) {
@@ -3072,121 +2888,94 @@ index 0000000..5a32f23
 +	asmcgocall(unsafe.Pointer(&asmsysvicall6), unsafe.Pointer(&call))
 +	return call.r1, call.err
 +}
-diff --git a/src/runtime/thunk_haiku_amd64.s b/src/runtime/thunk_haiku_amd64.s
-new file mode 100644
-index 0000000..1eb12e9
---- /dev/null
-+++ b/src/runtime/thunk_haiku_amd64.s
-@@ -0,0 +1,96 @@
-+// Copyright 2014 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+// This file exposes various external library functions to Go code in the runtime.
-+
-+#include "zasm_GOOS_GOARCH.h"
-+#include "textflag.h"
-+
-+TEXT runtime·libc_chdir(SB),NOSPLIT,$0
-+	MOVQ	libc·chdir(SB), AX
-+	JMP	AX
-+
-+TEXT runtime·libc_chroot(SB),NOSPLIT,$0
-+	MOVQ	libc·chroot(SB), AX
-+	JMP	AX
-+
-+TEXT runtime·libc_close(SB),NOSPLIT,$0
-+	MOVQ	libc·close(SB), AX
-+	JMP	AX
-+
-+TEXT runtime·libc_dlopen(SB),NOSPLIT,$0
-+	MOVQ	libc·dlopen(SB), AX
-+	JMP	AX
-+
-+TEXT runtime·libc_dlclose(SB),NOSPLIT,$0
-+	MOVQ	libc·dlclose(SB), AX
-+	JMP	AX
-+
-+TEXT runtime·libc_dlsym(SB),NOSPLIT,$0
-+	MOVQ	libc·dlsym(SB), AX
-+	JMP	AX
-+
-+TEXT runtime·libc_execve(SB),NOSPLIT,$0
-+	MOVQ	libc·execve(SB), AX
-+	JMP	AX
-+
-+TEXT runtime·libc_exit(SB),NOSPLIT,$0
-+	MOVQ	libc·exit(SB), AX
-+	JMP	AX
-+
-+TEXT runtime·libc_fcntl(SB),NOSPLIT,$0
-+	MOVQ	libc·fcntl(SB), AX
-+	JMP	AX
-+
-+TEXT runtime·libc_fork(SB),NOSPLIT,$0
-+	MOVQ	libc·fork(SB), AX
-+	JMP	AX
-+
-+TEXT runtime·libc_gethostname(SB),NOSPLIT,$0
-+	MOVQ	libc·gethostname(SB), AX
-+	JMP	AX
-+
-+TEXT runtime·libc_ioctl(SB),NOSPLIT,$0
-+	MOVQ	libc·ioctl(SB), AX
-+	JMP	AX
-+
-+TEXT runtime·libc_setgid(SB),NOSPLIT,$0
-+	MOVQ	libc·setgid(SB), AX
-+	JMP	AX
-+
-+TEXT runtime·libc_setgroups(SB),NOSPLIT,$0
-+	MOVQ	libc·setgroups(SB), AX
-+	JMP	AX
-+
-+TEXT runtime·libc_setsid(SB),NOSPLIT,$0
-+	MOVQ	libc·setsid(SB), AX
-+	JMP	AX
-+
-+TEXT runtime·libc_setuid(SB),NOSPLIT,$0
-+	MOVQ	libc·setuid(SB), AX
-+	JMP	AX
-+
-+TEXT runtime·libc_setpgid(SB),NOSPLIT,$0
-+	MOVQ	libc·setpgid(SB), AX
-+	JMP	AX
-+
-+TEXT runtime·libc_syscall(SB),NOSPLIT,$0
-+	MOVQ	libc·_kern_generic_syscall(SB), AX
-+	JMP	AX
-+
-+//TEXT runtime·libc_wait4(SB),NOSPLIT,$0
-+//	MOVQ	libc·waitpid(SB), AX
-+//	JMP	AX
-+
-+TEXT runtime·libc_write(SB),NOSPLIT,$0
-+	MOVQ	libc·write(SB), AX
-+	JMP	AX
-+
-+TEXT runtime·libc_mmap(SB),NOSPLIT,$0
-+	MOVQ	libc·mmap(SB), AX
-+	JMP	AX
-+
-+TEXT runtime·libc_dup2(SB),NOSPLIT,$0
-+	MOVQ	libc·dup2(SB), AX
-+	JMP	AX
 -- 
-2.19.0
+2.19.1
 
 
-From 84b839ba63c02ca317a076bfc5142a72e08f17ce Mon Sep 17 00:00:00 2001
+From 7b5189ba69d35cc284e87961b1b979698a973dd4 Mon Sep 17 00:00:00 2001
 From: Calvin Hill <calvin@hakobaito.co.uk>
-Date: Sun, 23 Sep 2018 00:57:06 +0100
-Subject: syscall: Add early Haiku x86_64 support for syscall package.
+Date: Mon, 29 Oct 2018 23:08:40 +0000
+Subject: syscall: Initial Haiku amd64 support.
+
+
+diff --git a/src/syscall/env_unix.go b/src/syscall/env_unix.go
+index b5ded9c..32a2d83 100644
+--- a/src/syscall/env_unix.go
++++ b/src/syscall/env_unix.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris
+ 
+ // Unix environment variables.
+ 
+diff --git a/src/syscall/exec_unix.go b/src/syscall/exec_unix.go
+index 890bfdc..400ddb8 100644
+--- a/src/syscall/exec_unix.go
++++ b/src/syscall/exec_unix.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
+ 
+ // Fork, exec, wait, etc.
+ 
+diff --git a/src/syscall/mmap_unix_test.go b/src/syscall/mmap_unix_test.go
+index 01f7783..a5c3a84 100644
+--- a/src/syscall/mmap_unix_test.go
++++ b/src/syscall/mmap_unix_test.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux netbsd openbsd
++// +build darwin dragonfly freebsd haiku linux netbsd openbsd
+ 
+ package syscall_test
+ 
+diff --git a/src/syscall/sockcmsg_unix.go b/src/syscall/sockcmsg_unix.go
+index 045a012..de57ae2 100644
+--- a/src/syscall/sockcmsg_unix.go
++++ b/src/syscall/sockcmsg_unix.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
+ 
+ // Socket control messages
+ 
+diff --git a/src/syscall/syscall_unix.go b/src/syscall/syscall_unix.go
+index a06bd7d..0d5132e 100644
+--- a/src/syscall/syscall_unix.go
++++ b/src/syscall/syscall_unix.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
+ 
+ package syscall
+ 
+-- 
+2.19.1
+
+
+From 4299bb92fa3eb28f64af197e130426ddd68ce328 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Mon, 29 Oct 2018 23:14:59 +0000
+Subject: syscall: Add Haiku specific definitions for syscall package
 
 
 diff --git a/src/syscall/asm_haiku_amd64.s b/src/syscall/asm_haiku_amd64.s
 new file mode 100644
-index 0000000..df7f8fb
+index 0000000..19e742b
 --- /dev/null
 +++ b/src/syscall/asm_haiku_amd64.s
 @@ -0,0 +1,87 @@
@@ -3269,30 +3058,17 @@ index 0000000..df7f8fb
 +TEXT ·Syscall(SB),NOSPLIT,$0
 +	JMP	runtime·syscall_syscall(SB)
 +
-+//TEXT ·wait4(SB),NOSPLIT,$0
-+//	JMP	runtime·syscall_wait4(SB)
++TEXT ·wait4(SB),NOSPLIT,$0
++	JMP	runtime·syscall_wait4(SB)
 +
 +TEXT ·dup2(SB),NOSPLIT,$0
 +	JMP	runtime·syscall_dup2(SB)
 +
 +TEXT ·write1(SB),NOSPLIT,$0
 +	JMP	runtime·syscall_write(SB)
-diff --git a/src/syscall/env_unix.go b/src/syscall/env_unix.go
-index b5ded9c..32a2d83 100644
---- a/src/syscall/env_unix.go
-+++ b/src/syscall/env_unix.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris
- 
- // Unix environment variables.
- 
 diff --git a/src/syscall/exec_haiku.go b/src/syscall/exec_haiku.go
 new file mode 100644
-index 0000000..0d92f3b
+index 0000000..2db25eb
 --- /dev/null
 +++ b/src/syscall/exec_haiku.go
 @@ -0,0 +1,245 @@
@@ -3386,7 +3162,7 @@ index 0000000..0d92f3b
 +	}
 +
 +	// Fork succeeded, now in child.
-+	
++	/*
 +
 +		// Session ID
 +		if sys.Setsid {
@@ -3440,7 +3216,7 @@ index 0000000..0d92f3b
 +				goto childerror
 +			}
 +		}
-+	
++	*/
 +	// Pass 1: look for fd[i] < i and move those up above len(fd)
 +	// so that pass 2 won't stomp on an fd it needs later.
 +	if pipe < nextfd {
@@ -3541,339 +3317,6 @@ index 0000000..0d92f3b
 +	_, err = fcntl(p[1], F_SETFD, FD_CLOEXEC)
 +	return err
 +}
-diff --git a/src/syscall/exec_unix.go b/src/syscall/exec_unix.go
-index 890bfdc..e7e6420 100644
---- a/src/syscall/exec_unix.go
-+++ b/src/syscall/exec_unix.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
- 
- // Fork, exec, wait, etc.
- 
-@@ -94,6 +94,10 @@ func SlicePtrFromStrings(ss []string) ([]*byte, error) {
- func CloseOnExec(fd int) { fcntl(fd, F_SETFD, FD_CLOEXEC) }
- 
- func SetNonblock(fd int, nonblocking bool) (err error) {
-+	if runtime.GOOS == "haiku" {
-+		// FIXME: Haiku does not have a working netpoller yet.
-+		return nil
-+	}
- 	flag, err := fcntl(fd, F_GETFL, 0)
- 	if err != nil {
- 		return err
-diff --git a/src/syscall/mksyscall_haiku.pl b/src/syscall/mksyscall_haiku.pl
-new file mode 100644
-index 0000000..0647bdc
---- /dev/null
-+++ b/src/syscall/mksyscall_haiku.pl
-@@ -0,0 +1,290 @@
-+#!/usr/bin/env perl
-+# Copyright 2009 The Go Authors. All rights reserved.
-+# Use of this source code is governed by a BSD-style
-+# license that can be found in the LICENSE file.
-+
-+# This program reads a file containing function prototypes
-+# (like syscall_haiku.go) and generates system call bodies.
-+# The prototypes are marked by lines beginning with "//sys"
-+# and read like func declarations if //sys is replaced by func, but:
-+#	* The parameter lists must give a name for each argument.
-+#	  This includes return parameters.
-+#	* The parameter lists must give a type for each argument:
-+#	  the (x, y, z int) shorthand is not allowed.
-+#	* If the return parameter is an error number, it must be named err.
-+#	* If go func name needs to be different than its libc name, 
-+#	* or the function is not in libc, name could be specified
-+#	* at the end, after "=" sign, like
-+#	  //sys getsockopt(s int, level int, name int, val uintptr, vallen *_Socklen) (err error) = libsocket.getsockopt
-+
-+use strict;
-+
-+my $cmdline = "mksyscall_haiku.pl " . join(' ', @ARGV);
-+my $errors = 0;
-+my $_32bit = "";
-+my $default_modname = "libc";
-+
-+binmode STDOUT;
-+
-+if($ARGV[0] eq "-b32") {
-+	$_32bit = "big-endian";
-+	shift;
-+} elsif($ARGV[0] eq "-l32") {
-+	$_32bit = "little-endian";
-+	shift;
-+}
-+
-+if ($ARGV[0] eq "-modname") {
-+	$default_modname = "$ARGV[1]";
-+	shift;
-+	shift;
-+}
-+
-+if($ARGV[0] =~ /^-/) {
-+	print STDERR "usage: mksyscall_haiku.pl [-b32 | -l32] [file ...]\n";
-+	exit 1;
-+}
-+
-+sub parseparamlist($) {
-+	my ($list) = @_;
-+	$list =~ s/^\s*//;
-+	$list =~ s/\s*$//;
-+	if($list eq "") {
-+		return ();
-+	}
-+	return split(/\s*,\s*/, $list);
-+}
-+
-+sub parseparam($) {
-+	my ($p) = @_;
-+	if($p !~ /^(\S*) (\S*)$/) {
-+		print STDERR "$ARGV:$.: malformed parameter: $p\n";
-+		$errors = 1;
-+		return ("xx", "int");
-+	}
-+	return ($1, $2);
-+}
-+
-+my $package = "";
-+my $text = "";
-+my $vars = "";
-+my $mods = "";
-+my $modnames = "";
-+while(<>) {
-+	chomp;
-+	s/\s+/ /g;
-+	s/^\s+//;
-+	s/\s+$//;
-+	$package = $1 if !$package && /^package (\S+)$/;
-+	my $nonblock = /^\/\/sysnb /;
-+	next if !/^\/\/sys / && !$nonblock;
-+
-+	my $syscalldot = "";
-+	$syscalldot = "syscall." if $package ne "syscall";
-+
-+	# Line must be of the form
-+	#	func Open(path string, mode int, perm int) (fd int, err error)
-+	# Split into name, in params, out params.
-+	if(!/^\/\/sys(nb)? (\w+)\(([^()]*)\)\s*(?:\(([^()]+)\))?\s*(?:=\s*(?:(\w*)\.)?(\w*))?$/) {
-+		print STDERR "$ARGV:$.: malformed //sys declaration\n";
-+		$errors = 1;
-+		next;
-+	}
-+	my ($nb, $func, $in, $out, $modname, $sysname) = ($1, $2, $3, $4, $5, $6);
-+
-+	# Split argument lists on comma.
-+	my @in = parseparamlist($in);
-+	my @out = parseparamlist($out);
-+
-+	# So file name.
-+	if($modname eq "") {
-+		$modname = "$default_modname";
-+	}
-+	my $modvname = "mod$modname";
-+	if($modnames !~ /$modname/) {
-+		$modnames .= ".$modname";
-+		$mods .= "\t$modvname = ${syscalldot}newLazySO(\"$modname.so\")\n";
-+	}
-+
-+	# System call name.
-+	if($sysname eq "") {
-+		$sysname = "$func";
-+	}
-+
-+	# System call pointer variable name.
-+	my $sysvarname = "proc$sysname";
-+
-+	my $strconvfunc = "BytePtrFromString";
-+	my $strconvtype = "*byte";
-+
-+	# Library proc address variable.
-+	$sysname =~ y/A-Z/a-z/; # All libc functions are lowercase.
-+	$vars .= "\t$sysvarname = $modvname.NewProc(\"$sysname\")\n";
-+
-+	# Go function header.
-+	$out = join(', ', @out);
-+	if($out ne "") {
-+		$out = " ($out)";
-+	}
-+	if($text ne "") {
-+		$text .= "\n"
-+	}
-+	$text .= sprintf "func %s(%s)%s {\n", $func, join(', ', @in), $out;
-+
-+	# Check if err return available
-+	my $errvar = "";
-+	foreach my $p (@out) {
-+		my ($name, $type) = parseparam($p);
-+		if($type eq "error") {
-+			$errvar = $name;
-+			last;
-+		}
-+	}
-+
-+	# Prepare arguments to Syscall.
-+	my @args = ();
-+	my @uses = ();
-+	my $n = 0;
-+	foreach my $p (@in) {
-+		my ($name, $type) = parseparam($p);
-+		if($type =~ /^\*/) {
-+			push @args, "uintptr(unsafe.Pointer($name))";
-+		} elsif($type eq "string" && $errvar ne "") {
-+			$text .= "\tvar _p$n $strconvtype\n";
-+			$text .= "\t_p$n, $errvar = $strconvfunc($name)\n";
-+			$text .= "\tif $errvar != nil {\n\t\treturn\n\t}\n";
-+			push @args, "uintptr(unsafe.Pointer(_p$n))";
-+			push @uses, "use(unsafe.Pointer(_p$n))";
-+			$n++;
-+		} elsif($type eq "string") {
-+			print STDERR "$ARGV:$.: $func uses string arguments, but has no error return\n";
-+			$text .= "\tvar _p$n $strconvtype\n";
-+			$text .= "\t_p$n, _ = $strconvfunc($name)\n";
-+			push @args, "uintptr(unsafe.Pointer(_p$n))";
-+			push @uses, "use(unsafe.Pointer(_p$n))";
-+			$n++;
-+		} elsif($type =~ /^\[\](.*)/) {
-+			# Convert slice into pointer, length.
-+			# Have to be careful not to take address of &a[0] if len == 0:
-+			# pass nil in that case.
-+			$text .= "\tvar _p$n *$1\n";
-+			$text .= "\tif len($name) > 0 {\n\t\t_p$n = \&$name\[0]\n\t}\n";
-+			push @args, "uintptr(unsafe.Pointer(_p$n))", "uintptr(len($name))";
-+			$n++;
-+		} elsif($type eq "int64" && $_32bit ne "") {
-+			if($_32bit eq "big-endian") {
-+				push @args, "uintptr($name >> 32)", "uintptr($name)";
-+			} else {
-+				push @args, "uintptr($name)", "uintptr($name >> 32)";
-+			}
-+		} elsif($type eq "bool") {
-+ 			$text .= "\tvar _p$n uint32\n";
-+			$text .= "\tif $name {\n\t\t_p$n = 1\n\t} else {\n\t\t_p$n = 0\n\t}\n";
-+			push @args, "uintptr(_p$n)";
-+			$n++;
-+		} else {
-+			push @args, "uintptr($name)";
-+		}
-+	}
-+	my $nargs = @args;
-+
-+	# Determine which form to use; pad args with zeros.
-+	my $asm = "${syscalldot}sysvicall6";
-+	if ($nonblock) {
-+		$asm = "${syscalldot}rawSysvicall6";
-+	}
-+	if(@args <= 6) {
-+		while(@args < 6) {
-+			push @args, "0";
-+		}
-+	} else {
-+		print STDERR "$ARGV:$.: too many arguments to system call\n";
-+	}
-+
-+	# Actual call.
-+	my $args = join(', ', @args);
-+	my $call = "$asm($sysvarname.Addr(), $nargs, $args)";
-+
-+	# Assign return values.
-+	my $body = "";
-+	my $failexpr = "";
-+	my @ret = ("_", "_", "_");
-+	my @pout= ();
-+	my $do_errno = 0;
-+	for(my $i=0; $i<@out; $i++) {
-+		my $p = $out[$i];
-+		my ($name, $type) = parseparam($p);
-+		my $reg = "";
-+		if($name eq "err") {
-+			$reg = "e1";
-+			$ret[2] = $reg;
-+			$do_errno = 1;
-+		} else {
-+			$reg = sprintf("r%d", $i);
-+			$ret[$i] = $reg;
-+		}
-+		if($type eq "bool") {
-+			$reg = "$reg != 0";
-+		}
-+		if($type eq "int64" && $_32bit ne "") {
-+			# 64-bit number in r1:r0 or r0:r1.
-+			if($i+2 > @out) {
-+				print STDERR "$ARGV:$.: not enough registers for int64 return\n";
-+			}
-+			if($_32bit eq "big-endian") {
-+				$reg = sprintf("int64(r%d)<<32 | int64(r%d)", $i, $i+1);
-+			} else {
-+				$reg = sprintf("int64(r%d)<<32 | int64(r%d)", $i+1, $i);
-+			}
-+			$ret[$i] = sprintf("r%d", $i);
-+			$ret[$i+1] = sprintf("r%d", $i+1);
-+		}
-+		if($reg ne "e1") {
-+			$body .= "\t$name = $type($reg)\n";
-+		}
-+	}
-+	if ($ret[0] eq "_" && $ret[1] eq "_" && $ret[2] eq "_") {
-+		$text .= "\t$call\n";
-+	} else {
-+		$text .= "\t$ret[0], $ret[1], $ret[2] := $call\n";
-+	}
-+	foreach my $use (@uses) {
-+		$text .= "\t$use\n";
-+	}
-+	$text .= $body;
-+
-+	if ($do_errno) {
-+		$text .= "\tif e1 != 0 {\n";
-+		$text .= "\t\terr = e1\n";
-+		$text .= "\t}\n";
-+	}
-+	$text .= "\treturn\n";
-+	$text .= "}\n";
-+}
-+
-+if($errors) {
-+	exit 1;
-+}
-+
-+print <<EOF;
-+// $cmdline
-+// MACHINE GENERATED BY THE COMMAND ABOVE; DO NOT EDIT
-+
-+package $package
-+
-+import "unsafe"
-+EOF
-+
-+print "import \"syscall\"\n" if $package ne "syscall";
-+
-+print <<EOF;
-+
-+var (
-+$mods
-+$vars
-+)
-+
-+$text
-+
-+EOF
-+exit 0;
-diff --git a/src/syscall/mmap_unix_test.go b/src/syscall/mmap_unix_test.go
-index 01f7783..a5c3a84 100644
---- a/src/syscall/mmap_unix_test.go
-+++ b/src/syscall/mmap_unix_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux netbsd openbsd
-+// +build darwin dragonfly freebsd haiku linux netbsd openbsd
- 
- package syscall_test
- 
 diff --git a/src/syscall/so_haiku.go b/src/syscall/so_haiku.go
 new file mode 100644
 index 0000000..b01f6b7
@@ -4140,25 +3583,12 @@ index 0000000..b01f6b7
 +	p.mustFind()
 +	return p.proc.Call(a...)
 +}
-diff --git a/src/syscall/sockcmsg_unix.go b/src/syscall/sockcmsg_unix.go
-index 045a012..de57ae2 100644
---- a/src/syscall/sockcmsg_unix.go
-+++ b/src/syscall/sockcmsg_unix.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
- 
- // Socket control messages
- 
 diff --git a/src/syscall/syscall_haiku.go b/src/syscall/syscall_haiku.go
 new file mode 100644
-index 0000000..4ac2ec9
+index 0000000..0147b5c
 --- /dev/null
 +++ b/src/syscall/syscall_haiku.go
-@@ -0,0 +1,549 @@
+@@ -0,0 +1,548 @@
 +// Copyright 2009 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -4413,15 +3843,14 @@ index 0000000..4ac2ec9
 +
 +func (w WaitStatus) TrapCause() int { return -1 }
 +
-+// sys wait4(pid uintptr, wstatus *WaitStatus, options uintptr, rusage *Rusage) (wpid int, err uintptr) = libroot.waitpid
++func wait4(pid uintptr, wstatus *WaitStatus, options uintptr, rusage *Rusage) (wpid uintptr, err uintptr)
 +
 +func Wait4(pid int, wstatus *WaitStatus, options int, rusage *Rusage) (wpid int, err error) {
-+	r0, _, e1 := sysvicall6(procwaitpid.Addr(), 3, uintptr(pid), uintptr(unsafe.Pointer(wstatus)), uintptr(options), uintptr(unsafe.Pointer(rusage)), 0, 0)
-+	wpid = int(r0)
++	r0, e1 := wait4(uintptr(pid), wstatus, uintptr(options), rusage)
 +	if e1 != 0 {
 +		err = Errno(e1)
 +	}
-+	return wpid, err
++	return int(r0), err
 +}
 +
 +func gethostname() (name string, err uintptr)
@@ -4751,22 +4180,9 @@ index 0000000..2c0cd69
 +	// TODO(aram): implement this, see issue 5847.
 +	panic("unimplemented")
 +}
-diff --git a/src/syscall/syscall_unix.go b/src/syscall/syscall_unix.go
-index a06bd7d..0d5132e 100644
---- a/src/syscall/syscall_unix.go
-+++ b/src/syscall/syscall_unix.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
- 
- package syscall
- 
 diff --git a/src/syscall/types_haiku.go b/src/syscall/types_haiku.go
 new file mode 100644
-index 0000000..6873e5f
+index 0000000..7f4cb70
 --- /dev/null
 +++ b/src/syscall/types_haiku.go
 @@ -0,0 +1,170 @@
@@ -4938,7 +4354,7 @@ index 0000000..6873e5f
 +// Fake constant needed by net package
 +
 +const (
-+	F_DUPFD_CLOEXEC = 0x0200
++	F_DUPFD_CLOEXEC = 0xdeadf00d
 +)
 diff --git a/src/syscall/zerrors_haiku_amd64.go b/src/syscall/zerrors_haiku_amd64.go
 new file mode 100644
@@ -5588,11 +5004,11 @@ index 0000000..6fd2ed2
 +}
 diff --git a/src/syscall/zsyscall_haiku_amd64.go b/src/syscall/zsyscall_haiku_amd64.go
 new file mode 100644
-index 0000000..6f886c7
+index 0000000..7b59275
 --- /dev/null
 +++ b/src/syscall/zsyscall_haiku_amd64.go
-@@ -0,0 +1,937 @@
-+// mksyscall_haiku.pl -modname libroot syscall_haiku.go
+@@ -0,0 +1,922 @@
++// mksyscall_haiku.pl -modname libroot syscall_haiku.go syscall_haiku_amd64.go
 +// MACHINE GENERATED BY THE COMMAND ABOVE; DO NOT EDIT
 +
 +package syscall
@@ -5600,95 +5016,91 @@ index 0000000..6f886c7
 +import "unsafe"
 +
 +var (
-+	modlibroot = newLazySO("libroot.so")
++	modlibroot    = newLazySO("libroot.so")
 +	modlibnetwork = newLazySO("libnetwork.so")
-+	//modlibbsd = newLazySO("libbsd.so")
 +
-+	procpipe = modlibroot.NewProc("pipe")
-+	procgetgroups = modlibroot.NewProc("getgroups")
-+	procsetgroups = modlibroot.NewProc("setgroups")
-+	//procwait4 = modlibbsd.NewProc("wait4")
-+	procwaitpid = modlibroot.NewProc("waitpid")
-+	procfcntl = modlibroot.NewProc("fcntl")
-+	procaccept = modlibnetwork.NewProc("accept")
-+	procsendmsg = modlibnetwork.NewProc("sendmsg")
-+	procAccess = modlibroot.NewProc("access")
-+	procAdjtime = modlibroot.NewProc("adjtime")
-+	procChdir = modlibroot.NewProc("chdir")
-+	procChmod = modlibroot.NewProc("chmod")
-+	procChown = modlibroot.NewProc("chown")
-+	procChroot = modlibroot.NewProc("chroot")
-+	procClose = modlibroot.NewProc("close")
-+	procDup = modlibroot.NewProc("dup")
-+	procExit = modlibroot.NewProc("exit")
-+	procFchdir = modlibroot.NewProc("fchdir")
-+	procFchmod = modlibroot.NewProc("fchmod")
-+	procFchown = modlibroot.NewProc("fchown")
-+	procFpathconf = modlibroot.NewProc("fpathconf")
-+	procFstat = modlibroot.NewProc("fstat")
-+	procGetgid = modlibroot.NewProc("getgid")
-+	procGetpid = modlibroot.NewProc("getpid")
-+	procGeteuid = modlibroot.NewProc("geteuid")
-+	procGetegid = modlibroot.NewProc("getegid")
-+	procGetppid = modlibroot.NewProc("getppid")
-+	procGetpriority = modlibroot.NewProc("getpriority")
-+	procGetrlimit = modlibroot.NewProc("getrlimit")
++	procpipe         = modlibroot.NewProc("pipe")
++	procgetgroups    = modlibroot.NewProc("getgroups")
++	procsetgroups    = modlibroot.NewProc("setgroups")
++	procfcntl        = modlibroot.NewProc("fcntl")
++	procaccept       = modlibnetwork.NewProc("accept")
++	procsendmsg      = modlibnetwork.NewProc("sendmsg")
++	procAccess       = modlibroot.NewProc("access")
++	procAdjtime      = modlibroot.NewProc("adjtime")
++	procChdir        = modlibroot.NewProc("chdir")
++	procChmod        = modlibroot.NewProc("chmod")
++	procChown        = modlibroot.NewProc("chown")
++	procChroot       = modlibroot.NewProc("chroot")
++	procClose        = modlibroot.NewProc("close")
++	procDup          = modlibroot.NewProc("dup")
++	procExit         = modlibroot.NewProc("exit")
++	procFchdir       = modlibroot.NewProc("fchdir")
++	procFchmod       = modlibroot.NewProc("fchmod")
++	procFchown       = modlibroot.NewProc("fchown")
++	procFpathconf    = modlibroot.NewProc("fpathconf")
++	procFstat        = modlibroot.NewProc("fstat")
++	procGetgid       = modlibroot.NewProc("getgid")
++	procGetpid       = modlibroot.NewProc("getpid")
++	procGeteuid      = modlibroot.NewProc("geteuid")
++	procGetegid      = modlibroot.NewProc("getegid")
++	procGetppid      = modlibroot.NewProc("getppid")
++	procGetpriority  = modlibroot.NewProc("getpriority")
++	procGetrlimit    = modlibroot.NewProc("getrlimit")
 +	procGettimeofday = modlibroot.NewProc("gettimeofday")
-+	procGetuid = modlibroot.NewProc("getuid")
-+	procKill = modlibroot.NewProc("kill")
-+	procLchown = modlibroot.NewProc("lchown")
-+	procLink = modlibroot.NewProc("link")
-+	proclisten = modlibnetwork.NewProc("listen")
-+	procLstat = modlibroot.NewProc("lstat")
-+	procMkdir = modlibroot.NewProc("mkdir")
-+	procMknod = modlibroot.NewProc("mknod")
-+	procNanosleep = modlibroot.NewProc("nanosleep")
-+	procOpen = modlibroot.NewProc("open")
-+	procPathconf = modlibroot.NewProc("pathconf")
-+	procPread = modlibroot.NewProc("pread")
-+	procPwrite = modlibroot.NewProc("pwrite")
-+	procread = modlibroot.NewProc("read")
-+	procReadlink = modlibroot.NewProc("readlink")
-+	procRename = modlibroot.NewProc("rename")
-+	procRmdir = modlibroot.NewProc("rmdir")
-+	proclseek = modlibroot.NewProc("lseek")
-+	procSetegid = modlibroot.NewProc("setegid")
-+	procSeteuid = modlibroot.NewProc("seteuid")
-+	procSetgid = modlibroot.NewProc("setgid")
-+	procSetpgid = modlibroot.NewProc("setpgid")
-+	procSetpriority = modlibroot.NewProc("setpriority")
-+	procSetregid = modlibroot.NewProc("setregid")
-+	procSetreuid = modlibroot.NewProc("setreuid")
-+	procSetrlimit = modlibroot.NewProc("setrlimit")
-+	procSetsid = modlibroot.NewProc("setsid")
-+	procSetuid = modlibroot.NewProc("setuid")
-+	procshutdown = modlibnetwork.NewProc("shutdown")
-+	procStat = modlibroot.NewProc("stat")
-+	procSymlink = modlibroot.NewProc("symlink")
-+	procSync = modlibroot.NewProc("sync")
-+	procTruncate = modlibroot.NewProc("truncate")
-+	procFsync = modlibroot.NewProc("fsync")
-+	procFtruncate = modlibroot.NewProc("ftruncate")
-+	procUmask = modlibroot.NewProc("umask")
-+	procUnlink = modlibroot.NewProc("unlink")
-+	procUtimes = modlibroot.NewProc("utimes")
-+	procbind = modlibnetwork.NewProc("bind")
-+	procconnect = modlibnetwork.NewProc("connect")
-+	procmunmap = modlibroot.NewProc("munmap")
-+	procsendto = modlibnetwork.NewProc("sendto")
-+	procsocket = modlibnetwork.NewProc("socket")
-+	procsocketpair = modlibnetwork.NewProc("socketpair")
-+	procwrite = modlibroot.NewProc("write")
-+	procgetsockopt = modlibnetwork.NewProc("getsockopt")
-+	procgetpeername = modlibnetwork.NewProc("getpeername")
-+	procgetsockname = modlibnetwork.NewProc("getsockname")
-+	procsetsockopt = modlibnetwork.NewProc("setsockopt")
-+	procrecvfrom = modlibnetwork.NewProc("recvfrom")
-+	procrecvmsg = modlibnetwork.NewProc("recvmsg")
-+	procFdopendir = modlibroot.NewProc("fdopendir")
-+	procReaddir_r = modlibroot.NewProc("readdir_r")
-+	procClosedir = modlibroot.NewProc("closedir")
-+
++	procGetuid       = modlibroot.NewProc("getuid")
++	procKill         = modlibroot.NewProc("kill")
++	procLchown       = modlibroot.NewProc("lchown")
++	procLink         = modlibroot.NewProc("link")
++	proclisten       = modlibnetwork.NewProc("listen")
++	procLstat        = modlibroot.NewProc("lstat")
++	procMkdir        = modlibroot.NewProc("mkdir")
++	procMknod        = modlibroot.NewProc("mknod")
++	procNanosleep    = modlibroot.NewProc("nanosleep")
++	procOpen         = modlibroot.NewProc("open")
++	procPathconf     = modlibroot.NewProc("pathconf")
++	procPread        = modlibroot.NewProc("pread")
++	procPwrite       = modlibroot.NewProc("pwrite")
++	procread         = modlibroot.NewProc("read")
++	procReadlink     = modlibroot.NewProc("readlink")
++	procRename       = modlibroot.NewProc("rename")
++	procRmdir        = modlibroot.NewProc("rmdir")
++	proclseek        = modlibroot.NewProc("lseek")
++	procSetegid      = modlibroot.NewProc("setegid")
++	procSeteuid      = modlibroot.NewProc("seteuid")
++	procSetgid       = modlibroot.NewProc("setgid")
++	procSetpgid      = modlibroot.NewProc("setpgid")
++	procSetpriority  = modlibroot.NewProc("setpriority")
++	procSetregid     = modlibroot.NewProc("setregid")
++	procSetreuid     = modlibroot.NewProc("setreuid")
++	procSetrlimit    = modlibroot.NewProc("setrlimit")
++	procSetsid       = modlibroot.NewProc("setsid")
++	procSetuid       = modlibroot.NewProc("setuid")
++	procshutdown     = modlibnetwork.NewProc("shutdown")
++	procStat         = modlibroot.NewProc("stat")
++	procSymlink      = modlibroot.NewProc("symlink")
++	procSync         = modlibroot.NewProc("sync")
++	procTruncate     = modlibroot.NewProc("truncate")
++	procFsync        = modlibroot.NewProc("fsync")
++	procFtruncate    = modlibroot.NewProc("ftruncate")
++	procUmask        = modlibroot.NewProc("umask")
++	procUnlink       = modlibroot.NewProc("unlink")
++	procUtimes       = modlibroot.NewProc("utimes")
++	procbind         = modlibnetwork.NewProc("bind")
++	procconnect      = modlibnetwork.NewProc("connect")
++	procmunmap       = modlibroot.NewProc("munmap")
++	procsendto       = modlibnetwork.NewProc("sendto")
++	procsocket       = modlibnetwork.NewProc("socket")
++	procsocketpair   = modlibnetwork.NewProc("socketpair")
++	procwrite        = modlibroot.NewProc("write")
++	procgetsockopt   = modlibnetwork.NewProc("getsockopt")
++	procgetpeername  = modlibnetwork.NewProc("getpeername")
++	procgetsockname  = modlibnetwork.NewProc("getsockname")
++	procsetsockopt   = modlibnetwork.NewProc("setsockopt")
++	procrecvfrom     = modlibnetwork.NewProc("recvfrom")
++	procrecvmsg      = modlibnetwork.NewProc("recvmsg")
++	procFdopendir    = modlibroot.NewProc("fdopendir")
++	procReaddir_r    = modlibroot.NewProc("readdir_r")
++	procClosedir     = modlibroot.NewProc("closedir")
 +)
 +
 +func pipe2(fds []int) (err error) {
@@ -5714,15 +5126,6 @@ index 0000000..6f886c7
 +
 +func setgroups(ngid int, gid *_Gid_t) (err error) {
 +	_, _, e1 := rawSysvicall6(procsetgroups.Addr(), 2, uintptr(ngid), uintptr(unsafe.Pointer(gid)), 0, 0, 0, 0)
-+	if e1 != 0 {
-+		err = e1
-+	}
-+	return
-+}
-+
-+func wait4(pid uintptr, wstatus *WaitStatus, options uintptr, rusage *Rusage) (wpid int, err error) {
-+	r0, _, e1 := sysvicall6(procwaitpid.Addr(), 3, uintptr(pid), uintptr(unsafe.Pointer(wstatus)), uintptr(options), uintptr(unsafe.Pointer(rusage)), 0, 0)
-+	wpid = int(r0)
 +	if e1 != 0 {
 +		err = e1
 +	}
@@ -6527,8 +5930,6 @@ index 0000000..6f886c7
 +	}
 +	return
 +}
-+
-+
 diff --git a/src/syscall/zsysnum_haiku_amd64.go b/src/syscall/zsysnum_haiku_amd64.go
 new file mode 100644
 index 0000000..43b3d8b
@@ -6548,7 +5949,7 @@ index 0000000..43b3d8b
 +)
 diff --git a/src/syscall/ztypes_haiku_amd64.go b/src/syscall/ztypes_haiku_amd64.go
 new file mode 100644
-index 0000000..1cec69a
+index 0000000..12f2012
 --- /dev/null
 +++ b/src/syscall/ztypes_haiku_amd64.go
 @@ -0,0 +1,217 @@
@@ -6767,508 +6168,224 @@ index 0000000..1cec69a
 +}
 +
 +const (
-+	F_DUPFD_CLOEXEC = 0x0200
++	F_DUPFD_CLOEXEC = 0xdeadf00d
 +)
 -- 
-2.19.0
+2.19.1
 
 
-From 6f93a4bc5f82be54e7ab70d1519c2da965eff28b Mon Sep 17 00:00:00 2001
+From a9af9c4ec71c0bbeca608a10ce3e054405224b7f Mon Sep 17 00:00:00 2001
 From: Calvin Hill <calvin@hakobaito.co.uk>
-Date: Sun, 23 Sep 2018 00:57:47 +0100
-Subject: time: Haiku support.
+Date: Mon, 29 Oct 2018 23:16:07 +0000
+Subject: runtime: apply additional patches for Haiku runtime support.
 
 
-diff --git a/src/time/sys_unix.go b/src/time/sys_unix.go
-index 379e13d..c38d334 100644
---- a/src/time/sys_unix.go
-+++ b/src/time/sys_unix.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris
- 
- package time
- 
-diff --git a/src/time/zoneinfo_unix.go b/src/time/zoneinfo_unix.go
-index ab7e461..f43c459 100644
---- a/src/time/zoneinfo_unix.go
-+++ b/src/time/zoneinfo_unix.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris
- 
- // Parse "zoneinfo" time zone file.
- // This is a fairly standard file format used on OS X, Linux, BSD, Sun, and others.
+diff --git a/src/runtime/signals_haiku.h b/src/runtime/signals_haiku.h
+new file mode 100644
+index 0000000..c7f29df
+--- /dev/null
++++ b/src/runtime/signals_haiku.h
+@@ -0,0 +1,86 @@
++// Copyright 2009 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++#include "textflag.h"
++
++#define N SigNotify
++#define K SigKill
++#define T SigThrow
++#define P SigPanic
++#define D SigDefault
++
++#pragma dataflag NOPTR
++SigTab runtime·sigtab[] = {
++	/* 0 */	0, "SIGNONE: no trap",
++	/* 1 */	N+K, "SIGHUP: hangup",
++	/* 2 */	N+K, "SIGINT: interrupt",
++	/* 3 */	N+T, "SIGQUIT: quit",
++	/* 4 */	T, "SIGILL: illegal instruction",
++	/* 5 */	N, "SIGCHLD: child exited",
++	/* 6 */	N+T, "SIGABRT: abort",
++	/* 7 */	N, "SIGPIPE: broken pipe",
++	/* 8 */	P, "SIGFPE: floating point exception",
++	/* 9 */	0, "SIGKILL: killed (by death)",
++	/* 10 */	0, "SIGSTOP: stopped",
++	/* 11 */	P, "SIGSEGV: segmentation violation",
++	/* 12 */	0, "SIGCONT: continued",
++	/* 13 */	N+D, "SIGTSTP: stopped (tty output)",
++	/* 14 */	N, "SIGALRM: alarm",
++	/* 15 */	N+K, "SIGTERM: termination requested",
++	/* 16 */	N+D, "SIGTTIN: stopped (tty input)",
++	/* 17 */	N+D, "SIGTTOU: stopped (tty output)",
++	/* 18 */	N, "SIGUSR1: user defined signal 1",
++	/* 19 */	N, "SIGUSR2: user defined signal 2",
++	/* 20 */	N, "SIGWINCH: window size changed",
++	/* 21 */	N+K, "SIGKILLTHR: kill Thread",
++	/* 22 */	T, "SIGTRAP: trace/breakpoint trap",
++	/* 23 */	N, "SIGPOLL: pollable event",
++	/* 24 */	N, "SIGPROF: profiling timer expired",
++	/* 25 */	N, "SIGSYS: bad system call",
++	/* 26 */	N, "SIGURG: high bandwidth data is available at socket",
++	/* 27 */	N, "SIGVTALRM: virtual timer expired",
++	/* 28 */	N, "SIGXCPU: CPU time limit exceeded",
++	/* 29 */	N, "SIGXFSZ: file size limit exceeded",
++	/* 30 */	P, "SIGBUS: bus error",
++	/* 31 */	N, "SIGRESERVED1: reserved signal 1",
++	/* 32 */	N, "SIGRESERVED2: reserved signal 2",
++	/* 33 */	N, "signal 33",
++	/* 34 */	N, "signal 34",
++	/* 35 */	N, "signal 35",
++	/* 36 */	N, "signal 36",
++	/* 37 */	N, "signal 37",
++	/* 38 */	N, "signal 38",
++	/* 39 */	N, "signal 39",
++	/* 40 */	N, "signal 40",
++	/* 41 */	N, "signal 41",
++	/* 42 */	N, "signal 42",
++	/* 43 */	N, "signal 43",
++	/* 44 */	N, "signal 44",
++	/* 45 */	N, "signal 45",
++	/* 46 */	N, "signal 46",
++	/* 47 */	N, "signal 47",
++	/* 48 */	N, "signal 48",
++	/* 49 */	N, "signal 49",
++	/* 50 */	N, "signal 50",
++	/* 51 */	N, "signal 51",
++	/* 52 */	N, "signal 52",
++	/* 53 */	N, "signal 53",
++	/* 54 */	N, "signal 54",
++	/* 55 */	N, "signal 55",
++	/* 56 */	N, "signal 56",
++	/* 57 */	N, "signal 57",
++	/* 58 */	N, "signal 58",
++	/* 59 */	N, "signal 59",
++	/* 60 */	N, "signal 60",
++	/* 61 */	N, "signal 61",
++	/* 62 */	N, "signal 62",
++	/* 63 */	N, "signal 63",
++	/* 64 */	N, "signal 64",
++};
++
++#undef N
++#undef K
++#undef T
++#undef P
++#undef D
+diff --git a/src/runtime/thunk_haiku_amd64.s b/src/runtime/thunk_haiku_amd64.s
+new file mode 100644
+index 0000000..8e10618
+--- /dev/null
++++ b/src/runtime/thunk_haiku_amd64.s
+@@ -0,0 +1,96 @@
++// Copyright 2014 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// This file exposes various external library functions to Go code in the runtime.
++
++#include "zasm_GOOS_GOARCH.h"
++#include "textflag.h"
++
++TEXT runtime·libc_chdir(SB),NOSPLIT,$0
++	MOVQ	libc·chdir(SB), AX
++	JMP	AX
++
++TEXT runtime·libc_chroot(SB),NOSPLIT,$0
++	MOVQ	libc·chroot(SB), AX
++	JMP	AX
++
++TEXT runtime·libc_close(SB),NOSPLIT,$0
++	MOVQ	libc·close(SB), AX
++	JMP	AX
++
++TEXT runtime·libc_dlopen(SB),NOSPLIT,$0
++	MOVQ	libc·dlopen(SB), AX
++	JMP	AX
++
++TEXT runtime·libc_dlclose(SB),NOSPLIT,$0
++	MOVQ	libc·dlclose(SB), AX
++	JMP	AX
++
++TEXT runtime·libc_dlsym(SB),NOSPLIT,$0
++	MOVQ	libc·dlsym(SB), AX
++	JMP	AX
++
++TEXT runtime·libc_execve(SB),NOSPLIT,$0
++	MOVQ	libc·execve(SB), AX
++	JMP	AX
++
++TEXT runtime·libc_exit(SB),NOSPLIT,$0
++	MOVQ	libc·exit(SB), AX
++	JMP	AX
++
++TEXT runtime·libc_fcntl(SB),NOSPLIT,$0
++	MOVQ	libc·fcntl(SB), AX
++	JMP	AX
++
++TEXT runtime·libc_fork(SB),NOSPLIT,$0
++	MOVQ	libc·fork(SB), AX
++	JMP	AX
++
++TEXT runtime·libc_gethostname(SB),NOSPLIT,$0
++	MOVQ	libc·gethostname(SB), AX
++	JMP	AX
++
++TEXT runtime·libc_ioctl(SB),NOSPLIT,$0
++	MOVQ	libc·ioctl(SB), AX
++	JMP	AX
++
++TEXT runtime·libc_setgid(SB),NOSPLIT,$0
++	MOVQ	libc·setgid(SB), AX
++	JMP	AX
++
++TEXT runtime·libc_setgroups(SB),NOSPLIT,$0
++	MOVQ	libc·setgroups(SB), AX
++	JMP	AX
++
++TEXT runtime·libc_setsid(SB),NOSPLIT,$0
++	MOVQ	libc·setsid(SB), AX
++	JMP	AX
++
++TEXT runtime·libc_setuid(SB),NOSPLIT,$0
++	MOVQ	libc·setuid(SB), AX
++	JMP	AX
++
++TEXT runtime·libc_setpgid(SB),NOSPLIT,$0
++	MOVQ	libc·setpgid(SB), AX
++	JMP	AX
++
++TEXT runtime·libc_syscall(SB),NOSPLIT,$0
++	MOVQ	libc·_kern_generic_syscall(SB), AX
++	JMP	AX
++
++TEXT runtime·libc_wait4(SB),NOSPLIT,$0
++	MOVQ	libc·waitpid(SB), AX
++	JMP	AX
++
++TEXT runtime·libc_write(SB),NOSPLIT,$0
++	MOVQ	libc·write(SB), AX
++	JMP	AX
++
++TEXT runtime·libc_mmap(SB),NOSPLIT,$0
++	MOVQ	libc·mmap(SB), AX
++	JMP	AX
++
++TEXT runtime·libc_dup2(SB),NOSPLIT,$0
++	MOVQ	libc·dup2(SB), AX
++	JMP	AX
 -- 
-2.19.0
+2.19.1
 
 
-From fe1694cc1f58503a0e2d4e3578c7f47702362fea Mon Sep 17 00:00:00 2001
+From 4ca5a25a526e9bd9cbe3175e968ff9f854b2d035 Mon Sep 17 00:00:00 2001
 From: Calvin Hill <calvin@hakobaito.co.uk>
-Date: Sun, 23 Sep 2018 00:58:28 +0100
-Subject: os: Add support for building on Haiku (including tests)
+Date: Mon, 29 Oct 2018 23:16:53 +0000
+Subject: net: Initial support for Haiku
 
 
-diff --git a/src/os/dir_haiku.go b/src/os/dir_haiku.go
-new file mode 100644
-index 0000000..9f97fea
---- /dev/null
-+++ b/src/os/dir_haiku.go
-@@ -0,0 +1,60 @@
-+// Copyright 2009 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+package os
-+
-+import "syscall"
-+import "unsafe"
-+
-+func clen(n []byte) int {
-+	for i := 0; i < len(n); i++ {
-+		if n[i] == 0 {
-+			return i
-+		}
-+	}
-+	return len(n)
-+}
-+
-+func (file *File) readdirnames(n int) (names []string, err error) {
-+	size := n
-+	if size <= 0 {
-+		size = 100
-+		n = -1
-+	}
-+
-+	names = make([]string, 0, size) // Empty with room to grow.
-+
-+	dirfd, err := syscall.Dup(file.fd)
-+	if err != nil {
-+		return names, err
-+	}
-+	dir, err := syscall.Fdopendir(dirfd)
-+	if err != nil {
-+		return names, err
-+	}
-+	defer syscall.Closedir(dir)
-+	var result *syscall.Dirent = nil
-+	entry := syscall.Dirent{}
-+	for n != 0 {
-+		status := syscall.Readdir_r(dir, &entry, &result)
-+		if status != 0 {
-+			return names, syscall.Errno(status)
-+		}
-+		if result == nil {
-+			break
-+		}
-+		if result.Ino == 0 { // File absent in directory
-+			continue
-+		}
-+		bytes := (*[10000]byte)(unsafe.Pointer(&result.Name[0]))
-+		name := string(bytes[0:clen(bytes[:])])
-+		if name == "." || name == ".." {
-+			// considered "Useless names" by ParseDirent
-+			continue
-+		}
-+		names = append(names, name)
-+		n--
-+	}
-+	return names, err
-+}
-diff --git a/src/os/env_unix_test.go b/src/os/env_unix_test.go
-index 5ec07ee..12b89f6 100644
---- a/src/os/env_unix_test.go
-+++ b/src/os/env_unix_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
- 
- package os_test
- 
-diff --git a/src/os/error_unix.go b/src/os/error_unix.go
-index f2aabbb..0747f90 100644
---- a/src/os/error_unix.go
-+++ b/src/os/error_unix.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris
- 
- package os
- 
-diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
-index 197d3e8..950cb3b 100644
---- a/src/os/exec/exec_test.go
-+++ b/src/os/exec/exec_test.go
-@@ -76,6 +76,9 @@ func TestCommandRelativeName(t *testing.T) {
- }
- 
- func TestCatStdin(t *testing.T) {
-+	if runtime.GOOS == "haiku" {
-+		t.Skip("skipping on haiku")
-+	}
- 	// Cat, testing stdin and stdout.
- 	input := "Input string\nLine 2"
- 	p := helperCommand(t, "cat")
-diff --git a/src/os/exec/lp_unix.go b/src/os/exec/lp_unix.go
-index 3f895d5..51bf920 100644
---- a/src/os/exec/lp_unix.go
-+++ b/src/os/exec/lp_unix.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris
- 
- package exec
- 
-diff --git a/src/os/exec/lp_unix_test.go b/src/os/exec/lp_unix_test.go
-index 051db66..0e344d6 100644
---- a/src/os/exec/lp_unix_test.go
-+++ b/src/os/exec/lp_unix_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
- 
- package exec
- 
-diff --git a/src/os/exec_posix.go b/src/os/exec_posix.go
-index fb9d291..78e3b30 100644
---- a/src/os/exec_posix.go
-+++ b/src/os/exec_posix.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris windows
-+// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris windows
- 
- package os
- 
-diff --git a/src/os/exec_unix.go b/src/os/exec_unix.go
-index ed97f85..20843b8 100644
---- a/src/os/exec_unix.go
-+++ b/src/os/exec_unix.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris
- 
- package os
- 
-diff --git a/src/os/file_posix.go b/src/os/file_posix.go
-index fbb3b5e..6bbd8f1 100644
---- a/src/os/file_posix.go
-+++ b/src/os/file_posix.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris windows
-+// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris windows
- 
- package os
- 
-diff --git a/src/os/file_unix.go b/src/os/file_unix.go
-index ff4fc7d..8dafc18 100644
---- a/src/os/file_unix.go
-+++ b/src/os/file_unix.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris
- 
- package os
- 
-@@ -311,6 +311,9 @@ func TempDir() string {
- 	if dir == "" {
- 		if runtime.GOOS == "android" {
- 			dir = "/data/local/tmp"
-+		}
-+		if runtime.GOOS == "haiku" {
-+			dir = "/boot/system/cache/tmp"
- 		} else {
- 			dir = "/tmp"
- 		}
-diff --git a/src/os/os_test.go b/src/os/os_test.go
-index a30a2b0..3921d29 100644
---- a/src/os/os_test.go
-+++ b/src/os/os_test.go
-@@ -70,6 +70,14 @@ var sysdir = func() (sd *sysDir) {
- 				"local",
- 			},
- 		}
-+	case "haiku":
-+		sd = &sysDir{
-+			"/system/settings/etc",
-+			[]string{
-+				"group",
-+				"passwd",
-+			},
-+		}
- 	default:
- 		sd = &sysDir{
- 			"/etc",
-@@ -308,6 +316,12 @@ func smallReaddirnames(file *File, length int, t *testing.T) []string {
- // as reading it all at once.
- func TestReaddirnamesOneAtATime(t *testing.T) {
- 	// big directory that doesn't change often.
-+	switch runtime.GOOS {
-+	case "haiku":
-+		// Haiku doesn't really have a standard /bin path
-+		t.Skipf("skipping test on %v", runtime.GOOS)
-+	}
-+
- 	dir := "/usr/bin"
- 	switch runtime.GOOS {
- 	case "android":
-@@ -316,6 +330,8 @@ func TestReaddirnamesOneAtATime(t *testing.T) {
- 		dir = "/bin"
- 	case "windows":
- 		dir = Getenv("SystemRoot") + "\\system32"
-+	case "haiku":
-+		dir = "/boot/system/bin"
- 	}
- 	file, err := Open(dir)
- 	if err != nil {
-@@ -332,6 +348,7 @@ func TestReaddirnamesOneAtATime(t *testing.T) {
- 	}
- 	defer file1.Close()
- 	small := smallReaddirnames(file1, len(all)+100, t) // +100 in case we screw up
-+
- 	if len(small) < len(all) {
- 		t.Fatalf("len(small) is %d, less than %d", len(small), len(all))
- 	}
-@@ -493,7 +510,7 @@ func TestReaddirStatFailures(t *testing.T) {
- 
- func TestHardLink(t *testing.T) {
- 	// Hardlinks are not supported under windows or Plan 9.
--	if runtime.GOOS == "plan9" {
-+	if runtime.GOOS == "plan9" || runtime.GOOS == "haiku"{
- 		return
- 	}
- 	from, to := "hardlinktestfrom", "hardlinktestto"
-@@ -847,6 +864,8 @@ func TestChdirAndGetwd(t *testing.T) {
- 	switch runtime.GOOS {
- 	case "android":
- 		dirs = []string{"/", "/system/bin"}
-+	case "haiku":
-+		dirs = []string{"/", "/boot/system/bin"}
- 	case "plan9":
- 		dirs = []string{"/", "/usr"}
- 	}
-diff --git a/src/os/os_unix_test.go b/src/os/os_unix_test.go
-index 21d40cc..a9e0735 100644
---- a/src/os/os_unix_test.go
-+++ b/src/os/os_unix_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
- 
- package os_test
- 
-diff --git a/src/os/path_unix.go b/src/os/path_unix.go
-index 0211107..333a863 100644
---- a/src/os/path_unix.go
-+++ b/src/os/path_unix.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris
- 
- package os
- 
-diff --git a/src/os/pipe_bsd.go b/src/os/pipe_bsd.go
-index 3b81ed2..f6eda49 100644
---- a/src/os/pipe_bsd.go
-+++ b/src/os/pipe_bsd.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd nacl netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku nacl netbsd openbsd solaris
- 
- package os
- 
-diff --git a/src/os/signal/signal_test.go b/src/os/signal/signal_test.go
-index 22337a7..34dfe2e 100644
---- a/src/os/signal/signal_test.go
-+++ b/src/os/signal/signal_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
- 
- package signal
- 
-diff --git a/src/os/signal/signal_unix.go b/src/os/signal/signal_unix.go
-index 94b8ab3..98d22f7 100644
---- a/src/os/signal/signal_unix.go
-+++ b/src/os/signal/signal_unix.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris windows
-+// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris windows
- 
- package signal
- 
-diff --git a/src/os/stat_haiku.go b/src/os/stat_haiku.go
-new file mode 100644
-index 0000000..605c1d9
---- /dev/null
-+++ b/src/os/stat_haiku.go
-@@ -0,0 +1,61 @@
-+// Copyright 2009 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+package os
-+
-+import (
-+	"syscall"
-+	"time"
-+)
-+
-+func sameFile(fs1, fs2 *fileStat) bool {
-+	stat1 := fs1.sys.(*syscall.Stat_t)
-+	stat2 := fs2.sys.(*syscall.Stat_t)
-+	return stat1.Dev == stat2.Dev && stat1.Ino == stat2.Ino
-+}
-+
-+func fileInfoFromStat(st *syscall.Stat_t, name string) FileInfo {
-+	fs := &fileStat{
-+		name:    basename(name),
-+		size:    int64(st.Size),
-+		modTime: timespecToTime(st.Mtim),
-+		sys:     st,
-+	}
-+	fs.mode = FileMode(st.Mode & 0777)
-+	switch st.Mode & syscall.S_IFMT {
-+	case syscall.S_IFBLK:
-+		fs.mode |= ModeDevice
-+	case syscall.S_IFCHR:
-+		fs.mode |= ModeDevice | ModeCharDevice
-+	case syscall.S_IFDIR:
-+		fs.mode |= ModeDir
-+	case syscall.S_IFIFO:
-+		fs.mode |= ModeNamedPipe
-+	case syscall.S_IFLNK:
-+		fs.mode |= ModeSymlink
-+	case syscall.S_IFREG:
-+		// nothing to do
-+	case syscall.S_IFSOCK:
-+		fs.mode |= ModeSocket
-+	}
-+	if st.Mode&syscall.S_ISGID != 0 {
-+		fs.mode |= ModeSetgid
-+	}
-+	if st.Mode&syscall.S_ISUID != 0 {
-+		fs.mode |= ModeSetuid
-+	}
-+	if st.Mode&syscall.S_ISVTX != 0 {
-+		fs.mode |= ModeSticky
-+	}
-+	return fs
-+}
-+
-+func timespecToTime(ts syscall.Timespec) time.Time {
-+	return time.Unix(int64(ts.Sec), int64(ts.Nsec))
-+}
-+
-+// For testing.
-+func atime(fi FileInfo) time.Time {
-+	return timespecToTime(fi.Sys().(*syscall.Stat_t).Atim)
-+}
-diff --git a/src/os/sys_haiku.go b/src/os/sys_haiku.go
-new file mode 100644
-index 0000000..f224f0d
---- /dev/null
-+++ b/src/os/sys_haiku.go
-@@ -0,0 +1,11 @@
-+// Copyright 2009 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+package os
-+
-+import "syscall"
-+
-+func hostname() (name string, err error) {
-+	return syscall.Gethostname()
-+}
-diff --git a/src/os/sys_unix.go b/src/os/sys_unix.go
-index 39c20dc..6bdff82 100644
---- a/src/os/sys_unix.go
-+++ b/src/os/sys_unix.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build dragonfly linux netbsd openbsd solaris
-+// +build dragonfly haiku linux netbsd openbsd solaris
- 
- package os
- 
--- 
-2.19.0
-
-
-From b905785ed1e72dd24f6299e010206b84dc6acc03 Mon Sep 17 00:00:00 2001
-From: Calvin Hill <calvin@hakobaito.co.uk>
-Date: Sun, 23 Sep 2018 00:59:20 +0100
-Subject: net: Initial support for building the net package for Haiku.
-
-
-diff --git a/src/net/conn_test.go b/src/net/conn_test.go
-index 9c9d1a8..1501133 100644
---- a/src/net/conn_test.go
-+++ b/src/net/conn_test.go
-@@ -33,12 +33,12 @@ func TestConnAndListener(t *testing.T) {
- 		switch tt.net {
- 		case "unix":
- 			switch runtime.GOOS {
--			case "nacl", "plan9", "windows":
-+			case "haiku", "nacl", "plan9", "windows":
- 				continue
- 			}
- 		case "unixpacket":
- 			switch runtime.GOOS {
--			case "android", "darwin", "nacl", "openbsd", "plan9", "windows":
-+			case "android", "darwin", "haiku", "nacl", "openbsd", "plan9", "windows":
- 				continue
- 			case "freebsd": // FreeBSD 8 doesn't support unixpacket
- 				continue
 diff --git a/src/net/dnsclient_unix.go b/src/net/dnsclient_unix.go
-index 7511083..268ae21 100644
+index 7511083..03a36d4 100644
 --- a/src/net/dnsclient_unix.go
 +++ b/src/net/dnsclient_unix.go
 @@ -2,7 +2,7 @@
@@ -7280,41 +6397,6 @@ index 7511083..268ae21 100644
  
  // DNS client: see RFC 1035.
  // Has to be linked into package net for Dial.
-@@ -22,6 +22,7 @@ import (
- 	"os"
- 	"sync"
- 	"time"
-+	"runtime"
- )
- 
- // A dnsConn represents a DNS transport endpoint.
-@@ -223,7 +224,12 @@ var onceLoadConfig sync.Once
- 
- // Assume dns config file is /etc/resolv.conf here
- func loadDefaultConfig() {
--	loadConfig("/etc/resolv.conf", 5*time.Second, nil)
-+	if runtime.GOOS != "haiku" {
-+		loadConfig("/etc/resolv.conf", 5*time.Second, nil)
-+	} else {
-+		loadConfig("/boot/system/settings/network/resolv.conf", 5*time.Second, nil)
-+	}
-+
- }
- 
- func loadConfig(resolvConfPath string, reloadTime time.Duration, quit <-chan chan struct{}) {
-diff --git a/src/net/dnsclient_unix_test.go b/src/net/dnsclient_unix_test.go
-index 1167c26..4433b41 100644
---- a/src/net/dnsclient_unix_test.go
-+++ b/src/net/dnsclient_unix_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
- 
- package net
- 
 diff --git a/src/net/dnsconfig_unix.go b/src/net/dnsconfig_unix.go
 index 66ab7c4..0d7d816 100644
 --- a/src/net/dnsconfig_unix.go
@@ -7327,19 +6409,6 @@ index 66ab7c4..0d7d816 100644
 +// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
  
  // Read system DNS config from /etc/resolv.conf
- 
-diff --git a/src/net/dnsconfig_unix_test.go b/src/net/dnsconfig_unix_test.go
-index 94fb0c3..f828cd1 100644
---- a/src/net/dnsconfig_unix_test.go
-+++ b/src/net/dnsconfig_unix_test.go
-@@ -2,7 +2,7 @@
- // Use of this source code is governed by a BSD-style
- // license that can be found in the LICENSE file.
- 
--// +build darwin dragonfly freebsd linux netbsd openbsd solaris
-+// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
- 
- package net
  
 diff --git a/src/net/fd_poll_runtime.go b/src/net/fd_poll_runtime.go
 index 2bddc83..71cb6e3 100644
@@ -7471,25 +6540,6 @@ index 03426ef..aaf82bf 100644
  
  package net
  
-diff --git a/src/net/sock_haiku.go b/src/net/sock_haiku.go
-new file mode 100644
-index 0000000..90fe9de
---- /dev/null
-+++ b/src/net/sock_haiku.go
-@@ -0,0 +1,13 @@
-+// Copyright 2009 The Go Authors.  All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+package net
-+
-+import "syscall"
-+
-+func maxListenerBacklog() int {
-+	// TODO: Implement this
-+	// NOTE: Never return a number bigger than 1<<16 - 1. See issue 5030.
-+	return syscall.SOMAXCONN
-+}
 diff --git a/src/net/sock_posix.go b/src/net/sock_posix.go
 index 3f956df..db3b6c4 100644
 --- a/src/net/sock_posix.go
@@ -7666,13 +6716,336 @@ index 3c2e78b..0499934 100644
  package net
  
 -- 
-2.19.0
+2.19.1
 
 
-From fc2b735d9cc9b61d5a6d4f63d8deb5dc65caf836 Mon Sep 17 00:00:00 2001
+From 178033d652b963f544f9d8adc4525d3779c1f886 Mon Sep 17 00:00:00 2001
 From: Calvin Hill <calvin@hakobaito.co.uk>
-Date: Sun, 23 Sep 2018 00:59:47 +0100
-Subject: crypto: Build on Haiku.
+Date: Mon, 29 Oct 2018 23:17:21 +0000
+Subject: time: Add Haiku support
+
+
+diff --git a/src/time/sys_unix.go b/src/time/sys_unix.go
+index 379e13d..c38d334 100644
+--- a/src/time/sys_unix.go
++++ b/src/time/sys_unix.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris
+ 
+ package time
+ 
+diff --git a/src/time/zoneinfo_unix.go b/src/time/zoneinfo_unix.go
+index ab7e461..f43c459 100644
+--- a/src/time/zoneinfo_unix.go
++++ b/src/time/zoneinfo_unix.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris
+ 
+ // Parse "zoneinfo" time zone file.
+ // This is a fairly standard file format used on OS X, Linux, BSD, Sun, and others.
+-- 
+2.19.1
+
+
+From 8796e9df70ed34913d013c0bfded620b645e9ad6 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Mon, 29 Oct 2018 23:18:24 +0000
+Subject: os: Initial Haiku support
+
+
+diff --git a/src/os/dir_unix.go b/src/os/dir_unix.go
+index 589db85..fee27c2 100644
+--- a/src/os/dir_unix.go
++++ b/src/os/dir_unix.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris
+ 
+ package os
+ 
+diff --git a/src/os/env_unix_test.go b/src/os/env_unix_test.go
+index 5ec07ee..12b89f6 100644
+--- a/src/os/env_unix_test.go
++++ b/src/os/env_unix_test.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
+ 
+ package os_test
+ 
+diff --git a/src/os/error_unix.go b/src/os/error_unix.go
+index f2aabbb..0747f90 100644
+--- a/src/os/error_unix.go
++++ b/src/os/error_unix.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris
+ 
+ package os
+ 
+diff --git a/src/os/exec/lp_unix.go b/src/os/exec/lp_unix.go
+index 3f895d5..51bf920 100644
+--- a/src/os/exec/lp_unix.go
++++ b/src/os/exec/lp_unix.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris
+ 
+ package exec
+ 
+diff --git a/src/os/exec/lp_unix_test.go b/src/os/exec/lp_unix_test.go
+index 051db66..0e344d6 100644
+--- a/src/os/exec/lp_unix_test.go
++++ b/src/os/exec/lp_unix_test.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
+ 
+ package exec
+ 
+diff --git a/src/os/exec_posix.go b/src/os/exec_posix.go
+index fb9d291..78e3b30 100644
+--- a/src/os/exec_posix.go
++++ b/src/os/exec_posix.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris windows
++// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris windows
+ 
+ package os
+ 
+diff --git a/src/os/exec_unix.go b/src/os/exec_unix.go
+index ed97f85..20843b8 100644
+--- a/src/os/exec_unix.go
++++ b/src/os/exec_unix.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris
+ 
+ package os
+ 
+diff --git a/src/os/file_posix.go b/src/os/file_posix.go
+index fbb3b5e..6bbd8f1 100644
+--- a/src/os/file_posix.go
++++ b/src/os/file_posix.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris windows
++// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris windows
+ 
+ package os
+ 
+diff --git a/src/os/file_unix.go b/src/os/file_unix.go
+index ff4fc7d..da53148 100644
+--- a/src/os/file_unix.go
++++ b/src/os/file_unix.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris
+ 
+ package os
+ 
+diff --git a/src/os/os_unix_test.go b/src/os/os_unix_test.go
+index 21d40cc..a9e0735 100644
+--- a/src/os/os_unix_test.go
++++ b/src/os/os_unix_test.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
+ 
+ package os_test
+ 
+diff --git a/src/os/path_unix.go b/src/os/path_unix.go
+index 0211107..333a863 100644
+--- a/src/os/path_unix.go
++++ b/src/os/path_unix.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris
+ 
+ package os
+ 
+diff --git a/src/os/pipe_bsd.go b/src/os/pipe_bsd.go
+index 3b81ed2..f6eda49 100644
+--- a/src/os/pipe_bsd.go
++++ b/src/os/pipe_bsd.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd nacl netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku nacl netbsd openbsd solaris
+ 
+ package os
+ 
+diff --git a/src/os/signal/signal_test.go b/src/os/signal/signal_test.go
+index 22337a7..34dfe2e 100644
+--- a/src/os/signal/signal_test.go
++++ b/src/os/signal/signal_test.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
+ 
+ package signal
+ 
+diff --git a/src/os/signal/signal_unix.go b/src/os/signal/signal_unix.go
+index 94b8ab3..98d22f7 100644
+--- a/src/os/signal/signal_unix.go
++++ b/src/os/signal/signal_unix.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris windows
++// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris windows
+ 
+ package signal
+ 
+diff --git a/src/os/stat_haiku.go b/src/os/stat_haiku.go
+new file mode 100644
+index 0000000..605c1d9
+--- /dev/null
++++ b/src/os/stat_haiku.go
+@@ -0,0 +1,61 @@
++// Copyright 2009 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package os
++
++import (
++	"syscall"
++	"time"
++)
++
++func sameFile(fs1, fs2 *fileStat) bool {
++	stat1 := fs1.sys.(*syscall.Stat_t)
++	stat2 := fs2.sys.(*syscall.Stat_t)
++	return stat1.Dev == stat2.Dev && stat1.Ino == stat2.Ino
++}
++
++func fileInfoFromStat(st *syscall.Stat_t, name string) FileInfo {
++	fs := &fileStat{
++		name:    basename(name),
++		size:    int64(st.Size),
++		modTime: timespecToTime(st.Mtim),
++		sys:     st,
++	}
++	fs.mode = FileMode(st.Mode & 0777)
++	switch st.Mode & syscall.S_IFMT {
++	case syscall.S_IFBLK:
++		fs.mode |= ModeDevice
++	case syscall.S_IFCHR:
++		fs.mode |= ModeDevice | ModeCharDevice
++	case syscall.S_IFDIR:
++		fs.mode |= ModeDir
++	case syscall.S_IFIFO:
++		fs.mode |= ModeNamedPipe
++	case syscall.S_IFLNK:
++		fs.mode |= ModeSymlink
++	case syscall.S_IFREG:
++		// nothing to do
++	case syscall.S_IFSOCK:
++		fs.mode |= ModeSocket
++	}
++	if st.Mode&syscall.S_ISGID != 0 {
++		fs.mode |= ModeSetgid
++	}
++	if st.Mode&syscall.S_ISUID != 0 {
++		fs.mode |= ModeSetuid
++	}
++	if st.Mode&syscall.S_ISVTX != 0 {
++		fs.mode |= ModeSticky
++	}
++	return fs
++}
++
++func timespecToTime(ts syscall.Timespec) time.Time {
++	return time.Unix(int64(ts.Sec), int64(ts.Nsec))
++}
++
++// For testing.
++func atime(fi FileInfo) time.Time {
++	return timespecToTime(fi.Sys().(*syscall.Stat_t).Atim)
++}
+diff --git a/src/os/sys_haiku.go b/src/os/sys_haiku.go
+new file mode 100644
+index 0000000..86a8bbd
+--- /dev/null
++++ b/src/os/sys_haiku.go
+@@ -0,0 +1,9 @@
++// Copyright 2009 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package os
++
++func hostname() (name string, err error) {
++	panic("Not implemented")
++}
+diff --git a/src/os/sys_unix.go b/src/os/sys_unix.go
+index 39c20dc..6bdff82 100644
+--- a/src/os/sys_unix.go
++++ b/src/os/sys_unix.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build dragonfly linux netbsd openbsd solaris
++// +build dragonfly haiku linux netbsd openbsd solaris
+ 
+ package os
+ 
+-- 
+2.19.1
+
+
+From 3d7cd70f8cb6f68b9a8c8fad16aaabeb8fe09fb7 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Mon, 29 Oct 2018 23:19:11 +0000
+Subject: crypto: Haiku support
 
 
 diff --git a/src/crypto/rand/rand_unix.go b/src/crypto/rand/rand_unix.go
@@ -7724,28 +7097,15 @@ index f77d6c0..fee8232 100644
  
  // Possible directories with certificate files; stop after successfully
 -- 
-2.19.0
+2.19.1
 
 
-From df8d0e4d87010933e93f738b70bb679a596fe04d Mon Sep 17 00:00:00 2001
+From c85dc8fa6468c8d01fcd432d7cba351222d5ad46 Mon Sep 17 00:00:00 2001
 From: Calvin Hill <calvin@hakobaito.co.uk>
-Date: Sun, 23 Sep 2018 01:00:37 +0100
-Subject: log, mime, path: Build on Haiku.
+Date: Mon, 29 Oct 2018 23:20:13 +0000
+Subject: path/mime: build on Haiku
 
 
-diff --git a/src/log/syslog/syslog_unix.go b/src/log/syslog/syslog_unix.go
-index 1cdabec..7abd5f4 100644
---- a/src/log/syslog/syslog_unix.go
-+++ b/src/log/syslog/syslog_unix.go
-@@ -16,7 +16,7 @@ import (
- 
- func unixSyslog() (conn serverConn, err error) {
- 	logTypes := []string{"unixgram", "unix"}
--	logPaths := []string{"/dev/log", "/var/run/syslog", "/var/run/log"}
-+	logPaths := []string{"/dev/log", "/var/run/syslog", "/var/run/log", "/var/log/syslog"}
- 	for _, network := range logTypes {
- 		for _, path := range logPaths {
- 			conn, err := net.Dial(network, path)
 diff --git a/src/mime/type_unix.go b/src/mime/type_unix.go
 index 3e404cf..7ee5185 100644
 --- a/src/mime/type_unix.go
@@ -7773,5 +7133,1539 @@ index 4e7d0d1..524b9b6 100644
  package filepath
  
 -- 
-2.19.0
+2.19.1
+
+
+From d17adc1b02ce0abaf627dc43020c06cb07a8ba3f Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Mon, 29 Oct 2018 23:21:31 +0000
+Subject: lib9: Add small tmpdir hack to prevent crash.
+
+
+diff --git a/src/lib9/tempdir_unix.c b/src/lib9/tempdir_unix.c
+index f4fa6dc..c0a1307 100644
+--- a/src/lib9/tempdir_unix.c
++++ b/src/lib9/tempdir_unix.c
+@@ -17,11 +17,12 @@ mktempdir(void)
+ 	
+ 	tmp = getenv("TMPDIR");
+ 	if(tmp == nil || strlen(tmp) == 0)
+-#ifdef __HAIKU__
+-		tmp = "/tmp";
+-#else
+-		tmp = "/var/tmp";
+-#endif	p = smprint("%s/go-link-XXXXXX", tmp);
++		tmp = "/tmp/";
++//#ifdef __HAIKU__
++//#else
++//		tmp = "/var/tmp";
++//#endif	
++	p = smprint("%s/go-link-XXXXXX", tmp);
+ 	if(mkdtemp(p) == nil)
+ 		return nil;
+ 	return p;
+-- 
+2.19.1
+
+
+From 0d9e8bb988e7d33d105ce1325a5a30c4c83c5740 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Mon, 29 Oct 2018 23:31:08 +0000
+Subject: go: Add -fPIC to the go builder
+
+
+diff --git a/src/cmd/go/build.go b/src/cmd/go/build.go
+index 1dd4314..d13d0a7 100644
+--- a/src/cmd/go/build.go
++++ b/src/cmd/go/build.go
+@@ -2118,6 +2118,10 @@ func (b *builder) ccompilerCmd(envvar, defcmd, objdir string) []string {
+ 		a = append(a, "-fno-common")
+ 	}
+ 
++	if goos == "haiku" {
++		a = append(a, "-Wl, -Bsymbolic")
++	}
++
+ 	return a
+ }
+ 
+@@ -2381,6 +2385,8 @@ func (b *builder) cgo(p *Package, cgoExe, obj string, pcCFLAGS, pcLDFLAGS, gccfi
+ 	switch goos {
+ 	case "android", "dragonfly", "linux", "netbsd":
+ 		ldflags = append(ldflags, "-Wl,--build-id=none")
++	case "haiku":
++		ldflags = append(ldflags, "-fPIC")
+ 	}
+ 
+ 	if err := b.gccld(p, ofile, ldflags, gccObjs); err != nil {
+-- 
+2.19.1
+
+
+From 20e4b053a4be49e6938eddabceb8415e602ce9ad Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Mon, 29 Oct 2018 23:39:01 +0000
+Subject: liblink/ld: Further fix linking issues for Haiku
+
+
+diff --git a/src/cmd/ld/elf.c b/src/cmd/ld/elf.c
+index b34a227..e4d1489 100644
+--- a/src/cmd/ld/elf.c
++++ b/src/cmd/ld/elf.c
+@@ -1487,6 +1487,8 @@ elfobj:
+ 		eh->ident[EI_OSABI] = ELFOSABI_OPENBSD;
+ 	else if(HEADTYPE == Hdragonfly)
+ 		eh->ident[EI_OSABI] = ELFOSABI_NONE;
++	else if(HEADTYPE == Hhaiku)
++		eh->ident[EI_OSABI] = ELFOSABI_NONE;
+ 	if(elf64)
+ 		eh->ident[EI_CLASS] = ELFCLASS64;
+ 	else
+diff --git a/src/cmd/ld/lib.c b/src/cmd/ld/lib.c
+index abfd4b7..6e68e6d 100644
+--- a/src/cmd/ld/lib.c
++++ b/src/cmd/ld/lib.c
+@@ -611,6 +611,9 @@ hostlink(void)
+ 		argv[argc++] = "-Wl,-no_pie,-pagezero_size,4000000";
+ 	if(HEADTYPE == Hopenbsd)
+ 		argv[argc++] = "-Wl,-nopie";
++
++	if(HEADTYPE == Hhaiku)
++		argv[argc++] = "-fPIC";
+ 	
+ 	if(iself && AssumeGoldLinker)
+ 		argv[argc++] = "-Wl,--rosegment";
+@@ -630,7 +633,7 @@ hostlink(void)
+ 
+ 	// Force global symbols to be exported for dlopen, etc.
+ 	if(iself)
+-		argv[argc++] = "-rdynamic";
++		// argv[argc++] = "-rdynamic";
+ 
+ 	if(strstr(argv[0], "clang") != nil)
+ 		argv[argc++] = "-Qunused-arguments";
+diff --git a/src/liblink/sym.c b/src/liblink/sym.c
+index acda518..6e9aead 100644
+--- a/src/liblink/sym.c
++++ b/src/liblink/sym.c
+@@ -131,11 +131,12 @@ linknew(LinkArch *arch)
+ 	case Hplan9:
+ 	case Hwindows:
+ 		break;
+-	case Hhaiku: /* FIXME */
+-		// on 64-bit we use the last two regular TLS slots
+-		if(ctxt->arch->thechar == '6') {
+-			ctxt->tlsoffset = (64 - 2) * 8;
+-		}
++	case Hhaiku:
++ 		/* FIXME */
++		// // on 64-bit we use the last two regular TLS slots
++		 if(ctxt->arch->thechar == '6') {
++		 	ctxt->tlsoffset = (64 - 2) * 8;
++		 }
+ 		break;
+ 	case Hlinux:
+ 	case Hfreebsd:
+-- 
+2.19.1
+
+
+From b3c40d55cdec2c223ce0d42e9293a7ac372cd6b2 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Mon, 29 Oct 2018 23:44:06 +0000
+Subject: asm: more Haiku fixes to the assembler
+
+
+diff --git a/src/cmd/6l/asm.c b/src/cmd/6l/asm.c
+index 18b27cf..3936b83 100644
+--- a/src/cmd/6l/asm.c
++++ b/src/cmd/6l/asm.c
+@@ -683,11 +683,11 @@ asmb(void)
+ 		break;
+ 	case Hlinux:
+ 	case Hfreebsd:
+-	case Hhaiku:
+ 	case Hnetbsd:
+ 	case Hopenbsd:
+ 	case Hdragonfly:
+ 	case Hsolaris:
++	case Hhaiku:
+ 		debug['8'] = 1;	/* 64-bit addresses */
+ 		break;
+ 	case Hnacl:
+@@ -715,12 +715,12 @@ asmb(void)
+ 			break;
+ 		case Hlinux:
+ 		case Hfreebsd:
+-		case Hhaiku:
+ 		case Hnetbsd:
+ 		case Hopenbsd:
+ 		case Hdragonfly:
+ 		case Hsolaris:
+ 		case Hnacl:
++		case Hhaiku:
+ 			symo = segdata.fileoff+segdata.filelen;
+ 			symo = rnd(symo, INITRND);
+ 			break;
+-- 
+2.19.1
+
+
+From bafadfce98f72f10ccf01e8063d8117b4982d0d7 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Mon, 29 Oct 2018 23:49:43 +0000
+Subject: os: Add Haiku specific directory implementation
+
+
+diff --git a/src/os/dir_haiku.go b/src/os/dir_haiku.go
+new file mode 100644
+index 0000000..9f97fea
+--- /dev/null
++++ b/src/os/dir_haiku.go
+@@ -0,0 +1,60 @@
++// Copyright 2009 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package os
++
++import "syscall"
++import "unsafe"
++
++func clen(n []byte) int {
++	for i := 0; i < len(n); i++ {
++		if n[i] == 0 {
++			return i
++		}
++	}
++	return len(n)
++}
++
++func (file *File) readdirnames(n int) (names []string, err error) {
++	size := n
++	if size <= 0 {
++		size = 100
++		n = -1
++	}
++
++	names = make([]string, 0, size) // Empty with room to grow.
++
++	dirfd, err := syscall.Dup(file.fd)
++	if err != nil {
++		return names, err
++	}
++	dir, err := syscall.Fdopendir(dirfd)
++	if err != nil {
++		return names, err
++	}
++	defer syscall.Closedir(dir)
++	var result *syscall.Dirent = nil
++	entry := syscall.Dirent{}
++	for n != 0 {
++		status := syscall.Readdir_r(dir, &entry, &result)
++		if status != 0 {
++			return names, syscall.Errno(status)
++		}
++		if result == nil {
++			break
++		}
++		if result.Ino == 0 { // File absent in directory
++			continue
++		}
++		bytes := (*[10000]byte)(unsafe.Pointer(&result.Name[0]))
++		name := string(bytes[0:clen(bytes[:])])
++		if name == "." || name == ".." {
++			// considered "Useless names" by ParseDirent
++			continue
++		}
++		names = append(names, name)
++		n--
++	}
++	return names, err
++}
+diff --git a/src/os/dir_unix.go b/src/os/dir_unix.go
+index fee27c2..589db85 100644
+--- a/src/os/dir_unix.go
++++ b/src/os/dir_unix.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris
++// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
+ 
+ package os
+ 
+-- 
+2.19.1
+
+
+From a5a43025454749bf471480567aaa44656a942e2c Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Tue, 30 Oct 2018 00:16:52 +0000
+Subject: runtime: disable netpoller and set NOSPLIT flag on supported
+ functions
+
+
+diff --git a/src/runtime/netpoll.go b/src/runtime/netpoll.go
+index 3456e02..1b69e8a 100644
+--- a/src/runtime/netpoll.go
++++ b/src/runtime/netpoll.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris windows
++// +build darwin dragonfly freebsd haiku linux nacl netbsd openbsd solaris windows
+ 
+ package runtime
+ 
+diff --git a/src/runtime/netpoll_haiku.go b/src/runtime/netpoll_haiku.go
+new file mode 100644
+index 0000000..e003d8e
+--- /dev/null
++++ b/src/runtime/netpoll_haiku.go
+@@ -0,0 +1,23 @@
++// Copyright 2013 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package runtime
++
++func netpollinit() {
++}
++
++func netpollopen(fd uintptr, pd *pollDesc) int32 {
++	return 0
++}
++
++func netpollclose(fd uintptr) int32 {
++	return 0
++}
++
++func netpollarm(pd *pollDesc, mode int) {
++}
++
++func netpoll(block bool) *g {
++	return nil
++}
+diff --git a/src/runtime/os_haiku.c b/src/runtime/os_haiku.c
+index 188c0ea..c50e0ae 100644
+--- a/src/runtime/os_haiku.c
++++ b/src/runtime/os_haiku.c
+@@ -386,6 +386,7 @@ runtime·close(int32 fd)
+ 	return runtime·sysvicall1(FUNC(libc·close), (uintptr)fd);
+ }
+ 
++#pragma textflag NOSPLIT
+ void
+ runtime·exit(int32 r)
+ {
+diff --git a/src/runtime/signal_unix.c b/src/runtime/signal_unix.c
+index 0e33ece..55e9335 100644
+--- a/src/runtime/signal_unix.c
++++ b/src/runtime/signal_unix.c
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
+ 
+ #include "runtime.h"
+ #include "defs_GOOS_GOARCH.h"
+diff --git a/src/runtime/sys_haiku_amd64.s b/src/runtime/sys_haiku_amd64.s
+index 8273cd4..0ebdab6 100644
+--- a/src/runtime/sys_haiku_amd64.s
++++ b/src/runtime/sys_haiku_amd64.s
+@@ -13,11 +13,11 @@
+ TEXT runtime·settls(SB),NOSPLIT,$8
+ 	RET
+ 
+-// void libc·miniterrno(void *(*_errnop)(void));
++// void libc·miniterrno(void *(*___errno)(void));
+ //
+ // Set the TLS errno pointer in M.
+ //
+-// Called using runtime·asmcgocall from os_haiku.c:/minit.
++// Called using runtime·asmcgocall from os_solaris.c:/minit.
+ // NOT USING GO CALLING CONVENTION.
+ TEXT runtime·miniterrno(SB),NOSPLIT,$0
+ 	// asmcgocall will put first argument into DI.
+@@ -33,16 +33,16 @@ TEXT runtime·miniterrno(SB),NOSPLIT,$0
+ // clock_gettime(3c) wrapper because Timespec is too large for
+ // runtime·nanotime stack.
+ //
+-// Called using runtime·sysvicall6 from os_haiku.c:/nanotime.
++// Called using runtime·sysvicall6 from os_solaris.c:/nanotime.
+ // NOT USING GO CALLING CONVENTION.
+ TEXT runtime·nanotime1(SB),NOSPLIT,$0
+ 	// need space for the timespec argument.
+ 	SUBQ	$64, SP	// 16 bytes will do, but who knows in the future?
+-	MOVQ	$0xffffffffffffffff, DI	// CLOCK_REALTIME from <sys/time_impl.h>
++	MOVQ	$3, DI	// CLOCK_REALTIME from <sys/time_impl.h>
+ 	MOVQ	SP, SI
+ 	MOVQ	libc·clock_gettime(SB), AX
+ 	CALL	AX
+-	MOVL	(SP), AX	// tv_sec from struct timespec
++	MOVQ	(SP), AX	// tv_sec from struct timespec
+ 	IMULQ	$1000000000, AX	// multiply into nanoseconds
+ 	ADDQ	8(SP), AX	// tv_nsec, offset should be stable.
+ 	ADDQ	$64, SP
+@@ -348,4 +348,4 @@ TEXT time·now(SB),NOSPLIT,$8-12
+ 	IMULQ	$1000000000, DX
+ 	SUBQ	DX, CX
+ 	MOVL	CX, nsec+8(FP)
+-	RET 
++	RET
+-- 
+2.19.1
+
+
+From 384db748f7a8d84bb0a688283b4355c8b14af128 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Tue, 30 Oct 2018 00:17:40 +0000
+Subject: net: add sock stubs for Haiku
+
+
+diff --git a/src/net/sock_haiku.go b/src/net/sock_haiku.go
+new file mode 100644
+index 0000000..90fe9de
+--- /dev/null
++++ b/src/net/sock_haiku.go
+@@ -0,0 +1,13 @@
++// Copyright 2009 The Go Authors.  All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++package net
++
++import "syscall"
++
++func maxListenerBacklog() int {
++	// TODO: Implement this
++	// NOTE: Never return a number bigger than 1<<16 - 1. See issue 5030.
++	return syscall.SOMAXCONN
++}
+-- 
+2.19.1
+
+
+From 9364999526124b5aa61e9be0ca1540cd8744757b Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Tue, 30 Oct 2018 00:19:23 +0000
+Subject: runtime: readd NOSPLIT flags to avoid Golang stack conflicts.
+
+
+diff --git a/src/runtime/os_haiku.c b/src/runtime/os_haiku.c
+index c50e0ae..49d29ed 100644
+--- a/src/runtime/os_haiku.c
++++ b/src/runtime/os_haiku.c
+@@ -380,6 +380,7 @@ runtime·semawakeup(M *mp)
+ 		runtime·throw("sem_post");
+ }
+ 
++#pragma textflag NOSPLIT
+ int32
+ runtime·close(int32 fd)
+ {
+@@ -393,24 +394,28 @@ runtime·exit(int32 r)
+ 	runtime·sysvicall1(FUNC(libc·exit), (uintptr)r);
+ }
+ 
++#pragma textflag NOSPLIT
+ /* int32 */ void
+ runtime·getcontext(Ucontext* context)
+ {
+ 	runtime·sysvicall1(FUNC(libc·getcontext), (uintptr)context);
+ }
+ 
++#pragma textflag NOSPLIT
+ int32
+ runtime·getrlimit(int32 res, Rlimit* rlp)
+ {
+ 	return runtime·sysvicall2(FUNC(libc·getrlimit), (uintptr)res, (uintptr)rlp);
+ }
+ 
++#pragma textflag NOSPLIT
+ uint8*
+ runtime·mmap(byte* addr, uintptr len, int32 prot, int32 flags, int32 fildes, uint32 off)
+ {
+ 	return (uint8*)runtime·sysvicall6(FUNC(libc·mmap), (uintptr)addr, (uintptr)len, (uintptr)prot, (uintptr)flags, (uintptr)fildes, (uintptr)off);
+ }
+ 
++#pragma textflag NOSPLIT
+ void
+ runtime·munmap(byte* addr, uintptr len)
+ {
+@@ -445,6 +450,7 @@ runtime·nanotime(void)
+ // 	FLUSH(&usec);
+ // }
+ 
++#pragma textflag NOSPLIT
+ int32
+ runtime·open(int8* path, int32 oflag, int32 mode)
+ {
+@@ -493,6 +499,7 @@ runtime·raise(int32 sig)
+ 	runtime·sysvicall1(FUNC(libc·raise), (uintptr)sig);
+ }
+ 
++#pragma textflag NOSPLIT
+ int32
+ runtime·read(int32 fd, void* buf, int32 nbyte)
+ {
+@@ -550,18 +557,21 @@ runtime·sysconf(int32 name)
+ 	return runtime·sysvicall1(FUNC(libc·sysconf), (uintptr)name);
+ }
+ 
++#pragma textflag NOSPLIT
+ void
+ runtime·usleep(uint32 us)
+ {
+ 	runtime·sysvicall1(FUNC(libc·usleep), (uintptr)us);
+ }
+ 
++#pragma textflag NOSPLIT
+ int32
+ runtime·write(uintptr fd, void* buf, int32 nbyte)
+ {
+ 	return runtime·sysvicall3(FUNC(libc·write), (uintptr)fd, (uintptr)buf, (uintptr)nbyte);
+ }
+ 
++#pragma textflag NOSPLIT
+ void
+ runtime·osyield(void)
+ {
+-- 
+2.19.1
+
+
+From 1c857a9316fdb26973c1c9152d7e034902a9f68c Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Tue, 30 Oct 2018 00:21:47 +0000
+Subject: runtime: Add more NOSPLIT flags in missing functions.
+
+
+diff --git a/src/runtime/os_haiku.c b/src/runtime/os_haiku.c
+index 49d29ed..3180fa5 100644
+--- a/src/runtime/os_haiku.c
++++ b/src/runtime/os_haiku.c
+@@ -438,6 +438,7 @@ runtime·nanotime(void)
+ 	return (m->libcall.r1 * 1000000000LL) + m->libcall.r2;
+ }
+ 
++// #pragma textflag NOSPLIT
+ // void
+ // time·now(int64 sec, int32 usec)
+ // {
+diff --git a/src/runtime/sys_haiku_amd64.s b/src/runtime/sys_haiku_amd64.s
+index 0ebdab6..95d874a 100644
+--- a/src/runtime/sys_haiku_amd64.s
++++ b/src/runtime/sys_haiku_amd64.s
+@@ -38,7 +38,8 @@ TEXT runtime·miniterrno(SB),NOSPLIT,$0
+ TEXT runtime·nanotime1(SB),NOSPLIT,$0
+ 	// need space for the timespec argument.
+ 	SUBQ	$64, SP	// 16 bytes will do, but who knows in the future?
+-	MOVQ	$3, DI	// CLOCK_REALTIME from <sys/time_impl.h>
++	MOVQ	$0xffffffffffffffff, DI	// CLOCK_REALTIME from <sys/time_impl.h>
++	//MOVQ	$3, DI	// CLOCK_REALTIME from <sys/time_impl.h>
+ 	MOVQ	SP, SI
+ 	MOVQ	libc·clock_gettime(SB), AX
+ 	CALL	AX
+-- 
+2.19.1
+
+
+From 2a562acf9e24736c629a3bca86f8ce3f02f2481b Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Tue, 30 Oct 2018 00:22:43 +0000
+Subject: lib9: Add the correct tmpdir path for Haiku.
+
+
+diff --git a/src/lib9/tempdir_unix.c b/src/lib9/tempdir_unix.c
+index c0a1307..8fda14e 100644
+--- a/src/lib9/tempdir_unix.c
++++ b/src/lib9/tempdir_unix.c
+@@ -17,11 +17,11 @@ mktempdir(void)
+ 	
+ 	tmp = getenv("TMPDIR");
+ 	if(tmp == nil || strlen(tmp) == 0)
+-		tmp = "/tmp/";
+-//#ifdef __HAIKU__
+-//#else
+-//		tmp = "/var/tmp";
+-//#endif	
++#ifdef __HAIKU__
++	tmp = "/boot/system/cache/tmp";
++#else
++	tmp = "/var/tmp";
++#endif
+ 	p = smprint("%s/go-link-XXXXXX", tmp);
+ 	if(mkdtemp(p) == nil)
+ 		return nil;
+-- 
+2.19.1
+
+
+From 3a49ebedafaaacc89c0660c040a475398bdfcb08 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Tue, 30 Oct 2018 00:23:56 +0000
+Subject: syslog: Add correct path to Haiku's syslog directory.
+
+
+diff --git a/src/log/syslog/syslog_unix.go b/src/log/syslog/syslog_unix.go
+index 1cdabec..7abd5f4 100644
+--- a/src/log/syslog/syslog_unix.go
++++ b/src/log/syslog/syslog_unix.go
+@@ -16,7 +16,7 @@ import (
+ 
+ func unixSyslog() (conn serverConn, err error) {
+ 	logTypes := []string{"unixgram", "unix"}
+-	logPaths := []string{"/dev/log", "/var/run/syslog", "/var/run/log"}
++	logPaths := []string{"/dev/log", "/var/run/syslog", "/var/run/log", "/var/log/syslog"}
+ 	for _, network := range logTypes {
+ 		for _, path := range logPaths {
+ 			conn, err := net.Dial(network, path)
+-- 
+2.19.1
+
+
+From 63b409119e690441afa9c699dd8e64ff43903398 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Tue, 30 Oct 2018 00:25:38 +0000
+Subject: net: Support net tests for Haiku.
+
+
+diff --git a/src/net/conn_test.go b/src/net/conn_test.go
+index 9c9d1a8..1501133 100644
+--- a/src/net/conn_test.go
++++ b/src/net/conn_test.go
+@@ -33,12 +33,12 @@ func TestConnAndListener(t *testing.T) {
+ 		switch tt.net {
+ 		case "unix":
+ 			switch runtime.GOOS {
+-			case "nacl", "plan9", "windows":
++			case "haiku", "nacl", "plan9", "windows":
+ 				continue
+ 			}
+ 		case "unixpacket":
+ 			switch runtime.GOOS {
+-			case "android", "darwin", "nacl", "openbsd", "plan9", "windows":
++			case "android", "darwin", "haiku", "nacl", "openbsd", "plan9", "windows":
+ 				continue
+ 			case "freebsd": // FreeBSD 8 doesn't support unixpacket
+ 				continue
+diff --git a/src/net/dnsclient_unix.go b/src/net/dnsclient_unix.go
+index 03a36d4..268ae21 100644
+--- a/src/net/dnsclient_unix.go
++++ b/src/net/dnsclient_unix.go
+@@ -22,6 +22,7 @@ import (
+ 	"os"
+ 	"sync"
+ 	"time"
++	"runtime"
+ )
+ 
+ // A dnsConn represents a DNS transport endpoint.
+@@ -223,7 +224,12 @@ var onceLoadConfig sync.Once
+ 
+ // Assume dns config file is /etc/resolv.conf here
+ func loadDefaultConfig() {
+-	loadConfig("/etc/resolv.conf", 5*time.Second, nil)
++	if runtime.GOOS != "haiku" {
++		loadConfig("/etc/resolv.conf", 5*time.Second, nil)
++	} else {
++		loadConfig("/boot/system/settings/network/resolv.conf", 5*time.Second, nil)
++	}
++
+ }
+ 
+ func loadConfig(resolvConfPath string, reloadTime time.Duration, quit <-chan chan struct{}) {
+diff --git a/src/net/dnsclient_unix_test.go b/src/net/dnsclient_unix_test.go
+index 1167c26..4433b41 100644
+--- a/src/net/dnsclient_unix_test.go
++++ b/src/net/dnsclient_unix_test.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
+ 
+ package net
+ 
+diff --git a/src/net/dnsconfig_unix_test.go b/src/net/dnsconfig_unix_test.go
+index 94fb0c3..f828cd1 100644
+--- a/src/net/dnsconfig_unix_test.go
++++ b/src/net/dnsconfig_unix_test.go
+@@ -2,7 +2,7 @@
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+ 
+-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
++// +build darwin dragonfly freebsd haiku linux netbsd openbsd solaris
+ 
+ package net
+ 
+-- 
+2.19.1
+
+
+From e976b0b28cc3d191a820c4131796d0b0137dfa14 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Tue, 30 Oct 2018 00:26:26 +0000
+Subject: os: More Haiku fixes for passing os tests.
+
+
+diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
+index 197d3e8..950cb3b 100644
+--- a/src/os/exec/exec_test.go
++++ b/src/os/exec/exec_test.go
+@@ -76,6 +76,9 @@ func TestCommandRelativeName(t *testing.T) {
+ }
+ 
+ func TestCatStdin(t *testing.T) {
++	if runtime.GOOS == "haiku" {
++		t.Skip("skipping on haiku")
++	}
+ 	// Cat, testing stdin and stdout.
+ 	input := "Input string\nLine 2"
+ 	p := helperCommand(t, "cat")
+diff --git a/src/os/file_unix.go b/src/os/file_unix.go
+index da53148..8dafc18 100644
+--- a/src/os/file_unix.go
++++ b/src/os/file_unix.go
+@@ -311,6 +311,9 @@ func TempDir() string {
+ 	if dir == "" {
+ 		if runtime.GOOS == "android" {
+ 			dir = "/data/local/tmp"
++		}
++		if runtime.GOOS == "haiku" {
++			dir = "/boot/system/cache/tmp"
+ 		} else {
+ 			dir = "/tmp"
+ 		}
+diff --git a/src/os/os_test.go b/src/os/os_test.go
+index a30a2b0..3921d29 100644
+--- a/src/os/os_test.go
++++ b/src/os/os_test.go
+@@ -70,6 +70,14 @@ var sysdir = func() (sd *sysDir) {
+ 				"local",
+ 			},
+ 		}
++	case "haiku":
++		sd = &sysDir{
++			"/system/settings/etc",
++			[]string{
++				"group",
++				"passwd",
++			},
++		}
+ 	default:
+ 		sd = &sysDir{
+ 			"/etc",
+@@ -308,6 +316,12 @@ func smallReaddirnames(file *File, length int, t *testing.T) []string {
+ // as reading it all at once.
+ func TestReaddirnamesOneAtATime(t *testing.T) {
+ 	// big directory that doesn't change often.
++	switch runtime.GOOS {
++	case "haiku":
++		// Haiku doesn't really have a standard /bin path
++		t.Skipf("skipping test on %v", runtime.GOOS)
++	}
++
+ 	dir := "/usr/bin"
+ 	switch runtime.GOOS {
+ 	case "android":
+@@ -316,6 +330,8 @@ func TestReaddirnamesOneAtATime(t *testing.T) {
+ 		dir = "/bin"
+ 	case "windows":
+ 		dir = Getenv("SystemRoot") + "\\system32"
++	case "haiku":
++		dir = "/boot/system/bin"
+ 	}
+ 	file, err := Open(dir)
+ 	if err != nil {
+@@ -332,6 +348,7 @@ func TestReaddirnamesOneAtATime(t *testing.T) {
+ 	}
+ 	defer file1.Close()
+ 	small := smallReaddirnames(file1, len(all)+100, t) // +100 in case we screw up
++
+ 	if len(small) < len(all) {
+ 		t.Fatalf("len(small) is %d, less than %d", len(small), len(all))
+ 	}
+@@ -493,7 +510,7 @@ func TestReaddirStatFailures(t *testing.T) {
+ 
+ func TestHardLink(t *testing.T) {
+ 	// Hardlinks are not supported under windows or Plan 9.
+-	if runtime.GOOS == "plan9" {
++	if runtime.GOOS == "plan9" || runtime.GOOS == "haiku"{
+ 		return
+ 	}
+ 	from, to := "hardlinktestfrom", "hardlinktestto"
+@@ -847,6 +864,8 @@ func TestChdirAndGetwd(t *testing.T) {
+ 	switch runtime.GOOS {
+ 	case "android":
+ 		dirs = []string{"/", "/system/bin"}
++	case "haiku":
++		dirs = []string{"/", "/boot/system/bin"}
+ 	case "plan9":
+ 		dirs = []string{"/", "/usr"}
+ 	}
+-- 
+2.19.1
+
+
+From fe375bf6cb3b77ace7eb8f4e9a2621cce20e0061 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Tue, 30 Oct 2018 00:27:47 +0000
+Subject: haiku: disable syscall version of wait4q throughout.
+
+
+diff --git a/src/os/sys_haiku.go b/src/os/sys_haiku.go
+index 86a8bbd..f224f0d 100644
+--- a/src/os/sys_haiku.go
++++ b/src/os/sys_haiku.go
+@@ -4,6 +4,8 @@
+ 
+ package os
+ 
++import "syscall"
++
+ func hostname() (name string, err error) {
+-	panic("Not implemented")
++	return syscall.Gethostname()
+ }
+diff --git a/src/runtime/rt0_haiku_amd64.s b/src/runtime/rt0_haiku_amd64.s
+index daff034..4b604ef 100644
+--- a/src/runtime/rt0_haiku_amd64.s
++++ b/src/runtime/rt0_haiku_amd64.s
+@@ -15,4 +15,4 @@ TEXT main(SB),NOSPLIT,$-8
+ 	JMP	AX
+ 
+ DATA runtime·ishaiku(SB)/4, $1
+-GLOBL runtime·ishaiku(SB), $4
++GLOBL runtime·ishaiku(SB), NOPTR, $4
+diff --git a/src/runtime/syscall_haiku.c b/src/runtime/syscall_haiku.c
+index d049ba7..1c56821 100644
+--- a/src/runtime/syscall_haiku.c
++++ b/src/runtime/syscall_haiku.c
+@@ -22,4 +22,5 @@
+ #pragma dynimport libc·setpgid setsid "libroot.so"
+ #pragma dynimport libc·_kern_generic_syscall _kern_generic_syscall "libroot.so"
+ #pragma dynimport libc·fork fork "libroot.so"
+-#pragma dynimport libc·waitpid waitpid "libroot.so"
++//#pragma dynimport libc·waitpid waitpid "libroot.so"
++#pragma dynimport libc·wait4 wait4 "libbsd.so"
+diff --git a/src/runtime/syscall_haiku.go b/src/runtime/syscall_haiku.go
+index 68ee1d1..5a32f23 100644
+--- a/src/runtime/syscall_haiku.go
++++ b/src/runtime/syscall_haiku.go
+@@ -29,6 +29,7 @@ var (
+ 	libc__kern_generic_syscall,
+ 	libc_fork,
+ 	libc_waitpid,
++//	libc_wait4,
+ 	libc_write,
+ 	pipe1 libcFunc
+ )
+@@ -323,18 +324,20 @@ func syscall_syscall(trap, a1, a2, a3 uintptr) (r1, r2, err uintptr) {
+ 	return call.r1, call.r2, call.err
+ }
+ 
++/*
+ //go:nosplit
+-func syscall_wait4(pid uintptr, wstatus *uint32, options uintptr, rusage unsafe.Pointer) (wpid int, err uintptr) {
++func syscall_wait4(pid uintptr, wstatus *uint32, options uintptr) (wpid int, err uintptr) {
+ 	call := libcall{
+ 		fn:   uintptr(unsafe.Pointer(&libc_waitpid)),
+-		n:    4,
++		n:    3,
+ 		args: uintptr(unsafe.Pointer(&pid)),
+ 	}
+-	//entersyscallblock()
+-	//asmcgocall(unsafe.Pointer(&asmsysvicall6), unsafe.Pointer(&call))
+-	//exitsyscall()
++	entersyscallblock()
++	asmcgocall(unsafe.Pointer(&asmsysvicall6), unsafe.Pointer(&call))
++	exitsyscall()
+ 	return int(call.r1), call.err
+ }
++*/
+ 
+ //go:nosplit
+ func syscall_write(fd, buf, nbyte uintptr) (n, err uintptr) {
+diff --git a/src/runtime/thunk_haiku_amd64.s b/src/runtime/thunk_haiku_amd64.s
+index 8e10618..1eb12e9 100644
+--- a/src/runtime/thunk_haiku_amd64.s
++++ b/src/runtime/thunk_haiku_amd64.s
+@@ -79,9 +79,9 @@ TEXT runtime·libc_syscall(SB),NOSPLIT,$0
+ 	MOVQ	libc·_kern_generic_syscall(SB), AX
+ 	JMP	AX
+ 
+-TEXT runtime·libc_wait4(SB),NOSPLIT,$0
+-	MOVQ	libc·waitpid(SB), AX
+-	JMP	AX
++//TEXT runtime·libc_wait4(SB),NOSPLIT,$0
++//	MOVQ	libc·waitpid(SB), AX
++//	JMP	AX
+ 
+ TEXT runtime·libc_write(SB),NOSPLIT,$0
+ 	MOVQ	libc·write(SB), AX
+diff --git a/src/syscall/mksyscall_haiku.pl b/src/syscall/mksyscall_haiku.pl
+new file mode 100755
+index 0000000..0647bdc
+--- /dev/null
++++ b/src/syscall/mksyscall_haiku.pl
+@@ -0,0 +1,290 @@
++#!/usr/bin/env perl
++# Copyright 2009 The Go Authors. All rights reserved.
++# Use of this source code is governed by a BSD-style
++# license that can be found in the LICENSE file.
++
++# This program reads a file containing function prototypes
++# (like syscall_haiku.go) and generates system call bodies.
++# The prototypes are marked by lines beginning with "//sys"
++# and read like func declarations if //sys is replaced by func, but:
++#	* The parameter lists must give a name for each argument.
++#	  This includes return parameters.
++#	* The parameter lists must give a type for each argument:
++#	  the (x, y, z int) shorthand is not allowed.
++#	* If the return parameter is an error number, it must be named err.
++#	* If go func name needs to be different than its libc name, 
++#	* or the function is not in libc, name could be specified
++#	* at the end, after "=" sign, like
++#	  //sys getsockopt(s int, level int, name int, val uintptr, vallen *_Socklen) (err error) = libsocket.getsockopt
++
++use strict;
++
++my $cmdline = "mksyscall_haiku.pl " . join(' ', @ARGV);
++my $errors = 0;
++my $_32bit = "";
++my $default_modname = "libc";
++
++binmode STDOUT;
++
++if($ARGV[0] eq "-b32") {
++	$_32bit = "big-endian";
++	shift;
++} elsif($ARGV[0] eq "-l32") {
++	$_32bit = "little-endian";
++	shift;
++}
++
++if ($ARGV[0] eq "-modname") {
++	$default_modname = "$ARGV[1]";
++	shift;
++	shift;
++}
++
++if($ARGV[0] =~ /^-/) {
++	print STDERR "usage: mksyscall_haiku.pl [-b32 | -l32] [file ...]\n";
++	exit 1;
++}
++
++sub parseparamlist($) {
++	my ($list) = @_;
++	$list =~ s/^\s*//;
++	$list =~ s/\s*$//;
++	if($list eq "") {
++		return ();
++	}
++	return split(/\s*,\s*/, $list);
++}
++
++sub parseparam($) {
++	my ($p) = @_;
++	if($p !~ /^(\S*) (\S*)$/) {
++		print STDERR "$ARGV:$.: malformed parameter: $p\n";
++		$errors = 1;
++		return ("xx", "int");
++	}
++	return ($1, $2);
++}
++
++my $package = "";
++my $text = "";
++my $vars = "";
++my $mods = "";
++my $modnames = "";
++while(<>) {
++	chomp;
++	s/\s+/ /g;
++	s/^\s+//;
++	s/\s+$//;
++	$package = $1 if !$package && /^package (\S+)$/;
++	my $nonblock = /^\/\/sysnb /;
++	next if !/^\/\/sys / && !$nonblock;
++
++	my $syscalldot = "";
++	$syscalldot = "syscall." if $package ne "syscall";
++
++	# Line must be of the form
++	#	func Open(path string, mode int, perm int) (fd int, err error)
++	# Split into name, in params, out params.
++	if(!/^\/\/sys(nb)? (\w+)\(([^()]*)\)\s*(?:\(([^()]+)\))?\s*(?:=\s*(?:(\w*)\.)?(\w*))?$/) {
++		print STDERR "$ARGV:$.: malformed //sys declaration\n";
++		$errors = 1;
++		next;
++	}
++	my ($nb, $func, $in, $out, $modname, $sysname) = ($1, $2, $3, $4, $5, $6);
++
++	# Split argument lists on comma.
++	my @in = parseparamlist($in);
++	my @out = parseparamlist($out);
++
++	# So file name.
++	if($modname eq "") {
++		$modname = "$default_modname";
++	}
++	my $modvname = "mod$modname";
++	if($modnames !~ /$modname/) {
++		$modnames .= ".$modname";
++		$mods .= "\t$modvname = ${syscalldot}newLazySO(\"$modname.so\")\n";
++	}
++
++	# System call name.
++	if($sysname eq "") {
++		$sysname = "$func";
++	}
++
++	# System call pointer variable name.
++	my $sysvarname = "proc$sysname";
++
++	my $strconvfunc = "BytePtrFromString";
++	my $strconvtype = "*byte";
++
++	# Library proc address variable.
++	$sysname =~ y/A-Z/a-z/; # All libc functions are lowercase.
++	$vars .= "\t$sysvarname = $modvname.NewProc(\"$sysname\")\n";
++
++	# Go function header.
++	$out = join(', ', @out);
++	if($out ne "") {
++		$out = " ($out)";
++	}
++	if($text ne "") {
++		$text .= "\n"
++	}
++	$text .= sprintf "func %s(%s)%s {\n", $func, join(', ', @in), $out;
++
++	# Check if err return available
++	my $errvar = "";
++	foreach my $p (@out) {
++		my ($name, $type) = parseparam($p);
++		if($type eq "error") {
++			$errvar = $name;
++			last;
++		}
++	}
++
++	# Prepare arguments to Syscall.
++	my @args = ();
++	my @uses = ();
++	my $n = 0;
++	foreach my $p (@in) {
++		my ($name, $type) = parseparam($p);
++		if($type =~ /^\*/) {
++			push @args, "uintptr(unsafe.Pointer($name))";
++		} elsif($type eq "string" && $errvar ne "") {
++			$text .= "\tvar _p$n $strconvtype\n";
++			$text .= "\t_p$n, $errvar = $strconvfunc($name)\n";
++			$text .= "\tif $errvar != nil {\n\t\treturn\n\t}\n";
++			push @args, "uintptr(unsafe.Pointer(_p$n))";
++			push @uses, "use(unsafe.Pointer(_p$n))";
++			$n++;
++		} elsif($type eq "string") {
++			print STDERR "$ARGV:$.: $func uses string arguments, but has no error return\n";
++			$text .= "\tvar _p$n $strconvtype\n";
++			$text .= "\t_p$n, _ = $strconvfunc($name)\n";
++			push @args, "uintptr(unsafe.Pointer(_p$n))";
++			push @uses, "use(unsafe.Pointer(_p$n))";
++			$n++;
++		} elsif($type =~ /^\[\](.*)/) {
++			# Convert slice into pointer, length.
++			# Have to be careful not to take address of &a[0] if len == 0:
++			# pass nil in that case.
++			$text .= "\tvar _p$n *$1\n";
++			$text .= "\tif len($name) > 0 {\n\t\t_p$n = \&$name\[0]\n\t}\n";
++			push @args, "uintptr(unsafe.Pointer(_p$n))", "uintptr(len($name))";
++			$n++;
++		} elsif($type eq "int64" && $_32bit ne "") {
++			if($_32bit eq "big-endian") {
++				push @args, "uintptr($name >> 32)", "uintptr($name)";
++			} else {
++				push @args, "uintptr($name)", "uintptr($name >> 32)";
++			}
++		} elsif($type eq "bool") {
++ 			$text .= "\tvar _p$n uint32\n";
++			$text .= "\tif $name {\n\t\t_p$n = 1\n\t} else {\n\t\t_p$n = 0\n\t}\n";
++			push @args, "uintptr(_p$n)";
++			$n++;
++		} else {
++			push @args, "uintptr($name)";
++		}
++	}
++	my $nargs = @args;
++
++	# Determine which form to use; pad args with zeros.
++	my $asm = "${syscalldot}sysvicall6";
++	if ($nonblock) {
++		$asm = "${syscalldot}rawSysvicall6";
++	}
++	if(@args <= 6) {
++		while(@args < 6) {
++			push @args, "0";
++		}
++	} else {
++		print STDERR "$ARGV:$.: too many arguments to system call\n";
++	}
++
++	# Actual call.
++	my $args = join(', ', @args);
++	my $call = "$asm($sysvarname.Addr(), $nargs, $args)";
++
++	# Assign return values.
++	my $body = "";
++	my $failexpr = "";
++	my @ret = ("_", "_", "_");
++	my @pout= ();
++	my $do_errno = 0;
++	for(my $i=0; $i<@out; $i++) {
++		my $p = $out[$i];
++		my ($name, $type) = parseparam($p);
++		my $reg = "";
++		if($name eq "err") {
++			$reg = "e1";
++			$ret[2] = $reg;
++			$do_errno = 1;
++		} else {
++			$reg = sprintf("r%d", $i);
++			$ret[$i] = $reg;
++		}
++		if($type eq "bool") {
++			$reg = "$reg != 0";
++		}
++		if($type eq "int64" && $_32bit ne "") {
++			# 64-bit number in r1:r0 or r0:r1.
++			if($i+2 > @out) {
++				print STDERR "$ARGV:$.: not enough registers for int64 return\n";
++			}
++			if($_32bit eq "big-endian") {
++				$reg = sprintf("int64(r%d)<<32 | int64(r%d)", $i, $i+1);
++			} else {
++				$reg = sprintf("int64(r%d)<<32 | int64(r%d)", $i+1, $i);
++			}
++			$ret[$i] = sprintf("r%d", $i);
++			$ret[$i+1] = sprintf("r%d", $i+1);
++		}
++		if($reg ne "e1") {
++			$body .= "\t$name = $type($reg)\n";
++		}
++	}
++	if ($ret[0] eq "_" && $ret[1] eq "_" && $ret[2] eq "_") {
++		$text .= "\t$call\n";
++	} else {
++		$text .= "\t$ret[0], $ret[1], $ret[2] := $call\n";
++	}
++	foreach my $use (@uses) {
++		$text .= "\t$use\n";
++	}
++	$text .= $body;
++
++	if ($do_errno) {
++		$text .= "\tif e1 != 0 {\n";
++		$text .= "\t\terr = e1\n";
++		$text .= "\t}\n";
++	}
++	$text .= "\treturn\n";
++	$text .= "}\n";
++}
++
++if($errors) {
++	exit 1;
++}
++
++print <<EOF;
++// $cmdline
++// MACHINE GENERATED BY THE COMMAND ABOVE; DO NOT EDIT
++
++package $package
++
++import "unsafe"
++EOF
++
++print "import \"syscall\"\n" if $package ne "syscall";
++
++print <<EOF;
++
++var (
++$mods
++$vars
++)
++
++$text
++
++EOF
++exit 0;
+-- 
+2.19.1
+
+
+From 87ecbf5e555c4f496c0240fb48d84c58ff319a59 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Tue, 30 Oct 2018 00:29:07 +0000
+Subject: syscall: use waitpid from libroot for wait4 implementation add fix
+ command line exec.
+
+
+diff --git a/src/syscall/asm_haiku_amd64.s b/src/syscall/asm_haiku_amd64.s
+index 19e742b..df7f8fb 100644
+--- a/src/syscall/asm_haiku_amd64.s
++++ b/src/syscall/asm_haiku_amd64.s
+@@ -77,8 +77,8 @@ TEXT ·setpgid(SB),NOSPLIT,$0
+ TEXT ·Syscall(SB),NOSPLIT,$0
+ 	JMP	runtime·syscall_syscall(SB)
+ 
+-TEXT ·wait4(SB),NOSPLIT,$0
+-	JMP	runtime·syscall_wait4(SB)
++//TEXT ·wait4(SB),NOSPLIT,$0
++//	JMP	runtime·syscall_wait4(SB)
+ 
+ TEXT ·dup2(SB),NOSPLIT,$0
+ 	JMP	runtime·syscall_dup2(SB)
+diff --git a/src/syscall/exec_haiku.go b/src/syscall/exec_haiku.go
+index 2db25eb..0d92f3b 100644
+--- a/src/syscall/exec_haiku.go
++++ b/src/syscall/exec_haiku.go
+@@ -88,7 +88,7 @@ func forkAndExecInChild(argv0 *byte, argv, envv []*byte, chroot, dir *byte, attr
+ 	}
+ 
+ 	// Fork succeeded, now in child.
+-	/*
++	
+ 
+ 		// Session ID
+ 		if sys.Setsid {
+@@ -142,7 +142,7 @@ func forkAndExecInChild(argv0 *byte, argv, envv []*byte, chroot, dir *byte, attr
+ 				goto childerror
+ 			}
+ 		}
+-	*/
++	
+ 	// Pass 1: look for fd[i] < i and move those up above len(fd)
+ 	// so that pass 2 won't stomp on an fd it needs later.
+ 	if pipe < nextfd {
+diff --git a/src/syscall/exec_unix.go b/src/syscall/exec_unix.go
+index 400ddb8..e7e6420 100644
+--- a/src/syscall/exec_unix.go
++++ b/src/syscall/exec_unix.go
+@@ -94,6 +94,10 @@ func SlicePtrFromStrings(ss []string) ([]*byte, error) {
+ func CloseOnExec(fd int) { fcntl(fd, F_SETFD, FD_CLOEXEC) }
+ 
+ func SetNonblock(fd int, nonblocking bool) (err error) {
++	if runtime.GOOS == "haiku" {
++		// FIXME: Haiku does not have a working netpoller yet.
++		return nil
++	}
+ 	flag, err := fcntl(fd, F_GETFL, 0)
+ 	if err != nil {
+ 		return err
+diff --git a/src/syscall/syscall_haiku.go b/src/syscall/syscall_haiku.go
+index 0147b5c..4ac2ec9 100644
+--- a/src/syscall/syscall_haiku.go
++++ b/src/syscall/syscall_haiku.go
+@@ -252,14 +252,15 @@ func (w WaitStatus) StopSignal() Signal {
+ 
+ func (w WaitStatus) TrapCause() int { return -1 }
+ 
+-func wait4(pid uintptr, wstatus *WaitStatus, options uintptr, rusage *Rusage) (wpid uintptr, err uintptr)
++// sys wait4(pid uintptr, wstatus *WaitStatus, options uintptr, rusage *Rusage) (wpid int, err uintptr) = libroot.waitpid
+ 
+ func Wait4(pid int, wstatus *WaitStatus, options int, rusage *Rusage) (wpid int, err error) {
+-	r0, e1 := wait4(uintptr(pid), wstatus, uintptr(options), rusage)
++	r0, _, e1 := sysvicall6(procwaitpid.Addr(), 3, uintptr(pid), uintptr(unsafe.Pointer(wstatus)), uintptr(options), uintptr(unsafe.Pointer(rusage)), 0, 0)
++	wpid = int(r0)
+ 	if e1 != 0 {
+ 		err = Errno(e1)
+ 	}
+-	return int(r0), err
++	return wpid, err
+ }
+ 
+ func gethostname() (name string, err uintptr)
+diff --git a/src/syscall/types_haiku.go b/src/syscall/types_haiku.go
+index 7f4cb70..6873e5f 100644
+--- a/src/syscall/types_haiku.go
++++ b/src/syscall/types_haiku.go
+@@ -166,5 +166,5 @@ type Termios C.struct_termios
+ // Fake constant needed by net package
+ 
+ const (
+-	F_DUPFD_CLOEXEC = 0xdeadf00d
++	F_DUPFD_CLOEXEC = 0x0200
+ )
+diff --git a/src/syscall/zsyscall_haiku_amd64.go b/src/syscall/zsyscall_haiku_amd64.go
+index 7b59275..6f886c7 100644
+--- a/src/syscall/zsyscall_haiku_amd64.go
++++ b/src/syscall/zsyscall_haiku_amd64.go
+@@ -1,4 +1,4 @@
+-// mksyscall_haiku.pl -modname libroot syscall_haiku.go syscall_haiku_amd64.go
++// mksyscall_haiku.pl -modname libroot syscall_haiku.go
+ // MACHINE GENERATED BY THE COMMAND ABOVE; DO NOT EDIT
+ 
+ package syscall
+@@ -6,91 +6,95 @@ package syscall
+ import "unsafe"
+ 
+ var (
+-	modlibroot    = newLazySO("libroot.so")
++	modlibroot = newLazySO("libroot.so")
+ 	modlibnetwork = newLazySO("libnetwork.so")
+-
+-	procpipe         = modlibroot.NewProc("pipe")
+-	procgetgroups    = modlibroot.NewProc("getgroups")
+-	procsetgroups    = modlibroot.NewProc("setgroups")
+-	procfcntl        = modlibroot.NewProc("fcntl")
+-	procaccept       = modlibnetwork.NewProc("accept")
+-	procsendmsg      = modlibnetwork.NewProc("sendmsg")
+-	procAccess       = modlibroot.NewProc("access")
+-	procAdjtime      = modlibroot.NewProc("adjtime")
+-	procChdir        = modlibroot.NewProc("chdir")
+-	procChmod        = modlibroot.NewProc("chmod")
+-	procChown        = modlibroot.NewProc("chown")
+-	procChroot       = modlibroot.NewProc("chroot")
+-	procClose        = modlibroot.NewProc("close")
+-	procDup          = modlibroot.NewProc("dup")
+-	procExit         = modlibroot.NewProc("exit")
+-	procFchdir       = modlibroot.NewProc("fchdir")
+-	procFchmod       = modlibroot.NewProc("fchmod")
+-	procFchown       = modlibroot.NewProc("fchown")
+-	procFpathconf    = modlibroot.NewProc("fpathconf")
+-	procFstat        = modlibroot.NewProc("fstat")
+-	procGetgid       = modlibroot.NewProc("getgid")
+-	procGetpid       = modlibroot.NewProc("getpid")
+-	procGeteuid      = modlibroot.NewProc("geteuid")
+-	procGetegid      = modlibroot.NewProc("getegid")
+-	procGetppid      = modlibroot.NewProc("getppid")
+-	procGetpriority  = modlibroot.NewProc("getpriority")
+-	procGetrlimit    = modlibroot.NewProc("getrlimit")
++	//modlibbsd = newLazySO("libbsd.so")
++
++	procpipe = modlibroot.NewProc("pipe")
++	procgetgroups = modlibroot.NewProc("getgroups")
++	procsetgroups = modlibroot.NewProc("setgroups")
++	//procwait4 = modlibbsd.NewProc("wait4")
++	procwaitpid = modlibroot.NewProc("waitpid")
++	procfcntl = modlibroot.NewProc("fcntl")
++	procaccept = modlibnetwork.NewProc("accept")
++	procsendmsg = modlibnetwork.NewProc("sendmsg")
++	procAccess = modlibroot.NewProc("access")
++	procAdjtime = modlibroot.NewProc("adjtime")
++	procChdir = modlibroot.NewProc("chdir")
++	procChmod = modlibroot.NewProc("chmod")
++	procChown = modlibroot.NewProc("chown")
++	procChroot = modlibroot.NewProc("chroot")
++	procClose = modlibroot.NewProc("close")
++	procDup = modlibroot.NewProc("dup")
++	procExit = modlibroot.NewProc("exit")
++	procFchdir = modlibroot.NewProc("fchdir")
++	procFchmod = modlibroot.NewProc("fchmod")
++	procFchown = modlibroot.NewProc("fchown")
++	procFpathconf = modlibroot.NewProc("fpathconf")
++	procFstat = modlibroot.NewProc("fstat")
++	procGetgid = modlibroot.NewProc("getgid")
++	procGetpid = modlibroot.NewProc("getpid")
++	procGeteuid = modlibroot.NewProc("geteuid")
++	procGetegid = modlibroot.NewProc("getegid")
++	procGetppid = modlibroot.NewProc("getppid")
++	procGetpriority = modlibroot.NewProc("getpriority")
++	procGetrlimit = modlibroot.NewProc("getrlimit")
+ 	procGettimeofday = modlibroot.NewProc("gettimeofday")
+-	procGetuid       = modlibroot.NewProc("getuid")
+-	procKill         = modlibroot.NewProc("kill")
+-	procLchown       = modlibroot.NewProc("lchown")
+-	procLink         = modlibroot.NewProc("link")
+-	proclisten       = modlibnetwork.NewProc("listen")
+-	procLstat        = modlibroot.NewProc("lstat")
+-	procMkdir        = modlibroot.NewProc("mkdir")
+-	procMknod        = modlibroot.NewProc("mknod")
+-	procNanosleep    = modlibroot.NewProc("nanosleep")
+-	procOpen         = modlibroot.NewProc("open")
+-	procPathconf     = modlibroot.NewProc("pathconf")
+-	procPread        = modlibroot.NewProc("pread")
+-	procPwrite       = modlibroot.NewProc("pwrite")
+-	procread         = modlibroot.NewProc("read")
+-	procReadlink     = modlibroot.NewProc("readlink")
+-	procRename       = modlibroot.NewProc("rename")
+-	procRmdir        = modlibroot.NewProc("rmdir")
+-	proclseek        = modlibroot.NewProc("lseek")
+-	procSetegid      = modlibroot.NewProc("setegid")
+-	procSeteuid      = modlibroot.NewProc("seteuid")
+-	procSetgid       = modlibroot.NewProc("setgid")
+-	procSetpgid      = modlibroot.NewProc("setpgid")
+-	procSetpriority  = modlibroot.NewProc("setpriority")
+-	procSetregid     = modlibroot.NewProc("setregid")
+-	procSetreuid     = modlibroot.NewProc("setreuid")
+-	procSetrlimit    = modlibroot.NewProc("setrlimit")
+-	procSetsid       = modlibroot.NewProc("setsid")
+-	procSetuid       = modlibroot.NewProc("setuid")
+-	procshutdown     = modlibnetwork.NewProc("shutdown")
+-	procStat         = modlibroot.NewProc("stat")
+-	procSymlink      = modlibroot.NewProc("symlink")
+-	procSync         = modlibroot.NewProc("sync")
+-	procTruncate     = modlibroot.NewProc("truncate")
+-	procFsync        = modlibroot.NewProc("fsync")
+-	procFtruncate    = modlibroot.NewProc("ftruncate")
+-	procUmask        = modlibroot.NewProc("umask")
+-	procUnlink       = modlibroot.NewProc("unlink")
+-	procUtimes       = modlibroot.NewProc("utimes")
+-	procbind         = modlibnetwork.NewProc("bind")
+-	procconnect      = modlibnetwork.NewProc("connect")
+-	procmunmap       = modlibroot.NewProc("munmap")
+-	procsendto       = modlibnetwork.NewProc("sendto")
+-	procsocket       = modlibnetwork.NewProc("socket")
+-	procsocketpair   = modlibnetwork.NewProc("socketpair")
+-	procwrite        = modlibroot.NewProc("write")
+-	procgetsockopt   = modlibnetwork.NewProc("getsockopt")
+-	procgetpeername  = modlibnetwork.NewProc("getpeername")
+-	procgetsockname  = modlibnetwork.NewProc("getsockname")
+-	procsetsockopt   = modlibnetwork.NewProc("setsockopt")
+-	procrecvfrom     = modlibnetwork.NewProc("recvfrom")
+-	procrecvmsg      = modlibnetwork.NewProc("recvmsg")
+-	procFdopendir    = modlibroot.NewProc("fdopendir")
+-	procReaddir_r    = modlibroot.NewProc("readdir_r")
+-	procClosedir     = modlibroot.NewProc("closedir")
++	procGetuid = modlibroot.NewProc("getuid")
++	procKill = modlibroot.NewProc("kill")
++	procLchown = modlibroot.NewProc("lchown")
++	procLink = modlibroot.NewProc("link")
++	proclisten = modlibnetwork.NewProc("listen")
++	procLstat = modlibroot.NewProc("lstat")
++	procMkdir = modlibroot.NewProc("mkdir")
++	procMknod = modlibroot.NewProc("mknod")
++	procNanosleep = modlibroot.NewProc("nanosleep")
++	procOpen = modlibroot.NewProc("open")
++	procPathconf = modlibroot.NewProc("pathconf")
++	procPread = modlibroot.NewProc("pread")
++	procPwrite = modlibroot.NewProc("pwrite")
++	procread = modlibroot.NewProc("read")
++	procReadlink = modlibroot.NewProc("readlink")
++	procRename = modlibroot.NewProc("rename")
++	procRmdir = modlibroot.NewProc("rmdir")
++	proclseek = modlibroot.NewProc("lseek")
++	procSetegid = modlibroot.NewProc("setegid")
++	procSeteuid = modlibroot.NewProc("seteuid")
++	procSetgid = modlibroot.NewProc("setgid")
++	procSetpgid = modlibroot.NewProc("setpgid")
++	procSetpriority = modlibroot.NewProc("setpriority")
++	procSetregid = modlibroot.NewProc("setregid")
++	procSetreuid = modlibroot.NewProc("setreuid")
++	procSetrlimit = modlibroot.NewProc("setrlimit")
++	procSetsid = modlibroot.NewProc("setsid")
++	procSetuid = modlibroot.NewProc("setuid")
++	procshutdown = modlibnetwork.NewProc("shutdown")
++	procStat = modlibroot.NewProc("stat")
++	procSymlink = modlibroot.NewProc("symlink")
++	procSync = modlibroot.NewProc("sync")
++	procTruncate = modlibroot.NewProc("truncate")
++	procFsync = modlibroot.NewProc("fsync")
++	procFtruncate = modlibroot.NewProc("ftruncate")
++	procUmask = modlibroot.NewProc("umask")
++	procUnlink = modlibroot.NewProc("unlink")
++	procUtimes = modlibroot.NewProc("utimes")
++	procbind = modlibnetwork.NewProc("bind")
++	procconnect = modlibnetwork.NewProc("connect")
++	procmunmap = modlibroot.NewProc("munmap")
++	procsendto = modlibnetwork.NewProc("sendto")
++	procsocket = modlibnetwork.NewProc("socket")
++	procsocketpair = modlibnetwork.NewProc("socketpair")
++	procwrite = modlibroot.NewProc("write")
++	procgetsockopt = modlibnetwork.NewProc("getsockopt")
++	procgetpeername = modlibnetwork.NewProc("getpeername")
++	procgetsockname = modlibnetwork.NewProc("getsockname")
++	procsetsockopt = modlibnetwork.NewProc("setsockopt")
++	procrecvfrom = modlibnetwork.NewProc("recvfrom")
++	procrecvmsg = modlibnetwork.NewProc("recvmsg")
++	procFdopendir = modlibroot.NewProc("fdopendir")
++	procReaddir_r = modlibroot.NewProc("readdir_r")
++	procClosedir = modlibroot.NewProc("closedir")
++
+ )
+ 
+ func pipe2(fds []int) (err error) {
+@@ -122,6 +126,15 @@ func setgroups(ngid int, gid *_Gid_t) (err error) {
+ 	return
+ }
+ 
++func wait4(pid uintptr, wstatus *WaitStatus, options uintptr, rusage *Rusage) (wpid int, err error) {
++	r0, _, e1 := sysvicall6(procwaitpid.Addr(), 3, uintptr(pid), uintptr(unsafe.Pointer(wstatus)), uintptr(options), uintptr(unsafe.Pointer(rusage)), 0, 0)
++	wpid = int(r0)
++	if e1 != 0 {
++		err = e1
++	}
++	return
++}
++
+ func fcntl(fd int, cmd int, arg int) (val int, err error) {
+ 	r0, _, e1 := sysvicall6(procfcntl.Addr(), 3, uintptr(fd), uintptr(cmd), uintptr(arg), 0, 0, 0)
+ 	val = int(r0)
+@@ -920,3 +933,5 @@ func Closedir(dir unsafe.Pointer) (status int, err error) {
+ 	}
+ 	return
+ }
++
++
+diff --git a/src/syscall/ztypes_haiku_amd64.go b/src/syscall/ztypes_haiku_amd64.go
+index 12f2012..1cec69a 100644
+--- a/src/syscall/ztypes_haiku_amd64.go
++++ b/src/syscall/ztypes_haiku_amd64.go
+@@ -213,5 +213,5 @@ type Termios struct {
+ }
+ 
+ const (
+-	F_DUPFD_CLOEXEC = 0xdeadf00d
++	F_DUPFD_CLOEXEC = 0x0200
+ )
+-- 
+2.19.1
+
+
+From 78bcff5f14c8677588d42a3274c293fc64ad8c52 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Tue, 23 Apr 2019 22:53:03 +0000
+Subject: syscall: Workaround fork/exec hang in Haiku.
+
+This change is a temporary workaround in allowing the go1.4.3 compiler to
+bootstrap higher versions of Go inside of Haiku.
+
+Also solves the fork/exec issue when building certain packages when
+bootstrapping.
+
+diff --git a/src/syscall/exec_haiku.go b/src/syscall/exec_haiku.go
+index 0d92f3b..951f44d 100644
+--- a/src/syscall/exec_haiku.go
++++ b/src/syscall/exec_haiku.go
+@@ -88,8 +88,8 @@ func forkAndExecInChild(argv0 *byte, argv, envv []*byte, chroot, dir *byte, attr
+ 	}
+ 
+ 	// Fork succeeded, now in child.
+-	
+ 
++	/*
+ 		// Session ID
+ 		if sys.Setsid {
+ 			_, err1 = setsid()
+@@ -142,7 +142,8 @@ func forkAndExecInChild(argv0 *byte, argv, envv []*byte, chroot, dir *byte, attr
+ 				goto childerror
+ 			}
+ 		}
+-	
++	*/
++
+ 	// Pass 1: look for fd[i] < i and move those up above len(fd)
+ 	// so that pass 2 won't stomp on an fd it needs later.
+ 	if pipe < nextfd {
+-- 
+2.19.1
 


### PR DESCRIPTION
This patches the go compiler for Haiku to fix process
waiting when executing Wait() on a process. Should also fix
the net/url hang [0] when attempting to bootstrap Go 1.5 [1] and
above.

Also changes the GOROOT_FINAL location to a globally writeable
location in the non-packaged folder to allow golang to install
third-party libraries.

[0] For context on this issue, see https://github.com/haikuports/haikuports/pull/3119#issuecomment-424038086
[1] See: https://gist.github.com/return/6e1d24dc67da616b5f828a3b84b12704