### PR TITLE
Package bear 2.4.2

### DIFF
--- a/dev-util/bear/bear-2.4.2.recipe
+++ b/dev-util/bear/bear-2.4.2.recipe
@@ -1,0 +1,58 @@
+SUMMARY="Automatically generate compilation database for Clang tooling"
+DESCRIPTION="Bear records the flags passed to the compiler for each translation unit and \
+stores them in a JSON file. This file can be used by Clang's tooling interface \
+and programs like clang-check to process a translation unit.\
+\
+cmake supports the generation of JSON compilation databases out of the box. \
+For any other build system that does not support this, Bear can be used \
+instead to intercept the invocation of the compiler."
+HOMEPAGE="https://github.com/rizsotto/Bear"
+COPYRIGHT="2012-2019 by László Nagy"
+LICENSE="GNU GPL v3"
+REVISION="1"
+SOURCE_URI="https://github.com/rizsotto/Bear/archive/$portVersion.tar.gz"
+CHECKSUM_SHA256="e80c0d622a8192a1ec0c0efa139e5767c6c4b1defe1c75fc99cf680c6d1816c0"
+SOURCE_DIR="Bear-$portVersion"
+
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64 ?arm"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	bear$secondaryArchSuffix = $portVersion
+	cmd:bear = $portVersion compat >= 3
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	cmd:python2
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:g++
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:python2
+	"
+
+BUILD()
+{
+	cmake . -DCMAKE_INSTALL_PREFIX=$prefix \
+		-DCMAKE_BUILD_TYPE=Release
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	mkdir -vp $manDir
+	cp -vrd $prefix/share/man/man1 $manDir
+
+	mkdir -p $dataDir
+	mv -v $prefix/share $dataDir
+}


### PR DESCRIPTION
Tested by building haiku and spot checking the compilation database produced. It appears to work just fine.

```
/Code/haiku/generated.x86_64> bear jam -q -j4 @image
...
/Code/haiku/generated.x86_64> bear -a jam -q -j4 unittests
...
/Code/haiku/generated.x86_64> grep -A 5 -B 30 '"file": "../src/system/kernel/vm/
VMUtils.cpp"' compile_commands.json
            "../headers/os/game", 
            "-I", 
            "../headers/os/interface", 
            "-I", 
            "../headers/os/kernel", 
            "-I", 
            "../headers/os/locale", 
            "-I", 
            "../headers/os/media", 
            "-I", 
            "../headers/os/mail", 
            "-I", 
            "../headers/os/midi", 
            "-I", 
            "../headers/os/midi2", 
            "-I", 
            "../headers/os/net", 
            "-I", 
            "../headers/os/storage", 
            "-I", 
            "../headers/os/support", 
            "-I", 
            "../headers/os/translation", 
            "-I", 
            "../headers/private/.", 
            "-o", 
            "objects/haiku/x86_64/release/system/kernel/vm/VMUtils.o", 
            "../src/system/kernel/vm/VMUtils.cpp"
        ], 
        "directory": "/Code/haiku/generated.x86_64", 
        "file": "../src/system/kernel/vm/VMUtils.cpp"
    }, 
    {
        "arguments": [
            "/Code/haiku/generated.x86_64/cross-tools-x86_64/bin/x86_64-unknown-haiku-gcc", 
            "-c", 
/Code/haiku/generated.x86_64> grep ResourceStringsTest.cpp compile_commands.json 
            "../src/tests/kits/storage/ResourceStringsTest.cpp"
        "file": "../src/tests/kits/storage/ResourceStringsTest.cpp"
/Code/haiku/generated.x86_64> grep ResourceStringsTest.cpp
compile_commands.json
            "../src/tests/kits/storage/ResourceStringsTest.cpp" "file":
        "../src/tests/kits/storage/ResourceStringsTest.cpp"
```