### PR TITLE
Rust: new revision of binary Rust 1.43.0 recipe

### DIFF
--- a/dev-lang/rust_bin/rust_bin-1.43.0.recipe
+++ b/dev-lang/rust_bin/rust_bin-1.43.0.recipe
@@ -4,22 +4,22 @@ prevents almost all crashes*, and eliminates data races."
 HOMEPAGE="https://www.rust-lang.org/"
 COPYRIGHT="2020 The Rust Project Developers"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 
 case "$effectiveTargetArchitecture" in
 	x86)
 SOURCE_URI="http://dl.rust-on-haiku.com/dist/$portVersion/rust-$portVersion-i686-unknown-haiku.tar.xz"
-CHECKSUM_SHA256="f7ed469585c3ef89d011d80fbc7824b4643c6a0dd89c9f965cadfcf4dc7c8f86"
+CHECKSUM_SHA256="41ef609e16ea8a237de2a1b6face5d336f20484aba4fb94a386b535c2342fe0c"
 SOURCE_DIR="rust-$portVersion-i686-unknown-haiku"
 		;;
 	x86_64)
 SOURCE_URI="http://dl.rust-on-haiku.com/dist/$portVersion/rust-$portVersion-x86_64-unknown-haiku.tar.xz"
-CHECKSUM_SHA256="c28abfa60abf652014e7e43e86cb9bee086b033d1770503ab910fe7e8c708853"
+CHECKSUM_SHA256="224a5073a03f9408aa5f9eb02058252b73d8f4c9c04d18bd17f1480fc9b8a32e"
 SOURCE_DIR="rust-$portVersion-x86_64-unknown-haiku"
 		;;
 	*)
 SOURCE_URI="http://dl.rust-on-haiku.com/dist/$portVersion/rustc-$portVersion-src.tar.xz"
-CHECKSUM_SHA256="55ffb85d1055258d725d3fc01d9a780fb9e924c805e27f368546f0b5ea292126"
+CHECKSUM_SHA256="a4d15e63d2c72599089e3212f5961653f5c2a8fc2de34de31e221273d2c2fe88"
 SOURCE_DIR="rustc-$portVersion-src"
 		;;
 esac


### PR DESCRIPTION
The previous binary build depended on an older libcurl which was built
against a binary-incompatible openssl version. It did not run on recent
Haiku builds. This build has been tested on recent builds that are close
to Haiku R1 beta 2.