### PR TITLE
Openblas bump, remove AVX512

### DIFF
--- a/sci-libs/openblas/openblas-0.3.17.recipe
+++ b/sci-libs/openblas/openblas-0.3.17.recipe
@@ -4,7 +4,7 @@ version."
 HOMEPAGE="http://www.openblas.net/"
 COPYRIGHT="2011-2021 The OpenBLAS Project"
 LICENSE="BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="http://github.com/xianyi/OpenBLAS/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="df2934fa33d04fd84d839ca698280df55c690c86a5a1133b3f7266fce1de279f"
 SOURCE_FILENAME="OpenBLAS-$portVersion.tar.gz"
@@ -67,6 +67,7 @@ BUILD_CONF="NO_STATIC=1 \
 		NO_LAPACKE=1 \
 		NO_AFFINITY=1 \
 		NO_WARMUP=1 \
+		NO_AVX512=1 \
 		NUM_THREADS=64 \
 		DYNAMIC_ARCH=1 \
 		USE_OPENMP=1"


### PR DESCRIPTION
This will disable AVX512 kernels from building on x86_64 as it appears we do not support AVX512 in Haiku yet.