### PR TITLE
Milkytracker: bump version

### DIFF
--- a/media-sound/milkytracker/milkytracker-1.02.00.recipe
+++ b/media-sound/milkytracker/milkytracker-1.02.00.recipe
@@ -1,0 +1,82 @@
+SUMMARY="Fasttracker II inspired music tracker"
+DESCRIPTION="MilkyTracker is an open source, multi-platform music application \
+for creating .MOD and .XM module files. It attempts to recreate the module \
+replay and user experience of the popular DOS program Fasttracker II, with \
+special playback modes available for improved Amiga ProTracker 2/3 \
+compatibility."
+HOMEPAGE="http://www.milkytracker.org/"
+COPYRIGHT="
+	1994-2013
+	Peter 'pailes' Barth,
+	Christopher 'Deltafire' O'Neill,
+	Antti S. Lankila,
+	Varthall,
+	Andrew Simper,
+	David Ross,
+	Stuart Caie,
+	Claudio Matsuoka,
+	Julian 'jua' Harnath
+	"
+LICENSE="GNU GPL v3
+	New-BSD"
+REVISION="1"
+SOURCE_URI="https://github.com/milkytracker/MilkyTracker/archive/v$portVersion.tar.gz"
+CHECKSUM_SHA256="6bcb6e74ee333e831137435a25c0f2f3da6e1462864deec9e693ef7d23a16023"
+SOURCE_DIR="MilkyTracker-$portVersion"
+PATCHES="milkytracker-$portVersion.patchset"
+if [ $effectiveTargetArchitecture != "x86_gcc2" ]; then
+	PATCHES="milkytracker-$portVersion-gcc4.patchset"
+fi
+
+ARCHITECTURES="?x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	milkytracker = $portVersion
+	app:MilkyTracker = $portVersion
+	app:MilkySettings = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix >= 1.2.3
+	lib:libzzip_0$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	devel:libz$secondaryArchSuffix >= 1.2.3
+	devel:libzzip_0$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:jam
+	cmd:lha
+	cmd:ld$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	VER_X=1; VER_YY=02; VER_ZZ=00;
+	echo "const int MILKYTRACKER_VERSION = 0x${VER_X}${VER_YY}${VER_ZZ};" \
+		> src/tracker/version.h
+	echo "const char MILKYTRACKER_VERSION_STRING[] = \"MilkyTracker ${VER_X}.${VER_YY}.${VER_ZZ}\";" \
+		>> src/tracker/version.h
+
+	pushd $sourceDir/platforms/haiku
+	bash ./Add_Jamfiles.sh
+	popd
+	jam -q $jobArgs
+}
+
+INSTALL()
+{
+	TARGET_DIR=$appsDir/MilkyTracker
+	mkdir -p $TARGET_DIR
+	cp -af src/tracker/MilkyTracker $TARGET_DIR/
+	cp -af src/tracker/haiku/MilkySettings/MilkySettings $TARGET_DIR/
+	cp -af docs/ChangeLog.html $TARGET_DIR/
+	cp -af docs/FAQ.html $TARGET_DIR/
+	cp -af docs/MilkyTracker.html $TARGET_DIR/
+	cp -af docs/TiTAN.nfo $TARGET_DIR/
+	cp -af COPYING $TARGET_DIR/
+	addAppDeskbarSymlink $TARGET_DIR/MilkyTracker MilkyTracker
+}

--- a/media-sound/milkytracker/patches/milkytracker-1.02.00-gcc4.patchset
+++ b/media-sound/milkytracker/patches/milkytracker-1.02.00-gcc4.patchset
@@ -1,0 +1,189 @@
+From d27ab27a0b248c688f1b22a8b42b7f9a7e383eaf Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Wed, 3 Sep 2014 16:22:32 +0000
+Subject: include <strings.h>
+
+
+diff --git a/src/ppui/BasicTypes.h b/src/ppui/BasicTypes.h
+index 23ab385..831c284 100644
+--- a/src/ppui/BasicTypes.h
++++ b/src/ppui/BasicTypes.h
+@@ -43,7 +43,7 @@ typedef signed int		pp_int32;
+ 	#include <stdio.h>
+ 	#include <stdlib.h>
+ 	#include <string.h>
+-	#include <string.h>
++	#include <strings.h>
+ 	#include "VirtualKeys.h"
+ 	#include "PPSystemString_POSIX.h"
+ #endif
+-- 
+2.12.2
+
+
+From fc6fc4fbb9ffde6b4d0f9dc31a0b45d67b566f97 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Wed, 3 Sep 2014 16:47:15 +0000
+Subject: link against libstdc++
+
+
+diff --git a/platforms/haiku/Jamfiles/src-tracker-Jamfile b/platforms/haiku/Jamfiles/src-tracker-Jamfile
+index 39e0412..2931ecf 100644
+--- a/platforms/haiku/Jamfiles/src-tracker-Jamfile
++++ b/platforms/haiku/Jamfiles/src-tracker-Jamfile
+@@ -11,7 +11,7 @@ SubDirHdrs $(PathPPUI) haiku ;
+ SubDirHdrs $(PathTracker) haiku ;
+ SubDirHdrs - ;
+ 
+-LINKLIBS on MilkyTracker = -lbe -lgame -lmedia -lmidi2 -ltextencoding -ltracker ;
++LINKLIBS on MilkyTracker = -lbe -lgame -lmedia -lmidi2 -ltextencoding -ltracker -lstdc++ ;
+ 
+ LinkLibraries MilkyTracker :
+ 	libcompression
+diff --git a/platforms/haiku/Jamfiles/src-tracker-haiku-MilkySettings-Jamfile b/platforms/haiku/Jamfiles/src-tracker-haiku-MilkySettings-Jamfile
+index 662ee18..b76c586 100644
+--- a/platforms/haiku/Jamfiles/src-tracker-haiku-MilkySettings-Jamfile
++++ b/platforms/haiku/Jamfiles/src-tracker-haiku-MilkySettings-Jamfile
+@@ -1,6 +1,6 @@
+ SubDir TOP src tracker haiku MilkySettings ;
+ 
+-LINKLIBS on MilkySettings = -lbe -lmidi2 ;
++LINKLIBS on MilkySettings = -lbe -lmidi2 -lstdc++ ;
+ 
+ Main MilkySettings :
+ 	MilkySettingsApplication.cpp
+-- 
+2.12.2
+
+
+From 3fadce6df023928645e011e81fb86d247bc768ed Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Tue, 23 May 2017 23:34:15 +0200
+Subject: Build update for 1.0.0.
+
+
+diff --git a/platforms/haiku/Add_Jamfiles.sh b/platforms/haiku/Add_Jamfiles.sh
+index c4601e8..1bcd1b3 100644
+--- a/platforms/haiku/Add_Jamfiles.sh
++++ b/platforms/haiku/Add_Jamfiles.sh
+@@ -7,7 +7,6 @@ echo "Copying Jamfiles..."
+ cp Jamfiles/Jamfile $MILKY_ROOT
+ cp Jamfiles/Jamrules $MILKY_ROOT
+ cp Jamfiles/src-compression-Jamfile $MILKY_ROOT/src/compression/Jamfile
+-cp Jamfiles/src-compression-zzlib-generic-Jamfile $MILKY_ROOT/src/compression/zziplib/generic/Jamfile
+ cp Jamfiles/src-fx-Jamfile $MILKY_ROOT/src/fx/Jamfile
+ cp Jamfiles/src-midi-Jamfile $MILKY_ROOT/src/midi/Jamfile
+ cp Jamfiles/src-milkyplay-Jamfile $MILKY_ROOT/src/milkyplay/Jamfile
+diff --git a/platforms/haiku/Jamfiles/Jamfile b/platforms/haiku/Jamfiles/Jamfile
+index a549511..8c3f7e5 100644
+--- a/platforms/haiku/Jamfiles/Jamfile
++++ b/platforms/haiku/Jamfiles/Jamfile
+@@ -1,7 +1,6 @@
+ SubDir TOP ;
+ 
+ SubInclude TOP src compression ;
+-SubInclude TOP src compression zziplib generic ;
+ SubInclude TOP src fx ;
+ SubInclude TOP src midi ;
+ SubInclude TOP src milkyplay ;
+diff --git a/platforms/haiku/Jamfiles/Jamrules b/platforms/haiku/Jamfiles/Jamrules
+index 7236a0f..dfce893 100644
+--- a/platforms/haiku/Jamfiles/Jamrules
++++ b/platforms/haiku/Jamfiles/Jamrules
+@@ -1,6 +1,6 @@
+ C++ = g++ ;
+ C++FLAGS = -O2 -DMILKYTRACKER -D__HAIKU__ ;
+-LINKFLAGS = -Xlinker -soname=_APP_ ;
++LINKFLAGS = -Xlinker -soname=_APP_ -Xlinker --whole-archive ;
+ 
+ # Paths to sources, used as include paths
+ PathCompression = $(TOP)/src/compression ;
+diff --git a/platforms/haiku/Jamfiles/src-compression-Jamfile b/platforms/haiku/Jamfiles/src-compression-Jamfile
+index e2323fa..4329ffa 100644
+--- a/platforms/haiku/Jamfiles/src-compression-Jamfile
++++ b/platforms/haiku/Jamfiles/src-compression-Jamfile
+@@ -1,17 +1,14 @@
+ SubDir TOP src compression ;
+ 
+-SubDirHdrs $(PathCompression) lha ;
+ SubDirHdrs $(PathMilkyPlay) ;
+ SubDirHdrs $(PathOSInterface) posix ;
+ SubDirHdrs $(PathPPUI) ;
+ SubDirHdrs $(PathZZIP) ;
+-SubDirHdrs - ;
+-SubDirHdrs $(PathZZIP) generic ;
+ 
+ Library libcompression :
+ 	Decompressor.cpp
+ 	DecompressorGZIP.cpp
+-	DecompressorLHA.cpp
++	#DecompressorLHA.cpp
+ 	DecompressorLZX.cpp
+ 	DecompressorPP20.cpp
+ 	DecompressorUMX.cpp
+@@ -19,6 +16,6 @@ Library libcompression :
+ 	PP20.cpp
+ 	unlzx.cpp
+ 	ZipExtractor.cpp
+-	lha/unlha.cpp
++	#lha/unlha.cpp
+ 	zziplib/MyIO.cpp
+ 	;
+diff --git a/platforms/haiku/Jamfiles/src-tracker-Jamfile b/platforms/haiku/Jamfiles/src-tracker-Jamfile
+index 2931ecf..a9dc7db 100644
+--- a/platforms/haiku/Jamfiles/src-tracker-Jamfile
++++ b/platforms/haiku/Jamfiles/src-tracker-Jamfile
+@@ -11,11 +11,10 @@ SubDirHdrs $(PathPPUI) haiku ;
+ SubDirHdrs $(PathTracker) haiku ;
+ SubDirHdrs - ;
+ 
+-LINKLIBS on MilkyTracker = -lbe -lgame -lmedia -lmidi2 -ltextencoding -ltracker -lstdc++ ;
++LINKLIBS on MilkyTracker = -Xlinker --no-whole-archive -lbe -lgame -lmedia -lmidi2 -ltextencoding -ltracker -lstdc++ -lz -lzzip ;
+ 
+ LinkLibraries MilkyTracker :
+ 	libcompression
+-	libzzip
+ 	libfx
+ 	libmilkyplay
+ 	libppui
+@@ -37,11 +36,11 @@ Main MilkyTracker :
+ 	DialogResample.cpp
+ 	DialogWithValues.cpp
+ 	DialogZap.cpp
++	EQConstants.cpp
+ 	EditorBase.cpp
+ 	EnvelopeContainer.cpp
+ 	EnvelopeEditor.cpp
+ 	EnvelopeEditorControl.cpp
+-	EQConstants.cpp
+ 	Equalizer.cpp
+ 	FileExtProvider.cpp
+ 	FileIdentificator.cpp
+diff --git a/platforms/haiku/Jamfiles/src-tracker-haiku-MilkySettings-Jamfile b/platforms/haiku/Jamfiles/src-tracker-haiku-MilkySettings-Jamfile
+index b76c586..4ece810 100644
+--- a/platforms/haiku/Jamfiles/src-tracker-haiku-MilkySettings-Jamfile
++++ b/platforms/haiku/Jamfiles/src-tracker-haiku-MilkySettings-Jamfile
+@@ -1,6 +1,6 @@
+ SubDir TOP src tracker haiku MilkySettings ;
+ 
+-LINKLIBS on MilkySettings = -lbe -lmidi2 -lstdc++ ;
++LINKLIBS on MilkySettings = -Xlinker --no-whole-archive -lbe -lmidi2 -lstdc++ ;
+ 
+ Main MilkySettings :
+ 	MilkySettingsApplication.cpp
+diff --git a/src/ppui/haiku/MilkyView.cpp b/src/ppui/haiku/MilkyView.cpp
+index 1ded1b3..2e56afe 100644
+--- a/src/ppui/haiku/MilkyView.cpp
++++ b/src/ppui/haiku/MilkyView.cpp
+@@ -424,7 +424,8 @@ MilkyView::MouseWheelChanged(float deltaX, float deltaY)
+ 	TMouseWheelEventParams wheelEventParams;
+ 	wheelEventParams.pos.x = (pp_int32)point.x;
+ 	wheelEventParams.pos.y = (pp_int32)point.y;
+-	wheelEventParams.delta = (pp_int32)-deltaY;
++	wheelEventParams.deltaX = (pp_int32)deltaX;
++	wheelEventParams.deltaY = -(pp_int32)deltaY;
+ 
+ 	MilkyWindow* milkyWindow = (MilkyWindow*)Window();
+ 
+-- 
+2.12.2

--- a/media-sound/milkytracker/patches/milkytracker-1.02.00.patchset
+++ b/media-sound/milkytracker/patches/milkytracker-1.02.00.patchset
@@ -1,0 +1,189 @@
+From cd4b51220d4482ff681278e89d2e296ec2b13323 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Wed, 3 Sep 2014 16:22:32 +0000
+Subject: include <strings.h>
+
+
+diff --git a/src/ppui/BasicTypes.h b/src/ppui/BasicTypes.h
+index 20eba8b..63e0c1c 100644
+--- a/src/ppui/BasicTypes.h
++++ b/src/ppui/BasicTypes.h
+@@ -43,7 +43,7 @@ typedef signed int		pp_int32;
+ 	#include <stdio.h>
+ 	#include <stdlib.h>
+ 	#include <string.h>
+-	#include <string.h>
++	#include <strings.h>
+ 	#include "VirtualKeys.h"
+ 	#include "PPSystemString_POSIX.h"
+ #endif
+-- 
+2.15.1
+
+
+From 911a07a0e82a830467635990332c8d595e3c11c4 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Wed, 3 Sep 2014 16:47:15 +0000
+Subject: link against libstdc++
+
+
+diff --git a/platforms/haiku/Jamfiles/src-tracker-Jamfile b/platforms/haiku/Jamfiles/src-tracker-Jamfile
+index 39e0412..2931ecf 100644
+--- a/platforms/haiku/Jamfiles/src-tracker-Jamfile
++++ b/platforms/haiku/Jamfiles/src-tracker-Jamfile
+@@ -11,7 +11,7 @@ SubDirHdrs $(PathPPUI) haiku ;
+ SubDirHdrs $(PathTracker) haiku ;
+ SubDirHdrs - ;
+ 
+-LINKLIBS on MilkyTracker = -lbe -lgame -lmedia -lmidi2 -ltextencoding -ltracker ;
++LINKLIBS on MilkyTracker = -lbe -lgame -lmedia -lmidi2 -ltextencoding -ltracker -lstdc++.r4 ;
+ 
+ LinkLibraries MilkyTracker :
+ 	libcompression
+diff --git a/platforms/haiku/Jamfiles/src-tracker-haiku-MilkySettings-Jamfile b/platforms/haiku/Jamfiles/src-tracker-haiku-MilkySettings-Jamfile
+index 662ee18..b76c586 100644
+--- a/platforms/haiku/Jamfiles/src-tracker-haiku-MilkySettings-Jamfile
++++ b/platforms/haiku/Jamfiles/src-tracker-haiku-MilkySettings-Jamfile
+@@ -1,6 +1,6 @@
+ SubDir TOP src tracker haiku MilkySettings ;
+ 
+-LINKLIBS on MilkySettings = -lbe -lmidi2 ;
++LINKLIBS on MilkySettings = -lbe -lmidi2 -lstdc++.r4 ;
+ 
+ Main MilkySettings :
+ 	MilkySettingsApplication.cpp
+-- 
+2.15.1
+
+
+From 3992ae5a2a6cec1b98757a5e18be8287747c1dbc Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Tue, 23 May 2017 23:34:15 +0200
+Subject: Build update for 1.0.0.
+
+
+diff --git a/platforms/haiku/Add_Jamfiles.sh b/platforms/haiku/Add_Jamfiles.sh
+index c4601e8..1bcd1b3 100644
+--- a/platforms/haiku/Add_Jamfiles.sh
++++ b/platforms/haiku/Add_Jamfiles.sh
+@@ -7,7 +7,6 @@ echo "Copying Jamfiles..."
+ cp Jamfiles/Jamfile $MILKY_ROOT
+ cp Jamfiles/Jamrules $MILKY_ROOT
+ cp Jamfiles/src-compression-Jamfile $MILKY_ROOT/src/compression/Jamfile
+-cp Jamfiles/src-compression-zzlib-generic-Jamfile $MILKY_ROOT/src/compression/zziplib/generic/Jamfile
+ cp Jamfiles/src-fx-Jamfile $MILKY_ROOT/src/fx/Jamfile
+ cp Jamfiles/src-midi-Jamfile $MILKY_ROOT/src/midi/Jamfile
+ cp Jamfiles/src-milkyplay-Jamfile $MILKY_ROOT/src/milkyplay/Jamfile
+diff --git a/platforms/haiku/Jamfiles/Jamfile b/platforms/haiku/Jamfiles/Jamfile
+index a549511..8c3f7e5 100644
+--- a/platforms/haiku/Jamfiles/Jamfile
++++ b/platforms/haiku/Jamfiles/Jamfile
+@@ -1,7 +1,6 @@
+ SubDir TOP ;
+ 
+ SubInclude TOP src compression ;
+-SubInclude TOP src compression zziplib generic ;
+ SubInclude TOP src fx ;
+ SubInclude TOP src midi ;
+ SubInclude TOP src milkyplay ;
+diff --git a/platforms/haiku/Jamfiles/Jamrules b/platforms/haiku/Jamfiles/Jamrules
+index 7236a0f..dfce893 100644
+--- a/platforms/haiku/Jamfiles/Jamrules
++++ b/platforms/haiku/Jamfiles/Jamrules
+@@ -1,6 +1,6 @@
+ C++ = g++ ;
+ C++FLAGS = -O2 -DMILKYTRACKER -D__HAIKU__ ;
+-LINKFLAGS = -Xlinker -soname=_APP_ ;
++LINKFLAGS = -Xlinker -soname=_APP_ -Xlinker --whole-archive ;
+ 
+ # Paths to sources, used as include paths
+ PathCompression = $(TOP)/src/compression ;
+diff --git a/platforms/haiku/Jamfiles/src-compression-Jamfile b/platforms/haiku/Jamfiles/src-compression-Jamfile
+index e2323fa..4329ffa 100644
+--- a/platforms/haiku/Jamfiles/src-compression-Jamfile
++++ b/platforms/haiku/Jamfiles/src-compression-Jamfile
+@@ -1,17 +1,14 @@
+ SubDir TOP src compression ;
+ 
+-SubDirHdrs $(PathCompression) lha ;
+ SubDirHdrs $(PathMilkyPlay) ;
+ SubDirHdrs $(PathOSInterface) posix ;
+ SubDirHdrs $(PathPPUI) ;
+ SubDirHdrs $(PathZZIP) ;
+-SubDirHdrs - ;
+-SubDirHdrs $(PathZZIP) generic ;
+ 
+ Library libcompression :
+ 	Decompressor.cpp
+ 	DecompressorGZIP.cpp
+-	DecompressorLHA.cpp
++	#DecompressorLHA.cpp
+ 	DecompressorLZX.cpp
+ 	DecompressorPP20.cpp
+ 	DecompressorUMX.cpp
+@@ -19,6 +16,6 @@ Library libcompression :
+ 	PP20.cpp
+ 	unlzx.cpp
+ 	ZipExtractor.cpp
+-	lha/unlha.cpp
++	#lha/unlha.cpp
+ 	zziplib/MyIO.cpp
+ 	;
+diff --git a/platforms/haiku/Jamfiles/src-tracker-Jamfile b/platforms/haiku/Jamfiles/src-tracker-Jamfile
+index 2931ecf..a9dc7db 100644
+--- a/platforms/haiku/Jamfiles/src-tracker-Jamfile
++++ b/platforms/haiku/Jamfiles/src-tracker-Jamfile
+@@ -11,11 +11,10 @@ SubDirHdrs $(PathPPUI) haiku ;
+ SubDirHdrs $(PathTracker) haiku ;
+ SubDirHdrs - ;
+ 
+-LINKLIBS on MilkyTracker = -lbe -lgame -lmedia -lmidi2 -ltextencoding -ltracker -lstdc++.r4 ;
++LINKLIBS on MilkyTracker = -Xlinker --no-whole-archive -lbe -lgame -lmedia -lmidi2 -ltextencoding -ltracker -lstdc++.r4 -lz -lzzip ;
+ 
+ LinkLibraries MilkyTracker :
+ 	libcompression
+-	libzzip
+ 	libfx
+ 	libmilkyplay
+ 	libppui
+@@ -37,11 +36,11 @@ Main MilkyTracker :
+ 	DialogResample.cpp
+ 	DialogWithValues.cpp
+ 	DialogZap.cpp
++	EQConstants.cpp
+ 	EditorBase.cpp
+ 	EnvelopeContainer.cpp
+ 	EnvelopeEditor.cpp
+ 	EnvelopeEditorControl.cpp
+-	EQConstants.cpp
+ 	Equalizer.cpp
+ 	FileExtProvider.cpp
+ 	FileIdentificator.cpp
+diff --git a/platforms/haiku/Jamfiles/src-tracker-haiku-MilkySettings-Jamfile b/platforms/haiku/Jamfiles/src-tracker-haiku-MilkySettings-Jamfile
+index b76c586..4ece810 100644
+--- a/platforms/haiku/Jamfiles/src-tracker-haiku-MilkySettings-Jamfile
++++ b/platforms/haiku/Jamfiles/src-tracker-haiku-MilkySettings-Jamfile
+@@ -1,6 +1,6 @@
+ SubDir TOP src tracker haiku MilkySettings ;
+ 
+-LINKLIBS on MilkySettings = -lbe -lmidi2 -lstdc++.r4 ;
++LINKLIBS on MilkySettings = -Xlinker --no-whole-archive -lbe -lmidi2 -lstdc++.r4 ;
+ 
+ Main MilkySettings :
+ 	MilkySettingsApplication.cpp
+diff --git a/src/ppui/haiku/MilkyView.cpp b/src/ppui/haiku/MilkyView.cpp
+index 1ded1b3..2e56afe 100644
+--- a/src/ppui/haiku/MilkyView.cpp
++++ b/src/ppui/haiku/MilkyView.cpp
+@@ -424,7 +424,8 @@ MilkyView::MouseWheelChanged(float deltaX, float deltaY)
+ 	TMouseWheelEventParams wheelEventParams;
+ 	wheelEventParams.pos.x = (pp_int32)point.x;
+ 	wheelEventParams.pos.y = (pp_int32)point.y;
+-	wheelEventParams.delta = (pp_int32)-deltaY;
++	wheelEventParams.deltaX = (pp_int32)deltaX;
++	wheelEventParams.deltaY = -(pp_int32)deltaY;
+ 
+ 	MilkyWindow* milkyWindow = (MilkyWindow*)Window();
+ 
+-- 
+2.15.1


### PR DESCRIPTION
24/02/2018 (v1.02):
What’s new:
    99 channel MOD support
    Alternative keybindings for inc/dec Row Insert

Bugs fixed:
    Fix Lxx command to also set panning envelope if volume sustain point is enabled.
    Infinite loop when processing 8 digit hexadecimal numbers
    SDL crash with -orientation command line parameter
    SDL mouse drag issue
    Fix fine global volume slide down handling
    Various loader memory corruption bugs