### PR TITLE
python: patched webbrowser module for Haiku

### DIFF
--- a/dev-lang/python/patches/python-2.7.16.patchset
+++ b/dev-lang/python/patches/python-2.7.16.patchset
@@ -1152,3 +1152,37 @@ index 6d4b3b3..8c42fb8 100644
 -- 
 2.21.0
 
+
+From 21502a9c6059d24d14924f518667f800764f5e42 Mon Sep 17 00:00:00 2001
+From: Philipp Wolfer <phil@parolu.io>
+Date: Mon, 23 Sep 2019 09:53:39 +0200
+Subject: [PATCH] webbrowser: Support for default browsers on Haiku
+
+---
+ Lib/webbrowser.py | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/Lib/webbrowser.py b/Lib/webbrowser.py
+index 15eeb660e2..d73749d696 100755
+--- a/Lib/webbrowser.py
++++ b/Lib/webbrowser.py
+@@ -644,6 +644,16 @@ if sys.platform == 'darwin':
+     register("chrome", None, MacOSXOSAScript('chrome'), -1)
+     register("MacOSX", None, MacOSXOSAScript('default'), -1)
+ 
++#
++# Platform support for Haiku
++#
++
++if sys.platform[:5] == "haiku":
++    # First try to use the default configured browser
++    register("haiku-default", None, GenericBrowser("open"))
++    # Fall back to WebPositive as the standard browser of Haiku
++    register("webpositive", None, BackgroundBrowser("WebPositive"))
++
+ 
+ #
+ # Platform support for OS/2
+-- 
+2.23.0
+

--- a/dev-lang/python/patches/python3-3.6.8.patchset
+++ b/dev-lang/python/patches/python3-3.6.8.patchset
@@ -647,3 +647,37 @@ index 339ae8a..d537963 100644
 -- 
 2.19.1
 
+
+From 4e03cd18f7d7305f8c3adb4e308f68af1959d5db Mon Sep 17 00:00:00 2001
+From: Philipp Wolfer <phil@parolu.io>
+Date: Mon, 23 Sep 2019 09:53:39 +0200
+Subject: [PATCH] webbrowser: Support for default browsers on Haiku
+
+---
+ Lib/webbrowser.py | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/Lib/webbrowser.py b/Lib/webbrowser.py
+index 1a553f0e65..074898b62d 100755
+--- a/Lib/webbrowser.py
++++ b/Lib/webbrowser.py
+@@ -614,6 +614,16 @@ if sys.platform == 'darwin':
+     register("chrome", None, MacOSXOSAScript('chrome'), -1)
+     register("MacOSX", None, MacOSXOSAScript('default'), -1)
+ 
++#
++# Platform support for Haiku
++#
++
++if sys.platform[:5] == "haiku":
++    # First try to use the default configured browser
++    register("haiku-default", None, GenericBrowser("open"))
++    # Fall back to WebPositive as the standard browser of Haiku
++    register("webpositive", None, BackgroundBrowser("WebPositive"))
++
+ 
+ # OK, now that we know what the default preference orders for each
+ # platform are, allow user to override them with the BROWSER variable.
+-- 
+2.23.0
+

--- a/dev-lang/python/patches/python3-3.7.3.patchset
+++ b/dev-lang/python/patches/python3-3.7.3.patchset
@@ -696,3 +696,32 @@ index 97973bc..b2e4095 100644
 -- 
 2.21.0
 
+
+From f55317a2a10d85c3240225d3c22f76e155cbe911 Mon Sep 17 00:00:00 2001
+From: Philipp Wolfer <phil@parolu.io>
+Date: Mon, 23 Sep 2019 09:14:58 +0200
+Subject: [PATCH] webbrowser: Support for default browsers on Haiku
+
+---
+ Lib/webbrowser.py | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/Lib/webbrowser.py b/Lib/webbrowser.py
+index 0af36c4301..0a39655ab9 100755
+--- a/Lib/webbrowser.py
++++ b/Lib/webbrowser.py
+@@ -527,6 +527,11 @@ def register_standard_browsers():
+                         "netscape", "opera", iexplore):
+             if shutil.which(browser):
+                 register(browser, None, BackgroundBrowser(browser))
++    elif sys.platform[:5] == "haiku":
++        # First try to use the default configured browser
++        register("haiku-default", None, GenericBrowser("open"))
++        # Fall back to WebPositive as the standard browser of Haiku
++        register("webpositive", None, BackgroundBrowser("WebPositive"))
+     else:
+         # Prefer X browsers if present
+         if os.environ.get("DISPLAY"):
+--
+2.23.0
+

--- a/dev-lang/python/python-2.7.16.recipe
+++ b/dev-lang/python/python-2.7.16.recipe
@@ -11,7 +11,7 @@ OSI-approved open source license.
 HOMEPAGE="https://www.python.org/"
 COPYRIGHT="1990-2018 Python Software Foundation"
 LICENSE="Python"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://www.python.org/ftp/python/$portVersion/Python-$portVersion.tar.xz"
 CHECKSUM_SHA256="f222ef602647eecb6853681156d32de4450a2c39f4de93bd5b20235f2e660ed7"
 SOURCE_DIR="Python-$portVersion"

--- a/dev-lang/python/python3-3.7.3.recipe
+++ b/dev-lang/python/python3-3.7.3.recipe
@@ -11,7 +11,7 @@ OSI-approved open source license.
 HOMEPAGE="https://www.python.org"
 LICENSE="Python"
 COPYRIGHT="1990-2018 Python Software Foundation"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://www.python.org/ftp/python/$portVersion/Python-$portVersion.tar.xz"
 CHECKSUM_SHA256="da60b54064d4cfcd9c26576f6df2690e62085123826cff2e667e72a91952d318"
 SOURCE_DIR="Python-$portVersion"

--- a/dev-lang/python/python36-3.6.8.recipe
+++ b/dev-lang/python/python36-3.6.8.recipe
@@ -11,7 +11,7 @@ OSI-approved open source license.
 HOMEPAGE="https://www.python.org"
 LICENSE="Python"
 COPYRIGHT="1990-2018 Python Software Foundation"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://www.python.org/ftp/python/$portVersion/Python-$portVersion.tar.xz"
 CHECKSUM_SHA256="35446241e995773b1bed7d196f4b624dadcadc8429f26282e756b2fb8a351193"
 SOURCE_DIR="Python-$portVersion"


### PR DESCRIPTION
This patches the Python webbrowser module to open the default browser on Haiku.

With this patch code like this actually works and opens the browser:

```python
import webbrowser
webbrowser.open('https://haiku-os.org')  # Will return True and open browser
```

Patch for all currently supported Python versions included (2, 3.6, 3.7). The code was previously already used in the patches for https://github.com/haikuports/haikuports/tree/08258e72b706303a4c61c72b370d670fdf8cd297/media-sound/picard/patches 