### PR TITLE
GCC 11: enable for every arch

### DIFF
--- a/sys-devel/gcc/gcc-11.1.0_2021_04_27.recipe
+++ b/sys-devel/gcc/gcc-11.1.0_2021_04_27.recipe
@@ -13,7 +13,7 @@ CHECKSUM_SHA256="4c4a6fb8a8396059241c2e674b85b351c26a5d678274007f076957afa1cc9dd
 SOURCE_DIR="gcc-$gccVersion"
 PATCHES="gcc-$portVersion.patchset"
 
-ARCHITECTURES="?all !x86_gcc2"
+ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 libatomicSoVersion="1"


### PR DESCRIPTION
It seems @pulkomandy have forgot about the 64 bit users. Lets fix it.