### PR TITLE
Scalapack: disable for every arch

### DIFF
--- a/sci-libs/scalapack/scalapack-2.1.0.recipe
+++ b/sci-libs/scalapack/scalapack-2.1.0.recipe
@@ -5,16 +5,16 @@ It is currently written in a Single-Program-Multiple-Data style using \
 explicit message passing for interprocessor communication. It assumes \
 matrices are laid out in a two-dimensional block cyclic decomposition."
 HOMEPAGE="http://www.netlib.org/scalapack/"
-COPYRIGHT="	1992-2011 The University of Tennessee and The University of \
+COPYRIGHT="1992-2011 The University of Tennessee and The University of \
 		Tennessee Research Foundation
 	2000-2011 The University of California Berkeley
 	2006-2011 The University of Colorado Denver"
 LICENSE="BSD (3-clause)"
-REVISION="3"
+REVISION="1"
 SOURCE_URI="http://netlib.org/scalapack/scalapack-$portVersion.tgz"
-CHECKSUM_SHA256="0c74aeae690fe5ee4db7926f49c5d0bb69ce09eea75beb915e00bba07530395c"
+CHECKSUM_SHA256="61d9216cf81d246944720cfce96255878a3f85dec13b9351f1fa0fd6768220a6"
 
-ARCHITECTURES="!x86_gcc2 x86 x86_64"
+ARCHITECTURES="!x86_gcc2 ?x86 ?x86_64"
 SECONDARY_ARCHITECTURES="?x86"
 
 PROVIDES="


### PR DESCRIPTION
Depends on OpenMPI, but i am convincied that it works. Nothing uses this.