### PR TITLE
Aranym: bump to 1.1.0

### DIFF
--- a/app-emulation/aranym/aranym-1.0.2.recipe
+++ b/app-emulation/aranym/aranym-1.0.2.recipe
@@ -1,0 +1,55 @@
+SUMMARY="Atari Running on Any Machine"
+DESCRIPTION="ARAnyM (Atari Running on Any Machine) is a multiplatform virtual \
+machine for running Atari ST/TT/Falcon operating systems and applications."
+HOMEPAGE="https://aranym.github.io/"
+COPYRIGHT="2001-2014 ARAnyM developer team"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="https://github.com/aranym/aranym/archive/ARANYM_1_0_2.tar.gz"
+CHECKSUM_SHA256="c0935aee14cca55c08e75a94b77dcd69f326ae563ae371b22c7b9d8efd82e24e"
+SOURCE_FILENAME="anarym-$portVersion.tar.gz"
+SOURCE_DIR="aranym-ARANYM_1_0_2"
+
+ARCHITECTURES="x86_gcc2 ?x86 ?x86_64"
+
+PROVIDES="
+	aranym = $portVersion
+	app:ARAnyM = $portVersion
+	cmd:aranym = $portVersion
+	"
+REQUIRES="
+	haiku
+	lib:libsdl
+	lib:libsdl_image
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	devel:libsdl
+	devel:libSDL_image
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:gcc
+	cmd:make
+	"
+
+BUILD()
+{
+	NO_CONFIGURE=1 ./autogen.sh
+	runConfigure ./configure
+	make $jobArgs
+}
+
+INSTALL()
+{
+	mkdir -p $docDir
+
+	make install
+	mv $prefix/share/doc/aranym/* $docDir
+	rm -r $prefix/share
+
+	mimeset $prefix/bin/aranym
+	addAppDeskbarSymlink /bin/aranym ARAnyM
+}

--- a/app-emulation/aranym/aranym-1.1.0.recipe
+++ b/app-emulation/aranym/aranym-1.1.0.recipe
@@ -11,7 +11,7 @@ SOURCE_FILENAME="anarym-$portVersion.tar.gz"
 SOURCE_DIR="aranym-ARANYM_${portVersion//./_}"
 PATCHES="aranym-$portVersion.patchset"
 
-ARCHITECTURES="x86_gcc2 x86_64"
+ARCHITECTURES="!x86_gcc2 x86_64"
 
 PROVIDES="
 	aranym = $portVersion

--- a/app-emulation/aranym/aranym-1.1.0.recipe
+++ b/app-emulation/aranym/aranym-1.1.0.recipe
@@ -46,7 +46,7 @@ BUILD()
 	
 	export CXXFLAGS="$CXXFLAGS -Wno-unused-function -Wno-unused-variable"
 	export CFLAGS="$CFLAGS -Wno-unused-function -Wno-unused-variable"
-	runConfigure ./configure --enable-fpe=uae $WITHDISDIP
+	runConfigure ./configure --enable-fpe=uae --enable-cxx-exceptions $WITHDISDIP
 	make $jobArgs
 }
 
@@ -56,6 +56,6 @@ INSTALL()
 
 	make install
 
-	mimeset /bin/aranym
+	mimeset $prefix/bin/aranym
 	addAppDeskbarSymlink /bin/aranym ARAnyM
 }

--- a/app-emulation/aranym/aranym-1.1.0.recipe
+++ b/app-emulation/aranym/aranym-1.1.0.recipe
@@ -55,9 +55,7 @@ INSTALL()
 	mkdir -p $docDir
 
 	make install
-	#mv $prefix/share/doc/aranym/* $docDir
-	#rm -r $prefix/share
 
-	mimeset $prefix/bin/aranym
+	mimeset /bin/aranym
 	addAppDeskbarSymlink /bin/aranym ARAnyM
 }

--- a/app-emulation/aranym/aranym-1.1.0.recipe
+++ b/app-emulation/aranym/aranym-1.1.0.recipe
@@ -5,12 +5,12 @@ HOMEPAGE="https://aranym.github.io/"
 COPYRIGHT="2001-2014 ARAnyM developer team"
 LICENSE="GNU GPL v2"
 REVISION="1"
-SOURCE_URI="https://github.com/aranym/aranym/archive/ARANYM_1_0_2.tar.gz"
-CHECKSUM_SHA256="c0935aee14cca55c08e75a94b77dcd69f326ae563ae371b22c7b9d8efd82e24e"
+SOURCE_URI="https://github.com/aranym/aranym/archive/ARANYM_${portVersion//./_}.tar.gz"
+CHECKSUM_SHA256="1636cf9ec68bd2089f537e3b5e82d04fafec61a4f8fb5e216a263d357e935b63"
 SOURCE_FILENAME="anarym-$portVersion.tar.gz"
-SOURCE_DIR="aranym-ARANYM_1_0_2"
+SOURCE_DIR="aranym-ARANYM_${portVersion//./_}"
 
-ARCHITECTURES="x86_gcc2 ?x86 ?x86_64"
+ARCHITECTURES="x86_gcc2 x86 x86_64"
 
 PROVIDES="
 	aranym = $portVersion
@@ -37,8 +37,16 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
+	WITHDISDIP=""
+	if [ $effectiveTargetArchitecture == x86_gcc2 ]; then
+		WITHDISDIP="--enable-disdip"
+	fi
+	
 	NO_CONFIGURE=1 ./autogen.sh
-	runConfigure ./configure
+	
+	export CXXFLAGS="$CXXFLAGS -Wno-unused-function -Wno-unused-variable"
+	export CFLAGS="$CFLAGS -Wno-unused-function -Wno-unused-variable"
+	runConfigure ./configure --enable-fpe=uae $WITHDISDIP
 	make $jobArgs
 }
 
@@ -47,8 +55,8 @@ INSTALL()
 	mkdir -p $docDir
 
 	make install
-	mv $prefix/share/doc/aranym/* $docDir
-	rm -r $prefix/share
+	#mv $prefix/share/doc/aranym/* $docDir
+	#rm -r $prefix/share
 
 	mimeset $prefix/bin/aranym
 	addAppDeskbarSymlink /bin/aranym ARAnyM

--- a/app-emulation/aranym/aranym-1.1.0.recipe
+++ b/app-emulation/aranym/aranym-1.1.0.recipe
@@ -42,9 +42,9 @@ BUILD()
 	if [ $effectiveTargetArchitecture == x86_gcc2 ]; then
 		WITHDISDIP="--enable-disdip"
 	fi
-	
+
 	NO_CONFIGURE=1 ./autogen.sh
-	
+
 	export CXXFLAGS="$CXXFLAGS -Wno-unused-function -Wno-unused-variable"
 	export CFLAGS="$CFLAGS -Wno-unused-function -Wno-unused-variable"
 	runConfigure ./configure --enable-fpe=uae --enable-cxx-exceptions $WITHDISDIP

--- a/app-emulation/aranym/aranym-1.1.0.recipe
+++ b/app-emulation/aranym/aranym-1.1.0.recipe
@@ -9,6 +9,7 @@ SOURCE_URI="https://github.com/aranym/aranym/archive/ARANYM_${portVersion//./_}.
 CHECKSUM_SHA256="1636cf9ec68bd2089f537e3b5e82d04fafec61a4f8fb5e216a263d357e935b63"
 SOURCE_FILENAME="anarym-$portVersion.tar.gz"
 SOURCE_DIR="aranym-ARANYM_${portVersion//./_}"
+PATCHES="aranym-$portVersion.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
 

--- a/app-emulation/aranym/patches/aranym-1.1.0.patchset
+++ b/app-emulation/aranym/patches/aranym-1.1.0.patchset
@@ -1,0 +1,21 @@
+From a46c58e7ce229a6de67d03a1cb751494d4731c51 Mon Sep 17 00:00:00 2001
+From: Gabriele Baldassarre <gabriele@gabrielebaldassarre.com>
+Date: Sun, 14 Jun 2020 23:28:00 +0200
+Subject: Haiku proper  path to config folder
+
+
+diff --git a/configure.ac b/configure.ac
+index 4c5fd67..59222c6 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -519,6 +519,7 @@ case "$host_os" in
+     AC_PATH_PROG(BEOS_SETVERSION, setversion, [AC_MSG_ERROR([setversion not found.])])
+     WANT_UNIXSERIALPORT=no
+     ac_cv_tun_tap_support=no
++	AC_DEFINE([ARANYMHOME], "config/settings/aranym")
+     ;;
+   *)
+     ;;
+-- 
+2.26.0
+


### PR DESCRIPTION
Works ok, although this recipe should deserve more love

- Enabled UAE FPU emulation. IEEE emulation doesn't work (@pulkomandy do u know something about that?), but UAE is fine.
- Some minor performance tweaks
- JIT not enabled. This would greatly speed up the emulation, but i don't know if  this works under Haiku actually

All the most relevant optional features (ethernet bridging, disk sharing, etc.) still disabled.

