### PR TITLE
cfitsio: bump to 3.48

### DIFF
--- a/sci-libs/cfitsio/cfitsio-3.48.recipe
+++ b/sci-libs/cfitsio/cfitsio-3.48.recipe
@@ -1,21 +1,32 @@
 SUMMARY="A FITS File Subroutine Library"
-DESCRIPTION="CFITSIO is a library of ANSI C routines for reading and writing
-FITS format data files.  A set of Fortran-callable wrapper routines are also
+DESCRIPTION="CFITSIO is a library of ANSI C routines for reading and writing \
+FITS format data files. A set of Fortran-callable wrapper routines are also \
 included for the convenience of Fortran programmers."
 HOMEPAGE="https://heasarc.gsfc.nasa.gov/docs/software/fitsio/fitsio.html"
 COPYRIGHT="1996-2019 William D. Pence - HEASARC, NASA/GSFC"
 LICENSE="CFITSIO"
-REVISION="3"
+REVISION="1"
 SOURCE_URI="http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-$portVersion.tar.gz"
-CHECKSUM_SHA256="418516f10ee1e0f1b520926eeca6b77ce639bed88804c7c545e74f26b3edf4ef"
+CHECKSUM_SHA256="91b48ffef544eb8ea3908543052331072c99bf09ceb139cb3c6977fc3e47aac1"
 PATCHES="cfitsio-$portVersion.patchset"
 
 ARCHITECTURES="!x86_gcc2 x86_64 ?arm ?ppc ?sparc"
 SECONDARY_ARCHITECTURES="x86"
 
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+portVersionCompat="$portVersion compat >= ${portVersion%%.*}"
+libVersion="9.3.48"
+libVersionCompat="$libVersion compat >= ${libVersion%.*.*}"
+
 PROVIDES="
-	cfitsio$secondaryArchSuffix = $portVersion
-	lib:libcfitsio$secondaryArchSuffix = $portVersion
+	cfitsio$secondaryArchSuffix = $portVersionCompat
+	lib:libcfitsio$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -29,8 +40,8 @@ REQUIRES="
 	"
 
 PROVIDES_devel="
-	cfitsio${secondaryArchSuffix}_devel = $portVersion
-	devel:libcfitsio$secondaryArchSuffix = $portVersion
+	cfitsio${secondaryArchSuffix}_devel = $portVersionCompat
+	devel:libcfitsio$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
 	cfitsio$secondaryArchSuffix == $portVersion base
@@ -45,9 +56,9 @@ REQUIRES_devel="
 	"
 
 PROVIDES_utils="
-	cfitsio${secondaryArchSuffix}_utils = $portVersion
-	cmd:fpack$secondaryArchSuffix = $portVersion
-	cmd:funpack$secondaryArchSuffix = $portVersion
+	cfitsio${secondaryArchSuffix}_utils = $portVersionCompat
+	cmd:fpack$commandSuffix = $portVersionCompat
+	cmd:funpack$commandSuffix = $portVersionCompat
 	"
 REQUIRES_utils="
 	cfitsio$secondaryArchSuffix == $portVersion base
@@ -74,6 +85,9 @@ TEST_REQUIRES="
 	cmd:diff
 	"
 
+defineDebugInfoPackage cfitsio$secondaryArchSuffix \
+	"$libDir"/libcfitsio.so.$libVersion
+
 BUILD()
 {
 	WITHSSE=""
@@ -85,7 +99,9 @@ BUILD()
 	sed -e 's|LDFLAGS=.*|LDFLAGS="$LDFLAGS"|g' -i configure.in
 
 	autoreconf -vfi
-	runConfigure ./configure --enable-reentrant --with-bzip2 $WITHSSE
+	runConfigure --omit-dirs binDir ./configure \
+		--enable-reentrant \
+		--with-bzip2 $WITHSSE
 
 	make $jobArgs
 	make utils $jobArgs

--- a/sci-libs/cfitsio/cfitsio-3.48.recipe
+++ b/sci-libs/cfitsio/cfitsio-3.48.recipe
@@ -100,6 +100,7 @@ BUILD()
 
 	autoreconf -vfi
 	runConfigure --omit-dirs binDir ./configure \
+		--bindir="$commandBinDir" \
 		--enable-reentrant \
 		--with-bzip2 $WITHSSE
 

--- a/sci-libs/cfitsio/patches/cfitsio-3.48.patchset
+++ b/sci-libs/cfitsio/patches/cfitsio-3.48.patchset
@@ -1,0 +1,82 @@
+From 08ec4c96a44d501b7c1e0cfe01f7a54b9355aedb Mon Sep 17 00:00:00 2001
+From: Gabriele Baldassarre <gabriele@gabrielebaldassarre.com>
+Date: Mon, 25 May 2020 23:11:01 +0000
+Subject: Added Haiku support to autotools
+
+
+diff --git a/Makefile.in b/Makefile.in
+index a0fbe2f..d546675 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -119,7 +119,7 @@ install:	lib${PACKAGE}.a ${INSTALL_DIRS}
+ 		done
+ 		/bin/cp fitsio.h fitsio2.h longnam.h drvrsmem.h ${CFITSIO_INCLUDE}
+ 		/bin/cp cfitsio.pc ${CFITSIO_LIB}/pkgconfig
+-		@for task in ${FPACK_UTILS} ${UTILS}; do \
++		@for task in ${FPACK_UTILS}; do \
+ 		    if [ -f $$task ]; then \
+ 			if [ ! -d ${CFITSIO_BIN} ]; then mkdir -p ${CFITSIO_BIN}; fi; \
+ 			echo "/bin/cp $$task ${CFITSIO_BIN}"; \
+@@ -134,7 +134,7 @@ UTILS		= cookbook fitscopy imcopy smem speed testprog
+ 
+ FPACK_UTILS	= fpack funpack
+ 
+-utils:		${FPACK_UTILS} ${UTILS}
++utils:		${FPACK_UTILS}
+ 
+ swapproc.o:	swapproc.c
+ 		${CC} -c ${CFLAGS} ${CPPFLAGS} ${SSE_FLAGS} ${DEFS} $<
+diff --git a/configure.in b/configure.in
+index 39414bd..866bf14 100644
+--- a/configure.in
++++ b/configure.in
+@@ -146,6 +146,11 @@ case $host in
+ 	ARCH="hp"
+ 	EXT="hpu"
+ 	;;
++    *haiku*)
++  # Haiku can be arm, i386 or x86_64
++  ARCH=`uname -p`
++  EXT="haiku"
++  ;;
+     *irix*)
+ 	ARCH="sgi"
+ 	EXT="sgi"
+@@ -319,6 +324,11 @@ case $host in
+         # LDFLAGS used by utilities:
+         LDFLAGS_BIN="$LDFLAGS_BIN -Wl,-rpath,\${CFITSIO_LIB}"
+ 	;;
++    *haiku*)
++        # For large file support:
++        AC_DEFINE(_LARGEFILE_SOURCE)
++        AC_DEFINE(_FILE_OFFSET_BITS,64)
++  ;;
+     *mingw32*)
+         AC_MSG_CHECKING([for large file support])
+         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <stdio.h>],
+@@ -425,6 +435,11 @@ case $EXT in
+     CFITSIO_SHLIB="lib\${PACKAGE}\${SHLIB_SUFFIX}.\${CFITSIO_SONAME}.\${CFITSIO_MAJOR}.\${CFITSIO_MINOR}"
+     CFITSIO_SHLIB_SONAME="lib\${PACKAGE}\${SHLIB_SUFFIX}.\${CFITSIO_SONAME}"
+     ;;
++  haiku)
++    SHLIB_LD=":"
++    CFITSIO_SHLIB="lib\${PACKAGE}\${SHLIB_SUFFIX}.\${CFITSIO_SONAME}.\${CFITSIO_MAJOR}.\${CFITSIO_MINOR}"
++    CFITSIO_SHLIB_SONAME="lib\${PACKAGE}\${SHLIB_SUFFIX}.\${CFITSIO_SONAME}"
++    ;;
+   osf)
+     SHLIB_LD="ld -shared -expect_unresolved '*'"
+     LD_FLAGS="-taso"
+@@ -632,8 +647,8 @@ AC_CHECK_FUNC(fmemopen, AC_DEFINE(HAVE_FMEMOPEN), [AC_MSG_WARN(Disabling support
+ # ==================== END OF SHARED MEMORY DRIVER SECTION ================
+ # ================= test for the unix networking functions ================
+ 
+-AC_SEARCH_LIBS([gethostbyname], [nsl], cfitsio_have_nsl=1, cfitsio_have_nsl=0)
+-AC_SEARCH_LIBS([connect], [socket], cfitsio_have_socket=1,
++AC_SEARCH_LIBS([gethostbyname], [nsl network], cfitsio_have_nsl=1, cfitsio_have_nsl=0)
++AC_SEARCH_LIBS([connect], [socket network], cfitsio_have_socket=1,
+                cfitsio_have_socket=0, [-lnsl])
+ 
+ if test "$cfitsio_have_nsl" = 1 -a "$cfitsio_have_socket" = 1; then
+-- 
+2.26.0
+


### PR DESCRIPTION
They changed the library interface and (finally) added a soname versioning scheme. So, $libVersion had to be added.

I also devoted a general bit more love to the port