### PR TITLE
Rust: add recipe for 1.38.0

### DIFF
--- a/dev-lang/rust/patches/rust-1.38.0.patchset
+++ b/dev-lang/rust/patches/rust-1.38.0.patchset
@@ -1,0 +1,111 @@
+From 5f1e2f562e193d3bf71352fa46c34cbd4711f801 Mon Sep 17 00:00:00 2001
+From: Niels Sascha Reedijk <niels.reedijk@gmail.com>
+Date: Tue, 8 Oct 2019 20:07:27 +0200
+Subject: Haiku: add patches for Rust 1.38.0
+
+
+diff --git a/Cargo.lock b/Cargo.lock
+index ab6731e..f6c5bd8 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1466,7 +1466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+- "libssh2-sys 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libssh2-sys 0.2.11 (git+https://github.com/alexcrichton/ssh2-rs?rev=74d7f04)",
+  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+  "openssl-sys 0.9.43 (registry+https://github.com/rust-lang/crates.io-index)",
+  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -1484,7 +1484,7 @@ dependencies = [
+ [[package]]
+ name = "libssh2-sys"
+ version = "0.2.11"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
++source = "git+https://github.com/alexcrichton/ssh2-rs?rev=74d7f04#74d7f04dbee9997510bdad5608bb06970c6b4c8a"
+ dependencies = [
+  "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -4486,7 +4486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ "checksum libflate 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "90c6f86f4b0caa347206f916f8b687b51d77c6ef8ff18d52dd007491fd580529"
+ "checksum libgit2-sys 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4c179ed6d19cd3a051e68c177fbbc214e79ac4724fac3a850ec9f3d3eb8a5578"
+ "checksum libnghttp2-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d75d7966bda4730b722d1eab8e668df445368a24394bae9fc1e8dc0ab3dbe4f4"
+-"checksum libssh2-sys 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "126a1f4078368b163bfdee65fbab072af08a1b374a5551b21e87ade27b1fbf9d"
++"checksum libssh2-sys 0.2.11 (git+https://github.com/alexcrichton/ssh2-rs?rev=74d7f04)" = "<none>"
+ "checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
+ "checksum lock_api 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "949826a5ccf18c1b3a7c3d57692778d21768b79e46eb9dd07bfc4c2160036c54"
+ "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+diff --git a/Cargo.toml b/Cargo.toml
+index ccd7e8b..b23710f 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -59,6 +59,7 @@ cargo = { path = "src/tools/cargo" }
+ # that we're shipping as well (to ensure that the rustfmt in RLS and the
+ # `rustfmt` executable are the same exact version).
+ rustfmt-nightly = { path = "src/tools/rustfmt" }
++libssh2-sys = { git = "https://github.com/alexcrichton/ssh2-rs", rev = "74d7f04" }
+ 
+ # See comments in `src/tools/rustc-workspace-hack/README.md` for what's going on
+ # here
+diff --git a/src/libstd/sys/unix/thread.rs b/src/libstd/sys/unix/thread.rs
+index 988881e..7b1e55f 100644
+--- a/src/libstd/sys/unix/thread.rs
++++ b/src/libstd/sys/unix/thread.rs
+@@ -178,8 +178,7 @@ impl Thread {
+         unsafe {
+             let ret = libc::pthread_join(self.id, ptr::null_mut());
+             mem::forget(self);
+-            assert!(ret == 0,
+-                    "failed to join thread: {}", io::Error::from_raw_os_error(ret));
++            debug_assert_eq!(ret, 0);
+         }
+     }
+ 
+diff --git a/src/libstd/sys/windows/c.rs b/src/libstd/sys/windows/c.rs
+index f706709..05d624a 100644
+--- a/src/libstd/sys/windows/c.rs
++++ b/src/libstd/sys/windows/c.rs
+@@ -254,7 +254,6 @@ pub const FILE_END: DWORD = 2;
+ 
+ pub const WAIT_OBJECT_0: DWORD = 0x00000000;
+ pub const WAIT_TIMEOUT: DWORD = 258;
+-pub const WAIT_FAILED: DWORD = 0xFFFFFFFF;
+ 
+ pub const PIPE_ACCESS_INBOUND: DWORD = 0x00000001;
+ pub const PIPE_ACCESS_OUTBOUND: DWORD = 0x00000002;
+diff --git a/src/libstd/sys/windows/thread.rs b/src/libstd/sys/windows/thread.rs
+index ebdf361..de198a6 100644
+--- a/src/libstd/sys/windows/thread.rs
++++ b/src/libstd/sys/windows/thread.rs
+@@ -58,11 +58,7 @@ impl Thread {
+     }
+ 
+     pub fn join(self) {
+-        let rc = unsafe { c::WaitForSingleObject(self.handle.raw(), c::INFINITE) };
+-        if rc == c::WAIT_FAILED {
+-            panic!("failed to join on thread: {}",
+-                   io::Error::last_os_error());
+-        }
++        unsafe { c::WaitForSingleObject(self.handle.raw(), c::INFINITE); }
+     }
+ 
+     pub fn yield_now() {
+diff --git a/src/libstd/thread/mod.rs b/src/libstd/thread/mod.rs
+index 764041d..2b94be9 100644
+--- a/src/libstd/thread/mod.rs
++++ b/src/libstd/thread/mod.rs
+@@ -1438,11 +1438,6 @@ impl<T> JoinHandle<T> {
+     /// [`panic`]: ../../std/macro.panic.html
+     /// [atomic memory orderings]: ../../std/sync/atomic/index.html
+     ///
+-    /// # Panics
+-    ///
+-    /// This function may panic on some platforms if a thread attempts to join
+-    /// itself or otherwise may create a deadlock with joining threads.
+-    ///
+     /// # Examples
+     ///
+     /// ```
+-- 
+2.19.0
+

--- a/dev-lang/rust/rust-1.38.0.recipe
+++ b/dev-lang/rust/rust-1.38.0.recipe
@@ -1,0 +1,167 @@
+SUMMARY="Modern and safe systems programming language"
+DESCRIPTION="Rust is a systems programming language that runs blazingly fast, \
+prevents almost all crashes*, and eliminates data races."
+HOMEPAGE="https://www.rust-lang.org/"
+COPYRIGHT="2018 The Rust Project Developers"
+LICENSE="MIT"
+REVISION="1"
+cargoVersion="0.39.0"
+rlsVersion="1.38.0"
+rustfmtVersion="1.4.4"
+clippyVersion="0.0.212"
+SOURCE_URI="https://static.rust-lang.org/dist/rustc-$portVersion-src.tar.xz"
+CHECKSUM_SHA256="3a7991aa4cb44ef941d71636e45a95468b520dc6fc7cf725364925bd3e3d3a34"
+SOURCE_DIR="rustc-$portVersion-src"
+PATCHES="rust-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
+SECONDARY_ARCHITECTURES="?x86"
+
+PROVIDES="
+	rust_bin$secondaryArchSuffix = $portVersion
+	cmd:rustc$secondaryArchSuffix = $portVersion
+	cmd:rustdoc$secondaryArchSuffix = $portVersion
+	cmd:rustfmt$secondaryArchSuffix = $portVersion
+	cmd:rust_gdb$secondaryArchSuffix = $portVersion
+	cmd:rust_lldb$secondaryArchSuffix = $portVersion
+	cmd:cargo$secondaryArchSuffix = $cargoVersion
+	cmd:cargo_clippy$secondaryArchSuffix = $clippyVersion
+	cmd:cargo_fmt$secondaryArchSuffix = $cargoVersion
+	cmd:clippy_driver$secondaryArchSuffix = $clippyVersion
+	cmd:rls$secondaryArchSuffix = $rlsVersion
+	cmd:rustfmt = $rustfmtVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcrypto$secondaryArchSuffix
+	lib:libcurl$secondaryArchSuffix
+	lib:libssl$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libcurl$secondaryArchSuffix
+	devel:libssl$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cargo$secondaryArchSuffix == $cargoVersion
+	cmd:cmake
+	cmd:cmp
+	cmd:file
+	cmd:find
+	cmd:gcc$secondaryArchSuffix
+	cmd:git
+	cmd:grep
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:python
+	cmd:rustc$secondaryArchSuffix == $portVersion
+	cmd:sed
+	cmd:tar
+	cmd:which
+	cmd:xargs
+	"
+
+relativeInstallDir="develop/tools$secondaryArchSubDir/rust"
+installDir="$prefix/$relativeInstallDir"
+
+BUILD()
+{
+	# write the build configuration
+	tr -d '\t' >config.toml <<- EOL
+		[llvm]
+		targets = "X86"
+		experimental-targets = ""
+
+		[build]
+		cargo = "/$relativeBinDir/cargo"
+		rustc = "/$relativeBinDir/rustc"
+		submodules = false
+		extended = true
+		tools = ["cargo", "clippy", "rls", "rustfmt", "analysis"]
+
+		[install]
+		prefix = "$installDir"
+		libdir = "$installDir/bin/lib"
+		mandir = "$manDir"
+		docdir = "$developDocDir"
+		sysconfdir = "$dataDir"
+
+		[rust]
+		channel = "stable"
+		rpath = false
+		deny-warnings = false
+		dist-src = false
+
+		[dist]
+		src-tarball = false
+EOL
+	# Disable ASLR: compiling stage 1 rustc requires a lot of RAM (about 1.5
+	# GB). Haiku has a per-process limit of 2GB on 32 bit systems. ASLR makes
+	# the available space even smaller. Disabling it will give us the space to
+	# compile Rust
+	export DISABLE_ASLR=1
+
+	# now build rust and cargo
+	./x.py dist
+}
+
+INSTALL()
+{
+	# we will manually invoke the install scripts
+	if [ $effectiveTargetArchitecture = x86 ]; then
+		architecture="i686-unknown-haiku"
+	fi
+	if [ $effectiveTargetArchitecture = x86_64 ]; then
+		architecture="x86_64-unknown-haiku"
+	fi
+
+	# let's install the packages one by one
+	cd $sourceDir/build/tmp/dist/
+	for module in "rust-docs-$srcGitRev-$architecture"     \
+	              "rust-std-$srcGitRev-$architecture"      \
+	              "rustc-$srcGitRev-$architecture"         \
+	              "rust-analysis-$srcGitRev-$architecture" \
+	              "cargo-$cargoVersion-$architecture"      \
+	              "clippy-$clippyVersion-$architecture"    \
+	              "rls-$rlsVersion-$architecture"          \
+	              "rustfmt-$rustfmtVersion-$architecture"
+	do
+		./$module/install.sh                               \
+				--prefix=$installDir                       \
+				--docdir=$developDocDir                    \
+				--mandir=$manDir                           \
+				--sysconfdir=$dataDir                      \
+				--disable-ldconfig
+	done
+
+	# move zsh data to the datadir
+	mv $installDir/share/zsh $dataDir
+	rm -rf $installDir/share
+
+	# clean out unneccesary files created by the rust installer
+	rm $installDir/lib/rustlib/components
+	rm $installDir/lib/rustlib/install.log
+	rm $installDir/lib/rustlib/manifest-*
+	rm $installDir/lib/rustlib/rust-installer-version
+	rm $installDir/lib/rustlib/uninstall.sh
+
+	# link the binaries in $binDir
+	mkdir -p $binDir
+	for f in cargo cargo-clippy cargo-fmt clippy-driver rls rust-gdb \
+	         rust-lldb rustc rustdoc rustfmt; do
+		symlinkRelative -sfn $installDir/bin/$f $binDir
+	done
+
+	# make sure runtime_loader can find the libraries in the lib dir relative
+	# to the binaries
+	symlinkRelative -sfn $installDir/lib $installDir/bin/lib
+}
+
+TEST()
+{
+	./x.py test
+}

--- a/dev-lang/rust_bin/rust_bin-1.38.0.recipe
+++ b/dev-lang/rust_bin/rust_bin-1.38.0.recipe
@@ -1,0 +1,88 @@
+SUMMARY="Modern and safe systems programming language"
+DESCRIPTION="Rust is a systems programming language that runs blazingly fast, \
+prevents almost all crashes*, and eliminates data races."
+HOMEPAGE="https://www.rust-lang.org/"
+COPYRIGHT="2018 The Rust Project Developers"
+LICENSE="MIT"
+REVISION="1"
+
+case "$effectiveTargetArchitecture" in
+	x86)
+SOURCE_URI="http://dl.rust-on-haiku.com/dist/$portVersion/rust-$portVersion-i686-unknown-haiku.tar.xz"
+CHECKSUM_SHA256="9cc8df2ebf571dc6d74e019ab29db044b11db8883c41b588f732c65b3a7ab1ea"
+SOURCE_DIR="rust-$portVersion-i686-unknown-haiku"
+		;;
+	x86_64)
+SOURCE_URI="http://dl.rust-on-haiku.com/dist/$portVersion/rust-$portVersion-x86_64-unknown-haiku.tar.xz"
+CHECKSUM_SHA256="dc2f709a5737e6373cf15f7dfd65766d512db25a1aa1022149c9c46ae9c54293"
+SOURCE_DIR="rust-$portVersion-x86_64-unknown-haiku"
+		;;
+	*)
+SOURCE_URI="http://dl.rust-on-haiku.com/dist/$portVersion/rustc-$portVersion-src.tar.xz"
+CHECKSUM_SHA256="116fd8215ffcc1686456aec363cf8fc7b5a3c7344d541b17af14e8afcf10d446"
+SOURCE_DIR="rustc-$portVersion-src"
+		;;
+esac
+
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+DISABLE_SOURCE_PACKAGE=yes
+
+cargoVersion="0.39.0"
+
+PROVIDES="
+	rust_bin$secondaryArchSuffix = $portVersion
+	cmd:rustc$secondaryArchSuffix = $portVersion
+	cmd:rustdoc$secondaryArchSuffix = $portVersion
+	cmd:rust_gdb$secondaryArchSuffix = $portVersion
+	cmd:rust_lldb$secondaryArchSuffix = $portVersion
+	cmd:cargo$secondaryArchSuffix = $cargoVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcrypto$secondaryArchSuffix
+	lib:libcurl$secondaryArchSuffix
+	lib:libssl$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+CONFLICTS="
+	rust$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+
+relativeInstallDir="develop/tools$secondaryArchSubDir/rust"
+installDir="$prefix/$relativeInstallDir"
+
+INSTALL()
+{
+	./install.sh                                   \
+		--prefix=$installDir                       \
+		--docdir=$developDocDir                    \
+		--mandir=$manDir                           \
+		--sysconfdir=$dataDir                      \
+		--disable-ldconfig
+
+	# move zsh data to the datadir
+	mv $installDir/share/zsh $dataDir
+	rm -rf $installDir/share
+
+	# clean out unneccesary files created by the rust installer
+	rm $installDir/lib/rustlib/components
+	rm $installDir/lib/rustlib/install.log
+	rm $installDir/lib/rustlib/manifest-*
+	rm $installDir/lib/rustlib/rust-installer-version
+	rm $installDir/lib/rustlib/uninstall.sh
+
+	# link the binaries in $binDir
+	mkdir -p $binDir
+	for f in cargo rust-gdb rust-lldb rustc rustdoc; do
+		symlinkRelative -sfn $installDir/bin/$f $binDir
+	done
+
+	# make sure runtime_loader can find the libraries in the lib dir relative
+	# to the binaries
+	symlinkRelative -sfn $installDir/lib $installDir/bin/lib
+}


### PR DESCRIPTION
Due to rust-lang/rust#61861 this will not include clippy, rustfmt and rls