### PR TITLE
hteditor: avoid putting th in /bin/x86

### DIFF
--- a/app-editors/hteditor/hteditor-2.1.0.recipe
+++ b/app-editors/hteditor/hteditor-2.1.0.recipe
@@ -8,7 +8,7 @@ HOMEPAGE="http://hte.sourceforge.net/"
 COPYRIGHT="1999-2002 Stefan Weyergraf
     1999-2002 Sebastian Biallas"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="http://sourceforge.net/projects/hte/files/ht-source/ht-$portVersion.tar.bz2"
 CHECKSUM_SHA256="31f5e8e2ca7f85d40bb18ef518bf1a105a6f602918a0755bc649f3f407b75d70"
 SOURCE_DIR="ht-$portVersion"
@@ -17,9 +17,16 @@ PATCHES="hteditor-2.1.0.patchset"
 ARCHITECTURES="!x86_gcc2 x86 ?x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
 PROVIDES="
 	hteditor$secondaryArchSuffix = $portVersion
-	cmd:ht$secondaryArchSuffix = $portVersion
+	cmd:ht$commandSuffix = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -45,7 +52,7 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	runConfigure ./configure
+	runConfigure ./configure --bindir="$commandBinDir"
 	make $jobArgs
 }
 


### PR DESCRIPTION
Since there's no gcc2 version, just the x86 built.