### PR TITLE
mutagen: update to 1.43.0

### DIFF
--- a/dev-python/mutagen/mutagen-1.43.0.recipe
+++ b/dev-python/mutagen/mutagen-1.43.0.recipe
@@ -11,7 +11,7 @@ COPYRIGHT="Joe Wreschnig, Michael Urman, Lukáš Lalinský, Christoph Reiter, Be
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/m/$portName/$portName-$portVersion.tar.gz"
-CHECKSUM_SHA256="bb61e2456f59a9a4a259fbc08def6d01ba45a42da8eeaa97d00633b0ec5de71c"
+CHECKSUM_SHA256="3a982d39f1b800520a32afdebe3543f972e83a6ddd0c0198739a161ee705b588"
 SOURCE_DIR="mutagen-$portVersion"
 
 ARCHITECTURES="any"


### PR DESCRIPTION
Update python-mutagen to new upstream release 1.43.0

For release details see https://github.com/quodlibet/mutagen/releases/tag/release-1.43.0

Tested building and running package locally on 64bit Haiku.