### PR TITLE
WIP blastem_libretro: disabled 32bit build

### DIFF
--- a/games-emulation/blastem_libretro/blastem_libretro-0.6.3_20210510.recipe
+++ b/games-emulation/blastem_libretro/blastem_libretro-0.6.3_20210510.recipe
@@ -16,25 +16,24 @@ SOURCE_FILENAME="blastem-${portVersion/_/-}-$srcGitRev.tar.gz"
 SOURCE_DIR="blastem-$srcGitRev"
 ADDITIONAL_FILES="blastem_libretro.info.in"
 
-ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="!x86_gcc2 !x86 x86_64"
 
 PROVIDES="
-	blastem_libretro$secondaryArchSuffix = $portVersion
-	addon:blastem_libretro$secondaryArchSuffix = $portVersion
+	blastem_libretro = $portVersion
+	addon:blastem_libretro = $portVersion
 	"
 REQUIRES="
-	haiku$secondaryArchSuffix
-	retroarch$secondaryArchSuffix
-	lib:libz$secondaryArchSuffix
+	haiku
+	retroarch
+	lib:libz
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libz$secondaryArchSuffix
+	devel:libz
 	"
 BUILD_PREREQUIRES="
-	cmd:gcc$secondaryArchSuffix
+	cmd:gcc
 	cmd:make
 	"
 


### PR DESCRIPTION
Disabling 32bit build to work around this : https://build.haiku-os.org/buildmaster/master/x86_gcc2/logviewer.html?buildruns/1450/builds/2550.log