### PR TITLE
netbpm, mark x86 as broken for now

### DIFF
--- a/media-libs/netpbm/netpbm-10.88.01.recipe
+++ b/media-libs/netpbm/netpbm-10.88.01.recipe
@@ -237,7 +237,7 @@ SOURCE_DIR="netpbm-$portVersion/"
 PATCHES="netpbm-$portVersion.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="x86_gcc2 x86"
+SECONDARY_ARCHITECTURES="x86_gcc2 !x86"
 
 PROVIDES="
 	netpbm$secondaryArchSuffix = $portVersion compat >= 10


### PR DESCRIPTION
Looking into bumping version, mark secondary architecture as broken for now