### PR TITLE
netperf: fix build

### DIFF
--- a/net-analyzer/netperf/netperf-2.6.0.recipe
+++ b/net-analyzer/netperf/netperf-2.6.0.recipe
@@ -12,11 +12,12 @@ HOMEPAGE="http://netperf.org"
 COPYRIGHT="1993 Hewlett-Packard Company"
 LICENSE="netperf"
 REVISION="1"
-SOURCE_URI="ftp://ftp.netperf.org/${portName}/${portName}-${portVersion}.tar.bz2"
-CHECKSUM_SHA256="cd8dac710d4273d29f70e8dbd09353a6362ac58a11926e0822233c0cb230323a"
-PATCHES="netperf-2.6.0.patchset"
+SOURCE_URI="https://github.com/HewlettPackard/netperf/archive/${portName}-${portVersion}.tar.gz"
+CHECKSUM_SHA256="560b9c0ef0eed826941f74708b3ac53d91ec13b0b8c565fb107a1b5e6d99ded4"
+PATCHES="${portName}-${portVersion}.patchset"
+SOURCE_DIR="${portName}-${portName}-${portVersion}"
 
-ARCHITECTURES="x86_gcc2"
+ARCHITECTURES="all"
 
 PROVIDES="
 	netperf = $portVersion
@@ -31,15 +32,22 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:autoheader
+	cmd:automake
 	cmd:awk
+	cmd:find
 	cmd:gcc
 	cmd:make
+	cmd:makeinfo
 	"
 
 BUILD()
 {
+	./autogen.sh
 	runConfigure ./configure
-	make
+	make $jobArgs
 }
 
 INSTALL()

--- a/net-analyzer/netperf/patches/netperf-2.6.0.patchset
+++ b/net-analyzer/netperf/patches/netperf-2.6.0.patchset
@@ -1,4 +1,4 @@
-From 08c3cdbadfc2679183619f71d05bae03c43cb23f Mon Sep 17 00:00:00 2001
+From 3364c74809e1aaba2518d3d54078778fd0662c38 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Wed, 4 Jun 2014 14:44:30 +0200
 Subject: Add missing include.
@@ -18,5 +18,28 @@ index 379a106..55c202b 100644
  #include <sys/socket.h>
  #endif
 -- 
-1.8.3.4
+2.30.2
+
+
+From 907b37e7c356d3e702e18156f32eefb26141f677 Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Sat, 30 Oct 2021 17:43:22 +0200
+Subject: fix for -lnetwork
+
+
+diff --git a/configure.ac b/configure.ac
+index 5c8948c..236724d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -48,6 +48,8 @@ if test "$ac_cv_lib_socket_main" = yes ; then
+     AC_SYS_LARGEFILE
+ fi
+ 
++AC_CHECK_LIB([network], [socket])
++
+ # this one is for Tru64 and bind_to_cpu_id
+ AC_HAVE_LIBRARY(mach)
+ 
+-- 
+2.30.2
 


### PR DESCRIPTION
fix download url
add -lnetwork to configure script (and therefore autoreconf is needed now)

builds on 32-bit and 64-bit
