### PR TITLE
Paladin: Added Haiku header requirement

### DIFF
--- a/haiku-apps/paladin/paladin-2.8~git.recipe
+++ b/haiku-apps/paladin/paladin-2.8~git.recipe
@@ -45,6 +45,8 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku
+	# required by templates
+	haiku_devel
 	lib:libpcre
 	lib:libz
 	"


### PR DESCRIPTION
After testing out one of Paladin's templates, a user on social media seemed unable to compile a template which included the lines;

```cpp
#include <Application.h>
#include <Window.h>
```

Consequently, they claim to have resolved that issue by installing `haiku_devel` in their system afterwards.

I believe that if the program itself assumes that the user has the Haiku headers installed on their system, does not check for it and bundles Haiku-specific code that's meant to be illustrating the system's capabilities to users experimenting with the system, then the recipe itself should cover this case scenario.