### PR TITLE
Vim: Get it compiling again in GCC2.

### DIFF
--- a/app-editors/vim/patches/vim-8.2.0803.patchset
+++ b/app-editors/vim/patches/vim-8.2.0803.patchset
@@ -1,0 +1,22 @@
+From 465cc1f2720666f2cd49899156b594239548f78b Mon Sep 17 00:00:00 2001
+From: "Alexander G. M. Smith" <agmsmith@ncf.ca>
+Date: Wed, 20 May 2020 15:57:56 -0400
+Subject: Override Haiku libs using HAIKUGUI_LIBS1 environment variable.
+
+
+diff --git a/src/Makefile b/src/Makefile
+index 9b50eca..7510706 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -1397,7 +1397,7 @@ HAIKUGUI_OBJ	= objects/gui.o objects/gui_haiku.o
+ HAIKUGUI_DEFS	= -DFEAT_GUI_HAIKU
+ HAIKUGUI_IPATH	=
+ HAIKUGUI_LIBS_DIR =
+-HAIKUGUI_LIBS1	= -lbe -lroot -ltracker -ltranslation -lsupc++ -lstdc++
++HAIKUGUI_LIBS1	?= -lbe -lroot -ltracker -ltranslation -lsupc++ -lstdc++
+ HAIKUGUI_LIBS2	=
+ HAIKUGUI_INSTALL = install_normal install_haiku_extra
+ HAIKUGUI_TARGETS	= installglinks_haiku
+-- 
+2.26.0
+

--- a/app-editors/vim/patches/vim-8.2.0803.patchset
+++ b/app-editors/vim/patches/vim-8.2.0803.patchset
@@ -1,19 +1,29 @@
-From 465cc1f2720666f2cd49899156b594239548f78b Mon Sep 17 00:00:00 2001
+From ff7e546a5c20349e42cc0dad282afcf0be69bb43 Mon Sep 17 00:00:00 2001
 From: "Alexander G. M. Smith" <agmsmith@ncf.ca>
 Date: Wed, 20 May 2020 15:57:56 -0400
-Subject: Override Haiku libs using HAIKUGUI_LIBS1 environment variable.
+Subject: Check for GCC compiler version 2 and adjust C++ std libraries to
+ match.
 
 
 diff --git a/src/Makefile b/src/Makefile
-index 9b50eca..7510706 100644
+index 9b50eca..3f644ea 100644
 --- a/src/Makefile
 +++ b/src/Makefile
-@@ -1397,7 +1397,7 @@ HAIKUGUI_OBJ	= objects/gui.o objects/gui_haiku.o
+@@ -1392,12 +1392,17 @@ APPDIR = $(VIMNAME).app
+ CARBONGUI_TESTARG = VIMPROG=../$(APPDIR)/Contents/MacOS/$(VIMTARGET)
+ 
+ ### Haiku GUI
++HAIKUCC_VER	:= $(word 1, $(subst -, , $(subst ., , $(shell $(CC) -dumpversion))))
+ HAIKUGUI_SRC	= gui.c gui_haiku.cc
+ HAIKUGUI_OBJ	= objects/gui.o objects/gui_haiku.o
  HAIKUGUI_DEFS	= -DFEAT_GUI_HAIKU
  HAIKUGUI_IPATH	=
  HAIKUGUI_LIBS_DIR =
--HAIKUGUI_LIBS1	= -lbe -lroot -ltracker -ltranslation -lsupc++ -lstdc++
-+HAIKUGUI_LIBS1	?= -lbe -lroot -ltracker -ltranslation -lsupc++ -lstdc++
++ifeq ($(HAIKUCC_VER),2)
++HAIKUGUI_LIBS1	= -lbe -lroot -ltracker -ltranslation -lstdc++.r4
++else
+ HAIKUGUI_LIBS1	= -lbe -lroot -ltracker -ltranslation -lsupc++ -lstdc++
++endif
  HAIKUGUI_LIBS2	=
  HAIKUGUI_INSTALL = install_normal install_haiku_extra
  HAIKUGUI_TARGETS	= installglinks_haiku

--- a/app-editors/vim/vim-8.2.0803.recipe
+++ b/app-editors/vim/vim-8.2.0803.recipe
@@ -14,18 +14,18 @@ COPYRIGHT="1991-2020 Bram Moleenar et al."
 LICENSE="Vim"
 REVISION="1"
 SOURCE_URI="https://github.com/vim/vim/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="f9105db5caa51addbdc1d4e49ce31760dcd7d5df78df7101798a93aa5c8721f2"
+CHECKSUM_SHA256="cf266b741f54064c8d9cb55855f372f3ca2ee54ea5cb5af76ca9813f28c57736"
 SOURCE_FILENAME="vim-$portVersion.tar.gz"
 
-ARCHITECTURES="!x86_gcc2 x86_64"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+#SECONDARY_ARCHITECTURES="x86"
 
 commandSuffix=$secondaryArchSuffix
 commandBinDir=$binDir
-if [ "$targetArchitecture" = x86_gcc2 ]; then
-	commandSuffix=
-	commandBinDir=$prefix/bin
-fi
+#if [ "$targetArchitecture" == "x86_gcc2" ]; then
+#	commandSuffix=
+#	commandBinDir=$prefix/bin
+#fi
 
 PROVIDES="
 	vim = $portVersion
@@ -51,7 +51,7 @@ REQUIRES="
 	lib:libncurses$secondaryArchSuffix >= 6
 	"
 
-if [ $effectiveTargetArchitecture != "x86_gcc2" ] ; then
+if [ "$effectiveTargetArchitecture" != "x86_gcc2" ] ; then
 	REQUIRES+="
 		lib:libssp$secondaryArchSuffix
 	"
@@ -61,16 +61,11 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libiconv$secondaryArchSuffix
 	devel:libintl$secondaryArchSuffix
-#	devel:liblua$secondaryArchSuffix
 	devel:libncurses$secondaryArchSuffix >= 6
-	devel:libtclstub8.5
 	"
-
-if [ $effectiveTargetArchitecture != "x86_gcc2" ] ; then
-	BUILD_REQUIRES+="
-		devel:libruby$secondaryArchSuffix
-	"
-fi
+#	devel:libtclstub8.5
+#	devel:liblua$secondaryArchSuffix
+#	devel:libruby$secondaryArchSuffix
 
 BUILD_PREREQUIRES="
 	cmd:autoconf
@@ -79,17 +74,28 @@ BUILD_PREREQUIRES="
 	cmd:gettext
 	cmd:grep
 	cmd:make
-#	cmd:perl
 	cmd:pkg_config$secondaryArchSuffix
 	cmd:python3
-	cmd:ruby
 	cmd:sed
+	"
+#	cmd:perl
+#	cmd:ruby
+
+
+PATCHES="
+	vim-8.2.0803.patchset
 	"
 
 BUILD()
 {
 
 # Global ----------------------------------------
+
+	# Override default libs for GCC2 (different C++ libraries).
+	if [ "$effectiveTargetArchitecture" == "x86_gcc2" ] ; then
+		export HAIKUGUI_LIBS1="-lbe -lroot -ltracker -ltranslation -lstdc++.r4"
+		echo "Switching to GCC2 standard C++ libraries for linking, using: $HAIKUGUI_LIBS1"
+	fi
 
 	cd src
 	autoconf
@@ -109,9 +115,11 @@ BUILD()
 		--with-features=huge \
 		--enable-cscope \
 		--enable-pythoninterp=dynamic \
-		--enable-rubyinterp=dynamic \
-		--enable-tclinterp=dynamic \
-		--with-compiledby=Haikuports \
+		--with-compiledby=Haikuports
+# Cut down on external dependencies and compile hassles - remove most
+# interpreters; just leave in python2 since pulkomandy uses it.
+#		--enable-rubyinterp=dynamic \
+#		--enable-tclinterp=dynamic
 #		--enable-luainterp=dynamic
 #		--enable-python3interp=dynamic currently broken
 #		--enable-perlinterp=dynamic not dynamic yet
@@ -127,9 +135,9 @@ BUILD()
 		--with-features=huge \
 		--enable-cscope \
 		--enable-pythoninterp=dynamic \
-		--enable-rubyinterp=dynamic \
-		--enable-tclinterp=dynamic \
-		--with-compiledby=Haikuports \
+		--with-compiledby=Haikuports
+#		--enable-rubyinterp=dynamic
+#		--enable-tclinterp=dynamic
 #		--enable-luainterp=dynamic
 #		--enable-python3interp=dynamic currently broken
 #		--enable-perlinterp=dynamic not dynamic yet

--- a/app-editors/vim/vim-8.2.0803.recipe
+++ b/app-editors/vim/vim-8.2.0803.recipe
@@ -17,7 +17,7 @@ SOURCE_URI="https://github.com/vim/vim/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="cf266b741f54064c8d9cb55855f372f3ca2ee54ea5cb5af76ca9813f28c57736"
 SOURCE_FILENAME="vim-$portVersion.tar.gz"
 
-ARCHITECTURES="x86_gcc2 x86 x86_64"
+ARCHITECTURES="x86_gcc2 x86_64"
 #SECONDARY_ARCHITECTURES="x86"
 
 commandSuffix=$secondaryArchSuffix
@@ -90,12 +90,6 @@ BUILD()
 {
 
 # Global ----------------------------------------
-
-	# Override default libs for GCC2 (different C++ libraries).
-	if [ "$effectiveTargetArchitecture" == "x86_gcc2" ] ; then
-		export HAIKUGUI_LIBS1="-lbe -lroot -ltracker -ltranslation -lstdc++.r4"
-		echo "Switching to GCC2 standard C++ libraries for linking, using: $HAIKUGUI_LIBS1"
-	fi
 
 	cd src
 	autoconf


### PR DESCRIPTION
Fixes #4995 by getting GCC2 builds to work again.  Just needed to hack the linker library list to use different (antique) StdC++ libraries.  Now x86_gcc2, x86, x86_64 all work and build usable packages.

Maybe someone can come up with a better hack, or upstream the Makefile changes.  Includes some Vim source updates from @bitigchi.