### PR TITLE
New Recipe: fitspng

### DIFF
--- a/sci-astronomy/fitspng/fitspng-1.4.recipe
+++ b/sci-astronomy/fitspng/fitspng-1.4.recipe
@@ -36,7 +36,6 @@ BUILD_PREREQUIRES="
 	cmd:autoreconf
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
-	cmd:aclocal
 	"
 
 BUILD()

--- a/sci-astronomy/fitspng/fitspng-1.4.recipe
+++ b/sci-astronomy/fitspng/fitspng-1.4.recipe
@@ -6,35 +6,42 @@ Fitspng does visualization of such array by converting them to the
 images in PNG format."
 HOMEPAGE="http://integral.physics.muni.cz/fitspng/"
 COPYRIGHT="2006 - 2019, F. Hroch,
-	Institute of Theoretical Physics and Astrophysics,
 	Masaryk University, Brno, Czech Republic."
 LICENSE="GNU GPL v3"
 REVISION="1"
 SOURCE_URI="ftp://integral.physics.muni.cz/pub/fitspng/fitspng-$portVersion.tar.gz"
 CHECKSUM_SHA256="caa7fc2f0c90bbd14b9499a705d74bb07df9f6ecf53454b9614ec3b30459f89e"
+
 ARCHITECTURES="!x86_gcc2 x86_64 ?arm ?ppc ?sparc"
 SECONDARY_ARCHITECTURES="x86"
 
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
 PROVIDES="
-	fitspng${secondaryArchSuffix} = $portVersion
-	cmd:fitspng${secondaryArchSuffix} = $portVersion
+	fitspng$secondaryArchSuffix = $portVersion
+	cmd:fitspng$commandSuffix = $portVersion
 	"
 REQUIRES="
-	haiku${secondaryArchSuffix}
-	lib:libcfitsio${secondaryArchSuffix} >= 3.47
-	lib:libpng${secondaryArchSuffix}
+	haiku$secondaryArchSuffix
+	lib:libcfitsio$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libcfitsio${secondaryArchSuffix} >= 3.47
-	devel:libpng${secondaryArchSuffix}
+	devel:libcfitsio$secondaryArchSuffix
+	devel:libpng16$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:aclocal
 	cmd:autoreconf
 	cmd:awk
-	cmd:gcc${secondaryArchSuffix}
+	cmd:gcc$secondaryArchSuffix
 	cmd:make
 	"
 
@@ -47,7 +54,7 @@ BUILD()
 	CFLAGS="-O4 -DNEBUG"
 
 	autoreconf -vfi
-	runConfigure ./configure
+	runConfigure --omit-dirs binDir ./configure --bindir="$commandBinDir"
 
 	make $jobArgs
 }

--- a/sci-astronomy/fitspng/fitspng-1.4.recipe
+++ b/sci-astronomy/fitspng/fitspng-1.4.recipe
@@ -16,25 +16,25 @@ ARCHITECTURES="!x86_gcc2 x86_64 ?arm ?ppc ?sparc"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	fitspng$secondaryArchSuffix = $portVersion
+	fitspng${secondaryArchSuffix} = $portVersion
 	cmd:fitspng${secondaryArchSuffix} = $portVersion
 	"
 REQUIRES="
-	haiku$secondaryArchSuffix
-	lib:libcfitsio$secondaryArchSuffix >= 3.47
-	lib:libpng$secondaryArchSuffix
+	haiku${secondaryArchSuffix}
+	lib:libcfitsio${secondaryArchSuffix} >= 3.47
+	lib:libpng${secondaryArchSuffix}
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libcfitsio$secondaryArchSuffix >= 3.47
-	devel:libpng$secondaryArchSuffix
+	devel:libcfitsio${secondaryArchSuffix} >= 3.47
+	devel:libpng${secondaryArchSuffix}
 	"
 BUILD_PREREQUIRES="
 	cmd:aclocal
-	cmd:awk
 	cmd:autoreconf
-	cmd:gcc$secondaryArchSuffix
+	cmd:awk
+	cmd:gcc${secondaryArchSuffix}
 	cmd:make
 	"
 
@@ -43,6 +43,8 @@ BUILD()
 	if [ $effectiveTargetArchitecture == x86_64 ]; then
 		GCC5FLAGS="--enable-x86-64"
 	fi
+
+	sed -e 's|LDFLAGS=.*|LDFLAGS="$LDFLAGS"|g' -i configure.ac
 	
 	CFLAGS="-O4 -DNEBUG"
 

--- a/sci-astronomy/fitspng/fitspng-1.4.recipe
+++ b/sci-astronomy/fitspng/fitspng-1.4.recipe
@@ -17,7 +17,7 @@ SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	fitspng$secondaryArchSuffix = $portVersion
-	cmd:fitspng = $portVersion
+	cmd:fitspng${secondaryArchSuffix} = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix

--- a/sci-astronomy/fitspng/fitspng-1.4.recipe
+++ b/sci-astronomy/fitspng/fitspng-1.4.recipe
@@ -45,7 +45,7 @@ BUILD()
 	fi
 
 	sed -e 's|LDFLAGS=.*|LDFLAGS="$LDFLAGS"|g' -i configure.ac
-	
+
 	CFLAGS="-O4 -DNEBUG"
 
 	autoreconf -vfi

--- a/sci-astronomy/fitspng/fitspng-1.4.recipe
+++ b/sci-astronomy/fitspng/fitspng-1.4.recipe
@@ -1,0 +1,59 @@
+SUMMARY="Utility to convert images in astronomical FITS to PNG format"
+DESCRIPTION="FITS format is a general purpose astronomical image format.
+FITS images stores measurements of a physical quantity - an array of the
+angular distribution of the photon events or the optical intensity.
+Fitspng does visualization of such array by converting them to the
+images in PNG format."
+HOMEPAGE="http://integral.physics.muni.cz/fitspng/"
+COPYRIGHT="2006 - 2019, F. Hroch,
+	Institute of Theoretical Physics and Astrophysics,
+	Masaryk University, Brno, Czech Republic."
+LICENSE="GNU GPL v3"
+REVISION="1"
+SOURCE_URI="ftp://integral.physics.muni.cz/pub/fitspng/fitspng-$portVersion.tar.gz"
+CHECKSUM_SHA256="caa7fc2f0c90bbd14b9499a705d74bb07df9f6ecf53454b9614ec3b30459f89e"
+ARCHITECTURES="!x86_gcc2 x86_64 ?arm ?ppc ?sparc"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	fitspng$secondaryArchSuffix = $portVersion
+	cmd:fitspng = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcfitsio$secondaryArchSuffix >= 3.47
+	lib:libpng$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libcfitsio$secondaryArchSuffix >= 3.47
+	devel:libpng$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:awk
+	cmd:autoreconf
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:aclocal
+	"
+
+BUILD()
+{
+	if [ $effectiveTargetArchitecture == x86_64 ]; then
+		GCC5FLAGS="--enable-x86-64"
+	fi
+	
+	CFLAGS="-O4 -DNEBUG"
+
+	autoreconf -vfi
+	runConfigure ./configure
+
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+}

--- a/sci-astronomy/fitspng/fitspng-1.4.recipe
+++ b/sci-astronomy/fitspng/fitspng-1.4.recipe
@@ -44,8 +44,6 @@ BUILD()
 		GCC5FLAGS="--enable-x86-64"
 	fi
 
-	sed -e 's|LDFLAGS=.*|LDFLAGS="$LDFLAGS"|g' -i configure.ac
-
 	CFLAGS="-O4 -DNEBUG"
 
 	autoreconf -vfi


### PR DESCRIPTION
Fitspng is a small posix utility used to convert from astronomical FITS image format to PNG.

Pls note that this PR should be merged first: https://github.com/haikuports/haikuports/pull/4847

This because CFITS version currently in Haikuports has a bug that will prevents fitspng working. That PR fixes this.