### PR TITLE
guile: move the guile interpreter tools to a 'tools' subpackage like guile1

### DIFF
--- a/dev-scheme/guile/guile-2.2.7.recipe
+++ b/dev-scheme/guile/guile-2.2.7.recipe
@@ -1,4 +1,5 @@
-SUMMARY="GNU Ubiquitous Intelligent Language for Extensions"
+SUMMARY="Libraries for GNU Ubiquitous Intelligent Language for Extensions"
+SUMMARY_tools="Binaries for GNU Ubiquitous Intelligent Language for Extensions"
 DESCRIPTION="Guile is a library designed to help programmers create flexible \
 applications. Using Guile in an application allows programmers to write \
 plug-ins, or modules (there are many names, but the concept is essentially \
@@ -6,7 +7,7 @@ the same) and users to use them to have an application fit their needs."
 HOMEPAGE="https://www.gnu.org/software/guile/"
 COPYRIGHT="1993-2020 Aubrey Jaffer, George Carrette, et al."
 LICENSE="GNU LGPL v3"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://ftpmirror.gnu.org/guile/guile-$portVersion.tar.lz
 	https://ftp.gnu.org/gnu/guile/guile-$portVersion.tar.lz"
 CHECKSUM_SHA256="5de7c4d28fa25c232512a4d1e76e6152a721dde568a6b1310971e1ea49e18c46"
@@ -29,10 +30,6 @@ portVers="${portVersion%.*}"
 
 PROVIDES="
 	guile$secondaryArchSuffix = $portVersionCompat
-	cmd:guild$commandSuffix = $portVersion
-	cmd:guile$commandSuffix = $portVersion
-	cmd:guile_snarf$commandSuffix = $portVersion
-	cmd:guile_tools$commandSuffix = $portVersion
 	lib:libguile_$portVers$secondaryArchSuffix = $libguileVersionCompat
 	"
 REQUIRES="
@@ -45,6 +42,25 @@ REQUIRES="
 	lib:libltdl$secondaryArchSuffix
 	lib:libncurses$secondaryArchSuffix
 	lib:libreadline$secondaryArchSuffix
+	lib:libunistring$secondaryArchSuffix
+	"
+
+PROVIDES_tools="
+	guile${secondaryArchSuffix}_tools = $portVersionCompat
+	cmd:guild$commandSuffix = $portVersion
+	cmd:guile$commandSuffix = $portVersion
+	cmd:guile_snarf$commandSuffix = $portVersion
+	cmd:guile_tools$commandSuffix = $portVersion
+	"
+REQUIRES_tools="
+	haiku$secondaryArchSuffix
+	guile$secondaryArchSuffix == $portVersion base
+	lib:libffi$secondaryArchSuffix
+	lib:libgc$secondaryArchSuffix
+	lib:libgmp$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libltdl$secondaryArchSuffix
 	lib:libunistring$secondaryArchSuffix
 	"
 
@@ -81,6 +97,7 @@ BUILD_PREREQUIRES="
 	"
 
 defineDebugInfoPackage guile$secondaryArchSuffix \
+	$(getPackagePrefix tools)/"$relativeBinDir"/guile \
 	"$libDir"/libguile-$portVers.so.$libguileVersion
 
 BUILD()
@@ -108,6 +125,13 @@ INSTALL()
 	prepareInstalledDevelLib libguile-$portVers
 
 	fixPkgconfig
+
+	packageEntries tools \
+		"$commandBinDir"/guild \
+		"$commandBinDir"/guile \
+		"$commandBinDir"/guile-snarf \
+		"$commandBinDir"/guile-tools \
+		"$manDir"
 
 	packageEntries devel \
 		"$binDir"/guile-config \

--- a/dev-scheme/guile/guile1-1.8.8.recipe
+++ b/dev-scheme/guile/guile1-1.8.8.recipe
@@ -7,7 +7,7 @@ the same) and users to use them to have an application fit their needs."
 HOMEPAGE="https://www.gnu.org/software/guile/"
 COPYRIGHT="1993-2018 Aubrey Jaffer, George Carrette, et al."
 LICENSE="GNU LGPL v3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://ftpmirror.gnu.org/guile/guile-$portVersion.tar.gz
 	https://ftp.gnu.org/gnu/guile/guile-$portVersion.tar.gz"
 CHECKSUM_SHA256="c3471fed2e72e5b04ad133bbaaf16369e8360283679bcf19800bc1b381024050"
@@ -34,10 +34,10 @@ PROVIDES="
 	guile1$secondaryArchSuffix = $portVersionCompat
 	lib:libguile$secondaryArchSuffix = $libguileVersionCompat
 	lib:libguilereadline_v_17$secondaryArchSuffix = $libguileVersionCompat
-	lib:libguile_srfi_srfi_1_v_3$secondaryArchSuffix = 3.0.2
-	lib:libguile_srfi_srfi_13_14_v_3$secondaryArchSuffix = 3.0.1
-	lib:libguile_srfi_srfi_4_v_3$secondaryArchSuffix = 3.0.1
-	lib:libguile_srfi_srfi_60_v_2$secondaryArchSuffix = 2.0.2
+	lib:libguile_srfi_srfi_1_v_3$secondaryArchSuffix = 3.0.2 compat >= 3
+	lib:libguile_srfi_srfi_13_14_v_3$secondaryArchSuffix = 3.0.1 compat >= 3
+	lib:libguile_srfi_srfi_4_v_3$secondaryArchSuffix = 3.0.1 compat >= 3
+	lib:libguile_srfi_srfi_60_v_2$secondaryArchSuffix = 2.0.2 compat >= 2
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -71,10 +71,10 @@ PROVIDES_devel="
 	cmd:guile_config$commandSuffix = $portVersion
 	devel:libguile$secondaryArchSuffix = $libguileVersionCompat
 	devel:libguilereadline_v_17$secondaryArchSuffix = $libguileVersionCompat
-	devel:libguile_srfi_srfi_1_v_3$secondaryArchSuffix = 3.0.2
-	devel:libguile_srfi_srfi_13_14_v_3$secondaryArchSuffix = 3.0.1
-	devel:libguile_srfi_srfi_4_v_3$secondaryArchSuffix = 3.0.1
-	devel:libguile_srfi_srfi_60_v_2$secondaryArchSuffix = 2.0.2
+	devel:libguile_srfi_srfi_1_v_3$secondaryArchSuffix = 3.0.2 compat >= 3
+	devel:libguile_srfi_srfi_13_14_v_3$secondaryArchSuffix = 3.0.1 compat >= 3
+	devel:libguile_srfi_srfi_4_v_3$secondaryArchSuffix = 3.0.1 compat >= 3
+	devel:libguile_srfi_srfi_60_v_2$secondaryArchSuffix = 2.0.2 compat >= 2
 	"
 REQUIRES_devel="
 	guile1$secondaryArchSuffix == $portVersion base
@@ -104,7 +104,13 @@ BUILD_PREREQUIRES="
 	"
 
 defineDebugInfoPackage guile1$secondaryArchSuffix \
-	"$libDir"/libguile.so.$libguileVersion
+	$(getPackagePrefix tools)/"$relativeBinDir"/guile \
+	"$libDir"/libguile.so.$libguileVersion \
+	"$libDir"/libguilereadline-v-17.so.17.0.3 \
+	"$libDir"/libguile-srfi-srfi-1-v-3.so.3.0.2 \
+	"$libDir"/libguile-srfi-srfi-13-14-v-3.so.3.0.1 \
+	"$libDir"/libguile-srfi-srfi-4-v-3.so.3.0.1 \
+	"$libDir"/libguile-srfi-srfi-60-v-2.so.2.0.2
 
 BUILD()
 {
@@ -142,7 +148,8 @@ INSTALL()
 	packageEntries tools \
 		"$commandBinDir"/guile \
 		"$commandBinDir"/guile-snarf \
-		"$commandBinDir"/guile-tools
+		"$commandBinDir"/guile-tools \
+		"$manDir"
 
 	packageEntries devel \
 		"$commandBinDir"/guile-config \


### PR DESCRIPTION
further changes (for both guile1 and guile2):
 * move man page also to tools as it concerns the interpreter
 * define debuginfo for guile and the other than main libraries
   - note: defining multple debuginfo packages is not possible using the predefined shell scriptlet
 * add/fix compat versions for libraries