### PR TITLE
nodejs: Fix npm package installation paths.

### DIFF
--- a/net-libs/nodejs/nodejs-12.3.1.recipe
+++ b/net-libs/nodejs/nodejs-12.3.1.recipe
@@ -7,7 +7,7 @@ to be done, Node will sleep."
 HOMEPAGE="https://nodejs.org/"
 COPYRIGHT="2006-2019 The Node.js Foundation"
 LICENSE="BSD (2-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://nodejs.org/dist/v$portVersion/node-v$portVersion.tar.gz"
 SOURCE_DIR="node-v$portVersion"
 CHECKSUM_SHA256="d9132342815f04fdb8eb6cac5607fcee929a79e0339449774f411efed81693ac"
@@ -18,6 +18,7 @@ ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
 
 GLOBAL_WRITABLE_FILES="
 	non-packaged/lib/node_modules directory keep-old
+	non-packaged/lib/node_modules/npm/npmrc auto-merge
 	"
 
 if [ "$targetArchitecture" = x86_gcc2 ]; then
@@ -38,6 +39,7 @@ PROVIDES="
 	cmd:node$commandSuffix = $portVersion
 	cmd:npm$secondaryArchSuffix = $portVersion
 	cmd:npx$secondaryArchSuffix = $portVersion
+	lib:libnode$secondaryArchSuffix = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -81,29 +83,33 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	./configure --with-intl=none --dest-os=haiku --dest-cpu=$ARCH --shared-v8 --shared \
+	./configure --with-intl=none --dest-os=haiku --dest-cpu=$ARCH --shared --shared-v8 \
 		--shared-v8-libpath="$(finddir B_SYSTEM_LIB_DIRECTORY)" --shared-zlib \
-		 --shared-cares --shared-libuv --shared-v8-includes="$(finddir B_SYSTEM_HEADERS_DIRECTORY)"/v8 \
-		--without-bundled-v8 --openssl-no-asm --prefix=$prefix
+		--shared-cares --shared-libuv --without-bundled-v8 --openssl-no-asm \
+		--shared-v8-includes="$(finddir B_SYSTEM_HEADERS_DIRECTORY)"/v8 \
+		--prefix=$prefix
 
 	make $jobArgs
 }
 
 INSTALL()
 {
-	mkdir -p $commandBinDir $prefix $developDir/headers $dataDir $docDir $manDir
+	mkdir -p $commandBinDir $libDir $dataDir $docDir $manDir
+	mkdir -p $prefix $developDir/headers $developDir/lib
 	mkdir -p $prefix/non-packaged/lib/node_modules
 
-	export PREFIX=$(finddir B_SYSTEM_NONPACKAGED_LIB_DIRECTORY)
+	export PREFIX=$prefix/non-packaged
 	export USER_CONFIG=$(finddir B_USER_SETTINGS_DIRECTORY)
 	export INCLUDEDIR=$developDir/headers
 
 	make install
 
-	# Create the node_modules folder in the non-packaged folder
-	cp -r $prefix/lib/node_modules $prefix/non-packaged/lib
+	# Move the node_modules folder into the non-packaged folder
+	mv $prefix/lib/node_modules $prefix/non-packaged/lib
 
-	echo -e "prefix = $PREFIX/node_modules/npm/npmrc" > $prefix/non-packaged/lib/node_modules/npm/npmrc
+	mkdir -p $prefix/non-packaged/lib/node_modules/npm/
+
+	echo -e "prefix = $prefix/non-packaged/" > $prefix/non-packaged/lib/node_modules/npm/npmrc
 	echo -e "userconfig = $USER_CONFIG/.npmrc" >> $prefix/non-packaged/lib/node_modules/npm/npmrc
 	echo -e "user = 1" >> $prefix/non-packaged/lib/node_modules/npm/npmrc
 


### PR DESCRIPTION
This commit fixes the npm installation paths that is required by most npm packages to function in Haiku.

The `node_modules` folder is placed in `/boot/system/non-packaged/lib/`

CLI packages installed via npm are placed in: `/boot/system/non-packaged/lib/node_modules/.bin`.
These packages are then symlinked by npm into the `/boot/system/non-packaged/bin` folder.

The .npmrc (npm user config) is placed in the `/boot/home/config/settings` folder.