### PR TITLE
Blind fix for the radare2 pkg

### DIFF
--- a/dev-util/radare2/radare2-5.4.0.recipe
+++ b/dev-util/radare2/radare2-5.4.0.recipe
@@ -96,7 +96,7 @@ COPYRIGHT="2007-2021 pancake
 	2010-2016 Sebastian Reichel"
 LICENSE="GNU GPL v3
 	GNU LGPL v3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/radare/radare2/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="21ddae80a18d5ceef4bcd3a7cae1ba09d14b510d68ac9134681e1e9967123b23"
 

--- a/dev-util/radare2/radare2-5.4.0.recipe
+++ b/dev-util/radare2/radare2-5.4.0.recipe
@@ -277,7 +277,7 @@ INSTALL()
 	mv $prefix/data/radare2 $docDir
 	rm -rf $prefix/share
 
-	prepareInstalledDevelLibs libr_shlr libr_anal libr_asm libr_bin \
+	prepareInstalledDevelLibs libr_anal libr_asm libr_bin libr_debug libr_main \
 	libr_bp libr_config libr_cons libr_core libr_crypto libr_debug libr_egg \
 	libr_flag libr_fs libr_hash libr_io libr_lang libr_magic libr_parse \
 	libr_reg libr_search libr_socket libr_syscall libr_util


### PR DESCRIPTION
The shlr lib is not suposed to be installed in the system, and the list after prepareInstalledDevelLibs was incomplete. i just updated this, is the CI going to verify that im not pushing something wrong? i dont have time for testing or learning how to build ports from haiku right now, so i would appreicate some help/feedback here if needed.

thanks