### PR TITLE
openmortal: new recipe

### DIFF
--- a/games-arcade/openmortal/openmortal-0.7.recipe
+++ b/games-arcade/openmortal/openmortal-0.7.recipe
@@ -1,0 +1,69 @@
+SUMMARY="A parody of the once popular coin-up fighting game, Mortal Kombat"
+DESCRIPTION="Mortál Szombat is a parody of the popular coin-up game, Mortal \
+Kombat. It is currently playable (maybe even enjoyable), although it is still \
+under development. Only two-player game is supported, single-player games \
+against computer opponent is not planned yet. There are currently 15 available \
+characters, and several more in the making!"
+HOMEPAGE="https://openmortal.sourceforge.net/"
+COPYRIGHT="2003 the OpenMortal Team"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="https://downloads.sourceforge.net/openmortal/openmortal-$portVersion.tar.bz2"
+CHECKSUM_SHA256="9c302560d71ddcd3473ba2a1022fd118cbce87a4cd4b3080cb46288a410bb710"
+
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	openmortal$secondaryArchSuffix = $portVersion
+	app:OpenMortal = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libfreetype$secondaryArchSuffix
+	lib:libperl
+	lib:libSDL_1.2$secondaryArchSuffix
+	lib:libSDL_gfx$secondaryArchSuffix
+	lib:libSDL_image_1.2$secondaryArchSuffix
+	lib:libSDL_mixer_1.2$secondaryArchSuffix
+	lib:libSDL_net_1.2$secondaryArchSuffix
+	lib:libSDL_ttf$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libfreetype$secondaryArchSuffix
+	devel:libSDL$secondaryArchSuffix
+	devel:libSDL_gfx$secondaryArchSuffix
+	devel:libSDL_image$secondaryArchSuffix
+	devel:libSDL_mixer$secondaryArchSuffix
+	devel:libSDL_net$secondaryArchSuffix
+	devel:libSDL_ttf$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:perl
+	"
+
+PATCH()
+{
+	sed -i 's/CChallengeMenu::CChallengeMenu/CChallengeMenu/g' src/OnlineChat.cpp
+	sed -i "s|require '\([A-Z].*\)'|require './\1'|g" data/script/*
+	sed -i "s|require 'DataHelper.pl'|require '../script/DataHelper.pl'|g" data/characters/*.pl
+}
+
+BUILD()
+{
+	runConfigure --omit-dirs "docDir dataRootDir" \
+		./configure --build=x86 --host=
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+	install -m 755 -d "$appsDir"
+	mv "$binDir/openmortal" "$appsDir/OpenMortal"
+	addAppDeskbarSymlink "$appsDir/OpenMortal"
+}

--- a/games-arcade/openmortal/openmortal-0.7.recipe
+++ b/games-arcade/openmortal/openmortal-0.7.recipe
@@ -10,6 +10,7 @@ LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://downloads.sourceforge.net/openmortal/openmortal-$portVersion.tar.bz2"
 CHECKSUM_SHA256="9c302560d71ddcd3473ba2a1022fd118cbce87a4cd4b3080cb46288a410bb710"
+PATCHES="openmortal-$portVersion.patch"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"

--- a/games-arcade/openmortal/openmortal-0.7.recipe
+++ b/games-arcade/openmortal/openmortal-0.7.recipe
@@ -46,6 +46,9 @@ BUILD_PREREQUIRES="
 	cmd:perl
 	"
 
+defineDebugInfoPackage openmortal$secondaryArchSuffix \
+	"$appsDir/OpenMortal"
+
 PATCH()
 {
 	sed -i 's/CChallengeMenu::CChallengeMenu/CChallengeMenu/g' src/OnlineChat.cpp

--- a/games-arcade/openmortal/openmortal-0.7.recipe
+++ b/games-arcade/openmortal/openmortal-0.7.recipe
@@ -45,6 +45,7 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
 	cmd:perl
+	cmd:sed
 	"
 
 defineDebugInfoPackage openmortal$secondaryArchSuffix \

--- a/games-arcade/openmortal/openmortal-0.7.recipe
+++ b/games-arcade/openmortal/openmortal-0.7.recipe
@@ -2,7 +2,7 @@ SUMMARY="A parody of the once popular coin-up fighting game, Mortal Kombat"
 DESCRIPTION="Mortál Szombat is a parody of the popular coin-up game, Mortal \
 Kombat. It is currently playable (maybe even enjoyable), although it is still \
 under development. Only two-player game is supported, single-player games \
-against computer opponent is not planned yet. There are currently 15 available \
+against computer opponent is not planned yet. There are currently 18 available \
 characters, and several more in the making!"
 HOMEPAGE="https://openmortal.sourceforge.net/"
 COPYRIGHT="2003 the OpenMortal Team"

--- a/games-arcade/openmortal/patches/openmortal-0.7.patch
+++ b/games-arcade/openmortal/patches/openmortal-0.7.patch
@@ -1,0 +1,21 @@
+--- a/src/State.cpp
++++ b/src/State.cpp
+@@ -14,6 +14,7 @@
+ #include "SDL_keysym.h"
+ #include "SDL_mixer.h"
+ 
++#include <FindDirectory.h>
+ #include <string>
+ #include <fstream>
+ //include <unistd.h>
+@@ -44,7 +45,9 @@
+ 	}
+ 	return "c:\\openmortal.ini";	
+ #else
+-	return std::string(getenv("HOME")) + "/.openmortalrc";
++	char path[B_PATH_NAME_LENGTH];
++	find_directory(B_USER_SETTINGS_DIRECTORY, 0, false, path, sizeof(path));
++	return std::string(path) + "/openmortalrc";
+ #endif
+ }
+ 


### PR DESCRIPTION
Notes:

- I didn't know anything good I could set the host to so I left it blank.
- I patched the Perl scripts to use relative paths for `require`; is there a better way to handle this?
- It fails to build in strict mode on x86 secondary architecture because it complains that it `can't find used library "libperl.so"`, but it seems to work fine otherwise. I'm guessing this is because it wants a secondary arch library but Perl doesn't have a secondary arch build enabled for some reason; any ideas on what do to here?
- I didn't split the package data as I felt that the difference isn't too much nowadays, but let me know if you feel otherwise.
- How much space should debug info take to warrant a debuginfo package? The debuginfo package takes 1.2 MB on my system, which I'm guessing is enough.