### PR TITLE
openssl: bump to 1.1.1l

### DIFF
--- a/dev-libs/openssl/openssl-1.1.1l.recipe
+++ b/dev-libs/openssl/openssl-1.1.1l.recipe
@@ -13,11 +13,11 @@ commercial and non-commercial purposes subject to some simple license \
 conditions."
 HOMEPAGE="https://www.openssl.org/"
 COPYRIGHT="1995-1998 Eric Young
-	1998-2020 The OpenSSL Project"
+	1998-2021 The OpenSSL Project"
 LICENSE="OpenSSL"
 REVISION="1"
 SOURCE_URI="https://www.openssl.org/source/openssl-$portVersion.tar.gz"
-CHECKSUM_SHA256="892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5"
+CHECKSUM_SHA256="0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1"
 SOURCE_DIR="openssl-$portVersion"
 PATCHES="openssl-$portVersion.patchset"
 

--- a/dev-libs/openssl/patches/openssl-1.1.1l.patchset
+++ b/dev-libs/openssl/patches/openssl-1.1.1l.patchset
@@ -1,11 +1,11 @@
-From 20e8d7801a02b24db87f0675d1295418c55b8a5a Mon Sep 17 00:00:00 2001
+From 4eaf700e5b10147d60e7b3bee6dc3574cd2ab1d0 Mon Sep 17 00:00:00 2001
 From: Augustin Cavalier <waddlesplash@gmail.com>
 Date: Sat, 14 Mar 2020 19:20:45 -0400
 Subject: Small changes for Haiku.
 
 
 diff --git a/config b/config
-index f28828d..2cf58af 100755
+index 26225ca..5d4d97d 100755
 --- a/config
 +++ b/config
 @@ -912,7 +912,7 @@ fi
@@ -27,10 +27,10 @@ index f28828d..2cf58af 100755
  	 __CNF_CPPINCLUDES="'$__CNF_CPPINCLUDES'" \
  	 __CNF_CPPFLAGS="'$__CNF_CPPFLAGS'" \
 diff --git a/crypto/rand/rand_unix.c b/crypto/rand/rand_unix.c
-index fe457ca..6389c6d 100644
+index 43f1069..2322060 100644
 --- a/crypto/rand/rand_unix.c
 +++ b/crypto/rand/rand_unix.c
-@@ -217,7 +217,9 @@ void rand_pool_keep_random_devices_open(int keep)
+@@ -220,7 +220,9 @@ void rand_pool_keep_random_devices_open(int keep)
  #   if !defined(DEVRANDOM)
  #    error "OS seeding requires DEVRANDOM to be configured"
  #   endif
@@ -63,10 +63,10 @@ index 7e908ef..7735f6d 100644
 +
 +#define OPENSSL_NO_SECURE_MEMORY
 -- 
-2.28.0
+2.30.2
 
 
-From 23a019c8e82e73be8761a02b164053e605ae021f Mon Sep 17 00:00:00 2001
+From 27a78947972212dfce97e11e3de20557e66c90bc Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Wed, 18 Nov 2020 18:29:38 +0100
 Subject: Use find_directory to locate user certificates
@@ -115,5 +115,5 @@ index bfa8d7d..69be76c 100644
  }
  
 -- 
-2.28.0
+2.30.2
 


### PR DESCRIPTION
Tested on R1beta3
Build and install looks good on 32-bit and 64-bit.