### PR TITLE
chromaprint: Build with fpcalc utility

### DIFF
--- a/media-libs/chromaprint/chromaprint-1.4.3.recipe
+++ b/media-libs/chromaprint/chromaprint-1.4.3.recipe
@@ -59,6 +59,7 @@ BUILD()
 		-DCMAKE_INSTALL_INCLUDEDIR=$includeDir \
 		-DCMAKE_INSTALL_BINDIR=$binDir \
 		-DBUILD_TOOLS=ON \
+		-DFFT_LIB=avfft \
 		-DCMAKE_BUILD_TYPE=Release .
 
 	make $jobArgs

--- a/media-libs/chromaprint/chromaprint-1.4.3.recipe
+++ b/media-libs/chromaprint/chromaprint-1.4.3.recipe
@@ -4,7 +4,7 @@ algorithm for extracting fingerprints from any audio source."
 HOMEPAGE="https://acoustid.org/chromaprint"
 COPYRIGHT="2010-2012, 2015 Lukas Lalinsky"
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/acoustid/chromaprint/releases/download/v$portVersion/chromaprint-$portVersion.tar.gz"
 CHECKSUM_SHA256="ea18608b76fb88e0203b7d3e1833fb125ce9bb61efe22c6e169a50c52c457f82"
 SOURCE_DIR="chromaprint-v$portVersion"
@@ -19,10 +19,13 @@ libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 PROVIDES="
 	chromaprint$secondaryArchSuffix = $portVersion
 	lib:libchromaprint$secondaryArchSuffix = $libVersionCompat
+	cmd:fpcalc$secondaryArchSuffix = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libfftw3$secondaryArchSuffix
+	lib:libavcodec$secondaryArchSuffix
+	lib:libavformat$secondaryArchSuffix
+	lib:libavutil$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
@@ -35,7 +38,9 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libfftw3$secondaryArchSuffix
+	devel:libavcodec$secondaryArchSuffix
+	devel:libavformat$secondaryArchSuffix
+	devel:libavutil$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:cmake
@@ -52,6 +57,8 @@ BUILD()
 	cmake -DCMAKE_INSTALL_PREFIX=$prefix \
 		-DCMAKE_INSTALL_LIBDIR=$libDir \
 		-DCMAKE_INSTALL_INCLUDEDIR=$includeDir \
+		-DCMAKE_INSTALL_BINDIR=$binDir \
+		-DBUILD_TOOLS=ON \
 		-DCMAKE_BUILD_TYPE=Release .
 
 	make $jobArgs


### PR DESCRIPTION
This builds chromaprint with the `fpcalc` command line utility.

`fpcalc` can be used to generate fingerprints for audio files on the command line. Among others this tool is needed by MusicBrainz Picard (for which I'm going to provide a recipe later) for audio fingerprinting.

This change introduces ffmpeg as a dependency since `fpcalc` cannot be build without it. However, ffmpeg is also the preferred choice for a FFT library as described in https://github.com/acoustid/chromaprint, so the dependency on libfftw3 is no longer needed.