### PR TITLE
coreutils: use posix-error-mapper

### DIFF
--- a/sys-apps/coreutils/coreutils-9.0.recipe
+++ b/sys-apps/coreutils/coreutils-9.0.recipe
@@ -17,7 +17,7 @@ uptime users vdir wc who whoami yes"
 HOMEPAGE="https://www.gnu.org/software/coreutils/"
 COPYRIGHT="1994-2017 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://ftpmirror.gnu.org/coreutils/coreutils-$portVersion.tar.xz
 	https://ftp.gnu.org/gnu/coreutils/coreutils-$portVersion.tar.xz"
 CHECKSUM_SHA256="ce30acdf4a41bc5bb30dd955e9eaa75fa216b4e3deb08889ed32433c7b3b97ce"
@@ -254,9 +254,12 @@ PATCH()
 
 BUILD()
 {
-	FORCE_UNSAFE_CONFIGURE=1 runConfigure ./configure \
+	CFLAGS="-DB_USE_POSITIVE_POSIX_ERRORS -D_BSD_SOURCE" \
+		LDFLAGS="-lposix_error_mapper" \
+		FORCE_UNSAFE_CONFIGURE=1 runConfigure ./configure \
 		--without-included-regex \
-		--disable-rpath --with-gnu-ld \
+		--disable-rpath \
+		--with-gnu-ld \
 		--enable-no-install-program=df \
 		--enable-install-program=hostname
 	touch doc/*.info


### PR DESCRIPTION
Should fix #6327

However: it is broken now:

`

make[4]: Leaving directory '/sources/coreutils-9.0'
 /bin/mkdir -p '/packages/coreutils-9.0-2/.self/bin'
  src/ginstall -c src/ginstall '/packages/coreutils-9.0-2/.self/bin/./install'
ginstall: failed to access '/packages/coreutils-9.0-2/.self/bin/./install': No such file or directory
Makefile:7440: recipe for target 'install-binPROGRAMS' failed
make[3]: *** [install-binPROGRAMS] Error 1
make[3]: Leaving directory '/sources/coreutils-9.0'
Makefile:13965: recipe for target 'install-am' failed
make[2]: *** [install-am] Error 2
make[2]: Leaving directory '/sources/coreutils-9.0'
Makefile:13464: recipe for target 'install-recursive' failed
make[1]: *** [install-recursive] Error 1
make[1]: Leaving directory '/sources/coreutils-9.0'
Makefile:13958: recipe for target 'install' failed
make: *** [install] Error 2
`