### PR TITLE
freac: bump revision to trigger new build

### DIFF
--- a/media-sound/freac/freac-1.1.5.recipe
+++ b/media-sound/freac/freac-1.1.5.recipe
@@ -17,7 +17,7 @@ Features include:
 HOMEPAGE="https://freac.org/"
 COPYRIGHT="2001-2021 Robert Kausch"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/enzo1982/freac/releases/download/v${portVersion}/freac-${portVersion}.tar.gz"
 CHECKSUM_SHA256="62c61840a935dba5230fb7295b508370cd4f1e861db9d479f21c858a8aac3470"
 SOURCE_DIR="freac-${portVersion}"


### PR DESCRIPTION
Update fre:ac revision to trigger new build after smooth 0.9.8 merge.

This should be merged after BoCA (#6024).