### PR TITLE
gutenprint: enable gutenprint9 build

### DIFF
--- a/net-print/gutenprint/gutenprint9-5.3.4.recipe
+++ b/net-print/gutenprint/gutenprint9-5.3.4.recipe
@@ -19,8 +19,8 @@ CHECKSUM_SHA256="db44a701d2b8e6a8931c83cec06c91226be266d23e5c189d20a39dd175f2023
 SOURCE_DIR="gutenprint-$portVersion"
 PATCHES="gutenprint-$portVersion.patchset"
 
-ARCHITECTURES="?x86_gcc2 ?x86_64"
-SECONDARY_ARCHITECTURES="?x86"
+ARCHITECTURES="?x86_gcc2 x86_64"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	gutenprint9$secondaryArchSuffix = $portVersion


### PR DESCRIPTION
Ref: https://dev.haiku-os.org/ticket/16300
Ref: https://github.com/haikuports/haikuports/issues/4980
NOTE: This just adds the packages to the repo. Needs kernel-side updates for newer API.