### PR TITLE
okular, revbump for rebuild

### DIFF
--- a/kde-apps/okular/okular-20.12.1.recipe
+++ b/kde-apps/okular/okular-20.12.1.recipe
@@ -9,7 +9,7 @@ Features:
 HOMEPAGE="https://okular.kde.org"
 COPYRIGHT="2010-2020 KDE Organisation"
 LICENSE="GNU LGPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://download.kde.org/stable/release-service/$portVersion/src/okular-$portVersion.tar.xz"
 CHECKSUM_SHA256="2ca17ad0b2a1a0f9f70c7ca4bc1f44a9ed758b0ca6a8e5c9935a467f883df53e"
 SOURCE_DIR="okular-$portVersion"


### PR DESCRIPTION
Failed buildlog for x86_gcc2: https://build.haiku-os.org/buildmaster/master/x86_gcc2/logviewer.html?buildruns/1029/builds/1750.log
Should be fixed now