### PR TITLE
libgpg_error: fix pkgconfig

### DIFF
--- a/dev-libs/libgpg_error/libgpg_error-1.36.recipe
+++ b/dev-libs/libgpg_error/libgpg_error-1.36.recipe
@@ -5,7 +5,7 @@ DirMngr, Pinentry, SmartCard Daemon and more."
 HOMEPAGE="https://www.gnupg.org/related_software/libraries.en.html#lib-libgpg-error"
 COPYRIGHT="2003-2018 g10 Code GmbH"
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-$portVersion.tar.bz2"
 CHECKSUM_SHA256="babd98437208c163175c29453f8681094bcaf92968a15cafb1a276076b33c97c"
 SOURCE_DIR="libgpg-error-$portVersion"
@@ -65,6 +65,8 @@ INSTALL()
 	rm -f "$libDir"/libgpg-error.la
 
 	prepareInstalledDevelLib libgpg-error
+
+	fixPkgconfig
 
 	if [ -n "$secondaryArchSuffix" ]; then
 		maybe_manDir=


### PR DESCRIPTION
One more package with the .pc file in the wrong folder.

original rev1: gpg-error.pc is installed in /boot/system/lib/pkgconfig/
pkg-config is not able to find gpg-error

after the change rev2: gpg-error.pc is installed in /boot/system/develop/lib/pkgconfig/
pkg-config is able to find gpg-error