### PR TITLE
mutagen: update to 1.44

### DIFF
--- a/dev-python/mutagen/mutagen-1.44.0.recipe
+++ b/dev-python/mutagen/mutagen-1.44.0.recipe
@@ -11,7 +11,7 @@ COPYRIGHT="Joe Wreschnig, Michael Urman, Lukáš Lalinský, Christoph Reiter, Be
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/m/$portName/$portName-$portVersion.tar.gz"
-CHECKSUM_SHA256="3a982d39f1b800520a32afdebe3543f972e83a6ddd0c0198739a161ee705b588"
+CHECKSUM_SHA256="56065d8a9ca0bc64610a4d0f37e2bd4453381dde3226b8835ee656faa3287be4"
 SOURCE_DIR="mutagen-$portVersion"
 
 ARCHITECTURES="any"
@@ -27,8 +27,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python python36 python3)
-PYTHON_VERSIONS=(2.7 3.6 3.7)
+PYTHON_PACKAGES=(python36 python3)
+PYTHON_VERSIONS=(3.6 3.7)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -45,7 +45,6 @@ BUILD_PREREQUIRES="$BUILD_PREREQUIRES
 	cmd:python$pythonVersion"
 done
 
-PROVIDES_python="$PROVIDES_python"
 PROVIDES_python36="$PROVIDES_python36"
 PROVIDES_python3="$PROVIDES_python3
 	cmd:mid3cp


### PR DESCRIPTION
Removed building the Python 2 package, it is no longer supported by mutagen.

We could consider keeping the 1.43 version around for Python 2 only, but there is currently no other package depending on it and Python 2 is deprecated for a long time and unsupported now anyway. So my recommendation is to remove the Python 2 package from the mutagen recipe as I've done here.

See https://mutagen.readthedocs.io/en/latest/changelog.html#release-1-44-0 for upstream changelog.