### PR TITLE
TinyEMU: X512 rev2 patch for x86-64

### DIFF
--- a/app-emulation/tinyemu/patches/tinyemu-2019.12.21.patchset
+++ b/app-emulation/tinyemu/patches/tinyemu-2019.12.21.patchset
@@ -1,8 +1,22 @@
-From 28b0d93f3fd754e25cb75ce657f1247a0f69dc7d Mon Sep 17 00:00:00 2001
+From 2baa0abbbb8a97b0c1eb70b1aeafcf7fdba25ad4 Mon Sep 17 00:00:00 2001
 From: X512 <danger_mail@list.ru>
 Date: Wed, 12 May 2021 18:03:24 +0900
 Subject: WIP: Haiku patches, share UART with RISC-V machine
 
+---
+ Makefile        |   9 +-
+ cutils.h        |   2 +-
+ fs_disk.c       |  15 +++
+ riscv_cpu.c     |   7 +-
+ riscv_machine.c |  26 ++++-
+ sdl.c           |   2 +-
+ temu.c          |  18 ++--
+ uart.c          | 228 +++++++++++++++++++++++++++++++++++++++
+ uart.h          |  58 ++++++++++
+ x86_machine.c   | 275 +-----------------------------------------------
+ 10 files changed, 349 insertions(+), 291 deletions(-)
+ create mode 100644 uart.c
+ create mode 100644 uart.h
 
 diff --git a/Makefile b/Makefile
 index 390ae37..dc059cd 100644
@@ -905,6 +919,121 @@ index db8f6bb..8497a45 100644
  
  #ifdef DEBUG_BIOS
  static void bios_debug_write(void *opaque, uint32_t offset,
+-- 
+2.30.2
+
+From da1e4672ff3f6fa53ee0c7ea72e6e116b8903999 Mon Sep 17 00:00:00 2001
+From: X512 <danger_mail@list.ru>
+Date: Sun, 16 May 2021 22:58:16 +0900
+Subject: implement `utime` register
+
+---
+ riscv_cpu.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/riscv_cpu.c b/riscv_cpu.c
+index cfb910a..b765be6 100644
+--- a/riscv_cpu.c
++++ b/riscv_cpu.c
+@@ -29,6 +29,8 @@
+ #include <assert.h>
+ #include <fcntl.h>
+ 
++#include <OS.h> // system_time()
++
+ #include "cutils.h"
+ #include "iomem.h"
+ #include "riscv_cpu.h"
+@@ -748,6 +750,9 @@ static int csr_read(RISCVCPUState *s, target_ulong *pval, uint32_t csr,
+         }
+         val = (int64_t)s->insn_counter;
+         break;
++    case 0xc01: /* utime */
++        val = system_time();
++        break;
+     case 0xc80: /* mcycleh */
+     case 0xc82: /* minstreth */
+         if (s->cur_xlen != 32)
+-- 
+2.30.2
+
+From beafad98395ef74fc64c9b3461ee46879d9ae647 Mon Sep 17 00:00:00 2001
+From: X512 <danger_mail@list.ru>
+Date: Sun, 16 May 2021 22:58:38 +0900
+Subject: virtio: increase queue size, style changes for Pe editor
+
+---
+ virtio.c | 22 +++++++++++-----------
+ 1 file changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/virtio.c b/virtio.c
+index 8d07f44..56746db 100644
+--- a/virtio.c
++++ b/virtio.c
+@@ -93,7 +93,7 @@
+ 
+ #define MAX_QUEUE 8
+ #define MAX_CONFIG_SPACE_SIZE 256
+-#define MAX_QUEUE_NUM 16
++#define MAX_QUEUE_NUM 32
+ 
+ typedef struct {
+     uint32_t ready; /* 0 or 1 */
+@@ -977,8 +977,8 @@ static void virtio_config_change_notify(VIRTIODevice *s)
+     set_irq(s->irq, 1);
+ }
+ 
+-/*********************************************************************/
+-/* block device */
++
++//#pragma mark block device
+ 
+ typedef struct {
+     uint32_t type;
+@@ -1131,8 +1131,8 @@ VIRTIODevice *virtio_block_init(VIRTIOBusDef *bus, BlockDevice *bs)
+     return (VIRTIODevice *)s;
+ }
+ 
+-/*********************************************************************/
+-/* network device */
++
++//#pragma mark network device
+ 
+ typedef struct VIRTIONetDevice {
+     VIRTIODevice common;
+@@ -1257,8 +1257,8 @@ VIRTIODevice *virtio_net_init(VIRTIOBusDef *bus, EthernetDevice *es)
+     return (VIRTIODevice *)s;
+ }
+ 
+-/*********************************************************************/
+-/* console device */
++
++//#pragma mark console device
+ 
+ typedef struct VIRTIOConsoleDevice {
+     VIRTIODevice common;
+@@ -1359,8 +1359,8 @@ VIRTIODevice *virtio_console_init(VIRTIOBusDef *bus, CharacterDevice *cs)
+     return (VIRTIODevice *)s;
+ }
+ 
+-/*********************************************************************/
+-/* input device */
++
++//#pragma mark input device
+ 
+ enum {
+     VIRTIO_INPUT_CFG_UNSET      = 0x00,
+@@ -1643,8 +1643,8 @@ VIRTIODevice *virtio_input_init(VIRTIOBusDef *bus, VirtioInputTypeEnum type)
+     return (VIRTIODevice *)s;
+ }
+ 
+-/*********************************************************************/
+-/* 9p filesystem device */
++
++//#pragma mark 9p filesystem device
+ 
+ typedef struct {
+     struct list_head link;
 -- 
 2.30.2
 

--- a/app-emulation/tinyemu/tinyemu-2019.12.21.recipe
+++ b/app-emulation/tinyemu/tinyemu-2019.12.21.recipe
@@ -6,15 +6,15 @@ Main features:
 
 RISC-V system emulator supporting the RV128IMAFDQC base ISA \
 (user level ISA version 2.2, priviledged architecture version 1.10) \
-including: 
-* 32/64/128 bit integer registers 
-* 32/64/128 bit floating point instructions (using the SoftFP Library) 
-* Compressed instructions 
-* Dynamic XLEN change 
-* VirtIO console, network, block device, input and 9P filesystem 
-* Graphical display with SDL 
-* JSON configuration file 
-* Remote HTTP block device and filesystem 
+including:
+* 32/64/128 bit integer registers
+* 32/64/128 bit floating point instructions (using the SoftFP Library)
+* Compressed instructions
+* Dynamic XLEN change
+* VirtIO console, network, block device, input and 9P filesystem
+* Graphical display with SDL
+* JSON configuration file
+* Remote HTTP block device and filesystem
 * Small code, easy to modify, few external dependancies."
 HOMEPAGE="https://bellard.org/tinyemu/"
 COPYRIGHT="2017-2019 Fabrice Bellard"
@@ -44,7 +44,7 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libcrypto$secondaryArchSuffix
 	lib:libcurl$secondaryArchSuffix
-	lib:libSDL_1.2$secondaryArchSuffix	
+	lib:libSDL_1.2$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
@@ -59,7 +59,7 @@ BUILD_PREREQUIRES="
 	"
 
 BUILD()
-{	
+{
 	make $jobArgs
 }
 

--- a/app-emulation/tinyemu/tinyemu-2019.12.21.recipe
+++ b/app-emulation/tinyemu/tinyemu-2019.12.21.recipe
@@ -19,7 +19,7 @@ including:
 HOMEPAGE="https://bellard.org/tinyemu/"
 COPYRIGHT="2017-2019 Fabrice Bellard"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://bellard.org/tinyemu/tinyemu-${portVersion//./-}.tar.gz"
 CHECKSUM_SHA256="be8351f2121819b3172fcedce5cb1826fa12c87da1b7ed98f269d3e802a05555"
 SOURCE_DIR="tinyemu-${portVersion//./-}"


### PR DESCRIPTION
Pulls in @X547's [latest patch for x86-64](https://gist.github.com/X547/4d345a9ebe65ebc954baf13807cf61be) needed to run their [RISC-V Haiku port rev2](https://github.com/X547/Haiku-riscv/releases/tag/rev2).

Screenshot of their Haiku RISC-V port rev2 running inside a x86-64 Haiku install with the new patch:
![temu_x86-64](https://user-images.githubusercontent.com/11584387/118403142-932a2480-b69f-11eb-8155-bcab9a62a719.png)

Authored-by: X512 (@X547)
