### PR TITLE
v8: Fix build error on macro definition.

### DIFF
--- a/dev-lang/v8/patches/v8-7.4.288.28.patchset
+++ b/dev-lang/v8/patches/v8-7.4.288.28.patchset
@@ -1,14 +1,14 @@
-From 4bfe04b667ac9f15961d55291e88e85282b0fe51 Mon Sep 17 00:00:00 2001
+From a32e8016cd69332a4a443aa0aa63179cee3c6a91 Mon Sep 17 00:00:00 2001
 From: Calvin Hill <calvin@hakobaito.co.uk>
 Date: Tue, 12 Feb 2019 12:51:52 +0000
 Subject: Haiku platform support.
 
 
 diff --git a/BUILD.gn b/BUILD.gn
-index d52d806..92ec21c 100644
+index fddd525..2614bcd 100644
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -603,7 +603,7 @@ config("toolchain") {
+@@ -607,7 +607,7 @@ config("toolchain") {
      }
    }
  
@@ -17,7 +17,7 @@ index d52d806..92ec21c 100644
      cflags += [
        "-Wmissing-field-initializers",
  
-@@ -3228,6 +3228,11 @@ v8_component("v8_libbase") {
+@@ -3350,6 +3350,11 @@ v8_component("v8_libbase") {
        "src/base/debug/stack_trace_fuchsia.cc",
        "src/base/platform/platform-fuchsia.cc",
      ]
@@ -29,7 +29,7 @@ index d52d806..92ec21c 100644
    } else if (is_mac) {
      sources += [
        "src/base/debug/stack_trace_posix.cc",
-@@ -3524,6 +3529,13 @@ if (is_fuchsia && !build_with_chromium) {
+@@ -3666,6 +3671,13 @@ if (is_fuchsia && !build_with_chromium) {
  
  group("v8_fuzzers") {
    testonly = true
@@ -43,7 +43,7 @@ index d52d806..92ec21c 100644
    data_deps = [
      ":v8_simple_json_fuzzer",
      ":v8_simple_multi_return_fuzzer",
-@@ -3535,6 +3547,8 @@ group("v8_fuzzers") {
+@@ -3677,6 +3689,8 @@ group("v8_fuzzers") {
      ":v8_simple_wasm_compile_fuzzer",
      ":v8_simple_wasm_fuzzer",
    ]
@@ -151,7 +151,7 @@ index 0000000..86bf945
 +}  // namespace base
 +}  // namespace v8
 diff --git a/src/base/platform/platform-posix.cc b/src/base/platform/platform-posix.cc
-index e7edbf5..387290c 100644
+index 33a9371..17d7a41 100644
 --- a/src/base/platform/platform-posix.cc
 +++ b/src/base/platform/platform-posix.cc
 @@ -60,7 +60,7 @@
@@ -206,7 +206,7 @@ index e7edbf5..387290c 100644
      ret = madvise(address, size, MADV_DONTNEED);
  #endif
 diff --git a/src/libsampler/sampler.cc b/src/libsampler/sampler.cc
-index eb804a7..cd3c2bb 100644
+index 94ad3fd..eec9861 100644
 --- a/src/libsampler/sampler.cc
 +++ b/src/libsampler/sampler.cc
 @@ -12,7 +12,7 @@
@@ -227,7 +227,7 @@ index eb804a7..cd3c2bb 100644
  #include <ucontext.h>
  #endif
  
-@@ -469,6 +469,16 @@ void SignalHandler::FillRegisterState(void* context, RegisterState* state) {
+@@ -470,6 +470,16 @@ void SignalHandler::FillRegisterState(void* context, RegisterState* state) {
    state->sp = reinterpret_cast<void*>(mcontext.mc_r13);
    state->fp = reinterpret_cast<void*>(mcontext.mc_r11);
  #endif  // V8_HOST_ARCH_*
@@ -245,7 +245,7 @@ index eb804a7..cd3c2bb 100644
  #if V8_HOST_ARCH_IA32
    state->pc = reinterpret_cast<void*>(mcontext.__gregs[_REG_EIP]);
 diff --git a/test/BUILD.gn b/test/BUILD.gn
-index 70c8b51..073ff09 100644
+index 6891634..0e32744 100644
 --- a/test/BUILD.gn
 +++ b/test/BUILD.gn
 @@ -7,6 +7,16 @@ import("../gni/v8.gni")
@@ -275,10 +275,10 @@ index 70c8b51..073ff09 100644
  
  ###############################################################################
 diff --git a/tools/mb/mb.py b/tools/mb/mb.py
-index cbb5b5d..3238a7a 100755
+index 1466079..a4fb2e9 100755
 --- a/tools/mb/mb.py
 +++ b/tools/mb/mb.py
-@@ -832,12 +832,15 @@ class MetaBuildWrapper(object):
+@@ -839,12 +839,15 @@ class MetaBuildWrapper(object):
        subdir, exe = 'linux64', 'gn'
      elif self.platform == 'darwin':
        subdir, exe = 'mac', 'gn'
@@ -296,5 +296,34 @@ index cbb5b5d..3238a7a 100755
        gn_path = 'gn'
      else:
 -- 
-2.19.1
+2.21.0
+
+
+From 685d3e51b0112c665fc7723a205127d1ec76f9bc Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Mon, 27 May 2019 11:57:08 +0000
+Subject: Fix template macro definition for GCC.
+
+
+diff --git a/src/base/export-template.h b/src/base/export-template.h
+index 861cfe4..8c6d885 100644
+--- a/src/base/export-template.h
++++ b/src/base/export-template.h
+@@ -83,6 +83,7 @@
+ // definition sites instead.
+ #define EXPORT_TEMPLATE_DECLARE_MSVC_HACK(export, _)
+ #define EXPORT_TEMPLATE_DEFINE_MSVC_HACK(export, _) export
++#define EXPORT_TEMPLATE_TEST_MSVC_HACK_DEFAULT(...) true
+ 
+ // EXPORT_TEMPLATE_STYLE is an internal helper macro that identifies which
+ // export style needs to be used for the provided FOO_EXPORT macro definition.
+@@ -159,5 +160,5 @@ EXPORT_TEMPLATE_TEST(DEFAULT, __declspec(dllimport));
+ #undef EXPORT_TEMPLATE_TEST
+ #undef EXPORT_TEMPLATE_TEST_DEFAULT_DEFAULT
+ #undef EXPORT_TEMPLATE_TEST_MSVC_HACK_MSVC_HACK
+-
++#undef EXPORT_TEMPLATE_TEST_MSVC_HACK_DEFAULT
+ #endif  // V8_BASE_EXPORT_TEMPLATE_H_
+-- 
+2.21.0
 

--- a/dev-lang/v8/v8-7.4.288.28.recipe
+++ b/dev-lang/v8/v8-7.4.288.28.recipe
@@ -8,7 +8,7 @@ any C++ application."
 HOMEPAGE="https://v8.dev/"
 COPYRIGHT="2006-2018 The V8 Project Authors"
 LICENSE="BSD (3-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/v8/v8/archive/$portVersion.tar.gz"
 SOURCE_DIR="v8-$portVersion"
 CHECKSUM_SHA256="a9b1c74ff2fae728e1c94acf525321669679ef56da9cc4d781c427b26032bbf7"
@@ -20,7 +20,7 @@ SOURCE_DIR_2="chromium-$srcChromeVersion"
 PATCHES="v8-$portVersion.patchset"
 PATCHES_2="build-$portVersion.patch"
 
-ARCHITECTURES="!x86_gcc2 x86 x86_64"
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
 
 if [ "$targetArchitecture" = x86_gcc2 ]; then
 	SECONDARY_ARCHITECTURES="x86"


### PR DESCRIPTION
This commit fixes the build error [1] when building V8 with GCC.

Tested on x86_64.

[1] https://build.haiku-os.org/buildmaster/master/x86_64/logviewer.html?buildruns/3120/builds/13532.log