### PR TITLE
dav1d: bump to 0.9.1

### DIFF
--- a/media-libs/dav1d/dav1d-0.9.1.recipe
+++ b/media-libs/dav1d/dav1d-0.9.1.recipe
@@ -7,7 +7,7 @@ COPYRIGHT="2018-2019, VideoLAN and dav1d authors"
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="https://code.videolan.org/videolan/dav1d/-/archive/$portVersion/dav1d-$portVersion.tar.bz2"
-CHECKSUM_SHA256="78ec7a1714d98a8f4ecbc4255e83e6c4c944cdd881871ea234ce40153fd3df04"
+CHECKSUM_SHA256="fb2a050e6c2410c99104f631e202a02697dfe1a2fc9acc3c50a16422aefb004c"
 
 ARCHITECTURES="!x86_gcc2 ?x86 x86_64 ?arm ?ppc"
 SECONDARY_ARCHITECTURES="x86"
@@ -19,7 +19,7 @@ if [ "$targetArchitecture" = x86_gcc2 ]; then
 	commandBinDir=$prefix/bin
 fi
 
-libVersion="5.0.1"
+libVersion="5.1.1"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="


### PR DESCRIPTION
This brings high bit depth (10- and 12-bit) acceleration on amd64 and i686.

This has been tested against the AVIF translator.