### PR TITLE
Added recipe for dav1d-0.5.2

### DIFF
--- a/media-libs/dav1d/dav1d-0.5.2.recipe
+++ b/media-libs/dav1d/dav1d-0.5.2.recipe
@@ -1,0 +1,74 @@
+SUMMARY="A new AV1 cross-platform decoder"
+DESCRIPTION="dav1d is a new AV1 cross-platform decoder, open-source, \
+and focused on speed and correctness. It supports all features from AV1, \
+including all subsampling and bit-depth parameters."
+HOMEPAGE="https://code.videolan.org/videolan/dav1d"
+COPYRIGHT="2018-2019, VideoLAN and dav1d authors"
+LICENSE="BSD (2-clause)"
+REVISION="1"
+SOURCE_URI="https://code.videolan.org/videolan/dav1d/-/archive/$portVersion/dav1d-$portVersion.tar.bz2"
+CHECKSUM_SHA256="1780199d71e62a82ca1bfca2d71da5c599c7e1edc68c72f6fc3c0c25ce1880b7"
+
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64 ?arm ?ppc"
+SECONDARY_ARCHITECTURES="x86"
+
+commandBinDir=$binDir
+commandSuffix=$secondaryArchSuffix
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+libVersion="3.1.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	dav1d$secondaryArchSuffix = $portVersion
+	cmd:dav1d$commandSuffix
+	lib:libdav1d$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	dav1d${secondaryArchSuffix}_devel = $portVersion
+	devel:libdav1d$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	dav1d$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:meson >= 0.47
+	cmd:nasm >= 2.13.02
+	cmd:ninja
+	"
+
+BUILD()
+{
+	meson configure build \
+		--prefix $prefix \
+		--bindir $commandBinDir \
+		--libdir $libDir \
+		--includedir $includeDir
+	ninja -C build $jobArgs
+}
+
+INSTALL()
+{
+	ninja -C build install
+
+	prepareInstalledDevelLib libdav1d
+	fixPkgconfig
+	packageEntries devel $developDir
+}
+
+TEST()
+{
+	ninja -C build test
+}


### PR DESCRIPTION
I've added the recipe for dav1d-0.5.2

The source builds and works on Haiku without patches.

The recipe packages properly now.

Here is the build log when running `haikuporter` with this recipe.
[dav1d-0.5.2_build.log](https://github.com/haikuports/haikuports/files/4093291/dav1d-0.5.2_build.log)
