### PR TITLE
mac: bump to 6.12

### DIFF
--- a/media-sound/mac/mac-6.12.recipe
+++ b/media-sound/mac/mac-6.12.recipe
@@ -7,7 +7,7 @@ COPYRIGHT="2000-2021 Matthew T. Ashland"
 LICENSE="Monkey's Audio SDK and Source Code License Agreement"
 REVISION="1"
 SOURCE_URI="https://www.monkeysaudio.com/files/MAC_SDK_${portVersion/./}.zip"
-CHECKSUM_SHA256="31899858b6d125e1ab81b6f391cd77f62087d5ceb9307ce8380138c2864dc5c9"
+CHECKSUM_SHA256="5ad08c5ea3ec646a0ad340389a07db2636a7c67bda55401cad90f35500e8648f"
 SOURCE_DIR=""
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"


### PR DESCRIPTION
Here's another bump for the Monkey's Audio package as #5717 failed because the upstream author removed the 6.11 zip.