### PR TITLE
Re-enable compiler hardening and zlib check.

### DIFF
--- a/net-misc/openssh/openssh-8.4p1.recipe
+++ b/net-misc/openssh/openssh-8.4p1.recipe
@@ -16,8 +16,8 @@ ssh-keyscan, ssh-keygen and sftp-server."
 HOMEPAGE="http://www.openssh.com/"
 COPYRIGHT="2005-2020 Tatu Ylonen et al."
 LICENSE="OpenSSH"
-REVISION="1"
-SOURCE_URI="https://ftp.fr.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$portVersion.tar.gz"
+REVISION="2"
+SOURCE_URI="https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$portVersion.tar.gz"
 CHECKSUM_SHA256="5a01d22e407eb1c05ba8a8f7c654d388a13e9f226e4ed33bd38748dafa1d2b24"
 PATCHES="openssh-$portVersion.patchset
 	0001-Fix-EOF-command-not-found-error-in-ssh-copy-id.patch
@@ -126,9 +126,7 @@ BUILD()
 		--with-default-path="$defaultPath" \
 		--with-md5-passwords \
 		--disable-utmpx \
-		--with-libedit \
-		--without-zlib-version-check \
-		--without-stackprotect
+		--with-libedit
 	make $jobArgs
 }
 


### PR DESCRIPTION
The configure tests have been fixed to work upstream.
Switch URL to canonical CDN URL which should be faster in most cases.