### PR TITLE
mutagen: bump version to 1.45.1

### DIFF
--- a/dev-python/mutagen/mutagen-1.45.1.recipe
+++ b/dev-python/mutagen/mutagen-1.45.1.recipe
@@ -11,7 +11,7 @@ COPYRIGHT="Joe Wreschnig, Michael Urman, Lukáš Lalinský, Christoph Reiter, Be
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/m/$portName/$portName-$portVersion.tar.gz"
-CHECKSUM_SHA256="b2d56a0471eabcce0881974bed98dfc2135126ab01d253652b74b64df4da73e8"
+CHECKSUM_SHA256="6397602efb3c2d7baebd2166ed85731ae1c1d475abca22090b7141ff5034b3e1"
 SOURCE_DIR="mutagen-$portVersion"
 
 ARCHITECTURES="any"


### PR DESCRIPTION
New upstream release with write performance improvements, see https://mutagen.readthedocs.io/en/latest/changelog.html#release-1-45-1

Build and tested locally (64bit)