### PR TITLE
codeblocks: new recipe

### DIFF
--- a/dev-util/codeblocks/codeblocks-20.03.recipe
+++ b/dev-util/codeblocks/codeblocks-20.03.recipe
@@ -15,8 +15,8 @@ CHECKSUM_SHA256="15eeb3e28aea054e1f38b0c7f4671b4d4d1116fd05f63c07aa95a91db89eaac
 SOURCE_DIR="codeblocks-$portVersion"
 PATCHES="codeblocks-$portVersion.patchset"
 
-ARCHITECTURES="!x86_gcc2 ?x86_64"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="?all !x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
 
 PROVIDES="
 	codeblocks$secondaryArchSuffix = $portVersion

--- a/dev-util/codeblocks/codeblocks-20.03.recipe
+++ b/dev-util/codeblocks/codeblocks-20.03.recipe
@@ -1,0 +1,149 @@
+SUMMARY="A open source, cross platform, free C, C++ and Fortran IDE"
+DESCRIPTION="Code::Blocks is a free C, C++ and Fortran IDE built to meet the most demanding \
+needs of its users. It is designed to be very extensible and fully configurable. \
+Finally, an IDE with all the features you need, having a consistent look, feel \
+and operation across platforms. \
+Built around a plugin framework, Code::Blocks can be extended with plugins. \
+Any kind of functionality can be added by installing/coding a plugin. \
+For instance, compiling and debugging functionality is already provided by plugins!"
+HOMEPAGE="https://codeblocks.org"
+COPYRIGHT="2020 The Code::Blocks team"
+LICENSE="GNU GPL v3"
+REVISION="1"
+SOURCE_URI="http://sourceforge.net/projects/codeblocks/files/Sources/$portVersion/codeblocks-$portVersion.tar.xz"
+CHECKSUM_SHA256="15eeb3e28aea054e1f38b0c7f4671b4d4d1116fd05f63c07aa95a91db89eaac5"
+SOURCE_DIR="codeblocks-$portVersion"
+PATCHES="codeblocks-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 ?x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	codeblocks$secondaryArchSuffix = $portVersion
+	app:CodeBlocks$secondaryArchSuffix = $portVersion
+	cmd:cb_console_runner$secondaryArchSuffix = $portVersion
+	cmd:cb_share_config$secondaryArchSuffix = $portVersion
+	cmd:codeblocks$secondaryArchSuffix = $portVersion
+	lib:libcodeblocks$secondaryArchSuffix = $portVersion
+	lib:codeblocks$secondaryArchSuffix = 0.0.0
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcairo$secondaryArchSuffix
+	lib:libGL$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
+	lib:libQt5Concurrent$secondaryArchSuffix
+	lib:libQt5Core$secondaryArchSuffix
+	lib:libQt5Designer$secondaryArchSuffix
+	lib:libQt5DesignerComponents$secondaryArchSuffix
+	lib:libQt5Gui$secondaryArchSuffix
+	lib:libQt5Help$secondaryArchSuffix
+	lib:libQt5Network$secondaryArchSuffix
+	lib:libQt5PrintSupport$secondaryArchSuffix
+	lib:libQt5Qml$secondaryArchSuffix
+	lib:libQt5Quick$secondaryArchSuffix
+	lib:libQt5QuickWidgets$secondaryArchSuffix
+	lib:libQt5Script$secondaryArchSuffix
+	lib:libQt5Sql$secondaryArchSuffix
+	lib:libQt5Svg$secondaryArchSuffix
+	lib:libQt5Widgets$secondaryArchSuffix
+	lib:libQt5Xml$secondaryArchSuffix
+	lib:libtiff$secondaryArchSuffix
+	lib:libwx_baseu_3.1$secondaryArchSuffix
+	lib:libwx_baseu_net_3.1$secondaryArchSuffix
+	lib:libwx_baseu_xml_3.1$secondaryArchSuffix
+	lib:libwx_qtu_adv_3.1$secondaryArchSuffix
+	lib:libwx_qtu_aui_3.1$secondaryArchSuffix
+	lib:libwx_qtu_core_3.1$secondaryArchSuffix
+	lib:libwx_qtu_html_3.1$secondaryArchSuffix
+	lib:libwx_qtu_media_3.1$secondaryArchSuffix
+	lib:libwx_qtu_propgrid_3.1$secondaryArchSuffix
+	lib:libwx_qtu_qa_3.1$secondaryArchSuffix
+	lib:libwx_qtu_ribbon_3.1$secondaryArchSuffix
+	lib:libwx_qtu_richtext_3.1$secondaryArchSuffix
+	lib:libwx_qtu_stc_3.1$secondaryArchSuffix
+	lib:libwx_qtu_xrc_3.1$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	codeblocks${secondaryArchSuffix}_devel = $portVersion
+	devel:libcodeblocks$secondaryArchSuffix = $portVersion compat >= 1
+	"
+REQUIRES_devel="
+	codeblocks$secondaryArchSuffix == $portVersion base
+	devel:libcodeblocks$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libcairo$secondaryArchSuffix
+	devel:libjpeg$secondaryArchSuffix
+	devel:libGL$secondaryArchSuffix
+	devel:liblzma$secondaryArchSuffix
+	devel:libQt5Concurrent$secondaryArchSuffix
+	devel:libQt5Core$secondaryArchSuffix
+	devel:libQt5Designer$secondaryArchSuffix
+	devel:libQt5DesignerComponents$secondaryArchSuffix
+	devel:libQt5Gui$secondaryArchSuffix
+	devel:libQt5Help$secondaryArchSuffix
+	devel:libQt5Network$secondaryArchSuffix
+	devel:libQt5PrintSupport$secondaryArchSuffix
+	devel:libQt5Qml$secondaryArchSuffix
+	devel:libQt5Quick$secondaryArchSuffix
+	devel:libQt5QuickWidgets$secondaryArchSuffix
+	devel:libQt5Script$secondaryArchSuffix
+	devel:libQt5Sql$secondaryArchSuffix
+	devel:libQt5Svg$secondaryArchSuffix
+	devel:libQt5Widgets$secondaryArchSuffix
+	devel:libQt5Xml$secondaryArchSuffix
+	devel:libpng16$secondaryArchSuffix
+	devel:libtiff$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	wxqt${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:automake
+	cmd:autoconf
+	cmd:g++$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:m4
+	cmd:make
+	cmd:python2
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:which
+	cmd:zip
+	"
+
+BUILD()
+{
+	libtoolize -fci
+
+	aclocal -I m4
+
+	automake --add-missing --force-missing
+
+	runConfigure ./configure --enable-compiler=yes \
+				--enable-debugger=yes --prefix=$prefix \
+				--libdir=$libDir --mandir=$manDir/man1 \
+				--bindir=$binDir --datadir=$dataDir \
+	--with-contrib-plugins=`yes,-DoxyBlocks,-keybinder,-dragscroll,-FileManager,-NassiShneiderman,-spellchecker,-wxsmith,-wxsmithcontrib,-wxcontrib,-wxsmithaui`
+
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	mkdir -p $appsDir
+
+	ln -s $prefix/bin/codeblocks $appsDir/CodeBlocks
+	addAppDeskbarSymlink $appsDir/CodeBlocks
+
+	prepareInstalledDevelLib libcodeblocks
+
+	packageEntries devel \
+		$developDir
+}

--- a/dev-util/codeblocks/patches/codeblocks-20.03.patchset
+++ b/dev-util/codeblocks/patches/codeblocks-20.03.patchset
@@ -1,0 +1,50 @@
+From 90a82a200e423868a2b6e607b02c933c2cd7576a Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Tue, 12 May 2020 17:26:53 +0000
+Subject: codeblocks: Fix build by defining wxqt
+
+
+diff --git a/src/src/app.h b/src/src/app.h
+index d9808a9..f89dd51 100644
+--- a/src/src/app.h
++++ b/src/src/app.h
+@@ -22,7 +22,7 @@
+     #include <wx/docview.h> // recent files history
+ #endif
+ 
+-#if defined(__WXGTK__) || defined(__WXMOTIF__) || defined(__WXMAC__) || defined(__WXMGL__) || defined(__WXX11__)
++#if defined(__WXGTK__) || defined(__WXMOTIF__) || defined(__WXMAC__) || defined(__WXMGL__) || defined(__WXX11__) || defined(__WXQT__)
+     #include "resources/icons/app.xpm"
+ #endif
+ 
+-- 
+2.26.0
+
+
+From f6bf52b28d6702629a153a4df2a0b74156d91cfd Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Sat, 23 May 2020 02:29:41 +0100
+Subject: codeblocks: Use /data/codeblocks to load resources.zip
+
+
+diff --git a/src/src/app.cpp b/src/src/app.cpp
+index 4ec80b1..a1370b7 100644
+--- a/src/src/app.cpp
++++ b/src/src/app.cpp
+@@ -412,7 +412,11 @@ bool CodeBlocksApp::LoadConfig()
+             data = env;
+     }
+ 
+-    data.append(_T("/share/codeblocks"));
++    #if defined(__HAIKU__)
++        data.append(_T("/data/codeblocks"));
++    #else
++        data.append(_T("/share/codeblocks"));
++    #endif
+ 
+     // Make sure the path to our resources is always an absolute path, because resource loading
+     // would fail with a relative path if some part of the code changes the current working
+-- 
+2.26.0
+
+


### PR DESCRIPTION
This is an initial work in progress recipe for CodeBlocks and addresses #2797 and I have disabled this recipe by default (Needs some improvements to wxqt first.)

First it soft-crashes after the splash screen on a missing implementation in the wxqt port.

![screenshot-23](https://user-images.githubusercontent.com/7050293/82735017-75d5ab00-9d16-11ea-9b2e-85bef36f2fcc.png)

If you skip and continue running CodeBlocks, the IDE will show up. But closing down the editor will hard crash the app (wxqt related). See: https://gist.github.com/return/e58b55c65300b88d8ee13709ca9857f4 for the report.

![screenshot2](https://user-images.githubusercontent.com/7050293/82735045-baf9dd00-9d16-11ea-8bb4-f351ec306d9d.png)

Mark this as WIP.