### PR TITLE
neocd_libretro: bump

### DIFF
--- a/games-emulation/neocd_libretro/additional-files/neocd_libretro.info.in
+++ b/games-emulation/neocd_libretro/additional-files/neocd_libretro.info.in
@@ -1,14 +1,16 @@
+# Software Information
 display_name = "SNK - Neo Geo CD (NeoCD)"
 authors = "Elta"
 supported_extensions = "cue|chd"
 corename = "NeoCD"
-manufacturer = "SNK"
-categories = "Emulator"
-systemname = "SNK Neo Geo CD"
-database = "SNK - Neo Geo CD"
 license = "LGPLv3"
 display_version = "@DISPLAY_VERSION@"
-supports_no_game = "false"
+categories = "Emulator"
+
+# Hardware Information
+manufacturer = "SNK"
+systemname = "SNK Neo Geo CD"
+database = "SNK - Neo Geo CD"
 
 # BIOS/Firmware
 firmware_count = 12
@@ -61,4 +63,9 @@ firmware11_desc = "neocd/uni-bioscd.rom (Universe BIOS 3.2)"
 firmware11_path = "neocd/uni-bioscd.rom"
 firmware11_opt = "true"
 
-notes = "(!) neocd/neocd_f.rom (sha1): a5f4a7a627b3083c979f6ebe1fabc5d2df6d083b|(!) neocd/neocd_sf.rom (sha1): c99c44a43bded1bff4570b30b74975601bd3f94e|(!) neocd/front-sp1.bin (sha1): 53bc1f283cdf00fa2efbb79f2e36d4c8038d743a|(!) neocd/neocd_t.rom (sha1): cc92b54a18a8bff6e595aabe8e5c360ba9e62eb5|(!) neocd/neocd_st.rom (sha1): d463b3a322b9674f9e227a21e43898019ce0e642|(!) neocd/top-sp1.bin (sha1): 235f4d1d74364415910f73c10ae5482d90b4274f|(!) neocd/neocd_z.rom (sha1): b0f1c4fa8d4492a04431805f6537138b842b549f|(!) neocd/neocd_sz.rom (sha1): 41ca1c031b844a46387be783ac862c76e65afbb3|(!) neocd/neocd.bin (sha1): 7bb26d1e5d1e930515219cb18bcde5b7b23e2eda|(!) neocd/ng-lo.rom (sha1): 2b1c719531dac9bb503f22644e6e4236b91e7cfc|(!) neocd/000-lo.lo (sha1): 5992277debadeb64d1c1c64b0a92d9293eaf7e4a|(!) neocd/uni-bioscd.rom (sha1): 5158b728e62b391fb69493743dcf7abbc62abc82"
+notes = "(!) neocd/neocd_f.rom (sha1): a5f4a7a627b3083c979f6ebe1fabc5d2df6d083b|(!) neocd/neocd_sf.rom (sha1): 4a94719ee5d0e3f2b981498f70efc1b8f1cef325|(!) neocd/front-sp1.bin (sha1): 53bc1f283cdf00fa2efbb79f2e36d4c8038d743a|(!) neocd/neocd_t.rom (sha1): cc92b54a18a8bff6e595aabe8e5c360ba9e62eb5|(!) neocd/neocd_st.rom (sha1): 19729b51bdab60c42aafef6e20ea9234c7eb8410|(!) neocd/top-sp1.bin (sha1): 235f4d1d74364415910f73c10ae5482d90b4274f|(!) neocd/neocd_z.rom (sha1): b0f1c4fa8d4492a04431805f6537138b842b549f|(!) neocd/neocd_sz.rom (sha1): 6a947457031dd3a702a296862446d7485aa89dbb|(!) neocd/neocd.bin (sha1): 7bb26d1e5d1e930515219cb18bcde5b7b23e2eda|(!) neocd/ng-lo.rom (sha1): 2b1c719531dac9bb503f22644e6e4236b91e7cfc|(!) neocd/000-lo.lo (sha1): 5992277debadeb64d1c1c64b0a92d9293eaf7e4a|(!) neocd/uni-bioscd.rom (sha1): 5142f205912869b673a71480c5828b1eaed782a8"
+
+# Libretro Features
+supports_no_game = "false"
+
+description = "A rewrite of the original NeoCD emulator for SNK's NeoGeo CD console, ported to libretro. This core is intended to improve the accuracy of the original project, while still maintaining full/usable speed on low-powered hardware, such as the Raspberry Pi. It is easier to load games with than some of the other, more complex cores that support the NeoGeo CD platform, such as MAME and FBNeo."

--- a/games-emulation/neocd_libretro/neocd_libretro-0.5_20210425.recipe
+++ b/games-emulation/neocd_libretro/neocd_libretro-0.5_20210425.recipe
@@ -1,21 +1,18 @@
 SUMMARY="A port of NeoCD, a Neo Geo CD/CDZ emulator for libretro"
-DESCRIPTION="NeoCD-Libretro is a complete rewrite of NeoCD from scratch in modern C++11. \
-It is designed with accuracy and portability in mind rather than being all about speed \
-like the the older versions. The goal is also to document all that is know about the \
-platform in the source code so other emulator authors can make their own implementations."
+DESCRIPTION="NeoCD-Libretro is a complete rewrite of NeoCD from scratch in \
+modern C++11. It is designed with accuracy and portability in mind rather \
+than being all about speed like the older versions. The goal is also to \
+document all that is known about the platform in the source code so other \
+emulator authors can make their own implementations."
 HOMEPAGE="https://github.com/libretro/neocd_libretro"
-COPYRIGHT="2005-2020, Fabrice Martinez, the libretro team"
+COPYRIGHT="2005-2021, Fabrice Martinez, the libretro team"
 LICENSE="GNU LGPL v3"
-REVISION="2"
-srcGitRev="3825848fe7dd7e0ef859729eefcb29e2ea2956b7"
+REVISION="1"
+srcGitRev="fc85ed4f5e3d075945493a3ae103df53b63cb340"
 SOURCE_URI="https://github.com/libretro/neocd_libretro/archive/$srcGitRev.tar.gz"
-CHECKSUM_SHA256="95f33dead4d0054d597cf785899e826eff6a494548c0c5eb935ea9ff55a9ea64"
+CHECKSUM_SHA256="0c70b36ca99f124c5d98993ee62c8de4a252b3370e9485164627054e547db5eb"
 SOURCE_FILENAME="neocd-libretro-${portVersion/_/-}-$srcGitRev.tar.gz"
 SOURCE_DIR="neocd_libretro-$srcGitRev"
-srcGitRev_2="db0ddbefe87ae5145191929eb6269597d039fa8b"
-SOURCE_URI_2="https://github.com/libretro/libretro-common/archive/$srcGitRev_2.tar.gz"
-CHECKSUM_SHA256_2="8772d31418c33383bf553531a351eafe0f3fef8bc85707e27a1ecd3367f0e4fd"
-SOURCE_FILENAME_2="libretro-common-$srcGitRev.tar.gz"
 ADDITIONAL_FILES="neocd_libretro.info.in"
 
 ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
@@ -43,9 +40,6 @@ BUILD()
 	sed -e "s/@DISPLAY_VERSION@/v${portVersion/_/-}/" \
 		$portDir/additional-files/neocd_libretro.info.in \
 		> neocd_libretro.info
-	# Remove the directory then copy the code from libretro-common
-	rmdir src/3rdparty/libretro-common
-	cp -r $sourceDir2/libretro-common-$srcGitRev_2 src/3rdparty/libretro-common
 	make  $jobArgs
 }
 


### PR DESCRIPTION
A rewrite of the original NeoCD emulator for SNK's NeoGeo CD console, ported to libretro. This core is intended to improve the accuracy of the original project, while still maintaining full/usable speed on low-powered hardware, such as the Raspberry Pi. It is easier to load games with than some of the other, more complex cores that support the NeoGeo CD platform, such as MAME and FBNeo.