### PR TITLE
gettext: bump

### DIFF
--- a/sys-devel/gettext/gettext-0.21.recipe
+++ b/sys-devel/gettext/gettext-0.21.recipe
@@ -1,0 +1,130 @@
+SUMMARY="GNU tools for native language support"
+DESCRIPTION="GNU 'gettext' is an important step for the GNU Translation \
+Project, as it is an asset on which we may build many other steps. This \
+package offers to programmers, translators, and even users, a well integrated \
+set of tools and documentation. Specifically, the GNU 'gettext' utilities are \
+a set of tools that provides a framework to help other GNU packages produce \
+multi-lingual messages. These tools include a set of conventions about how \
+programs should be written to support message catalogs, a directory and file \
+naming organization for the message catalogs themselves, a runtime library \
+supporting the retrieval of translated messages, and a few stand-alone \
+programs to massage in various ways the sets of translatable strings, or \
+already translated strings. A special GNU Emacs mode also helps interested \
+parties in preparing these sets, or bringing them up to date."
+HOMEPAGE="https://www.gnu.org/software/gettext/"
+COPYRIGHT="1998-2020 Free Software Foundation, Inc."
+LICENSE="GNU GPL v3"
+REVISION="1"
+SOURCE_URI="https://ftpmirror.gnu.org/gettext/gettext-$portVersion.tar.xz"
+CHECKSUM_SHA256="d20fcbb537e02dcf1383197ba05bd0734ef7bf5db06bdb241eb69b7d16b73192"
+
+ARCHITECTURES="all"
+SECONDARY_ARCHITECTURES="x86_gcc2 x86"
+
+PROVIDES="
+	gettext$secondaryArchSuffix = $portVersion compat >= 0.21
+	devel:libasprintf$secondaryArchSuffix = 0.0.0 compat >= 0
+	devel:libgettextlib$secondaryArchSuffix = $portVersion
+	devel:libgettextlib_$portVersion$secondaryArchSuffix
+	devel:libgettextpo$secondaryArchSuffix = 0.5.7 compat >= 0
+	devel:libgettextsrc$secondaryArchSuffix = $portVersion
+	devel:libgettextsrc_$portVersion$secondaryArchSuffix
+	devel:libintl$secondaryArchSuffix = 8.2.0 compat >= 8
+	devel:libtextstyle$secondaryArchSuffix = 0.1.1 compat >= 0
+	lib:libasprintf$secondaryArchSuffix = 0.0.0 compat >= 0
+	lib:libgettextlib_$portVersion$secondaryArchSuffix
+	lib:libgettextpo$secondaryArchSuffix = 0.5.7 compat >= 0
+	lib:libgettextsrc_$portVersion$secondaryArchSuffix
+	lib:libtextstyle$secondaryArchSuffix = 0.1.1 compat >= 0
+	cmd:autopoint$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:envsubst$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:gettext$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:gettext.sh$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:gettextize$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:msgattrib$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:msgcat$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:msgcmp$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:msgcomm$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:msgconv$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:msgen$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:msgexec$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:msgfilter$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:msgfmt$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:msggrep$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:msginit$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:msgmerge$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:msgunfmt$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:msguniq$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:ngettext$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:recode_sr_latin$secondaryArchSuffix = $portVersion compat >= 0
+	cmd:xgettext$secondaryArchSuffix = $portVersion compat >= 0
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	gettext${secondaryArchSuffix}_libintl == $portVersion base
+	lib:libiconv$secondaryArchSuffix
+	lib:libncurses$secondaryArchSuffix
+	"
+if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+	REQUIRES="$REQUIRES
+		lib:libgomp$secondaryArchSuffix
+		"
+fi
+
+SUMMARY_libintl="The gettext internationalization library"
+PROVIDES_libintl="
+	gettext${secondaryArchSuffix}_libintl = $portVersion compat >= 0.21
+	lib:libintl$secondaryArchSuffix = 8.2.0 compat >= 8
+	"
+REQUIRES_libintl="
+	haiku$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libiconv$secondaryArchSuffix
+	devel:libncurses$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:automake
+	cmd:autoheader
+	cmd:gcc$secondaryArchSuffix
+	cmd:groff
+	cmd:gzip
+	cmd:ld$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	cmd:makeinfo
+	"
+
+BUILD()
+{
+	runConfigure ./configure \
+		--disable-java --without-git \
+		--disable-rpath --disable-maintainer-mode
+	make $jobArgs AUTOCONF=: AUTOMAKE=: AUTOHEADER=: ACLOCAL=:
+}
+
+INSTALL()
+{
+	make install AUTOCONF=: AUTOMAKE=: AUTOHEADER=: ACLOCAL=:
+
+	# remove libtool files
+	rm -f $libDir/lib*.la
+
+	prepareInstalledDevelLibs libasprintf libgettextpo libintl libtextstyle
+	prepareInstalledDevelLib libgettextlib '*.so' '*'
+	prepareInstalledDevelLib libgettextsrc '*.so' '*'
+
+	# libintl package
+	packageEntries libintl \
+		$libDir/libintl*
+}
+
+TEST()
+{
+	make check
+}


### PR DESCRIPTION
The -presumably- gcc2 patches doesn't maintained. If needed, i can try to apply them, but i am unable to test it.
Question: why the gettext package doesn't have _devel subpackage?