### PR TITLE
Cleaned up libSDL* dependencies

### DIFF
--- a/dev-games/flatzebra/flatzebra-0.1.6.recipe
+++ b/dev-games/flatzebra/flatzebra-0.1.6.recipe
@@ -19,9 +19,9 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libGL$secondaryArchSuffix
 	lib:libjpeg$secondaryArchSuffix
-	lib:libsdl$secondaryArchSuffix
-	lib:libsdl_image$secondaryArchSuffix
-	lib:libsdl_mixer$secondaryArchSuffix
+	lib:libSDL_1.2$secondaryArchSuffix
+	lib:libSDL_image_1.2$secondaryArchSuffix
+	lib:libSDL_mixer_1.2$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
@@ -36,9 +36,9 @@ REQUIRES_devel="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libjpeg$secondaryArchSuffix
-	devel:libsdl$secondaryArchSuffix
-	devel:libsdl_image$secondaryArchSuffix
-	devel:libsdl_mixer$secondaryArchSuffix
+	devel:libSDL_1.2$secondaryArchSuffix
+	devel:libSDL_image_1.2$secondaryArchSuffix
+	devel:libSDL_mixer_1.2$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:aclocal

--- a/dev-games/t4k_common/t4k_common-0.1.1.recipe
+++ b/dev-games/t4k_common/t4k_common-0.1.1.recipe
@@ -23,12 +23,12 @@ REQUIRES="
 	lib:libiconv$secondaryArchSuffix
 	lib:libintl$secondaryArchSuffix
 	lib:libpng16$secondaryArchSuffix
-	lib:libsdl$secondaryArchSuffix
-	lib:libsdl_image$secondaryArchSuffix
-	lib:libsdl_mixer$secondaryArchSuffix
-	lib:libsdl_net_1.2$secondaryArchSuffix
-	lib:libsdl_pango$secondaryArchSuffix
-	lib:libsdl_ttf$secondaryArchSuffix
+	lib:libSDL_1.2$secondaryArchSuffix
+	lib:libSDL_image_1.2$secondaryArchSuffix
+	lib:libSDL_mixer_1.2$secondaryArchSuffix
+	lib:libSDL_net_1.2$secondaryArchSuffix
+	lib:libSDL_pango$secondaryArchSuffix
+	lib:libSDL_ttf_2.0$secondaryArchSuffix
 	lib:libxml2$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
@@ -49,12 +49,12 @@ BUILD_REQUIRES="
 	devel:libiconv$secondaryArchSuffix
 	devel:libintl$secondaryArchSuffix
 	devel:libpng$secondaryArchSuffix
-	devel:libsdl$secondaryArchSuffix
-	devel:libsdl_image$secondaryArchSuffix
-	devel:libsdl_mixer$secondaryArchSuffix
-	devel:libsdl_net$secondaryArchSuffix
-	devel:libsdl_pango$secondaryArchSuffix
-	devel:libsdl_ttf$secondaryArchSuffix
+	devel:libSDL_1.2$secondaryArchSuffix
+	devel:libSDL_image_1.2$secondaryArchSuffix
+	devel:libSDL_mixer_1.2$secondaryArchSuffix
+	devel:libSDL_net_1.2$secondaryArchSuffix
+	devel:libSDL_pango$secondaryArchSuffix
+	devel:libSDL_ttf_2.0$secondaryArchSuffix
 	devel:libxml2$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"

--- a/games-arcade/rocksndiamonds/rocksndiamonds-4.1.1.0.recipe
+++ b/games-arcade/rocksndiamonds/rocksndiamonds-4.1.1.0.recipe
@@ -25,19 +25,19 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libsdl$secondaryArchSuffix
-	lib:libsdl_image$secondaryArchSuffix
-	lib:libsdl_mixer$secondaryArchSuffix
-	lib:libsdl_net_1.2$secondaryArchSuffix
+	lib:libSDL_1.2$secondaryArchSuffix
+	lib:libSDL_image_1.2$secondaryArchSuffix
+	lib:libSDL_mixer_1.2$secondaryArchSuffix
+	lib:libSDL_net_1.2$secondaryArchSuffix
 	lib:libsmpeg$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libsdl$secondaryArchSuffix
-	devel:libsdl_image$secondaryArchSuffix
-	devel:libsdl_mixer$secondaryArchSuffix
-	devel:libsdl_net$secondaryArchSuffix
+	devel:libSDL_1.2$secondaryArchSuffix
+	devel:libSDL_image_1.2$secondaryArchSuffix
+	devel:libSDL_mixer_1.2$secondaryArchSuffix
+	devel:libSDL_net_1.2$secondaryArchSuffix
 	devel:libsmpeg$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="

--- a/games-kids/tuxmath/tuxmath-2.0.1.recipe
+++ b/games-kids/tuxmath/tuxmath-2.0.1.recipe
@@ -27,10 +27,10 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libiconv$secondaryArchSuffix
 	lib:libintl$secondaryArchSuffix
-	lib:libsdl$secondaryArchSuffix
-	lib:libsdl_image$secondaryArchSuffix
-	lib:libsdl_mixer$secondaryArchSuffix
-	lib:libsdl_net_1.2$secondaryArchSuffix
+	lib:libSDL_1.2$secondaryArchSuffix
+	lib:libSDL_image_1.2$secondaryArchSuffix
+	lib:libSDL_mixer_1.2$secondaryArchSuffix
+	lib:libSDL_net_1.2$secondaryArchSuffix
 	lib:libt4k_common$secondaryArchSuffix
 	lib:libxml2$secondaryArchSuffix
 	"
@@ -39,10 +39,10 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libiconv$secondaryArchSuffix
 	devel:libintl$secondaryArchSuffix
-	devel:libsdl$secondaryArchSuffix
-	devel:libsdl_image$secondaryArchSuffix
-	devel:libsdl_mixer$secondaryArchSuffix
-	devel:libsdl_net_1.2$secondaryArchSuffix
+	devel:libSDL_1.2$secondaryArchSuffix
+	devel:libSDL_image_1.2$secondaryArchSuffix
+	devel:libSDL_mixer_1.2$secondaryArchSuffix
+	devel:libSDL_net_1.2$secondaryArchSuffix
 	devel:libt4k_common$secondaryArchSuffix
 	devel:libxml2$secondaryArchSuffix
 	"

--- a/games-sports/xmoto/xmoto-0.5.11.recipe
+++ b/games-sports/xmoto/xmoto-0.5.11.recipe
@@ -33,10 +33,10 @@ REQUIRES="
 	lib:liblua$secondaryArchSuffix
 	lib:libode$secondaryArchSuffix
 	lib:libpng$secondaryArchSuffix
-	lib:libsdl$secondaryArchSuffix
-	lib:libsdl_mixer$secondaryArchSuffix
-	lib:libsdl_net$secondaryArchSuffix
-	lib:libsdl_ttf$secondaryArchSuffix
+	lib:libSDL_1.2$secondaryArchSuffix
+	lib:libSDL_mixer_1.2$secondaryArchSuffix
+	lib:libSDL_net_1.2$secondaryArchSuffix
+	lib:libSDL_ttf_2.0$secondaryArchSuffix
 	lib:libsqlite3$secondaryArchSuffix
 	lib:libxml2$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
@@ -52,10 +52,10 @@ BUILD_REQUIRES="
 	devel:liblua$secondaryArchSuffix
 	devel:libode$secondaryArchSuffix
 	devel:libpng$secondaryArchSuffix
-	devel:libsdl$secondaryArchSuffix
-	devel:libsdl_mixer$secondaryArchSuffix
-	devel:libsdl_net$secondaryArchSuffix
-	devel:libsdl_ttf$secondaryArchSuffix
+	devel:libSDL_1.2$secondaryArchSuffix
+	devel:libSDL_mixer_1.2$secondaryArchSuffix
+	devel:libSDL_net_1.2$secondaryArchSuffix
+	devel:libSDL_ttf_2.0$secondaryArchSuffix
 	devel:libsqlite3$secondaryArchSuffix
 	devel:libxml2$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix

--- a/games-sports/xut/xut-0.2.1.recipe
+++ b/games-sports/xut/xut-0.2.1.recipe
@@ -25,9 +25,9 @@ REQUIRES="
 	lib:libintl$secondaryArchSuffix
 	lib:libogg$secondaryArchSuffix
 	lib:libopenal$secondaryArchSuffix
-	lib:libsdl$secondaryArchSuffix
-	lib:libsdl_image$secondaryArchSuffix
-	lib:libsdl_ttf$secondaryArchSuffix
+	lib:libSDL_1.2$secondaryArchSuffix
+	lib:libSDL_image_1.2$secondaryArchSuffix
+	lib:libSDL_ttf_2.0$secondaryArchSuffix
 	lib:libvorbis$secondaryArchSuffix
 	lib:libvorbisfile$secondaryArchSuffix
 	"
@@ -38,9 +38,9 @@ BUILD_REQUIRES="
 	devel:libintl$secondaryArchSuffix
 	devel:libogg$secondaryArchSuffix
 	devel:libopenal$secondaryArchSuffix
-	devel:libsdl$secondaryArchSuffix
-	devel:libsdl_image$secondaryArchSuffix
-	devel:libsdl_ttf$secondaryArchSuffix
+	devel:libSDL_1.2$secondaryArchSuffix
+	devel:libSDL_image_1.2$secondaryArchSuffix
+	devel:libSDL_ttf_2.0$secondaryArchSuffix
 	devel:libvorbis$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="

--- a/games-strategy/crimson/crimson-0.5.3.recipe
+++ b/games-strategy/crimson/crimson-0.5.3.recipe
@@ -26,20 +26,20 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku
-	lib:libsdl
-	lib:libsdl_mixer
-	lib:libsdl_net_1.2
-	lib:libsdl_ttf
+	lib:libSDL_1.2
+	lib:libSDL_mixer_1.2
+	lib:libSDL_net_1.2
+	lib:libSDL_ttf_2.0
 	lib:libxml2
 	lib:libz
 	"
 
 BUILD_REQUIRES="
 	haiku_devel
-	devel:libsdl
-	devel:libsdl_mixer
-	devel:libsdl_net_1.2
-	devel:libsdl_ttf
+	devel:libSDL_1.2
+	devel:libSDL_mixer_1.2
+	devel:libSDL_net_1.2
+	devel:libSDL_ttf_2.0
 	devel:libxml2
 	devel:libz
 	"

--- a/games-strategy/openxcom/openxcom-1.0.recipe
+++ b/games-strategy/openxcom/openxcom-1.0.recipe
@@ -30,10 +30,10 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libgl$secondaryArchSuffix
 	lib:libglu$secondaryArchSuffix
-	lib:libsdl$secondaryArchSuffix
-	lib:libsdl_gfx$secondaryArchSuffix
-	lib:libsdl_image$secondaryArchSuffix
-	lib:libsdl_mixer$secondaryArchSuffix
+	lib:libSDL_1.2$secondaryArchSuffix
+	lib:libSDL_gfx$secondaryArchSuffix
+	lib:libSDL_image_1.2$secondaryArchSuffix
+	lib:libSDL_mixer_1.2$secondaryArchSuffix
 	lib:libyaml_cpp$secondaryArchSuffix
 	"
 
@@ -41,10 +41,10 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libgl$secondaryArchSuffix
 	devel:libglu$secondaryArchSuffix
-	devel:libsdl$secondaryArchSuffix
-	devel:libsdl_gfx$secondaryArchSuffix
-	devel:libsdl_image$secondaryArchSuffix
-	devel:libsdl_mixer$secondaryArchSuffix
+	devel:libSDL_1.2$secondaryArchSuffix
+	devel:libSDL_gfx$secondaryArchSuffix
+	devel:libSDL_image_1.2$secondaryArchSuffix
+	devel:libSDL_mixer_1.2$secondaryArchSuffix
 	devel:libyaml_cpp$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="

--- a/media-gfx/grafx2/grafx2-2.6.recipe
+++ b/media-gfx/grafx2/grafx2-2.6.recipe
@@ -26,9 +26,9 @@ REQUIRES="
 	lib:libjpeg
 	lib:liblua
 	lib:libpng16
-	lib:libsdl
-	lib:libsdl_image
-	lib:libsdl_ttf
+	lib:libSDL_1.2
+	lib:libSDL_image_1.2
+	lib:libSDL_ttf_2.0
 	lib:libtiff
 	lib:libz
 	"
@@ -40,9 +40,9 @@ BUILD_REQUIRES="
 	devel:libjpeg
 	devel:liblua
 	devel:libpng16
-	devel:libsdl
-	devel:libsdl_image
-	devel:libsdl_ttf
+	devel:libSDL_1.2
+	devel:libSDL_image_1.2
+	devel:libSDL_ttf_2.0
 	devel:libtiff
 	devel:libz
 	"


### PR DESCRIPTION
Relevant issue: #3878

I updated the recipes of the following recipes: `t4k_common`, `xmoto`, `xut`, `openxcom`, `flatzebra`, `crimson` and `tuxmath`.

I also made a small correction in the `tuxmath` recipe that prevented it from being compiled. I checked all recipes on the x86_64 architecture, however, some recipes (`xmoto`, `xut`) have not been checked properly due to the architecture and `openxcom` seems to be a bit broken either way, but has been presumptively updated, as well as the two other aforementioned recipes.

If there's a problem with that, I made my changes in separate commits so that they can be easily reverted.