### PR TITLE
dateutil: update to 2.8.1, add dependency on six

### DIFF
--- a/dev-python/dateutil/dateutil-2.8.0.recipe
+++ b/dev-python/dateutil/dateutil-2.8.0.recipe
@@ -4,7 +4,7 @@ datetime module, available in Python 2.3+."
 HOMEPAGE="https://github.com/dateutil/dateutil/"
 COPYRIGHT="2003-2010 Gustavo Niemeyer"
 LICENSE="BSD (3-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/dateutil/dateutil/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="954a935174384f7cfd11d66451052caf4baa8a600f9c7cb65897b0f7cd621b19"
 
@@ -31,7 +31,8 @@ eval "PROVIDES_${pythonPackage}=\"\
 	\"; \
 REQUIRES_$pythonPackage=\"\
 	haiku\n\
-	cmd:python$pythonVersion\
+	cmd:python$pythonVersion\n\
+	six_$pythonPackage\
 	\""
 BUILD_REQUIRES="$BUILD_REQUIRES
 	setuptools_$pythonPackage"

--- a/dev-python/dateutil/dateutil-2.8.1.recipe
+++ b/dev-python/dateutil/dateutil-2.8.1.recipe
@@ -4,9 +4,9 @@ datetime module, available in Python 2.3+."
 HOMEPAGE="https://github.com/dateutil/dateutil/"
 COPYRIGHT="2003-2010 Gustavo Niemeyer"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://github.com/dateutil/dateutil/archive/$portVersion.tar.gz"
-CHECKSUM_SHA256="954a935174384f7cfd11d66451052caf4baa8a600f9c7cb65897b0f7cd621b19"
+CHECKSUM_SHA256="6e74f970d6c0d31c1287642d0b556a53a21986c7844368a2e742c6db25837618"
 
 ARCHITECTURES="any"
 


### PR DESCRIPTION
Update python dateutil to latest release and add a dependency on python six. Without six the following fails:

```
>>> from dateutil import parser
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/packages/python3-3.7.7-2/.self/lib/python3.7/vendor-packages/dateutil/parser/__init__.py", line 2, in <module>
    from ._parser import parse, parser, parserinfo
  File "/packages/python3-3.7.7-2/.self/lib/python3.7/vendor-packages/dateutil/parser/_parser.py", line 42, in <module>
    import six
ModuleNotFoundError: No module named 'six'
```

See also https://github.com/dateutil/dateutil/blob/0905e27cc1e58eb33265d366834cbd55b420c122/setup.cfg#L35