### PR TITLE
acr: bump to 1.9.2

### DIFF
--- a/dev-util/acr/acr-1.9.2.recipe
+++ b/dev-util/acr/acr-1.9.2.recipe
@@ -7,7 +7,7 @@ COPYRIGHT="2005-2019 pancake"
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://github.com/radare/acr/archive/$portVersion.tar.gz"
-CHECKSUM_SHA256="93571bc141b53f838fb40f6e53f958c56b6abf7520d151874e8707db7cb9c4c6"
+CHECKSUM_SHA256="ac4c01cf189c8d7556f3424dfaaed0aab922b1deaac891bafbeef40a18c4226f"
 
 ARCHITECTURES="x86_gcc2 ?x86 x86_64 ?arm"
 


### PR DESCRIPTION
business as usual, here