### PR TITLE
gcc: add GCC 10.3.0 recipe

### DIFF
--- a/sys-devel/gcc/gcc-10.3.0_2021_04_08.recipe
+++ b/sys-devel/gcc/gcc-10.3.0_2021_04_08.recipe
@@ -13,8 +13,8 @@ CHECKSUM_SHA256="64f404c1a650f27fc33da242e1f2df54952e3963a49e06e73f6940f3223ac34
 SOURCE_DIR="gcc-$gccVersion"
 PATCHES="gcc-$portVersion.patchset"
 
-ARCHITECTURES="!x86_gcc2 ?x86_64 ?arm ?arm64 ?m68k ?ppc ?riscv64 ?sparc"
-SECONDARY_ARCHITECTURES="?x86"
+ARCHITECTURES="!x86_gcc2 x86_64 ?arm ?arm64 ?m68k ?ppc ?riscv64 ?sparc"
+SECONDARY_ARCHITECTURES="x86"
 
 libatomicSoVersion="1"
 libatomicLibVersion="1.2.0"
@@ -35,7 +35,7 @@ libsspSoVersion="0"
 libsspLibVersion="0.0.0"
 
 libstdcxxSoVersion="6"
-libstdcxxLibVersion="6.0.25"
+libstdcxxLibVersion="6.0.28"
 
 PROVIDES="
 	gcc$secondaryArchSuffix = $portVersion compat >= 7

--- a/sys-devel/gcc/gcc-10.3.0_2021_04_08.recipe
+++ b/sys-devel/gcc/gcc-10.3.0_2021_04_08.recipe
@@ -1,0 +1,462 @@
+SUMMARY="C/C++ compiler for target ${effectiveTargetMachineTriple}"
+DESCRIPTION="The standard compiler for non-legacy Haiku (i.e. for all \
+architectures other than x86_gcc2)."
+HOMEPAGE="https://gcc.gnu.org/"
+COPYRIGHT="1988-2021 Free Software Foundation, Inc."
+LICENSE="GNU GPL v3
+	GNU LGPL v3"
+REVISION="1"
+gccVersion="${portVersion%%_*}"
+SOURCE_URI="https://ftpmirror.gnu.org/gcc/gcc-$gccVersion/gcc-$gccVersion.tar.xz
+	https://ftp.gnu.org/gnu/gcc/gcc-$gccVersion/gcc-$gccVersion.tar.xz"
+CHECKSUM_SHA256="64f404c1a650f27fc33da242e1f2df54952e3963a49e06e73f6940f3223ac344"
+SOURCE_DIR="gcc-$gccVersion"
+PATCHES="gcc-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 ?x86_64 ?arm ?arm64 ?m68k ?ppc ?riscv64 ?sparc"
+SECONDARY_ARCHITECTURES="?x86"
+
+libatomicSoVersion="1"
+libatomicLibVersion="1.2.0"
+
+libgccSoVersion="1"
+libgccLibVersion="1"
+
+libgfortranSoVersion="5"
+libgfortranLibVersion="5.0.0"
+
+libgompSoVersion="1"
+libgompLibVersion="1.0.0"
+
+libquadmathSoVersion="0"
+libquadmathLibVersion="0.0.0"
+
+libsspSoVersion="0"
+libsspLibVersion="0.0.0"
+
+libstdcxxSoVersion="6"
+libstdcxxLibVersion="6.0.25"
+
+PROVIDES="
+	gcc$secondaryArchSuffix = $portVersion compat >= 7
+	cmd:c++$secondaryArchSuffix = $portVersion compat >= 7
+	cmd:cc$secondaryArchSuffix = $portVersion compat >= 7
+	cmd:cpp$secondaryArchSuffix = $portVersion compat >= 7
+	cmd:g++$secondaryArchSuffix = $portVersion compat >= 7
+	cmd:gcc$secondaryArchSuffix = $portVersion compat >= 7
+	cmd:gcc_ar$secondaryArchSuffix = $portVersion compat >= 7
+	cmd:gcc_nm$secondaryArchSuffix = $portVersion compat >= 7
+	cmd:gcc_ranlib$secondaryArchSuffix = $portVersion compat >= 7
+	cmd:gcov$secondaryArchSuffix = $portVersion compat >= 7
+	cmd:gcov_dump$secondaryArchSuffix = $portVersion compat >= 7
+	cmd:gcov_tool$secondaryArchSuffix = $portVersion compat >= 7
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	cmd:as$secondaryArchSuffix
+	lib:libgmp$secondaryArchSuffix
+	lib:libmpc$secondaryArchSuffix
+	lib:libmpfr$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+SUMMARY_fortran="C/C++-runtime static libraries and C++ headers, needed for gfortran"
+DESCRIPTION_fortran="This package is not of general interest - it \
+contains the set of gcc's C/C++-runtime libraries and headers that is \
+required by gfortran to build fortran source code."
+PROVIDES_fortran="
+	gcc${secondaryArchSuffix}_fortran = $portVersion compat >= 7
+	cmd:gfortran$secondaryArchSuffix = $portVersion compat >= 7
+	cmd:f951$secondaryArchSuffix = $portVersion compat >= 7
+	devel:libgfortran$secondaryArchSuffix = $libgfortranLibVersion compat >= $libgfortranSoVersion
+	devel:libcaf_single$secondaryArchSuffix = $libgfortranLibVersion compat >= $libgfortranSoVersion
+	"
+REQUIRES_fortran="
+	haiku$secondaryArchSuffix
+	gcc${secondaryArchSuffix}_syslibs == $portVersion base
+	"
+
+SUMMARY_syslibs="C/C++-runtime shared libraries, needed to execute C/C++ programs"
+DESCRIPTION_syslibs="The C/C++-runtime libraries that are part of the gcc \
+distribution. This package contains the shared libraries for the runtime \
+loader, so it is required for executing most c/c++ programs."
+PROVIDES_syslibs="
+	gcc${secondaryArchSuffix}_syslibs = $portVersion compat >= 7
+	lib:libatomic$secondaryArchSuffix = $libatomicLibVersion compat >= $libatomicSoVersion
+	lib:libgcc_s$secondaryArchSuffix = $libgccLibVersion compat >= $libgccSoVersion
+	lib:libgfortran$secondaryArchSuffix = $libgfortranLibVersion compat >= $libgfortranSoVersion
+	lib:libgomp$secondaryArchSuffix = $libgompLibVersion compat >= $libgompSoVersion
+	lib:libquadmath$secondaryArchSuffix = $libquadmathLibVersion compat >= $libquadmathSoVersion
+	lib:libssp$secondaryArchSuffix = $libsspLibVersion compat >= $libsspSoVersion
+	lib:libstdc++$secondaryArchSuffix = $libstdcxxLibVersion compat >= $libstdcxxSoVersion
+	lib:libsupc++$secondaryArchSuffix = $portVersion compat >= 7
+	"
+REQUIRES_syslibs="
+	haiku$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+SUMMARY_syslibs_devel="C/C++-runtime static libraries and C++ headers, needed to build Haiku"
+DESCRIPTION_syslibs_devel="This package is not of general interest - it \
+contains the set of gcc's C/C++-runtime libraries and headers that is \
+required by Haiku's build system when building Haiku."
+PROVIDES_syslibs_devel="
+	gcc${secondaryArchSuffix}_syslibs_devel = $portVersion compat >= 7
+	devel:libatomic$secondaryArchSuffix = $libatomicLibVersion compat >= $libatomicSoVersion
+	devel:libgcc$secondaryArchSuffix = $libgccLibVersion compat >= $libgccSoVersion
+	devel:libgcc_eh$secondaryArchSuffix = $libgccLibVersion compat >= $libgccSoVersion
+	devel:libgcc_eh_kernel$secondaryArchSuffix = $libgccLibVersion compat >= $libgccSoVersion
+	devel:libgcc_kernel$secondaryArchSuffix = $libgccLibVersion compat >= $libgccSoVersion
+	devel:libgcc_s$secondaryArchSuffix = $libgccLibVersion compat >= $libgccSoVersion
+	devel:libgfortran$secondaryArchSuffix = $libgfortranLibVersion compat >= $libgfortranSoVersion
+	devel:libgomp$secondaryArchSuffix = $libgompLibVersion compat >= $libgompSoVersion
+	devel:libquadmath$secondaryArchSuffix = $libquadmathLibVersion compat >= $libquadmathSoVersion
+	devel:libssp$secondaryArchSuffix = $libsspLibVersion compat >= $libsspSoVersion
+	devel:libssp_nonshared$secondaryArchSuffix = $libsspLibVersion
+	devel:libstdc++$secondaryArchSuffix = $libstdcxxLibVersion compat >= $libstdcxxSoVersion
+	devel:libstdc++fs$secondaryArchSuffix = $portVersion compat >= 7
+	devel:libsupc++$secondaryArchSuffix = $portVersion compat >= 7
+	devel:libsupc++_kernel$secondaryArchSuffix = $portVersion compat >= 7
+	"
+REQUIRES_syslibs_devel=""
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libgmp$secondaryArchSuffix >= 10.4.0
+	devel:libmpc$secondaryArchSuffix >= 3.2
+	devel:libmpfr$secondaryArchSuffix >= 6.1
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:autoconf
+	cmd:awk
+	cmd:find
+	cmd:flex
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:makeinfo
+	cmd:sed
+	cmd:strip
+	cmd:tar
+	cmd:xargs
+	"
+
+relativeInstallDir="develop/tools$secondaryArchSubDir"
+installDir="$prefix/$relativeInstallDir"
+objectsDir=$sourceDir/../${portVersionedName}-obj
+gccLibDir=lib/gcc/$effectiveTargetMachineTriple/$gccVersion
+
+defineDebugInfoPackage gcc$secondaryArchSuffix \
+	"$gccLibDir"/cc1 \
+	"$gccLibDir"/cc1obj \
+	"$gccLibDir"/cc1plus \
+	"$gccLibDir"/collect2 \
+	"$gccLibDir"/lto1 \
+	"$gccLibDir"/lto-wrapper \
+	"$installDir/bin"/cpp \
+	"$installDir/bin"/g++ \
+	"$installDir/bin"/gcc \
+	"$installDir/bin"/gcc-ar \
+	"$installDir/bin"/gcc-nm \
+	"$installDir/bin"/gcc-ranlib \
+	"$installDir/bin"/gcov \
+	"$installDir/bin"/gcov-dump \
+	"$installDir/bin"/gcov-tool \
+	"$(getPackagePrefix fortran)/$relativeInstallDir"/bin/gfortran \
+	"$(getPackagePrefix fortran)/$relativeInstallDir/$gccLibDir"/f951 \
+	"$(getPackagePrefix syslibs)/$relativeLibDir"/libatomic.so.$libatomicLibVersion \
+	"$(getPackagePrefix syslibs)/$relativeLibDir"/libgcc_s.so.$libgccSoVersion \
+	"$(getPackagePrefix syslibs)/$relativeLibDir"/libgfortran.so.$libgfortranLibVersion \
+	"$(getPackagePrefix syslibs)/$relativeLibDir"/libgomp.so.$libgompLibVersion \
+	"$(getPackagePrefix syslibs)/$relativeLibDir"/libquadmath.so.$libquadmathLibVersion \
+	"$(getPackagePrefix syslibs)/$relativeLibDir"/libssp.so.$libsspLibVersion \
+	"$(getPackagePrefix syslibs)/$relativeLibDir"/libstdc++.so.$libstdcxxLibVersion \
+	"$(getPackagePrefix syslibs)/$relativeLibDir"/libsupc++.so
+
+BUILD()
+{
+	rm -rf $objectsDir
+
+	# Touch some files generated by bison, so that bison won't run to update
+	# them. Fixes issues with newer bison versions.
+	# And while at it, touch gperf target, too (as gperf may not be installed).
+	(cd $sourceDir/gcc; touch c-parse.c c-parse.h cexp.c cp/parse.c \
+		cp/parse.h c-gperf.h)
+
+	mkdir -p $objectsDir
+	cd $objectsDir
+
+	local additionalConfigureFlags
+	if [ -n "$secondaryArchSuffix" ]; then
+		additionalConfigureFlags="\
+			--with-hybrid-secondary=${effectiveTargetArchitecture}"
+	fi
+	local kernelCcFlags="-D_KERNEL_MODE"
+	if [ $effectiveTargetArchitecture == x86_64 ]; then
+		# disable multilib support, as x86_64 by default tries to build the
+		# 32-bit libraries, too, which fails as no 32-bit libroot is available
+		additionalConfigureFlags+=" --disable-multilib"
+
+		# deactivate red zone for x86_64
+		kernelCcFlags="$kernelCcFlags -mno-red-zone"
+	fi
+
+	"$sourceDir/configure" \
+		--build=$effectiveTargetMachineTriple \
+		--prefix=$installDir --libexecdir=$installDir/lib --mandir=$manDir \
+		--docdir=$docDir --enable-threads=posix \
+		--disable-nls --enable-shared --with-gnu-ld --with-gnu-as \
+		--enable-version-specific-runtime-libs \
+		--enable-languages=c,c++,fortran,objc --enable-lto \
+		--enable-frame-pointer \
+		--with-pkgversion=$(echo $portVersion | cut -d_ -f2-) \
+		--enable-__cxa-atexit --with-system-zlib --enable-checking=release \
+		--with-bug-url=http://dev.haiku-os.org/ \
+		--with-default-libstdcxx-abi=gcc4-compatible \
+		--enable-libssp \
+		$additionalConfigureFlags
+
+	make $jobArgs
+
+	echo "######################## building special libraries ################"
+
+	echo "### libgcc"
+
+	# build kernel versions of libgcc.a and libgcc_eh.a (no threads or TLS)
+	cd $objectsDir/$effectiveTargetMachineTriple/libgcc
+	mkdir -p saved
+	mv libgcc.a libgcc_eh.a libgcc_s* libgcov* saved/
+	make clean
+	ln -sfn "$sourceDir/libgcc/gthr-single.h" gthr-default.h
+	make CFLAGS="-O2 $kernelCcFlags" CXXFLAGS="-O2 $kernelCcFlags"
+	mv libgcc.a libgcc-kernel.a
+	mv libgcc_eh.a libgcc_eh-kernel.a
+	ln -sfn "$sourceDir/libgcc/gthr-posix.h" gthr-default.h
+	mv saved/* .
+	rmdir saved
+
+	# build kernel version of libsupc++.a (without threads or TLS)
+	cd $objectsDir/$effectiveTargetMachineTriple/libstdc++-v3/libsupc++
+	mkdir -p saved
+	mv .libs/libsupc++* saved/
+	cp "../include/$effectiveTargetMachineTriple/bits/gthr-default.h" \
+		"../config.h" \
+		"../include/$effectiveTargetMachineTriple/bits/c++config.h" \
+		saved/
+	make clean
+	cp "../include/$effectiveTargetMachineTriple/bits/gthr-single.h" \
+		"../include/$effectiveTargetMachineTriple/bits/gthr-default.h"
+	sed -i -e 's,#define _GLIBCXX_HAS_GTHREADS 1,/* #undef _GLIBCXX_HAS_GTHREADS */,' \
+		"../config.h"
+	sed -i -e 's,#define _GLIBCXX_HAVE_TLS 1,/* #undef _GLIBCXX_HAVE_TLS */,' \
+		"../include/$effectiveTargetMachineTriple/bits/c++config.h"
+	make CFLAGS="-O2 $kernelCcFlags" CXXFLAGS="-O2 $kernelCcFlags"
+	mv .libs/libsupc++.a .libs/libsupc++-kernel.a
+	mv saved/libsupc++* .libs/
+	mv saved/gthr-default.h "../include/$effectiveTargetMachineTriple/bits/"
+	mv saved/config.h ..
+	mv saved/c++config.h "../include/$effectiveTargetMachineTriple/bits/"
+	rmdir saved
+}
+
+INSTALL()
+{
+	cd $objectsDir
+
+	make install
+	make install-html
+
+	### HTML documentation ####################################
+
+	echo "Organizing HTML documentation..."
+	cd $docDir
+	for dir in libquadmath; do
+		mv ${dir}.html $dir
+		ln -s $dir/index.html ${dir}.html
+	done
+
+	### Libraries #############################################
+
+	echo "Moving libraries around"
+
+	# Move/copy libraries such that copies of the runtime (shared) libs exist
+	# in $libDir and copies of static libraries exist in $developLibDir. These
+	# are put into separate packages gcc_syslibs and gcc_syslibs_devel, which
+	# are both used by Haiku's build system.
+	mkdir -p $libDir
+	mkdir -p $developLibDir
+	cd $installDir
+
+	# libatomic
+	cp -d $gccLibDir/libatomic.so \
+		$gccLibDir/libatomic.so.$libatomicSoVersion \
+		$gccLibDir/libatomic.so.$libatomicLibVersion \
+		$libDir/
+	rm $gccLibDir/libatomic*.a
+
+	# libgfortran
+	cp -d $gccLibDir/libgfortran.so \
+		$gccLibDir/libgfortran.so.$libgfortranSoVersion \
+		$gccLibDir/libgfortran.so.$libgfortranLibVersion \
+		$libDir/
+	cp $gccLibDir/libgfortran*.a $developLibDir/
+
+	# libgomp
+	cp -d $gccLibDir/libgomp.so \
+		$gccLibDir/libgomp.so.$libgompSoVersion \
+		$gccLibDir/libgomp.so.$libgompLibVersion \
+		$libDir/
+	rm $gccLibDir/libgomp*.a
+
+	# libquadmath
+	cp -d $gccLibDir/libquadmath.so \
+		$gccLibDir/libquadmath.so.$libquadmathSoVersion \
+		$gccLibDir/libquadmath.so.$libquadmathLibVersion \
+		$libDir/
+	rm $gccLibDir/libquadmath*.a
+
+	# libssp
+	cp -d $gccLibDir/libssp.so \
+		$gccLibDir/libssp.so.$libsspSoVersion \
+		$gccLibDir/libssp.so.$libsspLibVersion \
+		$libDir/
+	rm $gccLibDir/libssp.a
+	cp $gccLibDir/libssp_nonshared.a $developLibDir
+
+	# libstdc++
+	cp -d $gccLibDir/libstdc++.so \
+		$gccLibDir/libstdc++.so.$libstdcxxSoVersion \
+		$gccLibDir/libstdc++.so.$libstdcxxLibVersion \
+		$libDir/
+	rm $gccLibDir/libstdc++.a
+	cp $gccLibDir/libstdc++fs.a $developLibDir
+
+	# libsupc++
+	libstdcxxDir=$objectsDir/$effectiveTargetMachineTriple/libstdc++-v3
+	cp $libstdcxxDir/libsupc++/.libs/libsupc++-kernel.a \
+		$gccLibDir/
+	ln -s libstdc++.so $libDir/libsupc++.so
+	cp $gccLibDir/libsupc++*.a $developLibDir/
+
+	# libgcc
+	cp $objectsDir/$effectiveTargetMachineTriple/libgcc/libgcc-kernel.a \
+		$objectsDir/$effectiveTargetMachineTriple/libgcc/libgcc_eh-kernel.a \
+		$gccLibDir/
+	cp -d $gccLibDir/libgcc_s.so \
+		$gccLibDir/libgcc_s.so.$libgccSoVersion \
+		$libDir/
+	cp $gccLibDir/libgcc*.a $developLibDir/
+
+	# gcc and c++ headers
+	mkdir -p $includeDir/gcc
+	cp -r $gccLibDir/include $includeDir/gcc/
+	cp -r $gccLibDir/include-fixed $includeDir/gcc/
+	mv $includeDir/gcc/include/c++ $includeDir/
+
+	### Strip #################################################
+
+	echo "Strip"
+
+	strip --strip-debug \
+		$gccLibDir/*.a \
+		$developLibDir/*.a
+
+	### Disable ASLR ##########################################
+
+	echo "Add SYS:ENV attribute to disable ASLR"
+
+	cd $installDir
+	for f in bin/*; do
+		if [ -r "$f" ]; then
+			addattr SYS:ENV DISABLE_ASLR=1 $f
+		fi
+	done
+	for f in cc1 cc1plus collect2 f951 lto1; do
+		addattr SYS:ENV DISABLE_ASLR=1 \
+			$gccLibDir/$f
+	done
+
+	### Symlinks ##############################################
+
+	echo "Creating required symlinks"
+
+	# create missing cc symlink
+	ln -sf gcc $installDir/bin/cc
+
+	# make all tools available via default paths
+	mkdir -p $binDir
+	for f in c++ cc cpp g++ gcc gcov gfortran gcc-ar gcc-nm gcc-ranlib; do
+		symlinkRelative -sfn $installDir/bin/$f $binDir
+	done
+
+	# symlink all libraries from libDir -> developLibDir
+	mkdir -p $developLibDir
+	for l in libatomic libgomp libquadmath libssp libgcc_s libstdc++ \
+			libsupc++; do
+		for f in $libDir/$l*; do
+			symlinkRelative -sfn $f $developLibDir/
+		done
+	done
+
+	### Cleanup ###############################################
+
+	echo "Cleanup"
+	rm -rf $installDir/info
+	rm -rf $installDir/share
+	rm -rf $installDir/$gccLibDir/*.la
+	rm -rf $installDir/$gccLibdir/libobjc.*
+	rm -rf $installDir/$gccLibdir/include/objc
+	rm -rf $includeDir/gcc/include/objc
+
+	### Sub Packages ##########################################
+
+	packageEntries "fortran" \
+		$relativeBinDir/gfortran \
+		$developDir/tools$secondaryArchSubDir/bin/*gfortran \
+		$installDir/$gccLibDir/f951 \
+		$installDir/$gccLibDir/finclude \
+		$installDir/$gccLibDir/libcaf_single.a \
+		$installDir/$gccLibDir/libgfortran.a \
+		$installDir/$gccLibDir/libgfortran.spec
+
+	rm -rf $installDir/$gccLibDir/{f951, finclude, libcaf_single*, libgfortran*}
+
+	packageEntries "syslibs" \
+		$relativeLibDir/libatomic.so \
+		$relativeLibDir/libatomic.so.$libatomicSoVersion \
+		$relativeLibDir/libatomic.so.$libatomicLibVersion \
+		$relativeLibDir/libgcc_s.so \
+		$relativeLibDir/libgcc_s.so.$libgccSoVersion \
+		$relativeLibDir/libgfortran.so \
+		$relativeLibDir/libgfortran.so.$libgfortranSoVersion \
+		$relativeLibDir/libgfortran.so.$libgfortranLibVersion \
+		$relativeLibDir/libgomp.so \
+		$relativeLibDir/libgomp.so.$libgompSoVersion \
+		$relativeLibDir/libgomp.so.$libgompLibVersion \
+		$relativeLibDir/libquadmath.so \
+		$relativeLibDir/libquadmath.so.$libquadmathSoVersion \
+		$relativeLibDir/libquadmath.so.$libquadmathLibVersion \
+		$relativeLibDir/libssp.so \
+		$relativeLibDir/libssp.so.$libsspSoVersion \
+		$relativeLibDir/libssp.so.$libsspLibVersion \
+		$relativeLibDir/libstdc++.so \
+		$relativeLibDir/libstdc++.so.$libstdcxxSoVersion \
+		$relativeLibDir/libstdc++.so.$libstdcxxLibVersion \
+		$relativeLibDir/libsupc++.so
+
+	packageEntries "syslibs_devel" \
+		$developLibDir/*.so* \
+		$developLibDir/libgcc.a \
+		$developLibDir/libgcc-kernel.a \
+		$developLibDir/libgcc_eh.a \
+		$developLibDir/libgcc_eh-kernel.a \
+		$developLibDir/libssp_nonshared.a \
+		$developLibDir/libstdc++fs.a \
+		$developLibDir/libsupc++.a \
+		$developLibDir/libsupc++-kernel.a \
+		$relativeIncludeDir
+
+	rm -rf $includeDir
+	rm -rf $developLibDir
+}

--- a/sys-devel/gcc/patches/gcc-10.3.0_2021_04_08.patchset
+++ b/sys-devel/gcc/patches/gcc-10.3.0_2021_04_08.patchset
@@ -1,4 +1,4 @@
-From f86616e625cac00fcdade3209abfd796c5bbb9ee Mon Sep 17 00:00:00 2001
+From d2548c51f0b09791103b9258e67ecb8dc0e4ed5e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Sun, 19 Jul 2015 18:55:34 +0200
 Subject: Haiku patch
@@ -2113,7 +2113,7 @@ index 0020654..5aef292 100644
 2.30.2
 
 
-From a44e1e58f5363ad445040cae126fb91babbec0e0 Mon Sep 17 00:00:00 2001
+From ebdd14251e345fa9bb9321f72e53b17db037d9e3 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Thu, 5 May 2016 09:03:06 +0000
 Subject: fix for libstdc++/69506
@@ -2135,7 +2135,7 @@ index 4674f7b..02c8693 100644
 2.30.2
 
 
-From dddf921011ac58ec8db57a5f429e0bd922d6d1c8 Mon Sep 17 00:00:00 2001
+From 22af44d79358c815409c6225d2ab1b655d28d00c Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Thu, 5 May 2016 15:52:08 +0000
 Subject: rename x86_elf_aligned_common.
@@ -2162,7 +2162,7 @@ index 76ba48e..e2fa55a 100644
 2.30.2
 
 
-From f9f1ece2b58dadab7598d41e65c320ffed6d0c88 Mon Sep 17 00:00:00 2001
+From 49be16e562ba7506c8ef04ae6c19daf90f22b8d4 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Mon, 27 Jul 2015 16:32:32 +0200
 Subject: Haiku: disable -fno-PIE as this fails on x86_64.
@@ -2238,7 +2238,7 @@ index 646db21..b22bbfa 100644
 2.30.2
 
 
-From b683ca27f14028bbc10369fd0975c0a9142f0e80 Mon Sep 17 00:00:00 2001
+From f00cebb3bb2dadb43b80b0649194e07a8f94db2f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Sun, 19 Jul 2015 18:55:34 +0200
 Subject: Fix GCC config host
@@ -2284,7 +2284,7 @@ index 84f0433..422442f 100644
 2.30.2
 
 
-From 079c0a3a390ce98811ed6123e44ed1d2bd43b150 Mon Sep 17 00:00:00 2001
+From 4188c420426be5891f65547c409377b24c14fbbb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Sun, 19 Jul 2015 18:55:34 +0200
 Subject: Fix GCC config.gcc
@@ -2388,16 +2388,14 @@ index 6fcdd77..3c96140 100644
 2.30.2
 
 
-From 9297a7bbfc3266ec3e0ac13ec75524adb8727931 Mon Sep 17 00:00:00 2001
+From 1cddbcca5c8bb71d9742ecaae06f79904f4f122e Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 12 May 2017 23:49:00 +0200
 Subject: Haiku: regenerate configure.
 
 
 diff --git a/configure b/configure
-old mode 100755
-new mode 100644
-index f2ec106..29f7128
+index f2ec106..29f7128 100755
 --- a/configure
 +++ b/configure
 @@ -3106,6 +3106,9 @@ case "${host}" in
@@ -2692,7 +2690,7 @@ index 5240f7e..641681b 100755
 2.30.2
 
 
-From 0698f4c9ef1067f716e50a6a3fc23fbcaf064f4b Mon Sep 17 00:00:00 2001
+From f0a8147f46d68cb6d0198cbc0390aec9b3b34bd1 Mon Sep 17 00:00:00 2001
 From: Jessica Hamilton <jessica.l.hamilton@gmail.com>
 Date: Fri, 12 Jul 2019 18:17:00 +0000
 Subject: gcc: fix build configuration for libgcc.
@@ -2757,7 +2755,7 @@ index 115db3f..bdbd281 100644
 2.30.2
 
 
-From 6ec634843250cc57a581abd56f2ae0316898f044 Mon Sep 17 00:00:00 2001
+From a507a5c20b5c63cdc8ff33003dfeaf6469f9d27c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
 Date: Wed, 2 May 2018 08:37:20 +0200
 Subject: Enable libstdcxx_filesystem_ts for Haiku
@@ -2780,7 +2778,8 @@ index b6557a4..c789d7c 100644
 -- 
 2.30.2
 
-From d731c1a693b094965f408b9ec7d4e60dc16d2dd0 Mon Sep 17 00:00:00 2001
+
+From 5de4784cafb5be362d626636789ea2cde6107693 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Sun, 19 Jul 2015 18:55:34 +0200
 Subject: Haiku GCC configure patch
@@ -2930,7 +2929,8 @@ index 8fe9c91..4fb3890 100755
 -- 
 2.30.2
 
-From 51e2839394dcdbb1547644368e6fa67a7364d307 Mon Sep 17 00:00:00 2001
+
+From 2d03718c33946fbb395fc8ba0013ec8f9ec4d5ed Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Sun, 19 Jul 2015 18:55:34 +0200
 Subject: Haiku libstdc++-v3 configure patch
@@ -3099,6 +3099,48 @@ index 766a0a8..9f3a0b1 100755
        *)
          enable_libstdcxx_filesystem_ts=no
          ;;
+-- 
+2.30.2
+
+
+From 418129fc18b70e421ebee6af9490507840c01c21 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
+Date: Sun, 19 Jul 2015 18:55:34 +0200
+Subject: Haiku libgcc config.host patch
+
+
+diff --git a/libgcc/config.host b/libgcc/config.host
+index c529cc4..b1da45a 100644
+--- a/libgcc/config.host
++++ b/libgcc/config.host
+@@ -458,6 +458,12 @@ arm*-*-fuchsia*)
+ 	tm_file="${tm_file} arm/bpabi-lib.h"
+ 	unwind_header=config/arm/unwind-arm.h
+ 	;;
++arm-*-haiku*)
++	tmake_file="${tmake_file} arm/t-arm arm/t-elf arm/t-bpabi"
++	tmake_file="${tmake_file} t-softfp-sfdf t-softfp-excl arm/t-softfp t-softfp"
++	tm_file="${tm_file} arm/bpabi-lib.h"
++	unwind_header=config/arm/unwind-arm.h
++	;;
+ arm*-*-netbsdelf*)
+ 	tmake_file="$tmake_file arm/t-arm"
+ 	case ${host} in
+@@ -626,6 +632,14 @@ h8300-*-linux*)
+ 	tmake_file="t-linux h8300/t-linux t-softfp-sfdf t-softfp"
+ 	tm_file="$tm_file h8300/h8300-lib.h"
+ 	;;
++*-*-haiku*)
++  # This is the generic ELF configuration of Haiku.  Later
++  # machine-specific sections may refine and add to this
++  # configuration.
++  tmake_file="$tmake_file t-crtstuff-pic t-libgcc-pic t-haiku t-slibgcc t-slibgcc-gld t-slibgcc-elf-ver"
++  tmake_file="$tmake_file t-slibgcc-libgcc t-slibgcc-nolc-override"
++  extra_parts="crtbegin.o crtbeginS.o crtend.o crtendS.o"
++  ;;
+ hppa*64*-*-linux*)
+ 	tmake_file="$tmake_file pa/t-linux pa/t-linux64"
+ 	extra_parts="crtbegin.o crtbeginS.o crtbeginT.o crtend.o crtendS.o"
 -- 
 2.30.2
 

--- a/sys-devel/gcc/patches/gcc-10.3.0_2021_04_08.patchset
+++ b/sys-devel/gcc/patches/gcc-10.3.0_2021_04_08.patchset
@@ -1,0 +1,3091 @@
+From deee061bc53ce3f2a6cfd44f3a5ca135614ffbc5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
+Date: Sun, 19 Jul 2015 18:55:34 +0200
+Subject: Haiku patch
+
+
+diff --git a/compile b/compile
+old mode 100755
+new mode 100644
+diff --git a/config.rpath b/config.rpath
+index 4dea759..5bcc5be 100755
+--- a/config.rpath
++++ b/config.rpath
+@@ -161,6 +161,8 @@ if test "$with_gnu_ld" = yes; then
+       ;;
+     netbsd*)
+       ;;
++    haiku*)
++      ;;
+     solaris* | sysv5*)
+       if $LD -v 2>&1 | egrep 'BFD 2\.8' > /dev/null; then
+         ld_shlibs=no
+diff --git a/config/acx.m4 b/config/acx.m4
+index 87c1b5e..d9d53ca 100644
+--- a/config/acx.m4
++++ b/config/acx.m4
+@@ -428,24 +428,30 @@ dnl for the parameter format "cmp file1 file2 skip1 skip2" which is
+ dnl accepted by cmp on some systems.
+ AC_DEFUN([ACX_PROG_CMP_IGNORE_INITIAL],
+ [AC_CACHE_CHECK([how to compare bootstrapped objects], gcc_cv_prog_cmp_skip,
+-[ echo abfoo >t1
+-  echo cdfoo >t2
+-  gcc_cv_prog_cmp_skip='tail -c +17 $$f1 > tmp-foo1; tail -c +17 $$f2 > tmp-foo2; cmp tmp-foo1 tmp-foo2'
+-  if cmp t1 t2 2 2 > /dev/null 2>&1; then
+-    if cmp t1 t2 1 1 > /dev/null 2>&1; then
+-      :
+-    else
+-      gcc_cv_prog_cmp_skip='cmp $$f1 $$f2 16 16'
++[# comparing object files via cmp doesn't work on haiku (files will seemingly
++  # always differ), so we disassemble both files and compare the results:
++  if uname -o | grep -iq haiku; then
++    gcc_cv_prog_cmp_skip='objdump -Dz $$f1 | tail +6 >tmp-foo1; objdump -Dz $$f2 | tail +6 >tmp-foo2; cmp tmp-foo1 tmp-foo2'
++  else 
++    echo abfoo >t1
++    echo cdfoo >t2
++    gcc_cv_prog_cmp_skip='tail -c +17 $$f1 > tmp-foo1; tail -c +17 $$f2 > tmp-foo2; cmp tmp-foo1 tmp-foo2'
++    if cmp t1 t2 2 2 > /dev/null 2>&1; then
++      if cmp t1 t2 1 1 > /dev/null 2>&1; then
++        :
++      else
++        gcc_cv_prog_cmp_skip='cmp $$f1 $$f2 16 16'
++      fi
+     fi
+-  fi
+-  if cmp --ignore-initial=2 t1 t2 > /dev/null 2>&1; then
+-    if cmp --ignore-initial=1 t1 t2 > /dev/null 2>&1; then
+-      :
+-    else
+-      gcc_cv_prog_cmp_skip='cmp --ignore-initial=16 $$f1 $$f2'
++    if cmp --ignore-initial=2 t1 t2 > /dev/null 2>&1; then
++      if cmp --ignore-initial=1 t1 t2 > /dev/null 2>&1; then
++        :
++      else
++        gcc_cv_prog_cmp_skip='cmp --ignore-initial=16 $$f1 $$f2'
++      fi
+     fi
++    rm t1 t2
+   fi
+-  rm t1 t2
+ ])
+ do_compare="$gcc_cv_prog_cmp_skip"
+ AC_SUBST(do_compare)
+
+diff --git a/gcc/config/arm/haiku.h b/gcc/config/arm/haiku.h
+new file mode 100644
+index 0000000..f0c0d63
+--- /dev/null
++++ b/gcc/config/arm/haiku.h
+@@ -0,0 +1,80 @@
++/*	Definitions for ARM running Haiku systems using ELF
++	Copyright (C) 1993, 1994, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004,
++	2005 Free Software Foundation, Inc.
++
++	This file is part of GCC.
++
++	GCC is free software; you can redistribute it and/or modify
++	it under the terms of the GNU General Public License as published by
++	the Free Software Foundation; either version 2, or (at your option)
++	any later version.
++
++	GCC is distributed in the hope that it will be useful,
++	but WITHOUT ANY WARRANTY; without even the implied warranty of
++	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++	GNU General Public License for more details.
++
++	You should have received a copy of the GNU General Public License
++	along with GCC; see the file COPYING.  If not, write to
++	the Free Software Foundation, 59 Temple Place - Suite 330,
++	Boston, MA 02111-1307, USA.  */
++
++/* Unsigned chars produces much better code than signed.  */
++#define DEFAULT_SIGNED_CHAR  0
++
++#undef  TARGET_DEFAULT_FLOAT_ABI
++#define TARGET_DEFAULT_FLOAT_ABI ARM_FLOAT_ABI_SOFT
++
++/* We default to the "aapcs-linux" ABI so that enums are int-sized by
++   default.  */
++#undef  ARM_DEFAULT_ABI
++#define ARM_DEFAULT_ABI ARM_ABI_AAPCS_LINUX
++
++/* bpabi.h sets FPUTYPE_DEFAULT to VFP */
++
++#undef  MULTILIB_DEFAULTS
++#define MULTILIB_DEFAULTS \
++  { "marm", "mlittle-endian", "msoft-float", "mno-thumb-interwork" }
++
++/* Default is set by bpabi.h */
++/*
++#undef TARGET_DEFAULT
++*/
++
++#undef SUBTARGET_CPU_DEFAULT
++#define SUBTARGET_CPU_DEFAULT TARGET_CPU_arm6
++
++/* Now we define the strings used to build the spec file.  */
++/* interestingly, bpabi defines __GXX_TYPEINFO_EQUALITY_INLINE=0 too as we do. */
++
++#undef TARGET_OS_CPP_BUILTINS
++#define TARGET_OS_CPP_BUILTINS()		\
++  do									\
++    {									\
++      builtin_define ("__HAIKU__");					\
++      builtin_define ("__ARM__");					\
++      builtin_define ("__arm__");					\
++      builtin_define ("__stdcall=__attribute__((__stdcall__))");	\
++      builtin_define ("__cdecl=__attribute__((__cdecl__))");		\
++      builtin_define ("__STDC_ISO_10646__=201103L"); \
++      builtin_assert ("system=haiku");					\
++      /* Haiku apparently doesn't support merging of symbols across shared \
++		 object boundaries. Hence we need to explicitly specify that \
++         type_infos are not merged, so that they get compared by name \
++         instead of by pointer. */ \
++      builtin_define ("__GXX_MERGED_TYPEINFO_NAMES=0"); \
++      /*builtin_define ("__GXX_TYPEINFO_EQUALITY_INLINE=0"); done in bpabi: */\
++      TARGET_BPABI_CPP_BUILTINS();					\
++    }									\
++  while (0)
++
++/* Use the default LIBGCC_SPEC, not the empty version in haiku.h, as we
++   do not use multilib (needed ??).  */
++#undef LIBGCC_SPEC
++
++/* If ELF is the default format, we should not use /lib/elf.  */
++
++#undef	LINK_SPEC
++#define LINK_SPEC "%{!o*:-o %b} -m armelf %{!r:-shared} %{nostart:-e 0} %{shared:-e 0} %{!shared: %{!nostart: -no-undefined}}\
++  %{mbig-endian:-EB} %{mlittle-endian:-EL} -X"
++
+diff --git a/gcc/config/arm/t-haiku b/gcc/config/arm/t-haiku
+new file mode 100644
+index 0000000..3f7f488
+--- /dev/null
++++ b/gcc/config/arm/t-haiku
+@@ -0,0 +1,21 @@
++# build multilib for soft float and VFP 
++# (unsure about how it should be done...)
++# mix from t-symbian & t-wince-pe
++
++#LIB1ASMSRC = arm/lib1funcs.asm
++#LIB1ASMFUNCS = _udivsi3 _divsi3 _umodsi3 _modsi3 _dvmd_tls _call_via_rX _interwork_call_via_rX
++
++
++#MULTILIB_OPTIONS    += mhard-float
++#MULTILIB_DIRNAMES   += fpu
++
++MULTILIB_OPTIONS    += msoft-float
++MULTILIB_DIRNAMES   += fpu soft
++MULTILIB_EXCEPTIONS += *mthumb/*mhard-float*
++
++MULTILIB_OPTIONS    += mfloat-abi=softfp
++MULTILIB_DIRNAMES   += softfp
++
++#LIBGCC = stmp-multilib
++#INSTALL_LIBGCC = install-multilib
++#TARGET_LIBGCC2_CFLAGS = 
+diff --git a/gcc/config/haiku-stdint.h b/gcc/config/haiku-stdint.h
+new file mode 100644
+index 0000000..8f702d0
+--- /dev/null
++++ b/gcc/config/haiku-stdint.h
+@@ -0,0 +1,55 @@
++/* Definitions for <stdint.h> types on Haiku.
++   Copyright (C) 2014 Paweł Dziepak.
++
++This file is part of GCC.
++
++GCC is free software; you can redistribute it and/or modify
++it under the terms of the GNU General Public License as published by
++the Free Software Foundation; either version 3, or (at your option)
++any later version.
++
++GCC is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++GNU General Public License for more details.
++
++Under Section 7 of GPL version 3, you are granted additional
++permissions described in the GCC Runtime Library Exception, version
++3.1, as published by the Free Software Foundation.
++
++You should have received a copy of the GNU General Public License and
++a copy of the GCC Runtime Library Exception along with this program;
++see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++<http://www.gnu.org/licenses/>.  */
++
++#define SIG_ATOMIC_TYPE "int"
++
++#define INT8_TYPE "signed char"
++#define INT16_TYPE "short int"
++#define INT32_TYPE "int"
++#define INT64_TYPE (LONG_TYPE_SIZE == 64 ? "long int" : "long long int")
++#define UINT8_TYPE "unsigned char"
++#define UINT16_TYPE "short unsigned int"
++#define UINT32_TYPE "unsigned int"
++#define UINT64_TYPE (LONG_TYPE_SIZE == 64 ? "long unsigned int" : "long long unsigned int")
++
++#define INT_LEAST8_TYPE "signed char"
++#define INT_LEAST16_TYPE "short int"
++#define INT_LEAST32_TYPE "int"
++#define INT_LEAST64_TYPE (LONG_TYPE_SIZE == 64 ? "long int" : "long long int")
++#define UINT_LEAST8_TYPE "unsigned char"
++#define UINT_LEAST16_TYPE "short unsigned int"
++#define UINT_LEAST32_TYPE "unsigned int"
++#define UINT_LEAST64_TYPE (LONG_TYPE_SIZE == 64 ? "long unsigned int" : "long long unsigned int")
++
++#define INT_FAST8_TYPE "int"
++#define INT_FAST16_TYPE "int"
++#define INT_FAST32_TYPE "int"
++#define INT_FAST64_TYPE (LONG_TYPE_SIZE == 64 ? "long int" : "long long int")
++#define UINT_FAST8_TYPE "unsigned int"
++#define UINT_FAST16_TYPE "unsigned int"
++#define UINT_FAST32_TYPE "unsigned int"
++#define UINT_FAST64_TYPE (LONG_TYPE_SIZE == 64 ? "long unsigned int" : "long long unsigned int")
++
++#define INTPTR_TYPE "long int"
++#define UINTPTR_TYPE "long unsigned int"
+diff --git a/gcc/config/haiku.h b/gcc/config/haiku.h
+new file mode 100644
+index 0000000..8e9f101
+--- /dev/null
++++ b/gcc/config/haiku.h
+@@ -0,0 +1,214 @@
++/* Definitions of target machine for GCC.
++   Common Haiku definitions for all architectures.
++   Copyright (C) 1998, 1999, 2000, 2001, 2002, 2004, 2005
++   Free Software Foundation, Inc.
++
++This file is part of GCC.
++
++GCC is free software; you can redistribute it and/or modify
++it under the terms of the GNU General Public License as published by
++the Free Software Foundation; either version 2, or (at your option)
++any later version.
++
++GCC is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++GNU General Public License for more details.
++
++You should have received a copy of the GNU General Public License
++along with GCC; see the file COPYING.  If not, write to
++the Free Software Foundation, 59 Temple Place - Suite 330,
++Boston, MA 02111-1307, USA.  */
++
++
++/* Change debugging to Dwarf2.  */
++#undef PREFERRED_DEBUGGING_TYPE
++#define PREFERRED_DEBUGGING_TYPE DWARF2_DEBUG
++
++#undef MCOUNT_NAME
++#define MCOUNT_NAME "_mcount"
++
++#define TARGET_DECLSPEC 1
++
++#undef SIZE_TYPE
++#define SIZE_TYPE "long unsigned int"
++
++#undef PTRDIFF_TYPE
++#define PTRDIFF_TYPE "long int"
++
++#undef WCHAR_TYPE
++#define WCHAR_TYPE "int"
++
++#undef WCHAR_TYPE_SIZE
++#define WCHAR_TYPE_SIZE 32
++
++/* Haiku uses lots of multichars, so don't warn about them unless the
++   user explicitly asks for the warnings with -Wmultichar.  Note that
++   CC1_SPEC is used for both cc1 and cc1plus.  */
++#undef CC1_SPEC
++#define CC1_SPEC \
++  "%{fpic|fPIC|fpie|fPIE|fno-pic|fno-PIC|fno-pie|fno-PIE:;:-fPIC} \
++   %{!Wmultichar: -Wno-multichar} %(cc1_cpu) %{profile:-p}"
++
++#undef CC1PLUS_SPEC
++#define CC1PLUS_SPEC "%{!Wctor-dtor-privacy:-Wno-ctor-dtor-privacy}"
++
++/* LIB_SPEC for Haiku */
++#undef LIB_SPEC
++#define LIB_SPEC "-lroot"
++
++/* Use --as-needed -lgcc_s for eh support.  */
++#ifdef HAVE_LD_AS_NEEDED
++#define USE_LD_AS_NEEDED 1
++#endif
++
++#undef  STARTFILE_SPEC
++#define STARTFILE_SPEC "crti.o%s crtbeginS.o%s %{!shared:%{!nostart:start_dyn.o%s}} init_term_dyn.o%s"
++
++#undef  ENDFILE_SPEC
++#define ENDFILE_SPEC "crtendS.o%s crtn.o%s"
++
++/* Every program on Haiku links against libroot which contains the pthread
++   routines, so there's no need to explicitly call out when doing threaded
++   work.  */
++#undef GOMP_SELF_SPECS
++#define GOMP_SELF_SPECS ""
++#undef GTM_SELF_SPECS
++#define GTM_SELF_SPECS ""
++
++#ifdef HYBRID_SECONDARY
++/* For a secondary compiler on a hybrid system, use alternative search paths.*/
++#define INCLUDE_DEFAULTS \
++{ \
++    { GPLUSPLUS_INCLUDE_DIR, "G++", 1, 1, 0, 0 }, \
++    { GPLUSPLUS_TOOL_INCLUDE_DIR, "G++", 1, 1, 0, 0 }, \
++    { GPLUSPLUS_BACKWARD_INCLUDE_DIR, "G++", 1, 1, 0, 0 }, \
++    { GCC_INCLUDE_DIR, "GCC", 0, 0, 0, 0 }, \
++    { FIXED_INCLUDE_DIR, "GCC", 0, 0, 0, 0 }, \
++    { TOOL_INCLUDE_DIR, "BINUTILS", 0, 1, 0, 0 }, \
++    { "/boot/system/non-packaged/develop/headers/" HYBRID_SECONDARY, 0, 0, 0, 1, 0 }, \
++    { "/boot/system/develop/headers/os", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/app", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/device", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/drivers", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/game", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/interface", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/kernel", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/locale", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/mail", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/media", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/midi", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/midi2", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/net", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/opengl", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/storage", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/support", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/translation", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/add-ons/graphics", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/add-ons/input_server", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/add-ons/mail_daemon", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/add-ons/registrar", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/add-ons/screen_saver", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/add-ons/tracker", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/be_apps/Deskbar", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/be_apps/NetPositive", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/be_apps/Tracker", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/3rdparty", 0, 0, 0, 1, 0 }, \
++    { "/boot/system/develop/headers/bsd", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/glibc", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/gnu", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/posix", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/" HYBRID_SECONDARY, 0, 0, 0, 1, 0 }, \
++        /* Hybrid secondary folders for os kits not in base haiku package */\
++    { "/boot/system/develop/headers/" HYBRID_SECONDARY "/os", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/" HYBRID_SECONDARY "/os/opengl", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers", 0, 0, 0, 1, 0 }, \
++    { 0, 0, 0, 0, 0, 0 } \
++}
++#else /* HYBRID_SECONDARY */
++/* For both native and cross compiler, use standard Haiku include file
++   search paths.
++   For a cross compiler, it is expected that an appropriate sysroot has
++   been configured (e.g. /boot/system/develop/cross/x86) which will
++   be appended to each search folder given below. */
++#define INCLUDE_DEFAULTS \
++{ \
++    { GPLUSPLUS_INCLUDE_DIR, "G++", 1, 1, 0, 0 }, \
++    { GPLUSPLUS_TOOL_INCLUDE_DIR, "G++", 1, 1, 0, 0 }, \
++    { GPLUSPLUS_BACKWARD_INCLUDE_DIR, "G++", 1, 1, 0, 0 }, \
++    { GCC_INCLUDE_DIR, "GCC", 0, 0, 0, 0 }, \
++    { FIXED_INCLUDE_DIR, "GCC", 0, 0, 0, 0 }, \
++    { TOOL_INCLUDE_DIR, "BINUTILS", 0, 1, 0, 0 }, \
++    { "/boot/system/non-packaged/develop/headers", 0, 0, 0, 1, 0 }, \
++    { "/boot/system/develop/headers/os", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/app", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/device", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/drivers", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/game", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/interface", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/kernel", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/locale", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/mail", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/media", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/midi", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/midi2", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/net", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/opengl", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/storage", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/support", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/translation", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/add-ons/graphics", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/add-ons/input_server", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/add-ons/mail_daemon", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/add-ons/registrar", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/add-ons/screen_saver", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/add-ons/tracker", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/be_apps/Deskbar", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/be_apps/NetPositive", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/os/be_apps/Tracker", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/3rdparty", 0, 0, 0, 1, 0 }, \
++    	/* TODO: To be removed when libtiff has been outsourced. */\
++    { "/boot/system/develop/headers/bsd", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/glibc", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/gnu", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers/posix", 0, 0, 1, 1, 0 }, \
++    { "/boot/system/develop/headers", 0, 0, 0, 1, 0 }, \
++    { 0, 0, 0, 0, 0, 0 } \
++}
++#endif /* HYBRID_SECONDARY */
++
++/* Whee.  LIBRARY_PATH is Be's LD_LIBRARY_PATH, which of course will
++   cause nasty problems if we override it.  */
++#define LIBRARY_PATH_ENV        "BELIBRARIES"
++
++/* Set STANDARD_STARTFILE_PREFIX_1 set to "/boot/system/develop/lib/", or the
++   respective secondary architecture path. The user specific paths are set via
++   LIBRARY_PATH_ENV. */
++#undef STANDARD_STARTFILE_PREFIX_1
++#undef STANDARD_STARTFILE_PREFIX_2
++#undef MD_STARTFILE_PREFIX
++#undef STARTFILE_PREFIX_SPEC
++#ifdef HYBRID_SECONDARY
++/* For a secondary compiler on a hybrid system, use alternative search paths.*/
++#define STANDARD_STARTFILE_PREFIX_1 \
++  "/boot/system/non-packaged/develop/lib/" HYBRID_SECONDARY "/"
++#define STANDARD_STARTFILE_PREFIX_2 \
++  "/boot/system/develop/lib/" HYBRID_SECONDARY "/"
++#else /* HYBRID_SECONDARY */
++#define STANDARD_STARTFILE_PREFIX_1   "/boot/system/non-packaged/develop/lib/"
++#define STANDARD_STARTFILE_PREFIX_2   "/boot/system/develop/lib/"
++#endif /* HYBRID_SECONDARY */
++
++/* Haiku doesn't have a separate math library.  */
++#define MATH_LIBRARY ""
++
++/* Haiku headers are C++-aware (and often use C++).  */
++#define NO_IMPLICIT_EXTERN_C
++
++/* Only allow -lssp for SSP, as -lssp_nonshared is problematic in Haiku */
++#ifndef TARGET_LIBC_PROVIDES_SSP
++#define LINK_SSP_SPEC "%{fstack-protector|fstack-protector-all:-lssp}"
++#endif
++
++/* Do not use TM clone registry in Haiku for now */
++#define USE_TM_CLONE_REGISTRY 0
+diff --git a/gcc/config/i386/haiku.h b/gcc/config/i386/haiku.h
+new file mode 100644
+index 0000000..3379e19
+--- /dev/null
++++ b/gcc/config/i386/haiku.h
+@@ -0,0 +1,77 @@
++/* Definitions for Intel x86 running Haiku
++   Copyright (C) 1998, 1999, 2000, 2001, 2002, 2004
++   Free Software Foundation, Inc.
++
++This file is part of GCC.
++
++GCC is free software; you can redistribute it and/or modify
++it under the terms of the GNU General Public License as published by
++the Free Software Foundation; either version 2, or (at your option)
++any later version.
++
++GCC is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++GNU General Public License for more details.
++
++You should have received a copy of the GNU General Public License
++along with GCC; see the file COPYING.  If not, write to
++the Free Software Foundation, 59 Temple Place - Suite 330,
++Boston, MA 02111-1307, USA.  */
++
++
++#undef ASM_COMMENT_START
++#define ASM_COMMENT_START " #"
++
++/* The SVR4 ABI for the i386 says that records and unions are returned
++   in memory.  */
++#undef DEFAULT_PCC_STRUCT_RETURN
++#define DEFAULT_PCC_STRUCT_RETURN 1
++
++#undef DBX_REGISTER_NUMBER
++#define DBX_REGISTER_NUMBER(n) \
++  (TARGET_64BIT ? dbx64_register_map[n] : svr4_dbx_register_map[n])
++
++#define TARGET_OS_CPP_BUILTINS()					\
++  do									\
++    {									\
++	builtin_define ("__HAIKU__");					\
++	builtin_define ("__INTEL__");					\
++	builtin_define ("_X86_");					\
++	builtin_define ("__stdcall=__attribute__((__stdcall__))");	\
++	builtin_define ("__cdecl=__attribute__((__cdecl__))");		\
++    builtin_define ("__STDC_ISO_10646__=201103L"); \
++	builtin_assert ("system=haiku");					\
++    }									\
++  while (0)
++
++/* Provide a LINK_SPEC appropriate for Haiku.  Here we provide support
++   for the special GCC options -static and -shared, which allow us to
++   link things in one of these three modes by applying the appropriate
++   combinations of options at link-time.  */
++
++/* If ELF is the default format, we should not use /lib/elf.  */
++
++#undef	LINK_SPEC
++#define LINK_SPEC "-m elf_i386_haiku %{!r:-shared} %{nostart:-e 0} %{shared:-e 0} %{!shared: %{!nostart: -no-undefined}}"
++
++/* A C statement (sans semicolon) to output to the stdio stream
++   FILE the assembler definition of uninitialized global DECL named
++   NAME whose size is SIZE bytes and alignment is ALIGN bytes.
++   Try to use asm_output_aligned_bss to implement this macro.  */
++
++#define ASM_OUTPUT_ALIGNED_BSS(FILE, DECL, NAME, SIZE, ALIGN) \
++  asm_output_aligned_bss (FILE, DECL, NAME, SIZE, ALIGN)
++
++/* A C statement to output to the stdio stream FILE an assembler
++   command to advance the location counter to a multiple of 1<<LOG
++   bytes if it is within MAX_SKIP bytes.
++
++   This is used to align code labels according to Intel recommendations.  */
++
++#ifdef HAVE_GAS_MAX_SKIP_P2ALIGN
++#define ASM_OUTPUT_MAX_SKIP_ALIGN(FILE,LOG,MAX_SKIP) \
++  if ((LOG)!=0) \
++    if ((MAX_SKIP)==0) fprintf ((FILE), "\t.p2align %d\n", (LOG)); \
++    else fprintf ((FILE), "\t.p2align %d,,%d\n", (LOG), (MAX_SKIP))
++#endif
+diff --git a/gcc/config/i386/haiku64.h b/gcc/config/i386/haiku64.h
+new file mode 100644
+index 0000000..76ba48e
+--- /dev/null
++++ b/gcc/config/i386/haiku64.h
+@@ -0,0 +1,135 @@
++/* Definitions for AMD x86_64 running Haiku with ELF format.
++   Copyright (C) 1998, 1999, 2000, 2001, 2002, 2004
++   Free Software Foundation, Inc.
++
++This file is part of GCC.
++
++GCC is free software; you can redistribute it and/or modify
++it under the terms of the GNU General Public License as published by
++the Free Software Foundation; either version 2, or (at your option)
++any later version.
++
++GCC is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++GNU General Public License for more details.
++
++You should have received a copy of the GNU General Public License
++along with GCC; see the file COPYING.  If not, write to
++the Free Software Foundation, 59 Temple Place - Suite 330,
++Boston, MA 02111-1307, USA.  */
++
++
++#undef ASM_COMMENT_START
++#define ASM_COMMENT_START " #"
++
++/* The SVR4 ABI for the i386 says that records and unions are returned
++ * in memory. For 64-bit compilation this definition is ignored, however
++ * it is necessary for correct 32-bit code generation.
++ */
++#undef DEFAULT_PCC_STRUCT_RETURN
++#define DEFAULT_PCC_STRUCT_RETURN 1
++
++#undef DBX_REGISTER_NUMBER
++#define DBX_REGISTER_NUMBER(n) \
++  (TARGET_64BIT ? dbx64_register_map[n] : svr4_dbx_register_map[n])
++
++#define TARGET_OS_CPP_BUILTINS()					\
++  do									\
++    {									\
++      builtin_define ("__HAIKU__");					\
++      if (!TARGET_64BIT)						\
++        {								\
++          builtin_define ("__INTEL__");					\
++          builtin_define ("__X86__");					\
++        }								\
++      builtin_define ("__stdcall=__attribute__((__stdcall__))");	\
++      builtin_define ("__cdecl=__attribute__((__cdecl__))");		\
++      builtin_define ("__STDC_ISO_10646__=201103L");			\
++      builtin_assert ("system=haiku");					\
++    }									\
++  while (0)
++
++/* Provide a LINK_SPEC appropriate for Haiku.  Here we provide support
++   for the special GCC options -static and -shared, which allow us to
++   link things in one of these three modes by applying the appropriate
++   combinations of options at link-time.  */
++
++#if TARGET_64BIT_DEFAULT
++#define SPEC_32 "m32"
++#define SPEC_64 "!m32"
++#else
++#define SPEC_32 "!m64"
++#define SPEC_64 "m64"
++#endif
++
++#undef	LINK_SPEC
++#define LINK_SPEC "%{" SPEC_64 ":-m elf_x86_64_haiku} %{" SPEC_32 ":-m elf_i386_haiku} \
++	%{!r:-shared} %{nostart:-e 0} %{shared:-e 0} %{!shared: %{!nostart: -no-undefined}}"
++
++/* A C statement (sans semicolon) to output to the stdio stream
++   FILE the assembler definition of uninitialized global DECL named
++   NAME whose size is SIZE bytes and alignment is ALIGN bytes.
++   Try to use x86_output_aligned_bss to implement this macro.  */
++
++#define ASM_OUTPUT_ALIGNED_BSS(FILE, DECL, NAME, SIZE, ALIGN) \
++  x86_output_aligned_bss (FILE, DECL, NAME, SIZE, ALIGN)
++
++/* This is used to align code labels according to Intel recommendations.  */
++
++#ifdef HAVE_GAS_MAX_SKIP_P2ALIGN
++#define ASM_OUTPUT_MAX_SKIP_ALIGN(FILE,LOG,MAX_SKIP)			\
++  do {									\
++    if ((LOG) != 0) {							\
++      if ((MAX_SKIP) == 0) fprintf ((FILE), "\t.p2align %d\n", (LOG));	\
++      else {								\
++        fprintf ((FILE), "\t.p2align %d,,%d\n", (LOG), (MAX_SKIP));	\
++        /* Make sure that we have at least 8 byte alignment if > 8 byte	\
++           alignment is preferred.  */					\
++        if ((LOG) > 3							\
++            && (1 << (LOG)) > ((MAX_SKIP) + 1)				\
++            && (MAX_SKIP) >= 7)						\
++          fputs ("\t.p2align 3\n", (FILE));				\
++      }									\
++    }									\
++  } while (0)
++#undef  ASM_OUTPUT_MAX_SKIP_PAD
++#define ASM_OUTPUT_MAX_SKIP_PAD(FILE, LOG, MAX_SKIP)			\
++  if ((LOG) != 0)							\
++    {									\
++      if ((MAX_SKIP) == 0)						\
++        fprintf ((FILE), "\t.p2align %d\n", (LOG));			\
++      else								\
++        fprintf ((FILE), "\t.p2align %d,,%d\n", (LOG), (MAX_SKIP));	\
++    }
++#endif
++
++
++/* Output assembler code to FILE to call the profiler.  */
++#define NO_PROFILE_COUNTERS 1
++
++#undef ASM_SPEC
++#define ASM_SPEC "%{v:-V} %{Qy:} %{!Qn:-Qy} %{n} %{T} %{Ym,*} %{Yd,*} \
++ %{Wa,*:%*} %{" SPEC_32 ":--32} %{" SPEC_64 ":--64}"
++
++#undef  ASM_OUTPUT_ALIGNED_COMMON
++#define ASM_OUTPUT_ALIGNED_COMMON(FILE, NAME, SIZE, ALIGN)		\
++  x86_elf_aligned_common (FILE, NAME, SIZE, ALIGN);
++
++
++/* i386 System V Release 4 uses DWARF debugging info.
++   x86-64 ABI specifies DWARF2.  */
++
++#define DWARF2_DEBUGGING_INFO 1
++#define DWARF2_UNWIND_INFO 1
++
++#undef PREFERRED_DEBUGGING_TYPE
++#define PREFERRED_DEBUGGING_TYPE DWARF2_DEBUG
++
++#undef TARGET_ASM_SELECT_SECTION
++#define TARGET_ASM_SELECT_SECTION  x86_64_elf_select_section
++
++#undef TARGET_ASM_UNIQUE_SECTION
++#define TARGET_ASM_UNIQUE_SECTION  x86_64_elf_unique_section
++
++#define USE_X86_64_FRAME_POINTER 1
+diff --git a/gcc/config/i386/host-cygwin.c b/gcc/config/i386/host-cygwin.c
+old mode 100644
+new mode 100755
+diff --git a/gcc/config/i386/t-haiku64 b/gcc/config/i386/t-haiku64
+new file mode 100644
+index 0000000..9c8f8e6
+--- /dev/null
++++ b/gcc/config/i386/t-haiku64
+@@ -0,0 +1,16 @@
++MULTILIB_OPTIONS = m32 
++MULTILIB_DIRNAMES = 32
++
++LIBGCC = stmp-multilib
++INSTALL_LIBGCC = install-multilib
++
++EXTRA_MULTILIB_PARTS=crtbegin.o crtend.o
++
++# The pushl in CTOR initialization interferes with frame pointer elimination.
++# crtend*.o cannot be compiled without -fno-asynchronous-unwind-tables,
++# because then __FRAME_END__ might not be the last thing in .eh_frame
++# section.
++CRTSTUFF_T_CFLAGS = -fno-omit-frame-pointer -fno-asynchronous-unwind-tables
++
++# Compile libgcc2.a with pic.
++TARGET_LIBGCC2_CFLAGS = -fPIC
+diff --git a/gcc/config/i386/winnt-cxx.c b/gcc/config/i386/winnt-cxx.c
+old mode 100644
+new mode 100755
+diff --git a/gcc/config/i386/winnt-stubs.c b/gcc/config/i386/winnt-stubs.c
+old mode 100644
+new mode 100755
+diff --git a/gcc/config/m68k/haiku.h b/gcc/config/m68k/haiku.h
+new file mode 100644
+index 0000000..358c19f
+--- /dev/null
++++ b/gcc/config/m68k/haiku.h
+@@ -0,0 +1,268 @@
++/* Definitions for Motorola 68k running Haiku
++   Copyright (C) 1995, 1996, 1997, 1998, 1999, 2000, 2002, 2003, 2004, 2007
++   Free Software Foundation, Inc.
++
++This file is part of GCC.
++
++GCC is free software; you can redistribute it and/or modify
++it under the terms of the GNU General Public License as published by
++the Free Software Foundation; either version 2, or (at your option)
++any later version.
++
++GCC is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++GNU General Public License for more details.
++
++You should have received a copy of the GNU General Public License
++along with GCC; see the file COPYING.  If not, write to
++the Free Software Foundation, 51 Franklin Street, Fifth Floor,
++Boston, MA 02110-1301, USA.  */
++
++/* Default target comes from config.gcc.  */
++
++#undef TARGET_DEFAULT
++#ifdef TARGET_CPU_DEFAULT
++#define TARGET_DEFAULT TARGET_CPU_DEFAULT
++#else
++#define TARGET_DEFAULT (MASK_BITFIELD|MASK_68881|MASK_68020)
++#endif
++
++/* for 68k machines this only needs to be TRUE for the 68000 */
++
++#undef STRICT_ALIGNMENT
++#define STRICT_ALIGNMENT 0
++
++/* Here are four prefixes that are used by asm_fprintf to
++   facilitate customization for alternate assembler syntaxes.
++   Machines with no likelihood of an alternate syntax need not
++   define these and need not use asm_fprintf.  */
++
++/* The prefix for register names.  Note that REGISTER_NAMES
++   is supposed to include this prefix. Also note that this is NOT an
++   fprintf format string, it is a literal string */
++
++#undef REGISTER_PREFIX
++#define REGISTER_PREFIX "%"
++
++/* The prefix for local (compiler generated) labels.
++   These labels will not appear in the symbol table.  */
++
++#undef LOCAL_LABEL_PREFIX
++#define LOCAL_LABEL_PREFIX "."
++
++/* The prefix to add to user-visible assembler symbols.  */
++
++#undef USER_LABEL_PREFIX
++#define USER_LABEL_PREFIX ""
++
++#undef ASM_COMMENT_START
++#define ASM_COMMENT_START "|"
++
++/* Target OS builtins.  */
++
++#undef TARGET_OS_CPP_BUILTINS
++#define TARGET_OS_CPP_BUILTINS()					\
++  do									\
++    {									\
++	builtin_define ("__HAIKU__");					\
++	builtin_define ("__M68K__");					\
++	builtin_define_std ("mc68000");					\
++	builtin_define_std ("mc68020");					\
++	builtin_define ("__stdcall=__attribute__((__stdcall__))");	\
++	builtin_define ("__cdecl=__attribute__((__cdecl__))");		\
++    builtin_define ("__STDC_ISO_10646__=201103L"); \
++	builtin_assert ("system=haiku");				\
++    }									\
++  while (0)
++
++#define TARGET_OBJFMT_CPP_BUILTINS()		\
++  do						\
++    {						\
++	builtin_define ("__ELF__");		\
++    }						\
++  while (0)
++
++#undef CPP_SPEC
++#if TARGET_DEFAULT & MASK_68881
++#define CPP_SPEC \
++  "%{fPIC|fpic|fPIE|fpie:-D__PIC__ -D__pic__} %{!msoft-float:-D__HAVE_68881__} %{posix:-D_POSIX_SOURCE} %{pthread:-D_REENTRANT}"
++#else
++#define CPP_SPEC \
++  "%{fPIC|fpic|fPIE|fpie:-D__PIC__ -D__pic__} %{m68881:-D__HAVE_68881__} %{posix:-D_POSIX_SOURCE} %{pthread:-D_REENTRANT}"
++#endif
++
++/* We override the ASM_SPEC from svr4.h because we must pass -m68040 down
++   to the assembler.  */
++#undef ASM_SPEC
++#define ASM_SPEC \
++  "%{v:-V} %{Qy:} %{!Qn:-Qy} %{n} %{T} %{Ym,*} %{Yd,*} %{Wa,*:%*} \
++%{m68040} %{m68060:-m68040}"
++
++/* Provide a LINK_SPEC appropriate for Haiku.  Here we provide support
++   for the special GCC options -static and -shared, which allow us to
++   link things in one of these three modes by applying the appropriate
++   combinations of options at link-time.  */
++
++/* If ELF is the default format, we should not use /lib/elf.  */
++
++#undef	LINK_SPEC
++/*#define LINK_SPEC "%{!o*:-o %b} -m elf_m68k_haiku -shared -no-undefined %{nostart:-e 0}"*/
++#define LINK_SPEC "%{!o*:-o %b} -m m68kelf %{!r:-shared} -no-undefined %{nostart:-e 0}"
++
++/* XXX: not sure for the rest there... */
++
++/* Currently, JUMP_TABLES_IN_TEXT_SECTION must be defined in order to
++   keep switch tables in the text section.  */
++
++#define JUMP_TABLES_IN_TEXT_SECTION 1
++
++/* This is how to output an assembler line that says to advance the
++   location counter to a multiple of 2**LOG bytes.  */
++
++/* Use the default action for outputting the case label.  */
++#undef ASM_OUTPUT_CASE_LABEL
++#define ASM_RETURN_CASE_JUMP				\
++  do {							\
++    if (TARGET_COLDFIRE)				\
++      {							\
++	if (ADDRESS_REG_P (operands[0]))		\
++	  return "jmp %%pc@(2,%0:l)";			\
++	else						\
++	  return "ext%.l %0\n\tjmp %%pc@(2,%0:l)";	\
++      }							\
++    else						\
++      return "jmp %%pc@(2,%0:w)";			\
++  } while (0)
++
++#undef ASM_OUTPUT_ALIGN
++#define ASM_OUTPUT_ALIGN(FILE,LOG)				\
++  if ((LOG) > 0)						\
++    fprintf ((FILE), "%s%u\n", ALIGN_ASM_OP, 1 << (LOG));
++
++/* If defined, a C expression whose value is a string containing the
++   assembler operation to identify the following data as uninitialized global
++   data.  */
++
++#define BSS_SECTION_ASM_OP "\t.section\t.bss"
++
++/* A C statement (sans semicolon) to output to the stdio stream
++   FILE the assembler definition of uninitialized global DECL named
++   NAME whose size is SIZE bytes and alignment is ALIGN bytes.
++   Try to use asm_output_aligned_bss to implement this macro.  */
++
++#define ASM_OUTPUT_ALIGNED_BSS(FILE, DECL, NAME, SIZE, ALIGN) \
++  asm_output_aligned_bss (FILE, DECL, NAME, SIZE, ALIGN)
++
++/* Output assembler code to FILE to increment profiler label # LABELNO
++   for profiling a function entry.  */
++
++#undef FUNCTION_PROFILER
++#define FUNCTION_PROFILER(FILE, LABELNO) \
++{									\
++  asm_fprintf (FILE, "\tlea (%LLP%d,%Rpc),%Ra1\n", (LABELNO));		\
++  if (flag_pic)								\
++    fprintf (FILE, "\tbsr.l _mcount@PLTPC\n");				\
++  else									\
++    fprintf (FILE, "\tjbsr _mcount\n");					\
++}
++
++/* How to renumber registers for dbx and gdb.
++   On the Sun-3, the floating point registers have numbers
++   18 to 25, not 16 to 23 as they do in the compiler.  */
++
++#define DBX_REGISTER_NUMBER(REGNO) ((REGNO) < 16 ? (REGNO) : (REGNO) + 2)
++
++/* Do not break .stabs pseudos into continuations.  */
++
++#define DBX_CONTIN_LENGTH 0
++
++/* 1 if N is a possible register number for a function value.  For
++   m68k/SVR4 allow d0, a0, or fp0 as return registers, for integral,
++   pointer, or floating types, respectively.  Reject fp0 if not using
++   a 68881 coprocessor.  */
++
++#undef FUNCTION_VALUE_REGNO_P
++#define FUNCTION_VALUE_REGNO_P(N) \
++  ((N) == 0 || (N) == 8 || (TARGET_68881 && (N) == 16))
++
++/* Define this to be true when FUNCTION_VALUE_REGNO_P is true for
++   more than one register.  */
++
++#undef NEEDS_UNTYPED_CALL
++#define NEEDS_UNTYPED_CALL 1
++
++/* Define how to generate (in the callee) the output value of a
++   function and how to find (in the caller) the value returned by a
++   function.  VALTYPE is the data type of the value (as a tree).  If
++   the precise function being called is known, FUNC is its
++   FUNCTION_DECL; otherwise, FUNC is 0.  For m68k/SVR4 generate the
++   result in d0, a0, or fp0 as appropriate.  */
++
++#undef FUNCTION_VALUE
++#define FUNCTION_VALUE(VALTYPE, FUNC)					\
++  (TREE_CODE (VALTYPE) == REAL_TYPE && TARGET_68881			\
++   ? gen_rtx_REG (TYPE_MODE (VALTYPE), 16)				\
++   : (POINTER_TYPE_P (VALTYPE)						\
++      ? gen_rtx_REG (TYPE_MODE (VALTYPE), 8)				\
++      : gen_rtx_REG (TYPE_MODE (VALTYPE), 0)))
++
++/* For compatibility with the large body of existing code which does
++   not always properly declare external functions returning pointer
++   types, the m68k/SVR4 convention is to copy the value returned for
++   pointer functions from a0 to d0 in the function epilogue, so that
++   callers that have neglected to properly declare the callee can
++   still find the correct return value.  */
++
++#define FUNCTION_EXTRA_EPILOGUE(FILE, SIZE)				\
++do {									\
++  if (current_function_returns_pointer					\
++      && ! find_equiv_reg (0, get_last_insn (), 0, 0, 0, 8, Pmode))	\
++    asm_fprintf (FILE, "\tmove.l %Ra0,%Rd0\n");				\
++} while (0);
++
++/* Define how to find the value returned by a library function
++   assuming the value has mode MODE.
++   For m68k/SVR4 look for integer values in d0, pointer values in d0
++   (returned in both d0 and a0), and floating values in fp0.  */
++
++#undef LIBCALL_VALUE
++#define LIBCALL_VALUE(MODE)						\
++  ((((MODE) == SFmode || (MODE) == DFmode || (MODE) == XFmode)		\
++    && TARGET_68881)							\
++   ? gen_rtx_REG ((MODE), 16)						\
++   : gen_rtx_REG ((MODE), 0))
++
++/* For m68k SVR4, structures are returned using the reentrant
++   technique.  */
++#undef PCC_STATIC_STRUCT_RETURN
++#define DEFAULT_PCC_STRUCT_RETURN 0
++
++/* Finalize the trampoline by flushing the insn cache.  */
++
++#undef FINALIZE_TRAMPOLINE
++#define FINALIZE_TRAMPOLINE(TRAMP)					\
++  emit_library_call (gen_rtx_SYMBOL_REF (Pmode, "__clear_cache"),	\
++		     LCT_NORMAL, VOIDmode, 2, TRAMP, Pmode,			\
++		     plus_constant (Pmode, TRAMP, TRAMPOLINE_SIZE), \
++		     Pmode);
++
++/* Clear the instruction cache from `beg' to `end'.  This makes an
++   inline system call to SYS_cacheflush.  The arguments are as
++   follows:
++
++	cacheflush (addr, scope, cache, len)
++
++   addr	  - the start address for the flush
++   scope  - the scope of the flush (see the cpush insn)
++   cache  - which cache to flush (see the cpush insn)
++   len    - a factor relating to the number of flushes to perform:
++	    len/16 lines, or len/4096 pages.  */
++
++#define CLEAR_INSN_CACHE(BEG, END)					\
++{									\
++extern void clear_caches(void *address, int length, unsigned long flags); \
++  void *ptr = BEG;							\
++  int len = (END - BEG + 32);						\
++  clear_caches(ptr, len, 0x0005);					\
++}
+diff --git a/gcc/config/mips/haiku.h b/gcc/config/mips/haiku.h
+new file mode 100644
+index 0000000..f6d2efb
+--- /dev/null
++++ b/gcc/config/mips/haiku.h
+@@ -0,0 +1,44 @@
++/* Definitions for MIPS running Haiku
++   Copyright (C) 1998, 1999, 2000, 2001, 2002, 2004
++   Free Software Foundation, Inc.
++
++This file is part of GCC.
++
++GCC is free software; you can redistribute it and/or modify
++it under the terms of the GNU General Public License as published by
++the Free Software Foundation; either version 2, or (at your option)
++any later version.
++
++GCC is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++GNU General Public License for more details.
++
++You should have received a copy of the GNU General Public License
++along with GCC; see the file COPYING.  If not, write to
++the Free Software Foundation, 59 Temple Place - Suite 330,
++Boston, MA 02111-1307, USA.  */
++
++
++#define TARGET_OS_CPP_BUILTINS()					\
++  do									\
++    {									\
++	builtin_define ("__HAIKU__");					\
++	builtin_define ("__MIPS__");					\
++	builtin_define ("__MIPSEL__");					\
++	builtin_define ("_MIPSEL_");					\
++	builtin_define ("__stdcall=__attribute__((__stdcall__))");	\
++	builtin_define ("__cdecl=__attribute__((__cdecl__))");		\
++    builtin_define ("__STDC_ISO_10646__=201103L"); \
++	builtin_assert ("system=haiku");					\
++	if (flag_pic)							\
++	  {								\
++	    builtin_define ("__PIC__");					\
++	    builtin_define ("__pic__");					\
++	  }								\
++    }									\
++  while (0)
++
++#undef	LINK_SPEC
++#define LINK_SPEC "%{!o*:-o %b} -m elf_mipsel_haiku %{!r:-shared} %{nostart:-e 0}"
++
+diff --git a/gcc/config/rs6000/haiku.h b/gcc/config/rs6000/haiku.h
+new file mode 100644
+index 0000000..4dff89e
+--- /dev/null
++++ b/gcc/config/rs6000/haiku.h
+@@ -0,0 +1,56 @@
++/* Definitions for PowerPC running Haiku
++   Copyright (C) 1998, 1999, 2000, 2001, 2002, 2004, 2005
++   Free Software Foundation, Inc.
++
++This file is part of GCC.
++
++GCC is free software; you can redistribute it and/or modify
++it under the terms of the GNU General Public License as published by
++the Free Software Foundation; either version 2, or (at your option)
++any later version.
++
++GCC is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++GNU General Public License for more details.
++
++You should have received a copy of the GNU General Public License
++along with GCC; see the file COPYING.  If not, write to
++the Free Software Foundation, 59 Temple Place - Suite 330,
++Boston, MA 02111-1307, USA.  */
++
++
++/* long double is 128 bits wide; the documentation claims
++   LIBGCC2_LONG_DOUBLE_TYPE_SIZE to default to LONG_DOUBLE_TYPE_SIZE, but
++   it apparently does not */
++/*#undef LONG_DOUBLE_TYPE_SIZE
++#define LONG_DOUBLE_TYPE_SIZE 128
++#undef LIBGCC2_LONG_DOUBLE_TYPE_SIZE
++#define LIBGCC2_LONG_DOUBLE_TYPE_SIZE 128*/
++
++#undef TARGET_OS_CPP_BUILTINS
++#define TARGET_OS_CPP_BUILTINS()					\
++  do									\
++    {									\
++	builtin_define ("__HAIKU__");					\
++	builtin_define ("__POWERPC__");					\
++	builtin_define ("__powerpc__");					\
++	builtin_define ("__stdcall=__attribute__((__stdcall__))");	\
++	builtin_define ("__cdecl=__attribute__((__cdecl__))");		\
++    builtin_define ("__STDC_ISO_10646__=201103L"); \
++	builtin_assert ("system=haiku");					\
++	builtin_assert ("cpu=powerpc");					\
++	builtin_assert ("machine=powerpc");					\
++	TARGET_OS_SYSV_CPP_BUILTINS ();					\
++    }									\
++  while (0)
++
++/* Provide a LINK_SPEC appropriate for Haiku.  Here we provide support
++   for the special GCC options -static and -shared, which allow us to
++   link things in one of these three modes by applying the appropriate
++   combinations of options at link-time.  */
++
++/* If ELF is the default format, we should not use /lib/elf.  */
++
++#undef	LINK_SPEC
++#define LINK_SPEC "%{!o*:-o %b} -m elf32ppchaiku %{!r:-shared} %{nostart:-e 0} %{shared:-e 0} %{!shared: %{!nostart: -no-undefined}}"
+diff --git a/gcc/config/t-haiku b/gcc/config/t-haiku
+new file mode 100644
+index 0000000..587d1fb
+--- /dev/null
++++ b/gcc/config/t-haiku
+@@ -0,0 +1,4 @@
++# There are system headers elsewhere, but these are the ones that
++# we are most likely to want to apply any fixes to.
++NATIVE_SYSTEM_HEADER_DIR = /boot/system/develop/headers
++LIMITS_H_TEST = [ -f $(SYSTEM_HEADER_DIR)/posix/limits.h ]
+\ No newline at end of file
+diff --git a/gcc/configure.ac b/gcc/configure.ac
+index d6f2d5b..cea0e3a 100644
+--- a/gcc/configure.ac
++++ b/gcc/configure.ac
+@@ -771,6 +771,15 @@ fi
+ # Miscenalleous configure options
+ # -------------------------------
+ 
++# handle --with-hybrid-secondary
++AC_ARG_WITH(hybrid_secondary,
++  [AS_HELP_STRING([--with-hybrid_secondary],
++                  [specify the packaging architecture for building a secondary compiler for a Haiku hybrid system])],
++  [HYBRID_SECONDARY=$withval],
++  [HYBRID_SECONDARY=]
++)
++AC_SUBST(HYBRID_SECONDARY)
++
+ # With stabs
+ AC_ARG_WITH(stabs,
+ [AS_HELP_STRING([--with-stabs],
+@@ -1155,6 +1164,16 @@ ZW_PROG_COMPILER_DEPENDENCIES([CXX])
+ # --------
+ 
+ 
++# Configure -lm usage for host tools that need it
++build_math_library="-lm"
++case $build in
++  *-*-haiku*)
++    # no separate math library needed
++    build_math_library=
++    ;;
++esac
++AC_SUBST(build_math_library)
++
+ # These libraries may be used by collect2.
+ # We may need a special search path to get them linked.
+ AC_CACHE_CHECK(for collect2 libraries, gcc_cv_collect2_libs,
+@@ -1611,7 +1630,7 @@ case ${enable_threads} in
+     # default
+     target_thread_file='single'
+     ;;
+-  aix | dce | lynx | mipssde | posix | rtems | \
++  aix | dce | haiku | lynx | mipssde | posix | rtems | \
+   single | tpf | vxworks | win32)
+     target_thread_file=${enable_threads}
+     ;;
+diff --git a/gcc/ginclude/stdarg.h b/gcc/ginclude/stdarg.h
+index e4c73fd..cc73248 100644
+--- a/gcc/ginclude/stdarg.h
++++ b/gcc/ginclude/stdarg.h
+@@ -94,7 +94,7 @@ typedef __gnuc_va_list va_list;
+ #ifndef _VA_LIST
+ /* The macro _VA_LIST_T_H is used in the Bull dpx2  */
+ #ifndef _VA_LIST_T_H
+-/* The macro __va_list__ is used by BeOS.  */
++/* The macro __va_list__ is used by BeOS and Haiku.  */
+ #ifndef __va_list__
+ typedef __gnuc_va_list va_list;
+ #endif /* not __va_list__ */
+diff --git a/gcc/ginclude/stddef.h b/gcc/ginclude/stddef.h
+index 31b96a7..ca20f4d 100644
+--- a/gcc/ginclude/stddef.h
++++ b/gcc/ginclude/stddef.h
+@@ -167,7 +167,7 @@ typedef __PTRDIFF_TYPE__ ptrdiff_t;
+ /* Define this type if we are doing the whole job,
+    or if we want this type in particular.  */
+ #if defined (_STDDEF_H) || defined (__need_size_t)
+-#ifndef __size_t__	/* BeOS */
++#ifndef __size_t__	/* BeOS, Haiku */
+ #ifndef __SIZE_T__	/* Cray Unicos/Mk */
+ #ifndef _SIZE_T	/* in case <sys/types.h> has defined it. */
+ #ifndef _SYS_SIZE_T_H
+@@ -184,7 +184,7 @@ typedef __PTRDIFF_TYPE__ ptrdiff_t;
+ #ifndef _GCC_SIZE_T
+ #ifndef _SIZET_
+ #ifndef __size_t
+-#define __size_t__	/* BeOS */
++#define __size_t__	/* BeOS, Haiku */
+ #define __SIZE_T__	/* Cray Unicos/Mk */
+ #define _SIZE_T
+ #define _SYS_SIZE_T_H
+@@ -214,7 +214,7 @@ typedef __PTRDIFF_TYPE__ ptrdiff_t;
+ #endif
+ #if !(defined (__GNUG__) && defined (size_t))
+ typedef __SIZE_TYPE__ size_t;
+-#ifdef __BEOS__
++#if defined(__BEOS__)
+ typedef long ssize_t;
+ #endif /* __BEOS__ */
+ #endif /* !(defined (__GNUG__) && defined (size_t)) */
+@@ -247,7 +247,7 @@ typedef long ssize_t;
+ /* Define this type if we are doing the whole job,
+    or if we want this type in particular.  */
+ #if defined (_STDDEF_H) || defined (__need_wchar_t)
+-#ifndef __wchar_t__	/* BeOS */
++#ifndef __wchar_t__	/* BeOS, Haiku */
+ #ifndef __WCHAR_T__	/* Cray Unicos/Mk */
+ #ifndef _WCHAR_T
+ #ifndef _T_WCHAR_
+@@ -264,7 +264,7 @@ typedef long ssize_t;
+ #ifndef ___int_wchar_t_h
+ #ifndef __INT_WCHAR_T_H
+ #ifndef _GCC_WCHAR_T
+-#define __wchar_t__	/* BeOS */
++#define __wchar_t__	/* BeOS, Haiku */
+ #define __WCHAR_T__	/* Cray Unicos/Mk */
+ #define _WCHAR_T
+ #define _T_WCHAR_
+diff --git a/include/filenames.h b/include/filenames.h
+index 6164048..492b0c9 100644
+--- a/include/filenames.h
++++ b/include/filenames.h
+@@ -44,9 +44,11 @@ extern "C" {
+ #  define IS_ABSOLUTE_PATH(f) IS_DOS_ABSOLUTE_PATH (f)
+ #else /* not DOSish */
+ #  if defined(__APPLE__)
++/*
+ #    ifndef HAVE_CASE_INSENSITIVE_FILE_SYSTEM
+ #      define HAVE_CASE_INSENSITIVE_FILE_SYSTEM 1
+ #    endif
++*/
+ #  endif /* __APPLE__ */
+ #  define HAS_DRIVE_SPEC(f) (0)
+ #  define IS_DIR_SEPARATOR(c) IS_UNIX_DIR_SEPARATOR (c)
+diff --git a/libatomic/configure.ac b/libatomic/configure.ac
+index d9cdc8e..abbb751 100644
+--- a/libatomic/configure.ac
++++ b/libatomic/configure.ac
+@@ -209,21 +209,27 @@ LIBAT_WORDSIZE
+ case " $config_path " in
+  *" posix "*)
+   XPCFLAGS=""
+-  CFLAGS="$CFLAGS -pthread"
+   AC_LINK_IFELSE(
+     [AC_LANG_PROGRAM(
+      [#include <pthread.h>
+       void *g(void *d) { return NULL; }],
+      [pthread_t t; pthread_create(&t,NULL,g,NULL);])],
+-    [XPCFLAGS=" -pthread"],
+-    [CFLAGS="$save_CFLAGS $XCFLAGS" LIBS="-lpthread $LIBS"
++    [],
++    [CFLAGS="$CFLAGS -pthread"
+      AC_LINK_IFELSE(
+-      [AC_LANG_PROGRAM(
+-       [#include <pthread.h>
+-        void *g(void *d) { return NULL; }],
+-       [pthread_t t; pthread_create(&t,NULL,g,NULL);])],
+-      [],
+-      [AC_MSG_ERROR([Pthreads are required to build libatomic])])])
++       [AC_LANG_PROGRAM(
++        [#include <pthread.h>
++         void *g(void *d) { return NULL; }],
++        [pthread_t t; pthread_create(&t,NULL,g,NULL);])],
++       [XPCFLAGS=" -pthread"],
++       [CFLAGS="$save_CFLAGS $XCFLAGS" LIBS="-lpthread $LIBS"
++        AC_LINK_IFELSE(
++          [AC_LANG_PROGRAM(
++           [#include <pthread.h>
++            void *g(void *d) { return NULL; }],
++           [pthread_t t; pthread_create(&t,NULL,g,NULL);])],
++          [],
++          [AC_MSG_ERROR([Pthreads are required to build libatomic])])])])
+   CFLAGS="$save_CFLAGS $XPCFLAGS"
+   ;;
+ esac
+diff --git a/libatomic/configure.tgt b/libatomic/configure.tgt
+index ea8c34f..dc3b106 100644
+--- a/libatomic/configure.tgt
++++ b/libatomic/configure.tgt
+@@ -137,7 +137,7 @@ case "${target}" in
+   *-*-linux* | *-*-gnu* | *-*-k*bsd*-gnu \
+   | *-*-netbsd* | *-*-freebsd* | *-*-openbsd* | *-*-dragonfly* \
+   | *-*-solaris2* | *-*-sysv4* | *-*-irix6* | *-*-osf* | *-*-hpux11* \
+-  | *-*-darwin* | *-*-aix* | *-*-cygwin*)
++  | *-*-darwin* | *-*-aix* | *-*-cygwin* | *-*-haiku*)
+ 	# POSIX system.  The OS is supported.
+ 	config_path="${config_path} posix"
+ 	;;
+diff --git a/libgcc/Makefile.in b/libgcc/Makefile.in
+index dd8cee9..23850c8 100644
+--- a/libgcc/Makefile.in
++++ b/libgcc/Makefile.in
+@@ -397,10 +397,16 @@ ifeq ($(enable_shared),yes)
+   endif
+ endif
+ 
++ifneq ($(enable_shared),yes)
++# Maintain the same visibility as older GCC for now. Needed on Haiku
++# because the static library is included in libroot.so.
++vis_hide =
++else
+ # For -fvisibility=hidden.  We need both a -fvisibility=hidden on
+ # the command line, and a #define to prevent libgcc2.h etc from
+ # overriding that with #pragmas.
+ vis_hide = @vis_hide@
++endif
+ 
+ ifneq (,$(vis_hide))
+ 
+
+diff --git a/libgcc/config/i386/t-cygming b/libgcc/config/i386/t-cygming
+old mode 100644
+new mode 100755
+diff --git a/libgcc/config/t-haiku b/libgcc/config/t-haiku
+new file mode 100644
+index 0000000..b4fff2d
+--- /dev/null
++++ b/libgcc/config/t-haiku
+@@ -0,0 +1,3 @@
++# Use unwind-dw2-fde
++LIB2ADDEH = $(srcdir)/unwind-dw2.c $(srcdir)/unwind-dw2-fde.c \
++  $(srcdir)/unwind-sjlj.c $(srcdir)/unwind-c.c
+diff --git a/libgcc/crtstuff.c b/libgcc/crtstuff.c
+index 5e89445..41b8583 100644
+--- a/libgcc/crtstuff.c
++++ b/libgcc/crtstuff.c
+@@ -108,7 +108,9 @@ call_ ## FUNC (void)					\
+     && defined(HAVE_LD_EH_FRAME_HDR) \
+     && !defined(inhibit_libc) && !defined(CRTSTUFFT_O) \
+     && defined(__GLIBC__) && __GLIBC__ >= 2
++#ifndef __HAIKU__
+ #include <link.h>
++#endif
+ /* uClibc pretends to be glibc 2.2 and DT_CONFIG is defined in its link.h.
+    But it doesn't use PT_GNU_EH_FRAME ELF segment currently.  */
+ # if !defined(__UCLIBC__) \
+diff --git a/libgomp/configure.ac b/libgomp/configure.ac
+index 4e0bc81..f6503ef 100644
+--- a/libgomp/configure.ac
++++ b/libgomp/configure.ac
+@@ -188,21 +188,27 @@ case "$host" in
+   *)
+     # Check to see if -pthread or -lpthread is needed.  Prefer the former.
+     # In case the pthread.h system header is not found, this test will fail.
+-    CFLAGS="$CFLAGS -pthread"
+     AC_LINK_IFELSE(
+      [AC_LANG_PROGRAM(
+       [#include <pthread.h>
+        void *g(void *d) { return NULL; }],
+       [pthread_t t; pthread_create(&t,NULL,g,NULL);])],
+-     [XPCFLAGS=" -Wc,-pthread"],
+-     [CFLAGS="$save_CFLAGS" LIBS="-lpthread $LIBS"
++     [],
++     [CFLAGS="$CFLAGS -pthread"
+       AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM(
+         [#include <pthread.h>
+          void *g(void *d) { return NULL; }],
+         [pthread_t t; pthread_create(&t,NULL,g,NULL);])],
+-       [],
+-       [AC_MSG_ERROR([Pthreads are required to build libgomp])])])
++       [XPCFLAGS=" -Wc,-pthread"],
++       [CFLAGS="$save_CFLAGS" LIBS="-lpthread $LIBS"
++        AC_LINK_IFELSE(
++         [AC_LANG_PROGRAM(
++          [#include <pthread.h>
++           void *g(void *d) { return NULL; }],
++          [pthread_t t; pthread_create(&t,NULL,g,NULL);])],
++         [],
++         [AC_MSG_ERROR([Pthreads are required to build libgomp])])])])
+ esac
+ 
+ if test x$libgomp_use_pthreads != xno; then
+diff --git a/libstdc++-v3/config/os/haiku/ctype_base.h b/libstdc++-v3/config/os/haiku/ctype_base.h
+new file mode 100644
+index 0000000..e762aaa
+--- /dev/null
++++ b/libstdc++-v3/config/os/haiku/ctype_base.h
+@@ -0,0 +1,61 @@
++// Locale support -*- C++ -*-
++
++// Copyright (C) 1997-2015 Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++//
++// ISO C++ 14882: 22.1  Locales
++//
++
++// Default information, may not be appropriate for specific host.
++
++namespace std _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  /// @brief  Base class for ctype.
++  struct ctype_base
++  {
++    // Non-standard typedefs.
++    typedef const int* 		__to_type;
++
++    // NB: Offsets into ctype<char>::_M_table force a particular size
++    // on the mask type. Because of this, we don't use an enum.
++    typedef unsigned int 	mask;
++    static const mask upper    	= 1 << 0;
++    static const mask lower 	= 1 << 1;
++    static const mask alpha 	= 1 << 2;
++    static const mask digit 	= 1 << 3;
++    static const mask xdigit 	= 1 << 4;
++    static const mask space 	= 1 << 5;
++    static const mask print 	= 1 << 6;
++    static const mask graph 	= (1 << 2) | (1 << 3) | (1 << 9); // alnum|punct
++    static const mask cntrl 	= 1 << 8;
++    static const mask punct 	= 1 << 9;
++    static const mask alnum 	= (1 << 2) | (1 << 3);  // alpha|digit
++#if __cplusplus >= 201103L
++	static const mask blank		= 1 << 10;
++#endif
++  };
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
+diff --git a/libstdc++-v3/config/os/haiku/ctype_configure_char.cc b/libstdc++-v3/config/os/haiku/ctype_configure_char.cc
+new file mode 100644
+index 0000000..35e6b80
+--- /dev/null
++++ b/libstdc++-v3/config/os/haiku/ctype_configure_char.cc
+@@ -0,0 +1,99 @@
++// Locale support -*- C++ -*-
++
++// Copyright (C) 2011-2013 Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++/** @file ctype_configure_char.cc */
++
++//
++// ISO C++ 14882: 22.1  Locales
++//
++
++#include <locale>
++#include <cstdlib>
++#include <cstring>
++
++namespace std _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++// Information as gleaned from /usr/include/ctype.h
++
++  const ctype_base::mask*
++  ctype<char>::classic_table() throw()
++  { return 0; }
++
++  ctype<char>::ctype(__c_locale, const mask* __table, bool __del, 
++		     size_t __refs) 
++  : facet(__refs), _M_del(__table != 0 && __del), 
++  _M_toupper(NULL), _M_tolower(NULL), 
++  _M_table(__table ? __table : classic_table()) 
++  { 
++    memset(_M_widen, 0, sizeof(_M_widen));
++    _M_widen_ok = 0;
++    memset(_M_narrow, 0, sizeof(_M_narrow));
++    _M_narrow_ok = 0;
++  }
++
++  ctype<char>::ctype(const mask* __table, bool __del, size_t __refs) 
++  : facet(__refs), _M_del(__table != 0 && __del), 
++  _M_toupper(NULL), _M_tolower(NULL), 
++  _M_table(__table ? __table : classic_table())
++  { 
++    memset(_M_widen, 0, sizeof(_M_widen));
++    _M_widen_ok = 0;
++    memset(_M_narrow, 0, sizeof(_M_narrow));
++    _M_narrow_ok = 0;
++  }
++
++  char
++  ctype<char>::do_toupper(char __c) const
++  { return ::toupper((int) __c); }
++
++  const char*
++  ctype<char>::do_toupper(char* __low, const char* __high) const
++  {
++    while (__low < __high)
++      {
++	*__low = ::toupper((int) *__low);
++	++__low;
++      }
++    return __high;
++  }
++
++  char
++  ctype<char>::do_tolower(char __c) const
++  { return ::tolower((int) __c); }
++
++  const char* 
++  ctype<char>::do_tolower(char* __low, const char* __high) const
++  {
++    while (__low < __high)
++      {
++	*__low = ::tolower((int) *__low);
++	++__low;
++      }
++    return __high;
++  }
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
+diff --git a/libstdc++-v3/config/os/haiku/ctype_inline.h b/libstdc++-v3/config/os/haiku/ctype_inline.h
+new file mode 100644
+index 0000000..5b5cc56
+--- /dev/null
++++ b/libstdc++-v3/config/os/haiku/ctype_inline.h
+@@ -0,0 +1,173 @@
++// Locale support -*- C++ -*-
++
++// Copyright (C) 2000-2015 Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++/** @file bits/ctype_inline.h
++ *  This is an internal header file, included by other library headers.
++ *  Do not attempt to use it directly. @headername{locale}
++ */
++
++//
++// ISO C++ 14882: 22.1  Locales
++//
++  
++// ctype bits to be inlined go here. Non-inlinable (ie virtual do_*)
++// functions go in ctype.cc
++  
++// The following definitions are portable, but insanely slow. If one
++// cares at all about performance, then specialized ctype
++// functionality should be added for the native os in question: see
++// the config/os/bits/ctype_*.h files.
++
++// Constructing a synthetic "C" table should be seriously considered...
++
++namespace std _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  bool
++  ctype<char>::
++  is(mask __m, char __c) const
++  { 
++    if (_M_table)
++      return _M_table[static_cast<unsigned char>(__c)] & __m;
++    else
++      {
++	bool __ret = false;
++	const size_t __bitmasksize = 15; 
++	size_t __bitcur = 0; // Lowest bitmask in ctype_base == 0
++	for (; __bitcur <= __bitmasksize; ++__bitcur)
++	  {
++	    const mask __bit = static_cast<mask>(1 << __bitcur);
++	    if (__m & __bit)
++	      {
++		bool __testis;
++		switch (__bit)
++		  {
++		  case space:
++		    __testis = isspace(__c);
++		    break;
++		  case print:
++		    __testis = isprint(__c);
++		    break;
++		  case cntrl:
++		    __testis = iscntrl(__c);
++		    break;
++		  case upper:
++		    __testis = isupper(__c);
++		    break;
++		  case lower:
++		    __testis = islower(__c);
++		    break;
++		  case alpha:
++		    __testis = isalpha(__c);
++		    break;
++		  case digit:
++		    __testis = isdigit(__c);
++		    break;
++		  case punct:
++		    __testis = ispunct(__c);
++		    break;
++		  case xdigit:
++		    __testis = isxdigit(__c);
++		    break;
++		  case alnum:
++		    __testis = isalnum(__c);
++		    break;
++		  case graph:
++		    __testis = isgraph(__c);
++		    break;
++#if __cplusplus >= 201103L
++		  case blank:
++		    __testis = isblank(__c);
++		    break;
++#endif
++		  default:
++		    __testis = false;
++		    break;
++		  }
++		__ret |= __testis;
++	      }
++	  }
++	return __ret;
++      }
++  }
++   
++  const char*
++  ctype<char>::
++  is(const char* __low, const char* __high, mask* __vec) const
++  {
++    if (_M_table)
++      while (__low < __high)
++	*__vec++ = _M_table[static_cast<unsigned char>(*__low++)];
++    else
++      {
++	// Highest bitmask in ctype_base == 11.
++	const size_t __bitmasksize = 15; 
++	for (;__low < __high; ++__vec, ++__low)
++	  {
++	    mask __m = 0;
++	    // Lowest bitmask in ctype_base == 0
++	    size_t __i = 0; 
++	    for (;__i <= __bitmasksize; ++__i)
++	      {
++		const mask __bit = static_cast<mask>(1 << __i);
++		if (this->is(__bit, *__low))
++		  __m |= __bit;
++	      }
++	    *__vec = __m;
++	  }
++      }
++    return __high;
++  }
++
++  const char*
++  ctype<char>::
++  scan_is(mask __m, const char* __low, const char* __high) const
++  {
++    if (_M_table)
++      while (__low < __high
++	     && !(_M_table[static_cast<unsigned char>(*__low)] & __m))
++	++__low;
++    else
++      while (__low < __high && !this->is(__m, *__low))
++	++__low;
++    return __low;
++  }
++
++  const char*
++  ctype<char>::
++  scan_not(mask __m, const char* __low, const char* __high) const
++  {
++    if (_M_table)
++      while (__low < __high
++	     && (_M_table[static_cast<unsigned char>(*__low)] & __m) != 0)
++	++__low;
++    else
++      while (__low < __high && this->is(__m, *__low) != 0)
++	++__low;
++    return __low;
++  }
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
+diff --git a/libstdc++-v3/config/os/haiku/error_constants.h b/libstdc++-v3/config/os/haiku/error_constants.h
+new file mode 100644
+index 0000000..fa6d889
+--- /dev/null
++++ b/libstdc++-v3/config/os/haiku/error_constants.h
+@@ -0,0 +1,178 @@
++// Specific definitions for generic platforms  -*- C++ -*-
++
++// Copyright (C) 2007-2013 Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++/** @file bits/error_constants.h
++ *  This is an internal header file, included by other library headers.
++ *  Do not attempt to use it directly. @headername{system_error}
++ */
++
++#ifndef _GLIBCXX_ERROR_CONSTANTS
++#define _GLIBCXX_ERROR_CONSTANTS 1
++
++#include <bits/c++config.h>
++#include <cerrno>
++
++namespace std _GLIBCXX_VISIBILITY(default)
++{
++_GLIBCXX_BEGIN_NAMESPACE_VERSION
++
++  enum class errc
++    {
++      address_family_not_supported = 		EAFNOSUPPORT,
++      address_in_use = 				EADDRINUSE,
++      address_not_available = 			EADDRNOTAVAIL,
++      already_connected = 			EISCONN,
++      argument_list_too_long = 			E2BIG,
++      argument_out_of_domain = 			EDOM,
++      bad_address = 				EFAULT,
++      bad_file_descriptor = 			EBADF,
++
++#ifdef _GLIBCXX_HAVE_EBADMSG
++      bad_message = 				EBADMSG,
++#endif
++
++      broken_pipe = 				EPIPE,
++      connection_aborted = 			ECONNABORTED,
++      connection_already_in_progress = 		EALREADY,
++      connection_refused = 			ECONNREFUSED,
++      connection_reset = 			ECONNRESET,
++      cross_device_link = 			EXDEV,
++      destination_address_required = 		EDESTADDRREQ,
++      device_or_resource_busy = 		EBUSY,
++      directory_not_empty = 			ENOTEMPTY,
++      executable_format_error = 		ENOEXEC,
++      file_exists = 	       			EEXIST,
++      file_too_large = 				EFBIG,
++      filename_too_long = 			ENAMETOOLONG,
++      function_not_supported = 			ENOSYS,
++      host_unreachable = 			EHOSTUNREACH,
++
++#ifdef _GLIBCXX_HAVE_EIDRM
++      identifier_removed = 			EIDRM,
++#endif
++
++      illegal_byte_sequence = 			EILSEQ,
++      inappropriate_io_control_operation = 	ENOTTY,
++      interrupted = 				EINTR,
++      invalid_argument = 			EINVAL,
++      invalid_seek = 				ESPIPE,
++      io_error = 				EIO,
++      is_a_directory = 				EISDIR,
++      message_size = 				EMSGSIZE,
++      network_down = 				ENETDOWN,
++      network_reset = 				ENETRESET,
++      network_unreachable = 			ENETUNREACH,
++      no_buffer_space = 			ENOBUFS,
++      no_child_process = 			ECHILD,
++
++#ifdef _GLIBCXX_HAVE_ENOLINK
++      no_link = 				ENOLINK,
++#endif
++
++      no_lock_available = 			ENOLCK,
++
++#ifdef _GLIBCXX_HAVE_ENODATA
++      no_message_available = 			ENODATA, 
++#endif
++
++      no_message = 				ENOMSG, 
++      no_protocol_option = 			ENOPROTOOPT,
++      no_space_on_device = 			ENOSPC,
++
++#ifdef _GLIBCXX_HAVE_ENOSR
++      no_stream_resources = 			ENOSR,
++#endif
++
++      no_such_device_or_address = 		ENXIO,
++      no_such_device = 				ENODEV,
++      no_such_file_or_directory = 		ENOENT,
++      no_such_process = 			ESRCH,
++      not_a_directory = 			ENOTDIR,
++      not_a_socket = 				ENOTSOCK,
++
++#ifdef _GLIBCXX_HAVE_ENOSTR
++      not_a_stream = 				ENOSTR,
++#endif
++
++      not_connected = 				ENOTCONN,
++      not_enough_memory = 			ENOMEM,
++
++#ifdef _GLIBCXX_HAVE_ENOTSUP
++      not_supported = 				ENOTSUP,
++#endif
++
++#ifdef _GLIBCXX_HAVE_ECANCELED
++      operation_canceled = 			ECANCELED,
++#endif
++
++      operation_in_progress = 			EINPROGRESS,
++      operation_not_permitted = 		EPERM,
++      operation_not_supported = 		EOPNOTSUPP,
++      operation_would_block = 			EWOULDBLOCK,
++
++#ifdef _GLIBCXX_HAVE_EOWNERDEAD
++      owner_dead = 				EOWNERDEAD,
++#endif
++
++      permission_denied = 			EACCES,
++
++#ifdef _GLIBCXX_HAVE_EPROTO
++      protocol_error = 				EPROTO,
++#endif
++
++      protocol_not_supported = 			EPROTONOSUPPORT,
++      read_only_file_system = 			EROFS,
++      resource_deadlock_would_occur = 		EDEADLK,
++      resource_unavailable_try_again = 		EAGAIN,
++      result_out_of_range = 			ERANGE,
++
++#ifdef _GLIBCXX_HAVE_ENOTRECOVERABLE
++      state_not_recoverable = 			ENOTRECOVERABLE,
++#endif
++
++#ifdef _GLIBCXX_HAVE_ETIME
++      stream_timeout = 				ETIME,
++#endif
++
++#ifdef _GLIBCXX_HAVE_ETXTBSY
++      text_file_busy = 				ETXTBSY,
++#endif
++
++      timed_out = 				ETIMEDOUT,
++      too_many_files_open_in_system = 		ENFILE,
++      too_many_files_open = 			EMFILE,
++      too_many_links = 				EMLINK,
++      too_many_symbolic_link_levels = 		ELOOP,
++
++#ifdef _GLIBCXX_HAVE_EOVERFLOW
++      value_too_large = 			EOVERFLOW,
++#endif
++
++      wrong_protocol_type = 			EPROTOTYPE
++    };
++
++_GLIBCXX_END_NAMESPACE_VERSION
++} // namespace
++
++#endif
+diff --git a/libstdc++-v3/config/os/haiku/os_defines.h b/libstdc++-v3/config/os/haiku/os_defines.h
+new file mode 100644
+index 0000000..4674f7b
+--- /dev/null
++++ b/libstdc++-v3/config/os/haiku/os_defines.h
+@@ -0,0 +1,45 @@
++// Specific definitions for generic platforms  -*- C++ -*-
++
++// Copyright (C) 2000-2013 Free Software Foundation, Inc.
++//
++// This file is part of the GNU ISO C++ Library.  This library is free
++// software; you can redistribute it and/or modify it under the
++// terms of the GNU General Public License as published by the
++// Free Software Foundation; either version 3, or (at your option)
++// any later version.
++
++// This library is distributed in the hope that it will be useful,
++// but WITHOUT ANY WARRANTY; without even the implied warranty of
++// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++// GNU General Public License for more details.
++
++// Under Section 7 of GPL version 3, you are granted additional
++// permissions described in the GCC Runtime Library Exception, version
++// 3.1, as published by the Free Software Foundation.
++
++// You should have received a copy of the GNU General Public License and
++// a copy of the GCC Runtime Library Exception along with this program;
++// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++// <http://www.gnu.org/licenses/>.
++
++/** @file bits/os_defines.h
++ *  This is an internal header file, included by other library headers.
++ *  Do not attempt to use it directly. @headername{iosfwd}
++ */
++
++#ifndef _GLIBCXX_OS_DEFINES
++#define _GLIBCXX_OS_DEFINES 1
++
++// System-specific #define, typedefs, corrections, etc, go here.  This
++// file will come before all others.
++
++// On Haiku, nanosleep and sched_yield are always available except for the
++// kernel and the bootloader, so use them.
++#if !defined(_KERNEL_MODE) && !defined(_LOADER_MODE)
++	#define _GLIBCXX_USE_NANOSLEEP 1
++	#define _GLIBCXX_USE_SCHED_YIELD 1
++	#define _GLIBCXX_USE_CLOCK_MONOTONIC 1
++	#define _GLIBCXX_USE_CLOCK_REALTIME 1
++#endif
++
++#endif
+diff --git a/libstdc++-v3/configure.host b/libstdc++-v3/configure.host
+index 155a3cd..a1bc55c 100644
+--- a/libstdc++-v3/configure.host
++++ b/libstdc++-v3/configure.host
+@@ -273,6 +273,9 @@ case "${host_os}" in
+       os_include_dir="os/gnu-linux"
+     fi
+     ;;
++  haiku*)
++    os_include_dir="os/haiku"
++    ;;
+   hpux*)
+     os_include_dir="os/hpux"
+     ;;
+diff --git a/libstdc++-v3/crossconfig.m4 b/libstdc++-v3/crossconfig.m4
+index cb6e3af..23d4810 100644
+--- a/libstdc++-v3/crossconfig.m4
++++ b/libstdc++-v3/crossconfig.m4
+@@ -141,6 +141,46 @@ case "${host}" in
+     AC_SUBST(SECTION_FLAGS)
+     ;;
+ 
++  *-haiku*)
++    AC_CHECK_HEADERS([nan.h ieeefp.h endian.h sys/isa_defs.h \
++      machine/endian.h machine/param.h sys/machine.h sys/types.h \
++      fp.h float.h endian.h inttypes.h locale.h float.h stdint.h])
++    SECTION_FLAGS='-ffunction-sections -fdata-sections'
++    AC_SUBST(SECTION_FLAGS)
++
++    AC_DEFINE(HAVE_INT64_T)
++
++    AC_DEFINE(HAVE_ACOSF)
++    AC_DEFINE(HAVE_ASINF)
++    AC_DEFINE(HAVE_ATANF)
++    AC_DEFINE(HAVE_ATAN2F)
++    AC_DEFINE(HAVE_CEILF)
++    AC_DEFINE(HAVE_COSF)
++    AC_DEFINE(HAVE_COSHF)
++    AC_DEFINE(HAVE_EXPF)
++    AC_DEFINE(HAVE_FABSF)
++    AC_DEFINE(HAVE_FINITE)
++    AC_DEFINE(HAVE_FINITEF)
++    AC_DEFINE(HAVE_FLOORF)
++    AC_DEFINE(HAVE_FMODF)
++    AC_DEFINE(HAVE_FREXPF)
++    AC_DEFINE(HAVE_HYPOT)
++    AC_DEFINE(HAVE_HYPOTF)
++    AC_DEFINE(HAVE_ISINF)
++    AC_DEFINE(HAVE_ISINFF)
++    AC_DEFINE(HAVE_ISNAN)
++    AC_DEFINE(HAVE_ISNANF)
++    AC_DEFINE(HAVE_LOGF)
++    AC_DEFINE(HAVE_LOG10F)
++    AC_DEFINE(HAVE_MODFF)
++    AC_DEFINE(HAVE_SINF)
++    AC_DEFINE(HAVE_SINHF)
++    AC_DEFINE(HAVE_SQRTF)
++    AC_DEFINE(HAVE_TANF)
++    AC_DEFINE(HAVE_TANHF)
++    AC_DEFINE(HAVE_TLS)
++    ;;
++
+   *-hpux*)
+     SECTION_FLAGS='-ffunction-sections -fdata-sections'
+     AC_SUBST(SECTION_FLAGS)
+diff --git a/libstdc++-v3/libsupc++/tinfo.cc b/libstdc++-v3/libsupc++/tinfo.cc
+index 16097de..72447b1 100644
+--- a/libstdc++-v3/libsupc++/tinfo.cc
++++ b/libstdc++-v3/libsupc++/tinfo.cc
+@@ -30,6 +30,15 @@ std::type_info::
+ ~type_info ()
+ { }
+ 
++#ifdef __HAIKU__
++#ifndef __GXX_MERGED_TYPEINFO_NAMES
++#define __GXX_MERGED_TYPEINFO_NAMES 0
++#endif
++#ifndef __GXX_TYPEINFO_EQUALITY_INLINE
++#define __GXX_TYPEINFO_EQUALITY_INLINE 0
++#endif
++#endif
++
+ #if !__GXX_TYPEINFO_EQUALITY_INLINE
+ 
+ // We can't rely on common symbols being shared between shared objects.
+diff --git a/libtool.m4 b/libtool.m4
+index 24d13f3..94d96d9 100644
+--- a/libtool.m4
++++ b/libtool.m4
+@@ -1137,7 +1137,7 @@ fi
+ # Invoke $ECHO with all args, space-separated.
+ func_echo_all ()
+ {
+-    $ECHO "$*" 
++    $ECHO "$*"
+ }
+ 
+ case "$ECHO" in
+@@ -1722,7 +1722,7 @@ else
+   lt_cv_dlopen_libs=
+ 
+   case $host_os in
+-  beos*)
++  beos* | haiku* )
+     lt_cv_dlopen="load_add_on"
+     lt_cv_dlopen_libs=
+     lt_cv_dlopen_self=yes
+@@ -2342,8 +2342,9 @@ haiku*)
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/beos/system/lib'
+-  hardcode_into_libs=yes
++  sys_lib_search_path_spec='/boot/system/non-packaged/develop/lib /boot/system/develop/lib'
++  sys_lib_dlsearch_path_spec='/boot/home/config/non-packaged/lib /boot/home/config/lib /boot/system/non-packaged/lib /boot/system/lib'
++  hardcode_into_libs=no
+   ;;
+ 
+ hpux9* | hpux10* | hpux11*)
+@@ -3603,7 +3604,6 @@ m4_if([$1], [CXX], [
+         ;;
+       esac
+       ;;
+-
+     beos* | irix5* | irix6* | nonstopux* | osf3* | osf4* | osf5*)
+       # PIC is the default for these OSes.
+       ;;
+@@ -3626,8 +3626,6 @@ m4_if([$1], [CXX], [
+       ;;
+     haiku*)
+       # PIC is the default for Haiku.
+-      # The "-static" flag exists, but is broken.
+-      _LT_TAGVAR(lt_prog_compiler_static, $1)=
+       ;;
+     interix[[3-9]]*)
+       # Interix 3.x gcc -fpic/-fPIC options generate broken code.
+@@ -3937,8 +3935,6 @@ m4_if([$1], [CXX], [
+ 
+     haiku*)
+       # PIC is the default for Haiku.
+-      # The "-static" flag exists, but is broken.
+-      _LT_TAGVAR(lt_prog_compiler_static, $1)=
+       ;;
+ 
+     hpux*)
+-- 
+2.30.2
+
+
+From e414d842c0af7f79423a1934753e78f7b2e15bb8 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Thu, 5 May 2016 09:03:06 +0000
+Subject: fix for libstdc++/69506
+
+
+diff --git a/libstdc++-v3/config/os/haiku/os_defines.h b/libstdc++-v3/config/os/haiku/os_defines.h
+index 4674f7b..02c8693 100644
+--- a/libstdc++-v3/config/os/haiku/os_defines.h
++++ b/libstdc++-v3/config/os/haiku/os_defines.h
+@@ -42,4 +42,7 @@
+ 	#define _GLIBCXX_USE_CLOCK_REALTIME 1
+ #endif
+ 
++// See libstdc++/69506
++#define _GLIBCXX_USE_WEAK_REF 0
++
+ #endif
+-- 
+2.30.2
+
+
+From ceda9aa482a9023dec9816f67db66ac422c93c0e Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Thu, 5 May 2016 15:52:08 +0000
+Subject: rename x86_elf_aligned_common.
+
+
+diff --git a/gcc/config/i386/haiku64.h b/gcc/config/i386/haiku64.h
+index 76ba48e..e2fa55a 100644
+--- a/gcc/config/i386/haiku64.h
++++ b/gcc/config/i386/haiku64.h
+@@ -112,9 +112,9 @@ Boston, MA 02111-1307, USA.  */
+ #define ASM_SPEC "%{v:-V} %{Qy:} %{!Qn:-Qy} %{n} %{T} %{Ym,*} %{Yd,*} \
+  %{Wa,*:%*} %{" SPEC_32 ":--32} %{" SPEC_64 ":--64}"
+ 
+-#undef  ASM_OUTPUT_ALIGNED_COMMON
+-#define ASM_OUTPUT_ALIGNED_COMMON(FILE, NAME, SIZE, ALIGN)		\
+-  x86_elf_aligned_common (FILE, NAME, SIZE, ALIGN);
++#undef  ASM_OUTPUT_ALIGNED_DECL_COMMON
++#define ASM_OUTPUT_ALIGNED_DECL_COMMON(FILE, DECL, NAME, SIZE, ALIGN)	\
++  x86_elf_aligned_decl_common (FILE, DECL, NAME, SIZE, ALIGN);
+ 
+ 
+ /* i386 System V Release 4 uses DWARF debugging info.
+-- 
+2.30.2
+
+diff --git a/gcc/configure b/gcc/configure
+index 97ba7d7..bf0c5bc 100755
+--- a/gcc/configure
++++ b/gcc/configure
+@@ -751,6 +751,7 @@ LDEXP_LIB
+ EXTRA_GCC_LIBS
+ GNAT_LIBEXC
+ COLLECT2_LIBS
++build_math_library
+ CXXDEPMODE
+ DEPDIR
+ am__leading_dot
+@@ -787,6 +788,7 @@ with_float
+ with_cpu
+ enable_multiarch
+ enable_multilib
++HYBRID_SECONDARY
+ coverage_flags
+ valgrind_command
+ valgrind_path_defines
+@@ -903,6 +905,7 @@ enable_checking
+ enable_coverage
+ enable_gather_detailed_mem_stats
+ enable_valgrind_annotations
++with_hybrid_secondary
+ with_stabs
+ enable_multilib
+ enable_multiarch
+@@ -1724,6 +1727,8 @@ Optional Packages:
+   --with-demangler-in-ld  try to use demangler in GNU ld
+   --with-gnu-as           arrange to work with GNU as
+   --with-as               arrange to use the specified as (full pathname)
++  --with-hybrid_secondary specify the packaging architecture for building a
++                          secondary compiler for a Haiku hybrid system
+   --with-stabs            arrange to use stabs instead of host debug format
+   --with-dwarf2           force the default debug format to be DWARF 2
+   --with-specs=SPECS      add SPECS to driver command-line processing
+@@ -7386,6 +7391,18 @@ fi
+ # Miscenalleous configure options
+ # -------------------------------
+ 
++# handle --with-hybrid-secondary
++
++# Check whether --with-hybrid_secondary was given.
++if test "${with_hybrid_secondary+set}" = set; then :
++  withval=$with_hybrid_secondary; HYBRID_SECONDARY=$withval
++else
++  HYBRID_SECONDARY=
++
++fi
++
++
++
+ # With stabs
+ 
+ # Check whether --with-stabs was given.
+@@ -9393,6 +9410,16 @@ fi
+ # --------
+ 
+ 
++# Configure -lm usage for host tools that need it
++build_math_library="-lm"
++case $build in
++  *-*-haiku*)
++    # no separate math library needed
++    build_math_library=
++    ;;
++esac
++
++
+ # These libraries may be used by collect2.
+ # We may need a special search path to get them linked.
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for collect2 libraries" >&5
+@@ -11693,7 +11720,7 @@ case ${enable_threads} in
+     # default
+     target_thread_file='single'
+     ;;
+-  aix | dce | lynx | mipssde | posix | rtems | \
++  aix | dce | haiku | lynx | mipssde | posix | rtems | \
+   single | tpf | vxworks | win32)
+     target_thread_file=${enable_threads}
+     ;;
+@@ -15540,8 +15567,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+ 
+     haiku*)
+       # PIC is the default for Haiku.
+-      # The "-static" flag exists, but is broken.
+-      lt_prog_compiler_static=
+       ;;
+ 
+     hpux*)
+@@ -17653,8 +17678,9 @@ haiku*)
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/beos/system/lib'
+-  hardcode_into_libs=yes
++  sys_lib_search_path_spec='/boot/system/non-packaged/develop/lib /boot/system/develop/lib'
++  sys_lib_dlsearch_path_spec='/boot/home/config/non-packaged/lib /boot/home/config/lib /boot/system/non-packaged/lib /boot/system/lib'
++  hardcode_into_libs=no
+   ;;
+ 
+ hpux9* | hpux10* | hpux11*)
+@@ -18171,7 +18197,7 @@ else
+   lt_cv_dlopen_libs=
+ 
+   case $host_os in
+-  beos*)
++  beos* | haiku* )
+     lt_cv_dlopen="load_add_on"
+     lt_cv_dlopen_libs=
+     lt_cv_dlopen_self=yes
+@@ -20369,7 +20395,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+         ;;
+       esac
+       ;;
+-
+     beos* | irix5* | irix6* | nonstopux* | osf3* | osf4* | osf5*)
+       # PIC is the default for these OSes.
+       ;;
+@@ -20391,8 +20416,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       ;;
+     haiku*)
+       # PIC is the default for Haiku.
+-      # The "-static" flag exists, but is broken.
+-      lt_prog_compiler_static_CXX=
+       ;;
+     interix[3-9]*)
+       # Interix 3.x gcc -fpic/-fPIC options generate broken code.
+@@ -21313,8 +21336,9 @@ haiku*)
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/beos/system/lib'
+-  hardcode_into_libs=yes
++  sys_lib_search_path_spec='/boot/system/non-packaged/develop/lib /boot/system/develop/lib'
++  sys_lib_dlsearch_path_spec='/boot/home/config/non-packaged/lib /boot/home/config/lib /boot/system/non-packaged/lib /boot/system/lib'
++  hardcode_into_libs=no
+   ;;
+ 
+ hpux9* | hpux10* | hpux11*)
+
+diff --git a/libstdc++-v3/configure b/libstdc++-v3/configure
+index 61457e9..addc7fe 100755
+--- a/libstdc++-v3/configure
++++ b/libstdc++-v3/configure
+@@ -8874,8 +8874,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+ 
+     haiku*)
+       # PIC is the default for Haiku.
+-      # The "-static" flag exists, but is broken.
+-      lt_prog_compiler_static=
+       ;;
+ 
+     hpux*)
+@@ -10996,8 +10994,9 @@ haiku*)
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/beos/system/lib'
+-  hardcode_into_libs=yes
++  sys_lib_search_path_spec='/boot/system/non-packaged/develop/lib /boot/system/develop/lib'
++  sys_lib_dlsearch_path_spec='/boot/home/config/non-packaged/lib /boot/home/config/lib /boot/system/non-packaged/lib /boot/system/lib'
++  hardcode_into_libs=no
+   ;;
+ 
+ hpux9* | hpux10* | hpux11*)
+@@ -11517,7 +11516,7 @@ else
+   lt_cv_dlopen_libs=
+ 
+   case $host_os in
+-  beos*)
++  beos* | haiku* )
+     lt_cv_dlopen="load_add_on"
+     lt_cv_dlopen_libs=
+     lt_cv_dlopen_self=yes
+@@ -13736,7 +13735,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+         ;;
+       esac
+       ;;
+-
+     beos* | irix5* | irix6* | nonstopux* | osf3* | osf4* | osf5*)
+       # PIC is the default for these OSes.
+       ;;
+@@ -13758,8 +13756,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       ;;
+     haiku*)
+       # PIC is the default for Haiku.
+-      # The "-static" flag exists, but is broken.
+-      lt_prog_compiler_static_CXX=
+       ;;
+     interix[3-9]*)
+       # Interix 3.x gcc -fpic/-fPIC options generate broken code.
+@@ -14680,8 +14676,9 @@ haiku*)
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/beos/system/lib'
+-  hardcode_into_libs=yes
++  sys_lib_search_path_spec='/boot/system/non-packaged/develop/lib /boot/system/develop/lib'
++  sys_lib_dlsearch_path_spec='/boot/home/config/non-packaged/lib /boot/home/config/lib /boot/system/non-packaged/lib /boot/system/lib'
++  hardcode_into_libs=no
+   ;;
+ 
+ hpux9* | hpux10* | hpux11*)
+@@ -53608,6 +53605,89 @@ done
+ 
+     ;;
+ 
++  *-haiku*)
++    for ac_header in nan.h ieeefp.h endian.h sys/isa_defs.h \
++      machine/endian.h machine/param.h sys/machine.h sys/types.h \
++      fp.h float.h endian.h inttypes.h locale.h float.h stdint.h
++do :
++  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
++ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
++eval as_val=\$$as_ac_Header
++   if test "x$as_val" = x""yes; then :
++  cat >>confdefs.h <<_ACEOF
++#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
++_ACEOF
++
++fi
++
++done
++
++    SECTION_FLAGS='-ffunction-sections -fdata-sections'
++
++
++    $as_echo "#define HAVE_INT64_T 1" >>confdefs.h
++
++
++    $as_echo "#define HAVE_ACOSF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_ASINF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_ATANF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_ATAN2F 1" >>confdefs.h
++
++    $as_echo "#define HAVE_CEILF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_COSF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_COSHF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_EXPF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_FABSF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_FINITE 1" >>confdefs.h
++
++    $as_echo "#define HAVE_FINITEF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_FLOORF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_FMODF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_FREXPF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_HYPOT 1" >>confdefs.h
++
++    $as_echo "#define HAVE_HYPOTF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_ISINF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_ISINFF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_ISNAN 1" >>confdefs.h
++
++    $as_echo "#define HAVE_ISNANF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_LOGF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_LOG10F 1" >>confdefs.h
++
++    $as_echo "#define HAVE_MODFF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_SINF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_SINHF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_SQRTF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_TANF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_TANHF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_TLS 1" >>confdefs.h
++
++    ;;
++
+   *-hpux*)
+     SECTION_FLAGS='-ffunction-sections -fdata-sections'
+ 
+@@ -80300,6 +80380,9 @@ $as_echo_n "checking whether to build Filesystem TS support... " >&6; }
+       solaris*)
+         enable_libstdcxx_filesystem_ts=yes
+         ;;
++      haiku*)
++        enable_libstdcxx_filesystem_ts=yes
++        ;;
+       *)
+         enable_libstdcxx_filesystem_ts=no
+         ;;
+-- 
+2.30.2
+
+From 3e9dec2945b48f386a79f442e619648cd7ac9c7a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
+Date: Mon, 27 Jul 2015 16:32:32 +0200
+Subject: Haiku: disable -fno-PIE as this fails on x86_64.
+
+diff --git a/gcc/Makefile.in.orig b/gcc/Makefile.in
+index 646db21..b22bbfa 100644
+--- a/gcc/Makefile.in.orig
++++ b/gcc/Makefile.in
+@@ -106,6 +106,8 @@ build_objdir := $(toplevel_builddir)/$(build_subdir)
+ build_libobjdir := $(toplevel_builddir)/$(build_libsubdir)
+ target_objdir := $(toplevel_builddir)/$(target_subdir)
+ 
++HYBRID_SECONDARY = @HYBRID_SECONDARY@
++
+ # --------
+ # Defined vpaths
+ # --------
+@@ -266,7 +268,7 @@ NO_PIE_CFLAGS = @NO_PIE_CFLAGS@
+ NO_PIE_FLAG = @NO_PIE_FLAG@
+ 
+ # We don't want to compile the compilers with -fPIE, it make PCH fail.
+-COMPILER += $(NO_PIE_CFLAGS)
++#COMPILER += $(NO_PIE_CFLAGS)
+ 
+ # Link with -no-pie since we compile the compiler with -fno-PIE.
+ LINKER += $(NO_PIE_FLAG)
+@@ -787,9 +789,9 @@ NO_PIE_CFLAGS_FOR_BUILD = @NO_PIE_CFLAGS_FOR_BUILD@
+ NO_PIE_FLAG_FOR_BUILD = @NO_PIE_FLAG_FOR_BUILD@
+ BUILD_CFLAGS= @BUILD_CFLAGS@ $(GENERATOR_CFLAGS) -DGENERATOR_FILE
+ BUILD_CXXFLAGS = @BUILD_CXXFLAGS@ $(GENERATOR_CFLAGS) -DGENERATOR_FILE
+-BUILD_NO_PIE_CFLAGS = @BUILD_NO_PIE_CFLAGS@
+-BUILD_CFLAGS += $(BUILD_NO_PIE_CFLAGS)
+-BUILD_CXXFLAGS += $(BUILD_NO_PIE_CFLAGS)
++#BUILD_NO_PIE_CFLAGS = @BUILD_NO_PIE_CFLAGS@
++#BUILD_CFLAGS += $(BUILD_NO_PIE_CFLAGS)
++#BUILD_CXXFLAGS += $(BUILD_NO_PIE_CFLAGS)
+ 
+ # Native compiler that we use.  This may be C++ some day.
+ COMPILER_FOR_BUILD = $(CXX_FOR_BUILD)
+@@ -2229,6 +2231,10 @@ DRIVER_DEFINES = \
+   -DTOOL_INCLUDE_DIR=\"$(gcc_tooldir)/include\" \
+   -DNATIVE_SYSTEM_HEADER_DIR=\"$(NATIVE_SYSTEM_HEADER_DIR)\"
+ 
++ifneq ($(HYBRID_SECONDARY),)
++DRIVER_DEFINES += -DHYBRID_SECONDARY="\"$(HYBRID_SECONDARY)\""
++endif
++
+ CFLAGS-gcc.o += $(DRIVER_DEFINES) -DBASEVER=$(BASEVER_s)
+ gcc.o: $(BASEVER)
+ 
+@@ -2867,7 +2873,7 @@ $(genprogerr:%=build/gen%$(build_exeext)): $(BUILD_ERRORS)
+ genprog = $(genprogerr) check checksum match
+ 
+ # These programs need libs over and above what they get from the above list.
+-build/genautomata$(build_exeext) : BUILD_LIBS += -lm
++build/genautomata$(build_exeext) : BUILD_LIBS += @build_math_library@
+ 
+ build/genrecog$(build_exeext) : build/hash-table.o build/inchash.o
+ build/gencfn-macros$(build_exeext) : build/hash-table.o build/vec.o \
+@@ -2961,6 +2967,10 @@ PREPROCESSOR_DEFINES = \
+   -DSTANDARD_EXEC_PREFIX=\"$(libdir)/gcc/\" \
+   @TARGET_SYSTEM_ROOT_DEFINE@
+ 
++ifneq ($(HYBRID_SECONDARY),)
++PREPROCESSOR_DEFINES += -DHYBRID_SECONDARY="\"$(HYBRID_SECONDARY)\""
++endif
++
+ CFLAGS-cppbuiltin.o += $(PREPROCESSOR_DEFINES) -DBASEVER=$(BASEVER_s)
+ cppbuiltin.o: $(BASEVER)
+ 
+diff --git a/gcc/config.host.orig b/gcc/config.host
+index 84f0433..422442f 100644
+--- a/gcc/config.host.orig
++++ b/gcc/config.host
+@@ -99,7 +99,7 @@ case ${host} in
+ esac
+ 
+ case ${host} in
+-  aarch64*-*-freebsd* | aarch64*-*-linux* | aarch64*-*-fuchsia*)
++  aarch64*-*-freebsd* | aarch64*-*-linux* | aarch64*-*-fuchsia* | aarch64*-*-haiku*)
+     case ${target} in
+       aarch64*-*-*)
+ 	host_extra_gcc_objs="driver-aarch64.o"
+@@ -107,7 +107,7 @@ case ${host} in
+ 	;;
+     esac
+     ;;
+-  arm*-*-freebsd* | arm*-*-netbsd* | arm*-*-linux* | arm*-*-fuchsia*)
++  arm*-*-freebsd* | arm*-*-netbsd* | arm*-*-linux* | arm*-*-fuchsia* | arm*-*-haiku*)
+     case ${target} in
+       arm*-*-*)
+ 	host_extra_gcc_objs="driver-arm.o"
+@@ -133,9 +133,11 @@ case ${host} in
+ 	;;
+     esac
+     ;;
+-  mips*-*-linux*)
++  mips*-*-linux* \
++  | mips*-*-haiku* )
+     case ${target} in
+-      mips*-*-linux*)
++      mips*-*-linux* \
++      | mips*-*-haiku* )
+ 	host_extra_gcc_objs="driver-native.o"
+ 	host_xmake_file="${host_xmake_file} mips/x-native"
+       ;;
+
+diff --git a/gcc/config.gcc.orig b/gcc/config.gcc
+index 6fcdd77..3c96140 100644
+--- a/gcc/config.gcc.orig
++++ b/gcc/config.gcc
+@@ -806,6 +806,19 @@ case ${target} in
+ *-*-fuchsia*)
+   native_system_header_dir=/include
+   ;;
++*-*-haiku*)
++  # This is the generic ELF configuration of Haiku.  Later
++  # machine-specific sections may refine and add to this
++  # configuration.
++  #
++  gas=yes
++  gnu_ld=yes
++  tmake_file="t-slibgcc"
++  case ${enable_threads} in
++    "" | yes | posix) thread_file='posix' ;;
++  esac
++  default_use_cxa_atexit=yes
++  ;;
+ *-*-linux* | frv-*-*linux* | *-*-kfreebsd*-gnu | *-*-gnu* | *-*-kopensolaris*-gnu | *-*-uclinuxfdpiceabi)
+   extra_options="$extra_options gnu-user.opt"
+   gas=yes
+@@ -1282,6 +1295,16 @@ arm*-*-netbsdelf*)
+ 	armv7*) target_cpu_cname="generic-armv7-a";;
+ 	esac
+ 	;;
++arm*-*-haiku*)
++	tmake_file="${tmake_file} t-haiku arm/t-arm arm/t-arm-elf arm/t-bpabi arm/t-haiku"
++	tm_file="dbxelf.h elfos.h haiku.h arm/elf.h arm/bpabi.h arm/haiku.h haiku-stdint.h"
++	# The BPABI long long divmod functions return a 128-bit value in
++	# registers r0-r3.  Correctly modeling that requires the use of
++	# TImode.
++	need_64bit_hwint=yes
++	default_use_cxa_atexit=yes
++	tm_file="${tm_file} arm/aout.h arm/arm.h"
++	;;
+ arm*-*-linux-* | arm*-*-uclinuxfdpiceabi)
+ 	tm_file="dbxelf.h elfos.h gnu-user.h linux.h linux-android.h glibc-stdint.h arm/elf.h arm/linux-gas.h arm/linux-elf.h"
+ 	extra_options="${extra_options} linux-android.opt"
+@@ -1922,6 +1945,14 @@ i[34567]86-*-freebsd*)
+ x86_64-*-freebsd*)
+ 	tm_file="${tm_file} i386/unix.h i386/att.h dbxelf.h elfos.h ${fbsd_tm_file} i386/x86-64.h i386/freebsd.h i386/freebsd64.h"
+ 	;;
++i[34567]86-*-haiku*)
++	tmake_file="${tmake_file} t-haiku i386/t-crtpic"
++	tm_file="${tm_file} i386/unix.h i386/att.h dbxelf.h elfos.h haiku.h i386/haiku.h haiku-stdint.h"
++	;;
++x86_64-*-haiku*)
++	tmake_file="${tmake_file} t-haiku i386/t-haiku64"
++	tm_file="${tm_file} i386/unix.h i386/att.h dbxelf.h elfos.h haiku.h i386/haiku64.h haiku-stdint.h"
++	;;
+ i[34567]86-*-netbsdelf*)
+ 	tm_file="${tm_file} i386/unix.h i386/att.h dbxelf.h elfos.h ${nbsd_tm_file} i386/netbsd-elf.h"
+ 	extra_options="${extra_options} netbsd.opt netbsd-elf.opt"
+@@ -2408,6 +2439,13 @@ m68k-*-rtems*)
+ 	tm_file="${tm_file} m68k/m68k-none.h m68k/m68kelf.h dbxelf.h elfos.h m68k/m68kemb.h m68k/m68020-elf.h m68k/rtemself.h rtems.h newlib-stdint.h"
+ 	tm_defines="${tm_defines} MOTOROLA=1"
+ 	;;
++m68k-*-haiku*)
++	default_m68k_cpu=68020
++	default_cf_cpu=5206
++	tmake_file="${tmake_file} m68k/t-m68kbare m68k/t-crtstuff t-haiku" #??
++	tm_file="${tm_file} dbxelf.h elfos.h haiku.h m68k/haiku.h"
++	tm_defines="${tm_defines} MOTOROLA=1"
++	;;
+ mcore-*-elf)
+ 	tm_file="dbxelf.h elfos.h newlib-stdint.h ${tm_file} mcore/mcore-elf.h"
+ 	tmake_file=mcore/t-mcore
+@@ -2528,6 +2566,11 @@ mips*-mti-linux*)
+ 	gnu_ld=yes
+ 	gas=yes
+ 	;;
++mipsel-*-haiku*)
++	target_cpu_default="MASK_ABICALLS"
++	tm_file="elfos.h ${tm_file} haiku.h mips/haiku.h"
++	tmake_file="${tmake_file} mips/t-elf t-haiku"
++	;;
+ mips*-*-linux*)				# Linux MIPS, either endian.
+ 	tm_file="dbxelf.h elfos.h gnu-user.h linux.h linux-android.h glibc-stdint.h ${tm_file} mips/gnu-user.h mips/linux.h mips/linux-common.h"
+ 	extra_options="${extra_options} linux-android.opt"
+@@ -2953,6 +2996,11 @@ powerpc-*-eabi*)
+ 	tmake_file="rs6000/t-fprules rs6000/t-ppcgas rs6000/t-ppccomm"
+ 	use_gcc_stdint=wrap
+ 	;;
++powerpc-*-haiku*)
++	tmake_file="${tmake_file} rs6000/t-fprules rs6000/t-ppcos rs6000/t-ppccomm t-haiku"
++	tm_file="${tm_file} dbxelf.h elfos.h freebsd-spec.h rs6000/sysv4.h haiku.h rs6000/haiku.h"
++	extra_options="${extra_options} rs6000/sysv4.opt"
++	;;
+ powerpc-*-rtems*)
+ 	tm_file="rs6000/biarch64.h ${tm_file} dbxelf.h elfos.h gnu-user.h freebsd-spec.h newlib-stdint.h rs6000/sysv4.h rs6000/rtems.h rtems.h"
+ 	extra_options="${extra_options} rs6000/sysv4.opt rs6000/linux64.opt"
+
+From 5c0c284b60d2373ad2f9b994b3a585a087d3c381 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Fri, 12 May 2017 23:49:00 +0200
+Subject: Haiku: regenerate configure.
+
+diff --git a/configure.orig b/configure
+old mode 100755
+new mode 100644
+index f2ec106..29f7128
+--- a/configure.orig
++++ b/configure
+@@ -3106,6 +3106,9 @@ case "${host}" in
+   i[3456789]86-*-msdosdjgpp*)
+     noconfigdirs="$noconfigdirs tcl tk itcl"
+     ;;
++  *-*-haiku*)
++    noconfigdirs="$noconfigdirs tk itcl libgui gdb"
++    ;;
+ esac
+ 
+ 
+@@ -3211,7 +3214,7 @@ if test x$enable_libgomp = x ; then
+ 	;;
+     *-*-solaris2* | *-*-hpux11*)
+ 	;;
+-    *-*-darwin* | *-*-aix*)
++    *-*-darwin* | *-*-aix* | *-*-haiku*)
+ 	;;
+     nvptx*-*-* | amdgcn*-*-*)
+ 	;;
+@@ -3494,6 +3497,9 @@ case "${target}" in
+   *-*-darwin*)
+     noconfigdirs="$noconfigdirs target-libffi"
+     ;;
++  *-*-haiku*)
++    noconfigdirs="$noconfigdirs ${libgcj}"
++    ;;
+   *-*-netware*)
+     noconfigdirs="$noconfigdirs target-libffi"
+     ;;
+@@ -3703,6 +3709,9 @@ case "${target}" in
+   *-*-freebsd*)
+     noconfigdirs="$noconfigdirs target-newlib target-libgloss"
+     ;;
++  *-*-haiku*)
++    noconfigdirs="$noconfigdirs target-newlib target-libgloss"
++    ;;
+   *-*-linux* | *-*-gnu* | *-*-k*bsd*-gnu | *-*-kopensolaris*-gnu)
+     noconfigdirs="$noconfigdirs target-newlib target-libgloss"
+     ;;
+@@ -3767,6 +3776,9 @@ case "${target}" in
+       with_gmp=/usr/local
+     fi
+     ;;
++  *-*-haiku*)
++    noconfigdirs="$noconfigdirs gdb target-libiberty"
++    ;;
+   *-*-kaos*)
+     # Remove unsupported stuff on all kaOS configurations.
+     noconfigdirs="$noconfigdirs target-libgloss"
+@@ -5451,24 +5463,30 @@ $as_echo_n "checking how to compare bootstrapped objects... " >&6; }
+ if ${gcc_cv_prog_cmp_skip+:} false; then :
+   $as_echo_n "(cached) " >&6
+ else
+-   echo abfoo >t1
+-  echo cdfoo >t2
+-  gcc_cv_prog_cmp_skip='tail -c +17 $$f1 > tmp-foo1; tail -c +17 $$f2 > tmp-foo2; cmp tmp-foo1 tmp-foo2'
+-  if cmp t1 t2 2 2 > /dev/null 2>&1; then
+-    if cmp t1 t2 1 1 > /dev/null 2>&1; then
+-      :
+-    else
+-      gcc_cv_prog_cmp_skip='cmp $$f1 $$f2 16 16'
++  # comparing object files via cmp doesn't work on haiku (files will seemingly
++  # always differ), so we disassemble both files and compare the results:
++  if uname -o | grep -iq haiku; then
++    gcc_cv_prog_cmp_skip='objdump -Dz $$f1 | tail +6 >tmp-foo1; objdump -Dz $$f2 | tail +6 >tmp-foo2; cmp tmp-foo1 tmp-foo2'
++  else
++    echo abfoo >t1
++    echo cdfoo >t2
++    gcc_cv_prog_cmp_skip='tail -c +17 $$f1 > tmp-foo1; tail -c +17 $$f2 > tmp-foo2; cmp tmp-foo1 tmp-foo2'
++    if cmp t1 t2 2 2 > /dev/null 2>&1; then
++      if cmp t1 t2 1 1 > /dev/null 2>&1; then
++        :
++      else
++        gcc_cv_prog_cmp_skip='cmp $$f1 $$f2 16 16'
++      fi
+     fi
+-  fi
+-  if cmp --ignore-initial=2 t1 t2 > /dev/null 2>&1; then
+-    if cmp --ignore-initial=1 t1 t2 > /dev/null 2>&1; then
+-      :
+-    else
+-      gcc_cv_prog_cmp_skip='cmp --ignore-initial=16 $$f1 $$f2'
++    if cmp --ignore-initial=2 t1 t2 > /dev/null 2>&1; then
++      if cmp --ignore-initial=1 t1 t2 > /dev/null 2>&1; then
++        :
++      else
++        gcc_cv_prog_cmp_skip='cmp --ignore-initial=16 $$f1 $$f2'
++      fi
+     fi
++    rm t1 t2
+   fi
+-  rm t1 t2
+ 
+ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $gcc_cv_prog_cmp_skip" >&5
+
+diff --git a/libatomic/configure.orig b/libatomic/configure
+index 6e706e9..d610ca0 100755
+--- a/libatomic/configure.orig
++++ b/libatomic/configure
+@@ -8475,8 +8475,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+ 
+     haiku*)
+       # PIC is the default for Haiku.
+-      # The "-static" flag exists, but is broken.
+-      lt_prog_compiler_static=
+       ;;
+ 
+     hpux*)
+@@ -10588,8 +10586,9 @@ haiku*)
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/beos/system/lib'
+-  hardcode_into_libs=yes
++  sys_lib_search_path_spec='/boot/system/non-packaged/develop/lib /boot/system/develop/lib'
++  sys_lib_dlsearch_path_spec='/boot/home/config/non-packaged/lib /boot/home/config/lib /boot/system/non-packaged/lib /boot/system/lib'
++  hardcode_into_libs=no
+   ;;
+ 
+ hpux9* | hpux10* | hpux11*)
+@@ -11111,7 +11110,7 @@ else
+   lt_cv_dlopen_libs=
+ 
+   case $host_os in
+-  beos*)
++  beos* | haiku* )
+     lt_cv_dlopen="load_add_on"
+     lt_cv_dlopen_libs=
+     lt_cv_dlopen_self=yes
+@@ -14873,7 +14872,6 @@ _ACEOF
+ case " $config_path " in
+  *" posix "*)
+   XPCFLAGS=""
+-  CFLAGS="$CFLAGS -pthread"
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ #include <pthread.h>
+@@ -14886,14 +14884,30 @@ pthread_t t; pthread_create(&t,NULL,g,NULL);
+   return 0;
+ }
+ _ACEOF
++if ac_fn_c_try_link "$LINENO"; then :
++
++else
++  CFLAGS="$CFLAGS -pthread"
++     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++#include <pthread.h>
++         void *g(void *d) { return NULL; }
++int
++main ()
++{
++pthread_t t; pthread_create(&t,NULL,g,NULL);
++  ;
++  return 0;
++}
++_ACEOF
+ if ac_fn_c_try_link "$LINENO"; then :
+   XPCFLAGS=" -pthread"
+ else
+   CFLAGS="$save_CFLAGS $XCFLAGS" LIBS="-lpthread $LIBS"
+-     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++        cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ #include <pthread.h>
+-        void *g(void *d) { return NULL; }
++            void *g(void *d) { return NULL; }
+ int
+ main ()
+ {
+@@ -14910,6 +14924,9 @@ fi
+ rm -f core conftest.err conftest.$ac_objext \
+     conftest$ac_exeext conftest.$ac_ext
+ fi
++rm -f core conftest.err conftest.$ac_objext \
++    conftest$ac_exeext conftest.$ac_ext
++fi
+ rm -f core conftest.err conftest.$ac_objext \
+     conftest$ac_exeext conftest.$ac_ext
+   CFLAGS="$save_CFLAGS $XPCFLAGS"
+
+diff --git a/libgomp/configure.orig b/libgomp/configure
+index 5240f7e..641681b 100755
+--- a/libgomp/configure.orig
++++ b/libgomp/configure
+@@ -8520,8 +8520,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+ 
+     haiku*)
+       # PIC is the default for Haiku.
+-      # The "-static" flag exists, but is broken.
+-      lt_prog_compiler_static=
+       ;;
+ 
+     hpux*)
+@@ -10633,8 +10631,9 @@ haiku*)
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/beos/system/lib'
+-  hardcode_into_libs=yes
++  sys_lib_search_path_spec='/boot/system/non-packaged/develop/lib /boot/system/develop/lib'
++  sys_lib_dlsearch_path_spec='/boot/home/config/non-packaged/lib /boot/home/config/lib /boot/system/non-packaged/lib /boot/system/lib'
++  hardcode_into_libs=no
+   ;;
+ 
+ hpux9* | hpux10* | hpux11*)
+@@ -11156,7 +11155,7 @@ else
+   lt_cv_dlopen_libs=
+ 
+   case $host_os in
+-  beos*)
++  beos* | haiku* )
+     lt_cv_dlopen="load_add_on"
+     lt_cv_dlopen_libs=
+     lt_cv_dlopen_self=yes
+@@ -12405,8 +12404,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+ 
+     haiku*)
+       # PIC is the default for Haiku.
+-      # The "-static" flag exists, but is broken.
+-      lt_prog_compiler_static_FC=
+       ;;
+ 
+     hpux*)
+@@ -14283,8 +14280,9 @@ haiku*)
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/beos/system/lib'
+-  hardcode_into_libs=yes
++  sys_lib_search_path_spec='/boot/system/non-packaged/develop/lib /boot/system/develop/lib'
++  sys_lib_dlsearch_path_spec='/boot/home/config/non-packaged/lib /boot/home/config/lib /boot/system/non-packaged/lib /boot/system/lib'
++  hardcode_into_libs=no
+   ;;
+ 
+ hpux9* | hpux10* | hpux11*)
+@@ -14965,7 +14963,6 @@ case "$host" in
+   *)
+     # Check to see if -pthread or -lpthread is needed.  Prefer the former.
+     # In case the pthread.h system header is not found, this test will fail.
+-    CFLAGS="$CFLAGS -pthread"
+     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ #include <pthread.h>
+@@ -14979,9 +14976,9 @@ pthread_t t; pthread_create(&t,NULL,g,NULL);
+ }
+ _ACEOF
+ if ac_fn_c_try_link "$LINENO"; then :
+-  XPCFLAGS=" -Wc,-pthread"
++
+ else
+-  CFLAGS="$save_CFLAGS" LIBS="-lpthread $LIBS"
++  CFLAGS="$CFLAGS -pthread"
+       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ #include <pthread.h>
+@@ -14994,6 +14991,22 @@ pthread_t t; pthread_create(&t,NULL,g,NULL);
+   return 0;
+ }
+ _ACEOF
++if ac_fn_c_try_link "$LINENO"; then :
++  XPCFLAGS=" -Wc,-pthread"
++else
++  CFLAGS="$save_CFLAGS" LIBS="-lpthread $LIBS"
++        cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++#include <pthread.h>
++           void *g(void *d) { return NULL; }
++int
++main ()
++{
++pthread_t t; pthread_create(&t,NULL,g,NULL);
++  ;
++  return 0;
++}
++_ACEOF
+ if ac_fn_c_try_link "$LINENO"; then :
+ 
+ else
+@@ -15002,6 +15015,9 @@ fi
+ rm -f core conftest.err conftest.$ac_objext \
+     conftest$ac_exeext conftest.$ac_ext
+ fi
++rm -f core conftest.err conftest.$ac_objext \
++    conftest$ac_exeext conftest.$ac_ext
++fi
+ rm -f core conftest.err conftest.$ac_objext \
+     conftest$ac_exeext conftest.$ac_ext
+ esac
+
+From 8963c09cf713c11d5714d3c9417fb656cac5e4bc Mon Sep 17 00:00:00 2001
+From: Jessica Hamilton <jessica.l.hamilton@gmail.com>
+Date: Fri, 12 Jul 2019 18:17:00 +0000
+Subject: gcc: fix build configuration for libgcc.
+
+* libgcc_s.so now depends on libgcc.a for __cpu_model and friends,
+  which is needed for gfortran to produce working binaries.
+  
+diff --git a/libgcc/config.host.orig b/libgcc/config.host
+index 532941e..4ead494 100644
+--- a/libgcc/config.host.orig
++++ b/libgcc/config.host
+@@ -248,6 +248,14 @@ case ${host} in
+   tmake_file="$tmake_file t-crtstuff-pic t-libgcc-pic t-eh-dw2-dip t-slibgcc t-slibgcc-fuchsia"
+   extra_parts="crtbegin.o crtend.o"
+   ;;
++*-*-haiku*)
++  # This is the generic ELF configuration of Haiku.  Later
++  # machine-specific sections may refine and add to this
++  # configuration.
++  tmake_file="$tmake_file t-crtstuff-pic t-libgcc-pic t-haiku t-slibgcc t-slibgcc-gld t-slibgcc-elf-ver"
++  tmake_file="$tmake_file t-slibgcc-libgcc t-slibgcc-nolc-override"
++  extra_parts="crtbegin.o crtbeginS.o crtend.o crtendS.o"
++  ;;
+ *-*-linux* | frv-*-*linux* | *-*-kfreebsd*-gnu | *-*-gnu* | *-*-kopensolaris*-gnu | *-*-uclinuxfdpiceabi)
+   tmake_file="$tmake_file t-crtstuff-pic t-libgcc-pic t-eh-dw2-dip t-slibgcc t-slibgcc-gld t-slibgcc-elf-ver t-linux"
+   extra_parts="crtbegin.o crtbeginS.o crtbeginT.o crtend.o crtendS.o"
+@@ -458,6 +466,12 @@ arm*-*-fuchsia*)
+ 	tm_file="${tm_file} arm/bpabi-lib.h"
+ 	unwind_header=config/arm/unwind-arm.h
+ 	;;
++arm-*-haiku*)
++	tmake_file="${tmake_file} arm/t-arm arm/t-elf arm/t-bpabi"
++	tmake_file="${tmake_file} t-softfp-sfdf t-softfp-excl arm/t-softfp t-softfp"
++	tm_file="${tm_file} arm/bpabi-lib.h"
++	unwind_header=config/arm/unwind-arm.h
++	;;
+ arm*-*-netbsdelf*)
+ 	tmake_file="$tmake_file arm/t-arm"
+ 	case ${host} in
+diff --git a/configure.ac.orig b/configure.ac
+index 115db3f..bdbd281 100644
+--- a/configure.ac.orig
++++ b/configure.ac
+@@ -419,6 +419,9 @@ case "${host}" in
+   i[[3456789]]86-*-msdosdjgpp*)
+     noconfigdirs="$noconfigdirs tcl tk itcl"
+     ;;
++  *-*-haiku*)
++    noconfigdirs="$noconfigdirs tk itcl libgui gdb"
++    ;;
+ esac
+ 
+ 
+@@ -510,7 +513,7 @@ if test x$enable_libgomp = x ; then
+ 	;;
+     *-*-solaris2* | *-*-hpux11*)
+ 	;;
+-    *-*-darwin* | *-*-aix*)
++    *-*-darwin* | *-*-aix* | *-*-haiku*)
+ 	;;
+     nvptx*-*-* | amdgcn*-*-*)
+ 	;;
+@@ -772,6 +775,9 @@ case "${target}" in
+   *-*-darwin*)
+     noconfigdirs="$noconfigdirs target-libffi"
+     ;;
++  *-*-haiku*)
++    noconfigdirs="$noconfigdirs ${libgcj}"
++    ;;
+   *-*-netware*)
+     noconfigdirs="$noconfigdirs target-libffi"
+     ;;
+@@ -978,6 +984,9 @@ case "${target}" in
+   *-*-freebsd*)
+     noconfigdirs="$noconfigdirs target-newlib target-libgloss"
+     ;;
++  *-*-haiku*)
++    noconfigdirs="$noconfigdirs target-newlib target-libgloss"
++    ;;
+   *-*-linux* | *-*-gnu* | *-*-k*bsd*-gnu | *-*-kopensolaris*-gnu)
+     noconfigdirs="$noconfigdirs target-newlib target-libgloss"
+     ;;
+@@ -1042,6 +1051,9 @@ case "${target}" in
+       with_gmp=/usr/local
+     fi
+     ;;
++  *-*-haiku*)
++    noconfigdirs="$noconfigdirs gdb target-libiberty"
++    ;;
+   *-*-kaos*)
+     # Remove unsupported stuff on all kaOS configurations.
+     noconfigdirs="$noconfigdirs target-libgloss"
+
+From 979884a95dd2dc79d2e34e3b4e89d46d6326a007 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
+Date: Wed, 2 May 2018 08:37:20 +0200
+Subject: Enable libstdcxx_filesystem_ts for Haiku
+
+diff --git a/libstdc++-v3/acinclude.m4.orig b/libstdc++-v3/acinclude.m4
+index b6557a4..c789d7c 100644
+--- a/libstdc++-v3/acinclude.m4.orig
++++ b/libstdc++-v3/acinclude.m4
+@@ -4497,6 +4497,9 @@ AC_DEFUN([GLIBCXX_ENABLE_FILESYSTEM_TS], [
+       mingw*)
+         enable_libstdcxx_filesystem_ts=yes
+         ;;
++      haiku*)
++        enable_libstdcxx_filesystem_ts=yes
++        ;;
+       *)
+         enable_libstdcxx_filesystem_ts=no
+         ;;

--- a/sys-devel/gcc/patches/gcc-10.3.0_2021_04_08.patchset
+++ b/sys-devel/gcc/patches/gcc-10.3.0_2021_04_08.patchset
@@ -455,7 +455,7 @@ index 0000000..8e9f101
 +#define MATH_LIBRARY ""
 +
 +/* Haiku headers are C++-aware (and often use C++).  */
-+#define NO_IMPLICIT_EXTERN_C
++/* #define NO_IMPLICIT_EXTERN_C */
 +
 +/* Only allow -lssp for SSP, as -lssp_nonshared is problematic in Haiku */
 +#ifndef TARGET_LIBC_PROVIDES_SSP

--- a/sys-devel/gcc/patches/gcc-10.3.0_2021_04_08.patchset
+++ b/sys-devel/gcc/patches/gcc-10.3.0_2021_04_08.patchset
@@ -1,4 +1,4 @@
-From deee061bc53ce3f2a6cfd44f3a5ca135614ffbc5 Mon Sep 17 00:00:00 2001
+From f86616e625cac00fcdade3209abfd796c5bbb9ee Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Sun, 19 Jul 2015 18:55:34 +0200
 Subject: Haiku patch
@@ -70,7 +70,6 @@ index 87c1b5e..d9d53ca 100644
  ])
  do_compare="$gcc_cv_prog_cmp_skip"
  AC_SUBST(do_compare)
-
 diff --git a/gcc/config/arm/haiku.h b/gcc/config/arm/haiku.h
 new file mode 100644
 index 0000000..f0c0d63
@@ -1118,7 +1117,7 @@ index 0000000..587d1fb
 +LIMITS_H_TEST = [ -f $(SYSTEM_HEADER_DIR)/posix/limits.h ]
 \ No newline at end of file
 diff --git a/gcc/configure.ac b/gcc/configure.ac
-index d6f2d5b..cea0e3a 100644
+index 84dceb8..a3b2c1e 100644
 --- a/gcc/configure.ac
 +++ b/gcc/configure.ac
 @@ -771,6 +771,15 @@ fi
@@ -1137,7 +1136,7 @@ index d6f2d5b..cea0e3a 100644
  # With stabs
  AC_ARG_WITH(stabs,
  [AS_HELP_STRING([--with-stabs],
-@@ -1155,6 +1164,16 @@ ZW_PROG_COMPILER_DEPENDENCIES([CXX])
+@@ -1257,6 +1266,16 @@ ZW_PROG_COMPILER_DEPENDENCIES([CXX])
  # --------
  
  
@@ -1154,7 +1153,7 @@ index d6f2d5b..cea0e3a 100644
  # These libraries may be used by collect2.
  # We may need a special search path to get them linked.
  AC_CACHE_CHECK(for collect2 libraries, gcc_cv_collect2_libs,
-@@ -1611,7 +1630,7 @@ case ${enable_threads} in
+@@ -1805,7 +1824,7 @@ case ${enable_threads} in
      # default
      target_thread_file='single'
      ;;
@@ -1164,7 +1163,7 @@ index d6f2d5b..cea0e3a 100644
      target_thread_file=${enable_threads}
      ;;
 diff --git a/gcc/ginclude/stdarg.h b/gcc/ginclude/stdarg.h
-index e4c73fd..cc73248 100644
+index 6b122f9..d3c305e 100644
 --- a/gcc/ginclude/stdarg.h
 +++ b/gcc/ginclude/stdarg.h
 @@ -94,7 +94,7 @@ typedef __gnuc_va_list va_list;
@@ -1177,10 +1176,10 @@ index e4c73fd..cc73248 100644
  typedef __gnuc_va_list va_list;
  #endif /* not __va_list__ */
 diff --git a/gcc/ginclude/stddef.h b/gcc/ginclude/stddef.h
-index 31b96a7..ca20f4d 100644
+index 9d67eac..3575099 100644
 --- a/gcc/ginclude/stddef.h
 +++ b/gcc/ginclude/stddef.h
-@@ -167,7 +167,7 @@ typedef __PTRDIFF_TYPE__ ptrdiff_t;
+@@ -161,7 +161,7 @@ typedef __PTRDIFF_TYPE__ ptrdiff_t;
  /* Define this type if we are doing the whole job,
     or if we want this type in particular.  */
  #if defined (_STDDEF_H) || defined (__need_size_t)
@@ -1189,7 +1188,7 @@ index 31b96a7..ca20f4d 100644
  #ifndef __SIZE_T__	/* Cray Unicos/Mk */
  #ifndef _SIZE_T	/* in case <sys/types.h> has defined it. */
  #ifndef _SYS_SIZE_T_H
-@@ -184,7 +184,7 @@ typedef __PTRDIFF_TYPE__ ptrdiff_t;
+@@ -178,7 +178,7 @@ typedef __PTRDIFF_TYPE__ ptrdiff_t;
  #ifndef _GCC_SIZE_T
  #ifndef _SIZET_
  #ifndef __size_t
@@ -1198,7 +1197,7 @@ index 31b96a7..ca20f4d 100644
  #define __SIZE_T__	/* Cray Unicos/Mk */
  #define _SIZE_T
  #define _SYS_SIZE_T_H
-@@ -214,7 +214,7 @@ typedef __PTRDIFF_TYPE__ ptrdiff_t;
+@@ -207,7 +207,7 @@ typedef __PTRDIFF_TYPE__ ptrdiff_t;
  #endif
  #if !(defined (__GNUG__) && defined (size_t))
  typedef __SIZE_TYPE__ size_t;
@@ -1207,7 +1206,7 @@ index 31b96a7..ca20f4d 100644
  typedef long ssize_t;
  #endif /* __BEOS__ */
  #endif /* !(defined (__GNUG__) && defined (size_t)) */
-@@ -247,7 +247,7 @@ typedef long ssize_t;
+@@ -240,7 +240,7 @@ typedef long ssize_t;
  /* Define this type if we are doing the whole job,
     or if we want this type in particular.  */
  #if defined (_STDDEF_H) || defined (__need_wchar_t)
@@ -1216,7 +1215,7 @@ index 31b96a7..ca20f4d 100644
  #ifndef __WCHAR_T__	/* Cray Unicos/Mk */
  #ifndef _WCHAR_T
  #ifndef _T_WCHAR_
-@@ -264,7 +264,7 @@ typedef long ssize_t;
+@@ -257,7 +257,7 @@ typedef long ssize_t;
  #ifndef ___int_wchar_t_h
  #ifndef __INT_WCHAR_T_H
  #ifndef _GCC_WCHAR_T
@@ -1226,10 +1225,10 @@ index 31b96a7..ca20f4d 100644
  #define _WCHAR_T
  #define _T_WCHAR_
 diff --git a/include/filenames.h b/include/filenames.h
-index 6164048..492b0c9 100644
+index fcde227..f693733 100644
 --- a/include/filenames.h
 +++ b/include/filenames.h
-@@ -44,9 +44,11 @@ extern "C" {
+@@ -45,9 +45,11 @@ extern "C" {
  #  define IS_ABSOLUTE_PATH(f) IS_DOS_ABSOLUTE_PATH (f)
  #else /* not DOSish */
  #  if defined(__APPLE__)
@@ -1242,10 +1241,10 @@ index 6164048..492b0c9 100644
  #  define HAS_DRIVE_SPEC(f) (0)
  #  define IS_DIR_SEPARATOR(c) IS_UNIX_DIR_SEPARATOR (c)
 diff --git a/libatomic/configure.ac b/libatomic/configure.ac
-index d9cdc8e..abbb751 100644
+index 7ac8911..e5b5e7a 100644
 --- a/libatomic/configure.ac
 +++ b/libatomic/configure.ac
-@@ -209,21 +209,27 @@ LIBAT_WORDSIZE
+@@ -217,21 +217,27 @@ LIBAT_WORDSIZE
  case " $config_path " in
   *" posix "*)
    XPCFLAGS=""
@@ -1283,7 +1282,7 @@ index d9cdc8e..abbb751 100644
    ;;
  esac
 diff --git a/libatomic/configure.tgt b/libatomic/configure.tgt
-index ea8c34f..dc3b106 100644
+index 5dd0926..254b0f6 100644
 --- a/libatomic/configure.tgt
 +++ b/libatomic/configure.tgt
 @@ -137,7 +137,7 @@ case "${target}" in
@@ -1296,10 +1295,10 @@ index ea8c34f..dc3b106 100644
  	config_path="${config_path} posix"
  	;;
 diff --git a/libgcc/Makefile.in b/libgcc/Makefile.in
-index dd8cee9..23850c8 100644
+index 851e765..661ed4d 100644
 --- a/libgcc/Makefile.in
 +++ b/libgcc/Makefile.in
-@@ -397,10 +397,16 @@ ifeq ($(enable_shared),yes)
+@@ -402,10 +402,16 @@ ifeq ($(enable_shared),yes)
    endif
  endif
  
@@ -1316,7 +1315,6 @@ index dd8cee9..23850c8 100644
  
  ifneq (,$(vis_hide))
  
-
 diff --git a/libgcc/config/i386/t-cygming b/libgcc/config/i386/t-cygming
 old mode 100644
 new mode 100755
@@ -1330,7 +1328,7 @@ index 0000000..b4fff2d
 +LIB2ADDEH = $(srcdir)/unwind-dw2.c $(srcdir)/unwind-dw2-fde.c \
 +  $(srcdir)/unwind-sjlj.c $(srcdir)/unwind-c.c
 diff --git a/libgcc/crtstuff.c b/libgcc/crtstuff.c
-index 5e89445..41b8583 100644
+index 3f769a1..774a348 100644
 --- a/libgcc/crtstuff.c
 +++ b/libgcc/crtstuff.c
 @@ -108,7 +108,9 @@ call_ ## FUNC (void)					\
@@ -1344,10 +1342,10 @@ index 5e89445..41b8583 100644
     But it doesn't use PT_GNU_EH_FRAME ELF segment currently.  */
  # if !defined(__UCLIBC__) \
 diff --git a/libgomp/configure.ac b/libgomp/configure.ac
-index 4e0bc81..f6503ef 100644
+index ef5d293..2a060e9 100644
 --- a/libgomp/configure.ac
 +++ b/libgomp/configure.ac
-@@ -188,21 +188,27 @@ case "$host" in
+@@ -194,21 +194,27 @@ case "$host" in
    *)
      # Check to see if -pthread or -lpthread is needed.  Prefer the former.
      # In case the pthread.h system header is not found, this test will fail.
@@ -1967,7 +1965,7 @@ index 0000000..4674f7b
 +
 +#endif
 diff --git a/libstdc++-v3/configure.host b/libstdc++-v3/configure.host
-index 155a3cd..a1bc55c 100644
+index 898db37..0a882a9 100644
 --- a/libstdc++-v3/configure.host
 +++ b/libstdc++-v3/configure.host
 @@ -273,6 +273,9 @@ case "${host_os}" in
@@ -1981,10 +1979,10 @@ index 155a3cd..a1bc55c 100644
      os_include_dir="os/hpux"
      ;;
 diff --git a/libstdc++-v3/crossconfig.m4 b/libstdc++-v3/crossconfig.m4
-index cb6e3af..23d4810 100644
+index fe18288..b8c239f 100644
 --- a/libstdc++-v3/crossconfig.m4
 +++ b/libstdc++-v3/crossconfig.m4
-@@ -141,6 +141,46 @@ case "${host}" in
+@@ -136,6 +136,46 @@ case "${host}" in
      AC_SUBST(SECTION_FLAGS)
      ;;
  
@@ -2032,7 +2030,7 @@ index cb6e3af..23d4810 100644
      SECTION_FLAGS='-ffunction-sections -fdata-sections'
      AC_SUBST(SECTION_FLAGS)
 diff --git a/libstdc++-v3/libsupc++/tinfo.cc b/libstdc++-v3/libsupc++/tinfo.cc
-index 16097de..72447b1 100644
+index 051fa88..0dc9d6e 100644
 --- a/libstdc++-v3/libsupc++/tinfo.cc
 +++ b/libstdc++-v3/libsupc++/tinfo.cc
 @@ -30,6 +30,15 @@ std::type_info::
@@ -2052,10 +2050,10 @@ index 16097de..72447b1 100644
  
  // We can't rely on common symbols being shared between shared objects.
 diff --git a/libtool.m4 b/libtool.m4
-index 24d13f3..94d96d9 100644
+index 0020654..5aef292 100644
 --- a/libtool.m4
 +++ b/libtool.m4
-@@ -1137,7 +1137,7 @@ fi
+@@ -1139,7 +1139,7 @@ fi
  # Invoke $ECHO with all args, space-separated.
  func_echo_all ()
  {
@@ -2064,7 +2062,7 @@ index 24d13f3..94d96d9 100644
  }
  
  case "$ECHO" in
-@@ -1722,7 +1722,7 @@ else
+@@ -1724,7 +1724,7 @@ else
    lt_cv_dlopen_libs=
  
    case $host_os in
@@ -2073,7 +2071,7 @@ index 24d13f3..94d96d9 100644
      lt_cv_dlopen="load_add_on"
      lt_cv_dlopen_libs=
      lt_cv_dlopen_self=yes
-@@ -2342,8 +2342,9 @@ haiku*)
+@@ -2344,8 +2344,9 @@ haiku*)
    soname_spec='${libname}${release}${shared_ext}$major'
    shlibpath_var=LIBRARY_PATH
    shlibpath_overrides_runpath=yes
@@ -2085,7 +2083,7 @@ index 24d13f3..94d96d9 100644
    ;;
  
  hpux9* | hpux10* | hpux11*)
-@@ -3603,7 +3604,6 @@ m4_if([$1], [CXX], [
+@@ -3610,7 +3611,6 @@ m4_if([$1], [CXX], [
          ;;
        esac
        ;;
@@ -2093,7 +2091,7 @@ index 24d13f3..94d96d9 100644
      beos* | irix5* | irix6* | nonstopux* | osf3* | osf4* | osf5*)
        # PIC is the default for these OSes.
        ;;
-@@ -3626,8 +3626,6 @@ m4_if([$1], [CXX], [
+@@ -3633,8 +3633,6 @@ m4_if([$1], [CXX], [
        ;;
      haiku*)
        # PIC is the default for Haiku.
@@ -2102,7 +2100,7 @@ index 24d13f3..94d96d9 100644
        ;;
      interix[[3-9]]*)
        # Interix 3.x gcc -fpic/-fPIC options generate broken code.
-@@ -3937,8 +3935,6 @@ m4_if([$1], [CXX], [
+@@ -3944,8 +3942,6 @@ m4_if([$1], [CXX], [
  
      haiku*)
        # PIC is the default for Haiku.
@@ -2115,7 +2113,7 @@ index 24d13f3..94d96d9 100644
 2.30.2
 
 
-From e414d842c0af7f79423a1934753e78f7b2e15bb8 Mon Sep 17 00:00:00 2001
+From a44e1e58f5363ad445040cae126fb91babbec0e0 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Thu, 5 May 2016 09:03:06 +0000
 Subject: fix for libstdc++/69506
@@ -2137,7 +2135,7 @@ index 4674f7b..02c8693 100644
 2.30.2
 
 
-From ceda9aa482a9023dec9816f67db66ac422c93c0e Mon Sep 17 00:00:00 2001
+From dddf921011ac58ec8db57a5f429e0bd922d6d1c8 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Thu, 5 May 2016 15:52:08 +0000
 Subject: rename x86_elf_aligned_common.
@@ -2163,322 +2161,16 @@ index 76ba48e..e2fa55a 100644
 -- 
 2.30.2
 
-diff --git a/gcc/configure b/gcc/configure
-index 97ba7d7..bf0c5bc 100755
---- a/gcc/configure
-+++ b/gcc/configure
-@@ -751,6 +751,7 @@ LDEXP_LIB
- EXTRA_GCC_LIBS
- GNAT_LIBEXC
- COLLECT2_LIBS
-+build_math_library
- CXXDEPMODE
- DEPDIR
- am__leading_dot
-@@ -787,6 +788,7 @@ with_float
- with_cpu
- enable_multiarch
- enable_multilib
-+HYBRID_SECONDARY
- coverage_flags
- valgrind_command
- valgrind_path_defines
-@@ -903,6 +905,7 @@ enable_checking
- enable_coverage
- enable_gather_detailed_mem_stats
- enable_valgrind_annotations
-+with_hybrid_secondary
- with_stabs
- enable_multilib
- enable_multiarch
-@@ -1724,6 +1727,8 @@ Optional Packages:
-   --with-demangler-in-ld  try to use demangler in GNU ld
-   --with-gnu-as           arrange to work with GNU as
-   --with-as               arrange to use the specified as (full pathname)
-+  --with-hybrid_secondary specify the packaging architecture for building a
-+                          secondary compiler for a Haiku hybrid system
-   --with-stabs            arrange to use stabs instead of host debug format
-   --with-dwarf2           force the default debug format to be DWARF 2
-   --with-specs=SPECS      add SPECS to driver command-line processing
-@@ -7386,6 +7391,18 @@ fi
- # Miscenalleous configure options
- # -------------------------------
- 
-+# handle --with-hybrid-secondary
-+
-+# Check whether --with-hybrid_secondary was given.
-+if test "${with_hybrid_secondary+set}" = set; then :
-+  withval=$with_hybrid_secondary; HYBRID_SECONDARY=$withval
-+else
-+  HYBRID_SECONDARY=
-+
-+fi
-+
-+
-+
- # With stabs
- 
- # Check whether --with-stabs was given.
-@@ -9393,6 +9410,16 @@ fi
- # --------
- 
- 
-+# Configure -lm usage for host tools that need it
-+build_math_library="-lm"
-+case $build in
-+  *-*-haiku*)
-+    # no separate math library needed
-+    build_math_library=
-+    ;;
-+esac
-+
-+
- # These libraries may be used by collect2.
- # We may need a special search path to get them linked.
- { $as_echo "$as_me:${as_lineno-$LINENO}: checking for collect2 libraries" >&5
-@@ -11693,7 +11720,7 @@ case ${enable_threads} in
-     # default
-     target_thread_file='single'
-     ;;
--  aix | dce | lynx | mipssde | posix | rtems | \
-+  aix | dce | haiku | lynx | mipssde | posix | rtems | \
-   single | tpf | vxworks | win32)
-     target_thread_file=${enable_threads}
-     ;;
-@@ -15540,8 +15567,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
- 
-     haiku*)
-       # PIC is the default for Haiku.
--      # The "-static" flag exists, but is broken.
--      lt_prog_compiler_static=
-       ;;
- 
-     hpux*)
-@@ -17653,8 +17678,9 @@ haiku*)
-   soname_spec='${libname}${release}${shared_ext}$major'
-   shlibpath_var=LIBRARY_PATH
-   shlibpath_overrides_runpath=yes
--  sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/beos/system/lib'
--  hardcode_into_libs=yes
-+  sys_lib_search_path_spec='/boot/system/non-packaged/develop/lib /boot/system/develop/lib'
-+  sys_lib_dlsearch_path_spec='/boot/home/config/non-packaged/lib /boot/home/config/lib /boot/system/non-packaged/lib /boot/system/lib'
-+  hardcode_into_libs=no
-   ;;
- 
- hpux9* | hpux10* | hpux11*)
-@@ -18171,7 +18197,7 @@ else
-   lt_cv_dlopen_libs=
- 
-   case $host_os in
--  beos*)
-+  beos* | haiku* )
-     lt_cv_dlopen="load_add_on"
-     lt_cv_dlopen_libs=
-     lt_cv_dlopen_self=yes
-@@ -20369,7 +20395,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
-         ;;
-       esac
-       ;;
--
-     beos* | irix5* | irix6* | nonstopux* | osf3* | osf4* | osf5*)
-       # PIC is the default for these OSes.
-       ;;
-@@ -20391,8 +20416,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
-       ;;
-     haiku*)
-       # PIC is the default for Haiku.
--      # The "-static" flag exists, but is broken.
--      lt_prog_compiler_static_CXX=
-       ;;
-     interix[3-9]*)
-       # Interix 3.x gcc -fpic/-fPIC options generate broken code.
-@@ -21313,8 +21336,9 @@ haiku*)
-   soname_spec='${libname}${release}${shared_ext}$major'
-   shlibpath_var=LIBRARY_PATH
-   shlibpath_overrides_runpath=yes
--  sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/beos/system/lib'
--  hardcode_into_libs=yes
-+  sys_lib_search_path_spec='/boot/system/non-packaged/develop/lib /boot/system/develop/lib'
-+  sys_lib_dlsearch_path_spec='/boot/home/config/non-packaged/lib /boot/home/config/lib /boot/system/non-packaged/lib /boot/system/lib'
-+  hardcode_into_libs=no
-   ;;
- 
- hpux9* | hpux10* | hpux11*)
 
-diff --git a/libstdc++-v3/configure b/libstdc++-v3/configure
-index 61457e9..addc7fe 100755
---- a/libstdc++-v3/configure
-+++ b/libstdc++-v3/configure
-@@ -8874,8 +8874,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
- 
-     haiku*)
-       # PIC is the default for Haiku.
--      # The "-static" flag exists, but is broken.
--      lt_prog_compiler_static=
-       ;;
- 
-     hpux*)
-@@ -10996,8 +10994,9 @@ haiku*)
-   soname_spec='${libname}${release}${shared_ext}$major'
-   shlibpath_var=LIBRARY_PATH
-   shlibpath_overrides_runpath=yes
--  sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/beos/system/lib'
--  hardcode_into_libs=yes
-+  sys_lib_search_path_spec='/boot/system/non-packaged/develop/lib /boot/system/develop/lib'
-+  sys_lib_dlsearch_path_spec='/boot/home/config/non-packaged/lib /boot/home/config/lib /boot/system/non-packaged/lib /boot/system/lib'
-+  hardcode_into_libs=no
-   ;;
- 
- hpux9* | hpux10* | hpux11*)
-@@ -11517,7 +11516,7 @@ else
-   lt_cv_dlopen_libs=
- 
-   case $host_os in
--  beos*)
-+  beos* | haiku* )
-     lt_cv_dlopen="load_add_on"
-     lt_cv_dlopen_libs=
-     lt_cv_dlopen_self=yes
-@@ -13736,7 +13735,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
-         ;;
-       esac
-       ;;
--
-     beos* | irix5* | irix6* | nonstopux* | osf3* | osf4* | osf5*)
-       # PIC is the default for these OSes.
-       ;;
-@@ -13758,8 +13756,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
-       ;;
-     haiku*)
-       # PIC is the default for Haiku.
--      # The "-static" flag exists, but is broken.
--      lt_prog_compiler_static_CXX=
-       ;;
-     interix[3-9]*)
-       # Interix 3.x gcc -fpic/-fPIC options generate broken code.
-@@ -14680,8 +14676,9 @@ haiku*)
-   soname_spec='${libname}${release}${shared_ext}$major'
-   shlibpath_var=LIBRARY_PATH
-   shlibpath_overrides_runpath=yes
--  sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/beos/system/lib'
--  hardcode_into_libs=yes
-+  sys_lib_search_path_spec='/boot/system/non-packaged/develop/lib /boot/system/develop/lib'
-+  sys_lib_dlsearch_path_spec='/boot/home/config/non-packaged/lib /boot/home/config/lib /boot/system/non-packaged/lib /boot/system/lib'
-+  hardcode_into_libs=no
-   ;;
- 
- hpux9* | hpux10* | hpux11*)
-@@ -53608,6 +53605,89 @@ done
- 
-     ;;
- 
-+  *-haiku*)
-+    for ac_header in nan.h ieeefp.h endian.h sys/isa_defs.h \
-+      machine/endian.h machine/param.h sys/machine.h sys/types.h \
-+      fp.h float.h endian.h inttypes.h locale.h float.h stdint.h
-+do :
-+  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
-+ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
-+eval as_val=\$$as_ac_Header
-+   if test "x$as_val" = x""yes; then :
-+  cat >>confdefs.h <<_ACEOF
-+#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
-+_ACEOF
-+
-+fi
-+
-+done
-+
-+    SECTION_FLAGS='-ffunction-sections -fdata-sections'
-+
-+
-+    $as_echo "#define HAVE_INT64_T 1" >>confdefs.h
-+
-+
-+    $as_echo "#define HAVE_ACOSF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_ASINF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_ATANF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_ATAN2F 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_CEILF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_COSF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_COSHF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_EXPF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_FABSF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_FINITE 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_FINITEF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_FLOORF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_FMODF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_FREXPF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_HYPOT 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_HYPOTF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_ISINF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_ISINFF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_ISNAN 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_ISNANF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_LOGF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_LOG10F 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_MODFF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_SINF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_SINHF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_SQRTF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_TANF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_TANHF 1" >>confdefs.h
-+
-+    $as_echo "#define HAVE_TLS 1" >>confdefs.h
-+
-+    ;;
-+
-   *-hpux*)
-     SECTION_FLAGS='-ffunction-sections -fdata-sections'
- 
-@@ -80300,6 +80380,9 @@ $as_echo_n "checking whether to build Filesystem TS support... " >&6; }
-       solaris*)
-         enable_libstdcxx_filesystem_ts=yes
-         ;;
-+      haiku*)
-+        enable_libstdcxx_filesystem_ts=yes
-+        ;;
-       *)
-         enable_libstdcxx_filesystem_ts=no
-         ;;
--- 
-2.30.2
-
-From 3e9dec2945b48f386a79f442e619648cd7ac9c7a Mon Sep 17 00:00:00 2001
+From f9f1ece2b58dadab7598d41e65c320ffed6d0c88 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Mon, 27 Jul 2015 16:32:32 +0200
 Subject: Haiku: disable -fno-PIE as this fails on x86_64.
 
-diff --git a/gcc/Makefile.in.orig b/gcc/Makefile.in
+
+diff --git a/gcc/Makefile.in b/gcc/Makefile.in
 index 646db21..b22bbfa 100644
---- a/gcc/Makefile.in.orig
+--- a/gcc/Makefile.in
 +++ b/gcc/Makefile.in
 @@ -106,6 +106,8 @@ build_objdir := $(toplevel_builddir)/$(build_subdir)
  build_libobjdir := $(toplevel_builddir)/$(build_libsubdir)
@@ -2542,9 +2234,19 @@ index 646db21..b22bbfa 100644
  CFLAGS-cppbuiltin.o += $(PREPROCESSOR_DEFINES) -DBASEVER=$(BASEVER_s)
  cppbuiltin.o: $(BASEVER)
  
-diff --git a/gcc/config.host.orig b/gcc/config.host
+-- 
+2.30.2
+
+
+From b683ca27f14028bbc10369fd0975c0a9142f0e80 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
+Date: Sun, 19 Jul 2015 18:55:34 +0200
+Subject: Fix GCC config host
+
+
+diff --git a/gcc/config.host b/gcc/config.host
 index 84f0433..422442f 100644
---- a/gcc/config.host.orig
+--- a/gcc/config.host
 +++ b/gcc/config.host
 @@ -99,7 +99,7 @@ case ${host} in
  esac
@@ -2578,10 +2280,19 @@ index 84f0433..422442f 100644
  	host_extra_gcc_objs="driver-native.o"
  	host_xmake_file="${host_xmake_file} mips/x-native"
        ;;
+-- 
+2.30.2
 
-diff --git a/gcc/config.gcc.orig b/gcc/config.gcc
+
+From 079c0a3a390ce98811ed6123e44ed1d2bd43b150 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
+Date: Sun, 19 Jul 2015 18:55:34 +0200
+Subject: Fix GCC config.gcc
+
+
+diff --git a/gcc/config.gcc b/gcc/config.gcc
 index 6fcdd77..3c96140 100644
---- a/gcc/config.gcc.orig
+--- a/gcc/config.gcc
 +++ b/gcc/config.gcc
 @@ -806,6 +806,19 @@ case ${target} in
  *-*-fuchsia*)
@@ -2673,17 +2384,21 @@ index 6fcdd77..3c96140 100644
  powerpc-*-rtems*)
  	tm_file="rs6000/biarch64.h ${tm_file} dbxelf.h elfos.h gnu-user.h freebsd-spec.h newlib-stdint.h rs6000/sysv4.h rs6000/rtems.h rtems.h"
  	extra_options="${extra_options} rs6000/sysv4.opt rs6000/linux64.opt"
+-- 
+2.30.2
 
-From 5c0c284b60d2373ad2f9b994b3a585a087d3c381 Mon Sep 17 00:00:00 2001
+
+From 9297a7bbfc3266ec3e0ac13ec75524adb8727931 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 12 May 2017 23:49:00 +0200
 Subject: Haiku: regenerate configure.
 
-diff --git a/configure.orig b/configure
+
+diff --git a/configure b/configure
 old mode 100755
 new mode 100644
 index f2ec106..29f7128
---- a/configure.orig
+--- a/configure
 +++ b/configure
 @@ -3106,6 +3106,9 @@ case "${host}" in
    i[3456789]86-*-msdosdjgpp*)
@@ -2780,10 +2495,9 @@ index f2ec106..29f7128
  
  fi
  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $gcc_cv_prog_cmp_skip" >&5
-
-diff --git a/libatomic/configure.orig b/libatomic/configure
+diff --git a/libatomic/configure b/libatomic/configure
 index 6e706e9..d610ca0 100755
---- a/libatomic/configure.orig
+--- a/libatomic/configure
 +++ b/libatomic/configure
 @@ -8475,8 +8475,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
  
@@ -2866,10 +2580,9 @@ index 6e706e9..d610ca0 100755
  rm -f core conftest.err conftest.$ac_objext \
      conftest$ac_exeext conftest.$ac_ext
    CFLAGS="$save_CFLAGS $XPCFLAGS"
-
-diff --git a/libgomp/configure.orig b/libgomp/configure
+diff --git a/libgomp/configure b/libgomp/configure
 index 5240f7e..641681b 100755
---- a/libgomp/configure.orig
+--- a/libgomp/configure
 +++ b/libgomp/configure
 @@ -8520,8 +8520,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
  
@@ -2975,50 +2688,21 @@ index 5240f7e..641681b 100755
  rm -f core conftest.err conftest.$ac_objext \
      conftest$ac_exeext conftest.$ac_ext
  esac
+-- 
+2.30.2
 
-From 8963c09cf713c11d5714d3c9417fb656cac5e4bc Mon Sep 17 00:00:00 2001
+
+From 0698f4c9ef1067f716e50a6a3fc23fbcaf064f4b Mon Sep 17 00:00:00 2001
 From: Jessica Hamilton <jessica.l.hamilton@gmail.com>
 Date: Fri, 12 Jul 2019 18:17:00 +0000
 Subject: gcc: fix build configuration for libgcc.
 
 * libgcc_s.so now depends on libgcc.a for __cpu_model and friends,
   which is needed for gfortran to produce working binaries.
-  
-diff --git a/libgcc/config.host.orig b/libgcc/config.host
-index 532941e..4ead494 100644
---- a/libgcc/config.host.orig
-+++ b/libgcc/config.host
-@@ -248,6 +248,14 @@ case ${host} in
-   tmake_file="$tmake_file t-crtstuff-pic t-libgcc-pic t-eh-dw2-dip t-slibgcc t-slibgcc-fuchsia"
-   extra_parts="crtbegin.o crtend.o"
-   ;;
-+*-*-haiku*)
-+  # This is the generic ELF configuration of Haiku.  Later
-+  # machine-specific sections may refine and add to this
-+  # configuration.
-+  tmake_file="$tmake_file t-crtstuff-pic t-libgcc-pic t-haiku t-slibgcc t-slibgcc-gld t-slibgcc-elf-ver"
-+  tmake_file="$tmake_file t-slibgcc-libgcc t-slibgcc-nolc-override"
-+  extra_parts="crtbegin.o crtbeginS.o crtend.o crtendS.o"
-+  ;;
- *-*-linux* | frv-*-*linux* | *-*-kfreebsd*-gnu | *-*-gnu* | *-*-kopensolaris*-gnu | *-*-uclinuxfdpiceabi)
-   tmake_file="$tmake_file t-crtstuff-pic t-libgcc-pic t-eh-dw2-dip t-slibgcc t-slibgcc-gld t-slibgcc-elf-ver t-linux"
-   extra_parts="crtbegin.o crtbeginS.o crtbeginT.o crtend.o crtendS.o"
-@@ -458,6 +466,12 @@ arm*-*-fuchsia*)
- 	tm_file="${tm_file} arm/bpabi-lib.h"
- 	unwind_header=config/arm/unwind-arm.h
- 	;;
-+arm-*-haiku*)
-+	tmake_file="${tmake_file} arm/t-arm arm/t-elf arm/t-bpabi"
-+	tmake_file="${tmake_file} t-softfp-sfdf t-softfp-excl arm/t-softfp t-softfp"
-+	tm_file="${tm_file} arm/bpabi-lib.h"
-+	unwind_header=config/arm/unwind-arm.h
-+	;;
- arm*-*-netbsdelf*)
- 	tmake_file="$tmake_file arm/t-arm"
- 	case ${host} in
-diff --git a/configure.ac.orig b/configure.ac
+
+diff --git a/configure.ac b/configure.ac
 index 115db3f..bdbd281 100644
---- a/configure.ac.orig
+--- a/configure.ac
 +++ b/configure.ac
 @@ -419,6 +419,9 @@ case "${host}" in
    i[[3456789]]86-*-msdosdjgpp*)
@@ -3069,15 +2753,19 @@ index 115db3f..bdbd281 100644
    *-*-kaos*)
      # Remove unsupported stuff on all kaOS configurations.
      noconfigdirs="$noconfigdirs target-libgloss"
+-- 
+2.30.2
 
-From 979884a95dd2dc79d2e34e3b4e89d46d6326a007 Mon Sep 17 00:00:00 2001
+
+From 6ec634843250cc57a581abd56f2ae0316898f044 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
 Date: Wed, 2 May 2018 08:37:20 +0200
 Subject: Enable libstdcxx_filesystem_ts for Haiku
 
-diff --git a/libstdc++-v3/acinclude.m4.orig b/libstdc++-v3/acinclude.m4
+
+diff --git a/libstdc++-v3/acinclude.m4 b/libstdc++-v3/acinclude.m4
 index b6557a4..c789d7c 100644
---- a/libstdc++-v3/acinclude.m4.orig
+--- a/libstdc++-v3/acinclude.m4
 +++ b/libstdc++-v3/acinclude.m4
 @@ -4497,6 +4497,9 @@ AC_DEFUN([GLIBCXX_ENABLE_FILESYSTEM_TS], [
        mingw*)
@@ -3089,3 +2777,328 @@ index b6557a4..c789d7c 100644
        *)
          enable_libstdcxx_filesystem_ts=no
          ;;
+-- 
+2.30.2
+
+From d731c1a693b094965f408b9ec7d4e60dc16d2dd0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
+Date: Sun, 19 Jul 2015 18:55:34 +0200
+Subject: Haiku GCC configure patch
+
+
+diff --git a/gcc/configure b/gcc/configure
+index 8fe9c91..4fb3890 100755
+--- a/gcc/configure
++++ b/gcc/configure
+@@ -791,6 +791,7 @@ LDEXP_LIB
+ EXTRA_GCC_LIBS
+ GNAT_LIBEXC
+ COLLECT2_LIBS
++build_math_library
+ CXXDEPMODE
+ DEPDIR
+ am__leading_dot
+@@ -831,6 +832,7 @@ with_float
+ with_cpu
+ enable_multiarch
+ enable_multilib
++HYBRID_SECONDARY
+ coverage_flags
+ valgrind_command
+ valgrind_path_defines
+@@ -947,6 +949,7 @@ enable_checking
+ enable_coverage
+ enable_gather_detailed_mem_stats
+ enable_valgrind_annotations
++with_hybrid_secondary
+ with_stabs
+ enable_multilib
+ enable_multiarch
+@@ -1793,6 +1796,8 @@ Optional Packages:
+   --with-demangler-in-ld  try to use demangler in GNU ld
+   --with-gnu-as           arrange to work with GNU as
+   --with-as               arrange to use the specified as (full pathname)
++  --with-hybrid_secondary specify the packaging architecture for building a
++                          secondary compiler for a Haiku hybrid system
+   --with-stabs            arrange to use stabs instead of host debug format
+   --with-stack-clash-protection-guard-size=size
+                           Set the default stack clash protection guard size
+@@ -7488,6 +7493,18 @@ fi
+ # Miscenalleous configure options
+ # -------------------------------
+ 
++# handle --with-hybrid-secondary
++
++# Check whether --with-hybrid_secondary was given.
++if test "${with_hybrid_secondary+set}" = set; then :
++  withval=$with_hybrid_secondary; HYBRID_SECONDARY=$withval
++else
++  HYBRID_SECONDARY=
++
++fi
++
++
++
+ # With stabs
+ 
+ # Check whether --with-stabs was given.
+@@ -9622,6 +9639,16 @@ fi
+ # --------
+ 
+ 
++# Configure -lm usage for host tools that need it
++build_math_library="-lm"
++case $build in
++  *-*-haiku*)
++    # no separate math library needed
++    build_math_library=
++    ;;
++esac
++
++
+ # These libraries may be used by collect2.
+ # We may need a special search path to get them linked.
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for collect2 libraries" >&5
+@@ -12213,7 +12240,7 @@ case ${enable_threads} in
+     # default
+     target_thread_file='single'
+     ;;
+-  aix | dce | lynx | mipssde | posix | rtems | \
++  aix | dce | haiku | lynx | mipssde | posix | rtems | \
+   single | tpf | vxworks | win32)
+     target_thread_file=${enable_threads}
+     ;;
+@@ -16108,8 +16135,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+ 
+     haiku*)
+       # PIC is the default for Haiku.
+-      # The "-static" flag exists, but is broken.
+-      lt_prog_compiler_static=
+       ;;
+ 
+     hpux*)
+@@ -18221,8 +18246,9 @@ haiku*)
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/beos/system/lib'
+-  hardcode_into_libs=yes
++  sys_lib_search_path_spec='/boot/system/non-packaged/develop/lib /boot/system/develop/lib'
++  sys_lib_dlsearch_path_spec='/boot/home/config/non-packaged/lib /boot/home/config/lib /boot/system/non-packaged/lib /boot/system/lib'
++  hardcode_into_libs=no
+   ;;
+ 
+ hpux9* | hpux10* | hpux11*)
+@@ -18744,7 +18770,7 @@ else
+   lt_cv_dlopen_libs=
+ 
+   case $host_os in
+-  beos*)
++  beos* | haiku* )
+     lt_cv_dlopen="load_add_on"
+     lt_cv_dlopen_libs=
+     lt_cv_dlopen_self=yes
+@@ -20942,7 +20968,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+         ;;
+       esac
+       ;;
+-
+     beos* | irix5* | irix6* | nonstopux* | osf3* | osf4* | osf5*)
+       # PIC is the default for these OSes.
+       ;;
+@@ -20964,8 +20989,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       ;;
+     haiku*)
+       # PIC is the default for Haiku.
+-      # The "-static" flag exists, but is broken.
+-      lt_prog_compiler_static_CXX=
+       ;;
+     interix[3-9]*)
+       # Interix 3.x gcc -fpic/-fPIC options generate broken code.
+@@ -21886,8 +21909,9 @@ haiku*)
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/beos/system/lib'
+-  hardcode_into_libs=yes
++  sys_lib_search_path_spec='/boot/system/non-packaged/develop/lib /boot/system/develop/lib'
++  sys_lib_dlsearch_path_spec='/boot/home/config/non-packaged/lib /boot/home/config/lib /boot/system/non-packaged/lib /boot/system/lib'
++  hardcode_into_libs=no
+   ;;
+ 
+ hpux9* | hpux10* | hpux11*)
+-- 
+2.30.2
+
+From 51e2839394dcdbb1547644368e6fa67a7364d307 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
+Date: Sun, 19 Jul 2015 18:55:34 +0200
+Subject: Haiku libstdc++-v3 configure patch
+
+
+diff --git a/libstdc++-v3/configure b/libstdc++-v3/configure
+index 766a0a8..9f3a0b1 100755
+--- a/libstdc++-v3/configure
++++ b/libstdc++-v3/configure
+@@ -9120,8 +9120,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+ 
+     haiku*)
+       # PIC is the default for Haiku.
+-      # The "-static" flag exists, but is broken.
+-      lt_prog_compiler_static=
+       ;;
+ 
+     hpux*)
+@@ -11242,8 +11240,9 @@ haiku*)
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/beos/system/lib'
+-  hardcode_into_libs=yes
++  sys_lib_search_path_spec='/boot/system/non-packaged/develop/lib /boot/system/develop/lib'
++  sys_lib_dlsearch_path_spec='/boot/home/config/non-packaged/lib /boot/home/config/lib /boot/system/non-packaged/lib /boot/system/lib'
++  hardcode_into_libs=no
+   ;;
+ 
+ hpux9* | hpux10* | hpux11*)
+@@ -11768,7 +11767,7 @@ else
+   lt_cv_dlopen_libs=
+ 
+   case $host_os in
+-  beos*)
++  beos* | haiku* )
+     lt_cv_dlopen="load_add_on"
+     lt_cv_dlopen_libs=
+     lt_cv_dlopen_self=yes
+@@ -13987,7 +13986,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+         ;;
+       esac
+       ;;
+-
+     beos* | irix5* | irix6* | nonstopux* | osf3* | osf4* | osf5*)
+       # PIC is the default for these OSes.
+       ;;
+@@ -14009,8 +14007,6 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       ;;
+     haiku*)
+       # PIC is the default for Haiku.
+-      # The "-static" flag exists, but is broken.
+-      lt_prog_compiler_static_CXX=
+       ;;
+     interix[3-9]*)
+       # Interix 3.x gcc -fpic/-fPIC options generate broken code.
+@@ -14931,8 +14927,9 @@ haiku*)
+   soname_spec='${libname}${release}${shared_ext}$major'
+   shlibpath_var=LIBRARY_PATH
+   shlibpath_overrides_runpath=yes
+-  sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/beos/system/lib'
+-  hardcode_into_libs=yes
++  sys_lib_search_path_spec='/boot/system/non-packaged/develop/lib /boot/system/develop/lib'
++  sys_lib_dlsearch_path_spec='/boot/home/config/non-packaged/lib /boot/home/config/lib /boot/system/non-packaged/lib /boot/system/lib'
++  hardcode_into_libs=no
+   ;;
+ 
+ hpux9* | hpux10* | hpux11*)
+@@ -47421,6 +47418,89 @@ done
+ 
+     ;;
+ 
++  *-haiku*)
++    for ac_header in nan.h ieeefp.h endian.h sys/isa_defs.h \
++      machine/endian.h machine/param.h sys/machine.h sys/types.h \
++      fp.h float.h endian.h inttypes.h locale.h float.h stdint.h
++do :
++  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
++ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
++eval as_val=\$$as_ac_Header
++   if test "x$as_val" = x""yes; then :
++  cat >>confdefs.h <<_ACEOF
++#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
++_ACEOF
++
++fi
++
++done
++
++    SECTION_FLAGS='-ffunction-sections -fdata-sections'
++
++
++    $as_echo "#define HAVE_INT64_T 1" >>confdefs.h
++
++
++    $as_echo "#define HAVE_ACOSF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_ASINF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_ATANF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_ATAN2F 1" >>confdefs.h
++
++    $as_echo "#define HAVE_CEILF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_COSF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_COSHF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_EXPF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_FABSF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_FINITE 1" >>confdefs.h
++
++    $as_echo "#define HAVE_FINITEF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_FLOORF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_FMODF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_FREXPF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_HYPOT 1" >>confdefs.h
++
++    $as_echo "#define HAVE_HYPOTF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_ISINF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_ISINFF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_ISNAN 1" >>confdefs.h
++
++    $as_echo "#define HAVE_ISNANF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_LOGF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_LOG10F 1" >>confdefs.h
++
++    $as_echo "#define HAVE_MODFF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_SINF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_SINHF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_SQRTF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_TANF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_TANHF 1" >>confdefs.h
++
++    $as_echo "#define HAVE_TLS 1" >>confdefs.h
++
++    ;;
++
+   *-hpux*)
+     SECTION_FLAGS='-ffunction-sections -fdata-sections'
+ 
+@@ -75324,6 +75404,9 @@ $as_echo_n "checking whether to build Filesystem TS support... " >&6; }
+       mingw*)
+         enable_libstdcxx_filesystem_ts=yes
+         ;;
++      haiku*)
++        enable_libstdcxx_filesystem_ts=yes
++        ;;
+       *)
+         enable_libstdcxx_filesystem_ts=no
+         ;;
+-- 
+2.30.2
+


### PR DESCRIPTION
Work In Progress. Help welcome. Disabled.
Initial patchset migration work for GCC 10.3.0. 

NOTE: This PR may get superseded by the GCC 11.1 official release.