### PR TITLE
melonds_libretro: bump to 0.8.3 ~ 42c1acd

### DIFF
--- a/games-emulation/melonds_libretro/melonds_libretro-0.8.3_20190911.recipe
+++ b/games-emulation/melonds_libretro/melonds_libretro-0.8.3_20190911.recipe
@@ -3,12 +3,12 @@ DESCRIPTION="MelonDS is a Nintendo DS emulator with emphasis on performance. \
 It is attempting to do things 'right and fast' according to its original \
 author. This is the libretro core based of MelonDS."
 HOMEPAGE="http://melonds.kuribo64.net/"
-COPYRIGHT="2016-2018 StapleButter, the libretro team"
+COPYRIGHT="2016-2019 StapleButter, the libretro team"
 LICENSE="GNU GPL v3"
 REVISION="1"
-srcGitRev="154197dbcc60a4bc456ae527e80c1d60c070a7a4"
+srcGitRev="42c1acd5c47dcda17288dcb64ea4adb8e13b8732"
 SOURCE_URI="https://github.com/libretro/melonDS/archive/$srcGitRev.tar.gz"
-CHECKSUM_SHA256="cd35e6759b2f61df6923f994989c2bea139663b6fbcd1adc7305a09889e8f44e"
+CHECKSUM_SHA256="a21581bfdc122cfe740750f8049eb514cb82a8c2a0127a4488d7b7a08f61b0a3"
 SOURCE_FILENAME="melonds-libretro-${portVersion/_/-}-$srcGitRev.tar.gz"
 SOURCE_DIR="melonDS-$srcGitRev"
 ADDITIONAL_FILES="melonds_libretro.info.in"
@@ -27,6 +27,7 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	devel:libGL$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
@@ -36,7 +37,7 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	sed -e "s/@DISPLAY_VERSION@/v${portVersion/_/-}/" \
-		$portDir/additional-files/melonds_libretro.info.in \
+		${portDir}/additional-files/melonds_libretro.info.in \
 		> melonds_libretro.info
 	make $jobArgs
 }


### PR DESCRIPTION
This should resolve #4802 while keeping the current version numbering (libretro cores don't use strict versioning and are often out of sync with the original emulators / games)