### PR TITLE
openmw: rebuild after bullet soname bump

### DIFF
--- a/games-engines/openmw/openmw-0.45.0.recipe
+++ b/games-engines/openmw/openmw-0.45.0.recipe
@@ -11,7 +11,7 @@ LICENSE="
 	MIT
 	Zlib
 	"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/OpenMW/openmw/archive/openmw-$portVersion.tar.gz"
 SOURCE_FILENAME="openmw-$portVersion.tar.gz"
 CHECKSUM_SHA256="b63cf971f406ef5f28019f65e9e2bd9641a227459ede45d147562917f67e1c64"


### PR DESCRIPTION
Not sure if there's supposed to be a better way to fix this; I'm just copying a previous commit.