### PR TITLE
eiskaltdcpp: bump version + improve build script

### DIFF
--- a/net-p2p/eiskaltdcpp/eiskaltdcpp-2.3.0~git.recipe
+++ b/net-p2p/eiskaltdcpp/eiskaltdcpp-2.3.0~git.recipe
@@ -7,10 +7,10 @@ software."
 HOMEPAGE="https://sourceforge.net/projects/eiskaltdcpp/"
 COPYRIGHT="EiskaltDC++ team"
 LICENSE="GNU GPL v3"
-REVISION="7"
-srcGitRev="5a64bdff7ba0c1844730c8b28179a671c4e7afbb"
+REVISION="8"
+srcGitRev="bbc0b7cee6c9c24afecd2e90075cd37da0e84f7f"
 SOURCE_URI="https://github.com/eiskaltdcpp/eiskaltdcpp/archive/$srcGitRev.tar.gz"
-CHECKSUM_SHA256="056cea8c08e86eecc7275d6b1e54c9d1c18c38ed72eb9c9c75d8f9c57d96737f"
+CHECKSUM_SHA256="2fab8f57ab9f31a8a91fc208fc99c1aa3fb751d0ae3e1d4df7a661c8493a7637"
 SOURCE_DIR="eiskaltdcpp-$srcGitRev"
 ADDITIONAL_FILES="eiskaltdcpp.rdef.in"
 
@@ -23,7 +23,6 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libaspell$secondaryArchSuffix
 	lib:libboost_system$secondaryArchSuffix
 	lib:libbz2$secondaryArchSuffix
 	lib:libcrypto$secondaryArchSuffix
@@ -46,7 +45,6 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libaspell$secondaryArchSuffix
 	devel:libboost_system$secondaryArchSuffix
 	devel:libbz2$secondaryArchSuffix
 	devel:libcrypto$secondaryArchSuffix
@@ -79,22 +77,21 @@ BUILD()
 	mkdir -p build
 	cd build
 	cmake .. \
-		-DCMAKE_BUILD_TYPE=Release $cmakeDirArgs \
-		-DLUA_INCLUDE_DIR="`pkg-config --variable=includedir lua`"
+		-DCMAKE_INSTALL_PREFIX:PATH=$appsDir/Eiskaltdcpp \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DLUA_INCLUDE_DIR="`pkg-config --variable=includedir lua`" \
+		-DJSONRPC_DAEMON=OFF \
+		-DWITH_LUASCRIPTS=ON \
+		-DWITH_EXAMPLES=OFF \
+		-DUSE_ASPELL=OFF \
+		-DDBUS_NOTIFY=OFF
 	make $jobArgs
 }
 
 INSTALL()
 {
-	mkdir -p $appsDir/Eiskaltdcpp/translations
-	cp build/eiskaltdcpp-qt/eiskaltdcpp-qt $appsDir/Eiskaltdcpp/EiskaltDC++
-	cp build/eiskaltdcpp-qt/translations/*.qm $appsDir/Eiskaltdcpp/translations
-
-	cp -r eiskaltdcpp-qt/icons/* $appsDir/Eiskaltdcpp
-	cp -r data/emoticons $appsDir/Eiskaltdcpp
-	cp -r data/sounds $appsDir/Eiskaltdcpp
-
-	rm -rf $appsDir/Eiskaltdcpp/gv.xpm
+	cd build
+	make install
 
 	MAJOR="`echo "$portVersion" | cut -d. -f1`"
 	MIDDLE="`echo "$portVersion" | cut -d. -f2`"


### PR DESCRIPTION
This PR is not ready for merging yet.

For some unintelligible reason `addResourcesToBinaries` tool in build script does not see `$appsDir/Eiskaltdcpp/EiskaltDC++` file, which was explicitly installed during `make install`.

Any comments are welcome.