### PR TITLE
golang: fixed dead link in HOMEPAGE

### DIFF
--- a/dev-lang/golang/golang-1.4.3.recipe
+++ b/dev-lang/golang/golang-1.4.3.recipe
@@ -9,10 +9,10 @@ modular program construction. Go compiles quickly to machine code yet has the \
 convenience of garbage collection and the power of run-time reflection. It's a \
 fast, statically typed, compiled language that feels like a dynamically typed, \
 interpreted language."
-HOMEPAGE="https://golang.org/go"
+HOMEPAGE="https://golang.org/"
 COPYRIGHT="2009-2018 The Go Authors"
 LICENSE="BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://dl.google.com/go/go$portVersion.src.tar.gz"
 CHECKSUM_SHA256="9947fc705b0b841b5938c48b22dc33e9647ec0752bae66e50278df4f23f64959"
 SOURCE_DIR="go"


### PR DESCRIPTION
`https://golang.org/go` returns 404's, so I replaced it with `https://golang.org/` instead.