### PR TITLE
libavif: new recipe for version 0.8.0

### DIFF
--- a/media-libs/libavif/libavif-0.8.0.recipe
+++ b/media-libs/libavif/libavif-0.8.0.recipe
@@ -1,0 +1,87 @@
+SUMMARY="Library for encoding and decoding .avif files"
+DESCRIPTION="This library aims to be a friendly, portable C implementation of \
+the AV1 Image File Format, as described here: \
+https://aomediacodec.github.io/av1-avif/
+It is a work-in-progress, but can already encode and decode all AOM supported \
+YUV formats and bit depths (with alpha).
+For now, it is recommended that you checkout/use tagged releases instead of \
+just using the master branch. I will regularly create new versions as \
+bugfixes and features are added."
+HOMEPAGE="https://https://github.com/AOMediaCodec/libavif"
+COPYRIGHT="2019 Joe Drago"
+LICENSE="BSD (2-clause)"
+REVISION="1"
+SOURCE_URI="https://github.com/AOMediaCodec/libavif/archive/v$portVersion.tar.gz"
+CHECKSUM_SHA256="c917f4a27add61b8ad15f328090942d519460b71219f31e60e5fe6aa8cf3dc4e"
+
+ARCHITECTURES="!x86_gcc2 ?x86 !x86_64 ?arm ?riscv64 ?sparc ?m68k"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="5.0.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	libavif$secondaryArchSuffix = $portVersion
+	lib:libavif$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libdav1d$secondaryArchSuffix
+	"
+
+PROVIDES_tools="
+	cmd:avifenc$secondaryArchSuffix
+	cmd:avifdec$secondaryArchSuffix
+	"
+REQUIRES_tools="
+	haiku$secondaryArchSuffix
+	lib:libavif$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	lib:libpng$secondaryArchSuffix
+	lib:libjpeg$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	libavif${secondaryArchSuffix}_devel = $portVersion
+	devel:libavif$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	libavif$secondaryArchSuffix == $portVersion base
+	devel:libdav1d$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libdav1d$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	devel:libpng$secondaryArchSuffix
+	devel:libjpeg$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	"
+
+defineDebugInfoPackage libavif$secondaryArchSuffix \
+	"$libDir"/libavif.so.$libVersion
+
+BUILD()
+{
+	mkdir -p build && cd build
+	cmake .. \
+		-DAVIF_BUILD_APPS=ON \
+		-DAVIF_CODEC_DAV1D=ON \
+		$cmakeDirArgs
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make -C build install
+
+	prepareInstalledDevelLib libavif
+	fixPkgconfig
+	packageEntries devel $developDir
+	packageEntries tools $binDir
+}

--- a/media-libs/libavif/libavif-0.8.0.recipe
+++ b/media-libs/libavif/libavif-0.8.0.recipe
@@ -7,7 +7,7 @@ YUV formats and bit depths (with alpha).
 For now, it is recommended that you checkout/use tagged releases instead of \
 just using the master branch. I will regularly create new versions as \
 bugfixes and features are added."
-HOMEPAGE="https://https://github.com/AOMediaCodec/libavif"
+HOMEPAGE="https://github.com/AOMediaCodec/libavif"
 COPYRIGHT="2019 Joe Drago"
 LICENSE="BSD (2-clause)"
 REVISION="1"


### PR DESCRIPTION
Only decoding is supported for now, as there is no package for [rav1e](https://github.com/xiph/rav1e) yet, because cargo-c fails to build due to https://github.com/alexcrichton/socket2-rs/commit/43b75d3dd4a90e33b4b9ddb764f84f68914c9648 not being in a release yet.

Once rav1e is in haikuports, it will only be a matter of passing `-DAVIF_CODEC_RAV1E=ON` to cmake, and encoding will be possible.