### PR TITLE
mgba: bump to 0.8.1 and fix config directory

### DIFF
--- a/games-emulation/mgba/mgba-0.8.1.recipe
+++ b/games-emulation/mgba/mgba-0.8.1.recipe
@@ -9,12 +9,13 @@ most accurate GBA emulator around.
 Other goals include accurate enough emulation to provide a development \
 environment for homebrew software, a good workflow for tool-assist runners, \
 and a modern feature set for emulators that older emulators may not support."
-HOMEPAGE="https://mgba.io"
-COPYRIGHT="2013-2017 Jeffrey Pfau"
+HOMEPAGE="https://mgba.io/"
+COPYRIGHT="2013-2020 Jeffrey Pfau"
 LICENSE="MPL v2.0"
-REVISION="5"
+REVISION="1"
 SOURCE_URI="https://github.com/mgba-emu/mgba/archive/$portVersion.tar.gz"
-CHECKSUM_SHA256="665fbae8bcfaf3e3f4b83267ce5800b00b98f4bacbb36fc412e3829020019cf4"
+CHECKSUM_SHA256="df136ea50c9cca380ab93e00fd8d87811e41a49a804c5b0e018babef0c490f13"
+PATCHES="mgba-$portVersion.patch"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
@@ -45,7 +46,6 @@ REQUIRES="
 # SDL1.2 checks if one already exists first, so it's OK.
 	lib:libSDL_1.2$secondaryArchSuffix
 	lib:libswscale$secondaryArchSuffix
-	lib:libswresample$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	lib:libzip$secondaryArchSuffix
 	"
@@ -56,7 +56,9 @@ BUILD_REQUIRES="
 	devel:libavformat$secondaryArchSuffix
 	devel:libavutil$secondaryArchSuffix
 	devel:libedit$secondaryArchSuffix
+	devel:libelf$secondaryArchSuffix
 	devel:libncurses$secondaryArchSuffix
+	devel:libminizip$secondaryArchSuffix
 	devel:libpng16$secondaryArchSuffix
 	devel:libQt5Core$secondaryArchSuffix
 	devel:libQt5Gui$secondaryArchSuffix
@@ -65,7 +67,6 @@ BUILD_REQUIRES="
 	devel:libQt5Widgets$secondaryArchSuffix
 	devel:libSDL_1.2$secondaryArchSuffix
 	devel:libswscale$secondaryArchSuffix
-	devel:libswresample$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	devel:libzip$secondaryArchSuffix
 	"
@@ -80,12 +81,17 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	cmake . -GNinja -DBUILD_GL=OFF $cmakeDirArgs
+	cmake . $cmakeDirArgs \
+		-GNinja \
+		-DBUILD_GL=OFF \
+		-DBUILD_GLES2=OFF \
+		-DBUILD_GLES3=OFF \
+		-DUSE_DISCORD_RPC=OFF
 	ninja $jobArgs
 }
 
 INSTALL()
 {
 	ninja install
-	addAppDeskbarSymlink $binDir/mgba-qt "mGBA"
+	addAppDeskbarSymlink "$binDir/mgba-qt" "mGBA"
 }

--- a/games-emulation/mgba/mgba-0.8.1.recipe
+++ b/games-emulation/mgba/mgba-0.8.1.recipe
@@ -56,9 +56,7 @@ BUILD_REQUIRES="
 	devel:libavformat$secondaryArchSuffix
 	devel:libavutil$secondaryArchSuffix
 	devel:libedit$secondaryArchSuffix
-	devel:libelf$secondaryArchSuffix
 	devel:libncurses$secondaryArchSuffix
-	devel:libminizip$secondaryArchSuffix
 	devel:libpng16$secondaryArchSuffix
 	devel:libQt5Core$secondaryArchSuffix
 	devel:libQt5Gui$secondaryArchSuffix

--- a/games-emulation/mgba/patches/mgba-0.8.1.patch
+++ b/games-emulation/mgba/patches/mgba-0.8.1.patch
@@ -1,0 +1,42 @@
+diff --git a/src/core/config.c b/src/core/config.c
+index cd173dfb..9135e0fc 100644
+--- a/src/core/config.c
++++ b/src/core/config.c
+@@ -27,6 +27,10 @@
+ #include <mgba-util/platform/3ds/3ds-vfs.h>
+ #endif
+ 
++#ifdef __HAIKU__
++#include <FindDirectory.h>
++#endif
++
+ #define SECTION_NAME_MAX 128
+ 
+ struct mCoreConfigEnumerateData {
+@@ -227,6 +231,12 @@ void mCoreConfigDirectory(char* out, size_t outLength) {
+ 	UNUSED(portable);
+ 	snprintf(out, outLength, "/%s", projectName);
+ 	FSUSER_CreateDirectory(sdmcArchive, fsMakePath(PATH_ASCII, out), 0);
++#elif defined(__HAIKU__)
++	UNUSED(portable);
++	char path[B_PATH_NAME_LENGTH];
++	find_directory(B_USER_SETTINGS_DIRECTORY, 0, false, path, B_PATH_NAME_LENGTH);
++	snprintf(out, outLength, "%s/%s", path, binaryName);
++	mkdir(out, 0755);
+ #else
+ 	getcwd(out, outLength);
+ 	strncat(out, PATH_SEP "portable.ini", outLength - strlen(out));
+diff --git a/src/platform/qt/InputController.cpp b/src/platform/qt/InputController.cpp
+index c6a598ce..f19130dd 100644
+--- a/src/platform/qt/InputController.cpp
++++ b/src/platform/qt/InputController.cpp
+@@ -272,8 +272,8 @@ void InputController::setPreferredGamepad(uint32_t type, int index) {
+ 		return;
+ 	}
+ #ifdef BUILD_SDL
+-	char name[34] = {0};
+ #if SDL_VERSION_ATLEAST(2, 0, 0)
++	char name[34] = {0};
+ 	SDL_JoystickGetGUIDString(SDL_JoystickGetGUID(SDL_JoystickListGetPointer(&s_sdlEvents.joysticks, index)->joystick), name, sizeof(name));
+ #else
+ 	const char* name = SDL_JoystickName(SDL_JoystickIndex(SDL_JoystickListGetPointer(&s_sdlEvents.joysticks, index)->joystick));


### PR DESCRIPTION
I'm guessing that this was overlooked because it tries to use `XDG_CONFIG_HOME` by default, which is set in the terminal, but not when launched from Deskbar.

Note that I removed `libswresample` as it seems that it didn't seem to link against it. It optionally uses libavresample, but it isn't available in the current version of ffmpeg. Let me know if libavresample works on the build bots or if libswresample does something.