### PR TITLE
Colors: remove 2ndary arch

### DIFF
--- a/haiku-apps/colors/colors-2.3.recipe
+++ b/haiku-apps/colors/colors-2.3.recipe
@@ -1,41 +1,40 @@
 SUMMARY="A color picker like that in Adobe Photoshop"
-DESCRIPTION="
-	You can easily choose a color and then drag it to the place where you \
-	need it: for example the Haiku Desktop, Insite Constructor, any text \
-	editor (insert as HTML hex code) and much more...
+DESCRIPTION="You can easily choose a color and then drag it to the place where \
+you need it: for example the Haiku Desktop, Insite Constructor, any text \
+editor (insert as HTML hex code) and much more...
+
 The Features:
 
- * You can collect up to 10 favorite colors which are restored the next time \
- you start Colors.
- * You get a color preview for text (text and background color).
- * With an eye-dropper tool you can pick a color from anywhere on your desktop."
+* You can collect up to 10 favorite colors which are restored the next time \
+you start Colors.
+* You get a color preview for text (text and background color).
+* With an eye-dropper tool you can pick a color from anywhere on your desktop."
 HOMEPAGE="https://github.com/jscipione/Colors"
 COPYRIGHT="2001-2008 Werner Freytag
 	2009-2013 John Scipione"
 LICENSE="MIT"
-REVISION="5"
+REVISION="6"
 srcGitRev="146a127f7ab7cdbeadaefc74247b10cf00c7383c"
 SOURCE_URI="$HOMEPAGE/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="9a84bc025db4f0293d875a399aaa9dd944c90504ae218840065c823e4fbd1bf8"
 SOURCE_DIR="Colors-$srcGitRev"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
 PROVIDES="
-	colors$secondaryArchSuffix = $portVersion
+	colors = $portVersion
 	app:Colors = $portVersion
 	"
 REQUIRES="
-	haiku${secondaryArchSuffix}
+	haiku
 	"
 
 BUILD_REQUIRES="
-	haiku${secondaryArchSuffix}_devel
+	haiku_devel
 	"
 BUILD_PREREQUIRES="
 	makefile_engine
-	cmd:gcc$secondaryArchSuffix
+	cmd:gcc
 	cmd:make
 	"
 


### PR DESCRIPTION
Not being a library, Colors isn't needed as a gcc8 _x86 version.
Before, there were two instances of Colors in HaikuDepot, x86 and
x86_gcc2