### PR TITLE
Add sys-process/parallel.

### DIFF
--- a/sys-process/parallel/parallel-2020.04.22.recipe
+++ b/sys-process/parallel/parallel-2020.04.22.recipe
@@ -19,24 +19,24 @@ ARCHITECTURES="x86_gcc2 x86 x86_64"
 PROVIDES="
 	parallel = $portVersion
 	cmd:parallel = $portVersion
-	cmd:env_parallel
-	cmd:env_parallel.ash
-	cmd:env_parallel.bash
-	cmd:env_parallel.csh
-	cmd:env_parallel.dash
-	cmd:env_parallel.fish
-	cmd:env_parallel.ksh
-	cmd:env_parallel.mksh
-	cmd:env_parallel.pdksh
-	cmd:env_parallel.sh
-	cmd:env_parallel.tcsh
-	cmd:env_parallel.zsh
-	cmd:niceload
-	cmd:parcat
-	cmd:parset
-	cmd:parsort
-	cmd:sem
-	cmd:sql
+	cmd:env_parallel = $portVersion
+	cmd:env_parallel.ash = $portVersion
+	cmd:env_parallel.bash = $portVersion
+	cmd:env_parallel.csh = $portVersion
+	cmd:env_parallel.dash = $portVersion
+	cmd:env_parallel.fish = $portVersion
+	cmd:env_parallel.ksh = $portVersion
+	cmd:env_parallel.mksh = $portVersion
+	cmd:env_parallel.pdksh = $portVersion
+	cmd:env_parallel.sh = $portVersion
+	cmd:env_parallel.tcsh = $portVersion
+	cmd:env_parallel.zsh = $portVersion
+	cmd:niceload = $portVersion
+	cmd:parcat = $portVersion
+	cmd:parset = $portVersion
+	cmd:parsort = $portVersion
+	cmd:sem = $portVersion
+	cmd:sql = $portVersion
 	"
 REQUIRES="
 	cmd:perl

--- a/sys-process/parallel/parallel-2020.04.22.recipe
+++ b/sys-process/parallel/parallel-2020.04.22.recipe
@@ -1,0 +1,61 @@
+SUMMARY="A shell tool for executing jobs in parallel locally or on remote machines"
+DESCRIPTION="GNU parallel is a shell tool for executing jobs in parallel using one or more computers. A job can be a single command or a small script that has to be run for each of the lines in the input. The typical input is a list of files, a list of hosts, a list of users, a list of URLs, or a list of tables. A job can also be a command that reads from a pipe. GNU parallel can then split the input and pipe it into commands in parallel.
+If you use xargs and tee today you will find GNU parallel very easy to use as GNU parallel is written to have the same options as xargs. If you write loops in shell, you will find GNU parallel may be able to replace most of the loops and make them run faster by running several jobs in parallel.
+
+GNU parallel makes sure output from the commands is the same output as you would get had you run the commands sequentially. This makes it possible to use output from GNU parallel as input for other programs.
+
+For each line of input GNU parallel will execute command with the line as arguments. If no command is given, the line of input is executed. Several lines will be run in parallel. GNU parallel can often be used as a substitute for xargs or cat | bash."
+HOMEPAGE="https://www.gnu.org/software/parallel/"
+COPYRIGHT="2004-2020 Ole Tango"
+LICENSE="GNU GPL v3"
+REVISION="1"
+SOURCE_URI="ftp://ftp.gnu.org/gnu/parallel/parallel-20200422.tar.bz2"
+SOURCE_DIR="parallel-20200422"
+CHECKSUM_SHA256="4bdebf91cc39ea54dec384ad475463cb7c2758fda2ae4a30111e7cfdb3c85530"
+PATCHES="parallel-$portVersion.patchset"
+
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+
+PROVIDES="
+	parallel = $portVersion
+	cmd:parallel = $portVersion
+	cmd:env_parallel
+	cmd:env_parallel.ash
+	cmd:env_parallel.bash
+	cmd:env_parallel.csh
+	cmd:env_parallel.dash
+	cmd:env_parallel.fish
+	cmd:env_parallel.ksh
+	cmd:env_parallel.mksh
+	cmd:env_parallel.pdksh
+	cmd:env_parallel.sh
+	cmd:env_parallel.tcsh
+	cmd:env_parallel.zsh
+	cmd:niceload
+	cmd:parcat
+	cmd:parset
+	cmd:parsort
+	cmd:sem
+	cmd:sql
+	"
+REQUIRES="
+	cmd:perl
+	"
+
+BUILD_REQUIRES="
+"
+BUILD_PREREQUIRES="
+	cmd:make
+	cmd:awk
+	"
+
+BUILD()
+{
+	runConfigure ./configure
+	make
+}
+
+INSTALL()
+{
+	make install
+}

--- a/sys-process/parallel/parallel-2020.04.22.recipe
+++ b/sys-process/parallel/parallel-2020.04.22.recipe
@@ -1,16 +1,30 @@
 SUMMARY="A shell tool for executing jobs in parallel locally or on remote machines"
-DESCRIPTION="GNU parallel is a shell tool for executing jobs in parallel using one or more computers. A job can be a single command or a small script that has to be run for each of the lines in the input. The typical input is a list of files, a list of hosts, a list of users, a list of URLs, or a list of tables. A job can also be a command that reads from a pipe. GNU parallel can then split the input and pipe it into commands in parallel.
-If you use xargs and tee today you will find GNU parallel very easy to use as GNU parallel is written to have the same options as xargs. If you write loops in shell, you will find GNU parallel may be able to replace most of the loops and make them run faster by running several jobs in parallel.
+DESCRIPTION="GNU parallel is a shell tool for executing jobs in parallel using \
+one or more computers. A job can be a single command or a small script that \
+has to be run for each of the lines in the input. The typical input is \
+a list of files, a list of hosts, a list of users, a list of URLs, or a list \
+of tables. A job can also be a command that reads from a pipe. \
+GNU parallel can then split the input and pipe it into commands in parallel.
+If you use xargs and tee today you will find GNU parallel very easy to use \
+as GNU parallel is written to have the same options as xargs. If you write \
+loops in shell, you will find GNU parallel may be able to replace most of \
+the loops and make them run faster by running several jobs in parallel.
 
-GNU parallel makes sure output from the commands is the same output as you would get had you run the commands sequentially. This makes it possible to use output from GNU parallel as input for other programs.
+GNU parallel makes sure output from the commands is the same output as you \
+would get had you run the commands sequentially. \
+This makes it possible to use output from GNU parallel as input \
+for other programs.
 
-For each line of input GNU parallel will execute command with the line as arguments. If no command is given, the line of input is executed. Several lines will be run in parallel. GNU parallel can often be used as a substitute for xargs or cat | bash."
+For each line of input GNU parallel will execute command with the line as \
+arguments. If no command is given, the line of input is executed. \
+Several lines will be run in parallel. GNU parallel can often be used as \
+a substitute for xargs or cat | bash."
 HOMEPAGE="https://www.gnu.org/software/parallel/"
 COPYRIGHT="2004-2020 Ole Tango"
 LICENSE="GNU GPL v3"
 REVISION="1"
-SOURCE_URI="ftp://ftp.gnu.org/gnu/parallel/parallel-20200422.tar.bz2"
-SOURCE_DIR="parallel-20200422"
+SOURCE_URI="ftp://ftp.gnu.org/gnu/parallel/parallel-${portVersion//./}.tar.bz2"
+SOURCE_DIR="parallel-${portVersion//./}"
 CHECKSUM_SHA256="4bdebf91cc39ea54dec384ad475463cb7c2758fda2ae4a30111e7cfdb3c85530"
 PATCHES="parallel-$portVersion.patchset"
 

--- a/sys-process/parallel/patches/parallel-2020.04.22.patchset
+++ b/sys-process/parallel/patches/parallel-2020.04.22.patchset
@@ -1,0 +1,33 @@
+From 8d785ea26c4dda7b1165be3ffb8346c91def6fdc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Przemys=C5=82aw=20S=C5=82aby?= <przemub@przemub.pl>
+Date: Mon, 18 May 2020 18:08:03 +0100
+Subject: [PATCH] Disable ps processing due to Haiku's team/thread model
+
+---
+ src/parallel | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/parallel b/src/parallel
+index 03a3549..8ddd1ef 100755
+--- a/src/parallel
++++ b/src/parallel
+@@ -1732,7 +1732,7 @@ sub parse_options(@) {
+     if($opt::bug) { ::die_bug("test-bug"); }
+     $Global::debug = $opt::D;
+     $Global::shell = $ENV{'PARALLEL_SHELL'} || parent_shell($$)
+-	|| $ENV{'SHELL'} || "/bin/sh";
++	|| $ENV{'SHELL'} || "/bin/bash";
+     if(not -x $Global::shell and not which($Global::shell)) {
+ 	::error("Shell '$Global::shell' not found.");
+ 	wait_and_exit(255);
+@@ -5746,6 +5746,7 @@ sub which(@) {
+ 	     'dragonfly' => $bsd,
+ 	     'freebsd' => $bsd,
+ 	     'gnu' => $sysv,
++	     'haiku' => "echo ps not supported",
+ 	     'hpux' => $sysv,
+ 	     'linux' => $sysv,
+ 	     'mirbsd' => $bsd,
+-- 
+2.26.0
+


### PR DESCRIPTION
Adds a recipe for GNU Parallel, tool to run stuff in parallel :) https://www.gnu.org/software/parallel/

The patch disables failing feature to detect the parent shell of `parallel`. It relies on `ps` but since `parallel` gets launched in a different team I don't see a way to get the name of the process which launched `parallel` from its Haiku output. Therefore I set it to default to `/bin/bash` - user can change it using environment variables `PARALLEL_SHELL` and `SHELL`, as described in parallel's docs.