### PR TITLE
mplayer: mark as unsupported on 32bit

### DIFF
--- a/media-video/mplayer/mplayer-1.4.0.recipe
+++ b/media-video/mplayer/mplayer-1.4.0.recipe
@@ -22,15 +22,15 @@ DVD subtitles (SPU streams, VOBsub and Closed Captions) are supported as well."
 HOMEPAGE="http://www.mplayerhq.hu/"
 COPYRIGHT="2001-2019 The MPlayer Team"
 LICENSE="GNU LGPL v2.1"
-REVISION="8"
+REVISION="9"
 SOURCE_URI="http://www.mplayerhq.hu/MPlayer/releases/MPlayer-1.4.tar.xz"
 CHECKSUM_SHA256="82596ed558478d28248c7bc3828eb09e6948c099bbd76bb7ee745a0e3275b548"
 SOURCE_DIR="MPlayer-1.4"
 PATCHES="mplayer_x86-$portVersion.patchset"
 ADDITIONAL_FILES="mplayer.rdef.in"
 
-ARCHITECTURES="?x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="!x86_gcc2 x86_64"
+SECONDARY_ARCHITECTURES="!x86"
 
 # On x86_gcc2 we don't want to install the commands in bin/<arch>/, but in bin/.
 commandSuffix=$secondaryArchSuffix


### PR DESCRIPTION
* On 32bit running mplayer fails with:
  'runtime_loader: /boot/system/bin/mplayer: Could not map image: Out of memory'
  See #1978.

* Remove "x86", it's not an official target for Haiku anymore.