### PR TITLE
requests: Add certifi as requirement

### DIFF
--- a/dev-python/requests/requests-2.25.1.recipe
+++ b/dev-python/requests/requests-2.25.1.recipe
@@ -2,9 +2,9 @@ SUMMARY="A HTTP library for Python"
 DESCRIPTION="Requests is a HTTP library, written in Python, made for humans."
 HOMEPAGE="http://python-requests.org/
 	http://pypi.python.org/pypi/requests"
-COPYRIGHT="2019 Kenneth Reitz"
+COPYRIGHT="2019-2020 Kenneth Reitz"
 LICENSE="Apache v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/kennethreitz/requests/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="03b192fad682a33964df331d35f90918b1940c89f6c5bcb10060be688ba50315"
 SOURCE_FILENAME="requests-$portVersion.tar.gz"
@@ -35,6 +35,7 @@ REQUIRES_$pythonPackage=\"\
 	chardet_$pythonPackage\n\
 	idna_$pythonPackage\n\
 	urllib3_$pythonPackage\n\
+	certifi_$pythonPackage\n\
 	cmd:python$pythonVersion\
 	\""
 BUILD_REQUIRES="$BUILD_REQUIRES


### PR DESCRIPTION
requests needed certifi. Please note that #5664 added packages for python38 and python39 so make sure to merge them before.