### PR TITLE
mksh: Update user profile paths

### DIFF
--- a/app-shells/mksh/mksh-57.recipe
+++ b/app-shells/mksh/mksh-57.recipe
@@ -15,12 +15,13 @@ COPYRIGHT="2002-2019 Thorsten Glaser"
 LICENSE="MirOS
 	BSD (3-clause)
 	ISC"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://www.mirbsd.org/MirOS/dist/mir/mksh/mksh-R$portVersion.tgz"
 CHECKSUM_SHA256="3d101154182d52ae54ef26e1360c95bc89c929d28859d378cc1c84f3439dbe75"
 SOURCE_DIR="mksh"
+PATCHES="mksh-$portVersion.patchset"
 if [ "$targetArchitecture" != x86_gcc2 ]; then
-	PATCHES="mksh-$portVersion.patch"
+	PATCHES+=" mksh-$portVersion.patch"
 fi
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"

--- a/app-shells/mksh/patches/mksh-57.patchset
+++ b/app-shells/mksh/patches/mksh-57.patchset
@@ -1,0 +1,157 @@
+From 62b6f3d69d0e87bd1755164e866601f0bd27a048 Mon Sep 17 00:00:00 2001
+From: David Wildasin <dragonmaus@posteo.net>
+Date: Sun, 22 Mar 2020 13:50:21 -0400
+Subject: Update shell profile paths for Haiku
+
+
+diff --git a/Build.sh b/Build.sh
+index be3f711..7d1addf 100644
+--- a/Build.sh
++++ b/Build.sh
+@@ -2740,7 +2740,7 @@ HAVE_CAN_FSTACKPROTECTORALL	ac_flags
+ ==== cpp definitions ====
+ DEBUG				dont use in production, wants gcc, implies:
+ DEBUG_LEAKS			enable freeing resources before exiting
+-MKSHRC_PATH			"~/.mkshrc" (do not change)
++MKSHRC_PATH			"~/config/settings/mkshrc" (do not change)
+ MKSH_A4PB			force use of arc4random_pushb
+ MKSH_ASSUME_UTF8		(0=disabled, 1=enabled; default: unset)
+ MKSH_BINSHPOSIX			if */sh or */-sh, enable set -o posix
+diff --git a/check.t b/check.t
+index d5df4cb..a2ff0e0 100644
+--- a/check.t
++++ b/check.t
+@@ -8289,7 +8289,7 @@ expected-stderr-pattern:
+ ---
+ name: mkshrc-1
+ description:
+-	Check that ~/.mkshrc works correctly.
++	Check that ~/config/settings/mkshrc works correctly.
+ 	Part 1: verify user environment is not read (internal)
+ stdin:
+ 	echo x $FNORD
+@@ -8298,9 +8298,9 @@ expected-stdout:
+ ---
+ name: mkshrc-2a
+ description:
+-	Check that ~/.mkshrc works correctly.
++	Check that ~/config/settings/mkshrc works correctly.
+ 	Part 2: verify mkshrc is not read (non-interactive shells)
+-file-setup: file 644 ".mkshrc"
++file-setup: file 644 "mkshrc"
+ 	FNORD=42
+ env-setup: !HOME=.!ENV=!
+ stdin:
+@@ -8310,9 +8310,9 @@ expected-stdout:
+ ---
+ name: mkshrc-2b
+ description:
+-	Check that ~/.mkshrc works correctly.
++	Check that ~/config/settings/mkshrc works correctly.
+ 	Part 2: verify mkshrc can be read (interactive shells)
+-file-setup: file 644 ".mkshrc"
++file-setup: file 644 "mkshrc"
+ 	FNORD=42
+ need-ctty: yes
+ arguments: !-i!
+@@ -8326,9 +8326,9 @@ expected-stderr-pattern:
+ ---
+ name: mkshrc-3
+ description:
+-	Check that ~/.mkshrc works correctly.
++	Check that ~/config/settings/mkshrc works correctly.
+ 	Part 3: verify mkshrc can be turned off
+-file-setup: file 644 ".mkshrc"
++file-setup: file 644 "mkshrc"
+ 	FNORD=42
+ env-setup: !HOME=.!ENV=nonexistant!
+ stdin:
+diff --git a/dot.mkshrc b/dot.mkshrc
+index 4a3dfea..bfb8f64 100644
+--- a/dot.mkshrc
++++ b/dot.mkshrc
+@@ -20,7 +20,7 @@
+ # damage or existence of a defect, except proven that it results out
+ # of said person's immediate fault when using the work as intended.
+ #-
+-# ${ENV:-~/.mkshrc}: mksh initialisation file for interactive shells
++# ${ENV:-~/config/settings/mkshrc}: mksh initialisation file for interactive shells
+ 
+ # catch non-mksh, non-lksh, trying to run this file
+ case ${KSH_VERSION:-} in
+diff --git a/funcs.c b/funcs.c
+index a42c310..b2a4275 100644
+--- a/funcs.c
++++ b/funcs.c
+@@ -1815,7 +1815,7 @@ c_read(const char **wp)
+ 				if (Flag(FTALKING_I) && isatty(fd)) {
+ 					/*
+ 					 * set prompt in case this is
+-					 * called from .profile or $ENV
++					 * called from profile or $ENV
+ 					 */
+ 					set_prompt(PS2, NULL);
+ 					pprompt(prompt, 0);
+diff --git a/main.c b/main.c
+index cde0616..13ddd03 100644
+--- a/main.c
++++ b/main.c
+@@ -38,7 +38,7 @@
+ __RCSID("$MirOS: src/bin/mksh/main.c,v 1.351 2019/01/05 13:24:18 tg Exp $");
+ 
+ #ifndef MKSHRC_PATH
+-#define MKSHRC_PATH	"~/.mkshrc"
++#define MKSHRC_PATH	"~/config/settings/mkshrc"
+ #endif
+ 
+ #ifndef MKSH_DEFAULT_TMPDIR
+@@ -635,7 +635,7 @@ main_init(int argc, const char *argv[], Source **sp, struct block **lp)
+ 		break;
+ 	}
+ 
+-	/* Disable during .profile/ENV reading */
++	/* Disable during profile/ENV reading */
+ 	restricted_shell = Flag(FRESTRICTED);
+ 	Flag(FRESTRICTED) = 0;
+ 	errexit = Flag(FERREXIT);
+@@ -652,7 +652,7 @@ main_init(int argc, const char *argv[], Source **sp, struct block **lp)
+ 		include(MKSH_SYSTEM_PROFILE, 0, NULL, true);
+ 	if (!Flag(FPRIVILEGED)) {
+ 		if (Flag(FLOGIN))
+-			include(substitute("$HOME/.profile", 0), 0, NULL, true);
++			include(substitute("$HOME/config/settings/profile", 0), 0, NULL, true);
+ 		if (Flag(FTALKING)) {
+ 			cp = substitute("${ENV:-" MKSHRC_PATH "}", DOTILDE);
+ 			if (cp[0] != '\0')
+@@ -739,7 +739,7 @@ include(const char *name, int argc, const char **argv, bool intr_ok)
+ 			return (exstat & 0xFF);
+ 		case LINTR:
+ 			/*
+-			 * intr_ok is set if we are including .profile or $ENV.
++			 * intr_ok is set if we are including profile or $ENV.
+ 			 * If user ^Cs out, we don't want to kill the shell...
+ 			 */
+ 			if (intr_ok && ((exstat & 0xFF) - 128) != SIGTERM)
+diff --git a/mksh.1 b/mksh.1
+index 2e83428..2e3d0e7 100644
+--- a/mksh.1
++++ b/mksh.1
+@@ -6491,13 +6491,13 @@ removed to the history and a new prompt to be printed.
+ .El
+ .Sh FILES
+ .Bl -tag -width XetcXsuid_profile -compact
+-.It Pa \*(TI/.mkshrc
++.It Pa \*(TI/config/settings/mkshrc
+ User mkshrc profile (non-privileged interactive shells); see
+ .Sx Startup files.
+ The location can be changed at compile time (for embedded systems);
+ AOSP Android builds use
+ .Pa /system/etc/mkshrc .
+-.It Pa \*(TI/.profile
++.It Pa \*(TI/config/settings/profile
+ User profile (non-privileged login shells); see
+ .Sx Startup files
+ near the top of this manual.
+-- 
+2.24.1
+


### PR DESCRIPTION
Patch mksh to use `~/config/settings/mkshrc` and `~/config/settings/profile` instead of `~/.mkshrc` and `~/.profile`.