### PR TITLE
desmume_libretro: new recipe

### DIFF
--- a/games-emulation/desmume_libretro/additional-files/desmume_libretro.info.in
+++ b/games-emulation/desmume_libretro/additional-files/desmume_libretro.info.in
@@ -1,0 +1,47 @@
+# Software Information
+display_name = "Nintendo - DS (DeSmuME)"
+authors = "YopYop156|Zeromus"
+supported_extensions = "nds|bin"
+corename = "DeSmuME"
+license = "GPLv2"
+permissions = ""
+display_version = "@DISPLAY_VERSION@"
+categories = "Emulator"
+
+# Hardware Information
+manufacturer = "Nintendo"
+systemname = "DS"
+systemid = "nds"
+
+# Libretro Features
+database = "Nintendo - Nintendo DS|Nintendo - Nintendo DS Decrypted|Nintendo - Nintendo DS (Download Play)"
+supports_no_game = "false"
+savestate = "true"
+savestate_features = "serialized"
+cheats = "true"
+input_descriptors = "true"
+memory_descriptors = "false"
+libretro_saves = "true"
+core_options = "true"
+core_options_version = "1.0"
+load_subsystem = "false"
+hw_render = "true"
+required_hw_api = "OpenGL >= 2.0 | OpenGL Core >= 3.1"
+needs_fullpath = "true"
+disk_control = "false"
+is_experimental = "false"
+
+# BIOS/Firmware
+firmware_count = 3
+firmware0_desc = "firmware.bin (NDS Firmware)"
+firmware0_path = "firmware.bin"
+firmware0_opt = "true"
+firmware1_desc = "bios7.bin (ARM7 BIOS)"
+firmware1_path = "bios7.bin"
+firmware1_opt = "true"
+firmware2_desc = "bios9.bin (ARM9 BIOS)"
+firmware2_path = "bios9.bin"
+firmware2_opt = "true"
+notes = "(!) firmware.bin (md5): 145eaef5bd3037cbc247c213bb3da1b3|(!) bios7.bin (md5): df692a80a5b1bc90728bc3dfc76cd948|(!) bios9.bin (md5): a392174eb3e572fed6447e956bde4b25|[1] Enable 'Use External BIOS/Firmware' core option to use firmware files"
+
+description = "A port of the mature and longstanding DeSmuME emulator for Nintendo's DS console to libretro. The core has very good compatibility and many modern features, including increased internal resolution (very demanding)."

--- a/games-emulation/desmume_libretro/desmume_libretro-0.9.11_20210512.recipe
+++ b/games-emulation/desmume_libretro/desmume_libretro-0.9.11_20210512.recipe
@@ -1,0 +1,54 @@
+SUMMARY="A port of Desmume, a Nintendo DS emulator for the libretro API"
+DESCRIPTION="A port of the mature and longstanding DeSmuME emulator for \
+Nintendo's DS console to libretro. The core has very good compatibility \
+and many modern features, including increased internal resolution (very \
+demanding)."
+HOMEPAGE="http://desmume.org/"
+COPYRIGHT="2006-2021 YopYop156, Zeromus, the libretro team"
+LICENSE="GNU GPL v2"
+REVISION="1"
+srcGitRev="815a92f5c9e5afa7f0f4a3989745835bf83427de"
+SOURCE_URI="https://github.com/libretro/desmume/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="7993c8eded875b4acf14b252d1583ae070ce2d08dacfe071d9b6de44d1dbe499"
+SOURCE_FILENAME="desmume-${portVersion/_/-}-$srcGitRev.tar.gz"
+SOURCE_DIR="desmume-$srcGitRev"
+ADDITIONAL_FILES="desmume_libretro.info.in"
+
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	desmume_libretro$secondaryArchSuffix = $portVersion
+	addon:desmume_libretro$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	retroarch$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	libpcap${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	"
+
+BUILD()
+{
+	sed -e "s/@DISPLAY_VERSION@/v${portVersion/_/-}/" \
+		$portDir/additional-files/desmume_libretro.info.in \
+		> desmume_libretro.info
+	make -C desmume/src/frontend/libretro/ $jobArgs
+}
+
+INSTALL()
+{
+	install -m 0755 -d "$docDir"
+	install -m 0644 -t "$docDir" README.md
+	install -m 0755 -d "$addOnsDir"/libretro
+	install -m 0644 -t "$addOnsDir"/libretro \
+		desmume_libretro.info \
+		desmume/src/frontend/libretro/desmume_libretro.so
+}


### PR DESCRIPTION
A port of the mature and longstanding DeSmuME emulator for Nintendo's DS console to libretro. The core has very good compatibility and many modern features, including increased internal resolution (very demanding).