### PR TITLE
Cascadia Code: Rename package

### DIFF
--- a/media-fonts/cascadia_code/cascadia_code-2005.15.recipe
+++ b/media-fonts/cascadia_code/cascadia_code-2005.15.recipe
@@ -13,7 +13,7 @@ SOURCE_DIR="otf"
 ARCHITECTURES="any"
 DISABLE_SOURCE_PACKAGE="yes"
 
-PROVIDES="cascadia = $portVersion"
+PROVIDES="cascadia_code = $portVersion"
 REQUIRES=""
 
 BUILD_REQUIRES=""


### PR DESCRIPTION
Correct name is cascadia_code, not cascadia only.