### PR TITLE
libu2f_host: added recipe

### DIFF
--- a/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
+++ b/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
@@ -51,6 +51,8 @@ BUILD_PREREQUIRES="
 	cmd:awk
 	cmd:gcc$secondaryArchSuffix
 	cmd:gengetopt
+	cmd:gtkdoc_check
+    cmd:gtkdoc_mkpdf
 	cmd:help2man
 	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
@@ -60,6 +62,8 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	autoreconf -vfi
+	runConfigure ./configure \
+		--disable-gtk-doc-pdf
 	make $jobArgs
 }
 

--- a/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
+++ b/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
@@ -18,6 +18,7 @@ ARCHITECTURES="!x86_gcc2 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 commandBinDir=$binDir
+commandSuffix=$secondaryArchSuffix
 if [ "$targetArchitecture" = x86_gcc2 ]; then
 	commandSuffix=
 	commandBinDir=$prefix/bin
@@ -28,7 +29,7 @@ libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
 	libu2f_host$secondaryArchSuffix = $portVersion
-	cmd:u2f_host$secondaryArchSuffix = $portVersion
+	cmd:u2f_host$commandSuffix = $portVersion
 	lib:libu2f_host$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
@@ -65,7 +66,7 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	autoreconf -vfi
-	runConfigure ./configure \
+	runConfigure --omit-dirs "binDir" ./configure \
 		--bindir="$commandBinDir"
 	make $jobArgs
 }

--- a/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
+++ b/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
@@ -1,0 +1,83 @@
+SUMMARY="Yubico Universal 2nd Factor (U2F) Host C Library"
+DESCRIPTION="libu2fhost provides a C library and command-line tool \
+that implements the host-side of the U2F protocol. There are APIs to \
+talk to a U2F device and perform the U2F Register and U2F Authenticate \
+operations."
+HOMEPAGE="https://developers.yubico.com/libu2f-host/
+		https://github.com/Yubico/libu2f-host"
+COPYRIGHT="2013-2014 Yubico AB"
+LICENSE="GNU GPL v3"
+REVISION="1"
+SOURCE_URI="https://github.com/Yubico/libu2f-host/archive/libu2f-host-$portVersion.tar.gz"
+CHECKSUM_SHA256="45937c6c04349f865d9f047d3a68cc50ea24e9085d18ac2c7d31fa38eb749303"
+SOURCE_DIR="libu2f-host-libu2f-host-$portVersion"
+PATCHES="libu2f_host-1.1.10.patchset"
+
+ARCHITECTURES="!x86_gcc2 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="$portVersion"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	libu2f_host = $portVersion
+	cmd:u2f_host$secondaryArchSuffix = $portVersion
+	lib:libu2f_host$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libjson_c$secondaryArchSuffix
+	lib:libhidapi$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	libu2f_host_devel = $portVersion
+	devel:libu2f_host = $libVersionCompat
+	"
+REQUIRES_devel="
+	libu2f_host == $portVersion base
+	lib:libjson_c$secondaryArchSuffix
+	lib:libhidapi$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libjson_c$secondaryArchSuffix
+	devel:libhidapi$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:autoconf
+	cmd:automake
+	cmd:gawk
+	cmd:gcc$secondaryArchSuffix
+	cmd:gengetopt$secondaryArchSuffix
+	cmd:gtkdoc_check
+	cmd:help2man
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	"
+
+BUILD()
+{
+	autogen.sh
+	runConfigure ./configure \
+		--prefix=$prefix \
+		--disable-gtk-doc
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+	rm -f "$libDir"/*.la
+
+	prepareInstalledDevelLib libu2f-host
+	fixPkgconfig
+	packageEntries devel \
+		$developDir
+}
+
+TEST()
+{
+	make check
+}

--- a/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
+++ b/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
@@ -4,7 +4,7 @@ that implements the host-side of the U2F protocol. \
 There are APIs to talk to a U2F device and perform the \
 U2F Register and U2F Authenticate operations."
 HOMEPAGE="https://developers.yubico.com/libu2f-host/
-		https://github.com/Yubico/libu2f-host"
+	https://github.com/Yubico/libu2f-host"
 COPYRIGHT="2013-2014 Yubico AB"
 LICENSE="GNU GPL v3
 	GNU LGPL v2"
@@ -12,12 +12,13 @@ REVISION="1"
 SOURCE_URI="https://github.com/Yubico/libu2f-host/archive/libu2f-host-$portVersion.tar.gz"
 CHECKSUM_SHA256="45937c6c04349f865d9f047d3a68cc50ea24e9085d18ac2c7d31fa38eb749303"
 SOURCE_DIR="libu2f-host-libu2f-host-$portVersion"
-PATCHES="libu2f_host-1.1.10.patchset"
+PATCHES="libu2f_host-$portVersion.patchset"
 
 ARCHITECTURES="!x86_gcc2 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
-libVersion="$portVersion compat >= 1.1.10"
+libVersion="1.10" 
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}" 
 
 PROVIDES="
 	libu2f_host$secondaryArchSuffix = $portVersion
@@ -52,7 +53,6 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:gengetopt
 	cmd:gtkdoc_check
-    cmd:gtkdoc_mkpdf
 	cmd:help2man
 	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
@@ -62,8 +62,7 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	autoreconf -vfi
-	runConfigure ./configure \
-		--disable-gtk-doc-pdf
+	runConfigure ./configure
 	make $jobArgs
 }
 

--- a/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
+++ b/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
@@ -37,8 +37,6 @@ PROVIDES_devel="
 	"
 REQUIRES_devel="
 	libu2f_host$secondaryArchSuffix == $portVersion base
-	lib:libjson_c$secondaryArchSuffix
-	lib:libhidapi$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
@@ -55,7 +53,7 @@ BUILD_PREREQUIRES="
 	cmd:help2man
 	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
-	cmd:pkg_config
+	cmd:pkg_config$secondaryArchSuffix
 	"
 
 BUILD()

--- a/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
+++ b/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
@@ -52,7 +52,6 @@ BUILD_PREREQUIRES="
 	cmd:awk
 	cmd:gcc$secondaryArchSuffix
 	cmd:gengetopt
-	cmd:gtkdoc_check
 	cmd:help2man
 	cmd:libtoolize$secondaryArchSuffix
 	cmd:make

--- a/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
+++ b/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
@@ -1,12 +1,13 @@
 SUMMARY="Yubico Universal 2nd Factor (U2F) Host C Library"
 DESCRIPTION="libu2fhost provides a C library and command-line tool \
-that implements the host-side of the U2F protocol. There are APIs to \
-talk to a U2F device and perform the U2F Register and U2F Authenticate \
-operations."
+that implements the host-side of the U2F protocol. \
+There are APIs to talk to a U2F device and perform the \
+U2F Register and U2F Authenticate operations."
 HOMEPAGE="https://developers.yubico.com/libu2f-host/
 		https://github.com/Yubico/libu2f-host"
 COPYRIGHT="2013-2014 Yubico AB"
-LICENSE="GNU GPL v3"
+LICENSE="GNU GPL v3
+	GNU LGPL v2"
 REVISION="1"
 SOURCE_URI="https://github.com/Yubico/libu2f-host/archive/libu2f-host-$portVersion.tar.gz"
 CHECKSUM_SHA256="45937c6c04349f865d9f047d3a68cc50ea24e9085d18ac2c7d31fa38eb749303"
@@ -16,13 +17,12 @@ PATCHES="libu2f_host-1.1.10.patchset"
 ARCHITECTURES="!x86_gcc2 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
-libVersion="$portVersion"
-libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+libVersion="$portVersion compat >= 1.1.10"
 
 PROVIDES="
-	libu2f_host = $portVersion
+	libu2f_host$secondaryArchSuffix = $portVersion
 	cmd:u2f_host$secondaryArchSuffix = $portVersion
-	lib:libu2f_host$secondaryArchSuffix = $libVersionCompat
+	lib:libu2f_host$secondaryArchSuffix = $libVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -31,11 +31,11 @@ REQUIRES="
 	"
 
 PROVIDES_devel="
-	libu2f_host_devel = $portVersion
-	devel:libu2f_host = $libVersionCompat
+	libu2f_host_devel$secondaryArchSuffix = $portVersion
+	devel:libu2f_host$secondaryArchSuffix = $libVersion
 	"
 REQUIRES_devel="
-	libu2f_host == $portVersion base
+	libu2f_host$secondaryArchSuffix == $portVersion base
 	lib:libjson_c$secondaryArchSuffix
 	lib:libhidapi$secondaryArchSuffix
 	"
@@ -48,21 +48,18 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	cmd:autoconf
 	cmd:automake
-	cmd:gawk
+	cmd:awk
 	cmd:gcc$secondaryArchSuffix
-	cmd:gengetopt$secondaryArchSuffix
-	cmd:gtkdoc_check
+	cmd:gengetopt
 	cmd:help2man
 	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
+	cmd:pkg_config
 	"
 
 BUILD()
 {
-	autogen.sh
-	runConfigure ./configure \
-		--prefix=$prefix \
-		--disable-gtk-doc
+	autoreconf -vfi
 	make $jobArgs
 }
 
@@ -73,11 +70,7 @@ INSTALL()
 
 	prepareInstalledDevelLib libu2f-host
 	fixPkgconfig
+
 	packageEntries devel \
 		$developDir
-}
-
-TEST()
-{
-	make check
 }

--- a/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
+++ b/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
@@ -17,6 +17,12 @@ PATCHES="libu2f_host-$portVersion.patchset"
 ARCHITECTURES="!x86_gcc2 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
 libVersion="0.1.10"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
@@ -59,7 +65,8 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	autoreconf -vfi
-	runConfigure ./configure
+	runConfigure ./configure \
+		--bindir="$commandBinDir"
 	make $jobArgs
 }
 

--- a/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
+++ b/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
@@ -1,10 +1,10 @@
 SUMMARY="Yubico Universal 2nd Factor (U2F) Host C Library"
 DESCRIPTION="libu2fhost provides a C library and command-line tool \
-that implements the host-side of the U2F protocol. \
-There are APIs to talk to a U2F device and perform the \
-U2F Register and U2F Authenticate operations."
+that implements the host-side of the U2F protocol. There are APIs to \
+talk to a U2F device and perform the U2F Register and U2F Authenticate \
+operations."
 HOMEPAGE="https://developers.yubico.com/libu2f-host/
-	https://github.com/Yubico/libu2f-host"
+		https://github.com/Yubico/libu2f-host"
 COPYRIGHT="2013-2014 Yubico AB"
 LICENSE="GNU GPL v3
 	GNU LGPL v2"
@@ -12,18 +12,18 @@ REVISION="1"
 SOURCE_URI="https://github.com/Yubico/libu2f-host/archive/libu2f-host-$portVersion.tar.gz"
 CHECKSUM_SHA256="45937c6c04349f865d9f047d3a68cc50ea24e9085d18ac2c7d31fa38eb749303"
 SOURCE_DIR="libu2f-host-libu2f-host-$portVersion"
-PATCHES="libu2f_host-$portVersion.patchset"
+PATCHES="libu2f_host-1.1.10.patchset"
 
 ARCHITECTURES="!x86_gcc2 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
-libVersion="1.10" 
-libVersionCompat="$libVersion compat >= ${libVersion%%.*}" 
+libVersion="0.1.10"
+libVersionCompat="$libVersion >= ${libVersion%%.*}"
 
 PROVIDES="
 	libu2f_host$secondaryArchSuffix = $portVersion
 	cmd:u2f_host$secondaryArchSuffix = $portVersion
-	lib:libu2f_host$secondaryArchSuffix = $libVersion
+	lib:libu2f_host$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -33,7 +33,7 @@ REQUIRES="
 
 PROVIDES_devel="
 	libu2f_host_devel$secondaryArchSuffix = $portVersion
-	devel:libu2f_host$secondaryArchSuffix = $libVersion
+	devel:libu2f_host$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
 	libu2f_host$secondaryArchSuffix == $portVersion base
@@ -52,16 +52,17 @@ BUILD_PREREQUIRES="
 	cmd:awk
 	cmd:gcc$secondaryArchSuffix
 	cmd:gengetopt
+	cmd:gtkdoc_check
 	cmd:help2man
 	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
-	cmd:pkg_config
 	"
 
 BUILD()
 {
 	autoreconf -vfi
-	runConfigure ./configure
+	runConfigure ./configure \
+		--disable-gtk-doc-pdf
 	make $jobArgs
 }
 

--- a/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
+++ b/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
@@ -1,6 +1,6 @@
 SUMMARY="Yubico Universal 2nd Factor (U2F) Host C Library"
 DESCRIPTION="libu2fhost provides a C library and command-line tool \
-that implements the host-side of the U2F protocol. \
+that implements the host-side of the U2F protocol.
 There are APIs to talk to a U2F device and perform the \
 U2F Register and U2F Authenticate operations."
 HOMEPAGE="https://developers.yubico.com/libu2f-host/

--- a/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
+++ b/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
@@ -4,7 +4,7 @@ that implements the host-side of the U2F protocol. There are APIs to \
 talk to a U2F device and perform the U2F Register and U2F Authenticate \
 operations."
 HOMEPAGE="https://developers.yubico.com/libu2f-host/
-		https://github.com/Yubico/libu2f-host"
+	https://github.com/Yubico/libu2f-host"
 COPYRIGHT="2013-2014 Yubico AB"
 LICENSE="GNU GPL v3
 	GNU LGPL v2"
@@ -12,7 +12,7 @@ REVISION="1"
 SOURCE_URI="https://github.com/Yubico/libu2f-host/archive/libu2f-host-$portVersion.tar.gz"
 CHECKSUM_SHA256="45937c6c04349f865d9f047d3a68cc50ea24e9085d18ac2c7d31fa38eb749303"
 SOURCE_DIR="libu2f-host-libu2f-host-$portVersion"
-PATCHES="libu2f_host-1.1.10.patchset"
+PATCHES="libu2f_host-$portVersion.patchset"
 
 ARCHITECTURES="!x86_gcc2 x86_64"
 SECONDARY_ARCHITECTURES="x86"
@@ -52,7 +52,6 @@ BUILD_PREREQUIRES="
 	cmd:awk
 	cmd:gcc$secondaryArchSuffix
 	cmd:gengetopt
-	cmd:gtkdoc_check
 	cmd:help2man
 	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
@@ -61,8 +60,7 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	autoreconf -vfi
-	runConfigure ./configure \
-		--disable-gtk-doc-pdf
+	runConfigure ./configure
 	make $jobArgs
 }
 

--- a/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
+++ b/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
@@ -1,8 +1,8 @@
 SUMMARY="Yubico Universal 2nd Factor (U2F) Host C Library"
 DESCRIPTION="libu2fhost provides a C library and command-line tool \
-that implements the host-side of the U2F protocol. There are APIs to \
-talk to a U2F device and perform the U2F Register and U2F Authenticate \
-operations."
+that implements the host-side of the U2F protocol. \
+There are APIs to talk to a U2F device and perform the \
+U2F Register and U2F Authenticate operations."
 HOMEPAGE="https://developers.yubico.com/libu2f-host/
 	https://github.com/Yubico/libu2f-host"
 COPYRIGHT="2013-2014 Yubico AB"
@@ -18,7 +18,7 @@ ARCHITECTURES="!x86_gcc2 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 libVersion="0.1.10"
-libVersionCompat="$libVersion >= ${libVersion%%.*}"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
 	libu2f_host$secondaryArchSuffix = $portVersion
@@ -55,6 +55,7 @@ BUILD_PREREQUIRES="
 	cmd:help2man
 	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
+	cmd:pkg_config
 	"
 
 BUILD()

--- a/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
+++ b/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
@@ -1,4 +1,4 @@
-SUMMARY="Yubico Universal 2nd Factor (U2F) Host C Library"
+SUMMARY="Yubico universal 2nd factor (U2F) host C library"
 DESCRIPTION="libu2fhost provides a C library and command-line tool \
 that implements the host-side of the U2F protocol.
 There are APIs to talk to a U2F device and perform the \

--- a/app-crypt/libu2f_host/patches/libu2f_host-1.1.10.patchset
+++ b/app-crypt/libu2f_host/patches/libu2f_host-1.1.10.patchset
@@ -1,0 +1,24 @@
+From 2f7fb88111d3e92f9aa9bf0456ac28a20baa4e8b Mon Sep 17 00:00:00 2001
+From: Panagiotis Vasilopoulos <hello@alwayslivid.com>
+Date: Thu, 26 Dec 2019 21:00:00 +0200
+Subject: Disabled help2man
+
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 5dd747a..9cb7dee 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -31,12 +31,3 @@ cmdline.c cmdline.h: cmdline.ggo Makefile.am
+ 
+ BUILT_SOURCES = cmdline.c cmdline.h
+ MAINTAINERCLEANFILES = $(BUILT_SOURCES)
+-
+-dist_man_MANS = u2f-host.1
+-DISTCLEANFILES = $(dist_man_MANS)
+-
+-u2f-host.1: $(srcdir)/u2f-host.c $(srcdir)/cmdline.ggo $(top_srcdir)/configure.ac | $(builddir)/u2f-host$(EXEEXT)
+-       $(AM_V_GEN)$(HELP2MAN) \
+-               --output=$@ $(builddir)/u2f-host$(EXEEXT) \
+-               --name="Yubico Universal 2nd Factor (U2F) Host Tool" \
+-               --no-info
+-- 
+2.19.0

--- a/app-crypt/libu2f_host/patches/libu2f_host-1.1.10.patchset
+++ b/app-crypt/libu2f_host/patches/libu2f_host-1.1.10.patchset
@@ -12,7 +12,6 @@ index 5dd747a..777bfbd 100644
                 --output=$@ $(builddir)/u2f-host$(EXEEXT) \
                 --name="Yubico Universal 2nd Factor (U2F) Host Tool" \
 -               --no-info
-+               --no-info \
-+               --no-discard-stderr
++               --no-info --no-discard-stderr
 --
 2.19.0

--- a/app-crypt/libu2f_host/patches/libu2f_host-1.1.10.patchset
+++ b/app-crypt/libu2f_host/patches/libu2f_host-1.1.10.patchset
@@ -1,24 +1,18 @@
-From 2f7fb88111d3e92f9aa9bf0456ac28a20baa4e8b Mon Sep 17 00:00:00 2001
+From 2d6f6370722c0f2c41430d2e539d2a18a93f433c Mon Sep 17 00:00:00 2001
 From: Panagiotis Vasilopoulos <hello@alwayslivid.com>
-Date: Thu, 26 Dec 2019 21:00:00 +0200
-Subject: Disabled help2man
+Date: Fri, 27 Dec 2019 20:10:28 +0200
+Subject: Fixed help2man
+
 
 diff --git a/src/Makefile.am b/src/Makefile.am
-index 5dd747a..9cb7dee 100644
+index 5dd747a..777bfbd 100644
 --- a/src/Makefile.am
 +++ b/src/Makefile.am
-@@ -31,12 +31,3 @@ cmdline.c cmdline.h: cmdline.ggo Makefile.am
- 
- BUILT_SOURCES = cmdline.c cmdline.h
- MAINTAINERCLEANFILES = $(BUILT_SOURCES)
--
--dist_man_MANS = u2f-host.1
--DISTCLEANFILES = $(dist_man_MANS)
--
--u2f-host.1: $(srcdir)/u2f-host.c $(srcdir)/cmdline.ggo $(top_srcdir)/configure.ac | $(builddir)/u2f-host$(EXEEXT)
--       $(AM_V_GEN)$(HELP2MAN) \
--               --output=$@ $(builddir)/u2f-host$(EXEEXT) \
--               --name="Yubico Universal 2nd Factor (U2F) Host Tool" \
+@@ -40,3 +40,4 @@ u2f-host.1: $(srcdir)/u2f-host.c $(srcdir)/cmdline.ggo $(top_srcdir)/configure.a
+                --output=$@ $(builddir)/u2f-host$(EXEEXT) \
+                --name="Yubico Universal 2nd Factor (U2F) Host Tool" \
 -               --no-info
--- 
++               --no-info \
++               --no-discard-stderr
+--
 2.19.0

--- a/app-crypt/libu2f_host/patches/libu2f_host-1.1.10.patchset
+++ b/app-crypt/libu2f_host/patches/libu2f_host-1.1.10.patchset
@@ -1,17 +1,19 @@
-From 2d6f6370722c0f2c41430d2e539d2a18a93f433c Mon Sep 17 00:00:00 2001
+From 13c3c844649c028c3ade42e16efb50e4f0e576c1 Mon Sep 17 00:00:00 2001
 From: Panagiotis Vasilopoulos <hello@alwayslivid.com>
-Date: Fri, 27 Dec 2019 20:10:28 +0200
+Date: Sat, 28 Dec 2019 15:37:58 +0200
 Subject: Fixed help2man
 
 
 diff --git a/src/Makefile.am b/src/Makefile.am
-index 5dd747a..777bfbd 100644
+index 5dd747a..127ac6f 100644
 --- a/src/Makefile.am
 +++ b/src/Makefile.am
-@@ -40,3 +40,4 @@ u2f-host.1: $(srcdir)/u2f-host.c $(srcdir)/cmdline.ggo $(top_srcdir)/configure.a
-                --output=$@ $(builddir)/u2f-host$(EXEEXT) \
-                --name="Yubico Universal 2nd Factor (U2F) Host Tool" \
--               --no-info
-+               --no-info --no-discard-stderr
---
+@@ -39,4 +39,4 @@ u2f-host.1: $(srcdir)/u2f-host.c $(srcdir)/cmdline.ggo $(top_srcdir)/configure.a
+ 	$(AM_V_GEN)$(HELP2MAN) \
+ 		--output=$@ $(builddir)/u2f-host$(EXEEXT) \
+ 		--name="Yubico Universal 2nd Factor (U2F) Host Tool" \
+-		--no-info
++		--no-info --no-discard-stderr
+-- 
 2.19.0
+


### PR DESCRIPTION
As of the time of this writing, `libu2f_host` depends on `cmd:gengetopt`. Its recipe can be found on #4493 and has not been merged yet and the recipe won't work without gengetopt. For organization reasons, this recipe wasn't included in this pull request.