### PR TITLE
llvm: add lld-link, improve incremental build

### DIFF
--- a/sys-devel/llvm/llvm9-9.0.1.recipe
+++ b/sys-devel/llvm/llvm9-9.0.1.recipe
@@ -31,7 +31,7 @@ other than the ones listed above.
 HOMEPAGE="https://www.llvm.org/"
 COPYRIGHT="2003-2019 University of Illinois at Urbana-Champaign"
 LICENSE="Apache v2 with LLVM Exception"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/llvm/llvm-project/releases/download/llvmorg-$portVersion/llvm-$portVersion.src.tar.xz"
 CHECKSUM_SHA256="00a1ee1f389f81e9979f3a640a01c431b3021de0d42278f6508391a2f0b81c9a"
 SOURCE_DIR="llvm-$portVersion.src"
@@ -44,6 +44,9 @@ SOURCE_DIR_3="clang-tools-extra-$portVersion.src"
 SOURCE_URI_4="https://github.com/llvm/llvm-project/releases/download/llvmorg-$portVersion//compiler-rt-$portVersion.src.tar.xz"
 CHECKSUM_SHA256_4="c2bfab95c9986318318363d7f371a85a95e333bc0b34fbfa52edbd3f5e3a9077"
 SOURCE_DIR_4="compiler-rt-$portVersion.src"
+SOURCE_URI_5="https://github.com/llvm/llvm-project/releases/download/llvmorg-$portVersion//lld-$portVersion.src.tar.xz"
+CHECKSUM_SHA256_5="86262bad3e2fd784ba8c5e2158d7aa36f12b85f2515e95bc81d65d75bb9b0c82"
+SOURCE_DIR_5="lld-$portVersion.src"
 PATCHES="llvm-$portVersion.patchset"
 PATCHES_2="clang-$portVersion.patchset"
 
@@ -410,6 +413,29 @@ CONFLICTS_clang_analysis="
 	llvm8${secondaryArchSuffix}_clang_analysis
 	"
 
+PROVIDES_lld="
+	llvm9${secondaryArchSuffix}_lld = $portVersion
+	cmd:ld.lld = $portVersion
+	cmd:ld64.lld = $portVersion
+	cmd:lld = $portVersion
+	cmd:lld_link = $portVersion
+	cmd:wasm_ld = $portVersion
+	devel:liblldCOFF$secondaryArchSuffix = $portVersion
+	devel:liblldCommon$secondaryArchSuffix = $portVersion
+	devel:liblldCore$secondaryArchSuffix = $portVersion
+	devel:liblldDriver$secondaryArchSuffix = $portVersion
+	devel:liblldELF$secondaryArchSuffix = $portVersion
+	devel:liblldMachO$secondaryArchSuffix = $portVersion
+	devel:liblldMinGW$secondaryArchSuffix = $portVersion
+	devel:liblldReaderWriter$secondaryArchSuffix = $portVersion
+	devel:liblldWasm$secondaryArchSuffix = $portVersion
+	devel:liblldYAML$secondaryArchSuffix = $portVersion
+	"
+REQUIRES_lld="
+	haiku$secondaryArchSuffix
+	lib:libLLVM_9$secondaryArchSuffix
+	"
+
 PROVIDES_libs="
 	llvm9${secondaryArchSuffix}_libs = $portVersion
 	lib:libclang$secondaryArchSuffix = $portVersion compat >= 9
@@ -457,14 +483,17 @@ BUILD()
 {
 	# Add clang tools
 	mkdir -p tools/clang
-	cp -rd $sourceDir2/* tools/clang/
+	cp -rdn $sourceDir2/* tools/clang/
 
 	# Add clang tools's tool's (really llvm?)
 	mkdir -p tools/clang/tools/extra
-	cp -rd $sourceDir3/* tools/clang/tools/extra
+	cp -rdn $sourceDir3/* tools/clang/tools/extra
 
 	mkdir -p projects/compiler-rt
-	cp -rd $sourceDir4/* projects/compiler-rt
+	cp -rdn $sourceDir4/* projects/compiler-rt
+
+	mkdir -p tools/lld
+	cp -rdn $sourceDir5/* tools/lld
 
 	local cmakeFlags
 	if [ -n "$secondaryArchSuffix" ]; then
@@ -479,10 +508,10 @@ BUILD()
 		-DCMAKE_SKIP_RPATH=YES $cmakeFlags \
 		-DLLVM_ENABLE_RTTI=ON -DLLVM_LINK_LLVM_DYLIB=YES \
 		-DLLVM_ENABLE_BUILD_TESTS=YES \
+		-G Ninja \
 		..
 
-	make $jobArgs PROJ_datadir=$dataDir PROJ_docsdir=$docDir \
-		PROJ_mandir=$manDir PROJ_includedir=$includeDir PROJ_libdir=$libDir
+	ninja
 }
 
 INSTALL()
@@ -491,14 +520,7 @@ INSTALL()
 
 	mkdir -p $binDir $developDir $dataDir $docDir $includeDir $manDir $libDir
 
-	make install PROJ_datadir=$dataDir PROJ_docsdir=$docDir \
-		PROJ_mandir=$manDir PROJ_includedir=$includeDir PROJ_libdir=$libDir
-
-	make -C tools/clang install PROJ_datadir=$dataDir PROJ_docsdir=$docDir \
-		PROJ_mandir=$manDir PROJ_includedir=$includeDir PROJ_libdir=$libDir
-
-	make -C projects/compiler-rt install PROJ_datadir=$dataDir PROJ_docsdir=$docDir \
-		PROJ_mandir=$manDir PROJ_includedir=$includeDir PROJ_libdir=$libDir
+	ninja install
 
 	# GENERIC: all python_setuptools-based installs need this
 	local pythonPackageName="${portName}_python3-$portFullVersion"
@@ -524,6 +546,7 @@ INSTALL()
 		libLLVM* \
 		libLTO	\
 		libclang* \
+		liblld* \
 		libRemarks
 
 	mv $prefix/include/* $includeDir/
@@ -559,6 +582,16 @@ INSTALL()
 		$dataDir/scan-build \
 		$dataDir/scan-view \
 		$manDir/man1/scan-build.1
+
+	# lld package
+	packageEntries lld \
+		$binDir/ld.lld \
+		$binDir/ld64.lld \
+		$binDir/lld \
+		$binDir/lld-link \
+		$binDir/wasm-ld \
+		$includeDir/lld* \
+		$developLibDir/liblld*
 
 	# libs package
 	packageEntries libs \


### PR DESCRIPTION
* Use ninja instead of make to improve incremental build.
* Use -n option in cp to do not change existing files when installing source code.

Fixes #4786.