### PR TITLE
New Recipe: Wcslib

### DIFF
--- a/sci-astronomy/wcslib/patches/wcslib-7.2.patchset
+++ b/sci-astronomy/wcslib/patches/wcslib-7.2.patchset
@@ -1,0 +1,22 @@
+From 619f1d199dd6451f82659827792348bfc54d0610 Mon Sep 17 00:00:00 2001
+From: Gabriele Baldassarre <gabriele@gabrielebaldassarre.com>
+Date: Sun, 10 May 2020 22:41:35 +0000
+Subject: Changed -lsocket to -lnetwork
+
+
+diff --git a/configure.ac b/configure.ac
+index 4b5c521..317e90a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -434,7 +434,7 @@ if test "x$with_cfitsio" != xno -o \
+       AC_CHECK_FILE([$INCDIR/fitsio.h], [CFITSIOINC="-I$INCDIR"; break])
+     done
+ 
+-    AC_CHECK_LIB([socket],  [recv],   [CFITSIOLIB="-lsocket"], [], [$LIBS])
++    AC_CHECK_LIB([network],  [recv],   [CFITSIOLIB="-lnetwork"], [], [$LIBS])
+     AC_CHECK_LIB([cfitsio], [ffopen], [CFITSIOLIB="-lcfitsio $CFITSIOLIB"], [],
+                  [$CFITSIOLIB $LIBS])
+ 
+-- 
+2.26.0
+

--- a/sci-astronomy/wcslib/wcslib-7.2.recipe
+++ b/sci-astronomy/wcslib/wcslib-7.2.recipe
@@ -12,7 +12,7 @@ SOURCE_URI="ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-$portVersion.tar.
 CHECKSUM_SHA256="63959eb4859517a1ecca48c91542318bebeed62e4a1663656de9a983af376e39"
 PATCHES="wcslib-$portVersion.patchset"
 
-ARCHITECTURES="x86_gcc2 x86_64 ?arm ?ppc ?sparc"
+ARCHITECTURES="!x86_gcc2 x86_64 ?arm ?ppc ?sparc"
 SECONDARY_ARCHITECTURES="x86"
 
 portVersionCompat="$portVersion compat >= 7.1"
@@ -21,10 +21,6 @@ libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 commandSuffix=$secondaryArchSuffix
 commandBinDir=$binDir
-if [ "$targetArchitecture" = x86_gcc2 ]; then
-	commandSuffix=
-	commandBinDir=$prefix/bin
-fi
 
 PROVIDES="
 	wcslib$secondaryArchSuffix = $portVersionCompat
@@ -33,12 +29,8 @@ PROVIDES="
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libcfitsio$secondaryArchSuffix
-	"
-if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
-REQUIRES+="
 	lib:libgfortran$secondaryArchSuffix
 	"
-fi
 
 PROVIDES_devel="
 	wcslib${secondaryArchSuffix}_devel = $portVersionCompat
@@ -48,12 +40,8 @@ REQUIRES_devel="
 	wcslib$secondaryArchSuffix == $portVersion base
 	haiku$secondaryArchSuffix
 	lib:libcfitsio$secondaryArchSuffix
-	"
-if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
-REQUIRES_devel+="
 	lib:libgfortran$secondaryArchSuffix
 	"
-fi
 
 PROVIDES_utils="
 	wcslib${secondaryArchSuffix}_utils = $portVersion
@@ -65,32 +53,29 @@ REQUIRES_utils="
 	wcslib$secondaryArchSuffix == $portVersion base
 	haiku$secondaryArchSuffix
 	lib:libcfitsio$secondaryArchSuffix
+	lib:libgfortran$secondaryArchSuffix
+	lib:libquadmath$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libcfitsio$secondaryArchSuffix
-	"
-if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
-BUILD_REQUIRES+="
 	devel:libgfortran$secondaryArchSuffix
 	"
-fi
 BUILD_PREREQUIRES="
 	cmd:aclocal
 	cmd:autoreconf
 	cmd:awk
 	cmd:gcc$secondaryArchSuffix
+	cmd:gfortran$secondaryArchSuffix
 	cmd:make
 	cmd:xargs
-	"
-if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
-BUILD_PREREQUIRES+="
-	cmd:gfortran$secondaryArchSuffix
-	"
-fi
+"
 
 defineDebugInfoPackage wcslib$secondaryArchSuffix \
+	"$commandBinDir"/hpxcvt$commandSuffix \
+	"$commandBinDir"/fitshdr$commandSuffix \
+	"$commandBinDir"/wcsware$commandSuffix \
 	"$libDir"/libwcs.so.$libVersion
 
 BUILD()
@@ -110,7 +95,7 @@ INSTALL()
 {
 	make install
 
-	rm -f $libDir/libwcs.a
+	rm -f $libDir/libwcs-7.2.a
 
 	prepareInstalledDevelLib libwcs
 	fixPkgconfig

--- a/sci-astronomy/wcslib/wcslib-7.2.recipe
+++ b/sci-astronomy/wcslib/wcslib-7.2.recipe
@@ -1,0 +1,135 @@
+SUMMARY="Astronomical World Coordinate System transformations library"
+DESCRIPTION="WCSLIB is a C library, supplied with a full set of Fortran wrappers, \
+that implements the World Coordinate System (WCS) convention in FITS \
+(Flexible Image Transport System). Since PGPLOT is not yet available on Haiku,
+this package doesn't include PGBOX (routines for drawing general curvilinear \
+coordinate graticules)."
+HOMEPAGE="http://www.atnf.csiro.au/people/mcalabre/WCS/"
+COPYRIGHT="1995-2020 Mark Calabretta - Australia Telescope National Facility, CSIRO."
+LICENSE="GNU GPL v3"
+REVISION="1"
+SOURCE_URI="ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-$portVersion.tar.bz2"
+CHECKSUM_SHA256="63959eb4859517a1ecca48c91542318bebeed62e4a1663656de9a983af376e39"
+PATCHES="wcslib-$portVersion.patchset"
+
+ARCHITECTURES="x86_gcc2 x86_64 ?arm ?ppc ?sparc"
+SECONDARY_ARCHITECTURES="x86"
+
+portVersionCompat="$portVersion compat >= 7.1"
+libVersion="$portVersion"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+PROVIDES="
+	wcslib$secondaryArchSuffix = $portVersionCompat
+	lib:libwcs$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcfitsio$secondaryArchSuffix
+	"
+if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+REQUIRES+="
+	lib:libgfortran$secondaryArchSuffix
+	"
+fi
+
+PROVIDES_devel="
+	wcslib${secondaryArchSuffix}_devel = $portVersionCompat
+	devel:libwcs$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	wcslib$secondaryArchSuffix == $portVersion base
+	haiku$secondaryArchSuffix
+	lib:libcfitsio$secondaryArchSuffix
+	"
+if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+REQUIRES_devel+="
+	lib:libgfortran$secondaryArchSuffix
+	"
+fi
+
+PROVIDES_utils="
+	wcslib${secondaryArchSuffix}_utils = $portVersion
+	cmd:hpxcvt$secondaryArchSuffix = $portVersionCompat
+	cmd:fitshdr$secondaryArchSuffix = $portVersionCompat
+	cmd:wcsware$secondaryArchSuffix = $portVersionCompat
+	"
+REQUIRES_utils="
+	wcslib$secondaryArchSuffix == $portVersion base
+	haiku$secondaryArchSuffix
+	lib:libcfitsio$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libcfitsio$secondaryArchSuffix
+	"
+if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+BUILD_REQUIRES+="
+	devel:libgfortran$secondaryArchSuffix
+	"
+fi
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoreconf
+	cmd:awk
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:xargs
+	"
+if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+BUILD_PREREQUIRES+="
+	cmd:gfortran$secondaryArchSuffix
+	"
+fi
+
+defineDebugInfoPackage wcslib$secondaryArchSuffix \
+	"$libDir"/libwcs.so.$libVersion
+
+BUILD()
+{
+	autoreconf -vfi
+	runConfigure --omit-dirs binDir ./configure \
+		--bindir="$commandBinDir" \
+		--with-cfitsiolib=`finddir B_SYSTEM_LIB_DIRECTORY` \
+		--with-cfitsioinc=`finddir B_SYSTEM_HEADERS_DIRECTORY` \
+		--without-pgplot \
+		--enable-fortran
+
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	rm -f $libDir/libwcs.a
+
+	prepareInstalledDevelLib libwcs
+	fixPkgconfig
+
+	# copy pdf documentation
+	mkdir -p $developDocDir
+	cp -rd *.pdf $developDocDir
+
+	# copy html documentation
+	cp -rd html $developDocDir/
+
+	# devel package
+	packageEntries devel $developDir
+
+	# utils package
+	packageEntries utils $commandBinDir
+}
+
+TEST()
+{
+	make check $jobArgs
+}

--- a/sci-astronomy/wcslib/wcslib-7.2.recipe
+++ b/sci-astronomy/wcslib/wcslib-7.2.recipe
@@ -21,6 +21,10 @@ libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 commandSuffix=$secondaryArchSuffix
 commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
 
 PROVIDES="
 	wcslib$secondaryArchSuffix = $portVersionCompat
@@ -45,9 +49,9 @@ REQUIRES_devel="
 
 PROVIDES_utils="
 	wcslib${secondaryArchSuffix}_utils = $portVersion
-	cmd:hpxcvt$secondaryArchSuffix = $portVersionCompat
-	cmd:fitshdr$secondaryArchSuffix = $portVersionCompat
-	cmd:wcsware$secondaryArchSuffix = $portVersionCompat
+	cmd:hpxcvt$commandSuffix = $portVersionCompat
+	cmd:fitshdr$commandSuffix = $portVersionCompat
+	cmd:wcsware$commandSuffix = $portVersionCompat
 	"
 REQUIRES_utils="
 	wcslib$secondaryArchSuffix == $portVersion base

--- a/sci-astronomy/wcslib/wcslib-7.2.recipe
+++ b/sci-astronomy/wcslib/wcslib-7.2.recipe
@@ -15,16 +15,16 @@ PATCHES="wcslib-$portVersion.patchset"
 ARCHITECTURES="!x86_gcc2 x86_64 ?arm ?ppc ?sparc"
 SECONDARY_ARCHITECTURES="x86"
 
-portVersionCompat="$portVersion compat >= 7.1"
-libVersion="$portVersion"
-libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
-
 commandSuffix=$secondaryArchSuffix
 commandBinDir=$binDir
 if [ "$targetArchitecture" = x86_gcc2 ]; then
 	commandSuffix=
 	commandBinDir=$prefix/bin
 fi
+
+portVersionCompat="$portVersion compat >= 7.1"
+libVersion="$portVersion"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
 	wcslib$secondaryArchSuffix = $portVersionCompat

--- a/sci-astronomy/wcslib/wcslib-7.2.recipe
+++ b/sci-astronomy/wcslib/wcslib-7.2.recipe
@@ -1,9 +1,9 @@
 SUMMARY="Astronomical World Coordinate System transformations library"
 DESCRIPTION="WCSLIB is a C library, supplied with a full set of Fortran wrappers, \
 that implements the World Coordinate System (WCS) convention in FITS \
-(Flexible Image Transport System). Since PGPLOT is not yet available on Haiku,
+(Flexible Image Transport System). Since PGPLOT is not yet available on Haiku, \
 this package doesn't include PGBOX (routines for drawing general curvilinear \
-coordinate graticules)."
+coordinate graticules) and related utilities."
 HOMEPAGE="http://www.atnf.csiro.au/people/mcalabre/WCS/"
 COPYRIGHT="1995-2020 Mark Calabretta - Australia Telescope National Facility, CSIRO."
 LICENSE="GNU GPL v3"
@@ -73,9 +73,6 @@ BUILD_PREREQUIRES="
 "
 
 defineDebugInfoPackage wcslib$secondaryArchSuffix \
-	"$commandBinDir"/hpxcvt$commandSuffix \
-	"$commandBinDir"/fitshdr$commandSuffix \
-	"$commandBinDir"/wcsware$commandSuffix \
 	"$libDir"/libwcs.so.$libVersion
 
 BUILD()
@@ -100,18 +97,15 @@ INSTALL()
 	prepareInstalledDevelLib libwcs
 	fixPkgconfig
 
-	# copy pdf documentation
-	mkdir -p $developDocDir
-	cp -rd *.pdf $developDocDir
-
-	# copy html documentation
-	cp -rd html $developDocDir/
-
 	# devel package
-	packageEntries devel $developDir
+	packageEntries devel \
+		$docDir \
+		$developDir
 
 	# utils package
-	packageEntries utils $commandBinDir
+	packageEntries utils \
+		$commandBinDir \
+		$manDir
 }
 
 TEST()

--- a/sci-astronomy/wcslib/wcslib-7.2.recipe
+++ b/sci-astronomy/wcslib/wcslib-7.2.recipe
@@ -84,8 +84,8 @@ BUILD()
 	autoreconf -vfi
 	runConfigure --omit-dirs binDir ./configure \
 		--bindir="$commandBinDir" \
-		--with-cfitsiolib=`finddir B_SYSTEM_LIB_DIRECTORY` \
-		--with-cfitsioinc=`finddir B_SYSTEM_HEADERS_DIRECTORY` \
+		--with-cfitsiolib=`finddir B_SYSTEM_LIB_DIRECTORY`${secondaryArchSubDir}  \
+		--with-cfitsioinc=`finddir B_SYSTEM_HEADERS_DIRECTORY`${secondaryArchSubDir}  \
 		--without-pgplot \
 		--enable-fortran
 


### PR DESCRIPTION
WCSLIB is a C library, supplied with a full set of Fortran wrappers, that implements the World Coordinate System (WCS) convention in FITS. Since PGPLOT is not yet available on Haiku, \
this package doesn't include PGBOX (routines for drawing general curvilinear coordinate graticules) and related utilities.

Porting PGPLOT seems to be tricky at first look. I'll probably need much time to port it. That's why I decided to push this library without that (very optional) dependency in the meantime.

SIDE NOTE: I'm not an experienced Fortran dev so there're room for future improvements in this recipe:

- ~~Where exactly the fortran wrappers are supposed to be installed in the tree? Perhaps a sibling package?~~
- ~~I don't know which files must be copied and which files must be not (install doesn't seem to handle these, neither original Gentoo port seems to do)~~