### PR TITLE
pax-utils: new recipe for version 1.2.6

### DIFF
--- a/app-misc/pax-utils/patches/pax_utils-1.2.6.patchset
+++ b/app-misc/pax-utils/patches/pax_utils-1.2.6.patchset
@@ -1,0 +1,52 @@
+From 0be676587939332de0de419e542f56beca91ad4c Mon Sep 17 00:00:00 2001
+From: Chris Roberts <cpr420@gmail.com>
+Date: Sun, 5 Jul 2020 14:21:41 -0600
+Subject: Add support for Haiku
+
+
+diff --git a/lddtree.sh b/lddtree.sh
+index 96163e3..ed21863 100755
+--- a/lddtree.sh
++++ b/lddtree.sh
+@@ -45,7 +45,12 @@ elf_specs() {
+ 		sed -E 's: (LINUX|GNU)$: NONE:'
+ }
+ 
+-lib_paths_fallback="${ROOT}lib* ${ROOT}usr/lib* ${ROOT}usr/local/lib*"
++if [[ ${OSTYPE} == "haiku" ]] ; then
++	lib_paths_fallback="${ROOT}lib* ${ROOT}boot/system/lib* ${ROOT}boot/home/config/lib* ${ROOT}boot/system/non-packaged/lib* ${ROOT}boot/home/config/non-packaged/lib*"
++else
++	lib_paths_fallback="${ROOT}lib* ${ROOT}usr/lib* ${ROOT}usr/local/lib*"
++fi
++
+ c_ldso_paths_loaded='false'
+ find_elf() {
+ 	_find_elf=''
+@@ -77,6 +82,11 @@ find_elf() {
+ 		fi
+ 		check_paths "${elf}" ${c_last_needed_by_rpaths} && return 0
+ 
++		if [[ -n ${LIBRARY_PATH} ]] ; then
++			# Use LIBRARY_PATH on Haiku
++			LD_LIBRARY_PATH=${LIBRARY_PATH}
++		fi
++
+ 		if [[ -n ${LD_LIBRARY_PATH} ]] ; then
+ 			# Need to handle empty paths as $PWD,
+ 			# and handle spaces in between the colons
+diff --git a/porting.h b/porting.h
+index 636e862..d63b149 100644
+--- a/porting.h
++++ b/porting.h
+@@ -59,6 +59,8 @@
+ # include <sys/isa_defs.h>
+ #elif defined(__MACH__)
+ # include <machine/endian.h>
++#elif defined(__HAIKU__)
++# include <endian.h>
+ #endif
+ 
+ #if defined(__GLIBC__) || defined(__UCLIBC__)
+-- 
+2.27.0
+

--- a/app-misc/pax-utils/pax_utils-1.2.6.recipe
+++ b/app-misc/pax-utils/pax_utils-1.2.6.recipe
@@ -1,0 +1,62 @@
+SUMMARY="ELF utils that can check files for security relevant properties"
+DESCRIPTION="A suite of ELF tools to aid auditing systems. Contains various \
+ELF related utils for ELF32, ELF64 binaries useful for displaying PaX and \
+security info on a large groups of binary files."
+HOMEPAGE="https://wiki.gentoo.org/index.php?title=Project:Hardened/PaX_Utilities"
+COPYRIGHT="
+	2003-2016 Gentoo Foundation
+	2003-2012 Ned Ludd
+	2004-2016 Mike Frysinger
+	"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="https://dev.gentoo.org/~slyfox/distfiles/pax-utils-$portVersion.tar.xz"
+CHECKSUM_SHA256="9742d2a31d53a4e0f6df0d3721ab6f7cf8b0404c95fee3b00e678c1ff6db7f21"
+SOURCE_DIR="pax-utils-$portVersion"
+PATCHES="pax_utils-$portVersion.patchset"
+ARCHITECTURES="?x86_gcc2 ?x86 x86_64"
+
+PROVIDES="
+	pax_utils = $portVersion
+	cmd:dumpelf = $portVersion
+	cmd:lddtree = $portVersion
+	cmd:pspax = $portVersion
+	cmd:scanelf = $portVersion
+	cmd:scanmacho = $portVersion
+	cmd:symtree = $portVersion
+	"
+
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:cmp
+	cmd:dd
+	cmd:make
+	cmd:gcc
+	cmd:grep
+	cmd:egrep
+	cmd:sed
+	"
+
+BUILD()
+{
+	runConfigure ./configure
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+}
+
+TEST()
+{
+	make check
+}


### PR DESCRIPTION
Test suite needs to be fixed but the commands seem to be functioning normally.  This recipe includes a working copy of the lddtree command and might fix issue #4000 if it builds for gcc2.