### PR TITLE
discid: fixed missing dependency on libdiscid

### DIFF
--- a/dev-python/discid/discid-1.2.0.recipe
+++ b/dev-python/discid/discid-1.2.0.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="Python-discid implements Python bindings for MusicBrainz Libdiscid.
 HOMEPAGE="https://python-discid.readthedocs.io/"
 COPYRIGHT="Johannes Dewender"
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/d/$portName/$portName-$portVersion.tar.gz"
 CHECKSUM_SHA256="cd9630bc53f5566df92819641040226e290b2047573f2c74a6e92b8eed9e86b9"
 SOURCE_DIR="discid-$portVersion"
@@ -30,8 +30,7 @@ pythonVersion=${PYTHON_VERSIONS[$i]}
 eval "PROVIDES_${pythonPackage}=\"\
 	${portName}_$pythonPackage = $portVersion\
 	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
+REQUIRES_$pythonPackage=\"$REQUIRES\
 	cmd:python$pythonVersion\
 	\""
 BUILD_REQUIRES="$BUILD_REQUIRES


### PR DESCRIPTION
The requirement of libdiscid was overwritten for the individual packages.

See also discussion on https://github.com/haikuports/haikuports/pull/4018