### PR TITLE
jam: Update to latest commit and add debuginfo

### DIFF
--- a/sys-devel/jam/jam-2.5_2018_11_21.recipe
+++ b/sys-devel/jam/jam-2.5_2018_11_21.recipe
@@ -15,10 +15,10 @@ HOMEPAGE="http://www.perforce.com/jam/jam.html"
 COPYRIGHT="1993-2003 Christopher Seiwald
 	2005-2018 Haiku, Inc."
 LICENSE="Jam"
-REVISION="6"
-srcGitRev="b3407e33b36bf1bfaee2c97739986ab8afb9d106"
+REVISION="7"
+srcGitRev="18e01e2af6dd1a4145d91f47cc1d658a36b0bd56"
 SOURCE_URI="https://github.com/haiku/buildtools/archive/$srcGitRev.tar.gz"
-CHECKSUM_SHA256="cadc7458fc343e914d0ee326e08bc58857d3051cd08c3e0badbaf563416f7f50"
+CHECKSUM_SHA256="0d44d06d18530d453d9b444732cea7f838543e323ebb00cde0323a5e7f13c171"
 SOURCE_FILENAME="$portVersionedName.tar.gz"
 SOURCE_DIR="buildtools-$srcGitRev/jam"
 
@@ -41,15 +41,18 @@ BUILD_PREREQUIRES="
 	cmd:make
 	"
 
+defineDebugInfoPackage jam \
+	"$binDir"/jam
+
 BUILD()
 {
-	make
+	DEBUG=1 make
 }
 
 INSTALL()
 {
 	mkdir -p "$binDir"
-	cp bin.haikux86/jam "$binDir"
+	cp bin.haikux86/g/jam "$binDir"
 
 	mkdir -p "$docDir"
 	cp Jam.html Jambase.html Jamfile.html README* "$docDir"


### PR DESCRIPTION
This updates jam to the latest commit in the buildtools repository (fixing [a crash I encountered today](https://dev.haiku-os.org/ticket/15250)) and adds a debuginfo package to make future debugging easier.