### PR TITLE
eiskaltdcpp: bump version.

### DIFF
--- a/net-p2p/eiskaltdcpp/eiskaltdcpp-2.3.0~git.recipe
+++ b/net-p2p/eiskaltdcpp/eiskaltdcpp-2.3.0~git.recipe
@@ -7,10 +7,10 @@ software."
 HOMEPAGE="https://sourceforge.net/projects/eiskaltdcpp/"
 COPYRIGHT="EiskaltDC++ team"
 LICENSE="GNU GPL v3"
-REVISION="6"
-srcGitRev="e3791e20daa9a878f79684ed54e1564088306025"
+REVISION="7"
+srcGitRev="5a64bdff7ba0c1844730c8b28179a671c4e7afbb"
 SOURCE_URI="https://github.com/eiskaltdcpp/eiskaltdcpp/archive/$srcGitRev.tar.gz"
-CHECKSUM_SHA256="cadea7afe0caf5bd45af777ec2a1ac5f8afd0c38fcdca7bb072e2936f9015a2e"
+CHECKSUM_SHA256="056cea8c08e86eecc7275d6b1e54c9d1c18c38ed72eb9c9c75d8f9c57d96737f"
 SOURCE_DIR="eiskaltdcpp-$srcGitRev"
 ADDITIONAL_FILES="eiskaltdcpp.rdef.in"
 
@@ -20,7 +20,6 @@ SECONDARY_ARCHITECTURES="x86"
 PROVIDES="
 	eiskaltdcpp$secondaryArchSuffix = $portVersion
 	app:EiskaltDC++ = $portVersion
-	lib:libeiskaltdcpp$secondaryArchSuffix = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -87,9 +86,8 @@ BUILD()
 
 INSTALL()
 {
-	mkdir -p $appsDir/Eiskaltdcpp/{translations,lib}
+	mkdir -p $appsDir/Eiskaltdcpp/translations
 	cp build/eiskaltdcpp-qt/eiskaltdcpp-qt $appsDir/Eiskaltdcpp/EiskaltDC++
-	cp build/dcpp/libeiskaltdcpp.so* $appsDir/Eiskaltdcpp/lib
 	cp build/eiskaltdcpp-qt/translations/*.qm $appsDir/Eiskaltdcpp/translations
 
 	cp -r eiskaltdcpp-qt/icons/* $appsDir/Eiskaltdcpp


### PR DESCRIPTION
Some Haiku-specific changes were done in upstream:
* Static core library.
* Fixed loading of translations in UI from non-standard path `<EiskaltDC++ bin dir>/translations`.

Translations for core library are still not available in this package as well as some other resources necessary for UI.

More Haiku-specific changes will be done later. Not sure how soon though.