### PR TITLE
opensubdiv: remove RPATH, fixes module search paths on 32 bit x86

### DIFF
--- a/media-libs/opensubdiv/opensubdiv-3.4.0.recipe
+++ b/media-libs/opensubdiv/opensubdiv-3.4.0.recipe
@@ -7,7 +7,7 @@ surface matches Pixar's Renderman to numerical precision."
 HOMEPAGE="http://graphics.pixar.com/opensubdiv/"
 COPYRIGHT="2013-2018 Pixar"
 LICENSE="Apache v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/PixarAnimationStudios/OpenSubdiv/archive/v${portVersion//\./_}.tar.gz"
 CHECKSUM_SHA256="d932b292f83371c7518960b2135c7a5b931efb43cdd8720e0b27268a698973e4"
 SOURCE_FILENAME="opensubdiv-$portVersion.tar.gz"
@@ -93,6 +93,7 @@ BUILD()
 		-DCMAKE_BINDIR_BASE=$prefix/bin \
 		-DCMAKE_INCDIR_BASE=$includeDir/opensubdiv \
 		-DCMAKE_LIBDIR_BASE=$libDir \
+		-DCMAKE_SKIP_RPATH=ON \
 		-DNO_EXAMPLES=ON \
 		-DNO_TUTORIALS=ON \
 		-DNO_GLFW_X11=ON \


### PR DESCRIPTION
Related posts: https://discuss.haiku-os.org/t/blender-2-81-is-working-on-haiku/9235/11.