### PR TITLE
guile1: add version-less symlinks for the libraries to facilitate dynamically loading

### DIFF
--- a/dev-scheme/guile/guile1-1.8.8.recipe
+++ b/dev-scheme/guile/guile1-1.8.8.recipe
@@ -147,12 +147,9 @@ INSTALL()
 
 	fixPkgconfig
 
-	# add version-less symlinks of the libraries (which are needed because they are loaded dynamically)
-	ln -s libguile.so.$libguileVersion "$libDir"/libguile.so
+	# add version-less symlinks of the libraries which are loaded dynamically
 	ln -s libguilereadline-v-17.so.17.0.3 "$libDir"/libguilereadline-v-17.so
 	ln -s libguile-srfi-srfi-1-v-3.so.3.0.2 "$libDir"/libguile-srfi-srfi-1-v-3.so
-	ln -s libguile-srfi-srfi-13-14-v-3.so.3.0.1 "$libDir"/libguile-srfi-srfi-13-14-v-3.so
-	ln -s libguile-srfi-srfi-4-v-3.so.3.0.1 "$libDir"/libguile-srfi-srfi-4-v-3.so
 	ln -s libguile-srfi-srfi-60-v-2.so.2.0.2 "$libDir"/libguile-srfi-srfi-60-v-2.so
 
 	packageEntries tools \

--- a/dev-scheme/guile/guile1-1.8.8.recipe
+++ b/dev-scheme/guile/guile1-1.8.8.recipe
@@ -7,7 +7,7 @@ the same) and users to use them to have an application fit their needs."
 HOMEPAGE="https://www.gnu.org/software/guile/"
 COPYRIGHT="1993-2018 Aubrey Jaffer, George Carrette, et al."
 LICENSE="GNU LGPL v3"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://ftpmirror.gnu.org/guile/guile-$portVersion.tar.gz
 	https://ftp.gnu.org/gnu/guile/guile-$portVersion.tar.gz"
 CHECKSUM_SHA256="c3471fed2e72e5b04ad133bbaaf16369e8360283679bcf19800bc1b381024050"
@@ -35,7 +35,7 @@ portVers="${portVersion%.*}"
 PROVIDES="
 	guile1$secondaryArchSuffix = $portVersionCompat
 	lib:libguile$secondaryArchSuffix = $libguileVersionCompat
-	lib:libguilereadline_v_17$secondaryArchSuffix = $libguileVersionCompat
+	lib:libguilereadline_v_17$secondaryArchSuffix = 17.0.3 compat >= 17
 	lib:libguile_srfi_srfi_1_v_3$secondaryArchSuffix = 3.0.2 compat >= 3
 	lib:libguile_srfi_srfi_13_14_v_3$secondaryArchSuffix = 3.0.1 compat >= 3
 	lib:libguile_srfi_srfi_4_v_3$secondaryArchSuffix = 3.0.1 compat >= 3
@@ -72,7 +72,7 @@ PROVIDES_devel="
 	guile1${secondaryArchSuffix}_devel = $portVersionCompat
 	cmd:guile_config$commandSuffix = $portVersion
 	devel:libguile$secondaryArchSuffix = $libguileVersionCompat
-	devel:libguilereadline_v_17$secondaryArchSuffix = $libguileVersionCompat
+	devel:libguilereadline_v_17$secondaryArchSuffix = 17.0.3 compat >= 17
 	devel:libguile_srfi_srfi_1_v_3$secondaryArchSuffix = 3.0.2 compat >= 3
 	devel:libguile_srfi_srfi_13_14_v_3$secondaryArchSuffix = 3.0.1 compat >= 3
 	devel:libguile_srfi_srfi_4_v_3$secondaryArchSuffix = 3.0.1 compat >= 3
@@ -146,6 +146,14 @@ INSTALL()
 		libguile-srfi-srfi-60-v-2
 
 	fixPkgconfig
+
+	# add version-less symlinks of the libraries (which are needed because they are loaded dynamically)
+	ln -s libguile.so.$libguileVersion "$libDir"/libguile.so
+	ln -s libguilereadline-v-17.so.17.0.3 "$libDir"/libguilereadline-v-17.so
+	ln -s libguile-srfi-srfi-1-v-3.so.3.0.2 "$libDir"/libguile-srfi-srfi-1-v-3.so
+	ln -s libguile-srfi-srfi-13-14-v-3.so.3.0.1 "$libDir"/libguile-srfi-srfi-13-14-v-3.so
+	ln -s libguile-srfi-srfi-4-v-3.so.3.0.1 "$libDir"/libguile-srfi-srfi-4-v-3.so
+	ln -s libguile-srfi-srfi-60-v-2.so.2.0.2 "$libDir"/libguile-srfi-srfi-60-v-2.so
 
 	packageEntries tools \
 		"$commandBinDir"/guile \


### PR DESCRIPTION
Fixes #5993

Also, fix the version number of libguile-readline in provides.