### PR TITLE
tcl, revbump, remove sqlite3 dependency (solves build on x86_64)

### DIFF
--- a/dev-lang/tcl/tcl-8.6.10.recipe
+++ b/dev-lang/tcl/tcl-8.6.10.recipe
@@ -8,13 +8,13 @@ is truly cross platform, easily deployed and highly extensible."
 HOMEPAGE="http://www.tcl.tk"
 COPYRIGHT="Regents of the University of California, Sun Microsystems, Inc., Scriptics Corporation, and other parties"
 LICENSE="BSD (2-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://sourceforge.net/projects/tcl/files/Tcl/$portVersion/tcl$portVersion-src.tar.gz"
 CHECKSUM_SHA256="5196dbf6638e3df8d5c87b5815c8c2b758496eb6f0e41446596c9a4e638d87ed"
 SOURCE_DIR="tcl$portVersion"
 PATCHES="tcl-$portVersion.patchset"
 
-ARCHITECTURES="x86 x86_gcc2 x86_64"
+ARCHITECTURES="x86_gcc2 x86_64"
 
 PROVIDES="
 	tcl = $portVersion compat >= 8.6
@@ -54,6 +54,7 @@ defineDebugInfoPackage tcl \
 
 BUILD()
 {
+	export CFLAGS="-USQLITE_API -USQLITE_EXTERN"
 	cd unix
 	autoconf -f
 	runConfigure ./configure \


### PR DESCRIPTION
This should fix the build for 64 bit Haiku, checked so far with expect and sqlcipher