### PR TITLE
libidn, fix build for gcc2

### DIFF
--- a/net-dns/libidn/libidn-1.36.recipe
+++ b/net-dns/libidn/libidn-1.36.recipe
@@ -4,10 +4,11 @@ on the Stringprep, Punycode, IDNA and TLD specifications."
 HOMEPAGE="https://www.gnu.org/software/libidn/"
 COPYRIGHT="2002-2018 Simon Josefsson"
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://ftpmirror.gnu.org/libidn/libidn-$portVersion.tar.gz
 	https://ftp.gnu.org/gnu/libidn/libidn-$portVersion.tar.gz"
 CHECKSUM_SHA256="14b67108344d81ba844631640df77c9071d9fb0659b080326ff5424e86b14038"
+PATCHES="libidn-$portVersion.patchset"
 
 ARCHITECTURES="x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"

--- a/net-dns/libidn/patches/libidn-1.36.patchset
+++ b/net-dns/libidn/patches/libidn-1.36.patchset
@@ -1,0 +1,55 @@
+From cc357bdbece703ccbefe06529e50d71160e62d02 Mon Sep 17 00:00:00 2001
+From: begasus <begasus@gmail.com>
+Date: Tue, 19 Jan 2021 12:39:38 +0000
+Subject: Fix build for gcc2
+
+
+diff --git a/gl/version-etc.h b/gl/version-etc.h
+index 813084c..dd1edaf 100644
+--- a/gl/version-etc.h
++++ b/gl/version-etc.h
+@@ -61,7 +61,7 @@ extern void version_etc (FILE *stream,
+                          const char *command_name, const char *package,
+                          const char *version,
+                          /* const char *author1, ..., NULL */ ...)
+-  _GL_ATTRIBUTE_SENTINEL ();
++  _GL_ATTRIBUTE_SENTINEL ((0));
+ 
+ /* Display the usual "Report bugs to" stanza.  */
+ extern void emit_bug_reporting_address (void);
+diff --git a/lib/gl/attribute.h b/lib/gl/attribute.h
+index 9c09ecc..842c75b 100644
+--- a/lib/gl/attribute.h
++++ b/lib/gl/attribute.h
+@@ -80,7 +80,7 @@
+ /* Attributes for variadic functions.  */
+ 
+ /* The variadic function expects a trailing NULL argument.
+-   ATTRIBUTE_SENTINEL () - The last argument is NULL.
++   ATTRIBUTE_SENTINEL () - The last argument is NULL (requires c99).
+    ATTRIBUTE_SENTINEL ((N)) - The (N+1)st argument from the end is NULL.  */
+ /* Applies to: functions.  */
+ #define ATTRIBUTE_SENTINEL(pos) _GL_ATTRIBUTE_SENTINEL (pos)
+diff --git a/lib/gl/strverscmp.c b/lib/gl/strverscmp.c
+index f55856e..3b4dd58 100644
+--- a/lib/gl/strverscmp.c
++++ b/lib/gl/strverscmp.c
+@@ -73,6 +73,7 @@ __strverscmp (const char *s1, const char *s2)
+   if (p1 == p2)
+     return 0;
+ 
++{  
+   unsigned char c1 = *p1++;
+   unsigned char c2 = *p2++;
+   /* Hint: '0' is a digit too.  */
+@@ -107,6 +108,7 @@ __strverscmp (const char *s1, const char *s2)
+     default:
+       return state;
+   }
++  }
+ }
+ libc_hidden_def (__strverscmp)
+ weak_alias (__strverscmp, strverscmp)
+-- 
+2.30.0
+


### PR DESCRIPTION
Primary patch came from Oracle patch: https://www.mail-archive.com/bug-gnulib@gnu.org/msg39296.html