### PR TITLE
links: bump to 2.20.2

### DIFF
--- a/www-client/links/links-2.20.2.recipe
+++ b/www-client/links/links-2.20.2.recipe
@@ -1,0 +1,91 @@
+SUMMARY="A graphics and text mode web browser"
+DESCRIPTION="Links is a multi-platform web browser you can run in Terminal."
+HOMEPAGE="http://links.twibright.com/"
+COPYRIGHT="1999-2019 Mikulas Patocka
+	2000-2011 Petr Kulhavy, Karel Kulhavy, Martin Pergel"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="http://links.twibright.com/download/links-$portVersion.tar.bz2"
+CHECKSUM_SHA256="4b4f07d0e6261118d1365a5a5bfa31e1eafdbd280cfae6f0e9eedfea51a2f424"
+#PATCHES="links-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 !x86 x86_64"
+SECONDARY_ARCHITECTURES="!x86"
+
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+USER_SETTINGS_FILES="
+	settings/links directory
+	"
+
+PROVIDES="
+	links$secondaryArchSuffix = $portVersion
+	cmd:links$commandSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libbrotlicommon$secondaryArchSuffix
+	lib:libbz2$secondaryArchSuffix
+	lib:libcrypto$secondaryArchSuffix
+	lib:libevent_2.1$secondaryArchSuffix
+	lib:libfontconfig$secondaryArchSuffix
+	lib:libfreetype$secondaryArchSuffix
+	lib:libgomp$secondaryArchSuffix
+	lib:libjpeg$secondaryArchSuffix
+	lib:liblzma$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
+	lib:libssl$secondaryArchSuffix
+	lib:libtiff$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libbrotlicommon$secondaryArchSuffix
+	devel:libbz2$secondaryArchSuffix
+	devel:libcrypto$secondaryArchSuffix
+	devel:libevent_2.1$secondaryArchSuffix
+	devel:libfontconfig$secondaryArchSuffix
+	devel:libfreetype$secondaryArchSuffix
+	devel:libglu$secondaryArchSuffix
+	devel:libjpeg$secondaryArchSuffix
+	devel:liblzma$secondaryArchSuffix
+	devel:libpng16$secondaryArchSuffix
+	devel:libssl$secondaryArchSuffix
+	devel:libtiff$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix >= 1.2.8
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:aclocal
+	cmd:autoreconf
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+defineDebugInfoPackage links$secondaryArchSuffix \
+	"$commandBinDir"/links
+
+BUILD()
+{
+	autoreconf -vfi
+	runConfigure --omit-dirs binDir ./configure \
+		--bindir="$commandBinDir" \
+		--without-x \
+		--with-haiku \
+		--with-ssl \
+		--enable-graphics
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+	addAppDeskbarSymlink $commandBinDir/links Links
+}

--- a/www-client/links/links-2.20.2.recipe
+++ b/www-client/links/links-2.20.2.recipe
@@ -9,8 +9,8 @@ SOURCE_URI="http://links.twibright.com/download/links-$portVersion.tar.bz2"
 CHECKSUM_SHA256="4b4f07d0e6261118d1365a5a5bfa31e1eafdbd280cfae6f0e9eedfea51a2f424"
 #PATCHES="links-$portVersion.patchset"
 
-ARCHITECTURES="!x86_gcc2 !x86 x86_64"
-SECONDARY_ARCHITECTURES="!x86"
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
 
 commandSuffix=$secondaryArchSuffix
 commandBinDir=$binDir


### PR DESCRIPTION
NOTE:  links 2.20.2 - Mouse didn't work in GUI mode on x86 platform. Fix later.
Mouse works in GUI mode for links 2.19 x86.
Mouse works in GUI mode for links 2.20.2 x86_64.