### PR TITLE
fheroes2: disabled recipe

### DIFF
--- a/games-rpg/fheroes2/fheroes2-r3279.recipe
+++ b/games-rpg/fheroes2/fheroes2-r3279.recipe
@@ -6,14 +6,14 @@ magazine in May 1997."
 HOMEPAGE="https://sourceforge.net/projects/fheroes2/"
 COPYRIGHT="2006-2015 Andrey Afletdinov"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://sourceforge.net/code-snapshots/svn/f/fh/fheroes2/code/fheroes2-code-$portVersion-trunk.zip"
 CHECKSUM_SHA256="250bf73ce8f4b1ab69b3d63ecd0727e10196f86d5e42b34bae78ce574e34c3c1"
 SOURCE_DIR="fheroes2-code-$portVersion-trunk"
 PATCHES="fheroes2-$portVersion.patchset"
 
-ARCHITECTURES="!x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="!x86_gcc2 !x86 !x86_64"
+SECONDARY_ARCHITECTURES="!x86"
 
 PROVIDES="
 	fheroes2$secondaryArchSuffix = $portVersion


### PR DESCRIPTION
As of this moment, there's no reliable download link for the `r3279` version of `fheroes2`.

This pull request is meant to disable the recipe itself.