### PR TITLE
picard: Support for opening supported mimetypes

### DIFF
--- a/media-sound/picard/additional-files/picard.rdef.in
+++ b/media-sound/picard/additional-files/picard.rdef.in
@@ -1,6 +1,6 @@
 resource app_signature "application/x-vnd.musicbrainz-picard";
 
-resource app_flags B_MULTIPLE_LAUNCH;
+resource app_flags B_SINGLE_LAUNCH;
 
 resource app_version {
 	major  = @MAJOR@,
@@ -12,6 +12,40 @@ resource app_version {
 
 	short_info = "MusicBrainz Picard",
 	long_info = "MusicBrainz's music tagger"
+};
+
+resource file_types message {
+	"types" = "audio/ac3",
+	"types" = "audio/dsf",
+	"types" = "audio/midi",
+	"types" = "audio/mp4",
+	"types" = "audio/mpeg",
+	"types" = "audio/ogg",
+	"types" = "audio/vorbis",
+	"types" = "audio/x-aac",
+	"types" = "audio/x-aiff",
+	"types" = "audio/x-ape",
+	"types" = "audio/x-flac",
+	"types" = "audio/x-m4a",
+	"types" = "audio/x-midi",
+	"types" = "audio/x-mp3",
+	"types" = "audio/x-mpc",
+	"types" = "audio/x-mpeg",
+	"types" = "audio/x-ms-wma",
+	"types" = "audio/x-ms-wmv",
+	"types" = "audio/x-musepack",
+	"types" = "audio/x-speex",
+	"types" = "audio/x-tak",
+	"types" = "audio/x-tta",
+	"types" = "audio/x-vorbis",
+	"types" = "audio/x-wav",
+	"types" = "audio/x-wavpack",
+	"types" = "audio/x-wma",
+	"types" = "video/mp4",
+	"types" = "video/ogg",
+	"types" = "video/x-ms-asf",
+	"types" = "video/x-theora",
+	"types" = "video/x-wmv"
 };
 
 resource vector_icon array {

--- a/media-sound/picard/patches/picard-2.2.3.patchset
+++ b/media-sound/picard/patches/picard-2.2.3.patchset
@@ -36,3 +36,30 @@ index 857b7850..d3decda5 100644
          move = []
 --
 2.23.0
+
+From b240d3d6dc668dca0408807053633e432d48660c Mon Sep 17 00:00:00 2001
+From: Philipp Wolfer <ph.wolfer@gmail.com>
+Date: Thu, 9 Jan 2020 08:11:49 +0000
+Subject: [PATCH 5/5] Fix initialization of QApplication with argv
+
+---
+ picard/tagger.py | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/picard/tagger.py b/picard/tagger.py
+index 65a2a985..f43c48bb 100644
+--- a/picard/tagger.py
++++ b/picard/tagger.py
+@@ -143,9 +143,7 @@ class Tagger(QtWidgets.QApplication):
+         if not IS_MACOS and not IS_HAIKU:
+             self.setStyle('Fusion')
+
+-        # Set the WM_CLASS to 'MusicBrainz-Picard' so desktop environments
+-        # can use it to look up the app
+-        super().__init__(['MusicBrainz-Picard'] + unparsed_args)
++        super().__init__(sys.argv)
+         self.__class__.__instance = self
+         config._setup(self, picard_args.config_file)
+
+--
+2.24.1

--- a/media-sound/picard/picard-2.2.3.recipe
+++ b/media-sound/picard/picard-2.2.3.recipe
@@ -12,7 +12,7 @@ HOMEPAGE="https://picard.musicbrainz.org/"
 COPYRIGHT="2004-2019 Robert Kaye, Lukas Lalinsky, Laurent Monin, \
 Sambhav Kothari, Philipp Wolfer and others"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="ftp://ftp.eu.metabrainz.org/pub/musicbrainz/picard/picard-$portVersion.tar.gz"
 CHECKSUM_SHA256="920bc0ffc1b5ae395456698a133799aee06c66b4446f6a388a64046e07d8716b"
 SOURCE_DIR="picard-release-$portVersion"
@@ -79,6 +79,7 @@ INSTALL()
 
 	rc $sourceDir/build/picard.rdef
 	resattr -o $appsDir/Picard $sourceDir/build/picard.rsrc
+	mimeset -f $appsDir/Picard
 	addAppDeskbarSymlink $appsDir/Picard
 
 	rm -rf $dataDir/share


### PR DESCRIPTION
This adds supported mimetypes to Picard with the ability to open those files from tracker or via drag and drop on deskbar item.

This ads a small patch to fix Picard's handling of argv, but I will upstream so we will be able to remove this patch again in the next release.

Please note that this currently will always ignore the first file provided this way due to a current limitation of qthaikuplugins. We'll hopefully sort this out soon, see https://github.com/threedeyes/qthaikuplugins/pull/14