### PR TITLE
libdiscid: does not depend on libmusicbrainz

### DIFF
--- a/media-libs/libdiscid/libdiscid-0.6.2.recipe
+++ b/media-libs/libdiscid/libdiscid-0.6.2.recipe
@@ -7,7 +7,7 @@ database and gathers ISRCs and the MCN (=UPC/EAN) from disc."
 HOMEPAGE="https://musicbrainz.org/doc/libdiscid"
 COPYRIGHT="2006-2017 MetaBrainz Foundation"
 LICENSE="GNU LGPL v2.1"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="http://ftp.musicbrainz.org/pub/musicbrainz/libdiscid/libdiscid-$portVersion.tar.gz"
 CHECKSUM_SHA256="f9e443ac4c0dd4819c2841fcc82169a46fb9a626352cdb9c7f65dd3624cd31b9"
 PATCHES="libdiscid-$portVersion.patchset"
@@ -24,7 +24,6 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libmusicbrainz5$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
@@ -37,7 +36,6 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libmusicbrainz5$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:aclocal


### PR DESCRIPTION
Removed dependency on libmusicbrainz from libdiscid. libdiscid is a standalone library not requiring anything from libmusicbrainz to build or run.