### PR TITLE
picard: Release 2.2.1

### DIFF
--- a/media-sound/picard/patches/picard-2.2.1.patchset
+++ b/media-sound/picard/patches/picard-2.2.1.patchset
@@ -37,30 +37,6 @@ index 857b7850..d3decda5 100644
 --
 2.23.0
 
-From 6410e8e4d8826bb0fd1e9caa819bc566af3334e2 Mon Sep 17 00:00:00 2001
-From: Philipp Wolfer <ph.wolfer@gmail.com>
-Date: Fri, 19 Jul 2019 10:36:05 +0000
-Subject: [PATCH 4/6] Haiku: introduce IS_HAIKU variable
-
----
- picard/const/sys.py | 1 +
- 1 file changed, 1 insertion(+)
-
-diff --git a/picard/const/sys.py b/picard/const/sys.py
-index baa80732..177fbe4b 100644
---- a/picard/const/sys.py
-+++ b/picard/const/sys.py
-@@ -23,6 +23,7 @@ import sys
- IS_WIN = sys.platform == 'win32'
- IS_LINUX = sys.platform == 'linux'
- IS_MACOS = sys.platform == 'darwin'
-+IS_HAIKU = sys.platform == 'haiku1'
- 
- # These variables are set by pyinstaller if running from a packaged build
- # See http://pyinstaller.readthedocs.io/en/stable/runtime-information.html
--- 
-2.23.0
-
 From 58b389cffecca65ef916aa4986424e4c413e436f Mon Sep 17 00:00:00 2001
 From: Philipp Wolfer <ph.wolfer@gmail.com>
 Date: Tue, 29 Jan 2019 11:35:33 +0000
@@ -76,7 +52,7 @@ index c7426918..f087b462 100644
 --- a/picard/util/webbrowser2.py
 +++ b/picard/util/webbrowser2.py
 @@ -29,6 +29,14 @@ from PyQt5 import QtWidgets
- 
+
  from picard import log
  from picard.const import PICARD_URLS
 +from picard.const.sys import IS_HAIKU
@@ -87,42 +63,8 @@ index c7426918..f087b462 100644
 +    webbrowser.register("haiku-default", None, haiku_default, True)
 +    webpositive = webbrowser.GenericBrowser("WebPositive")
 +    webbrowser.register("webpositive", None, webpositive)
- 
- 
+
+
  def open(url):
--- 
+--
 2.23.0
-
-From e5107f049ebc63248912ccea78ed88f2d5de5c73 Mon Sep 17 00:00:00 2001
-From: Philipp Wolfer <ph.wolfer@gmail.com>
-Date: Fri, 19 Jul 2019 10:37:17 +0000
-Subject: [PATCH 6/6] Haiku: use Haiku Qt style
-
----
- picard/tagger.py | 3 ++-
- 1 file changed, 2 insertions(+), 1 deletion(-)
-
-diff --git a/picard/tagger.py b/picard/tagger.py
-index a5aeb6e3..0c081850 100644
---- a/picard/tagger.py
-+++ b/picard/tagger.py
-@@ -66,6 +66,7 @@ from picard.const import (
- )
- from picard.const.sys import (
-     IS_FROZEN,
-+    IS_HAIKU,
-     IS_MACOS,
-     IS_WIN,
- )
-@@ -137,7 +138,7 @@ class Tagger(QtWidgets.QApplication):
- 
-         # Use the new fusion style from PyQt5 for a modern and consistent look
-         # across all OSes.
--        if not IS_MACOS:
-+        if not IS_MACOS and not IS_HAIKU:
-             self.setStyle('Fusion')
- 
-         # Set the WM_CLASS to 'MusicBrainz-Picard' so desktop environments
--- 
-2.23.0
-

--- a/media-sound/picard/picard-2.2.1.recipe
+++ b/media-sound/picard/picard-2.2.1.recipe
@@ -1,4 +1,4 @@
-SUMMARY="MusicBrainz Picard music tagger"
+SUMMARY="MusicBrainz music tagger"
 DESCRIPTION="Tag your music with the next generation MusicBrainz tagger.
 
 * Multiple formats - Picard supports all popular music formats, including MP3, \
@@ -13,8 +13,8 @@ COPYRIGHT="2004-2019 Robert Kaye, Lukas Lalinsky, Laurent Monin, \
 Sambhav Kothari, Philipp Wolfer and others"
 LICENSE="GNU GPL v2"
 REVISION="1"
-SOURCE_URI="https://github.com/metabrainz/picard/archive/release-$portVersion.tar.gz"
-CHECKSUM_SHA256="53a2e298398e8ca5ba8e7771c59ff4caf9cdc73be2d6092c4cad6734bd4a8116"
+SOURCE_URI="ftp://ftp.eu.metabrainz.org/pub/musicbrainz/picard/picard-$portVersion.tar.gz"
+CHECKSUM_SHA256="eac065db0c2bd84e34aeb061602cf1f188b602744015905fb498596acfd426b0"
 SOURCE_DIR="picard-release-$portVersion"
 PATCHES="picard-$portVersion.patchset"
 ADDITIONAL_FILES="picard.rdef.in"


### PR DESCRIPTION
Picard 2.2.1 release. Also gets rid of some minor patches now upstreamed.

The remaining patches are more difficult. One is a strange crash when calling `locale.strxfrm`, which probably is threading related. Not sure right now where this needs to be fixed, so far I haven't found the time to really dig for the root cause here and the patch included here is a workaround (just avoid calling this).

The other patch is opening the proper webbrowser, and this is something I would rather like to add to the Python packages so other programs benefit from this as well. My goal is to submit this as a Python patch for existing Haiku Python packages and also upstream. I just need to find the time for this ;)