### PR TITLE
supertux: bump to 0.6.1 and fix build

### DIFF
--- a/games-arcade/supertux/patches/supertux-0.6.1.patch
+++ b/games-arcade/supertux/patches/supertux-0.6.1.patch
@@ -1,0 +1,18 @@
+--- a/src/supertux/main.cpp
++++ b/src/supertux/main.cpp
+@@ -242,6 +242,7 @@
+   #pragma GCC diagnostic pop
+ #endif
+ 
++#ifndef __HAIKU__
+ #ifdef _WIN32
+ 	std::string olduserdir = FileSystem::join(physfs_userdir, PACKAGE_NAME);
+ #else
+@@ -282,6 +283,7 @@
+ 	    log_info << "Moved old config dir " << olduserdir << " to " << userdir << std::endl;
+ 	  }
+ 	}
++#endif
+ 
+     if (!FileSystem::is_directory(userdir))
+     {

--- a/games-arcade/supertux/supertux-0.6.1.recipe
+++ b/games-arcade/supertux/supertux-0.6.1.recipe
@@ -1,21 +1,21 @@
 SUMMARY="A game similar to Super Mario Bros"
 DESCRIPTION="SuperTux is a classic 2D jump'n run sidescroller game in a style \
 similar to the original Super Mario games."
-HOMEPAGE="https://supertux.lethargik.org/"
-COPYRIGHT="2003-2018 SuperTux Devel Team"
-LICENSE="GNU GPL v2"
-REVISION="3"
+HOMEPAGE="https://supertux.org/"
+COPYRIGHT="2003-2020 The SuperTux Team"
+LICENSE="GNU GPL v3"
+REVISION="1"
 SOURCE_URI="https://github.com/SuperTux/supertux/releases/download/v$portVersion/SuperTux-v$portVersion-Source.tar.gz"
 SOURCE_DIR="SuperTux-v$portVersion-Source"
-CHECKSUM_SHA256="c4c3e5fa6f90e87b8c5ad6b22a179e9a9839bf997e7f219e22bbcd1c97223ac0"
-#PATCHES="supertux-$portVersion.patchset"
+CHECKSUM_SHA256="3a19e042cb10933bcbdc50a296779082a3bb46c8e98fe4afb68c19cc5e810c53"
+PATCHES="supertux-$portVersion.patch"
 
-ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
-SECONDARY_ARCHITECTURES="?x86"
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	supertux$secondaryArchSuffix = $portVersion
-	cmd:supertux$secondaryArchSuffix = $portVersion
+	app:SuperTux
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -25,7 +25,7 @@ REQUIRES="
 	lib:libfribidi$secondaryArchSuffix
 	lib:libGL$secondaryArchSuffix
 	lib:libglew$secondaryArchSuffix
-	lib:libglu$secondaryArchSuffix
+	lib:libGLU$secondaryArchSuffix
 	lib:libharfbuzz$secondaryArchSuffix
 	lib:libiconv$secondaryArchSuffix
 	lib:libogg$secondaryArchSuffix
@@ -73,8 +73,8 @@ BUILD()
 	cd build
 	cmake .. $cmakeDirArgs \
 		-DUSE_SYSTEM_PHYSFS=ON \
-		-DCMAKE_INSTALL_PREFIX=$appsDir/SuperTux \
-		-DINSTALL_SUBDIR_BIN=$appsDir/SuperTux \
+		-DCMAKE_INSTALL_PREFIX="$appsDir/SuperTux" \
+		-DINSTALL_SUBDIR_BIN="$appsDir/SuperTux" \
 		-DCMAKE_BUILD_TYPE=Release
 	make $jobArgs
 }
@@ -83,6 +83,6 @@ INSTALL()
 {
 	cd build
 	make install
-	mv $appsDir/SuperTux/supertux2 $appsDir/SuperTux/SuperTux
+	mv "$appsDir/SuperTux/supertux2" "$appsDir/SuperTux/SuperTux"
 	addAppDeskbarSymlink $appsDir/SuperTux/SuperTux
 }


### PR DESCRIPTION
Resolves #4456 

Apparently it tries to move an old config directory, constructed like `~/.$PACKAGE_NAME`, to the new one, and `PACKAGE_NAME` wasn't defined for some reason... resolving in `~/.`. Yikes! I just disabled the entire thing because I don't think we ever had the old config directory, anyway.