### PR TITLE
libyubikey: Rebuild for libusb 1.0.24

### DIFF
--- a/sys-auth/libyubikey/libyubikey-1.13.recipe
+++ b/sys-auth/libyubikey/libyubikey-1.13.recipe
@@ -4,11 +4,11 @@ DESCRIPTION="C library for manipulating Yubico YubiKey One-Time Passwords \
 HOMEPAGE="https://developers.yubico.com/yubico-c/"
 COPYRIGHT="2008-2015 Yubico AB"
 LICENSE="BSD (2-clause)"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://developers.yubico.com/yubico-c/Releases/libyubikey-$portVersion.tar.gz"
 CHECKSUM_SHA256="04edd0eb09cb665a05d808c58e1985f25bb7c5254d2849f36a0658ffc51c3401"
 
-ARCHITECTURES="x86_gcc2 x86 x86_64"
+ARCHITECTURES="!x86_gcc2 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="


### PR DESCRIPTION
Migrate from GCC2 to GCC8 x86.