### PR TITLE
devilutionx: Build binary release version

### DIFF
--- a/games-rpg/devilutionx/devilutionx-0.4.0.recipe
+++ b/games-rpg/devilutionx/devilutionx-0.4.0.recipe
@@ -5,7 +5,7 @@ operating systems nicely."
 HOMEPAGE="https://github.com/diasurgical/devilutionX"
 COPYRIGHT="2018 GalaXyHaXz"
 LICENSE="Public Domain"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/diasurgical/devilutionX/archive/$portVersion.zip"
 CHECKSUM_SHA256="9bc3e3f17338dea8d8d7d9829de1afe59e06865a5459e09f09b222045154da41"
 SOURCE_DIR="devilutionX-$portVersion"
@@ -47,7 +47,7 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	mkdir -p haiku_build && cd haiku_build
-	cmake ..
+	cmake -DBINARY_RELEASE=ON ..
 	make $jobArgs
 }
 


### PR DESCRIPTION
DevilutionX builds a debug version by default, specify the building of a release version. Also bump revision.