### PR TITLE
gd: bump version and fix build

### DIFF
--- a/media-libs/gd/gd-2.3.0.recipe
+++ b/media-libs/gd/gd-2.3.0.recipe
@@ -4,10 +4,10 @@ by programmers."
 HOMEPAGE="https://www.libgd.org/"
 COPYRIGHT="1999-2017 Pierre-Alain Joye"
 LICENSE="Libgd"
-REVISION="4"
-SOURCE_URI="https://github.com/libgd/libgd/releases/download/gd-$portVersion/libgd-$portVersion.tar.gz"
-CHECKSUM_SHA256="a66111c9b4a04e818e9e2a37d7ae8d4aae0939a100a36b0ffb52c706a09074b5"
-SOURCE_DIR="libgd-$portVersion"
+REVISION="1"
+SOURCE_URI="https://github.com/libgd/libgd/archive/gd-$portVersion.tar.gz"
+CHECKSUM_SHA256="a77dfbbf8bfa7f19c935c11f3b939321f8c1059953a91203158cb2dbf27a0f9e"
+SOURCE_DIR="libgd-gd-$portVersion"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
@@ -27,7 +27,7 @@ PROVIDES="
 	cmd:pngtogd$secondaryArchSuffix
 	cmd:pngtogd2$secondaryArchSuffix
 	cmd:webpng$secondaryArchSuffix
-	lib:libgd$secondaryArchSuffix = 3.0.5 compat >= 3
+	lib:libgd$secondaryArchSuffix = 3.0.8 compat >= 3
 	"
 REQUIRES="
 	haiku${secondaryArchSuffix}
@@ -46,7 +46,7 @@ REQUIRES="
 PROVIDES_devel="
 	gd${secondaryArchSuffix}_devel = $portVersion
 	cmd:gdlib_config$secondaryArchSuffix
-	devel:libgd$secondaryArchSuffix = 3.0.5 compat >= 3
+	devel:libgd$secondaryArchSuffix = 3.0.8 compat >= 3
 	"
 REQUIRES_devel="
 	gd$secondaryArchSuffix == $portVersion base
@@ -102,6 +102,5 @@ INSTALL()
 	fixPkgconfig
 
 	packageEntries devel \
-		$developDir \
-		$binDir/gdlib-config
+		$developDir
 }

--- a/media-libs/gd/gd-2.3.0.recipe
+++ b/media-libs/gd/gd-2.3.0.recipe
@@ -45,7 +45,6 @@ REQUIRES="
 
 PROVIDES_devel="
 	gd${secondaryArchSuffix}_devel = $portVersion
-	cmd:gdlib_config$secondaryArchSuffix
 	devel:libgd$secondaryArchSuffix = 3.0.8 compat >= 3
 	"
 REQUIRES_devel="


### PR DESCRIPTION
use the github archive instead of the official tarball because it misses a file needed by libtool