### PR TITLE
psi_plus: bump version to 1.4.675

### DIFF
--- a/net-im/psi_plus/psi_plus-1.4.675.recipe
+++ b/net-im/psi_plus/psi_plus-1.4.675.recipe
@@ -3,12 +3,12 @@ DESCRIPTION="Psi is a cross-platform powerful XMPP client designed for experienc
 HOMEPAGE="https://psi-plus.com/"
 COPYRIGHT="2005-2019, Psi+ Project"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://github.com/psi-plus/psi-plus-snapshots/archive/$portVersion.tar.gz"
-CHECKSUM_SHA256="e2311ceed559b4ef54d555e9147532eb65a54ab008269f443ead3ef4b54fd165"
+CHECKSUM_SHA256="26485a24f3e1d665ccdd2c6af0cea6462ec93fae9eb38644aa7ca2dea900593e"
 SOURCE_DIR="psi-plus-snapshots-$portVersion"
 SOURCE_URI_2="https://github.com/psi-plus/psi-plus-l10n/archive/$portVersion.tar.gz"
-CHECKSUM_SHA256_2="22ed13c77ebe8a56fba2820ac08a772c5ecd9a3629006016334964e529c211e9"
+CHECKSUM_SHA256_2="7d725cb4f5bfae559a967a9f8b8e767f25111bce4656d41cfd4aa17d891e1b2e"
 SOURCE_FILENAME_2="psi-plus-l10n-$portVersion.tar.gz"
 SOURCE_DIR_2="psi-plus-l10n-$portVersion"
 spcVersion="2.3.2"
@@ -27,7 +27,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libcrypto$secondaryArchSuffix	
+	lib:libcrypto$secondaryArchSuffix
 	lib:libgcrypt$secondaryArchSuffix
 	lib:libhunspell_1.6$secondaryArchSuffix
 	lib:libidn$secondaryArchSuffix
@@ -95,11 +95,7 @@ BUILD()
 		-DCHAT_TYPE=WEBKIT \
 		-DENABLE_PLUGINS=ON \
 		-DPLUGINS_PATH=plugins \
-		-DBUNDLED_IRIS=ON \
-		-DUSE_HUNSPELL=ON \
-		-DONLY_PLUGINS=OFF \
-		-DUSE_QJDNS=OFF \
-		-DBUILD_PLUGINS="ALL"
+		-DUSE_HUNSPELL=ON
 
 	make $jobArgs
 }


### PR DESCRIPTION
+ delete configuration options which default values fit fine Haiku needs
  and will not be changed in upstream in the future.

Changes in upstream: fixed segfault on program exit.