### PR TITLE
Add recipe for BeScreenCapture 2.5.3

### DIFF
--- a/haiku-apps/bescreencapture/bescreencapture-2.5.3.recipe
+++ b/haiku-apps/bescreencapture/bescreencapture-2.5.3.recipe
@@ -5,14 +5,13 @@ to any media format supported in Haiku.
 BeScreenCapture can record either the entire screen, or just a section you \
 select."
 HOMEPAGE="https://github.com/jackburton79/bescreencapture/releases"
-COPYRIGHT="2014-2020 Stefano Ceccherini"
+COPYRIGHT="2014-2021 Stefano Ceccherini"
 LICENSE="BSD (3-clause)
 	MIT"
 REVISION="1"
 SOURCE_URI="https://github.com/jackburton79/bescreencapture/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="c07207a291fa33862649d2de440a9b3da1d6db01750d5365bca7a619ae902031"
+CHECKSUM_SHA256="19ae9f17f6218bf5e8238a52e79bcd68d9d1c2bc337c2c2854891021094ad6ca"
 SOURCE_FILENAME="bescreencapture-$portVersion.tar.gz"
-PATCHES="bescreencapture-$portVersion.patchset"
 
 ARCHITECTURES="all"
 


### PR DESCRIPTION
Bugfix release: Fixed crash / hang after recording many frames with virtual memory enabled
Also removed recipe for BeScreenCapture 2.5.1