### PR TITLE
Picard revbump

### DIFF
--- a/media-sound/picard/picard-2.2.1.recipe
+++ b/media-sound/picard/picard-2.2.1.recipe
@@ -12,7 +12,7 @@ HOMEPAGE="https://picard.musicbrainz.org/"
 COPYRIGHT="2004-2019 Robert Kaye, Lukas Lalinsky, Laurent Monin, \
 Sambhav Kothari, Philipp Wolfer and others"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="ftp://ftp.eu.metabrainz.org/pub/musicbrainz/picard/picard-$portVersion.tar.gz"
 CHECKSUM_SHA256="eac065db0c2bd84e34aeb061602cf1f188b602744015905fb498596acfd426b0"
 SOURCE_DIR="picard-release-$portVersion"

--- a/media-sound/picard/picard-2.2.1.recipe
+++ b/media-sound/picard/picard-2.2.1.recipe
@@ -29,33 +29,33 @@ PROVIDES="
 REQUIRES="
 	haiku$secondaryArchSuffix
 	cmd:fpcalc
-	cmd:python3.6
-	discid_python36
+	cmd:python3.7
+	discid_python3
 	lib:libdiscid$secondaryArchSuffix
-	mutagen_python36
+	mutagen_python3
 	pyqt_python3
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	setuptools_python36
+	setuptools_python3
 	"
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:msgfmt$secondaryArchSuffix
-	cmd:python3.6
+	cmd:python3.7
 	"
 
 BUILD()
 {
 	LC_ALL=en_US.UTF-8
-	python3.6 setup.py config
+	python3 setup.py config
 }
 
 INSTALL()
 {
 	LC_ALL=en_US.UTF-8
-	python3.6 setup.py install \
+	python3 setup.py install \
 		--root=/ --prefix=$prefix \
 		--install-data=$dataDir \
 		--install-locales=$dataDir/share/locale/ \


### PR DESCRIPTION
Revbump and cleanup for the new PyQT recipe. Builds, packages but fails with a seemingly unrelated error:

```
Traceback (most recent call last):
  File "/boot/system/apps/Picard", line 2, in <module>
    from picard.tagger import main; main('/packages/picard-2.2.1-2/.self/data/share/locale', False)
  File "/packages/python3-3.7.3-3/.self/lib/python3.7/vendor-packages/picard/tagger.py", line 55, in <module>
    from picard.browser.filelookup import FileLookup
  File "/packages/python3-3.7.3-3/.self/lib/python3.7/vendor-packages/picard/browser/filelookup.py", line 31, in <module>
    from picard.util import (
  File "/packages/python3-3.7.3-3/.self/lib/python3.7/vendor-packages/picard/util/webbrowser2.py", line 37, in <module>
    webbrowser.register("haiku-default", None, haiku_default, True)
TypeError: register() takes from 2 to 3 positional arguments but 4 were given
```