### PR TITLE
gcc: enable build for arm

### DIFF
--- a/sys-devel/gcc/gcc-8.3.0_2019_05_24.recipe
+++ b/sys-devel/gcc/gcc-8.3.0_2019_05_24.recipe
@@ -13,7 +13,7 @@ CHECKSUM_SHA256="64baadfe6cc0f4947a84cb12d7f0dfaf45bb58b7e92461639596c21e02d97d2
 SOURCE_DIR="gcc-$gccVersion"
 PATCHES="gcc-$portVersion.patchset"
 
-ARCHITECTURES="all !x86_gcc2 ?x86 ?arm ?ppc"
+ARCHITECTURES="all !x86_gcc2 ?x86 ?ppc"
 SECONDARY_ARCHITECTURES="x86"
 
 libatomicSoVersion="1"


### PR DESCRIPTION
one more change that seems to be required for a successful arm bootstrap