### PR TITLE
dosbox_pure_libretro: enabled 32bit build

### DIFF
--- a/games-emulation/dosbox_pure_libretro/dosbox_pure_libretro-0.13_20210514.recipe
+++ b/games-emulation/dosbox_pure_libretro/dosbox_pure_libretro-0.13_20210514.recipe
@@ -15,22 +15,23 @@ SOURCE_FILENAME="dosbox-pure-${portVersion/_/-}-$srcGitRev.tar.gz"
 SOURCE_DIR="dosbox-pure-$srcGitRev"
 ADDITIONAL_FILES="dosbox_pure_libretro.info.in"
 
-ARCHITECTURES="!x86_gcc2 !x86 x86_64"
+ARCHITECTURES="!x86_gcc2 x86_64"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	dosbox_pure_libretro = $portVersion
-	addon:dosbox_pure_libretro = $portVersion
+	dosbox_pure_libretro$secondaryArchSuffix = $portVersion
+	addon:dosbox_pure_libretro$secondaryArchSuffix = $portVersion
 	"
 REQUIRES="
-	haiku
-	retroarch
+	haiku$secondaryArchSuffix
+	retroarch$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
+	haiku${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
-	cmd:gcc
+	cmd:gcc$secondaryArchSuffix
 	cmd:make
 	"
 


### PR DESCRIPTION
Thanks to help from @Begasus - this allows building the dosbox_pure libretro core on 32bit Haiku