### PR TITLE
speed_dreams: Set CMAKE_BUILD_TYPE

### DIFF
--- a/games-sports/speed-dreams/speed_dreams-2.2.3.recipe
+++ b/games-sports/speed-dreams/speed_dreams-2.2.3.recipe
@@ -72,6 +72,7 @@ BUILD()
 
 	cmake .. -Wno-dev -DCMAKE_INSTALL_PREFIX=$appsDir/SpeedDreams \
 		-DSD_LOCALDIR=~/config/settings/speed-dreams \
+		-DCMAKE_BUILD_TYPE=Release \
 		-DOPTION_OFFICIAL_ONLY:BOOL=true \
 		-DOPTION_OSGGRAPH:BOOL=false \
 		-DOPTION_WEBSERVER:BOOL=false \


### PR DESCRIPTION
Explicitly set CMAKE_BUILD_TYPE=Release. 
Speed Dreams already does this if it is not explicitly set by the user, so this should not change anything, but will be needed for haikuporter version 1.2.5
I did not change the Revision.