### PR TITLE
aranym 0.9.15: backported libsdl dependency fix

### DIFF
--- a/app-emulation/aranym/aranym-0.9.15_git.recipe
+++ b/app-emulation/aranym/aranym-0.9.15_git.recipe
@@ -5,7 +5,7 @@ running Atari ST/TT/Falcon operating systems and applications.
 "
 HOMEPAGE="http://aranym.org/"
 SOURCE_URI="git://git.code.sf.net/p/aranym/code"
-REVISION="1"
+REVISION="2"
 #CHECKSUM_MD5=""
 COPYRIGHT="2001-2010 ARAnyM developer team"
 LICENSE="GNU GPL v2"
@@ -21,7 +21,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku
-	libsdl
+	lib:libsdl
 	lib:libsdl_image_1.2
 	"
 BUILD_REQUIRES="


### PR DESCRIPTION
Relevant issue: #3878