### PR TITLE
libpurple, include icons

### DIFF
--- a/dev-libs/libpurple/libpurple-2.14.5.recipe
+++ b/dev-libs/libpurple/libpurple-2.14.5.recipe
@@ -4,7 +4,7 @@ source IM clients. It implements a variety of protocols, for example IRC, \
 Jabber or ICQ."
 HOMEPAGE="https://pidgin.im/"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://downloads.sourceforge.net/project/pidgin/Pidgin/$portVersion/pidgin-$portVersion.tar.bz2"
 CHECKSUM_SHA256="26db80d2a3c1e740952757bd53c15b8fc8dd780dc8819a74b53b2ef3bfaf041f"
 COPYRIGHT="1998-2018 Rob Flynn et al."
@@ -157,6 +157,8 @@ BUILD()
 
 INSTALL()
 {
+	make install
+	cd pidgin/pixmaps/
 	make install
 
 	rm -rf $prefix/share


### PR DESCRIPTION
Pidgin's icons (including icons for protocols included with libpurple) might be useful to add to the port― this just pops them in.