### PR TITLE
boehm_gc:  fix for "mmap(PROT_NONE) failed" in building GNU Guile 2.2.7 

### DIFF
--- a/dev-libs/boehm_gc/boehm_gc-8.0.4.recipe
+++ b/dev-libs/boehm_gc/boehm_gc-8.0.4.recipe
@@ -22,6 +22,7 @@ REVISION="1"
 SOURCE_URI="https://github.com/ivmai/bdwgc/releases/download/v$portVersion/gc-$portVersion.tar.gz"
 CHECKSUM_SHA256="436a0ddc67b1ac0b0405b61a9675bca9e075c8156f4debd1d06f3a56c7cd289d"
 SOURCE_DIR="gc-$portVersion"
+PATCHES="boehm_gc-8.0.4.patchset"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"

--- a/dev-libs/boehm_gc/boehm_gc-8.0.4.recipe
+++ b/dev-libs/boehm_gc/boehm_gc-8.0.4.recipe
@@ -22,7 +22,7 @@ REVISION="1"
 SOURCE_URI="https://github.com/ivmai/bdwgc/releases/download/v$portVersion/gc-$portVersion.tar.gz"
 CHECKSUM_SHA256="436a0ddc67b1ac0b0405b61a9675bca9e075c8156f4debd1d06f3a56c7cd289d"
 SOURCE_DIR="gc-$portVersion"
-PATCHES="boehm_gc-8.0.4.patchset"
+PATCHES="boehm_gc-$portVersion.patchset"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"

--- a/dev-libs/boehm_gc/boehm_gc-8.0.4.recipe
+++ b/dev-libs/boehm_gc/boehm_gc-8.0.4.recipe
@@ -18,7 +18,7 @@ COPYRIGHT="1988, 1989 Hans-J. Boehm, Alan J. Demers
 	2011 Ludovic Courtes
 	2018 Petter A. Urkedal"
 LICENSE="Boehm"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/ivmai/bdwgc/releases/download/v$portVersion/gc-$portVersion.tar.gz"
 CHECKSUM_SHA256="436a0ddc67b1ac0b0405b61a9675bca9e075c8156f4debd1d06f3a56c7cd289d"
 SOURCE_DIR="gc-$portVersion"

--- a/dev-libs/boehm_gc/patches/boehm_gc-8.0.4.patchset
+++ b/dev-libs/boehm_gc/patches/boehm_gc-8.0.4.patchset
@@ -1,7 +1,7 @@
 From bbc09e8c410f0e2ff3e0b0c93884e87b5a75c15f Mon Sep 17 00:00:00 2001
 From: Massimiliano Gubinelli <m.gubinelli@gmail.com>
 Date: Mon, 23 Mar 2020 16:36:01 +0000
-Subject: fix
+Subject: fix for "mmap(PROT_NONE) failed" in compiling GNU Guile 2.2.7
 
 
 diff --git a/os_dep.c b/os_dep.c

--- a/dev-libs/boehm_gc/patches/boehm_gc-8.0.4.patchset
+++ b/dev-libs/boehm_gc/patches/boehm_gc-8.0.4.patchset
@@ -1,0 +1,22 @@
+From bbc09e8c410f0e2ff3e0b0c93884e87b5a75c15f Mon Sep 17 00:00:00 2001
+From: Massimiliano Gubinelli <m.gubinelli@gmail.com>
+Date: Mon, 23 Mar 2020 16:36:01 +0000
+Subject: fix
+
+
+diff --git a/os_dep.c b/os_dep.c
+index f0c3eae..03fb984 100644
+--- a/os_dep.c
++++ b/os_dep.c
+@@ -2560,7 +2560,7 @@ GC_INNER void GC_unmap(ptr_t start, size_t bytes)
+       /* We immediately remap it to prevent an intervening mmap from    */
+       /* accidentally grabbing the same address space.                  */
+       {
+-#       ifdef CYGWIN32
++#       if defined(CYGWIN32) || defined(__HAIKU__)
+           /* Calling mmap() with the new protection flags on an         */
+           /* existing memory map with MAP_FIXED is broken on Cygwin.    */
+           /* However, calling mprotect() on the given address range     */
+-- 
+2.24.1
+


### PR DESCRIPTION
The build of Guile 2.2.7 aborts with the following error
```
mmap(PROT_NONE) failed
```
which is due to the GC. This new patch solves the problem. I've also submitted an issue upstream.  The patch follows what happens in other architectures: see
(https://github.com/ivmai/bdwgc/blob/master/os_dep.c) line 2578 in the upcoming 1.0 version of the GC.