### PR TITLE
libu2f_host: removed unnecessary dependencies

### DIFF
--- a/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
+++ b/app-crypt/libu2f_host/libu2f_host-1.1.10.recipe
@@ -8,7 +8,7 @@ HOMEPAGE="https://developers.yubico.com/libu2f-host/
 COPYRIGHT="2013-2014 Yubico AB"
 LICENSE="GNU GPL v3
 	GNU LGPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/Yubico/libu2f-host/archive/libu2f-host-$portVersion.tar.gz"
 CHECKSUM_SHA256="45937c6c04349f865d9f047d3a68cc50ea24e9085d18ac2c7d31fa38eb749303"
 SOURCE_DIR="libu2f-host-libu2f-host-$portVersion"
@@ -52,8 +52,7 @@ BUILD_REQUIRES="
 	devel:libhidapi$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:autoconf
-	cmd:automake
+	cmd:autoreconf
 	cmd:awk
 	cmd:gcc$secondaryArchSuffix
 	cmd:gengetopt


### PR DESCRIPTION
Successfully compiles on x86_64.

`cmd:automake` seems unnecessary and most other recipes use `cmd:autoreconf`, rather than `cmd:autoconf`.