### PR TITLE
ytdl-gui: Update to 2.0

### DIFF
--- a/net-misc/ytdl-gui/ytdl_gui-2.0.recipe
+++ b/net-misc/ytdl-gui/ytdl_gui-2.0.recipe
@@ -8,11 +8,10 @@ HOMEPAGE="https://github.com/JaGoLi/ytdl-gui"
 COPYRIGHT="2020 JaGoLi"
 LICENSE="GNU GPL v3"
 REVISION="1"
-srcGitTag="1.0"
-SOURCE_URI="https://github.com/JaGoLi/ytdl-gui/archive/$srcGitTag.tar.gz"
-CHECKSUM_SHA256="20d262cd3e5ce77b075e0ffee6b9d0480560856f687e1c63097fc146825166c6"
+SOURCE_URI="https://github.com/JaGoLi/ytdl-gui/archive/$portVersion.tar.gz"
+CHECKSUM_SHA256="59c60fc76344f8ef218fdda71818c6ec045e19964be507f265223db0b7f08b4e"
 SOURCE_FILENAME="ytdl-gui-$portVersion-tar.gz"
-SOURCE_DIR="ytdl-gui-$srcGitTag"
+SOURCE_DIR="ytdl-gui-$portVersion"
 ADDITIONAL_FILES="ytdl_gui.rdef.in"
 
 ARCHITECTURES="!x86_gcc2 x86_64"
@@ -65,7 +64,7 @@ BUILD()
 INSTALL()
 {
 	mkdir -p $appsDir
-	mv ./src/ytdl_gui $appsDir/ytdl_gui
+	mv ./src/youtubedl-gui $appsDir/ytdl-gui
 
 	local APP_SIGNATURE="application/x-vnd.ytdl_gui"
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
@@ -75,6 +74,6 @@ INSTALL()
 		-e "s|@MAJOR@|$MAJOR|" \
 		-e "s|@LONG_INFO@|$LONG_INFO|" \
 		$portDir/additional-files/ytdl_gui.rdef.in > $sourceDir/ytdl_gui.rdef
-	addResourcesToBinaries $sourceDir/ytdl_gui.rdef $appsDir/ytdl_gui
-	addAppDeskbarSymlink $appsDir/ytdl_gui "YouTubeDL-GUI"
+	addResourcesToBinaries $sourceDir/ytdl_gui.rdef $appsDir/ytdl-gui
+	addAppDeskbarSymlink $appsDir/ytdl-gui "YouTubeDL-GUI"
 }


### PR DESCRIPTION
Updates the app to 2.0, bringing a checkbox to let `youtube-dl` select format options and 1.9's playlist support. At the advice of @Begasus in a prior attempted PR (https://github.com/haikuports/haikuports/pull/5669), `$srcGitTag` has been removed in favour of using `$portVersion` in its place.