### PR TITLE
eigen: respin for mpfr 4.1.0 update

### DIFF
--- a/dev-cpp/eigen/eigen-3.3.9.recipe
+++ b/dev-cpp/eigen/eigen-3.3.9.recipe
@@ -27,12 +27,12 @@ HOMEPAGE="http://eigen.tuxfamily.org"
 COPYRIGHT="2006-2011 Benoit Jacob
 	2008-2012 Gael Guennebaud, et al."
 LICENSE="MPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://gitlab.com/libeigen/eigen/-/archive/$portVersion/eigen-$portVersion.tar.gz"
 CHECKSUM_SHA256="7985975b787340124786f092b3a07d594b2e9cd53bbfe5f3d9b1daee7d55f56f"
 PATCHES="eigen-$portVersion.patchset"
 
-ARCHITECTURES="!x86_gcc2 x86 x86_64"
+ARCHITECTURES="!x86_gcc2 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="


### PR DESCRIPTION
x86 build depends on mpfr3 (3.1.6-5).