### PR TITLE
libOpenMPT: bump

### DIFF
--- a/media-libs/libopenmpt/libopenmpt-0.4.6.recipe
+++ b/media-libs/libopenmpt/libopenmpt-0.4.6.recipe
@@ -6,10 +6,11 @@ HOMEPAGE="https://openmpt.org/"
 COPYRIGHT="2004-2019 OpenMPT contributors
 	1997-2003 Olivier Lapicque"
 LICENSE="BSD (3-clause)"
-REVISION="3"
+REVISION="1"
 SOURCE_URI="https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-$portVersion+release.autotools.tar.gz"
-CHECKSUM_SHA256="57834bd4e67485019584e19a1080615269c1e92551230a7c96e79c4fc97b0f75"
+CHECKSUM_SHA256="fa8f2ff5d9b74c00b3fed5edad2aefdfb79a6cd370bf5ec9894b2121f49fb67e"
 SOURCE_DIR="libopenmpt-$portVersion+release.autotools"
+PATCHES="libopenmpt-$portVersion.patchset"
 
 ARCHITECTURES="?x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="?x86_gcc2 x86"

--- a/media-libs/libopenmpt/patches/libopenmpt-0.4.6.patchset
+++ b/media-libs/libopenmpt/patches/libopenmpt-0.4.6.patchset
@@ -1,0 +1,41 @@
+From d5d848d10ba580ec47879915780a1fb8d17068c3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
+Date: Sat, 24 Aug 2019 10:26:19 +0200
+Subject: Haiku support
+
+
+diff --git a/common/CompilerDetect.h b/common/CompilerDetect.h
+index 3b3dbec..0259347 100644
+--- a/common/CompilerDetect.h
++++ b/common/CompilerDetect.h
+@@ -246,6 +246,8 @@
+ 	#define MPT_OS_NETBSD 1
+ #elif defined(__unix__)
+ 	#define MPT_OS_GENERIC_UNIX 1
++#elif defined(__HAIKU__)
++	#define MPT_OS_HAIKU 1
+ #else
+ 	#define MPT_OS_UNKNOWN 1
+ #endif
+@@ -286,6 +288,9 @@
+ #ifndef MPT_OS_GENERIC_UNIX
+ #define MPT_OS_GENERIC_UNIX 0
+ #endif
++#ifndef MPT_OS_HAIKU
++#define MPT_OS_HAIKU 0
++#endif
+ #ifndef MPT_OS_UNKNOWN
+ #define MPT_OS_UNKNOWN 0
+ #endif
+@@ -312,7 +317,7 @@
+ #endif
+ 
+ #if MPT_CXX_AT_LEAST(17)
+-#if MPT_COMPILER_MSVC || MPT_GCC_BEFORE(8,1,0) || MPT_CLANG_BEFORE(5,0,0) || (MPT_COMPILER_GCC && defined(__GLIBCXX__) && (defined(__MINGW32__) || defined(__MINGW64__))) || (MPT_COMPILER_CLANG && defined(__GLIBCXX__)) || (MPT_COMPILER_CLANG && MPT_OS_MACOSX_OR_IOS) || MPT_OS_OPENBSD || MPT_OS_EMSCRIPTEN || (defined(__clang__) && defined(_MSC_VER))
++#if MPT_COMPILER_MSVC || MPT_GCC_BEFORE(8,1,0) || MPT_CLANG_BEFORE(5,0,0) || (MPT_COMPILER_GCC && defined(__GLIBCXX__) && (defined(__MINGW32__) || defined(__MINGW64__))) || (MPT_COMPILER_CLANG && defined(__GLIBCXX__)) || (MPT_COMPILER_CLANG && MPT_OS_MACOSX_OR_IOS) || MPT_OS_OPENBSD || MPT_OS_EMSCRIPTEN || MPT_OS_HAIKU || (defined(__clang__) && defined(_MSC_VER))
+ #define MPT_COMPILER_QUIRK_NO_ALIGNEDALLOC
+ #endif
+ #endif
+-- 
+2.23.0
+


### PR DESCRIPTION
Patch upstreamed.
Test passes, plays music. Even rebuilt ffmpeg with it (not needed, just to make sure)