### PR TITLE
Update libSDL references

### DIFF
--- a/games-fps/eduke32/eduke32-20190304_7392.recipe
+++ b/games-fps/eduke32/eduke32-20190304_7392.recipe
@@ -34,7 +34,7 @@ COPYRIGHT="1993-1997 Ken Silverman
 	2006-2018 eduke32 Team"
 LICENSE="GNU GPL v2
 	Build_Engine"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="http://dukeworld.com/eduke32/synthesis/${portVersion/_/-}/eduke32_src_${portVersion/_/-}.tar.xz"
 CHECKSUM_SHA256="3f5ceb08ffde091c2cca6d88710e0796126faa5ff6975ce059498b3faf645c42"
 SOURCE_DIR="eduke32_${portVersion/_/-}"
@@ -72,8 +72,8 @@ BUILD_REQUIRES="
 	devel:libGLU$secondaryArchSuffix
 	devel:libogg$secondaryArchSuffix
 	devel:libpng16$secondaryArchSuffix
-	devel:libSDL2$secondaryArchSuffix
-	devel:libSDL2_mixer$secondaryArchSuffix
+	devel:libSDL2_2.0$secondaryArchSuffix
+	devel:libSDL2_mixer_2.0$secondaryArchSuffix
 	devel:libvorbis$secondaryArchSuffix
 	devel:libvorbisfile$secondaryArchSuffix
 	devel:libvpx$secondaryArchSuffix

--- a/games-fps/openarena/openarena-0.8.9~git.recipe
+++ b/games-fps/openarena/openarena-0.8.9~git.recipe
@@ -5,7 +5,7 @@ heavily on the Quake III Arena-style deathmatch. The OpenArena project was estab
 HOMEPAGE="http://openarena.ws/"
 COPYRIGHT="OpenArena Team"
 LICENSE="GNU GPL v2"
-REVISION="4"
+REVISION="5"
 srcGitRev="e120f49e660aab5420e6acb3a5131992645f39c3"
 SOURCE_URI="https://github.com/OpenArena/engine/archive/$srcGitRev.zip"
 CHECKSUM_SHA256="5d92a0fab326bb5f80eb662e741add908bafc7b76ee023adf6846c86354b0d7c"
@@ -25,7 +25,7 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libGL$secondaryArchSuffix
 	lib:libogg$secondaryArchSuffix
-	lib:libSDL$secondaryArchSuffix
+	lib:libSDL_1.2$secondaryArchSuffix
 	lib:libvorbis$secondaryArchSuffix
 	lib:libxmp$secondaryArchSuffix
 	"
@@ -37,7 +37,7 @@ BUILD_REQUIRES="
 	devel:libglu$secondaryArchSuffix
 	devel:libogg$secondaryArchSuffix
 	devel:libopenal$secondaryArchSuffix
-	devel:libSDL$secondaryArchSuffix
+	devel:libSDL_1.2$secondaryArchSuffix
 	devel:libvorbis$secondaryArchSuffix
 	devel:libxmp$secondaryArchSuffix
 

--- a/games-fps/uhexen2/uhexen2-1.5.9.recipe
+++ b/games-fps/uhexen2/uhexen2-1.5.9.recipe
@@ -6,7 +6,7 @@ documentation among many others."
 HOMEPAGE="https://sourceforge.net/projects/uhexen2/"
 COPYRIGHT="2000 Raven Software"
 LICENSE="GNU GPL v2"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://sourceforge.net/projects/uhexen2/files/Hammer%20of%20Thyrion/$portVersion/Source/hexen2source-$portVersion.tgz"
 CHECKSUM_SHA256="2aa84c141a820f9087850aacf3684a5f71c434428bc57545899eda1b9a28c3e0"
 SOURCE_DIR="hexen2source-$portVersion"
@@ -34,7 +34,7 @@ BUILD_REQUIRES="
 	haiku_devel
 	devel:libmad
 	devel:libogg
-	devel:libSDL
+	devel:libSDL_1.2
 	devel:libvorbis
 	"
 BUILD_PREREQUIRES="

--- a/games-kids/abe/abe-1.1.recipe
+++ b/games-kids/abe/abe-1.1.recipe
@@ -5,7 +5,7 @@ In addition, this game also comes with a Map Editor."
 HOMEPAGE="http://abe.sourceforge.net/"
 COPYRIGHT="2001-2013 Gabor Torok"
 LICENSE="GNU GPL v2"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://sourceforge.net/projects/abe/files/abe/abe-1.1/abe-1.1.tar.gz"
 CHECKSUM_SHA256="dfc4ea74c04c92175abc5c9d65cfa6aad218209854d87d87758878e303b677f7"
 SOURCE_DIR="abe-1.1"
@@ -25,8 +25,8 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku_devel
-	devel:libSDL
-	devel:libSDL_mixer
+	devel:libSDL_1.2
+	devel:libSDL_mixer_1.2
 	"
 BUILD_PREREQUIRES="
 	cmd:aclocal

--- a/games-kids/dragonmemory/dragonmemory-1.recipe
+++ b/games-kids/dragonmemory/dragonmemory-1.recipe
@@ -4,7 +4,7 @@ graphics and addictive gameplay."
 HOMEPAGE="https://sourceforge.net/projects/dragonmemory/"
 COPYRIGHT="2011 Santiago Radeff Leria http://www.dragontech.net/"
 LICENSE="GNU GPL v3"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://sf.net/projects/dragonmemory/files/DragonMemory-source.tgz"
 CHECKSUM_SHA256="e0d7ff168cc7a5e01247e4c290346bf26a8423e0fc7b7b3047f437451c8f37b5"
 SOURCE_FILENAME="DragonMemory-1-source.tgz"
@@ -28,9 +28,9 @@ REQUIRES="
 BUILD_REQUIRES="
 	haiku_devel
 	devel:libGL
-	devel:libSDL
-	devel:libSDL_image
-	devel:libSDL_mixer
+	devel:libSDL_1.2
+	devel:libSDL_image_1.2
+	devel:libSDL_mixer_1.2
 	"
 BUILD_PREREQUIRES="
 	cmd:gcc

--- a/games-kids/tuxmath/tuxmath-1.7.2.recipe
+++ b/games-kids/tuxmath/tuxmath-1.7.2.recipe
@@ -5,7 +5,7 @@ practicing math, and having a great time doing it."
 HOMEPAGE="https://sourceforge.net/projects/tuxmath/"
 COPYRIGHT="2000-2009 Sam Hart"
 LICENSE="GNU GPL v2"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://downloads.sf.net/tuxmath/tuxmath_w_fonts-$portVersion.tar.gz"
 CHECKSUM_SHA256="7a3e39b17b88402a89780ac56368d8d92322c3b91f50ee4f9b747a8e2901b3a4"
 SOURCE_DIR="tuxmath_w_fonts-$portVersion"
@@ -24,10 +24,10 @@ REQUIRES="
 	lib:libcrypto$secondaryArchSuffix
 	lib:libiconv$secondaryArchSuffix
 	lib:libintl$secondaryArchSuffix
-	lib:libsdl$secondaryArchSuffix
-	lib:libsdl_image$secondaryArchSuffix
-	lib:libsdl_mixer$secondaryArchSuffix
-	lib:libsdl_ttf$secondaryArchSuffix
+	lib:libSDL_1.2$secondaryArchSuffix
+	lib:libSDL_image_1.2$secondaryArchSuffix
+	lib:libSDL_mixer_1.2$secondaryArchSuffix
+	lib:libSDL_ttf_2.0$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
@@ -35,10 +35,10 @@ BUILD_REQUIRES="
 	devel:libcrypto$secondaryArchSuffix
 	devel:libiconv$secondaryArchSuffix
 	devel:libintl$secondaryArchSuffix
-	devel:libsdl$secondaryArchSuffix
-	devel:libsdl_image$secondaryArchSuffix
-	devel:libsdl_mixer$secondaryArchSuffix
-	devel:libsdl_ttf$secondaryArchSuffix
+	devel:libSDL_1.2$secondaryArchSuffix
+	devel:libSDL_image_1.2$secondaryArchSuffix
+	devel:libSDL_mixer_1.2$secondaryArchSuffix
+	devel:libSDL_ttf_2.0$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:aclocal

--- a/games-kids/tuxtype/tuxtype2-1.5.2.recipe
+++ b/games-kids/tuxtype/tuxtype2-1.5.2.recipe
@@ -5,7 +5,7 @@ practicing typing, and having a great time doing it."
 HOMEPAGE="https://sourceforge.net/projects/tuxtype/"
 COPYRIGHT="2000-2009 Sam Hart"
 LICENSE="GNU GPL v2"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://sf.net/projects/tuxtype/files/OldFiles/tuxtype2-1.5.2.tar.gz"
 CHECKSUM_SHA256="d9552a3fe8367f14358e01d47aeb2603c6891fe0ec2e73414c541d91f0466d5d"
 PATCHES="tuxtype2-$portVersion.patchset"
@@ -21,19 +21,19 @@ PROVIDES="
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libcrypto$secondaryArchSuffix
-	lib:libsdl$secondaryArchSuffix
-	lib:libsdl_image$secondaryArchSuffix
-	lib:libsdl_mixer$secondaryArchSuffix
-	lib:libsdl_ttf$secondaryArchSuffix
+	lib:libSDL_1.2$secondaryArchSuffix
+	lib:libSDL_image_1.2$secondaryArchSuffix
+	lib:libSDL_mixer_1.2$secondaryArchSuffix
+	lib:libSDL_ttf_2.0$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libcrypto$secondaryArchSuffix
-	devel:libsdl$secondaryArchSuffix
-	devel:libsdl_image$secondaryArchSuffix
-	devel:libsdl_mixer$secondaryArchSuffix
-	devel:libsdl_ttf$secondaryArchSuffix
+	devel:libSDL_1.2$secondaryArchSuffix
+	devel:libSDL_image_1.2$secondaryArchSuffix
+	devel:libSDL_mixer_1.2$secondaryArchSuffix
+	devel:libSDL_ttf_2.0$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:aclocal

--- a/games-misc/sdljoytest/sdljoytest-11102003.recipe
+++ b/games-misc/sdljoytest/sdljoytest-11102003.recipe
@@ -5,7 +5,7 @@ joystick or other game controller."
 HOMEPAGE="http://sdljoytest.sourceforge.net"
 COPYRIGHT="2003 Samuel E. Bray"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="http://downloads.sf.net/sdljoytest/SDLJoytest-GL-$portVersion.tar.bz2"
 CHECKSUM_SHA256="306aa4b825ad880e71aac77d410f7a040ee6c1a372eb3d1db3301a8536a3c468"
 SOURCE_DIR="SDLJoytest-GL"
@@ -28,8 +28,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	devel:libGL
 	devel:libGLU
-	devel:libSDL
-	devel:libSDL_image
+	devel:libSDL_1.2
+	devel:libSDL_image_1.2
 	"
 BUILD_PREREQUIRES="
 	cmd:gcc


### PR DESCRIPTION
I've built (not installed or run) these for x86_64, x86_gcc2 as primary and x86 as secondary arch for the cases that they are declared compatible or untested, except for eduke32-20190304_7392, that does not compile for me in x86_gcc2, asking for C++11, but so does the unchanged recipe.

