### PR TITLE
[New Recipe] Acme Cross-Assembler for 65**

### DIFF
--- a/dev-lang/acme/acme-0.96.5.recipe
+++ b/dev-lang/acme/acme-0.96.5.recipe
@@ -62,7 +62,7 @@ INSTALL()
 	# copy documentation
 	mkdir -p $docDir/acme
 	mkdir -p $docDir/toacme
-	
+
 	cp -rd docs/* $docDir/acme
 	cp -rd contrib/toacme/docs/* $docDir/toacme
 	cp -rd examples $docDir/

--- a/dev-lang/acme/acme-0.96.5.recipe
+++ b/dev-lang/acme/acme-0.96.5.recipe
@@ -38,6 +38,7 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
+	cmd:sed
 	"
 
 TEST_REQUIRES="

--- a/dev-lang/acme/acme-0.96.5.recipe
+++ b/dev-lang/acme/acme-0.96.5.recipe
@@ -44,11 +44,14 @@ TEST_REQUIRES="
 	cmd:test
 	"
 
-BUILD()
+PATCH()
 {
 	sed -i "s|/usr/local/bin|$commandBinDir|g" src/Makefile
 	sed -i "s|/usr/local/bin|$commandBinDir|g" contrib/toacme/src/Makefile
+}
 
+BUILD()
+{
 	make -C src $jobArgs all
 	make -C contrib/toacme/src $jobArgs all
 }

--- a/dev-lang/acme/acme-0.96.5.recipe
+++ b/dev-lang/acme/acme-0.96.5.recipe
@@ -58,7 +58,7 @@ INSTALL()
 {
 	make -C src install
 	make -C contrib/toacme/src install
-	
+
 	# copy documentation
 	mkdir -p $docDir/acme
 	mkdir -p $docDir/toacme

--- a/dev-lang/acme/acme-0.96.5.recipe
+++ b/dev-lang/acme/acme-0.96.5.recipe
@@ -1,0 +1,86 @@
+SUMMARY="Multi-platform cross assembler for 6502/6510/65816 CPU"
+DESCRIPTION="ACME is a free cross assembler that can produce code for the following processors: \
+6502, 6510 (including illegal opcodes), 65c02 and 65816.
+ACME supports the standard assembler stuff like global/local/anonymous labels, \
+offset assembly, conditional assembly and looping assembly. \
+It can include other source files as well as binaries while assembling. \
+Calculations can be done in integer or float mode."
+HOMEPAGE="http://sourceforge.net/p/acme-crossass/"
+COPYRIGHT="2012-2020 Marco Baye"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="https://sourceforge.net/code-snapshots/svn/a/ac/acme-crossass/code-0/acme-crossass-code-0-r190-trunk.zip"
+CHECKSUM_SHA256="f9831fc85639788c0943f9fa0d56dbea03e7162570388d5bdaee75a65c30e008"
+SOURCE_DIR="acme-crossass-code-0-r190-trunk"
+
+ARCHITECTURES="!x86_gcc2 x86_64 ?arm ?ppc ?sparc"
+SECONDARY_ARCHITECTURES="x86"
+
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+PROVIDES="
+	acme$secondaryArchSuffix = $portVersion
+	cmd:acme$secondaryArchSuffix = $portVersion
+	cmd:toacme$commandSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	"
+
+TEST_REQUIRES="
+	cmd:test
+	"
+
+BUILD()
+{
+	sed -i "s|/usr/local/bin|$commandBinDir|g" src/Makefile
+	sed -i "s|/usr/local/bin|$commandBinDir|g" contrib/toacme/src/Makefile
+
+	make -C src $jobArgs all
+	make -C contrib/toacme/src $jobArgs all
+}
+
+
+INSTALL()
+{
+	make -C src install
+	make -C contrib/toacme/src install
+	
+	# copy documentation
+	mkdir -p $docDir/acme
+	mkdir -p $docDir/toacme
+
+	cp -rd docs/* $docDir/acme
+	cp -rd contrib/toacme/docs/* $docDir/toacme
+	cp -rd examples $docDir/
+
+	# copy the ACME_Lib and the syntax file for joe
+	mkdir -p $dataDir
+	cp -rd ACME_Lib $dataDir
+}
+
+TEST()
+{
+	sed -i "s| acme| $sourceDir/src/acme|g" examples/Makefile
+
+	ACME=$sourceDir/ACME_Lib make -C examples $jobArgs
+
+	declare -a testfiles=("ddrv128.prg" "ddrv64.prg" "macedit.o" "trigono.o")
+	for i in "${testfiles[@]}"
+	do
+		test -f examples/${i}
+	done
+}


### PR DESCRIPTION
ACME is a free cross assembler that can produce code for the following processors: \
6502, 6510 (including illegal opcodes), 65c02 and 65816.

I've ported the assembler and the migration tool. I've added some tests using the provided code examples, too.

Source code is packaged very badly. I had no choice other than binding to a particular commit (r190)

tested on x86_64, but the code looks like to be completely portable.