### PR TITLE
armadillo: bump to 9.880.3

### DIFF
--- a/sci-libs/armadillo/armadillo-9.880.1.recipe
+++ b/sci-libs/armadillo/armadillo-9.880.1.recipe
@@ -64,6 +64,12 @@ BUILD_PREREQUIRES="
 defineDebugInfoPackage armadillo$secondaryArchSuffix \
 	"$libDir"/libarmadillo.so.$libVersion
 
+PATCH()
+{
+	# Enable some optional features
+	sed --regexp-extended -i '/ARMA_USE_(SUPERLU|ARPACK)/s/^\/\///g' include/armadillo_bits/config.hpp
+}
+
 BUILD()
 {
 	mkdir -p build && cd "$_"
@@ -99,9 +105,12 @@ INSTALL()
 
 TEST()
 {
-	sed -i "s|LIB_FLAGS = -larmadillo|LIB_FLAGS = -lopenblas -llapack -larmadillo -L$sourceDir/build|g" tests/Makefile
-	
+	export LIBRARY_PATH=$LIBRARY_PATH:$sourceDir/build
 	export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:$sourceDir/include
 	
+	sed -i "s|LIB_FLAGS = -larmadillo|LIB_FLAGS = -lopenblas -llapack -larpack -lsuperlu -larmadillo -L$sourceDir/build|g" tests/Makefile
+	
 	make -C tests all $jobArgs
+	
+	./tests/main
 }

--- a/sci-libs/armadillo/armadillo-9.880.1.recipe
+++ b/sci-libs/armadillo/armadillo-9.880.1.recipe
@@ -11,7 +11,7 @@ COPYRIGHT="2008-2019 Conrad Sanderson
 LICENSE="Apache v2"
 REVISION="1"
 SOURCE_URI="https://downloads.sourceforge.net/arma/armadillo-$portVersion.tar.xz"
-CHECKSUM_SHA256="a481e1dc880b7cb352f8a28b67fe005dc1117d4341277f12999a2355d40d7599"
+CHECKSUM_SHA256="900f3e8d35d8b722217bed979fa618faf6f3e4f56964c887a1fce44c3d4c4b9f"
 SOURCE_DIR="armadillo-$portVersion"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
@@ -99,7 +99,9 @@ INSTALL()
 
 TEST()
 {
-	#make test
-	# Armadillo provides no tests through cmake AFAIK
-	true
+	sed -i "s|LIB_FLAGS = -larmadillo|LIB_FLAGS = -lopenblas -llapack -larmadillo -L$sourceDir/build|g" tests/Makefile
+	
+	export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:$sourceDir/include
+	
+	make -C tests all $jobArgs
 }


### PR DESCRIPTION
Changelog:

- bump to 9.880.3
- added a test block
- (fix) added a couple of optional requirements which were already in the recipe but were not enabled at build