### PR TITLE
m4: bump

### DIFF
--- a/sys-devel/m4/m4-1.4.19.recipe
+++ b/sys-devel/m4/m4-1.4.19.recipe
@@ -12,11 +12,11 @@ be used either as a front-end to a compiler or as a macro processor in its own \
 right.
 One of the biggest users of M4 is the GNU Autoconf project."
 HOMEPAGE="https://www.gnu.org/software/m4/"
-COPYRIGHT="2000, 2005-2016 Free Software Foundation, Inc."
+COPYRIGHT="2000, 2005-2014, 2016-2017, 2020-2021 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3"
-REVISION="3"
+REVISION="1"
 SOURCE_URI="https://ftp.gnu.org/gnu/m4/m4-$portVersion.tar.gz"
-CHECKSUM_SHA256="ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab"
+CHECKSUM_SHA256="3be4a26d825ffdfda52a56fc43246456989a3630093cced3fbddf4771ee58a70"
 
 ARCHITECTURES="all"
 
@@ -61,9 +61,6 @@ BUILD()
 INSTALL()
 {
 	make install
-
-	rm $libDir/charset.alias
-	rmdir $libDir
 }
 
 TEST()


### PR DESCRIPTION
```
Testsuite summary for GNU M4 1.4.19
============================================================================
# TOTAL: 267
# PASS:  227
# SKIP:  35
# XFAIL: 0
# FAIL:  5
# XPASS: 0
# ERROR: 0

```