### PR TITLE
freeimage: add libfreeimage.so.3 to $libDir

### DIFF
--- a/media-libs/freeimage/freeimage-3.18.0.recipe
+++ b/media-libs/freeimage/freeimage-3.18.0.recipe
@@ -70,8 +70,10 @@ INSTALL()
 	prepareInstalledDevelLibs libfreeimage libfreeimage-$portVersion \
 		libfreeimageplus libfreeimageplus-$portVersion
 
-	ln -s $libDir/libfreeimage-"$portVersion".so $libDir/libfreeimage.so.${portVersion%.*.*}
-	ln -s $libDir/libfreeimageplus-"$portVersion".so $libDir/libfreeimageplus.so.${portVersion%.*.*}
+	ln -s $libDir/libfreeimage-"$portVersion".so \
+		$libDir/libfreeimage.so.${portVersion%.*.*}
+	ln -s $libDir/libfreeimageplus-"$portVersion".so \
+		$libDir/libfreeimageplus.so.${portVersion%.*.*}
 
 	mkdir -p "$developLibDir"/pkgconfig
 	cat > "$developLibDir"/pkgconfig/freeimage.pc << EOF

--- a/media-libs/freeimage/freeimage-3.18.0.recipe
+++ b/media-libs/freeimage/freeimage-3.18.0.recipe
@@ -18,7 +18,10 @@ SECONDARY_ARCHITECTURES="x86"
 PROVIDES="
 	freeimage$secondaryArchSuffix = $portVersion
 	lib:libfreeimage$secondaryArchSuffix = 3
-	lib:libfreeimage_3.18.0$secondaryArchSuffix
+	lib:libfreeimage_$portVersion$secondaryArchSuffix
+	lib:libfreeimageplus$secondaryArchSuffix = 3
+	lib:libfreeimageplus_$portVersion$secondaryArchSuffix
+
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -27,7 +30,9 @@ REQUIRES="
 PROVIDES_devel="
 	freeimage${secondaryArchSuffix}_devel = $portVersion
 	devel:libfreeimage$secondaryArchSuffix = 3
-	devel:libfreeimage_3.18.0$secondaryArchSuffix
+	devel:libfreeimage_$portVersion$secondaryArchSuffix
+	devel:libfreeimageplus$secondaryArchSuffix = 3
+	devel:libfreeimageplus_$portVersion$secondaryArchSuffix
 	"
 REQUIRES_devel="
 	freeimage$secondaryArchSuffix == $portVersion base
@@ -46,6 +51,10 @@ BUILD()
 	make -f Makefile.gnu \
 		INCDIR=$includeDir \
 		INSTALLDIR=$libDir
+
+	make -f Makefile.fip \
+		INCDIR=$includeDir \
+		INSTALLDIR=$libDir
 }
 
 INSTALL()
@@ -54,8 +63,15 @@ INSTALL()
 		INCDIR=$includeDir \
 		INSTALLDIR=$libDir
 
-	prepareInstalledDevelLibs libfreeimage libfreeimage-$portVersion
+	make -f Makefile.fip install \
+		INCDIR=$includeDir \
+		INSTALLDIR=$libDir
+
+	prepareInstalledDevelLibs libfreeimage libfreeimage-$portVersion \
+							  libfreeimageplus libfreeimageplus-$portVersion
+
 	ln -s $libDir/libfreeimage-"$portVersion".so $libDir/libfreeimage.so.${portVersion%.*.*}
+	ln -s $libDir/libfreeimageplus-"$portVersion".so $libDir/libfreeimageplus.so.${portVersion%.*.*}
 
 	mkdir -p "$developLibDir"/pkgconfig
 	cat > "$developLibDir"/pkgconfig/freeimage.pc << EOF
@@ -67,7 +83,7 @@ includedir=${includeDir}
 Name: freeimage
 Description: FreeImage
 Version: ${portVersion}
-Libs: -L${developLibDir} -lfreeimage
+Libs: -L${developLibDir} -lfreeimage -lfreeimageplus
 Cflags: -I${includeDir}
 EOF
 

--- a/media-libs/freeimage/freeimage-3.18.0.recipe
+++ b/media-libs/freeimage/freeimage-3.18.0.recipe
@@ -68,7 +68,7 @@ INSTALL()
 		INSTALLDIR=$libDir
 
 	prepareInstalledDevelLibs libfreeimage libfreeimage-$portVersion \
-							  libfreeimageplus libfreeimageplus-$portVersion
+		libfreeimageplus libfreeimageplus-$portVersion
 
 	ln -s $libDir/libfreeimage-"$portVersion".so $libDir/libfreeimage.so.${portVersion%.*.*}
 	ln -s $libDir/libfreeimageplus-"$portVersion".so $libDir/libfreeimageplus.so.${portVersion%.*.*}

--- a/media-libs/freeimage/freeimage-3.18.0.recipe
+++ b/media-libs/freeimage/freeimage-3.18.0.recipe
@@ -83,7 +83,7 @@ includedir=${includeDir}
 Name: freeimage
 Description: FreeImage
 Version: ${portVersion}
-Libs: -L${developLibDir} -lfreeimage -lfreeimageplus
+Libs: -L${developLibDir} -lfreeimage
 Cflags: -I${includeDir}
 EOF
 

--- a/media-libs/freeimage/freeimage-3.18.0.recipe
+++ b/media-libs/freeimage/freeimage-3.18.0.recipe
@@ -6,7 +6,7 @@ HOMEPAGE="http://freeimage.sourceforge.net"
 COPYRIGHT="2003-2018 FreeImage Project"
 LICENSE="GNU GPL v2
 	GNU GPL v3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://downloads.sourceforge.net/freeimage/FreeImage${portVersion//.}.zip"
 CHECKSUM_SHA256="f41379682f9ada94ea7b34fe86bf9ee00935a3147be41b6569c9605a53e438fd"
 SOURCE_DIR="FreeImage"
@@ -55,6 +55,7 @@ INSTALL()
 		INSTALLDIR=$libDir
 
 	prepareInstalledDevelLibs libfreeimage libfreeimage-3.18.0
+	cp $developLibDir/libfreeimage.so.3 $libDir/
 
 	mkdir -p "$developLibDir"/pkgconfig
 	cat > "$developLibDir"/pkgconfig/freeimage.pc << EOF

--- a/media-libs/freeimage/freeimage-3.18.0.recipe
+++ b/media-libs/freeimage/freeimage-3.18.0.recipe
@@ -54,8 +54,8 @@ INSTALL()
 		INCDIR=$includeDir \
 		INSTALLDIR=$libDir
 
-	prepareInstalledDevelLibs libfreeimage libfreeimage-3.18.0
-	cp $developLibDir/libfreeimage.so.3 $libDir/
+	prepareInstalledDevelLibs libfreeimage libfreeimage-$portVersion
+	ln -s $libDir/libfreeimage-"$portVersion".so $libDir/libfreeimage.so.${portVersion%.*.*}
 
 	mkdir -p "$developLibDir"/pkgconfig
 	cat > "$developLibDir"/pkgconfig/freeimage.pc << EOF

--- a/media-libs/freeimage/patches/freeimage-3.18.0.patchset
+++ b/media-libs/freeimage/patches/freeimage-3.18.0.patchset
@@ -1,4 +1,4 @@
-From 00cdab4825d526b9a75a530b9a71bc999b3b51a8 Mon Sep 17 00:00:00 2001
+From f8d00fc443550561df9ccd701c1063706a8f7378 Mon Sep 17 00:00:00 2001
 From: begasus <begasus@gmail.com>
 Date: Wed, 26 Dec 2018 13:44:27 +0100
 Subject: import patch from v3.15.3
@@ -22,5 +22,37 @@ index 92f6358..9d136c6 100644
  	ln -sf $(VERLIBNAME) $(INSTALLDIR)/$(LIBNAME)	
  #	ldconfig
 -- 
-2.19.1
+2.21.0
+
+
+From 60d11d2cdb8b189fd21c2cd5aaf1eef16e811d50 Mon Sep 17 00:00:00 2001
+From: kikadf <kikadf.01@gmail.com>
+Date: Tue, 2 Jul 2019 09:39:58 +0200
+Subject: Fix Makefile.fip
+
+
+diff --git a/Makefile.fip b/Makefile.fip
+index b59c419..34269f5 100644
+--- a/Makefile.fip
++++ b/Makefile.fip
+@@ -72,12 +72,12 @@ $(SHAREDLIB): $(MODULES)
+ 
+ install:
+ 	install -d $(INCDIR) $(INSTALLDIR)
+-	install -m 644 -o root -g root $(HEADER) $(INCDIR)
+-	install -m 644 -o root -g root $(HEADERFIP) $(INCDIR)
+-	install -m 644 -o root -g root $(STATICLIB) $(INSTALLDIR)
+-	install -m 755 -o root -g root $(SHAREDLIB) $(INSTALLDIR)
++	install -m 644 $(HEADER) $(INCDIR)
++	install -m 644 $(HEADERFIP) $(INCDIR)
++	install -m 644 $(STATICLIB) $(INSTALLDIR)
++	install -m 755 $(SHAREDLIB) $(INSTALLDIR)
+ 	ln -sf $(SHAREDLIB) $(INSTALLDIR)/$(VERLIBNAME)
+-	ln -sf $(VERLIBNAME) $(INSTALLDIR)/$(LIBNAME)	
++	ln -sf $(VERLIBNAME) $(INSTALLDIR)/$(LIBNAME)
+ 
+ clean:
+ 	rm -f core Dist/*.* u2dtmp* $(MODULES) $(STATICLIB) $(SHAREDLIB) $(LIBNAME)
+-- 
+2.21.0
 


### PR DESCRIPTION
The freeimage package only contain libfreeimage-3.18.0.so, but some package (one of these porting in progress :P) need libfreeimage.so.3, and runtime_loader don't find in $developDir.