### PR TITLE
psi_plus: build program without webkit

### DIFF
--- a/net-im/psi_plus/psi_plus-1.4.675.recipe
+++ b/net-im/psi_plus/psi_plus-1.4.675.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="Psi is a cross-platform powerful XMPP client designed for experienc
 HOMEPAGE="https://psi-plus.com/"
 COPYRIGHT="2005-2019, Psi+ Project"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/psi-plus/psi-plus-snapshots/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="26485a24f3e1d665ccdd2c6af0cea6462ec93fae9eb38644aa7ca2dea900593e"
 SOURCE_DIR="psi-plus-snapshots-$portVersion"
@@ -92,7 +92,7 @@ BUILD()
 		-DCMAKE_INSTALL_DATAROOTDIR:PATH=$appsDir/Psi-plus \
 		-DSIGNAL_PROTOCOL_C_ROOT:PATH=$sourceDir/libsignal-protocol-c \
 		-DCMAKE_BUILD_TYPE=RELEASE \
-		-DCHAT_TYPE=WEBKIT \
+		-DCHAT_TYPE=BASIC \
 		-DENABLE_PLUGINS=ON \
 		-DPLUGINS_PATH=plugins \
 		-DUSE_HUNSPELL=ON


### PR DESCRIPTION
After recent changes in memory allocator in Haiku kernel
QtWebKit regulary segfaults at program startup.

As a temporary workaround we may disable webkit usage in
Psi+. Once QtWebKit will be fixed this commit should be
reverted.