### PR TITLE
Bump version to address CVE-2017-7467

### DIFF
--- a/net-dialup/minicom/minicom-2.7.1.recipe
+++ b/net-dialup/minicom/minicom-2.7.1.recipe
@@ -1,12 +1,12 @@
 SUMMARY="A menu driven communications program"
 DESCRIPTION="Minicom is a menu driven communications program. It emulates \
 ANSI and VT102 terminals. It has a dialing directory and auto zmodem download."
-HOMEPAGE="https://alioth.debian.org/projects/minicom/"
+HOMEPAGE="https://salsa.debian.org/minicom-team/minicom"
 COPYRIGHT="1991-1996 Miquel van Smoorenburg"
 LICENSE="GNU GPL v2"
-REVISION="3"
-SOURCE_URI="https://alioth.debian.org/frs/download.php/file/3869/minicom-2.6.2.tar.gz"
-CHECKSUM_SHA256="f3cf215f7914ffa5528e398962176102ad74df27ba38958142f56aa6d15c9168"
+REVISION="1"
+SOURCE_URI="https://salsa.debian.org/minicom-team/minicom/uploads/1d9cf62c488b78029faab88c5fd3727b/minicom-2.7.1.tar.gz"
+CHECKSUM_SHA256="532f836b7a677eb0cb1dca8d70302b73729c3d30df26d58368d712e5cca041f1"
 
 ARCHITECTURES="x86 x86_64"
 SECONDARY_ARCHITECTURES="!x86_gcc2 x86"


### PR DESCRIPTION
Bump to the latest version; addresses CVE-2017-7467.