### PR TITLE
curl: bump to 7.70.0

### DIFF
--- a/net-misc/curl/curl-7.70.0.recipe
+++ b/net-misc/curl/curl-7.70.0.recipe
@@ -11,7 +11,7 @@ COPYRIGHT="1996-2020 Daniel Stenberg"
 LICENSE="Curl"
 REVISION="2"
 SOURCE_URI="https://curl.haxx.se/download/curl-$portVersion.tar.bz2"
-CHECKSUM_SHA256="2ff5e5bd507adf6aa88ff4bbafd4c7af464867ffb688be93b9930717a56c4de8"
+CHECKSUM_SHA256="a50bfe62ad67a24f8b12dd7fd655ac43a0f0299f86ec45b11354f25fbb5829d0"
 ADDITIONAL_FILES="curl.rdef"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64 ?arm ?ppc sparc m68k"


### PR DESCRIPTION
Test n. 116 fails, dunno if it is blocking or not as there's nothing relevant on curl changelog about it

aside that, business as usual.