### PR TITLE
stella*_libretro: bump + new recipe

### DIFF
--- a/games-emulation/stella2014_libretro/stella2014_libretro-3.9.3_20210506.recipe
+++ b/games-emulation/stella2014_libretro/stella2014_libretro-3.9.3_20210506.recipe
@@ -2,15 +2,15 @@ SUMMARY="A port of Stella, an Atari 2600 VCS emulator to the libretro API"
 DESCRIPTION="Stella is a multi-platform Atari 2600 VCS emulator originally \
 developed for Linux by Bradford W. Mott, and currently maintained by Stephen \
 Anthony. The Atari 2600 Video Computer System (VCS), introduced in 1977, was \
-the most popular home video game system of the early 1980's.  Now you can \
-enjoy all of your favorite Atari 2600 games on your PC thanks to Stella."
+the most popular home video game system of the early 1980's. This is a fork \
+from the 2014 Stella codebase with lower accuracy, for low-spec systems."
 HOMEPAGE="https://stella-emu.github.io/"
-COPYRIGHT="1995-2020 the Stella team, the libretro team"
+COPYRIGHT="1995-2021 the Stella team, the libretro team"
 LICENSE="GNU GPL v2"
 REVISION="1"
-srcGitRev="b4b4cf3266ce6dc8ed891978761209272000009c"
+srcGitRev="7be813894574c75b16d53f0e8fb86f6e8f06afc0"
 SOURCE_URI="https://github.com/libretro/stella2014-libretro/archive/$srcGitRev.tar.gz"
-CHECKSUM_SHA256="c02a1708deb97450e25ae0c04c0c0fea17a19d51fa954f2308ca0cad637ae7a5"
+CHECKSUM_SHA256="8039ddbc588f9a1bf8ca6077482f729c8a422558178b53a725c4eb838a6bee29"
 SOURCE_FILENAME="stella2014-libretro-${portVersion/_/-}-$srcGitRev.tar.gz"
 SOURCE_DIR="stella2014-libretro-$srcGitRev"
 ADDITIONAL_FILES="stella2014_libretro.info.in"

--- a/games-emulation/stella_libretro/additional-files/stella_libretro.info.in
+++ b/games-emulation/stella_libretro/additional-files/stella_libretro.info.in
@@ -1,8 +1,7 @@
-# Software Information
-display_name = "Atari - 2600 (Stella 2014)"
+display_name = "Atari - 2600 (Stella)"
 authors = "Stephen Anthony|Bradford Mott|Eckhard Stolberg|Brian Watson"
 supported_extensions = "a26|bin"
-corename = "Stella 2014"
+corename = "Stella"
 license = "GPLv2"
 permissions = ""
 display_version = "@DISPLAY_VERSION@"
@@ -14,8 +13,8 @@ systemname = "Atari 2600"
 systemid = "atari_2600"
 
 # Libretro Features
-supports_no_game = "false"
 database = "Atari - 2600"
+supports_no_game = "false"
 savestate = "true"
 savestate_features = "deterministic"
 cheats = "false"
@@ -28,4 +27,4 @@ hw_render = "false"
 needs_fullpath = "false"
 disk_control = "false"
 
-description = "A port of Stella, the multi-platform Atari 2600 VCS emulator, to libretro. This core was forked off from the main Stella codebase circa 2014 and, as such, is a snapshot of the features, compatibility and performance from that time. As a result, it is missing many of the accuracy improvements of the up-to-date core and should only be used in cases where the host device cannot run the up-to-date core at full speed."
+description = "A port of Stella, the multi-platform Atari 2600 VCS emulator, to libretro. This core has high accuracy and wide compatibility with the Atari 2600 library, making it an excellent first choice for users wanting to play these games. On devices that are too weak to maintain full speed, the older Stella2014 core runs significantly faster at the cost of significantly lower accuracy."

--- a/games-emulation/stella_libretro/stella_libretro-6.5.3_20210508.recipe
+++ b/games-emulation/stella_libretro/stella_libretro-6.5.3_20210508.recipe
@@ -1,0 +1,55 @@
+SUMMARY="A port of Stella, an Atari 2600 VCS emulator to the libretro API"
+DESCRIPTION="Stella is a multi-platform Atari 2600 VCS emulator originally \
+developed for Linux by Bradford W. Mott, and currently maintained by Stephen \
+Anthony. The Atari 2600 Video Computer System (VCS), introduced in 1977, was \
+the most popular home video game system of the early 1980's. This is a fork \
+of the more recent version of Stella, updated for accuracy."
+HOMEPAGE="https://stella-emu.github.io/"
+COPYRIGHT="1995-2021 the Stella team, the libretro team"
+LICENSE="GNU GPL v2"
+REVISION="1"
+srcGitRev="4ebf3f22031e881968494a613131e8d6cc1498fa"
+SOURCE_URI="https://github.com/stella-emu/stella/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="777c91e27e511b08dd6ab016da9d2e069c9aabb9088d2263dbfd14485fa0fe49"
+SOURCE_FILENAME="stella-${portVersion/_/-}-$srcGitRev.tar.gz"
+SOURCE_DIR="stella-$srcGitRev"
+ADDITIONAL_FILES="stella_libretro.info.in"
+
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	stella_libretro$secondaryArchSuffix = $portVersion
+	addon:stella_libretro$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	retroarch$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	"
+
+BUILD()
+{
+	sed -e "s/@DISPLAY_VERSION@/v${portVersion/_/-}/" \
+		$portDir/additional-files/stella_libretro.info.in \
+		> stella_libretro.info
+	cd src/libretro
+	make -f Makefile platform="unix" -j4 CC="gcc" CXX="g++" $jobArgs
+}
+
+INSTALL()
+{
+	install -m 0755 -d "$docDir"
+	install -m 0644 -t "$docDir" README.md
+	install -m 0755 -d "$addOnsDir"/libretro
+	install -m 0644 -t "$addOnsDir"/libretro \
+		stella_libretro.info \
+		src/libretro/stella_libretro.so
+}


### PR DESCRIPTION
stella2014_libretro: bump of this code, forked from the 2014 codebase of Stella. More stable but less accurate. Also faster on low-end systems.
stella_libretro: new recipe, straight from upstream. Might crash more, but more accuracy. Requires more powerful systems.