### PR TITLE
kdevelop, revbump after updated libkomparediff

### DIFF
--- a/dev-util/kdevelop/kdevelop-5.6.0.recipe
+++ b/dev-util/kdevelop/kdevelop-5.6.0.recipe
@@ -7,7 +7,7 @@ HOMEPAGE="https://www.kdevelop.org/"
 COPYRIGHT="2010-2020 KDE Organisation"
 LICENSE="GNU GPL v3
 	GNU LGPL v3"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/KDE/kdevelop/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="b79ca564b09493168cba0b4a600f2af533922b7a98c05628e5400105eabb500a"
 ADDITIONAL_FILES="kdevelop.rdef.in"


### PR DESCRIPTION
From the report:
```
kdevelop-5.6.0-3-x86_64.hpkg:
	requires "lib:libkomparediff2 >= 17.12.0" of package "kdevelop-5.6.0-3" could not be resolved
```