### PR TITLE
pango: bump version and add missing REQUIRES_devel declarations

### DIFF
--- a/x11-libs/pango/pango-1.48.5.recipe
+++ b/x11-libs/pango/pango-1.48.5.recipe
@@ -20,8 +20,8 @@ SOURCE_URI="http://ftp.gnome.org/pub/GNOME/sources/pango/${portVersion%.*}/pango
 CHECKSUM_SHA256="501e74496173c02dcd024ded7fbb3f09efd37e2a488e248aa40799424dbb3b2a"
 PATCHES="pango-$portVersion.patchset"
 
-ARCHITECTURES="!x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
+ARCHITECTURES="!x86_gcc2 x86_64"
+SECONDARY_ARCHITECTURES="x86"
 
 libVersion="0.4800.5"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"

--- a/x11-libs/pango/pango-1.48.5.recipe
+++ b/x11-libs/pango/pango-1.48.5.recipe
@@ -17,19 +17,22 @@ COPYRIGHT="1999-2007,2010 Red Hat Software
 LICENSE="GNU LGPL v2.1"
 REVISION="1"
 SOURCE_URI="http://ftp.gnome.org/pub/GNOME/sources/pango/${portVersion%.*}/pango-$portVersion.tar.xz"
-CHECKSUM_SHA256="1d2b74cd63e8bd41961f2f8d952355aa0f9be6002b52c8aa7699d9f5da597c9d"
+CHECKSUM_SHA256="501e74496173c02dcd024ded7fbb3f09efd37e2a488e248aa40799424dbb3b2a"
 PATCHES="pango-$portVersion.patchset"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
 
+libVersion="0.4800.5"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
 PROVIDES="
 	pango$secondaryArchSuffix = $portVersion compat >= 1
 	cmd:pango_list$secondaryArchSuffix
 	cmd:pango_view$secondaryArchSuffix
-	lib:libpango_1.0$secondaryArchSuffix = 0.4200.4 compat >= 0
-	lib:libpangocairo_1.0$secondaryArchSuffix = 0.4200.4 compat >= 0
-	lib:libpangoft2_1.0$secondaryArchSuffix = 0.4200.4 compat >= 0
+	lib:libpango_1.0$secondaryArchSuffix = $libVersionCompat
+	lib:libpangocairo_1.0$secondaryArchSuffix = $libVersionCompat
+	lib:libpangoft2_1.0$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -45,13 +48,20 @@ REQUIRES="
 
 PROVIDES_devel="
 	pango${secondaryArchSuffix}_devel = $portVersion compat >= 1
-	devel:libpango_1.0$secondaryArchSuffix = 0.4200.4 compat >= 0
-	devel:libpangocairo_1.0$secondaryArchSuffix = 0.4200.4 compat >= 0
-	devel:libpangoft2_1.0$secondaryArchSuffix = 0.4200.4 compat >= 0
+	devel:libpango_1.0$secondaryArchSuffix = $libVersionCompat
+	devel:libpangocairo_1.0$secondaryArchSuffix = $libVersionCompat
+	devel:libpangoft2_1.0$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
 	pango$secondaryArchSuffix == $portVersion base
+	devel:libcairo$secondaryArchSuffix
+	devel:libfontconfig$secondaryArchSuffix
+	devel:libfreetype$secondaryArchSuffix
+	devel:libfribidi$secondaryArchSuffix
+	devel:libglib_2.0$secondaryArchSuffix
 	devel:libharfbuzz$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
+	devel:libintl$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
@@ -67,23 +77,21 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:gtkdocize
 	cmd:ld$secondaryArchSuffix
-	cmd:libtoolize$secondaryArchSuffix
-	cmd:make
+	cmd:meson
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
 BUILD()
 {
-	runConfigure ./configure
-	make $jobArgs
+	meson build \
+		--prefix="$prefix" --libdir="$libDir" --includedir="$includeDir" \
+		--bindir="$binDir"
+	meson compile -C build
 }
 
 INSTALL()
 {
-	make install
-
-	# remove libtool library files
-	rm $libDir/libpango*.la
+	meson install -C build
 
 	prepareInstalledDevelLibs libpango-1.0 \
 		libpangocairo-1.0 libpangoft2-1.0
@@ -96,5 +104,5 @@ INSTALL()
 
 TEST()
 {
-	make check
+	meson test -C build
 }

--- a/x11-libs/pango/patches/pango-1.48.5.patchset
+++ b/x11-libs/pango/patches/pango-1.48.5.patchset
@@ -1,23 +1,23 @@
-From 88c1e88b8635d53c0662e2bbca6c1e36abdb2941 Mon Sep 17 00:00:00 2001
+From 2d117cae0c7298d1e408e39e2056e7ff2950fcce Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Mon, 12 Oct 2015 22:19:59 +0000
 Subject: Haiku patch
 
 
 diff --git a/tests/testattributes.c b/tests/testattributes.c
-index f4c33f1..52d3b67 100644
+index 8e63201..1c9f8d9 100644
 --- a/tests/testattributes.c
 +++ b/tests/testattributes.c
-@@ -343,7 +343,7 @@ test_list_filter (void)
+@@ -412,7 +412,7 @@ test_list_filter (void)
    g_assert_null (out);
  
    out = pango_attr_list_filter (list, just_weight, NULL);
 -  g_assert_nonnull (out);
 +  g_assert (out != NULL);
  
-   s = g_string_new ("");
-   print_attributes (attr_list_to_list (list), s);
-@@ -436,11 +436,11 @@ test_iter_get (void)
+   assert_attr_list (list, "[0,-1]size=10\n"
+                           "[10,20]stretch=2\n");
+@@ -505,11 +505,11 @@ test_iter_get (void)
    iter = pango_attr_list_get_iterator (list);
    pango_attr_iterator_next (iter);
    attr = pango_attr_iterator_get (iter, PANGO_ATTR_SIZE);
@@ -31,7 +31,7 @@ index f4c33f1..52d3b67 100644
    g_assert_cmpuint (attr->start_index, ==, 10);
    g_assert_cmpuint (attr->end_index, ==, 30);
    attr = pango_attr_iterator_get (iter, PANGO_ATTR_WEIGHT);
-@@ -499,7 +499,7 @@ test_iter_get_font (void)
+@@ -567,7 +567,7 @@ test_iter_get_font (void)
    pango_attr_iterator_get_font (iter, desc, &lang, &attrs);
    desc2 = pango_font_description_from_string ("Times Condensed 10");
    g_assert_true (pango_font_description_equal (desc, desc2));
@@ -41,5 +41,5 @@ index f4c33f1..52d3b67 100644
    g_assert_null (attrs);
    pango_font_description_free (desc);
 -- 
-2.14.2
+2.30.2
 


### PR DESCRIPTION
the build system was changed to meson
also, use libVersion and libVersionCompat variables

test results: 5 of the tests crash, the others pass