### PR TITLE
abuse: change save localization to settings

### DIFF
--- a/games-action/abuse/abuse-0.8.recipe
+++ b/games-action/abuse/abuse-0.8.recipe
@@ -38,6 +38,8 @@ BUILD_REQUIRES="
 	devel:libGLU
 	"
 BUILD_PREREQUIRES="
+	cmd:autoconf
+	cmd:libtool
 	cmd:make
 	cmd:gcc
 	cmd:awk
@@ -45,6 +47,7 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
+	autoreconf -fi
 	runConfigure ./configure
 	make $jobArgs
 }

--- a/games-action/abuse/abuse-0.8.recipe
+++ b/games-action/abuse/abuse-0.8.recipe
@@ -11,10 +11,11 @@ COPYRIGHT="2001-2005 Sam Hocevar
 	1995 Crack dot Com
 	1996-2008 Justin Cassidy"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://abuse.zoy.org/raw-attachment/wiki/download/abuse-$portVersion.tar.gz"
 CHECKSUM_SHA256="0104db5fd2695c9518583783f7aaa7e5c0355e27c5a803840a05aef97f9d3488"
 PATCHES="abuse-$portVersion.patchset"
+
 ARCHITECTURES="x86_gcc2"
 
 PROVIDES="

--- a/games-action/abuse/patches/abuse-0.8.patchset
+++ b/games-action/abuse/patches/abuse-0.8.patchset
@@ -1,4 +1,4 @@
-From 70602ecce40c1502303d83500a01fff697cfcd60 Mon Sep 17 00:00:00 2001
+From 702f1407e6990dd1ed714815d8fa3a0cfcd181e5 Mon Sep 17 00:00:00 2001
 From: Yourself <user@shredder.home>
 Date: Tue, 25 Sep 2018 16:05:19 +0000
 Subject: removed reference to unused sys/shm.h
@@ -17,10 +17,10 @@ index 000071c..a13ad9d 100644
  #   include <unistd.h>
  #   ifdef HAVE_BSTRING_H
 -- 
-2.19.0
+2.23.0
 
 
-From 691507d92603cc5d4b0d12205e469060741c5493 Mon Sep 17 00:00:00 2001
+From 9731e79743d481e3c2001aabc757c47b6b1efaab Mon Sep 17 00:00:00 2001
 From: Yourself <user@shredder.home>
 Date: Tue, 25 Sep 2018 16:08:30 +0000
 Subject: added missing stdint.h reference
@@ -39,5 +39,32 @@ index 8df9cbf..85fc0ec 100644
  void pushback(int32_t x1,int32_t y1,int32_t &x2,int32_t &y2,
               int32_t xp1, int32_t yp1, int32_t xp2, int32_t yp2, int xdir, int ydir, int inside)
 -- 
-2.19.0
+2.23.0
+
+
+From f97f9da2765b6669a6ea9196ffa17f1a775a58c2 Mon Sep 17 00:00:00 2001
+From: Ra-V2 <rav.bernacki@gmail.com>
+Date: Thu, 16 Jan 2020 10:52:46 +0000
+Subject: change localization to settings directory
+
+
+diff --git a/src/sdlport/setup.cpp b/src/sdlport/setup.cpp
+index 3ece66c..aba563e 100644
+--- a/src/sdlport/setup.cpp
++++ b/src/sdlport/setup.cpp
+@@ -391,7 +391,11 @@ void setup( int argc, char **argv )
+     if( (homedir = getenv( "HOME" )) != NULL )
+     {
+         savedir = (char *)malloc( strlen( homedir ) + 9 );
+-        sprintf( savedir, "%s/.abuse/", homedir );
++        #ifdef __HAIKU__
++        	sprintf( savedir, "%s/config/settings/abuse/", homedir );
++        #else
++        	sprintf( savedir, "%s/.abuse/", homedir );
++        #endif
+         // Check if we already have a savegame directory
+         if( (fd = fopen( savedir, "r" )) == NULL )
+         {
+-- 
+2.23.0
 

--- a/games-action/abuse/patches/abuse-0.8.patchset
+++ b/games-action/abuse/patches/abuse-0.8.patchset
@@ -1,4 +1,4 @@
-From 702f1407e6990dd1ed714815d8fa3a0cfcd181e5 Mon Sep 17 00:00:00 2001
+From b2a372158b3efa2d97527542eca90b8c0131abaa Mon Sep 17 00:00:00 2001
 From: Yourself <user@shredder.home>
 Date: Tue, 25 Sep 2018 16:05:19 +0000
 Subject: removed reference to unused sys/shm.h
@@ -20,7 +20,7 @@ index 000071c..a13ad9d 100644
 2.23.0
 
 
-From 9731e79743d481e3c2001aabc757c47b6b1efaab Mon Sep 17 00:00:00 2001
+From 6988b0ded22146bf1c51c1f4898b6c976f763b06 Mon Sep 17 00:00:00 2001
 From: Yourself <user@shredder.home>
 Date: Tue, 25 Sep 2018 16:08:30 +0000
 Subject: added missing stdint.h reference
@@ -42,29 +42,72 @@ index 8df9cbf..85fc0ec 100644
 2.23.0
 
 
-From f97f9da2765b6669a6ea9196ffa17f1a775a58c2 Mon Sep 17 00:00:00 2001
+From 909dbebf708534dfd1b1e4cd32483289cc0710d8 Mon Sep 17 00:00:00 2001
 From: Ra-V2 <rav.bernacki@gmail.com>
-Date: Thu, 16 Jan 2020 10:52:46 +0000
-Subject: change localization to settings directory
+Date: Thu, 16 Jan 2020 15:28:40 +0000
+Subject: change localization of saves to settings directory
 
 
+diff --git a/src/sdlport/Makefile.am b/src/sdlport/Makefile.am
+index 202f0d1..b17da01 100644
+--- a/src/sdlport/Makefile.am
++++ b/src/sdlport/Makefile.am
+@@ -16,7 +16,7 @@ libsdlport_a_SOURCES = \
+     $(NULL)
+ libsdlport_a_LIBADD =
+ 
+-INCLUDES = -I$(srcdir)/../ -I$(srcdir)/../imlib $(SDL_CFLAGS)
++INCLUDES = -I$(srcdir)/../ -I$(srcdir)/../imlib -I$(srcdir)/../lisp -I- $(SDL_CFLAGS)
+ 
+ CPPFLAGS = @CPPFLAGS@ -DNO_CHECK -DASSETDIR=\"$(assetdir)\"
+ 
 diff --git a/src/sdlport/setup.cpp b/src/sdlport/setup.cpp
-index 3ece66c..aba563e 100644
+index 3ece66c..5dd6b46 100644
 --- a/src/sdlport/setup.cpp
 +++ b/src/sdlport/setup.cpp
-@@ -391,7 +391,11 @@ void setup( int argc, char **argv )
-     if( (homedir = getenv( "HOME" )) != NULL )
-     {
-         savedir = (char *)malloc( strlen( homedir ) + 9 );
--        sprintf( savedir, "%s/.abuse/", homedir );
-+        #ifdef __HAIKU__
-+        	sprintf( savedir, "%s/config/settings/abuse/", homedir );
-+        #else
-+        	sprintf( savedir, "%s/.abuse/", homedir );
-+        #endif
-         // Check if we already have a savegame directory
-         if( (fd = fopen( savedir, "r" )) == NULL )
-         {
+@@ -38,6 +38,11 @@
+ #endif    /* __APPLE__ */
+ #endif    /* HAVE_OPENGL */
+ 
++#ifdef __HAIKU__
++#include <FindDirectory.h>
++#include <fs_info.h>
++#endif
++
+ #include "specs.h"
+ #include "keys.h"
+ #include "setup.h"
+@@ -384,6 +389,22 @@ void setup( int argc, char **argv )
+     atexit( SDL_Quit );
+ 
+     // Set the savegame directory
++#ifdef __HAIKU__
++    dev_t volume = dev_for_path("/boot");
++    char buffer[B_PATH_NAME_LENGTH+B_FILE_NAME_LENGTH];
++    if(find_directory(B_USER_SETTINGS_DIRECTORY, volume, true, buffer, sizeof(buffer)) == B_OK)
++    {
++    	strlcat(buffer, "/abuse/", sizeof(buffer));
++    	mkdir(buffer, 0700);
++    	set_save_filename_prefix(buffer);
++    }
++    else
++    {
++        printf( "WARNING: Unable to get B_USER_SETTINGS_DIRECTORY.\n" );
++        printf( "         Savegames will probably fail.\n" );
++        set_save_filename_prefix( "" );
++    }
++#else
+     char *homedir;
+     char *savedir;
+     FILE *fd = NULL;
+@@ -414,6 +435,7 @@ void setup( int argc, char **argv )
+         // Hopefully they have write permissions....
+         set_save_filename_prefix( "" );
+     }
++#endif
+ 
+     // Set the datadir to a default value
+     // (The current directory)
 -- 
 2.23.0
 


### PR DESCRIPTION
There is a problem with header FindDirectory.h. When I try to compile it with this header, I get a lot of compilation errors:
[errors.txt](https://github.com/haikuports/haikuports/files/4071135/errors.txt)
For now I only changed this directory to settings without find_directory because this doesn't work.
