### PR TITLE
raceintospace: New recipe

### DIFF
--- a/games-simulation/raceintospace/raceintospace-v2.0~git.recipe
+++ b/games-simulation/raceintospace/raceintospace-v2.0~git.recipe
@@ -1,0 +1,76 @@
+SUMMARY="A game to relive the 1960s Space Race"
+DESCRIPTION="Race Into Space is a simulation of the US-Soviet Space Race. \
+In it, you take charge of your country’s space program as Director (US) or \
+Designer (USSR). You will purchase and develop space hardware, recruit and \
+manage astronauts/cosmonauts, and plan and send missions into space. \
+The ultimate goal is to be the first to complete a Moon landing and return \
+your people safely to Earth.
+
+Race Into Space (RIS) is a port to modern operating systems of Buzz Aldrin’s \
+Race Into Space (BARIS), a DOS game originally released in 1993 on floppy \
+disk, and a year later in an expanded CD version. BARIS was developed by \
+Fritz Bronner based on his 1989 board game Liftoff!. Dr. Aldrin’s name and \
+imagery have been dropped because permission to use them was limited to the \
+old DOS game."
+HOMEPAGE="https://github.com/raceintospace/raceintospace"
+COPYRIGHT="1993-2005 Strategic Visions, Interplay"
+LICENSE="GNU GPL v2"
+REVISION="1"
+srcGitRev="a3ecec0d123793b561652e29478eebc438a66537"
+SOURCE_URI="https://github.com/raceintospace/raceintospace/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="97584463df7d453e80bd8dd188b4b5af16bb9c0627ef2045b43e9aa6a0921d13"
+SOURCE_DIR="raceintospace-$srcGitRev"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	raceintospace$secondaryArchSuffix = $portVersion
+	app:raceintospace = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	boost170$secondaryArchSuffix
+	lib:libjsoncpp$secondaryArchSuffix
+	lib:libpng$secondaryArchSuffix
+	lib:libprotobuf$secondaryArchSuffix
+	lib:libSDL_1.2$secondaryArchSuffix
+	lib:libtheora$secondaryArchSuffix
+	lib:libvorbis$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	boost170${secondaryArchSuffix}_devel
+	devel:libjsoncpp$secondaryArchSuffix
+	devel:libpng$secondaryArchSuffix
+	devel:libprotobuf$secondaryArchSuffix
+	devel:libprotoc$secondaryArchSuffix
+	devel:libphysfs$secondaryArchSuffix
+	devel:libSDL_1.2$secondaryArchSuffix
+	devel:libtheora$secondaryArchSuffix
+	devel:libvorbis$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:zip
+	"
+
+BUILD()
+{
+	mkdir -p raceintospace-build; cd raceintospace-build
+	cmake -DCMAKE_INSTALL_PREFIX=$appsDir/raceintospace ..
+	make $jobArgs
+}
+
+INSTALL()
+{
+	cd raceintospace-build
+	make install
+	addAppDeskbarSymlink $appsDir/raceintospace/bin/raceintospace "Race Into Space"
+}

--- a/games-simulation/raceintospace/raceintospace-v2.0~git.recipe
+++ b/games-simulation/raceintospace/raceintospace-v2.0~git.recipe
@@ -32,7 +32,7 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	boost170$secondaryArchSuffix
 	lib:libjsoncpp$secondaryArchSuffix
-	lib:libpng$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
 	lib:libprotobuf$secondaryArchSuffix
 	lib:libSDL_1.2$secondaryArchSuffix
 	lib:libtheora$secondaryArchSuffix
@@ -44,7 +44,7 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	boost170${secondaryArchSuffix}_devel
 	devel:libjsoncpp$secondaryArchSuffix
-	devel:libpng$secondaryArchSuffix
+	devel:libpng16$secondaryArchSuffix
 	devel:libprotobuf$secondaryArchSuffix
 	devel:libprotoc$secondaryArchSuffix
 	devel:libphysfs$secondaryArchSuffix

--- a/games-simulation/raceintospace/raceintospace-v2.0~git.recipe
+++ b/games-simulation/raceintospace/raceintospace-v2.0~git.recipe
@@ -30,7 +30,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	boost170$secondaryArchSuffix
+	lib:libboost_system$secondaryArchSuffix
 	lib:libjsoncpp$secondaryArchSuffix
 	lib:libpng16$secondaryArchSuffix
 	lib:libprotobuf$secondaryArchSuffix

--- a/games-simulation/raceintospace/raceintospace-v2.0~git.recipe
+++ b/games-simulation/raceintospace/raceintospace-v2.0~git.recipe
@@ -42,7 +42,7 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	boost170${secondaryArchSuffix}_devel
+	devel:libboost_system$secondaryArchSuffix >= 1.70.0
 	devel:libjsoncpp$secondaryArchSuffix
 	devel:libpng16$secondaryArchSuffix
 	devel:libprotobuf$secondaryArchSuffix
@@ -63,14 +63,13 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	mkdir -p raceintospace-build; cd raceintospace-build
-	cmake -DCMAKE_INSTALL_PREFIX=$appsDir/raceintospace ..
-	make $jobArgs
+	cmake -S. -Bbuild -DCMAKE_INSTALL_PREFIX=$appsDir/raceintospace \
+		-DCMAKE_BUILD_TYPE=Release
+	make -C build $jobArgs
 }
 
 INSTALL()
 {
-	cd raceintospace-build
-	make install
+	make -C build install
 	addAppDeskbarSymlink $appsDir/raceintospace/bin/raceintospace "Race Into Space"
 }


### PR DESCRIPTION
*Race Into Space* (RIS) is a port to modern operating systems of *Buzz Aldrin’s Race Into Space* (BARIS), a DOS game originally released in 1993 on floppy disk, and a year later in an expanded CD version. BARIS was developed by Fritz Bronner based on his 1989 board game *Liftoff!*. Dr. Aldrin’s name and imagery have been dropped because permission to use them was limited to the old DOS game.

Screenshot of the game working on the latest `x86_64` nightly:
![Screenshot_Haiku (Linked Base for Haiku and Haiku Beta)  Running  - Oracle VM VirtualBox_1](https://user-images.githubusercontent.com/11584387/137781847-3923b355-6a3a-4102-9e00-f7babde1b2fd.png)

