### PR TITLE
avisynthplus-3.7.0: new recipe

### DIFF
--- a/media-libs/avisynthplus/avisynthplus-3.7.0.recipe
+++ b/media-libs/avisynthplus/avisynthplus-3.7.0.recipe
@@ -1,0 +1,67 @@
+SUMMARY="A frameserver controlled by scripting"
+DESCRIPTION="A powerful nonlinear scripting language for media. Includes a set \
+of core filters for editing, pre-production and post-production, and the \
+ability to extend its capabilities through the use of external plugins."
+HOMEPAGE="https://avs-plus.net"
+COPYRIGHT="2000-2015 Ben Rudiak-Gould, et al.
+	2013-2021 AviSynth+ Project"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="https://github.com/AviSynth/AviSynthPlus/archive/v$portVersion.tar.gz"
+CHECKSUM_SHA256="8906d9e46dc90a194413d69b710e3106c0aafddc0c5c62004885d0c3beb79862"
+SOURCE_FILENAME="avisynthplus-$portVersion.tar.gz"
+SOURCE_DIR="AviSynthPlus-$portVersion"
+PATCHES="0001-CMakeLists-fix-setting-local-plugindir.patch
+	0002-avisynth_conf.h.in-use-mounted-system-libdir-on-Haik.patch
+	"
+
+ARCHITECTURES="!x86_gcc2 x86 x86_64 ?arm ?ppc"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="$portVersion"
+libVersionCompat="$libVersion compat >= 8"
+
+PROVIDES="
+	avisynthplus$secondaryArchSuffix = $portVersion
+	lib:libavisynth$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libIL$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	avisynthplus${secondaryArchSuffix}_devel = $portVersion
+	devel:libavisynth$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	avisynthplus$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libIL${secondaryArchSuffix}
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	"
+
+BUILD()
+{
+	mkdir -p avisynth-build
+	cd avisynth-build
+	cmake ../ $cmakeDirArgs -DCMAKE_CXX_FLAGS="-DRELEASE_TARBALL"
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make -C avisynth-build install
+
+	fixPkgconfig
+
+	packageEntries devel \
+		$developDir
+}

--- a/media-libs/avisynthplus/avisynthplus-3.7.0.recipe
+++ b/media-libs/avisynthplus/avisynthplus-3.7.0.recipe
@@ -18,7 +18,7 @@ PATCHES="0001-CMakeLists-fix-setting-local-plugindir.patch
 ARCHITECTURES="!x86_gcc2 x86 x86_64 ?arm ?ppc"
 SECONDARY_ARCHITECTURES="x86"
 
-libVersion="$portVersion"
+libVersion="8"
 libVersionCompat="$libVersion compat >= 8"
 
 PROVIDES="

--- a/media-libs/avisynthplus/patches/0001-CMakeLists-fix-setting-local-plugindir.patch
+++ b/media-libs/avisynthplus/patches/0001-CMakeLists-fix-setting-local-plugindir.patch
@@ -1,0 +1,41 @@
+From 20377502a81eefa9356b04174a12508133ed733e Mon Sep 17 00:00:00 2001
+From: Stephen Hutchinson <qyot27@gmail.com>
+Date: Sun, 17 Jan 2021 14:11:56 -0500
+Subject: [PATCH 1/2] CMakeLists: fix setting local plugindir
+
+---
+ CMakeLists.txt                                                | 4 +---
+ .../docs/english/source/avisynthdoc/contributing/posix.rst    | 2 +-
+ 2 files changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9ea2c954..7da15fbb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -66,9 +66,7 @@ if(NOT HEADERS_ONLY)
+ 
+   option(ENABLE_PLUGINS "Build set of default external plugins" ON)
+   option(ENABLE_INTEL_SIMD "Enable SIMD intrinsics for Intel processors" "${INTEL_SIMD}")
+-  option(LOCAL_PLUGINDIR "Override path for user-local plugins" "${USER_AVS_PLUGINDIR_LOCATION}")
+-
+-  set(USER_AVS_PLUGINDIR_LOCATION "$ENV{HOME}/.local/lib/avisynth")
++  set(USER_AVS_PLUGINDIR_LOCATION "$ENV{HOME}/.local/lib/avisynth" CACHE STRING "Override path for user-local plugins (default: $HOME/.local/lib/avisynth)")
+ 
+   if(CMAKE_CONFIGURATION_TYPES)
+     set(CMAKE_CONFIGURATION_TYPES Debug Release RelWithDebInfo)
+diff --git a/distrib/docs/english/source/avisynthdoc/contributing/posix.rst b/distrib/docs/english/source/avisynthdoc/contributing/posix.rst
+index 43a4e71c..c7e51303 100644
+--- a/distrib/docs/english/source/avisynthdoc/contributing/posix.rst
++++ b/distrib/docs/english/source/avisynthdoc/contributing/posix.rst
+@@ -373,7 +373,7 @@ Plugin autoloading
+ 
+ AviSynth+ will use several directories for autoloading:
+ the `avisynth/` subdirectory where libavisynth.so was installed,
+-`$HOME/.avisynth`, and the directory given to the LOCAL_PLUGINDIR
++`$HOME/.avisynth`, and the directory given to the USER_AVS_PLUGINDIR_LOCATION
+ configuration option (defaults to `$HOME/.local/lib/avisynth`).
+ The latter of which can hold plugins (and symlinks to plugins)
+ or AVSI files without needing root permissions.
+-- 
+2.30.0
+

--- a/media-libs/avisynthplus/patches/0002-avisynth_conf.h.in-use-mounted-system-libdir-on-Haik.patch
+++ b/media-libs/avisynthplus/patches/0002-avisynth_conf.h.in-use-mounted-system-libdir-on-Haik.patch
@@ -1,0 +1,33 @@
+From acd6cab76425fed45a300822cd41f30548948d44 Mon Sep 17 00:00:00 2001
+From: Stephen Hutchinson <qyot27@gmail.com>
+Date: Mon, 18 Jan 2021 04:41:52 -0500
+Subject: [PATCH 2/2] avisynth_conf.h.in: use mounted system libdir on Haiku
+
+---
+ avs_core/avisynth_conf.h.in | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/avs_core/avisynth_conf.h.in b/avs_core/avisynth_conf.h.in
+index 57bc107f..cdf96f19 100644
+--- a/avs_core/avisynth_conf.h.in
++++ b/avs_core/avisynth_conf.h.in
+@@ -5,7 +5,15 @@
+ 
+ #ifdef AVS_POSIX
+ #define user_avs_plugindir_configurable "@USER_AVS_PLUGINDIR_LOCATION@"
+-#define system_avs_plugindir "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/avisynth"
++    #ifdef AVS_HAIKU
++        #ifdef X86_32
++            #define system_avs_plugindir "/system/lib/x86/avisynth"
++        #else
++            #define system_avs_plugindir "/system/lib/avisynth"
++        #endif
++    #else
++        #define system_avs_plugindir "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/avisynth"
++    #endif
+ #endif
+ 
+ #endif // _AVS_CONF_H_
+-- 
+2.30.0
+


### PR DESCRIPTION
Hopefully I did this right.  It completes successfully for me on 64-bit, but on 32-bit it kept failing when trying to populate dependencies because it didn't seem to be recognizing $secondaryArchSuffix at all (or in other cases, just erroring out with a 'is broken on this architecture'; I'm hoping that maybe that's just an issue with my local configuration and not with the recipe).

The patch section there is something we'll address upstream.