### PR TITLE
mesa: fixed mako_python3 for x86

### DIFF
--- a/sys-libs/mesa/mesa-21.0.3.recipe
+++ b/sys-libs/mesa/mesa-21.0.3.recipe
@@ -10,10 +10,9 @@ REVISION="1"
 SOURCE_URI="https://mesa.freedesktop.org/archive/mesa-${portVersion}.tar.xz"
 CHECKSUM_SHA256="565c6f4bd2d5747b919454fc1d439963024fc78ca56fd05158c3b2cde2f6912b"
 SOURCE_DIR="mesa-${portVersion}"
-#PATCHES="mesa-${portVersion}.patchset"
 
-ARCHITECTURES="!x86_gcc2 ?x86_64 ?arm ?arm64 ?m68k ?ppc ?riscv64 ?sparc"
-SECONDARY_ARCHITECTURES="?x86"
+ARCHITECTURES="!x86_gcc2 x86_64 ?arm ?arm64 ?m68k ?ppc ?riscv64 ?sparc"
+SECONDARY_ARCHITECTURES="x86"
 
 libVersion=1.0.0
 libOSMesaVersion=8.0.0
@@ -75,7 +74,7 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	python3$secondaryArchSuffix
-	mako_python3$secondaryArchSuffix
+	mako_python3
 	cmd:ninja
 	cmd:bison
 	cmd:find

--- a/sys-libs/mesa/mesa-21.0.3.recipe
+++ b/sys-libs/mesa/mesa-21.0.3.recipe
@@ -11,8 +11,8 @@ SOURCE_URI="https://mesa.freedesktop.org/archive/mesa-${portVersion}.tar.xz"
 CHECKSUM_SHA256="565c6f4bd2d5747b919454fc1d439963024fc78ca56fd05158c3b2cde2f6912b"
 SOURCE_DIR="mesa-${portVersion}"
 
-ARCHITECTURES="!x86_gcc2 x86_64 ?arm ?arm64 ?m68k ?ppc ?riscv64 ?sparc"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="!x86_gcc2 ?x86_64 ?arm ?arm64 ?m68k ?ppc ?riscv64 ?sparc"
+SECONDARY_ARCHITECTURES="?x86"
 
 libVersion=1.0.0
 libOSMesaVersion=8.0.0


### PR DESCRIPTION
Built and unit tested on Haiku R1B2 x86. For use on Haiku R1B3 and compatible nightly builds.

Mesa 21.0.3 implements the OpenGL 4.6 API and Vulkan 1.2 API.

    Stable release
    Compiled and packaged fine on Haiku hrev54972 x86 and x86_64 platforms.
    Unit tested. Only 7 failed out of 74 unit tests - minor Haiku GL type symbol export check errors.
    Works with Blender 2.92/2.93.1, Dragengine 1.4/1.5, and Godot 3.3.2
