### PR TITLE
openssh: Work around first boot user creation bug.

### DIFF
--- a/net-misc/openssh/additional-files/fix_openssh_post_install_usergroup.sh
+++ b/net-misc/openssh/additional-files/fix_openssh_post_install_usergroup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Create the users and groups needed by sshd.  They are part of the package
+# metadata, but that currently (Beta1, Beta2) doesn't work for packages in a
+# newly installed system (the installation actions aren't run since the files
+# are just copied to the new system).  So until running installation stuff
+# on first boot is fixed (Beta3?), redundantly create the user and group in
+# the post-install script, which is run on the first boot by launch_daemon.
+# See https://dev.haiku-os.org/ticket/14382
+
+# Remove the user created by the installer (if it did install), has the wrong group.
+userdel "sshd"
+
+groupadd "sshd"
+useradd -n "sshd user" -d "SubstUserHomeDirHere" -s "/bin/true" -g "sshd" "sshd"

--- a/net-misc/openssh/openssh-8.2p1.recipe
+++ b/net-misc/openssh/openssh-8.2p1.recipe
@@ -50,7 +50,7 @@ POST_INSTALL_SCRIPTS="
 	"
 sshdUserHomeDir="/packages/$portVersionedName-$REVISION/.self/$relativeDataDir/openssh/empty"
 PACKAGE_USERS="
-	sshd real-name \"sshd user\" home \"$sshdUserHomeDir\" shell \"/bin/true\"
+	sshd real-name \"sshd user\" home \"$sshdUserHomeDir\" shell \"/bin/true\" groups \"sshd\"
 	"
 PACKAGE_GROUPS="sshd"
 

--- a/net-misc/openssh/openssh-8.2p1.recipe
+++ b/net-misc/openssh/openssh-8.2p1.recipe
@@ -16,7 +16,7 @@ ssh-keyscan, ssh-keygen and sftp-server."
 HOMEPAGE="http://www.openssh.com/"
 COPYRIGHT="2005-2020 Tatu Ylonen et al."
 LICENSE="OpenSSH"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://ftp.fr.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$portVersion.tar.gz"
 CHECKSUM_SHA256="43925151e6cf6cee1450190c0e9af4dc36b41c12737619edff8bcebdff64e671"
 PATCHES="sshd_config.patch
@@ -28,6 +28,7 @@ PATCHES="sshd_config.patch
 ADDITIONAL_FILES="
 	sshd_keymaker.sh
 	fix_openssh_config_paths.sh
+	fix_openssh_post_install_usergroup.sh
 	"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64 sparc m68k"
@@ -45,6 +46,7 @@ USER_SETTINGS_FILES="
 POST_INSTALL_SCRIPTS="
 	$relativePostInstallDir/sshd_keymaker.sh
 	$relativePostInstallDir/fix_openssh_config_paths.sh
+	$relativePostInstallDir/fix_openssh_post_install_usergroup.sh
 	"
 sshdUserHomeDir="/packages/$portVersionedName-$REVISION/.self/$relativeDataDir/openssh/empty"
 PACKAGE_USERS="
@@ -139,6 +141,10 @@ INSTALL()
 	mkdir -p $postInstallDir
 	cp -f $portDir/additional-files/sshd_keymaker.sh $postInstallDir
 	cp -f $portDir/additional-files/fix_openssh_config_paths.sh $postInstallDir
+	sed -e "s|SubstUserHomeDirHere|$sshdUserHomeDir|" \
+		< "$portDir/additional-files/fix_openssh_post_install_usergroup.sh" \
+		> "$postInstallDir/fix_openssh_post_install_usergroup.sh"
+	chmod a+rx "$postInstallDir/fix_openssh_post_install_usergroup.sh"
 
 	install -m 755 contrib/ssh-copy-id $binDir
 	install -m 644 contrib/ssh-copy-id.1 $manDir/man1


### PR DESCRIPTION
Here's a quick fix for https://dev.haiku-os.org/ticket/14382 where we create the user and group in the post-install script too.  Needed for beta 2.  BTW, couldn't download from https when building in Haiku GCC2, changed URL so it works.