### PR TITLE
singularity: Add recipe

### DIFF
--- a/games-simulation/singularity/singularity-1.00.recipe
+++ b/games-simulation/singularity/singularity-1.00.recipe
@@ -1,0 +1,51 @@
+SUMMARY="Become a self-aware AI and take over the world"
+DESCRIPTION="Endgame: Singularity is a simulation of a true AI. Go from \
+computer to computer, pursued by the entire world. Keep hidden, and you might \
+have a chance."
+HOMEPAGE="https://singularity.github.io/"
+COPYRIGHT="EMH Software, Singularity community 2005-2020"
+LICENSE="GNU GPL v2"
+REVISION="1"
+srcGitTag="1.00"
+SOURCE_URI="https://github.com/singularity/singularity/archive/v$srcGitTag.tar.gz"
+CHECKSUM_SHA256="5e747268d9e96e69adace1f346fe40d0c3ec05764b98e82cc3ab0335d96d9171"
+SOURCE_DIR="singularity-$srcGitTag"
+
+ARCHITECTURES="!x86_gcc2 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	singularity$secondaryArchSuffix = $portVersion
+	app:singularity = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	numpy
+	pillow
+	pygame$secondaryArchSuffix
+	python3$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	numpy
+	pillow
+	pygame$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	pip_python3
+	python3$secondaryArchSuffix
+	setuptools
+"
+
+BUILD()
+{
+	python3 setup.py build
+}
+
+INSTALL()
+{
+	mkdir -p $appsDir/singularity
+	python3 setup.py install
+	addAppDeskbarSymlink $appsDir/singularity "Endgame: Singularity"
+}

--- a/games-simulation/singularity/singularity-1.00.recipe
+++ b/games-simulation/singularity/singularity-1.00.recipe
@@ -20,10 +20,10 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	cmd:python3$secondaryArchSuffix
 	numpy
 	pillow
 	pygame$secondaryArchSuffix
-	python3$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
@@ -31,11 +31,11 @@ BUILD_REQUIRES="
 	numpy
 	pillow
 	pygame$secondaryArchSuffix
+	setuptools_python3
 	"
 BUILD_PREREQUIRES="
+	cmd:python3$secondaryArchSuffix
 	pip_python3
-	python3$secondaryArchSuffix
-	setuptools
 "
 
 BUILD()
@@ -45,7 +45,11 @@ BUILD()
 
 INSTALL()
 {
-	mkdir -p $appsDir/singularity
-	python3 setup.py install
-	addAppDeskbarSymlink $appsDir/singularity "Endgame: Singularity"
+	python3 setup.py install \
+		--root=/ --prefix=$prefix \
+		--install-data=$dataDir
+	mkdir -p $appsDir
+	mv $prefix/bin/singularity $appsDir/Singularity
+	settype -t application/x-vnd.Be-elfexecutable $appsDir/Singularity
+	addAppDeskbarSymlink $appsDir/Singularity "Endgame: Singularity"
 }


### PR DESCRIPTION
[*Endgame: Singularity*](https://singularity.github.io/) is a game where players become a self-aware artificial intelligence with the goals of covertly taking over the world and achieving technological singularity.

To be honest, I am still not quite sure if this belongs in `games-simulation` or `games-strategy`. It's only in the former since most official material describes it as a simulation, even within the code. However, some places like its [Wikipedia page](https://en.wikipedia.org/wiki/Endgame:_Singularity) classify it more as a strategy game.

The recipe as it is right now does not work, since I have not yet figured out where to tell `setup.py` to install the files to. Setting the prefix to `$appsDir/singularity` doesn't work, since Python will error out saying that it does not support `.pth` files. Only ever had experience with porting native programs to Haiku, so this is a first time with one that is Python-based.