### PR TITLE
64tass: new recipe

### DIFF
--- a/dev-lang/64tass/64tass-1.55.recipe
+++ b/dev-lang/64tass/64tass-1.55.recipe
@@ -1,0 +1,64 @@
+SUMMARY="Multi pass optimizing macro assembler for the 65xx series of processors"
+DESCRIPTION="64tass is cross assembler targeting the 65xx series of micro processors \
+which features the familiar syntax of Omicron TASS and TASM"
+HOMEPAGE="https://sourceforge.net/projects/tass64/"
+COPYRIGHT="2013-2020 Soci/Singular
+	1997-2001 Benjamin Sittler"
+LICENSE="GNU LGPL v2.1
+	my_getopt"
+REVISION="1"
+SOURCE_URI="https://github.com/irmen/64tass/archive/v$portVersion.2202.tar.gz"
+CHECKSUM_SHA256="c9222531a711cf7f23fe0294dd953c2a7cda37f84070fdaeaf8c83a7284cc582"
+SOURCE_DIR="64tass-$portVersion.2202"
+
+ARCHITECTURES="!x86_gcc2 x86_64 ?arm ?ppc ?sparc"
+SECONDARY_ARCHITECTURES="x86"
+
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+portVersionCompat="$portVersion compat >= ${portVersion%%.*}"
+
+PROVIDES="
+	64tass$secondaryArchSuffix = $portVersionCompat
+	cmd:64tass$secondaryArchSuffix = $portVersionCompat"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:svnversion
+	cmd:which
+	"
+
+PATCH()
+{
+	sed -i "s|\$(exec_prefix)/bin|$commandBinDir|g" Makefile
+	sed -i "s|\$(prefix)/share|$dataRootDir|g" Makefile
+	sed -i "s|\$(datarootdir)/man|$manDir|g" Makefile
+	sed -i "s|\$(datarootdir)/doc/\$(TARGET)|$docDir|g" Makefile
+	sed -i "s|/usr/bin/install|`which install`|g" Makefile
+	sed -i "s|\sLICENSE-L\{0,1\}GPL-2.[0-1]||g;s|\sLICENSE-my_getopt||g" Makefile
+}
+
+BUILD()
+{
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install $jobArgs
+	
+	mkdir -p $dataDir/vim/vim82/syntax
+	cp -r syntax/vim/syntax/*.vim $dataDir/vim/vim82/syntax
+}

--- a/dev-lang/64tass/64tass-1.55.recipe
+++ b/dev-lang/64tass/64tass-1.55.recipe
@@ -37,7 +37,6 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:gzip
 	cmd:make
-	cmd:svnversion
 	cmd:which
 	"
 

--- a/dev-lang/64tass/64tass-1.55.recipe
+++ b/dev-lang/64tass/64tass-1.55.recipe
@@ -59,9 +59,10 @@ BUILD()
 INSTALL()
 {
 	make install $jobArgs
-	
+
 	# vim syntax
-	# TODO: better version checking
+	# TODO: better version checking, still ok until
+	# we are on the 8.2 branch or we repackage vim itself
 	mkdir -p $dataDir/vim/vim82/syntax
 	cp -r syntax/vim/syntax/*.vim $dataDir/vim/vim82/syntax
 }

--- a/dev-lang/64tass/64tass-1.55.recipe
+++ b/dev-lang/64tass/64tass-1.55.recipe
@@ -1,6 +1,6 @@
 SUMMARY="Multi pass optimizing macro assembler for the 65xx series of processors"
 DESCRIPTION="64tass is cross assembler targeting the 65xx series of micro processors \
-which features the familiar syntax of Omicron TASS and TASM"
+which features the familiar syntax of Omicron TASS and TASM."
 HOMEPAGE="https://sourceforge.net/projects/tass64/"
 COPYRIGHT="2013-2020 Soci/Singular
 	1997-2001 Benjamin Sittler"
@@ -35,6 +35,7 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
+	cmd:gzip
 	cmd:make
 	cmd:svnversion
 	cmd:which
@@ -59,6 +60,8 @@ INSTALL()
 {
 	make install $jobArgs
 	
+	# vim syntax
+	# TODO: better version checking
 	mkdir -p $dataDir/vim/vim82/syntax
 	cp -r syntax/vim/syntax/*.vim $dataDir/vim/vim82/syntax
 }

--- a/dev-lang/64tass/licenses/my_getopt
+++ b/dev-lang/64tass/licenses/my_getopt
@@ -1,0 +1,22 @@
+my_getopt - a command-line argument parser
+Copyright 1997-2001, Benjamin Sittler
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
64tass is cross assembler targeting the 65xx series of micro processors which features the familiar syntax of Omicron TASS and TASM, one of the most popular assembler on C64 during the 80s and 90s.

Port is working perfectly, but has two small defects:

- Licensing is a bit confused. Main package is LGPL, but an embedded component has a custom one (provided) which I'm not sure is compatible with LGPL itself. No real names are provided (but demo scener/crew nicknames)

- In the INSTALL() block I copy the syntax file to vim settings dir. A better version check should be made here to proof which version of vim is installed. Have I to use a post install script?
