### PR TITLE
picard: add back dependency on cmd:fpcalc

### DIFF
--- a/media-sound/picard/picard-2.1.3.recipe
+++ b/media-sound/picard/picard-2.1.3.recipe
@@ -28,12 +28,12 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libdiscid$secondaryArchSuffix
-	cmd:python3.6
-	pyqt_python3
-	mutagen_python36
-	discid_python36
 	cmd:fpcalc
+	cmd:python3.6
+	discid_python36
+	lib:libdiscid$secondaryArchSuffix
+	mutagen_python36
+	pyqt_python3
 	"
 
 BUILD_REQUIRES="

--- a/media-sound/picard/picard-2.1.3.recipe
+++ b/media-sound/picard/picard-2.1.3.recipe
@@ -12,7 +12,7 @@ HOMEPAGE="https://picard.musicbrainz.org/"
 COPYRIGHT="2004-2019 Robert Kaye, Lukas Lalinsky, Laurent Monin, \
 Sambhav Kothari, Philipp Wolfer and others"
 LICENSE="GNU GPL v2"
-REVISION="6"
+REVISION="7"
 SOURCE_URI="ftp://ftp.eu.metabrainz.org/pub/musicbrainz/picard/picard-$portVersion.tar.gz"
 CHECKSUM_SHA256="8e044fe68c44d345c19f98952c3c7f20c72da74dbac9ce7c7b0621e2d69885a7"
 SOURCE_DIR="picard-release-$portVersion"
@@ -33,6 +33,7 @@ REQUIRES="
 	pyqt_python3
 	mutagen_python36
 	discid_python36
+	cmd:fpcalc
 	"
 
 BUILD_REQUIRES="


### PR DESCRIPTION
Add back the dependency for `cmd:fpcalc` to the recipe. This got lost in the last update, but actually is required for the fingerprinting to work.