### PR TITLE
libopenmpt-modplug: fix

### DIFF
--- a/media-libs/libopenmpt-modplug/libopenmpt_modplug-0.8.9.0.recipe
+++ b/media-libs/libopenmpt-modplug/libopenmpt_modplug-0.8.9.0.recipe
@@ -6,7 +6,7 @@ HOMEPAGE="https://openmpt.org/"
 COPYRIGHT="2004-2020 OpenMPT contributors
 	1997-2003 Olivier Lapicque"
 LICENSE="BSD (3-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://lib.openmpt.org/files/libopenmpt-modplug/libopenmpt-modplug-$portVersion-openmpt1.tar.gz"
 CHECKSUM_SHA256="ecce1a0eecfdb0b5824cab89c270dce59596295a2c17c2b043215ecf4d7c4ff7"
 SOURCE_DIR="libopenmpt-modplug-$portVersion-openmpt1"
@@ -34,6 +34,9 @@ PROVIDES_devel="
 REQUIRES_devel="
 	libopenmpt_modplug$secondaryArchSuffix == $portVersion base
 	devel:libopenmpt$secondaryArchSuffix
+	"
+CONFLICTS_devel="
+	libmodplug${secondaryArchSuffix}_devel
 	"
 
 BUILD_REQUIRES="
@@ -64,6 +67,10 @@ BUILD()
 INSTALL()
 {
 	make install
+
+	mkdir -p $includeDir
+	cp -r libmodplug $includeDir
+
 	prepareInstalledDevelLib libopenmpt_modplug
 	rm $developLibDir/*.la
 	fixPkgconfig


### PR DESCRIPTION
The devel subpackage should include the headers, but they doesn't gets copied, but this headers can conflict with the ones provided by modplug ,so define it as  conflicting package.