### PR TITLE
chromaprint, fix _x86 build

### DIFF
--- a/media-libs/chromaprint/chromaprint-1.4.3.recipe
+++ b/media-libs/chromaprint/chromaprint-1.4.3.recipe
@@ -4,7 +4,7 @@ algorithm for extracting fingerprints from any audio source."
 HOMEPAGE="https://acoustid.org/chromaprint"
 COPYRIGHT="2010-2012, 2015 Lukas Lalinsky"
 LICENSE="GNU LGPL v2.1"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/acoustid/chromaprint/releases/download/v$portVersion/chromaprint-$portVersion.tar.gz"
 CHECKSUM_SHA256="ea18608b76fb88e0203b7d3e1833fb125ce9bb61efe22c6e169a50c52c457f82"
 SOURCE_DIR="chromaprint-v$portVersion"
@@ -19,7 +19,7 @@ libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 PROVIDES="
 	chromaprint$secondaryArchSuffix = $portVersion
 	lib:libchromaprint$secondaryArchSuffix = $libVersionCompat
-	cmd:fpcalc$secondaryArchSuffix = $portVersion
+	cmd:fpcalc = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -57,7 +57,6 @@ BUILD()
 	cmake -DCMAKE_INSTALL_PREFIX=$prefix \
 		-DCMAKE_INSTALL_LIBDIR=$libDir \
 		-DCMAKE_INSTALL_INCLUDEDIR=$includeDir \
-		-DCMAKE_INSTALL_BINDIR=$binDir \
 		-DBUILD_TOOLS=ON \
 		-DFFT_LIB=avfft \
 		-DCMAKE_BUILD_TYPE=Release .


### PR DESCRIPTION
fpcalc is installed in $prefix/bin so no $secondaryArchSuffix is needed