### PR TITLE
jdTextEdit: Add setutools to dependencies

### DIFF
--- a/app-editors/jdtextedit/jdtextedit-8.2.recipe
+++ b/app-editors/jdtextedit/jdtextedit-8.2.recipe
@@ -10,7 +10,7 @@ DESCRIPTION="An advanced text editor, written in Python, with useful features:
 HOMEPAGE="https://gitlab.com/JakobDev/jdTextEdit"
 COPYRIGHT="2019-2021 JakobDev"
 LICENSE="GNU GPL v3"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://gitlab.com/JakobDev/jdTextEdit/-/archive/$portVersion/jdTextEdit-$portVersion.tar.gz"
 CHECKSUM_SHA256="8cb18faa11a2551b275a7ac2a8540abe7712ec9ebcd8d63f2805d06dfc786aaf"
 SOURCE_DIR="jdTextEdit-$portVersion"
@@ -35,6 +35,7 @@ REQUIRES="
 	pyqt5_python38
 	qscintilla_python38
 	requests_python38
+	setuptools_python38
 	"
 
 BUILD_REQUIRES="


### PR DESCRIPTION
I totally forgot that programs that are installed with setuptools also need setuptools to run.