### PR TITLE
mpg123: bump versions

### DIFF
--- a/media-sound/mpg123/mpg123-1.25.15.recipe
+++ b/media-sound/mpg123/mpg123-1.25.15.recipe
@@ -2,21 +2,19 @@ SUMMARY="A fast console MPEG audio player and decoder library"
 DESCRIPTION="mpg123 is the fast and free console based real time MPEG audio \
 player for layer 1, 2 and 3."
 HOMEPAGE="https://www.mpg123.org/"
-COPYRIGHT="1995-2020 Michael Hipp and others"
+COPYRIGHT="1995-2021 Michael Hipp and others"
 LICENSE="GNU LGPL v2.1"
 REVISION="1"
 SOURCE_URI="https://downloads.sourceforge.net/mpg123/mpg123-$portVersion.tar.bz2"
-CHECKSUM_SHA256="081991540df7a666b29049ad870f293cfa28863b36488ab4d58ceaa7b5846454"
+CHECKSUM_SHA256="503a76d82d97f1a6513bbeb284e460a99fb17ef80f23a661d8fc026ce6adcbbc"
 
-ARCHITECTURES="!x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
+ARCHITECTURES="x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
-libmpg123Version="0.45.3"
-libout123Version="0.3.0"
-libsyn123Version="0.1.1"
+libmpg123Version="0.44.12"
+libout123Version="0.2.2"
 libmpg123VersionCompat="$libmpg123Version compat >= ${libmpg123Version%%.*}"
 libout123VersionCompat="$libout123Version compat >= ${libout123Version%%.*}"
-libsyn123VersionCompat="$libsyn123Version compat >= ${libsyn123Version%%.*}"
 PROVIDES="
 	mpg123$secondaryArchSuffix = $portVersion
 	cmd:mpg123$secondaryArchSuffix = $portVersion
@@ -25,7 +23,6 @@ PROVIDES="
 	cmd:out123$secondaryArchSuffix = $portVersion
 	lib:libmpg123$secondaryArchSuffix = $libmpg123VersionCompat
 	lib:libout123$secondaryArchSuffix = $libout123VersionCompat
-	lib:libsyn123$secondaryArchSuffix = $libsyn123VersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -36,7 +33,6 @@ PROVIDES_devel="
 	mpg123${secondaryArchSuffix}_devel = $portVersion
 	devel:libmpg123$secondaryArchSuffix = $libmpg123VersionCompat
 	devel:libout123$secondaryArchSuffix = $libout123VersionCompat
-	devel:libsyn123$secondaryArchSuffix = $libsyn123VersionCompat
 	"
 REQUIRES_devel="
 	haiku$secondaryArchSuffix
@@ -65,7 +61,6 @@ defineDebugInfoPackage mpg123$secondaryArchSuffix \
 	"$binDir"/out123 \
 	"$libDir"/libmpg123.so.$libmpg123Version \
 	"$libDir"/libout123.so.$libout123Version \
-	"$libDir"/libsyn123.so.$libsyn123Version \
 	"$libDir"/mpg123/output_dummy.so
 
 BUILD()
@@ -86,8 +81,7 @@ INSTALL()
 
 	prepareInstalledDevelLibs \
 		libmpg123 \
-		libout123 \
-		libsyn123
+		libout123
 	fixPkgconfig
 	packageEntries devel $developDir
 }

--- a/media-sound/mpg123/mpg123-1.28.0.recipe
+++ b/media-sound/mpg123/mpg123-1.28.0.recipe
@@ -2,19 +2,21 @@ SUMMARY="A fast console MPEG audio player and decoder library"
 DESCRIPTION="mpg123 is the fast and free console based real time MPEG audio \
 player for layer 1, 2 and 3."
 HOMEPAGE="https://www.mpg123.org/"
-COPYRIGHT="1995-2019 Michael Hipp and others"
+COPYRIGHT="1995-2021 Michael Hipp and others"
 LICENSE="GNU LGPL v2.1"
 REVISION="1"
 SOURCE_URI="https://downloads.sourceforge.net/mpg123/mpg123-$portVersion.tar.bz2"
-CHECKSUM_SHA256="90306848359c793fd43b9906e52201df18775742dc3c81c06ab67a806509890a"
+CHECKSUM_SHA256="e49466853685026da5d113dc7ff026b1b2ad0b57d78df693a446add9db88a7d5"
 
-ARCHITECTURES="x86_gcc2 x86 x86_64"
-SECONDARY_ARCHITECTURES="x86_gcc2 x86"
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
 
-libmpg123Version="0.44.10"
-libout123Version="0.2.2"
+libmpg123Version="0.46.2"
+libout123Version="0.4.0"
+libsyn123Version="0.1.3"
 libmpg123VersionCompat="$libmpg123Version compat >= ${libmpg123Version%%.*}"
 libout123VersionCompat="$libout123Version compat >= ${libout123Version%%.*}"
+libsyn123VersionCompat="$libsyn123Version compat >= ${libsyn123Version%%.*}"
 PROVIDES="
 	mpg123$secondaryArchSuffix = $portVersion
 	cmd:mpg123$secondaryArchSuffix = $portVersion
@@ -23,6 +25,7 @@ PROVIDES="
 	cmd:out123$secondaryArchSuffix = $portVersion
 	lib:libmpg123$secondaryArchSuffix = $libmpg123VersionCompat
 	lib:libout123$secondaryArchSuffix = $libout123VersionCompat
+	lib:libsyn123$secondaryArchSuffix = $libsyn123VersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -33,6 +36,7 @@ PROVIDES_devel="
 	mpg123${secondaryArchSuffix}_devel = $portVersion
 	devel:libmpg123$secondaryArchSuffix = $libmpg123VersionCompat
 	devel:libout123$secondaryArchSuffix = $libout123VersionCompat
+	devel:libsyn123$secondaryArchSuffix = $libsyn123VersionCompat
 	"
 REQUIRES_devel="
 	haiku$secondaryArchSuffix
@@ -61,6 +65,7 @@ defineDebugInfoPackage mpg123$secondaryArchSuffix \
 	"$binDir"/out123 \
 	"$libDir"/libmpg123.so.$libmpg123Version \
 	"$libDir"/libout123.so.$libout123Version \
+	"$libDir"/libsyn123.so.$libsyn123Version \
 	"$libDir"/mpg123/output_dummy.so
 
 BUILD()
@@ -81,7 +86,8 @@ INSTALL()
 
 	prepareInstalledDevelLibs \
 		libmpg123 \
-		libout123
+		libout123 \
+		libsyn123
 	fixPkgconfig
 	packageEntries devel $developDir
 }


### PR DESCRIPTION
Update mpg123 versions to 1.28.0 and 1.25.15 (fox x86_gcc2).