### PR TITLE
Spout: New recipe

### DIFF
--- a/games-arcade/spout/spout-1.4b.recipe
+++ b/games-arcade/spout/spout-1.4b.recipe
@@ -23,7 +23,8 @@ REVISION="1"
 SOURCE_URI="https://github.com/win8linux/spout/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="3f3c1d9e9c67e5512e786fc94eaeaf3c6adabd5abe08653adbaff4bb03cfaf66"
 
-ARCHITECTURES="all"
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	spout$secondaryArchSuffix = $portVersion
@@ -50,7 +51,7 @@ BUILD()
 
 INSTALL()
 {
-	mkdir -p $appsDir/spout
+	mkdir -p $appsDir
 	mv ./spout $appsDir/spout
 	addAppDeskbarSymlink $appsDir/spout "Spout"
 }

--- a/games-arcade/spout/spout-1.4b.recipe
+++ b/games-arcade/spout/spout-1.4b.recipe
@@ -1,0 +1,59 @@
+SUMMARY="A simple caveflying game"
+DESCRIPTION="Spout was originally written for a handheld by kuni, and soon \
+afterwards was ported to Windows using Cygwin and SDL and released under the \
+MIT license.
+
+In 2004 a 'Unix version' was released, which mostly just slapped autotools \
+into the Windows version and infringed the license.
+
+This is a new Unix version, based on the original Windows code by kuni, \
+which aims to add useful features and simplify the code.
+
+Controls:
+
+Left: Rotate left
+Right: Rotate right
+Space: Thrust
+Esc: Pause
+Shift-Esc: Quit"
+HOMEPAGE="https://njw.me.uk/spout/"
+COPYRIGHT="2001-2006 Kuni, 2010 Nick White"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://github.com/win8linux/spout/archive/$portVersion.tar.gz"
+CHECKSUM_SHA256="3f3c1d9e9c67e5512e786fc94eaeaf3c6adabd5abe08653adbaff4bb03cfaf66"
+SOURCE_DIR="spout-$portVersion"
+
+ARCHITECTURES="all x86_64"
+
+PROVIDES="
+	spout$secondaryArchSuffix = $portVersion
+	app:spout = $portVersion
+	"
+REQUIRES="
+    haiku$secondaryArchSuffix
+	lib:libSDL_1.2$secondaryArchSuffix
+    "
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libSDL_1.2$secondaryArchSuffix
+	"
+
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	make $jobArgs
+}
+
+INSTALL()
+{
+	mkdir -p $appsDir/spout
+	mv ./spout $appsDir/spout
+	addAppDeskbarSymlink $appsDir/spout "Spout"
+}

--- a/games-arcade/spout/spout-1.4b.recipe
+++ b/games-arcade/spout/spout-1.4b.recipe
@@ -22,24 +22,21 @@ LICENSE="MIT"
 REVISION="1"
 SOURCE_URI="https://github.com/win8linux/spout/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="3f3c1d9e9c67e5512e786fc94eaeaf3c6adabd5abe08653adbaff4bb03cfaf66"
-SOURCE_DIR="spout-$portVersion"
 
-ARCHITECTURES="all x86_64"
+ARCHITECTURES="all"
 
 PROVIDES="
 	spout$secondaryArchSuffix = $portVersion
 	app:spout = $portVersion
 	"
 REQUIRES="
-    haiku$secondaryArchSuffix
+	haiku$secondaryArchSuffix
 	lib:libSDL_1.2$secondaryArchSuffix
-    "
-
+	"
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libSDL_1.2$secondaryArchSuffix
 	"
-
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:make


### PR DESCRIPTION
*Spout* is a simple game originally developed by kuni wherein the player flies through an endless cave in a box-shaped ship and must use the ship's exhaust to clear the way.

This recipe is based on a [fork](https://github.com/win8linux/spout/tree/patched) of the [Unix version by Nick White](https://njw.me.uk/spout/) that integrates the following patches from Debian:

* [Fix hardening errors from unused result](https://salsa.debian.org/smlx-guest/spout/-/blob/debian/sid/debian/patches/0002-Fix-hardening-errors-from-unused-result.patch)
* [Fix call to open with missing argument](https://salsa.debian.org/smlx-guest/spout/-/blob/debian/sid/debian/patches/0003-Fix-call-to-open-with-missing-argument.patch)
* [Fix segfault on 64-bit platforms due to incorrect types](https://salsa.debian.org/smlx-guest/spout/-/blob/debian/sid/debian/patches/0004-Fix-segfault-on-64-bit-platforms-due-to-incorrect-ty.patch)
* [Remove hard-coded library search path /usr/lib](https://salsa.debian.org/smlx-guest/spout/-/blob/debian/sid/debian/patches/0007-Remove-hard-coded-library-search-path-usr-lib.patch)
* [Remove redundant out-of-range comparison](https://salsa.debian.org/smlx-guest/spout/-/blob/debian/sid/debian/patches/0008-Remove-redundant-out-of-range-comparison.patch)
* [Add exit instructions on scroll screen](https://salsa.debian.org/smlx-guest/spout/-/blob/debian/sid/debian/patches/0009-Add-exit-instructions-on-scroll-screen.patch)

Currently a work in progress, as the recipe fails to build for now.
