### PR TITLE
Angband: fix libSDL references

### DIFF
--- a/games-roguelike/angband/angband-4.2.0.recipe
+++ b/games-roguelike/angband/angband-4.2.0.recipe
@@ -11,7 +11,7 @@ COPYRIGHT="1985 Robert Alan Koeneke
 	1994-1999 Ben Harrison
 	2000-2014 Robert Ruehlmann"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://rephial.org/downloads/4.2/angband-$portVersion.tar.gz"
 CHECKSUM_SHA256="d3e1495c7cc2a4ee66de7b4e612d3b133048072e37504bd2e58a2351ab0fb56d"
 PATCHES="angband-$portVersion.patchset"
@@ -76,19 +76,19 @@ PROVIDES="
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libncursesw$secondaryArchSuffix
-	lib:libSDL$secondaryArchSuffix
-	lib:libSDL_image$secondaryArchSuffix
-	lib:libSDL_mixer$secondaryArchSuffix
-	lib:libSDL_ttf$secondaryArchSuffix
+	lib:libSDL_1.2$secondaryArchSuffix
+	lib:libSDL_image_1.2$secondaryArchSuffix
+	lib:libSDL_mixer_1.2$secondaryArchSuffix
+	lib:libSDL_ttf_2.0$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libncurses$secondaryArchSuffix
-	devel:libsdl$secondaryArchSuffix
-	devel:libsdl_image$secondaryArchSuffix
-	devel:libsdl_mixer$secondaryArchSuffix
-	devel:libsdl_ttf$secondaryArchSuffix
+	devel:libSDL_1.2$secondaryArchSuffix
+	devel:libSDL_image_1.2$secondaryArchSuffix
+	devel:libSDL_mixer_1.2$secondaryArchSuffix
+	devel:libSDL_ttf_2.0$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:aclocal


### PR DESCRIPTION
There should be no problems, but this is untested, I've only checked that it compiles in my x86_64 system.

Once I'm sure this is the kind of change expected from #3878, I'll try and continue sending PR with more than one recipe, if that's OK.