### PR TITLE
mpg123: bump to 1.26.4

### DIFF
--- a/media-sound/mpg123/mpg123-1.26.4.recipe
+++ b/media-sound/mpg123/mpg123-1.26.4.recipe
@@ -1,0 +1,98 @@
+SUMMARY="A fast console MPEG audio player and decoder library"
+DESCRIPTION="mpg123 is the fast and free console based real time MPEG audio \
+player for layer 1, 2 and 3."
+HOMEPAGE="https://www.mpg123.org/"
+COPYRIGHT="1995-2020 Michael Hipp and others"
+LICENSE="GNU LGPL v2.1"
+REVISION="1"
+SOURCE_URI="https://downloads.sourceforge.net/mpg123/mpg123-$portVersion.tar.bz2"
+CHECKSUM_SHA256="081991540df7a666b29049ad870f293cfa28863b36488ab4d58ceaa7b5846454"
+
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
+
+libmpg123Version="0.45.3"
+libout123Version="0.3.0"
+libsyn123Version="0.1.1"
+libmpg123VersionCompat="$libmpg123Version compat >= ${libmpg123Version%%.*}"
+libout123VersionCompat="$libout123Version compat >= ${libout123Version%%.*}"
+libsyn123VersionCompat="$libsyn123Version compat >= ${libsyn123Version%%.*}"
+PROVIDES="
+	mpg123$secondaryArchSuffix = $portVersion
+	cmd:mpg123$secondaryArchSuffix = $portVersion
+	cmd:mpg123_id3dump$secondaryArchSuffix = $portVersion
+	cmd:mpg123_strip$secondaryArchSuffix = $portVersion
+	cmd:out123$secondaryArchSuffix = $portVersion
+	lib:libmpg123$secondaryArchSuffix = $libmpg123VersionCompat
+	lib:libout123$secondaryArchSuffix = $libout123VersionCompat
+	lib:libsyn123$secondaryArchSuffix = $libsyn123VersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libltdl$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	mpg123${secondaryArchSuffix}_devel = $portVersion
+	devel:libmpg123$secondaryArchSuffix = $libmpg123VersionCompat
+	devel:libout123$secondaryArchSuffix = $libout123VersionCompat
+	devel:libsyn123$secondaryArchSuffix = $libsyn123VersionCompat
+	"
+REQUIRES_devel="
+	haiku$secondaryArchSuffix
+	mpg123$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:autoheader
+	cmd:automake
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+defineDebugInfoPackage mpg123$secondaryArchSuffix \
+	"$binDir"/mpg123 \
+	"$binDir"/mpg123-id3dump \
+	"$binDir"/mpg123-strip \
+	"$binDir"/out123 \
+	"$libDir"/libmpg123.so.$libmpg123Version \
+	"$libDir"/libout123.so.$libout123Version \
+	"$libDir"/libsyn123.so.$libsyn123Version \
+	"$libDir"/mpg123/output_dummy.so
+
+BUILD()
+{
+	runConfigure ./configure
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	if [ -n "$secondaryArchSuffix" ]; then
+		rm -rf "$manDir"
+	fi
+
+	rm $libDir/lib*.la
+
+	prepareInstalledDevelLibs \
+		libmpg123 \
+		libout123 \
+		libsyn123
+	fixPkgconfig
+	packageEntries devel $developDir
+}
+
+TEST()
+{
+	make check
+}


### PR DESCRIPTION
Leaving the old 1.25.13 release in the repo as the new version no longer compiles with gcc2.