### PR TITLE
Dragengine - New feature

### DIFF
--- a/games-engines/dragengine/dragengine-1.6.recipe
+++ b/games-engines/dragengine/dragengine-1.6.recipe
@@ -15,9 +15,9 @@ COPYRIGHT="2020-2021 DragonDreams"
 LICENSE="GNU GPL v3
 	GNU LGPL v3"
 REVISION="1"
-HAIKU_PATCH=""
+HAIKU_PATCH="-haiku1"
 SOURCE_URI="https://github.com/LordOfDragons/dragengine/archive/v$portVersion$HAIKU_PATCH.tar.gz"
-CHECKSUM_SHA256="7fb60a501794d60bff685fa498257f9c1d71b67becf92b48aaa7d0f2a443a5eb"
+CHECKSUM_SHA256="e0ea90a8192cc80e08d99e04f0c0ae47cfc410aff54f9686accdc718acdf0839"
 SOURCE_FILENAME="dragengine-$portVersion.tar.gz"
 SOURCE_DIR="dragengine-$portVersion$HAIKU_PATCH"
 ADDITIONAL_FILES="custom.py"
@@ -32,12 +32,14 @@ DISABLE_SOURCE_PACKAGE="yes"
 
 PROVIDES="
 	dragengine$secondaryArchSuffix = $portVersion
-	lib:libdragengine$secondaryArchSuffix = $portVersion compat >= 1.5
+	lib:libdragengine$secondaryArchSuffix = $portVersion compat >= $portVersion
+	lib:libdelauncher$secondaryArchSuffix = $portVersion compat >= $portVersion
 	cmd:delauncher_console$secondaryArchSuffix = $portVersion
 	"
 PROVIDES_devel="
 	dragengine${secondaryArchSuffix}_devel = $portVersion
-	devel:libdragengine$secondaryArchSuffix = $portVersion compat >= 1.5
+	devel:libdragengine$secondaryArchSuffix = $portVersion compat >= $portVersion
+	devel:libdelauncher$secondaryArchSuffix = $portVersion compat >= $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -91,14 +93,16 @@ BUILD()
 	echo "docdir = '$manDir'" >>custom.py
 
 	# scons $jobArgs build
-	# scons crashes with multi-thread. force single thread. happens only on haiku
+	# scons crashes with multi-thread in some situations. this is a python problem especially with version 3 onwards
 	scons -j 1 build
 }
 
 INSTALL()
 {
 	scons --config=cache -j 1 install_engine_runtime dragengine_develop
+	scons --config=cache -j 1 delauncher_runtime delauncher_develop
 	# scons --config=cache -j 1 install_igde_runtime deigde_shared_develop
 	prepareInstalledDevelLib libdragengine
+	prepareInstalledDevelLib libdelauncher
 	packageEntries devel $developDir
 }


### PR DESCRIPTION
Updated to version 1.6 . This one includes now also "libdelauncher.so", which can be used to create launchers for Haiku.