### PR TITLE
Blender: cleanup, release settings, ninja

### DIFF
--- a/media-gfx/blender/blender-2.79b.recipe
+++ b/media-gfx/blender/blender-2.79b.recipe
@@ -156,7 +156,7 @@ BUILD_PREREQUIRES="
 	cmd:find
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
-	cmd:make
+	cmd:ninja
 	cmd:python${PYTHON_VERSION}
 	cmd:sed
 	cmd:strip
@@ -167,7 +167,20 @@ defineDebugInfoPackage blender$secondaryArchSuffix \
 
 BUILD()
 {
-	PORT_SUBFOLDER=`echo $portVersion | sed 's/.$//'`
+	# IMPORTANT INFORMATION, PLEASE READ BEFORE CHANGE ANYTHING.
+
+	# Please do not make any changes here if they not *REALLY* necessary.
+	# Keep this list short and tidy.
+
+	# Blender uses the following settings to produce the official releases:
+	# https://github.com/blender/blender/blob/master/build_files/cmake/config/blender_release.cmake
+	# This settings are used on Haiku too, but we had to override some settings.
+	# We should follow their settings as closely as possible to make interoperability possible between diferent platforms.
+	# In the recipe there are 3 group for the compiler flags:
+	# - platform specific (required to build Blender on Haiku)
+	# - bugous (these settings should work but they breaks build / functionality on Haiku, should be fixed)
+	# - missing deps (required dependency is not (yet) available for Haiku, should be ported)
+	# If a change required please put it in the correct category, if you are unsure, ask at HaikuPorts.
 
 	INCLUDE_DIR="`finddir B_SYSTEM_HEADERS_DIRECTORY`${secondaryArchSubDir}"
 
@@ -207,50 +220,6 @@ BUILD()
 		-DWITH_MEM_JEMALLOC=OFF \
 		-DWITH_INPUT_NDOF=OFF"
 
-	# Release build settings
-	BLENDER_RELEASE="-DWITH_ALEMBIC=ON \
-		-DWITH_BULLET=ON \
-		-DWITH_CODEC_AVI=ON \
-		-DWITH_CODEC_FFMPEG=ON \
-		-DWITH_CODEC_SNDFILE=ON \
-		-DWITH_CYCLES=ON \
-		-DWITH_CYCLES_OPENSUBDIV=ON \
-		-DWITH_CYCLES_OSL=ON \
-		-DWITH_FFTW3=ON \
-		-DWITH_LIBMV=ON \
-		-DWITH_LIBMV_SCHUR_SPECIALIZATIONS=ON \
-		-DWITH_GAMEENGINE=ON \
-		-DWITH_COMPOSITOR=ON \
-		-DWITH_FREESTYLE=ON \
-		-DWITH_GHOST_XDND=ON \
-		-DWITH_IK_SOLVER=ON \
-		-DWITH_IK_ITASC=ON \
-		-DWITH_IMAGE_CINEON=ON \
-		-DWITH_IMAGE_DDS=ON \
-		-DWITH_IMAGE_FRAMESERVER=ON \
-		-DWITH_IMAGE_HDR=ON \
-		-DWITH_IMAGE_OPENEXR=ON \
-		-DWITH_IMAGE_TIFF=ON \
-		-DWITH_INTERNATIONAL=ON \
-		-DWITH_LZMA=ON \
-		-DWITH_LZO=ON \
-		-DWITH_MOD_BOOLEAN=ON \
-		-DWITH_MOD_FLUID=ON \
-		-DWITH_MOD_REMESH=ON \
-		-DWITH_MOD_SMOKE=ON \
-		-DWITH_MOD_OCEANSIM=ON \
-		-DWITH_AUDASPACE=ON \
-		-DWITH_OPENAL=ON \
-		-DWITH_OPENCOLLADA=ON \
-		-DWITH_OPENCOLORIO=ON \
-		-DWITH_OPENMP=ON \
-		-DWITH_OPENVDB=ON \
-		-DWITH_OPENVDB_BLOSC=ON \
-		-DWITH_RAYOPTIMIZATION=ON \
-		-DWITH_SDL=ON \
-		-DWITH_PLAYER=OFF \
-		-DWITH_OPENSUBDIV=ON"
-
 	# Extra CXX Flags
 	BLENDER_CXX="-std=c++11"
 
@@ -258,19 +227,20 @@ BUILD()
 	cd build_haiku
 
 	cmake .. \
+		-G Ninja \
+		-C ../build_files/cmake/config/blender_release.cmake \
 		$BLENDER_PLATFORM_SPECIFIC \
 		$BLENDER_BUGOUS \
 		$BLENDER_MISSING \
-		$BLENDER_RELEASE \
 		-DCMAKE_CXX_FLAGS="$BLENDER_CXX"
 
-	make $jobArgs
+	ninja $jobArgs
 }
 
 INSTALL()
 {
 	cd build_haiku
-	make install $jobArgs
+	ninja install $jobArgs
 
 	mv $appsDir/Blender/blender $appsDir/Blender/Blender
 

--- a/media-gfx/blender/blender-2.79b.recipe
+++ b/media-gfx/blender/blender-2.79b.recipe
@@ -165,6 +165,14 @@ BUILD_PREREQUIRES="
 defineDebugInfoPackage blender$secondaryArchSuffix \
 	$appsDir/Blender/Blender
 
+PATCH()
+{
+	# Blender 2.79 doesn't support Python3.7 correctly
+	# and Python3.6 package doesn't provides cmd:python3.
+	# This should be removed if we switch to Blender 2.8x.
+	find . -type f -name "*.py" | xargs sed -i -e 's,python3,python3.6,g'
+}
+
 BUILD()
 {
 	# IMPORTANT INFORMATION, PLEASE READ BEFORE CHANGE ANYTHING.

--- a/media-gfx/blender/blender-2.79b.recipe
+++ b/media-gfx/blender/blender-2.79b.recipe
@@ -168,7 +168,7 @@ defineDebugInfoPackage blender$secondaryArchSuffix \
 PATCH()
 {
 	# Blender 2.79 doesn't support Python3.7 correctly
-	# and Python3.6 package doesn't provides cmd:python3.
+	# and Python3.6 package doesn't provide cmd:python3.
 	# This should be removed if we switch to Blender 2.8x.
 	find . -type f -name "*.py" | xargs sed -i -e 's,python3,python3.6,g'
 }


### PR DESCRIPTION
It fails during the build stage:
```
[3075/3075] cd /sources/blender-2.79b/...b/build_haiku/source/creator/blender.1
FAILED: source/creator/CMakeFiles/blender_man_page 
cd /sources/blender-2.79b/build_haiku/source/creator && /sources/blender-2.79b/doc/manpage/blender.1.py /sources/blender-2.79b/build_haiku/bin/blender /sources/blender-2.79b/build_haiku/source/creator/blender.1
env: 'python3': No such file or directory
ninja: build stopped: subcommand failed.
```


Blender 2.79 uses Python3.6 (it builds with 3.7, but @X547 reported missing GUI elements). Python3.6 doesn't provides `cmd:python3`, but `cmd:python3.6`.
Tried to create an `alias` in the recipe, but that didn't worked.

Ofc, we can disable the manpage generation, but grepping the source tree shows plenty scripts referring `python3`. Should we `sed` them?