### PR TITLE
Fixed koder "Makefile" and "ja.catkeys"

### DIFF
--- a/haiku-apps/koder/koder-0.5.3.recipe
+++ b/haiku-apps/koder/koder-0.5.3.recipe
@@ -11,6 +11,7 @@ REVISION="1"
 SOURCE_URI="https://github.com/KapiX/Koder/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="8dbbf9fc73e0e8ad461e702b793a72c009b9098752bc36c70e374100db4fb1eb"
 SOURCE_DIR="Koder-$portVersion"
+PATCHES="koder-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -43,6 +44,10 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
+	addattr -t mime "BEOS:TYPE" locale/x-vnd.Be.locale-catalog.plaintext locales/ja.catkeys
+	addattr -t string "BEOS:LOCALE_LANGUAGE" Japanese locales/ja.catkeys
+	addattr -t string "BEOS:LOCALE_SIGNATURE" x-vnd.KapiX-Koder locales/ja.catkeys
+	addattr -t uint32 "BEOS:LOCALE_FINGERPRINT" 822155924 locales/ja.catkeys
 	make $jobArgs OBJ_DIR=objects
 	make bindcatalogs OBJ_DIR=objects
 }
@@ -54,6 +59,9 @@ INSTALL()
 
 	mkdir -p $dataDir/Koder
 	cp -r data/* $dataDir/Koder
+
+	mkdir -p $dataDir/locale/catalogs/x-vnd.KapiX-Koder
+	cp -r locales/* $dataDir/locale/catalogs/x-vnd.KapiX-Koder
 
 	addAppDeskbarSymlink $appsDir/Koder
 }

--- a/haiku-apps/koder/patches/koder-0.5.3.patchset
+++ b/haiku-apps/koder/patches/koder-0.5.3.patchset
@@ -1,0 +1,45 @@
+From 00000000000000000000000000000000000001 Fri Sep 24 00:00:00 2021
+From: FuRuYa7 <humdinger@mymail.com>
+Date: 2021-09-24 10:48:00.000000000 +0900
+Subject: Add translation file (Japanese + etc)
+
+
+diff --git a/Makefile b/Makefile
+index f317d4e..979c9b6 100644
+--- a/Makefile
++++ b/Makefile
+@@ -23,7 +23,7 @@ SYSTEM_INCLUDE_PATHS = \
+        $(shell findpaths -e -a $(shell uname -p) B_FIND_PATH_HEADERS_DIRECTORY scintilla)
+ 
+ LOCAL_INCLUDE_PATHS = src/controls src/support src/windows
+-LOCALES = de en en_GB es fr pt pl ro ru uk
++LOCALES = ca de en en_GB es fi fr fur hu id it ja lt pl pt ro ru sv tr uk
+ 
+ SYMBOLS := FALSE
+ DEBUGGER := FALSE
+--
+0.5.3
+
+
+From 00000000000000000000000000000000000002 Fri Sep 24 00:00:00 2021
+From: FuRuYa7 <humdinger@mymail.com>
+Date: 2021-09-24 10:48:00.000000000 +0900
+Subject: Translation correction (Japanese)
+
+
+diff --git a/locales/ja.catkeys b/locales/ja.catkeys
+index 86927ee..4a91f88 100644
+--- a/locales/ja.catkeys
++++ b/locales/ja.catkeys
+@@ -61,7 +61,6 @@ Undo  EditorWindow            元に戻す
+ Unix format    EditorWindow            Unix 形式
+ Unsaved changes        EditorWindow            保存されていない変更
+ Untitled       EditorWindow            無題
+-
+ View   EditorWindow            表示
+ Windows format EditorWindow            Windows 形式
+ Wrap lines     EditorWindow            行を折り返す
+--
+0.5.3
+
+


### PR DESCRIPTION
#### 1). When I added a translation file, the added language was not added to the "Makefile" locale.

Translations may not have been applied in many other languages.

Makefile:

```
- LOCALES = de en en_GB es fr pt pl ro ru uk
+ LOCALES = ca de en en_GB es fi fr fur hu id it ja lt pl pt ro ru sv tr uk
```

#### 2). I registered it in the "locale/catalogs" folder of the system so that I can see which translation files are installed. 

#### 3). An error occurs when converting a translation file at build time.

locales/ja.catkeys:

Removed the blank line on line 64 of "ja.catkeys".

#### 4). An error occurs when converting a translation file at build time.

Only "ja.catkeys" has missing file attributes, so an error will occur during conversion. it is necessary to set the file attribute of " ja.catkeys " in Haiku:

locales/ja.catkeys:

```
> addattr -t mime "BEOS:TYPE" locale/x-vnd.Be.locale-catalog.plaintext locales/ja.catkeys
> addattr -t string "BEOS:LOCALE_LANGUAGE" Japanese locales/ja.catkeys
> addattr -t string "BEOS:LOCALE_SIGNATURE" x-vnd.KapiX-Koder locales/ja.catkeys
> addattr -t uint32 "BEOS:LOCALE_FINGERPRINT" 822155924 locales/ja.catkeys
```

Maybe it should be done before creating ".tar.gz". I used the recipe file to change the file attributes. 