### PR TITLE
sanity: migrate to x86 2ndary arch

### DIFF
--- a/haiku-apps/sanity/sanity-0.6.recipe
+++ b/haiku-apps/sanity/sanity-0.6.recipe
@@ -11,7 +11,7 @@ SOURCE_URI="https://github.com/diversys/sanity/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="b00dd169aed69f74c599dfee432371d725d0007c15a3083330e0a7456f6190ba"
 SOURCE_DIR="sanity-$srcGitRev"
 
-ARCHITECTURES="!x86_gcc2 x86_64"
+ARCHITECTURES="?x86_gcc2 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="

--- a/haiku-apps/sanity/sanity-0.6.recipe
+++ b/haiku-apps/sanity/sanity-0.6.recipe
@@ -5,30 +5,31 @@ translation kit."
 HOMEPAGE="http://philippe.houdoin.free.fr/phil/beos/sanity/index-en.html"
 COPYRIGHT="2001-2015 Philippe Houdoin"
 LICENSE="MIT"
-REVISION="5"
+REVISION="6"
 srcGitRev="f602688e85e5aea269c12cd9eef19da3029201c4"
 SOURCE_URI="https://github.com/diversys/sanity/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="b00dd169aed69f74c599dfee432371d725d0007c15a3083330e0a7456f6190ba"
 SOURCE_DIR="sanity-$srcGitRev"
 
-ARCHITECTURES="x86_gcc2 x86 x86_64"
+ARCHITECTURES="?x86_gcc2 x86_64"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	sanity = $portVersion
 	app:Sanity = $portVersion
 	"
 REQUIRES="
-	haiku
-	lib:libsane
+	haiku$secondaryArchSuffix
+	lib:libsane$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
-	devel:libsane
+	haiku$secondaryArchSuffix_devel
+	devel:libsane$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	makefile_engine
-	cmd:gcc
+	cmd:gcc$secondaryArchSuffix
 	cmd:make
 	"
 

--- a/haiku-apps/sanity/sanity-0.6.recipe
+++ b/haiku-apps/sanity/sanity-0.6.recipe
@@ -24,7 +24,7 @@ REQUIRES="
 	"
 
 BUILD_REQUIRES="
-	haiku$secondaryArchSuffix_devel
+	haiku${secondaryArchSuffix}_devel
 	devel:libsane$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="

--- a/haiku-apps/sanity/sanity-0.6.recipe
+++ b/haiku-apps/sanity/sanity-0.6.recipe
@@ -11,7 +11,7 @@ SOURCE_URI="https://github.com/diversys/sanity/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="b00dd169aed69f74c599dfee432371d725d0007c15a3083330e0a7456f6190ba"
 SOURCE_DIR="sanity-$srcGitRev"
 
-ARCHITECTURES="?x86_gcc2 x86_64"
+ARCHITECTURES="!x86_gcc2 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="


### PR DESCRIPTION
Ref: https://github.com/haikuports/haikuports/issues/5124
NOTE Recipe W-I-P. Needs further tweaking on x86 (GGC8). Passes manual build test on x86.