### PR TITLE
blender: enforce boost 1.69 depend only build

### DIFF
--- a/media-gfx/blender/blender-2.79b.recipe
+++ b/media-gfx/blender/blender-2.79b.recipe
@@ -89,6 +89,7 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	boost169${secondaryArchSuffix}_devel
 	devel:eigen$secondaryArchSuffix
 	devel:libalembic$secondaryArchSuffix
 	devel:libavcodec$secondaryArchSuffix

--- a/media-gfx/blender/blender-2.79b.recipe
+++ b/media-gfx/blender/blender-2.79b.recipe
@@ -93,14 +93,14 @@ BUILD_REQUIRES="
 	devel:libalembic$secondaryArchSuffix
 	devel:libavcodec$secondaryArchSuffix
 	devel:libavdevice$secondaryArchSuffix
-	devel:libboost_atomic$secondaryArchSuffix == 1.69.0
-	devel:libboost_chrono$secondaryArchSuffix == 1.69.0
-	devel:libboost_date_time$secondaryArchSuffix == 1.69.0
-	devel:libboost_filesystem$secondaryArchSuffix == 1.69.0
-	devel:libboost_locale$secondaryArchSuffix == 1.69.0
-	devel:libboost_regex$secondaryArchSuffix == 1.69.0
-	devel:libboost_system$secondaryArchSuffix == 1.69.0
-	devel:libboost_thread$secondaryArchSuffix == 1.69.0
+	devel:libboost_atomic$secondaryArchSuffix >= 1.69
+	devel:libboost_chrono$secondaryArchSuffix >= 1.69
+	devel:libboost_date_time$secondaryArchSuffix >= 1.69
+	devel:libboost_filesystem$secondaryArchSuffix >= 1.69
+	devel:libboost_locale$secondaryArchSuffix >= 1.69
+	devel:libboost_regex$secondaryArchSuffix >= 1.69
+	devel:libboost_system$secondaryArchSuffix >= 1.69
+	devel:libboost_thread$secondaryArchSuffix >= 1.69
 	devel:libexecinfo$secondaryArchSuffix
 	devel:libfftw3$secondaryArchSuffix
 	devel:libfreetype$secondaryArchSuffix

--- a/media-gfx/blender/blender-2.79b.recipe
+++ b/media-gfx/blender/blender-2.79b.recipe
@@ -89,19 +89,18 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	boost169${secondaryArchSuffix}_devel
 	devel:eigen$secondaryArchSuffix
 	devel:libalembic$secondaryArchSuffix
 	devel:libavcodec$secondaryArchSuffix
 	devel:libavdevice$secondaryArchSuffix
-	devel:libboost_atomic$secondaryArchSuffix
-	devel:libboost_chrono$secondaryArchSuffix
-	devel:libboost_date_time$secondaryArchSuffix
-	devel:libboost_filesystem$secondaryArchSuffix
-	devel:libboost_locale$secondaryArchSuffix
-	devel:libboost_regex$secondaryArchSuffix
-	devel:libboost_system$secondaryArchSuffix
-	devel:libboost_thread$secondaryArchSuffix
+	devel:libboost_atomic$secondaryArchSuffix == 1.69.0
+	devel:libboost_chrono$secondaryArchSuffix == 1.69.0
+	devel:libboost_date_time$secondaryArchSuffix == 1.69.0
+	devel:libboost_filesystem$secondaryArchSuffix == 1.69.0
+	devel:libboost_locale$secondaryArchSuffix == 1.69.0
+	devel:libboost_regex$secondaryArchSuffix == 1.69.0
+	devel:libboost_system$secondaryArchSuffix == 1.69.0
+	devel:libboost_thread$secondaryArchSuffix == 1.69.0
 	devel:libexecinfo$secondaryArchSuffix
 	devel:libfftw3$secondaryArchSuffix
 	devel:libfreetype$secondaryArchSuffix


### PR DESCRIPTION
Enforces usage of boost 1.69 on buildbots - versus boost 1.70 which breaks build.
Recipe needed to block the installation of boost 1.70 devel package.

[blender-2.79b_buildlog.txt](https://github.com/haikuports/haikuports/files/6062673/blender-2.79b_buildlog.txt)
