### PR TITLE
fossil: update to version 2.10, circa October 2019.

### DIFF
--- a/dev-vcs/fossil/fossil-2.10.recipe
+++ b/dev-vcs/fossil/fossil-2.10.recipe
@@ -1,17 +1,17 @@
 SUMMARY="A tool for distributed software configuration management"
 DESCRIPTION="Fossil is a simple, high-reliability, distributed version \
 control system like Git and Mercurial, but Fossil also supports distributed \
-bug tracking, distributed wiki, and a distributed blog mechanism all in a \
-single integrated package.
+bug tracking, distributed wiki, distributed forums, and a distributed blog \
+mechanism all in a single integrated package.
 
 Additionally, Fossil also has a built-in and easy-to-use web interface that \
 simplifies project tracking and promotes situational awareness."
 HOMEPAGE="https://www.fossil-scm.org/"
-COPYRIGHT="2007-2018 D. Richard Hipp"
+COPYRIGHT="2007-2019 D. Richard Hipp"
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="https://www.fossil-scm.org/index.html/uv/fossil-src-$portVersion.tar.gz"
-CHECKSUM_SHA256="76a794555918be179850739a90f157de0edb8568ad552b4c40ce186c79ff6ed9"
+CHECKSUM_SHA256="d8a3776d2ce77385ed5ff20a2776d13bb534fb2508e87351e14e94f91cd12b10"
 SOURCE_DIR="fossil-$portVersion"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"


### PR DESCRIPTION
It compiles and runs OK on 32 bit x86 (not on GCC2) and 64 bit Haiku.  Didn't have to change the recipe, other than the checksum and new version number.  Though when running you see a lot of log messages about failing to find libroot-addon-icu.so, which is actually there in system/libs.  And some probably harmless warnings when compiling on 32 bit about printing the long int GetPID() with a %d.