### PR TITLE
openblas: bump with patch

### DIFF
--- a/sci-libs/openblas/openblas-0.3.17.recipe
+++ b/sci-libs/openblas/openblas-0.3.17.recipe
@@ -62,7 +62,8 @@ case "$effectiveTargetArchitecture" in
 	*) target=;;
 esac
 
-BUILD_CONF="NO_LAPACK=1 \
+BUILD_CONF="NO_STATIC=1 \
+		NO_LAPACK=1 \
 		NO_LAPACKE=1 \
 		NO_AFFINITY=1 \
 		NO_WARMUP=1 \
@@ -74,7 +75,8 @@ BUILD()
 {
 	make MAKE_NB_JOBS=${jobArgs#-j} \
 		$BUILD_CONF \
-		${target:+TARGET=$target}
+		${target:+TARGET=$target} \
+		libs shared
 }
 
 INSTALL()

--- a/sci-libs/openblas/openblas-0.3.17.recipe
+++ b/sci-libs/openblas/openblas-0.3.17.recipe
@@ -4,11 +4,12 @@ version."
 HOMEPAGE="http://www.openblas.net/"
 COPYRIGHT="2011-2021 The OpenBLAS Project"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="http://github.com/xianyi/OpenBLAS/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="df2934fa33d04fd84d839ca698280df55c690c86a5a1133b3f7266fce1de279f"
 SOURCE_FILENAME="OpenBLAS-$portVersion.tar.gz"
 SOURCE_DIR="OpenBLAS-$portVersion"
+PATCHES="openblas-$portVersion.patchset"
 
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
@@ -61,11 +62,10 @@ case "$effectiveTargetArchitecture" in
 	*) target=;;
 esac
 
-BUILD_CONF="NO_STATIC=1 NO_LAPACK=1 \
+BUILD_CONF="NO_LAPACK=1 \
 		NO_LAPACKE=1 \
 		NO_AFFINITY=1 \
 		NO_WARMUP=1 \
-		NO_AVX=1 \
 		NUM_THREADS=64 \
 		DYNAMIC_ARCH=1 \
 		USE_OPENMP=1"
@@ -74,8 +74,7 @@ BUILD()
 {
 	make MAKE_NB_JOBS=${jobArgs#-j} \
 		$BUILD_CONF \
-		${target:+TARGET=$target} \
-		libs shared
+		${target:+TARGET=$target}
 }
 
 INSTALL()

--- a/sci-libs/openblas/patches/openblas-0.3.17.patchset
+++ b/sci-libs/openblas/patches/openblas-0.3.17.patchset
@@ -1,0 +1,67 @@
+From d05e2ec0713ba49796faa04641644156e171e4c5 Mon Sep 17 00:00:00 2001
+From: Craig Watson <watsoncraigjohn@gmail.com>
+Date: Sat, 24 Jul 2021 13:36:09 +0000
+Subject: Include Haiku in processor count checks
+
+
+diff --git a/driver/others/memory.c b/driver/others/memory.c
+index 6e654cc..aac8341 100644
+--- a/driver/others/memory.c
++++ b/driver/others/memory.c
+@@ -428,7 +428,7 @@ extern int openblas_goto_num_threads_env();
+ extern int openblas_omp_num_threads_env();
+ 
+ int blas_get_cpu_number(void){
+-#if defined(OS_LINUX) || defined(OS_WINDOWS) || defined(OS_FREEBSD) || defined(OS_OPENBSD) || defined(OS_NETBSD) || defined(OS_DRAGONFLY) || defined(OS_DARWIN) || defined(OS_ANDROID)
++#if defined(OS_LINUX) || defined(OS_WINDOWS) || defined(OS_FREEBSD) || defined(OS_OPENBSD) || defined(OS_NETBSD) || defined(OS_DRAGONFLY) || defined(OS_DARWIN) || defined(OS_ANDROID) || defined(OS_HAIKU)
+   int max_num;
+ #endif
+   int blas_goto_num   = 0;
+@@ -436,7 +436,7 @@ int blas_get_cpu_number(void){
+ 
+   if (blas_num_threads) return blas_num_threads;
+ 
+-#if defined(OS_LINUX) || defined(OS_WINDOWS) || defined(OS_FREEBSD) || defined(OS_OPENBSD) || defined(OS_NETBSD) || defined(OS_DRAGONFLY) || defined(OS_DARWIN) || defined(OS_ANDROID)
++#if defined(OS_LINUX) || defined(OS_WINDOWS) || defined(OS_FREEBSD) || defined(OS_OPENBSD) || defined(OS_NETBSD) || defined(OS_DRAGONFLY) || defined(OS_DARWIN) || defined(OS_ANDROID) || defined(OS_HAIKU)
+   max_num = get_num_procs();
+ #endif
+ 
+@@ -460,7 +460,7 @@ int blas_get_cpu_number(void){
+   else if (blas_omp_num > 0) blas_num_threads = blas_omp_num;
+   else blas_num_threads = MAX_CPU_NUMBER;
+ 
+-#if defined(OS_LINUX) || defined(OS_WINDOWS) || defined(OS_FREEBSD) || defined(OS_OPENBSD) || defined(OS_NETBSD) || defined(OS_DRAGONFLY) || defined(OS_DARWIN) || defined(OS_ANDROID)
++#if defined(OS_LINUX) || defined(OS_WINDOWS) || defined(OS_FREEBSD) || defined(OS_OPENBSD) || defined(OS_NETBSD) || defined(OS_DRAGONFLY) || defined(OS_DARWIN) || defined(OS_ANDROID) || defined(OS_HAIKU)
+   if (blas_num_threads > max_num) blas_num_threads = max_num;
+ #endif
+ 
+@@ -1979,7 +1979,7 @@ extern int openblas_goto_num_threads_env();
+ extern int openblas_omp_num_threads_env();
+ 
+ int blas_get_cpu_number(void){
+-#if defined(OS_LINUX) || defined(OS_WINDOWS) || defined(OS_FREEBSD) || defined(OS_OPENBSD) || defined(OS_NETBSD) || defined(OS_DRAGONFLY) || defined(OS_DARWIN) || defined(OS_ANDROID)
++#if defined(OS_LINUX) || defined(OS_WINDOWS) || defined(OS_FREEBSD) || defined(OS_OPENBSD) || defined(OS_NETBSD) || defined(OS_DRAGONFLY) || defined(OS_DARWIN) || defined(OS_ANDROID)|| defined(OS_HAIKU)
+   int max_num;
+ #endif
+   int blas_goto_num   = 0;
+@@ -1987,7 +1987,7 @@ int blas_get_cpu_number(void){
+ 
+   if (blas_num_threads) return blas_num_threads;
+ 
+-#if defined(OS_LINUX) || defined(OS_WINDOWS) || defined(OS_FREEBSD) || defined(OS_OPENBSD) || defined(OS_NETBSD) || defined(OS_DRAGONFLY) || defined(OS_DARWIN) || defined(OS_ANDROID)
++#if defined(OS_LINUX) || defined(OS_WINDOWS) || defined(OS_FREEBSD) || defined(OS_OPENBSD) || defined(OS_NETBSD) || defined(OS_DRAGONFLY) || defined(OS_DARWIN) || defined(OS_ANDROID)|| defined(OS_HAIKU)
+   max_num = get_num_procs();
+ #endif
+ 
+@@ -2011,7 +2011,7 @@ int blas_get_cpu_number(void){
+   else if (blas_omp_num > 0) blas_num_threads = blas_omp_num;
+   else blas_num_threads = MAX_CPU_NUMBER;
+ 
+-#if defined(OS_LINUX) || defined(OS_WINDOWS) || defined(OS_FREEBSD) || defined(OS_OPENBSD) || defined(OS_NETBSD) || defined(OS_DRAGONFLY) || defined(OS_DARWIN) || defined(OS_ANDROID)
++#if defined(OS_LINUX) || defined(OS_WINDOWS) || defined(OS_FREEBSD) || defined(OS_OPENBSD) || defined(OS_NETBSD) || defined(OS_DRAGONFLY) || defined(OS_DARWIN) || defined(OS_ANDROID)|| defined(OS_HAIKU)
+   if (blas_num_threads > max_num) blas_num_threads = max_num;
+ #endif
+ 
+-- 
+2.30.2
+


### PR DESCRIPTION
Run full build successfully, also launches digiKam, etc. without crashing.

I've also re-enabled AVX since this should be supported now, original issue for disabling it was here: https://github.com/xianyi/OpenBLAS/issues/1916 - this was due to Haiku not supporting AVX at all at the time.

It should be detecting the processor and using AVX if the processor supports it at runtime (basically compiles a bunch of different versions for various x64 cpu types.)  If anyone is concerned about this it can always be taken out again with some performance hit, although if we can find someone with a Prescott x64 CPU, eg. a Pentium 4F and derivative to test, this would be helpful.

Patch should be upstreamed to openblas project so will hopefully not be needed in future.  I can attempt a pull for this unless someone else wants to volunteer.