### PR TITLE
retroarch: re-enabled qt5 to allow shiny QT interface build

### DIFF
--- a/games-emulation/retroarch/retroarch-1.8.5.recipe
+++ b/games-emulation/retroarch/retroarch-1.8.5.recipe
@@ -6,7 +6,7 @@ shaders, netplay, rewinding, next-frame response times, and more!"
 HOMEPAGE="https://www.retroarch.com/"
 COPYRIGHT="2010-2018 The RetroArch Team"
 LICENSE="GNU GPL v3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/libretro/RetroArch/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="f29b6dd9b18f874571803afac760b7fc99dc177dd079b38216b7576bd7d86dd4"
 SOURCE_FILENAME="retroarch-$portVersion.tar.gz"
@@ -42,6 +42,7 @@ REQUIRES="
 	lib:libsdl2_2.0$secondaryArchSuffix
 	lib:libswresample$secondaryArchSuffix
 	lib:libswscale$secondaryArchSuffix
+	lib:libqt5$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
 
@@ -55,6 +56,7 @@ BUILD_REQUIRES="
 	devel:libsdl2$secondaryArchSuffix
 	devel:libswresample$secondaryArchSuffix
 	devel:libswscale$secondaryArchSuffix
+	devel:libqt5$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="


### PR DESCRIPTION
Now that #2484 is closed, we can re-enable the QT interface in the Retroarch build.