### PR TITLE
wxqt: Bump version to 3.1.3

### DIFF
--- a/dev-qt/wxqt/wxqt-3.1.3.recipe
+++ b/dev-qt/wxqt/wxqt-3.1.3.recipe
@@ -1,0 +1,217 @@
+SUMMARY="Cross-platform GUI library"
+DESCRIPTION="wxWidgets is a C++ library that lets developers create \
+applications for Windows, macOS, Linux and other platforms with a single \
+code base. It has popular language bindings for Python, Perl, Ruby and many \
+other languages, and unlike other cross-platform toolkits, wxWidgets gives \
+applications a truly native look and feel because it uses the platform's \
+native API rather than emulating the GUI. It's also extensive, free, \
+open-source and mature."
+HOMEPAGE="https://www.wxwidgets.org/"
+COPYRIGHT="1998-2018 Julian Smart, Robert Roebling et al"
+LICENSE="GNU LGPL v2"
+REVISION="1"
+SOURCE_URI="https://github.com/wxWidgets/wxWidgets/archive/v$portVersion.tar.gz"
+CHECKSUM_SHA256="a5cb5ea326d76b5e472e9400933cef17c900d5c9b549e40eef00b64fe86d7cb0"
+SOURCE_DIR="wxWidgets-$portVersion"
+PATCHES="wxwidgets-sckaddr.patch"
+
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="$portVersion"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+libSoVersion="3.0.0"
+
+PROVIDES="
+	wxqt$secondaryArchSuffix = $portVersion
+	lib:libwx_baseu_3.1$secondaryArchSuffix = $libVersionCompat
+	lib:libwx_baseu_net_3.1$secondaryArchSuffix = $libVersionCompat
+	lib:libwx_baseu_xml_3.1$secondaryArchSuffix = $libVersionCompat
+	lib:libwx_qtu_adv_3.1$secondaryArchSuffix = $libVersionCompat
+	lib:libwx_qtu_aui_3.1$secondaryArchSuffix = $libVersionCompat
+	lib:libwx_qtu_core_3.1$secondaryArchSuffix = $libVersionCompat
+#	lib:libwx_qtu_gl_3.1$secondaryArchSuffix = $libVersionCompat
+	lib:libwx_qtu_html_3.1$secondaryArchSuffix = $libVersionCompat
+	lib:libwx_qtu_media_3.1$secondaryArchSuffix = $libVersionCompat
+	lib:libwx_qtu_propgrid_3.1$secondaryArchSuffix = $libVersionCompat
+	lib:libwx_qtu_qa_3.1$secondaryArchSuffix = $libVersionCompat
+	lib:libwx_qtu_ribbon_3.1$secondaryArchSuffix = $libVersionCompat
+	lib:libwx_qtu_richtext_3.1$secondaryArchSuffix = $libVersionCompat
+	lib:libwx_qtu_stc_3.1$secondaryArchSuffix = $libVersionCompat
+	lib:libwx_qtu_xrc_3.1$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcairo$secondaryArchSuffix
+	lib:libexecinfo$secondaryArchSuffix
+	lib:libexpat$secondaryArchSuffix
+#	lib:libGL$secondaryArchSuffix
+#	lib:libGLU$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libjpeg$secondaryArchSuffix
+	lib:liblzma$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
+	lib:libQt5Core$secondaryArchSuffix
+	lib:libQt5Gui$secondaryArchSuffix
+	lib:libQt5Widgets$secondaryArchSuffix
+	lib:libSDL$secondaryArchSuffix
+	lib:libtiff$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	wxqt${secondaryArchSuffix}_devel = $portVersion
+	cmd:wx_config$secondaryArchSuffix = $portVersion compat >= 3
+	cmd:wxrc$secondaryArchSuffix = $portVersion compat >= 3
+	cmd:wxrc_3.1$secondaryArchSuffix = $libVersionCompat
+	devel:libwx_baseu_3.1$secondaryArchSuffix = $libVersionCompat
+	devel:libwx_baseu_net_3.1$secondaryArchSuffix = $libVersionCompat
+	devel:libwx_baseu_xml_3.1$secondaryArchSuffix = $libVersionCompat
+	devel:libwx_qtu_adv_3.1$secondaryArchSuffix = $libVersionCompat
+	devel:libwx_qtu_aui_3.1$secondaryArchSuffix = $libVersionCompat
+	devel:libwx_qtu_core_3.1$secondaryArchSuffix = $libVersionCompat
+#	devel:libwx_qtu_gl_3.1$secondaryArchSuffix = $libVersionCompat
+	devel:libwx_qtu_html_3.1$secondaryArchSuffix = $libVersionCompat
+	devel:libwx_qtu_media_3.1$secondaryArchSuffix = $libVersionCompat
+	devel:libwx_qtu_propgrid_3.1$secondaryArchSuffix = $libVersionCompat
+	devel:libwx_qtu_qa_3.1$secondaryArchSuffix = $libVersionCompat
+	devel:libwx_qtu_ribbon_3.1$secondaryArchSuffix = $libVersionCompat
+	devel:libwx_qtu_richtext_3.1$secondaryArchSuffix = $libVersionCompat
+	devel:libwx_qtu_stc_3.1$secondaryArchSuffix = $libVersionCompat
+	devel:libwx_qtu_xrc_3.1$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	haiku$secondaryArchSuffix
+	wxqt$secondaryArchSuffix == $portVersion base
+	devel:libcairo$secondaryArchSuffix
+	devel:libjpeg$secondaryArchSuffix
+	devel:libpng16$secondaryArchSuffix
+	devel:libQt5Widgets$secondaryArchSuffix
+	devel:libtiff$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	lib:libexecinfo$secondaryArchSuffix
+	lib:libexpat$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:liblzma$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libcairo$secondaryArchSuffix
+	devel:libexecinfo$secondaryArchSuffix
+	devel:libexpat$secondaryArchSuffix
+#	devel:libGL$secondaryArchSuffix
+#	devel:libGLU$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
+	devel:libjpeg$secondaryArchSuffix
+	devel:liblzma$secondaryArchSuffix
+	devel:libpng16$secondaryArchSuffix
+	devel:libQt5Core$secondaryArchSuffix
+	devel:libQt5Gui$secondaryArchSuffix
+	devel:libQt5Widgets$secondaryArchSuffix
+	devel:libSDL$secondaryArchSuffix
+	devel:libtiff$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:find
+	cmd:gawk
+	cmd:gcc$secondaryArchSuffix
+	cmd:grep
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+defineDebugInfoPackage wxqt$secondaryArchSuffix \
+	"$libDir"/libwx_baseu-3.1.so.$libSoVersion \
+	"$libDir"/libwx_baseu_net-3.1.so.$libSoVersion \
+	"$libDir"/libwx_baseu_xml-3.1.so.$libSoVersion \
+	"$libDir"/libwx_qtu_adv-3.1.so.$libSoVersion \
+	"$libDir"/libwx_qtu_aui-3.1.so.$libSoVersion \
+	"$libDir"/libwx_qtu_core-3.1.so.$libSoVersion \
+	"$libDir"/libwx_qtu_html-3.1.so.$libSoVersion \
+	"$libDir"/libwx_qtu_media-3.1.so.$libSoVersion \
+	"$libDir"/libwx_qtu_propgrid-3.1.so.$libSoVersion \
+	"$libDir"/libwx_qtu_qa-3.1.so.$libSoVersion \
+	"$libDir"/libwx_qtu_ribbon-3.1.so.$libSoVersion \
+	"$libDir"/libwx_qtu_richtext-3.1.so.$libSoVersion \
+	"$libDir"/libwx_qtu_stc-3.1.so.$libSoVersion \
+	"$libDir"/libwx_qtu_xrc-3.1.so.$libSoVersion
+#	"$libDir"/libwx_qtu_gl-3.1.so.$libSoVersion
+
+PATCH()
+{
+	# autoconf chokes for whatever reason while trying to reconfigure,
+	# so just sed-patch the configure script.
+	sed -i s/lsocket/lnetwork/g configure
+	sed -i s/INET_LINK=\"socket\"/INET_LINK=\"network\"/g configure
+	sed -i 's@\*-\*-freebsd\* | \*-\*-openbsd\*@\*-\*-haiku\* | \*-\*-openbsd\*@' \
+		configure
+}
+
+BUILD()
+{
+	export CXXFLAGS="-std=c++11 -fpermissive"
+
+	runConfigure ./configure \
+		--with-qt \
+		--with-sdl \
+		--enable-shared \
+		--enable-printfposparam \
+		--enable-unicode \
+		--enable-sound
+
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	prepareInstalledDevelLibs \
+		libwx_baseu-3.1 \
+		libwx_baseu_net-3.1 \
+		libwx_baseu_xml-3.1 \
+		libwx_qtu_adv-3.1 \
+		libwx_qtu_aui-3.1 \
+		libwx_qtu_core-3.1 \
+		libwx_qtu_html-3.1 \
+		libwx_qtu_media-3.1 \
+		libwx_qtu_propgrid-3.1 \
+		libwx_qtu_qa-3.1 \
+		libwx_qtu_ribbon-3.1 \
+		libwx_qtu_richtext-3.1 \
+		libwx_qtu_stc-3.1 \
+		libwx_qtu_xrc-3.1
+#		libwx_qtu_gl-3.1
+
+	# Install some missing headers that the build system didn't install.
+	cp  include/wx/generic/caret.h \
+		include/wx/generic/clrpickerg.h \
+		include/wx/generic/imaglist.h \
+		include/wx/generic/filepickerg.h \
+		$includeDir/wx-3.1/wx/generic/
+
+	cp  include/wx/qt/nonownedwnd.h \
+		$includeDir/wx-3.1/wx/qt/
+
+	# Remove the symlinked wx-config and put the real one there instead.
+	rm $binDir/wx-config
+	mv $libDir/wx/config/qt-unicode-3.1 $binDir/wx-config
+
+	# Move setup.h to the main include directory.
+	mv $libDir/wx/include/qt-unicode-3.1/wx/setup.h $includeDir/wx-3.1/wx/
+
+	rm -rf $libDir/wx/
+
+	# Patch wx-config to pass in the Qt libs & etc. as they're usually needed.
+	sed -i 's/wx_libs="$_guildflags/wx_libs="$ldlibs_core $_guildflags/' \
+		$binDir/wx-config
+
+	packageEntries devel \
+		$developDir \
+		$prefix/bin \
+		$dataDir/aclocal
+}


### PR DESCRIPTION
This updates wxqt to version 3.1.3.

Compiles fine on x86_64 but is a WIP to make sure that existing applications don't break with this update.

Please mark this as a WIP until apps/libraries using wxqt are tested to function correctly.