### PR TITLE
mutagen: bump version to 1.45

### DIFF
--- a/dev-python/mutagen/mutagen-1.45.0.recipe
+++ b/dev-python/mutagen/mutagen-1.45.0.recipe
@@ -11,7 +11,7 @@ COPYRIGHT="Joe Wreschnig, Michael Urman, Lukáš Lalinský, Christoph Reiter, Be
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/m/$portName/$portName-$portVersion.tar.gz"
-CHECKSUM_SHA256="56065d8a9ca0bc64610a4d0f37e2bd4453381dde3226b8835ee656faa3287be4"
+CHECKSUM_SHA256="b2d56a0471eabcce0881974bed98dfc2135126ab01d253652b74b64df4da73e8"
 SOURCE_DIR="mutagen-$portVersion"
 
 ARCHITECTURES="any"


### PR DESCRIPTION
New upstream release. See https://mutagen.readthedocs.io/en/latest/changelog.html#release-1-45-0