### PR TITLE
psi_plus: bump to 1.4.1514

### DIFF
--- a/net-im/psi_plus/psi_plus-1.4.1514.recipe
+++ b/net-im/psi_plus/psi_plus-1.4.1514.recipe
@@ -1,14 +1,14 @@
 SUMMARY="A development branch of Psi IM XMPP/Jabber client"
 DESCRIPTION="Psi is a cross-platform powerful XMPP client designed for experienced users."
 HOMEPAGE="https://psi-plus.com/"
-COPYRIGHT="2005-2019, Psi+ Project"
+COPYRIGHT="2005-2020, Psi+ Project"
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://github.com/psi-plus/psi-plus-snapshots/archive/$portVersion.tar.gz"
-CHECKSUM_SHA256="acaa534739591cf68815db863db57b283847f182afc317c85717a4a35cd86186"
+CHECKSUM_SHA256="24f214de8e7ea2ab5feb4e08974281d698d726e13e22a34b493fbb4cd4cc882b"
 SOURCE_DIR="psi-plus-snapshots-$portVersion"
 SOURCE_URI_2="https://github.com/psi-plus/psi-plus-l10n/archive/$portVersion.tar.gz"
-CHECKSUM_SHA256_2="cde59bdcc9be9aa6dd2fc72398907052d60ce24bdd67436c28f0c5f75f22d26f"
+CHECKSUM_SHA256_2="b17f75e5eca476af29de97cc4dc5eab8f623e1834436e7a7e001b65c53687b34"
 SOURCE_FILENAME_2="psi-plus-l10n-$portVersion.tar.gz"
 SOURCE_DIR_2="psi-plus-l10n-$portVersion"
 spcVersion="2.3.3"
@@ -30,7 +30,6 @@ REQUIRES="
 	lib:libcrypto$secondaryArchSuffix
 	lib:libgcrypt$secondaryArchSuffix
 	lib:libhunspell_1.7$secondaryArchSuffix
-	lib:libidn$secondaryArchSuffix
 	lib:libotr$secondaryArchSuffix
 	lib:libqca_qt5$secondaryArchSuffix
 	lib:libQt5Core$secondaryArchSuffix
@@ -49,7 +48,6 @@ BUILD_REQUIRES="
 	devel:libcrypto$secondaryArchSuffix
 	devel:libgcrypt$secondaryArchSuffix
 	devel:libhunspell_1.7$secondaryArchSuffix
-	devel:libidn$secondaryArchSuffix
 	devel:libotr$secondaryArchSuffix
 	devel:libqca$secondaryArchSuffix >= 2.1.3
 	devel:libQt5Core$secondaryArchSuffix


### PR DESCRIPTION
I cannot build latest version of Psi+ (1.5.1477) because it has new build dependency from `usrsctp` library which is nor packaged in Haikuports, nor could be built from sources without additional patches.