### PR TITLE
Bescreencapture v2.5.1

### DIFF
--- a/haiku-apps/bescreencapture/bescreencapture-2.5.1.recipe
+++ b/haiku-apps/bescreencapture/bescreencapture-2.5.1.recipe
@@ -1,0 +1,74 @@
+SUMMARY="A screen recorder utility"
+DESCRIPTION="BeScreenCapture is a screen recorder utility for Haiku.
+It allows you to record what happens on your screen, then save it \
+to any media format supported in Haiku.
+BeScreenCapture can record either the entire screen, or just a section you \
+select."
+HOMEPAGE="https://github.com/jackburton79/bescreencapture/releases"
+COPYRIGHT="2014-2020 Stefano Ceccherini"
+LICENSE="BSD (3-clause)
+	MIT"
+REVISION="1"
+SOURCE_URI="https://github.com/jackburton79/bescreencapture/archive/v$portVersion.tar.gz"
+CHECKSUM_SHA256="c07207a291fa33862649d2de440a9b3da1d6db01750d5365bca7a619ae902031"
+SOURCE_FILENAME="bescreencapture-$portVersion.tar.gz"
+PATCHES="bescreencapture-$portVersion.patchset"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	bescreencapture = $portVersion
+	app:BeScreenCapture = $portVersion
+	"
+REQUIRES="
+	haiku
+	"
+
+SUMMARY_inputfilter="Shortcut handler for BeScreenCapture"
+DESCRIPTION_inputfilter="Input Server Addon for BeScreenCapture. Allows the \
+user to launch BeScreenCapture and start/stop recording using a keyboard \
+combination (CTRL-COMMAND-SHIFT + R)."
+PROVIDES_inputfilter="
+	bescreencapture_inputfilter = $portVersion
+	app:BeScreenCaptureInputFilter = $portVersion
+	"
+REQUIRES_inputfilter="
+	bescreencapture == $portVersion base
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	makefile_engine
+	cmd:gcc
+	cmd:make
+	"
+
+BUILD()
+{
+	make OBJ_DIR=objects \
+		BUILDHOME=`finddir B_SYSTEM_DEVELOP_DIRECTORY`
+
+	make -C inputfilter OBJ_DIR=objects \
+		BUILDHOME=`finddir B_SYSTEM_DEVELOP_DIRECTORY`
+}
+
+INSTALL()
+{
+	install -m 0755 -d "$appsDir"
+	install -m 0755 -t "$appsDir" objects/BeScreenCapture
+
+	install -m 0755 -d "$addOnsDir"/input_server/filters
+	install -m 0755 -t "$addOnsDir"/input_server/filters \
+		inputfilter/objects/BeScreenCaptureInputFilter
+
+	install -m 0755 -d "$docDir"
+	install -m 0644 -t "$docDir" README.md
+
+	packageEntries inputfilter \
+		$addOnsDir/input_server/filters/BeScreenCaptureInputFilter
+
+	addAppDeskbarSymlink $appsDir/BeScreenCapture
+}

--- a/haiku-apps/bescreencapture/patches/bescreencapture-2.5.1.patchset
+++ b/haiku-apps/bescreencapture/patches/bescreencapture-2.5.1.patchset
@@ -1,0 +1,21 @@
+From 5ac8d968c0f016d61d64fe0884f6ad6b69707b21 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Sat, 24 Nov 2018 15:55:31 +0100
+Subject: include algorithm for std::max.
+
+
+diff --git a/OutputView.cpp b/OutputView.cpp
+index 8e56611..2bf0315 100644
+--- a/OutputView.cpp
++++ b/OutputView.cpp
+@@ -16,6 +16,7 @@
+ #include <Screen.h>
+ #include <TextControl.h>
+ 
++#include <algorithm>
+ #include <iostream>
+ 
+ 
+-- 
+2.24.0
+


### PR DESCRIPTION
Bugfix release for BeScreenCapture
I fixed a bug in BeScreenCapture where the GIF export would only export a few frames.
Here's the PR.