### PR TITLE
new recipe: fig2dev

### DIFF
--- a/media-gfx/fig2dev/fig2dev-3.2.8b.recipe
+++ b/media-gfx/fig2dev/fig2dev-3.2.8b.recipe
@@ -56,7 +56,7 @@ TEST_REQUIRES="
 "
 
 defineDebugInfoPackage fig2dev$secondaryArchSuffix \
-	$binDir/fig2dev
+	$commandBinDir/fig2dev
 
 BUILD()
 {

--- a/media-gfx/fig2dev/fig2dev-3.2.8b.recipe
+++ b/media-gfx/fig2dev/fig2dev-3.2.8b.recipe
@@ -52,7 +52,15 @@ BUILD_PREREQUIRES="
 	"
 
 TEST_REQUIRES="
+	cmd:aclocal
+	cmd:convert$secondaryArchSuffix
 	cmd:find
+	cmd:pnmtotiff
+
+# the latex tests don't work
+#	cmd:fmtutil
+#	cmd:latex
+#	texlive_latex
 "
 
 defineDebugInfoPackage fig2dev$secondaryArchSuffix \
@@ -72,5 +80,8 @@ INSTALL()
 
 TEST()
 {
+	# update the TeX formats for latex tests (doesn't work)
+	# fmtutil-sys --missing
+
 	make check
 }

--- a/media-gfx/fig2dev/fig2dev-3.2.8b.recipe
+++ b/media-gfx/fig2dev/fig2dev-3.2.8b.recipe
@@ -1,7 +1,13 @@
 SUMMARY="Set of tools for creating TeX documents with graphics"
 DESCRIPTION="Fig2dev is a set of tools for creating TeX documents with \
 graphics which are portable, in the sense that they can be printed in a wide \
-variety of environments."
+variety of environments.
+
+Fig2dev consists of the fig2dev and the transfig commands.  The fig2dev
+command translates Fig code to other graphic description languages.  The
+transfig command generates transfig.tex, a macro file for \input in a
+TeX document, and a Makefile which translates Fig code to various
+graphics description languages using the fig2dev program."
 HOMEPAGE="http://mcj.sourceforge.net/"
 COPYRIGHT="1991 by Micah Beck
 	1985-1988 by Supoj Sutanthavibul
@@ -27,6 +33,7 @@ PROVIDES="
 	cmd:fig2dev$commandSuffix = $portVersion
 	cmd:fig2ps2tex$commandSuffix
 	cmd:pic2tpic$commandSuffix
+	cmd:transfig$commandSuffix = 3.2.4
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -64,12 +71,13 @@ TEST_REQUIRES="
 "
 
 defineDebugInfoPackage fig2dev$secondaryArchSuffix \
-	$commandBinDir/fig2dev
+	$commandBinDir/fig2dev \
+	$commandBinDir/transfig
 
 BUILD()
 {
 	runConfigure --omit-dirs "binDir" ./configure \
-		--bindir="$commandBinDir"
+		--bindir="$commandBinDir" --enable-transfig
 	make $jobArgs
 }
 

--- a/media-gfx/fig2dev/fig2dev-3.2.8b.recipe
+++ b/media-gfx/fig2dev/fig2dev-3.2.8b.recipe
@@ -12,19 +12,29 @@ REVISION="1"
 SOURCE_URI="https://sourceforge.net/projects/mcj/files/fig2dev-$portVersion.tar.xz"
 CHECKSUM_SHA256="418a164aa9fad72d25bb4fec8d7b452fe3a2f12f990cf22e05c0eb16cecb68cb"
 
-ARCHITECTURES="all ?x86_gcc2"
-SECONDARY_ARCHITECTURES="?x86"
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+commandBinDir=$binDir
+commandSuffix=$secondaryArchSuffix
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
 
 PROVIDES="
 	fig2dev$secondaryArchSuffix = $portVersion
-	cmd:fig2dev$secondaryArchSuffix
-	cmd:fig2ps2tex$secondaryArchSuffix
-	cmd:pic2tpic$secondaryArchSuffix
+	cmd:fig2dev$commandSuffix = $portVersion
+	cmd:fig2ps2tex$commandSuffix
+	cmd:pic2tpic$commandSuffix
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	cmd:awk
+	cmd:bc
 	cmd:convert$secondaryArchSuffix
 	cmd:gs
+	cmd:sed
 	lib:libpng16$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
@@ -50,7 +60,8 @@ defineDebugInfoPackage fig2dev$secondaryArchSuffix \
 
 BUILD()
 {
-	runConfigure ./configure
+	runConfigure --omit-dirs "binDir" ./configure \
+		--bindir="$commandBinDir"
 	make $jobArgs
 }
 

--- a/media-gfx/fig2dev/fig2dev-3.2.8b.recipe
+++ b/media-gfx/fig2dev/fig2dev-3.2.8b.recipe
@@ -1,0 +1,65 @@
+SUMMARY="Set of tools for creating TeX documents with graphics"
+DESCRIPTION="Fig2dev is a set of tools for creating TeX documents with \
+graphics which are portable, in the sense that they can be printed in a wide \
+variety of environments."
+HOMEPAGE="http://mcj.sourceforge.net/"
+COPYRIGHT="1991 by Micah Beck
+	1985-1988 by Supoj Sutanthavibul
+	1989-2015 by Brian V. Smith
+	2015-2020 by Thomas Loimer"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://sourceforge.net/projects/mcj/files/fig2dev-$portVersion.tar.xz"
+CHECKSUM_SHA256="418a164aa9fad72d25bb4fec8d7b452fe3a2f12f990cf22e05c0eb16cecb68cb"
+
+ARCHITECTURES="all ?x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
+
+PROVIDES="
+	fig2dev$secondaryArchSuffix = $portVersion
+	cmd:fig2dev$secondaryArchSuffix
+	cmd:fig2ps2tex$secondaryArchSuffix
+	cmd:pic2tpic$secondaryArchSuffix
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	cmd:convert$secondaryArchSuffix
+	cmd:gs
+	lib:libpng16$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	cmd:gs
+	devel:libpng16$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	"
+
+TEST_REQUIRES="
+	cmd:find
+"
+
+defineDebugInfoPackage fig2dev$secondaryArchSuffix \
+	$binDir/fig2dev
+
+BUILD()
+{
+	runConfigure ./configure
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+}
+
+TEST()
+{
+	make check
+}


### PR DESCRIPTION
This is an optional dependency of dblatex (see #6078).

Quite a number of tests fail when run via haikuporter that work when running it without. I don't know why.

Tested (building the package) on 64 bit (nightly) and 32 bit (beta 3)