### PR TITLE
keepassxc: bump revision

### DIFF
--- a/app-admin/keepassxc/keepassxc-2.3.4.recipe
+++ b/app-admin/keepassxc/keepassxc-2.3.4.recipe
@@ -134,5 +134,5 @@ INSTALL()
 TEST()
 {
 	cd build
-	make test	
+	make test
 }

--- a/app-admin/keepassxc/keepassxc-2.3.4.recipe
+++ b/app-admin/keepassxc/keepassxc-2.3.4.recipe
@@ -28,7 +28,7 @@ COPYRIGHT="
 	2016-2018, KeePassXC Team
 	"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/keepassxreboot/keepassxc/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="3610eccb06b04f901d5f5fbdbc4bd474d56a8e35f23c4a7873a844e44ba762b4"
 PATCHES="keepassxc-$portVersion.patchset"


### PR DESCRIPTION
* See 144ddc1 (bump of argon2, which is a dependency of keepassxc).