### PR TITLE
glib: bump to 2.68.4

### DIFF
--- a/dev-libs/glib/glib2-2.68.4.recipe
+++ b/dev-libs/glib/glib2-2.68.4.recipe
@@ -128,6 +128,7 @@ BUILD()
 {
 	CFLAGS="-D_BSD_SOURCE" \
 		LDFLAGS="-lbsd -lgnu -lnetwork" meson build \
+		-D glib_debug=disabled --buildtype=debugoptimized \
 		-Diconv=external --prefix=$prefix --includedir=$includeDir \
 		--libdir=$libDir --datadir=$dataDir --bindir=$binDir \
 		--localedir=$dataDir/locale

--- a/dev-libs/glib/glib2-2.68.4.recipe
+++ b/dev-libs/glib/glib2-2.68.4.recipe
@@ -1,0 +1,169 @@
+SUMMARY="GLib is a cross-platform software utility library"
+DESCRIPTION="GLib is a cross-platform software utility library that began as \
+part of the GTK+ project. However, before releasing version 2 of GTK+, the \
+project's developers decided to separate non-GUI-specific code from the GTK+ \
+platform, thus creating GLib as a separate product. GLib was released as a \
+separate library so other developers, those who did not make use of the \
+GUI-related portions of GTK+, could make use of the non-GUI portions of the \
+library without the overhead of depending on the entire GUI library.
+Since GLib is a cross-platform library, applications using it to interface \
+with the operating system are usually portable across different operating \
+systems without major changes."
+HOMEPAGE="https://www.gtk.org/"
+COPYRIGHT="1995-1997  Peter Mattis, Spencer Kimball and Josh MacDonald
+	1991-2003 Free Software Foundation, Inc.
+	1997-2006 University of Cambridge.
+	1998-2001, 2003-2010 Red Hat, Inc.
+	2007-2009 Nokia Corporation
+	2008, 2010 Oracle and/or its affiliates, Inc. All rights
+	2008-2010 Codethink Limited
+	2008-2010 Collabora Ltd.
+	1995-2010 Several others"
+LICENSE="GNU LGPL v2"
+REVISION="1"
+SOURCE_URI="https://gitlab.gnome.org/GNOME/glib/-/archive/$portVersion/glib-$portVersion.tar.gz"
+CHECKSUM_SHA256="7277475bebbecd3369b793c7b628d78290e016f7d6bcb463173c17e90f3bb96d"
+SOURCE_DIR="glib-$portVersion"
+PATCHES="glib2-$portVersion.patchset"
+
+ARCHITECTURES="?x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="0.6800.4"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	glib2$secondaryArchSuffix = $portVersion
+	cmd:gapplication$secondaryArchSuffix
+	cmd:gdbus$secondaryArchSuffix
+	cmd:gdbus_codegen$secondaryArchSuffix
+	cmd:gio$secondaryArchSuffix
+	cmd:gio_launch_desktop$secondaryArchSuffix
+	cmd:gio_querymodules$secondaryArchSuffix
+	cmd:glib_compile_resources$secondaryArchSuffix
+	cmd:glib_compile_schemas$secondaryArchSuffix
+	cmd:gresource$secondaryArchSuffix
+	cmd:gsettings$secondaryArchSuffix
+	lib:libgio_2.0$secondaryArchSuffix = $libVersionCompat
+	lib:libglib_2.0$secondaryArchSuffix = $libVersionCompat
+	lib:libgmodule_2.0$secondaryArchSuffix = $libVersionCompat
+	lib:libgobject_2.0$secondaryArchSuffix = $libVersionCompat
+	lib:libgthread_2.0$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	gettext$secondaryArchSuffix
+	lib:libffi$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libpcre$secondaryArchSuffix >= 1
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	glib2${secondaryArchSuffix}_devel = $portVersion compat >= 0
+	cmd:glib_genmarshal$secondaryArchSuffix
+	cmd:glib_gettextize$secondaryArchSuffix
+	cmd:glib_mkenums$secondaryArchSuffix
+	cmd:gobject_query$secondaryArchSuffix
+	cmd:gtester$secondaryArchSuffix
+	cmd:gtester_report$secondaryArchSuffix
+	devel:libgio_2.0$secondaryArchSuffix = $libVersionCompat
+	devel:libglib_2.0$secondaryArchSuffix = $libVersionCompat
+	devel:libgmodule_2.0$secondaryArchSuffix = $libVersionCompat
+	devel:libgobject_2.0$secondaryArchSuffix = $libVersionCompat
+	devel:libgthread_2.0$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	glib2$secondaryArchSuffix == $portVersion base
+	haiku$secondaryArchSuffix
+	cmd:perl
+	cmd:python3
+	devel:libffi$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
+	devel:libintl$secondaryArchSuffix
+	devel:libpcre$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	lib:libffi$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libpcre$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+#	devel:libdbus_1$secondaryArchSuffix
+#	devel:libelf$secondaryArchSuffix
+	devel:libffi$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
+	devel:libintl$secondaryArchSuffix
+	devel:libpcre$secondaryArchSuffix >= 1
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:meson
+	cmd:python3
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+defineDebugInfoPackage glib2$secondaryArchSuffix \
+	$binDir/gapplication \
+	$binDir/gdbus \
+	$binDir/gio \
+	$binDir/gio-querymodules \
+	$binDir/glib-compile-resources \
+	$binDir/glib-compile-schemas \
+	$binDir/gresource \
+	$binDir/gsettings \
+	$libDir/libgio-2.0.so.$libVersion \
+	$libDir/libglib-2.0.so.$libVersion \
+	$libDir/libgmodule-2.0.so.$libVersion \
+	$libDir/libgobject-2.0.so.$libVersion \
+	$libDir/libgthread-2.0.so.$libVersion
+
+BUILD()
+{
+	CFLAGS="-D_BSD_SOURCE" \
+		LDFLAGS="-lbsd -lgnu -lnetwork" meson build \
+		-Diconv=external --prefix=$prefix --includedir=$includeDir \
+		--libdir=$libDir --datadir=$dataDir --bindir=$binDir \
+		--localedir=$dataDir/locale
+
+	ninja $jobArgs -C build
+}
+
+INSTALL()
+{
+	ninja -C build install
+
+	prepareInstalledDevelLibs libgio-2.0 \
+					libglib-2.0 \
+					libgmodule-2.0 \
+					libgobject-2.0 \
+					libgthread-2.0
+
+	# move the glibconfig header into devel as well
+	mv $libDir/glib-2.0 $developLibDir
+
+	fixPkgconfig
+
+	# devel package
+	packageEntries devel \
+		$developDir \
+		$binDir/glib-genmarshal \
+		$binDir/glib-gettextize \
+		$binDir/glib-mkenums \
+		$binDir/gobject-query \
+		$binDir/gtester \
+		$binDir/gtester-report
+
+	rm -rf $prefix/libexec
+}
+
+TEST()
+{
+	meson test -C build
+}

--- a/dev-libs/glib/patches/glib2-2.68.4.patchset
+++ b/dev-libs/glib/patches/glib2-2.68.4.patchset
@@ -1,0 +1,295 @@
+From e1b248c02e0259f4f0b38c13596d24ce233fbdfb Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Sat, 29 Jul 2017 12:13:00 +0200
+Subject: g_dbus_message_print: use B_PRIiDEV on Haiku
+
+because Haiku doesn't define major() and minor()
+
+diff --git a/gio/gdbusmessage.c b/gio/gdbusmessage.c
+index 852a704..968d33f 100644
+--- a/gio/gdbusmessage.c
++++ b/gio/gdbusmessage.c
+@@ -35,8 +35,12 @@
+ #elif MAJOR_IN_TYPES
+ #include <sys/types.h>
+ #else
++#ifdef __HAIKU__
++#include <SupportDefs.h>
++#else
+ #define MAJOR_MINOR_NOT_FOUND 1
+ #endif
++#endif
+ 
+ #include "gdbusutils.h"
+ #include "gdbusmessage.h"
+@@ -3514,8 +3518,14 @@ g_dbus_message_print (GDBusMessage *message,
+               if (fstat (fds[n], &statbuf) == 0)
+                 {
+ #ifndef MAJOR_MINOR_NOT_FOUND                       
++#ifdef __HAIKU__
++                  g_string_append_printf (fs, "%s" "dev=%" B_PRIiDEV, fs->len > 0 ? "," : "",
++                                          statbuf.st_dev);
++#else
++
+                   g_string_append_printf (fs, "%s" "dev=%d:%d", fs->len > 0 ? "," : "",
+                                           (gint) major (statbuf.st_dev), (gint) minor (statbuf.st_dev));
++#endif
+ #endif                  
+                   g_string_append_printf (fs, "%s" "mode=0%o", fs->len > 0 ? "," : "",
+                                           (guint) statbuf.st_mode);
+@@ -3526,9 +3536,14 @@ g_dbus_message_print (GDBusMessage *message,
+                   g_string_append_printf (fs, "%s" "gid=%u", fs->len > 0 ? "," : "",
+                                           (guint) statbuf.st_gid);
+ #ifndef MAJOR_MINOR_NOT_FOUND                     
++#ifdef __HAIKU__
++                  g_string_append_printf (fs, "%s" "rdev=%" B_PRIiDEV, fs->len > 0 ? "," : "",
++                                          statbuf.st_rdev);
++#else
+                   g_string_append_printf (fs, "%s" "rdev=%d:%d", fs->len > 0 ? "," : "",
+                                           (gint) major (statbuf.st_rdev), (gint) minor (statbuf.st_rdev));
+ #endif                  
++#endif
+                   g_string_append_printf (fs, "%s" "size=%" G_GUINT64_FORMAT, fs->len > 0 ? "," : "",
+                                           (guint64) statbuf.st_size);
+                   g_string_append_printf (fs, "%s" "atime=%" G_GUINT64_FORMAT, fs->len > 0 ? "," : "",
+-- 
+2.30.2
+
+
+From 970d6d6d789a572c3b28de48188abc28939d8675 Mon Sep 17 00:00:00 2001
+From: Emmanuel Gil Peyrot <linkmauve@linkmauve.fr>
+Date: Mon, 23 Aug 2021 19:31:38 +0000
+Subject: gunixmounts.c: Add Haiku support
+
+---
+ gio/gunixmounts.c | 57 ++++++++++++++++++++++++++++++++++++++---------
+ 1 file changed, 47 insertions(+), 10 deletions(-)
+
+diff --git a/gio/gunixmounts.c b/gio/gunixmounts.c
+index 32b9362..5196eb4 100644
+--- a/gio/gunixmounts.c
++++ b/gio/gunixmounts.c
+@@ -58,6 +58,9 @@
+ #endif
+ #include <sys/mount.h>
+ #endif
++#ifdef __HAIKU__
++#include <kernel/fs_info.h>
++#endif
+ 
+ #ifndef O_BINARY
+ #define O_BINARY 0
+@@ -956,6 +959,49 @@ _g_get_unix_mounts (void)
+   return return_list;
+ }
+ 
++/* Haiku {{{2 */
++#elif defined(__HAIKU__)
++
++static const char *
++get_mtab_monitor_file (void)
++{
++  return NULL;
++}
++
++static GList *
++_g_get_unix_mounts (void)
++{
++  int32 pos = 0;
++  GList* return_list = NULL;
++  struct fs_info info;
++  GUnixMountEntry* mount_entry;
++
++  while (1)
++    {
++      dev_t dev = next_dev (&pos);
++      if (dev < 0)
++        break;
++
++      if (fs_stat_dev (dev, &info) < 0)
++        continue;
++
++      mount_entry = g_new0 (GUnixMountEntry, 1);
++
++      mount_entry->mount_path = g_strdup (info.volume_name);
++      mount_entry->device_path = g_strdup (info.device_name);
++      mount_entry->filesystem_type = g_strdup (info.fsh_name);
++
++      mount_entry->is_read_only = (info.flags & B_FS_IS_READONLY) ? TRUE : FALSE;
++      mount_entry->is_system_internal = (info.flags & B_FS_IS_REMOVABLE) ? FALSE : TRUE;
++
++      return_list = g_list_prepend (return_list, mount_entry);
++    }
++
++  return_list = g_list_reverse (return_list);
++
++  return return_list;
++}
++
+ /* QNX {{{2 */
+ #elif defined (HAVE_QNX)
+ 
+@@ -1488,16 +1534,8 @@ _g_get_unix_mount_points (void)
+   
+   return g_list_reverse (return_list);
+ }
+-/* Interix {{{2 */
+-#elif defined(__INTERIX)
+-static GList *
+-_g_get_unix_mount_points (void)
+-{
+-  return _g_get_unix_mounts ();
+-}
+-
+-/* QNX {{{2 */
+-#elif defined (HAVE_QNX)
++/* Interix, QNX, Haiku {{{2 */
++#elif defined (__INTERIX) || defined (HAVE_QNX) || defined (__HAIKU__)
+ static GList *
+ _g_get_unix_mount_points (void)
+ {
+-- 
+2.30.2
+
+
+From 3cb1e89ee25160bd94ea15ca2324dec90d03f1bd Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Sat, 29 Jul 2017 12:32:14 +0200
+Subject: glib/gutils.c: on Haiku define load_user_special_dirs()
+
+use find_directory() from SupportDefs.h
+
+diff --git a/glib/gutils.c b/glib/gutils.c
+index 988d0a5..7248ead 100644
+--- a/glib/gutils.c
++++ b/glib/gutils.c
+@@ -74,6 +74,10 @@
+ #include "gwin32.h"
+ #endif
+ 
++#if defined(__HAIKU__)
++#include <FindDirectory.h>
++#include <fs_info.h>
++#endif
+ 
+ /**
+  * SECTION:misc_utils
+@@ -1513,6 +1517,35 @@ load_user_special_dirs (void)
+   load_user_special_dirs_macos (g_user_special_dirs);
+ }
+ 
++#elif defined(__HAIKU__)
++static void
++load_user_special_dirs (void)
++{
++  char path[B_PATH_NAME_LENGTH + B_FILE_NAME_LENGTH];
++
++  dev_t volume = dev_for_path("/boot");
++  if (find_directory(B_DESKTOP_DIRECTORY, volume, false, path, sizeof(path))
++      == B_OK) {
++    g_user_special_dirs[G_USER_DIRECTORY_DESKTOP] = g_strdup(path);
++    g_user_special_dirs[G_USER_DIRECTORY_DOWNLOAD] = g_strdup(path);
++  } else {
++    g_user_special_dirs[G_USER_DIRECTORY_DOCUMENTS] = NULL;
++    g_user_special_dirs[G_USER_DIRECTORY_DESKTOP] = NULL;
++  }
++
++  if (find_directory(B_USER_DIRECTORY, volume, false, path, sizeof(path))
++      == B_OK) {
++    g_user_special_dirs[G_USER_DIRECTORY_DOCUMENTS] = g_strdup(path);
++  } else
++    g_user_special_dirs[G_USER_DIRECTORY_DOWNLOAD] = NULL;
++
++  g_user_special_dirs[G_USER_DIRECTORY_MUSIC] = NULL;
++  g_user_special_dirs[G_USER_DIRECTORY_PICTURES] = NULL;
++  g_user_special_dirs[G_USER_DIRECTORY_PUBLIC_SHARE] = NULL;
++  g_user_special_dirs[G_USER_DIRECTORY_TEMPLATES] = NULL;
++  g_user_special_dirs[G_USER_DIRECTORY_VIDEOS] = NULL;
++}
++
+ #elif defined(G_OS_WIN32)
+ 
+ static void
+-- 
+2.30.2
+
+
+From b84a08f536145a49ed19aba44a504f4526dd892c Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Sat, 23 Nov 2019 20:10:10 +0100
+Subject: Haiku patch for x86
+
+
+diff --git a/tests/mapping-test.c b/tests/mapping-test.c
+index ad776fa..49d2ea4 100644
+--- a/tests/mapping-test.c
++++ b/tests/mapping-test.c
+@@ -182,6 +182,10 @@ test_private (void)
+   g_message ("test_private: ok");
+ }
+ 
++#ifdef __HAIKU__
++#include <SupportDefs.h>
++#endif
++
+ static void
+ test_child_private (gchar *argv0)
+ {
+@@ -208,7 +212,11 @@ test_child_private (gchar *argv0)
+   signal (SIGUSR1, handle_usr1);
+ #endif
+ 
++#ifdef __HAIKU__
++  g_snprintf (pid, sizeof(pid), B_PRId32, getpid ());
++#else
+   g_snprintf (pid, sizeof(pid), "%d", getpid ());
++#endif
+   child_argv[0] = argv0;
+   child_argv[1] = "mapchild";
+   child_argv[2] = pid;
+-- 
+2.30.2
+
+
+From 9fa3354d07e11a9d0d6b2dc3d630ce9837830bb6 Mon Sep 17 00:00:00 2001
+From: Gerasim Troeglazov <3dEyes@gmail.com>
+Date: Tue, 17 Aug 2021 08:29:48 +0000
+Subject: Fix network detection
+
+---
+ gio/meson.build | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/gio/meson.build b/gio/meson.build
+index 49a37a7..8d77588 100644
+--- a/gio/meson.build
++++ b/gio/meson.build
+@@ -21,6 +21,7 @@ if host_system not in ['windows', 'android']
+                         int qclass = C_IN;''',
+                      name : 'C_IN in public headers (no arpa/nameser_compat.h needed)')
+     if cc.compiles('''#include <sys/types.h>
++                      #include <stdint.h>
+                       #include <arpa/nameser.h>
+                       #include <arpa/nameser_compat.h>
+                       int qclass = C_IN;''',
+@@ -41,6 +42,7 @@ if host_system != 'windows'
+                         return res_query("test", 0, 0, (void *)0, 0);
+                       }'''
+   res_query_test_full = '''#include <sys/types.h>
++                           #include <stdint.h>
+                            #include <netinet/in.h>
+                            #include <arpa/nameser.h>
+                         ''' + res_query_test
+@@ -54,6 +56,9 @@ if host_system != 'windows'
+     elif cc.links(res_query_test, args : '-lsocket', name : 'res_query() in -lsocket')
+       network_libs += [ cc.find_library('socket') ]
+       network_args += [ '-lsocket' ]
++    elif cc.links(res_query_test, args : '-lnetwork', name : 'res_query() in -lnetwork')
++      network_libs += [ cc.find_library('network') ]
++      network_args += [ '-lnetwork' ]
+     else
+       error('Could not find res_query()')
+     endif
+-- 
+2.30.2
+


### PR DESCRIPTION
On an unrelated note, is it useful to keep all of the old versions here?  glib 2.x is fully backwards compatible from 2.0 (released in 2002) up until latest master, so maybe we could drop those?  I’m also not sure whether glib 1.x is still used anywhere, it has been removed from all Linux distributions I checked and isn’t maintained since 2002.