### PR TITLE
blender: enforce boost < 1.70 version depend

### DIFF
--- a/media-gfx/blender/blender-2.79b.recipe
+++ b/media-gfx/blender/blender-2.79b.recipe
@@ -93,14 +93,14 @@ BUILD_REQUIRES="
 	devel:libalembic$secondaryArchSuffix
 	devel:libavcodec$secondaryArchSuffix
 	devel:libavdevice$secondaryArchSuffix
-	devel:libboost_atomic$secondaryArchSuffix >= 1.69
-	devel:libboost_chrono$secondaryArchSuffix >= 1.69
-	devel:libboost_date_time$secondaryArchSuffix >= 1.69
-	devel:libboost_filesystem$secondaryArchSuffix >= 1.69
-	devel:libboost_locale$secondaryArchSuffix >= 1.69
-	devel:libboost_regex$secondaryArchSuffix >= 1.69
-	devel:libboost_system$secondaryArchSuffix >= 1.69
-	devel:libboost_thread$secondaryArchSuffix >= 1.69
+	devel:libboost_atomic$secondaryArchSuffix < 1.70
+	devel:libboost_chrono$secondaryArchSuffix < 1.70
+	devel:libboost_date_time$secondaryArchSuffix < 1.70
+	devel:libboost_filesystem$secondaryArchSuffix < 1.70
+	devel:libboost_locale$secondaryArchSuffix < 1.70
+	devel:libboost_regex$secondaryArchSuffix < 1.70
+	devel:libboost_system$secondaryArchSuffix < 1.70
+	devel:libboost_thread$secondaryArchSuffix < 1.70
 	devel:libexecinfo$secondaryArchSuffix
 	devel:libfftw3$secondaryArchSuffix
 	devel:libfreetype$secondaryArchSuffix


### PR DESCRIPTION
This works locally and prevents newer boost packages during compilation.
Using '>= 1.69' constraint puls in the boost 1.70 devel package - which we don't want for this compilation.

NOTE: Haiku R1B2 doesn't provide any pre-installed boost packages.