### PR TITLE
regex: mark as untested for 32 bit

### DIFF
--- a/dev-python/regex/regex-2020.1.8.recipe
+++ b/dev-python/regex/regex-2020.1.8.recipe
@@ -9,7 +9,7 @@ SOURCE_URI="https://pypi.org/packages/source/r/regex/regex-$portVersion.tar.gz"
 CHECKSUM_SHA256="d0f424328f9822b0323b3b6f2e4b9c90960b24743d220763c7f07071e0778351"
 
 ARCHITECTURES="!x86_gcc2 x86_64"
-SECONDARY_ARCHITECTURES="x86"
+SECONDARY_ARCHITECTURES="?x86"
 
 PROVIDES="
 	$portName = $portVersion


### PR DESCRIPTION
No idea why it fails on 32 bit.