### PR TITLE
pdfwriter: bump recipe

### DIFF
--- a/haiku-misc/pdfwriter/pdfwriter-1.0.recipe
+++ b/haiku-misc/pdfwriter/pdfwriter-1.0.recipe
@@ -4,13 +4,13 @@ instead of sending output to a printer."
 HOMEPAGE="https://github.com/HaikuArchives/PDFWriter"
 COPYRIGHT="2003 Phillipe Houdoin, Michael Pfeiffer, Simon Gauvin"
 LICENSE="MIT"
-REVISION="3"
+REVISION="4"
 srcGitRev="ec11100d870e967d04fd1b89bc6964beddbe0122"
 SOURCE_URI="$HOMEPAGE/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="046eacb405b715a2565d5ccd4ad5045f70e9daefc2f85b4e82332fb5401d2423"
 SOURCE_DIR="PDFWriter-$srcGitRev"
 
-ARCHITECTURES="x86_gcc2 ?x86 x86_64"
+ARCHITECTURES="x86_gcc2 x86_64"
 
 PROVIDES="
 	PDFWriter = $portVersion


### PR DESCRIPTION
Rebuilt on Haiku R1B2 (+134) x86_64. No build issues as of May 19, 2021.
Closes: https://dev.haiku-os.org/ticket/13313