### PR TITLE
supermariowar: new recipe

### DIFF
--- a/games-action/supermariowar/patches/supermariowar-beta1.1.patch
+++ b/games-action/supermariowar/patches/supermariowar-beta1.1.patch
@@ -33,3 +33,83 @@
  #else // catch-all for Linux-based systems
      std::string result(".smw/");
      char* folder = getenv("HOME");
+--- a/src/leveleditor/leveleditor.cpp	2020-02-27 20:22:35.953679872 +0800
++++ b/src/leveleditor/leveleditor.cpp	2020-02-27 20:23:58.894173184 +0800
+@@ -75,6 +75,10 @@
+ #include <emscripten.h>
+ #endif
+ 
++#ifdef __HAIKU__
++#include <FindDirectory.h>
++#endif
++
+ 
+ #define MAPTITLESTRING "SMW 2.0 Level Editor"
+ 
+@@ -364,6 +368,13 @@
+ {
+ 	if (argc >= 2)
+ 		RootDataDirectory = argv[1];
++#ifdef __HAIKU__
++    else {
++        char path[B_PATH_NAME_LENGTH];
++        if (find_path(B_APP_IMAGE_SYMBOL, B_FIND_PATH_DATA_DIRECTORY, "supermariowar", path, B_PATH_NAME_LENGTH) == B_OK)
++            RootDataDirectory = std::string(path);
++    }
++#endif
+ 
+ 	smw = new CGame(RootDataDirectory.c_str());
+ 	rm = new CResourceManager();
+--- a/src/smw/main.cpp	2020-02-27 20:22:35.963117056 +0800
++++ b/src/smw/main.cpp	2020-02-27 20:23:02.737935360 +0800
+@@ -53,6 +53,9 @@
+ #endif
+ #endif
+ 
++#ifdef __HAIKU__
++#include <FindDirectory.h>
++#endif
+ 
+ //now it's really time for an "engine" (aka resource manager)
+ 
+@@ -276,6 +279,13 @@
+ {
+     if (argc >= 2)
+         RootDataDirectory = argv[1];
++#ifdef __HAIKU__
++    else {
++        char path[B_PATH_NAME_LENGTH];
++        if (find_path(B_APP_IMAGE_SYMBOL, B_FIND_PATH_DATA_DIRECTORY, "supermariowar", path, B_PATH_NAME_LENGTH) == B_OK)
++            RootDataDirectory = std::string(path);
++    }
++#endif
+ 
+ 
+     create_globals();
+--- a/src/worldeditor/worldeditor.cpp	2020-02-27 20:22:35.998506496 +0800
++++ b/src/worldeditor/worldeditor.cpp	2020-02-27 20:23:24.569376768 +0800
+@@ -62,6 +62,10 @@
+ #define SDL_Delay(n) ;
+ #endif
+ 
++#ifdef __HAIKU__
++#include <FindDirectory.h>
++#endif
++
+ #define MAPTITLESTRING "SMW 2.0 World Editor"
+ 
+ enum {EDITOR_EDIT, EDITOR_WATER, EDITOR_BACKGROUND, EDITOR_STAGEFOREGROUND, EDITOR_STRUCTUREFOREGROUND, EDITOR_BRIDGES, EDITOR_PATHSPRITE, EDITOR_VEHICLES, EDITOR_QUIT, SAVE_AS, FIND, CLEAR_WORLD, NEW_WORLD, RESIZE_WORLD, SAVE, EDITOR_WARP, DISPLAY_HELP, EDITOR_PATH, EDITOR_TYPE, EDITOR_BOUNDARY, EDITOR_START_ITEMS, EDITOR_STAGE};
+@@ -456,6 +460,13 @@
+ {
+ 	if (argc >= 2)
+ 		RootDataDirectory = argv[1];
++#ifdef __HAIKU__
++    else {
++        char path[B_PATH_NAME_LENGTH];
++        if (find_path(B_APP_IMAGE_SYMBOL, B_FIND_PATH_DATA_DIRECTORY, "supermariowar", path, B_PATH_NAME_LENGTH) == B_OK)
++            RootDataDirectory = std::string(path);
++    }
++#endif
+ 
+     smw = new CGame(RootDataDirectory.c_str());
+     rm = new CResourceManager();

--- a/games-action/supermariowar/patches/supermariowar-beta1.1.patch
+++ b/games-action/supermariowar/patches/supermariowar-beta1.1.patch
@@ -1,0 +1,35 @@
+--- a/src/common/Game.cpp	2020-02-26 21:09:52.337117184 +0800
++++ b/src/common/Game.cpp	2020-02-26 21:09:41.111411200 +0800
+@@ -8,7 +8,7 @@
+ #include <windows.h>
+ #endif
+ 
+-#if defined(unix) || defined(__unix__) || defined(__unix) || defined(__APPLE__)
++#if defined(unix) || defined(__unix__) || defined(__unix) || defined(__APPLE__) || defined(__HAIKU__)
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <unistd.h>
+--- a/src/common/path.cpp	2020-02-26 21:08:47.775684096 +0800
++++ b/src/common/path.cpp	2020-02-26 21:08:50.727187456 +0800
+@@ -11,6 +11,8 @@
+         #include <shlobj.h>
+         #include "SDL_platform.h"
+     #endif
++#elif __HAIKU__
++#include <FindDirectory.h>
+ #else
+ #include <stdlib.h>
+ #endif
+@@ -47,6 +49,12 @@
+     result += "/supermariowar/";
+     return result;
+ 
++#elif __HAIKU__
++    char path[B_PATH_NAME_LENGTH];
++    find_directory(B_USER_SETTINGS_DIRECTORY, 0, false, path, B_PATH_NAME_LENGTH);
++    std::string result(std::string(path) + "/supermariowar/");
++    return result;
++
+ #else // catch-all for Linux-based systems
+     std::string result(".smw/");
+     char* folder = getenv("HOME");

--- a/games-action/supermariowar/supermariowar-beta1.1.recipe
+++ b/games-action/supermariowar/supermariowar-beta1.1.recipe
@@ -55,10 +55,10 @@ BUILD_PREREQUIRES="
 	"
 
 defineDebugInfoPackage supermariowar$secondaryArchSuffix \
-	"$appsDir/smw" \
-	"$appsDir/smw-leveledit" \
+	"$appsDir/SMW" \
+	"$appsDir/SMW-LevelEdit" \
 	"$commandBinDir/smw-server" \
-	"$appsDir/smw-worldedit"
+	"$appsDir/SMW-WorldEdit"
 
 PATCH()
 {
@@ -84,26 +84,13 @@ INSTALL()
 
 	install -m 755 -d "$appsDir" "$commandBinDir"
 	install -m 755 Binaries/Release/smw-server "$commandBinDir"
+
 	set smw SMW "Super Mario War" \
 		smw-leveledit SMW-LevelEdit "Super Mario War Level Editor" \
 		smw-worldedit SMW-WorldEdit "Super Mario War World Editor"
 
 	while [ $# != 0 ]; do
-		cat <<-EOF >"$appsDir/$2"
-		#!/bin/sh
-		relativeAppsDir=$relativeAppsDir
-		relativeDataDir=$relativeDataDir
-		cd "\${0%/*}"
-
-		for path in \$(findpaths B_FIND_PATH_APPS_DIRECTORY); do
-		    if [ "\$path" = "\$PWD" ]; then
-		        prefix=\${path%"/\$relativeAppsDir"}
-		    fi
-		done
-
-		exec ./$1 "\$prefix/\$relativeDataDir/supermariowar"
-		EOF
-
+		mv "$appsDir/$1" "$appsDir/$2"
 		addAppDeskbarSymlink "$appsDir/$2" "$3"
 		shift 3
 	done

--- a/games-action/supermariowar/supermariowar-beta1.1.recipe
+++ b/games-action/supermariowar/supermariowar-beta1.1.recipe
@@ -1,0 +1,112 @@
+SUMMARY="A fan-made multiplayer Super Mario Bros. style deathmatch game"
+DESCRIPTION="Super Mario War is a fan-made multiplayer Super Mario Bros. style \
+deathmatch game in which plyaers try to beat one another in a variety of \
+gameplay modes. You can play on teams, design your own levels, design your own \
+worlds, and much more!"
+HOMEPAGE="https://github.com/mmatyas/supermariowar"
+COPYRIGHT="2003-2018 Super Mario War developers"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="$HOMEPAGE/archive/v2.0-${portVersion%%[0-9]*}.${portVersion##*[a-z]}.tar.gz"
+CHECKSUM_SHA256="ff0890e348c6fd56d4e1e7a3c3af405cb9ff7e23e7492f11e18832495366424d"
+SOURCE_FILENAME="supermariowar-$portVersion.tar.gz"
+SOURCE_DIR="supermariowar-2.0-${portVersion%%[0-9]*}.${portVersion##*[a-z]}"
+PATCHES="supermariowar-$portVersion.patch"
+
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+SECONDARY_ARCHITECTURES="x86"
+commandBinDir=$prefix/bin
+fi
+
+PROVIDES="
+	supermariowar$secondaryArchSuffix = $portVersion
+	app:SMW = $portVersion
+	app:SMW_LevelEdit = $portVersion
+	app:SMW_WorldEdit = $portVersion
+	cmd:smw_server
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libenet$secondaryArchSuffix
+	lib:libSDL_1.2$secondaryArchSuffix
+	lib:libSDL_image_1.2$secondaryArchSuffix
+	lib:libSDL_mixer_1.2$secondaryArchSuffix
+	lib:libyaml_cpp$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libenet$secondaryArchSuffix
+	devel:libSDL$secondaryArchSuffix
+	devel:libSDL_image$secondaryArchSuffix
+	devel:libSDL_mixer$secondaryArchSuffix
+	devel:libyaml_cpp$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:sed
+	cmd:unzip
+	"
+
+defineDebugInfoPackage supermariowar$secondaryArchSuffix \
+	"$appsDir/smw" \
+	"$appsDir/smw-leveledit" \
+	"$commandBinDir/smw-server" \
+	"$appsDir/smw-worldedit"
+
+PATCH()
+{
+	sed -i "/SMW_BINDIR/ s|/games|/$relativeAppsDir|" CMakeLists.txt
+}
+
+BUILD()
+{
+	unzip -n data.zip
+	mkdir -p build
+	cd build
+	cmake .. \
+		-DBUILD_STATIC_LIBS=OFF \
+		-DCMAKE_INSTALL_PREFIX="$prefix" \
+		-DSMW_DATADIR="$dataDir/supermariowar"
+	make $jobArgs
+}
+
+INSTALL()
+{
+	cd build
+	make install
+
+	install -m 755 -d "$appsDir" "$commandBinDir"
+	install -m 755 Binaries/Release/smw-server "$commandBinDir"
+	set smw SMW "Super Mario War" \
+		smw-leveledit SMW-LevelEdit "Super Mario War Level Editor" \
+		smw-worldedit SMW-WorldEdit "Super Mario War World Editor"
+
+	while [ $# != 0 ]; do
+		cat <<-EOF >"$appsDir/$2"
+		#!/bin/sh
+		relativeAppsDir=$relativeAppsDir
+		relativeDataDir=$relativeDataDir
+		cd "\${0%/*}"
+
+		for path in \$(findpaths B_FIND_PATH_APPS_DIRECTORY); do
+		    if [ "\$path" = "\$PWD" ]; then
+		        prefix=\${path%"/\$relativeAppsDir"}
+		    fi
+		done
+
+		exec ./$1 "\$prefix/\$relativeDataDir/supermariowar"
+		EOF
+
+		addAppDeskbarSymlink "$appsDir/$2" "$3"
+		shift 3
+	done
+
+	chmod 755 "$appsDir"/*
+}

--- a/games-action/supermariowar/supermariowar-beta1.1.recipe
+++ b/games-action/supermariowar/supermariowar-beta1.1.recipe
@@ -40,9 +40,9 @@ REQUIRES="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libenet$secondaryArchSuffix
-	devel:libSDL$secondaryArchSuffix
-	devel:libSDL_image$secondaryArchSuffix
-	devel:libSDL_mixer$secondaryArchSuffix
+	devel:libSDL_1.2$secondaryArchSuffix
+	devel:libSDL_image_1.2$secondaryArchSuffix
+	devel:libSDL_mixer_1.2$secondaryArchSuffix
 	devel:libyaml_cpp$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"


### PR DESCRIPTION
Notes:
- Depends on #4753 
- I was going to put this in `games-arcade`, but Gentoo had it in `games-action`
- I'm not sure if the unzipping should be done in another function
- Am I supposed to put the apps in a directory in `$appsDir`?
- I wasn't sure what to name the version; would it be preferred to make it a `~git` package?
- I create shell scripts to run them because it's designed to have the data directory path passed as an argument, but because of that it uses the icon for text files and has a different name on startup. Does this mean I have to patch the program?
- Should I enable `USE_PNG_SAVE`?
- I was also able to run the original version (this is an unofficial fork); would a recipe for it be accepted if I feel like making one in the future?