### PR TITLE
pip: bump version to 19.3.1

### DIFF
--- a/dev-python/pip/pip-19.3.1.recipe
+++ b/dev-python/pip/pip-19.3.1.recipe
@@ -5,7 +5,7 @@ COPYRIGHT="2006-2019 Python Packaging Authority"
 LICENSE="Python"
 REVISION="1"
 SOURCE_URI="https://pypi.io/packages/source/p/pip/pip-$portVersion.tar.gz"
-CHECKSUM_SHA256="e7a31f147974362e6c82d84b91c7f2bdf57e4d3163d3d454e6c3e71944d67135"
+CHECKSUM_SHA256="21207d76c1031e517668898a6b46a9fb1501c7a4710ef5dfd6a40ad9e6757ea7"
 
 ARCHITECTURES="any"
 


### PR DESCRIPTION
This bumps the version of pip to 19.3.1 and includes the fix for #3420 when installing external packages.

Tested on x86_64 Haiku R1 Beta 1.