### PR TITLE
bam: enable x86_64

### DIFF
--- a/dev-util/bam/bam-0.5.1.recipe
+++ b/dev-util/bam/bam-0.5.1.recipe
@@ -11,7 +11,7 @@ SOURCE_URI="http://github.com/matricks/bam/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="cc8596af3325ecb18ebd6ec2baee550e82cb7b2da19588f3f843b02e943a15a9"
 PATCHES="bam-$portVersion.patchset"
 
-ARCHITECTURES="?x86_gcc2 ?x86 ?x86_64"
+ARCHITECTURES="?x86_gcc2 ?x86 x86_64"
 
 PROVIDES="
 	bam = $portVersion


### PR DESCRIPTION
Ran several tests to verify the x86_64 build of bam 0.5.1 is functional.