### PR TITLE
Rust: Add version 1.45.0

### DIFF
--- a/dev-lang/rust/patches/rust-1.45.0.patchset
+++ b/dev-lang/rust/patches/rust-1.45.0.patchset
@@ -1,0 +1,82 @@
+From 92b85fb06f8286c78c59bd8896a23fcdac22768d Mon Sep 17 00:00:00 2001
+From: Niels Sascha Reedijk <niels.reedijk@gmail.com>
+Date: Sun, 9 Aug 2020 10:36:23 +0000
+Subject: Haiku-specific patches for Rust 1.45.0
+
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 6cfedd4..83caf54 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -4735,9 +4735,9 @@ checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
+ 
+ [[package]]
+ name = "socket2"
+-version = "0.3.12"
++version = "0.3.11"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
++checksum = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
+ dependencies = [
+  "cfg-if",
+  "libc",
+diff --git a/src/libstd/sys/unix/thread.rs b/src/libstd/sys/unix/thread.rs
+index 895ea48..fb2632e 100644
+--- a/src/libstd/sys/unix/thread.rs
++++ b/src/libstd/sys/unix/thread.rs
+@@ -190,7 +190,7 @@ impl Thread {
+         unsafe {
+             let ret = libc::pthread_join(self.id, ptr::null_mut());
+             mem::forget(self);
+-            assert!(ret == 0, "failed to join thread: {}", io::Error::from_raw_os_error(ret));
++            debug_assert_eq!(ret, 0);
+         }
+     }
+ 
+diff --git a/src/libstd/sys/windows/c.rs b/src/libstd/sys/windows/c.rs
+index 6115d65..1484dce 100644
+--- a/src/libstd/sys/windows/c.rs
++++ b/src/libstd/sys/windows/c.rs
+@@ -254,7 +254,6 @@ pub const FILE_END: DWORD = 2;
+ 
+ pub const WAIT_OBJECT_0: DWORD = 0x00000000;
+ pub const WAIT_TIMEOUT: DWORD = 258;
+-pub const WAIT_FAILED: DWORD = 0xFFFFFFFF;
+ 
+ pub const PIPE_ACCESS_INBOUND: DWORD = 0x00000001;
+ pub const PIPE_ACCESS_OUTBOUND: DWORD = 0x00000002;
+diff --git a/src/libstd/sys/windows/thread.rs b/src/libstd/sys/windows/thread.rs
+index 38839ea..7bb8c95 100644
+--- a/src/libstd/sys/windows/thread.rs
++++ b/src/libstd/sys/windows/thread.rs
+@@ -70,10 +70,7 @@ impl Thread {
+     }
+ 
+     pub fn join(self) {
+-        let rc = unsafe { c::WaitForSingleObject(self.handle.raw(), c::INFINITE) };
+-        if rc == c::WAIT_FAILED {
+-            panic!("failed to join on thread: {}", io::Error::last_os_error());
+-        }
++        unsafe { c::WaitForSingleObject(self.handle.raw(), c::INFINITE); }
+     }
+ 
+     pub fn yield_now() {
+diff --git a/src/libstd/thread/mod.rs b/src/libstd/thread/mod.rs
+index 3134a59..0d16aef 100644
+--- a/src/libstd/thread/mod.rs
++++ b/src/libstd/thread/mod.rs
+@@ -1469,11 +1469,6 @@ impl<T> JoinHandle<T> {
+     /// [`panic`]: ../../std/macro.panic.html
+     /// [atomic memory orderings]: ../../std/sync/atomic/index.html
+     ///
+-    /// # Panics
+-    ///
+-    /// This function may panic on some platforms if a thread attempts to join
+-    /// itself or otherwise may create a deadlock with joining threads.
+-    ///
+     /// # Examples
+     ///
+     /// ```
+-- 
+2.26.0
+

--- a/dev-lang/rust/rust-1.45.0.recipe
+++ b/dev-lang/rust/rust-1.45.0.recipe
@@ -1,0 +1,167 @@
+SUMMARY="Modern and safe systems programming language"
+DESCRIPTION="Rust is a systems programming language that runs blazingly fast, \
+prevents almost all crashes*, and eliminates data races."
+HOMEPAGE="https://www.rust-lang.org/"
+COPYRIGHT="2020 The Rust Project Developers"
+LICENSE="MIT"
+REVISION="1"
+cargoVersion="0.46.0"
+rlsVersion="1.41.0"
+rustfmtVersion="1.4.15"
+clippyVersion="0.0.212"
+SOURCE_URI="https://static.rust-lang.org/dist/rustc-$portVersion-src.tar.xz"
+CHECKSUM_SHA256="c436034db42bc0ea7e7f32816ac6555b70d1f76c834407597966dfaf2ec839d6"
+SOURCE_DIR="rustc-$portVersion-src"
+PATCHES="rust-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
+SECONDARY_ARCHITECTURES="?x86"
+
+PROVIDES="
+	rust_bin$secondaryArchSuffix = $portVersion
+	cmd:rustc$secondaryArchSuffix = $portVersion
+	cmd:rustdoc$secondaryArchSuffix = $portVersion
+	cmd:rustfmt$secondaryArchSuffix = $portVersion
+	cmd:rust_gdb$secondaryArchSuffix = $portVersion
+	cmd:rust_lldb$secondaryArchSuffix = $portVersion
+	cmd:cargo$secondaryArchSuffix = $cargoVersion
+	cmd:cargo_clippy$secondaryArchSuffix = $clippyVersion
+	cmd:cargo_fmt$secondaryArchSuffix = $cargoVersion
+	cmd:clippy_driver$secondaryArchSuffix = $clippyVersion
+	cmd:rls$secondaryArchSuffix = $rlsVersion
+	cmd:rustfmt = $rustfmtVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcrypto$secondaryArchSuffix
+	lib:libcurl$secondaryArchSuffix
+	lib:libssl$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libcurl$secondaryArchSuffix
+	devel:libssl$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cargo$secondaryArchSuffix == $cargoVersion
+	cmd:cmake
+	cmd:cmp
+	cmd:file
+	cmd:find
+	cmd:gcc$secondaryArchSuffix
+	cmd:git
+	cmd:grep
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:python
+	cmd:rustc$secondaryArchSuffix == $portVersion
+	cmd:sed
+	cmd:tar
+	cmd:which
+	cmd:xargs
+	"
+
+relativeInstallDir="develop/tools$secondaryArchSubDir/rust"
+installDir="$prefix/$relativeInstallDir"
+
+BUILD()
+{
+	# write the build configuration
+	tr -d '\t' >config.toml <<- EOL
+		[llvm]
+		targets = "X86"
+		experimental-targets = ""
+
+		[build]
+		cargo = "/$relativeBinDir/cargo"
+		rustc = "/$relativeBinDir/rustc"
+		submodules = false
+		extended = true
+		tools = ["cargo", "clippy", "rls", "rustfmt", "analysis"]
+
+		[install]
+		prefix = "$installDir"
+		libdir = "$installDir/bin/lib"
+		mandir = "$manDir"
+		docdir = "$developDocDir"
+		sysconfdir = "$dataDir"
+
+		[rust]
+		channel = "stable"
+		rpath = false
+		deny-warnings = false
+		dist-src = false
+
+		[dist]
+		src-tarball = false
+EOL
+	# Disable ASLR: compiling stage 1 rustc requires a lot of RAM (about 1.5
+	# GB). Haiku has a per-process limit of 2GB on 32 bit systems. ASLR makes
+	# the available space even smaller. Disabling it will give us the space to
+	# compile Rust
+	export DISABLE_ASLR=1
+
+	# now build rust and cargo
+	./x.py dist
+}
+
+INSTALL()
+{
+	# we will manually invoke the install scripts
+	if [ $effectiveTargetArchitecture = x86 ]; then
+		architecture="i686-unknown-haiku"
+	fi
+	if [ $effectiveTargetArchitecture = x86_64 ]; then
+		architecture="x86_64-unknown-haiku"
+	fi
+
+	# let's install the packages one by one
+	cd $sourceDir/build/tmp/dist/
+	for module in "rust-docs-$srcGitRev-$architecture"     \
+	              "rust-std-$srcGitRev-$architecture"      \
+	              "rustc-$srcGitRev-$architecture"         \
+	              "rust-analysis-$srcGitRev-$architecture" \
+	              "cargo-$cargoVersion-$architecture"      \
+	              "clippy-$clippyVersion-$architecture"    \
+	              "rls-$rlsVersion-$architecture"          \
+	              "rustfmt-$rustfmtVersion-$architecture"
+	do
+		./$module/install.sh                               \
+				--prefix=$installDir                       \
+				--docdir=$developDocDir                    \
+				--mandir=$manDir                           \
+				--sysconfdir=$dataDir                      \
+				--disable-ldconfig
+	done
+
+	# move zsh data to the datadir
+	mv $installDir/share/zsh $dataDir
+	rm -rf $installDir/share
+
+	# clean out unneccesary files created by the rust installer
+	rm $installDir/lib/rustlib/components
+	rm $installDir/lib/rustlib/install.log
+	rm $installDir/lib/rustlib/manifest-*
+	rm $installDir/lib/rustlib/rust-installer-version
+	rm $installDir/lib/rustlib/uninstall.sh
+
+	# link the binaries in $binDir
+	mkdir -p $binDir
+	for f in cargo cargo-clippy cargo-fmt clippy-driver rls rust-gdb \
+	         rust-lldb rustc rustdoc rustfmt; do
+		symlinkRelative -sfn $installDir/bin/$f $binDir
+	done
+
+	# make sure runtime_loader can find the libraries in the lib dir relative
+	# to the binaries
+	symlinkRelative -sfn $installDir/lib $installDir/bin/lib
+}
+
+TEST()
+{
+	./x.py test
+}

--- a/dev-lang/rust_bin/rust_bin-1.45.0.recipe
+++ b/dev-lang/rust_bin/rust_bin-1.45.0.recipe
@@ -1,0 +1,97 @@
+SUMMARY="Modern and safe systems programming language"
+DESCRIPTION="Rust is a systems programming language that runs blazingly fast, \
+prevents almost all crashes*, and eliminates data races."
+HOMEPAGE="https://www.rust-lang.org/"
+COPYRIGHT="2020 The Rust Project Developers"
+LICENSE="MIT"
+REVISION="1"
+
+case "$effectiveTargetArchitecture" in
+	x86)
+SOURCE_URI="http://dl.rust-on-haiku.com/dist/$portVersion/rust-$portVersion-i686-unknown-haiku.tar.xz"
+CHECKSUM_SHA256="6ea6f96cbce84a5a6ee11714d449a23717626417d1e5e02bcca4824d03cdd11b"
+SOURCE_DIR="rust-$portVersion-i686-unknown-haiku"
+		;;
+	x86_64)
+SOURCE_URI="http://dl.rust-on-haiku.com/dist/$portVersion/rust-$portVersion-x86_64-unknown-haiku.tar.xz"
+CHECKSUM_SHA256="faee4d2e4bf4b217d6100626b7a3bdae86564fe1eee65d602852c6c70d75bc8f"
+SOURCE_DIR="rust-$portVersion-x86_64-unknown-haiku"
+		;;
+	*)
+SOURCE_URI="http://dl.rust-on-haiku.com/dist/$portVersion/rustc-$portVersion-src.tar.xz"
+CHECKSUM_SHA256="d5199dead7c6d8c00b4faf41016bb878a62922577949d51bd838ab1af35fd875"
+SOURCE_DIR="rustc-$portVersion-src"
+		;;
+esac
+
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+DISABLE_SOURCE_PACKAGE=yes
+
+cargoVersion="0.46.0"
+#rlsVersion="1.41.0"
+rustfmtVersion="1.4.15"
+clippyVersion="0.0.212"
+
+PROVIDES="
+	rust_bin$secondaryArchSuffix = $portVersion
+	cmd:rustc$secondaryArchSuffix = $portVersion
+	cmd:rustdoc$secondaryArchSuffix = $portVersion
+	cmd:rustfmt$secondaryArchSuffix = $portVersion
+	cmd:rust_gdb$secondaryArchSuffix = $portVersion
+	cmd:rust_lldb$secondaryArchSuffix = $portVersion
+	cmd:cargo$secondaryArchSuffix = $cargoVersion
+	cmd:cargo_clippy$secondaryArchSuffix = $clippyVersion
+	cmd:cargo_fmt$secondaryArchSuffix = $cargoVersion
+	cmd:clippy_driver$secondaryArchSuffix = $clippyVersion
+	cmd:rustfmt = $rustfmtVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcrypto$secondaryArchSuffix
+	lib:libcurl$secondaryArchSuffix
+	lib:libssl$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+CONFLICTS="
+	rust$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+
+relativeInstallDir="develop/tools$secondaryArchSubDir/rust"
+installDir="$prefix/$relativeInstallDir"
+
+INSTALL()
+{
+	./install.sh                                   \
+		--prefix=$installDir                       \
+		--docdir=$developDocDir                    \
+		--mandir=$manDir                           \
+		--sysconfdir=$dataDir                      \
+		--disable-ldconfig
+
+	# move zsh data to the datadir
+	mv $installDir/share/zsh $dataDir
+	rm -rf $installDir/share
+
+	# clean out unneccesary files created by the rust installer
+	rm $installDir/lib/rustlib/components
+	rm $installDir/lib/rustlib/install.log
+	rm $installDir/lib/rustlib/manifest-*
+	rm $installDir/lib/rustlib/rust-installer-version
+	rm $installDir/lib/rustlib/uninstall.sh
+
+	# link the binaries in $binDir
+	mkdir -p $binDir
+	for f in cargo cargo-clippy cargo-fmt clippy-driver rust-gdb \
+	         rust-lldb rustc rustdoc rustfmt; do
+		symlinkRelative -sfn $installDir/bin/$f $binDir
+	done
+
+	# make sure runtime_loader can find the libraries in the lib dir relative
+	# to the binaries
+	symlinkRelative -sfn $installDir/lib $installDir/bin/lib
+}


### PR DESCRIPTION
Note that rust_bin does not include rls in this version, as the current
incarnation depends on an unsupported dependency. Rls seems to be
falling out of favour for rust-analyser anyway, so this is not a
blocker.