### PR TITLE
psi_plus: use native DNS resolver from Qt

### DIFF
--- a/net-im/psi_plus/psi_plus-1.4.672.recipe
+++ b/net-im/psi_plus/psi_plus-1.4.672.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="Psi is a cross-platform powerful XMPP client designed for experienc
 HOMEPAGE="https://psi-plus.com/"
 COPYRIGHT="2005-2019, Psi+ Project"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/psi-plus/psi-plus-snapshots/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="e2311ceed559b4ef54d555e9147532eb65a54ab008269f443ead3ef4b54fd165"
 SOURCE_DIR="psi-plus-snapshots-$portVersion"
@@ -98,7 +98,7 @@ BUILD()
 		-DBUNDLED_IRIS=ON \
 		-DUSE_HUNSPELL=ON \
 		-DONLY_PLUGINS=OFF \
-		-DUSE_QJDNS=ON \
+		-DUSE_QJDNS=OFF \
 		-DBUILD_PLUGINS="ALL"
 
 	make $jobArgs


### PR DESCRIPTION
It was recently improved in Haiku port of Qt:
https://github.com/haikuports/haikuports/blob/53f29b56/dev-qt/qt5/patches/qt5-5.12.3.patchset#L343