### PR TITLE
discid: add recipe for version 1.2.0

### DIFF
--- a/dev-python/discid/discid-1.2.0.recipe
+++ b/dev-python/discid/discid-1.2.0.recipe
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python python36)
-PYTHON_VERSIONS=(2.7 3.6)
+PYTHON_PACKAGES=(python python36 python3)
+PYTHON_VERSIONS=(2.7 3.6 3.7)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/discid/discid-1.2.0.recipe
+++ b/dev-python/discid/discid-1.2.0.recipe
@@ -1,0 +1,61 @@
+SUMMARY="Python bindings of libdiscid by MusicBrainz"
+DESCRIPTION="Python-discid implements Python bindings for MusicBrainz Libdiscid."
+HOMEPAGE="https://python-discid.readthedocs.io/"
+COPYRIGHT="Johannes Dewender"
+LICENSE="GNU LGPL v2.1"
+REVISION="1"
+SOURCE_URI="https://files.pythonhosted.org/packages/source/d/$portName/$portName-$portVersion.tar.gz"
+CHECKSUM_SHA256="cd9630bc53f5566df92819641040226e290b2047573f2c74a6e92b8eed9e86b9"
+SOURCE_DIR="discid-$portVersion"
+
+ARCHITECTURES="any"
+
+PROVIDES="
+	$portName = $portVersion
+	"
+REQUIRES="
+	haiku
+	libdiscid
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+
+PYTHON_PACKAGES=(python python36)
+PYTHON_VERSIONS=(2.7 3.6)
+for i in "${!PYTHON_PACKAGES[@]}"; do
+pythonPackage=${PYTHON_PACKAGES[i]}
+pythonVersion=${PYTHON_VERSIONS[$i]}
+eval "PROVIDES_${pythonPackage}=\"\
+	${portName}_$pythonPackage = $portVersion\
+	\"; \
+REQUIRES_$pythonPackage=\"\
+	haiku\n\
+	cmd:python$pythonVersion\
+	\""
+BUILD_REQUIRES="$BUILD_REQUIRES
+	setuptools_$pythonPackage"
+BUILD_PREREQUIRES="$BUILD_PREREQUIRES
+	cmd:python$pythonVersion"
+done
+
+
+INSTALL()
+{
+	for i in "${!PYTHON_PACKAGES[@]}"; do
+		pythonPackage=${PYTHON_PACKAGES[i]}
+		pythonVersion=${PYTHON_VERSIONS[$i]}
+
+		python=python$pythonVersion
+		installLocation=$prefix/lib/$python/vendor-packages/
+		export PYTHONPATH=$installLocation:$PYTHONPATH
+		mkdir -p $installLocation
+		rm -rf build
+		$python setup.py build install \
+			--root=/ --prefix=$prefix
+
+		packageEntries  $pythonPackage \
+			$prefix/lib/python*
+	done
+}


### PR DESCRIPTION
This adds a recipe for python-discid.

Adding as a requirement for MusicBrainz Picard, for which I'll submit a recipe later.