### PR TITLE
SMPlayer: bump version to 19.5

### DIFF
--- a/media-video/smplayer/patches/smplayer-19.5.0.patchset
+++ b/media-video/smplayer/patches/smplayer-19.5.0.patchset
@@ -1,0 +1,231 @@
+From 3fa0c45b2f84301ec6efe43c347789848aae7711 Mon Sep 17 00:00:00 2001
+From: Sergei Reznikov <diver@gelios.net>
+Date: Fri, 5 Jun 2015 17:43:34 +0300
+Subject: Disabling QtSingleApplication on Haiku
+
+
+diff --git a/src/qtsingleapplication/qtsingleapplication.cpp b/src/qtsingleapplication/qtsingleapplication.cpp
+index d0fb15d..fe60eb8 100644
+--- a/src/qtsingleapplication/qtsingleapplication.cpp
++++ b/src/qtsingleapplication/qtsingleapplication.cpp
+@@ -239,7 +239,11 @@ QtSingleApplication::QtSingleApplication(Display* dpy, const QString &appId, int
+ 
+ bool QtSingleApplication::isRunning()
+ {
++#ifdef Q_OS_HAIKU
++    return false;
++#else
+     return peer->isClient();
++#endif
+ }
+ 
+ 
+@@ -258,7 +262,11 @@ bool QtSingleApplication::isRunning()
+ */
+ bool QtSingleApplication::sendMessage(const QString &message, int timeout)
+ {
+-    return peer->sendMessage(message, timeout);
++#ifdef Q_OS_HAIKU
++    return false;
++#else
++     return peer->sendMessage(message, timeout);
++#endif
+ }
+ 
+ 
+-- 
+2.19.0
+
+
+From 1f87d2860cdae862a5bdd4c5b4ff8cf31a6fac97 Mon Sep 17 00:00:00 2001
+From: Sergei Reznikov <diver@gelios.net>
+Date: Fri, 5 Jun 2015 17:54:14 +0300
+Subject: Correctly identify Haiku instead of Other OS
+
+
+diff --git a/src/smplayer.cpp b/src/smplayer.cpp
+index 6369e53..8cb6cb7 100644
+--- a/src/smplayer.cpp
++++ b/src/smplayer.cpp
+@@ -574,10 +574,14 @@ void SMPlayer::showInfo() {
+ #else
+ #ifdef Q_OS_OS2
+            .arg("eCS (OS/2)")
++#else
++#ifdef Q_OS_HAIKU
++           .arg("Haiku")
+ #else
+ 		   .arg("Other OS")
+ #endif
+ #endif
++#endif
+ #endif
+            ;
+ 
+-- 
+2.19.0
+
+
+From 39308adf56bc540cc37e398af3e7fa07a2b62ef4 Mon Sep 17 00:00:00 2001
+From: Sergei Reznikov <diver@gelios.net>
+Date: Fri, 7 Jul 2017 18:58:29 +0300
+Subject: Disable UPDATE_CHECKER and GLOBALSHORTCUTS
+
+
+diff --git a/src/smplayer.pro b/src/smplayer.pro
+index d07ac36..07fe642 100644
+--- a/src/smplayer.pro
++++ b/src/smplayer.pro
+@@ -24,13 +24,13 @@ DEFINES += MINIGUI
+ DEFINES += MPCGUI
+ DEFINES += SKINS
+ DEFINES += MPRIS2
+-DEFINES += UPDATE_CHECKER
++DEFINES -= UPDATE_CHECKER
+ #DEFINES += CHECK_UPGRADED
+ DEFINES += AUTO_SHUTDOWN_PC
+ #DEFINES += CAPTURE_STREAM
+ DEFINES += BOOKMARKS
+ DEFINES += MOUSE_GESTURES
+-DEFINES += GLOBALSHORTCUTS
++DEFINES -= GLOBALSHORTCUTS
+ DEFINES += ADD_BLACKBORDERS_FS
+ DEFINES += INITIAL_BLACKBORDERS
+ DEFINES += CHROMECAST_SUPPORT
+-- 
+2.19.0
+
+
+From 42f07e21ebd0c45a7c1a4aeb321d069153009925 Mon Sep 17 00:00:00 2001
+From: Sergei Reznikov <diver@gelios.net>
+Date: Fri, 7 Jul 2017 19:00:30 +0300
+Subject: Disable webserver
+
+
+diff --git a/Makefile b/Makefile
+index c88d046..e137a53 100644
+--- a/Makefile
++++ b/Makefile
+@@ -21,7 +21,7 @@ DEFS=DATA_PATH=\\\"$(DATA_PATH)\\\" \
+      DOC_PATH=\\\"$(DOC_PATH)\\\" THEMES_PATH=\\\"$(THEMES_PATH)\\\" \
+      SHORTCUTS_PATH=\\\"$(SHORTCUTS_PATH)\\\"
+ 
+-all: src/smplayer webserver/simple_web_server
++all: src/smplayer #webserver/simple_web_server
+ 
+ src/smplayer:
+ 	./get_svn_revision.sh
+-- 
+2.19.0
+
+
+From b857228c6382f36506c6c41df529f4469889cde3 Mon Sep 17 00:00:00 2001
+From: Sergei Reznikov <diver@gelios.net>
+Date: Sun, 9 Jul 2017 16:06:00 +0300
+Subject: Fix PATHS on Haiku
+
+
+diff --git a/Makefile b/Makefile
+index e137a53..f02a1b9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,14 +1,14 @@
+ 
+-PREFIX=/usr/local
++PREFIX=.
+ #PREFIX=/tmp/smplayer
+ 
+ CONF_PREFIX=$(PREFIX)
+ 
+-DATA_PATH=$(PREFIX)/share/smplayer
+-DOC_PATH=$(PREFIX)/share/doc/packages/smplayer
+-TRANSLATION_PATH=$(PREFIX)/share/smplayer/translations
+-THEMES_PATH=$(PREFIX)/share/smplayer/themes
+-SHORTCUTS_PATH=$(PREFIX)/share/smplayer/shortcuts
++DATA_PATH=$(PREFIX)/data
++DOC_PATH=$(PREFIX)/documentation
++TRANSLATION_PATH=$(PREFIX)/translations
++THEMES_PATH=$(PREFIX)/themes
++SHORTCUTS_PATH=$(PREFIX)/shortcuts
+ 
+ ICONS_DIR=$(PREFIX)/share/icons/hicolor/
+ APPLNK_DIR=$(PREFIX)/share/applications/
+-- 
+2.19.0
+
+
+From 1083b40bb8b6b8c0f85117511e71907def029f1d Mon Sep 17 00:00:00 2001
+From: Sergei Reznikov <diver@gelios.net>
+Date: Sun, 9 Jul 2017 16:06:44 +0300
+Subject: Use default style on Haiku
+
+
+diff --git a/src/preferences.cpp b/src/preferences.cpp
+index 0ac0fed..7f99f48 100644
+--- a/src/preferences.cpp
++++ b/src/preferences.cpp
+@@ -409,12 +409,14 @@ void Preferences::reset() {
+ 
+ 	resize_method = Never;
+ 
++#ifndef Q_OS_HAIKU
+ #if STYLE_SWITCHING
+ 	#if QT_VERSION >= 0x050000
+ 	style = "Fusion";
+ 	#else
+ 	style="";
+ 	#endif
++#endif
+ #endif
+ 
+ 	center_window = false;
+-- 
+2.19.0
+
+
+From 1519cd87f34252a047db5ab4127f8fb8c25c05ff Mon Sep 17 00:00:00 2001
+From: Gerasim Troeglazov <3dEyes@gmail.com>
+Date: Thu, 14 Jun 2018 05:45:06 +0000
+Subject: Fix winId for haiku
+
+
+diff --git a/src/core.cpp b/src/core.cpp
+index 323acb7..6da2e22 100644
+--- a/src/core.cpp
++++ b/src/core.cpp
+@@ -1831,6 +1831,8 @@ void Core::startMplayer( QString file, double seek ) {
+ #if defined(Q_OS_OS2)
+ 		#define WINIDFROMHWND(hwnd) ( ( hwnd ) - 0x80000000UL )
+ 		proc->setOption("wid", QString::number( WINIDFROMHWND( (int) mplayerwindow->videoLayer()->winId() ) ));
++#elif defined(Q_OS_HAIKU)
++		proc->setOption("wid", QString::number(0));
+ #else
+ 		proc->setOption("wid", QString::number( (qint64) mplayerwindow->videoLayer()->winId() ) );
+ #endif
+-- 
+2.19.0
+
+
+From 319d3043ea31ca40f3750ffe0e99882fb63ab82d Mon Sep 17 00:00:00 2001
+From: Sergei Reznikov <diver@gelios.net>
+Date: Wed, 19 Sep 2018 15:36:35 +0300
+Subject: Use default iconset on Haiku
+
+
+diff --git a/src/preferences.cpp b/src/preferences.cpp
+index 7f99f48..77b5556 100644
+--- a/src/preferences.cpp
++++ b/src/preferences.cpp
+@@ -491,6 +491,9 @@ void Preferences::reset() {
+ 	gui = "DefaultGUI";
+ 	iconset = "H2O";
+ 
++#ifdef Q_OS_HAIKU
++	iconset = "Default";
++#endif
+ 
+ #if USE_MINIMUMSIZE
+ 	gui_minimum_width = 0; // 0 == disabled
+-- 
+2.19.0
+

--- a/media-video/smplayer/smplayer-19.5.0.recipe
+++ b/media-video/smplayer/smplayer-19.5.0.recipe
@@ -1,0 +1,100 @@
+SUMMARY="Great Qt GUI front-end for MPlayer/mpv"
+DESCRIPTION="SMPlayer is a graphical user interface (GUI) for the \
+award-winning MPlayer, which is capable of playing almost all known video and \
+audio formats. But apart from providing access for the most common and useful \
+options of MPlayer, SMPlayer adds other interesting features like the \
+possibility to play Youtube videos or download subtitles."
+HOMEPAGE="https://www.smplayer.info/"
+COPYRIGHT="2006-2019 Ricardo Villalba"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="https://downloads.sf.net/smplayer/smplayer-$portVersion.tar.bz2"
+CHECKSUM_SHA256="b5cb2b37fc9a225bb7287bf26a0a499f7b46bff688161b8e5eae0d96d74daaf5"
+PATCHES="smplayer-$portVersion.patchset"
+ADDITIONAL_FILES="smplayer.rdef"
+
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+# On x86_gcc2 we don't want to install the commands in bin/<arch>/, but in bin/.
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+
+PROVIDES="
+	smplayer$secondaryArchSuffix = $portVersion
+	app:SMPlayer = $portVersion
+	cmd:smplayer = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libgl$secondaryArchSuffix
+	lib:libQt5Core$secondaryArchSuffix
+	lib:libQt5DBus$secondaryArchSuffix
+	lib:libQt5Gui$secondaryArchSuffix
+	lib:libQt5Network$secondaryArchSuffix
+	lib:libQt5Script$secondaryArchSuffix
+	lib:libQt5Widgets$secondaryArchSuffix
+	lib:libQt5Xml$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	cmd:mpv$secondaryArchSuffix
+	cmd:smtube$commandSuffix
+	"
+
+BUILD_REQUIRES="
+	devel:libQt5Core$secondaryArchSuffix
+	devel:libQt5DBus$secondaryArchSuffix
+	devel:libQt5Gui$secondaryArchSuffix
+	devel:libQt5Network$secondaryArchSuffix
+	devel:libQt5Script$secondaryArchSuffix
+	devel:libQt5Widgets$secondaryArchSuffix
+	devel:libQt5Xml$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	cmd:gcc$secondaryArchSuffix
+	cmd:lrelease$secondaryArchSuffix
+	cmd:make
+	"
+
+GLOBAL_WRITABLE_FILES="settings/smplayer/input.conf keep-old"
+
+BUILD()
+{
+	make $jobArgs
+}
+
+INSTALL()
+{
+	smplayerDir=$appsDir/SMPlayer
+	mkdir -p $smplayerDir/translations $settingsDir/smplayer
+	cp src/translations/*.qm $smplayerDir/translations
+	cp src/input.conf $settingsDir/smplayer
+	cp src/smplayer $smplayerDir/SMPlayer$commandSuffix
+
+	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
+	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
+	local MINOR="`echo "$portVersion" | cut -d. -f3`"
+	sed \
+		-e "s|@APP_SIGNATURE@|$APP_SIGNATURE|" \
+		-e "s|@MAJOR@|$MAJOR|" \
+		-e "s|@MIDDLE@|$MIDDLE|" \
+		-e "s|@MINOR@|$MINOR|" \
+		$portDir/additional-files/smplayer.rdef > smplayer.rdef
+
+	addResourcesToBinaries smplayer.rdef $smplayerDir/SMPlayer$commandSuffix
+
+	mkdir -p $commandBinDir
+	if [ -n "$commandSuffix" ]; then
+	  mkdir -p $prefix/bin
+	  symlinkRelative -s $smplayerDir/SMPlayer$commandSuffix $prefix/bin
+	fi
+	symlinkRelative -s $smplayerDir/SMPlayer$commandSuffix \
+		$commandBinDir/smplayer
+	addAppDeskbarSymlink $smplayerDir/SMPlayer
+}


### PR DESCRIPTION
Version 19.5:

 * Fix for YouTube.
 * Fix YouTube live streams (works only with mpv).
 * New actions available for previous subtitle track, previous audio track
   and previous video track.
 * New command line option -start.