### PR TITLE
QPDFView: Reflection of Japanese translation

### DIFF
--- a/app-text/qpdfview/patches/qpdfview-0.4.18.patchset
+++ b/app-text/qpdfview/patches/qpdfview-0.4.18.patchset
@@ -42,3 +42,156 @@ index 6363c32..dc10a8c 100644
 -- 
 2.30.0
 
+
+From c5d6a0ffa020ce7b75469ef778ef7d1f250e0245 Mon Sep 17 00:00:00 2001
+From: FuRuYa7 <mymail@mydomain.org>
+Date: Fri, 29 Oct 2021 15:03:10 +0900
+Subject: [PATCH 1/2] Fix installation path
+
+---
+ qpdfview.pri | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/qpdfview.pri b/qpdfview.pri
+index 6dbd353..6155ab7 100644
+--- a/qpdfview.pri
++++ b/qpdfview.pri
+@@ -1,12 +1,12 @@
+ isEmpty(APPLICATION_VERSION):APPLICATION_VERSION = 0.4.18
+ 
+-isEmpty(TARGET_INSTALL_PATH):TARGET_INSTALL_PATH = /usr/bin
+-isEmpty(PLUGIN_INSTALL_PATH):PLUGIN_INSTALL_PATH = /usr/lib/qpdfview
+-isEmpty(DATA_INSTALL_PATH):DATA_INSTALL_PATH = /usr/share/qpdfview
+-isEmpty(MANUAL_INSTALL_PATH):MANUAL_INSTALL_PATH = /usr/share/man/man1
+-isEmpty(ICON_INSTALL_PATH):ICON_INSTALL_PATH = /usr/share/icons/hicolor/scalable/apps
+-isEmpty(LAUNCHER_INSTALL_PATH):LAUNCHER_INSTALL_PATH = /usr/share/applications
+-isEmpty(APPDATA_INSTALL_PATH):APPDATA_INSTALL_PATH = /usr/share/appdata
++isEmpty(TARGET_INSTALL_PATH):TARGET_INSTALL_PATH = $appsDir/qPDFView
++isEmpty(PLUGIN_INSTALL_PATH):PLUGIN_INSTALL_PATH = $appsDir/qPDFView/lib
++isEmpty(DATA_INSTALL_PATH):DATA_INSTALL_PATH = $appsDir/qPDFView/data
++isEmpty(MANUAL_INSTALL_PATH):MANUAL_INSTALL_PATH = $appsDir/qPDFView/man/man1
++isEmpty(ICON_INSTALL_PATH):ICON_INSTALL_PATH = $appsDir/qPDFView/icons/hicolor/scalable/apps
++isEmpty(LAUNCHER_INSTALL_PATH):LAUNCHER_INSTALL_PATH = $appsDir/qPDFView/applications
++isEmpty(APPDATA_INSTALL_PATH):APPDATA_INSTALL_PATH = $appsDir/qPDFView/appdata
+ 
+ win32:include(qpdfview_win32.pri)
+ os2:include(qpdfview_os2.pri)
+-- 
+2.30.2
+
+
+From b5af672c965a1febb3521ed1875d712804fc6350 Mon Sep 17 00:00:00 2001
+From: FuRuYa7 <mymail@mydomain.org>
+Date: Fri, 29 Oct 2021 15:04:08 +0900
+Subject: [PATCH 2/2] Changed to reflect Japanese translation files
+
+---
+ qpdfview.pro     | 14 +++++++++++++-
+ translations.qrc | 12 ++++++++++++
+ 2 files changed, 25 insertions(+), 1 deletion(-)
+
+diff --git a/qpdfview.pro b/qpdfview.pro
+index b9c112f..2170492 100644
+--- a/qpdfview.pro
++++ b/qpdfview.pro
+@@ -41,11 +41,13 @@ TRANSLATIONS += \
+     translations/qpdfview_da.ts \
+     translations/qpdfview_de.ts \
+     translations/qpdfview_el.ts \
++    translations/qpdfview_en_AU.ts \
+     translations/qpdfview_en_GB.ts \
+     translations/qpdfview_eo.ts \
+     translations/qpdfview_es.ts \
+     translations/qpdfview_eu.ts \
+     translations/qpdfview_fi.ts \
++    translations/qpdfview_fa.ts \
+     translations/qpdfview_fr.ts \
+     translations/qpdfview_gl.ts \
+     translations/qpdfview_he.ts \
+@@ -53,21 +55,31 @@ TRANSLATIONS += \
+     translations/qpdfview_hu.ts \
+     translations/qpdfview_id.ts \
+     translations/qpdfview_it.ts \
++    translations/qpdfview_ja.ts \
+     translations/qpdfview_kk.ts \
++    translations/qpdfview_ko.ts \
++    translations/qpdfview_ku.ts \
+     translations/qpdfview_ky.ts \
+     translations/qpdfview_lt.ts \
++    translations/qpdfview_lv.ts \
+     translations/qpdfview_ms.ts \
+     translations/qpdfview_my.ts \
++    translations/qpdfview_nb.ts \
++    translations/qpdfview_nds.ts \
++    translations/qpdfview_oc.ts \
+     translations/qpdfview_pl.ts \
+     translations/qpdfview_pt.ts \
+     translations/qpdfview_pt_BR.ts \
+     translations/qpdfview_ro.ts \
+     translations/qpdfview_ru.ts \
+     translations/qpdfview_sk.ts \
++    translations/qpdfview_sr.ts \
+     translations/qpdfview_sv.ts \
+     translations/qpdfview_th.ts \
+     translations/qpdfview_tr.ts \
+     translations/qpdfview_ug.ts \
+     translations/qpdfview_uk.ts \
++    translations/qpdfview_uz.ts \
+     translations/qpdfview_vi.ts \
+-    translations/qpdfview_zh_CN.ts
++    translations/qpdfview_zh_CN.ts \
++    translations/qpdfview_zh_TW.ts
+diff --git a/translations.qrc b/translations.qrc
+index 7627a38..d631e13 100644
+--- a/translations.qrc
++++ b/translations.qrc
+@@ -10,10 +10,12 @@
+         <file alias="qpdfview_da.qm">translations/qpdfview_da.qm</file>
+         <file alias="qpdfview_de.qm">translations/qpdfview_de.qm</file>
+         <file alias="qpdfview_el.qm">translations/qpdfview_el.qm</file>
++        <file alias="qpdfview_en_GB.qm">translations/qpdfview_en_AU.qm</file>
+         <file alias="qpdfview_en_GB.qm">translations/qpdfview_en_GB.qm</file>
+         <file alias="qpdfview_eo.qm">translations/qpdfview_eo.qm</file>
+         <file alias="qpdfview_es.qm">translations/qpdfview_es.qm</file>
+         <file alias="qpdfview_eu.qm">translations/qpdfview_eu.qm</file>
++        <file alias="qpdfview_fa.qm">translations/qpdfview_fa.qm</file>
+         <file alias="qpdfview_fi.qm">translations/qpdfview_fi.qm</file>
+         <file alias="qpdfview_fr.qm">translations/qpdfview_fr.qm</file>
+         <file alias="qpdfview_gl.qm">translations/qpdfview_gl.qm</file>
+@@ -22,23 +24,33 @@
+         <file alias="qpdfview_hu.qm">translations/qpdfview_hu.qm</file>
+         <file alias="qpdfview_id.qm">translations/qpdfview_id.qm</file>
+         <file alias="qpdfview_it.qm">translations/qpdfview_it.qm</file>
++        <file alias="qpdfview_ja.qm">translations/qpdfview_ja.qm</file>
+         <file alias="qpdfview_kk.qm">translations/qpdfview_kk.qm</file>
++        <file alias="qpdfview_ko.qm">translations/qpdfview_ko.qm</file>
++        <file alias="qpdfview_ku.qm">translations/qpdfview_ku.qm</file>
+         <file alias="qpdfview_ky.qm">translations/qpdfview_ky.qm</file>
+         <file alias="qpdfview_lt.qm">translations/qpdfview_lt.qm</file>
++        <file alias="qpdfview_lv.qm">translations/qpdfview_lv.qm</file>
+         <file alias="qpdfview_ms.qm">translations/qpdfview_ms.qm</file>
+         <file alias="qpdfview_my.qm">translations/qpdfview_my.qm</file>
++        <file alias="qpdfview_nb.qm">translations/qpdfview_nb.qm</file>
++        <file alias="qpdfview_nds.qm">translations/qpdfview_nds.qm</file>
++        <file alias="qpdfview_oc.qm">translations/qpdfview_oc.qm</file>
+         <file alias="qpdfview_pl.qm">translations/qpdfview_pl.qm</file>
+         <file alias="qpdfview_pt_BR.qm">translations/qpdfview_pt_BR.qm</file>
+         <file alias="qpdfview_pt.qm">translations/qpdfview_pt.qm</file>
+         <file alias="qpdfview_ro.qm">translations/qpdfview_ro.qm</file>
+         <file alias="qpdfview_ru.qm">translations/qpdfview_ru.qm</file>
+         <file alias="qpdfview_sk.qm">translations/qpdfview_sk.qm</file>
++        <file alias="qpdfview_sr.qm">translations/qpdfview_sr.qm</file>
+         <file alias="qpdfview_sv.qm">translations/qpdfview_sv.qm</file>
+         <file alias="qpdfview_th.qm">translations/qpdfview_th.qm</file>
+         <file alias="qpdfview_tr.qm">translations/qpdfview_tr.qm</file>
+         <file alias="qpdfview_ug.qm">translations/qpdfview_ug.qm</file>
+         <file alias="qpdfview_uk.qm">translations/qpdfview_uk.qm</file>
++        <file alias="qpdfview_uz.qm">translations/qpdfview_uz.qm</file>
+         <file alias="qpdfview_vi.qm">translations/qpdfview_vi.qm</file>
+         <file alias="qpdfview_zh_CN.qm">translations/qpdfview_zh_CN.qm</file>
++        <file alias="qpdfview_zh_TW.qm">translations/qpdfview_zh_TW.qm</file>
+     </qresource>
+ </RCC>
+-- 
+2.30.2
+

--- a/app-text/qpdfview/patches/qpdfview-0.4.18.patchset
+++ b/app-text/qpdfview/patches/qpdfview-0.4.18.patchset
@@ -43,44 +43,10 @@ index 6363c32..dc10a8c 100644
 2.30.0
 
 
-From c5d6a0ffa020ce7b75469ef778ef7d1f250e0245 Mon Sep 17 00:00:00 2001
-From: FuRuYa7 <mymail@mydomain.org>
-Date: Fri, 29 Oct 2021 15:03:10 +0900
-Subject: [PATCH 1/2] Fix installation path
-
-
-diff --git a/qpdfview.pri b/qpdfview.pri
-index 6dbd353..6155ab7 100644
---- a/qpdfview.pri
-+++ b/qpdfview.pri
-@@ -1,12 +1,12 @@
- isEmpty(APPLICATION_VERSION):APPLICATION_VERSION = 0.4.18
- 
--isEmpty(TARGET_INSTALL_PATH):TARGET_INSTALL_PATH = /usr/bin
--isEmpty(PLUGIN_INSTALL_PATH):PLUGIN_INSTALL_PATH = /usr/lib/qpdfview
--isEmpty(DATA_INSTALL_PATH):DATA_INSTALL_PATH = /usr/share/qpdfview
--isEmpty(MANUAL_INSTALL_PATH):MANUAL_INSTALL_PATH = /usr/share/man/man1
--isEmpty(ICON_INSTALL_PATH):ICON_INSTALL_PATH = /usr/share/icons/hicolor/scalable/apps
--isEmpty(LAUNCHER_INSTALL_PATH):LAUNCHER_INSTALL_PATH = /usr/share/applications
--isEmpty(APPDATA_INSTALL_PATH):APPDATA_INSTALL_PATH = /usr/share/appdata
-+isEmpty(TARGET_INSTALL_PATH):TARGET_INSTALL_PATH = $appsDir/qPDFView
-+isEmpty(PLUGIN_INSTALL_PATH):PLUGIN_INSTALL_PATH = $appsDir/qPDFView/lib
-+isEmpty(DATA_INSTALL_PATH):DATA_INSTALL_PATH = $appsDir/qPDFView/data
-+isEmpty(MANUAL_INSTALL_PATH):MANUAL_INSTALL_PATH = $appsDir/qPDFView/man/man1
-+isEmpty(ICON_INSTALL_PATH):ICON_INSTALL_PATH = $appsDir/qPDFView/icons/hicolor/scalable/apps
-+isEmpty(LAUNCHER_INSTALL_PATH):LAUNCHER_INSTALL_PATH = $appsDir/qPDFView/applications
-+isEmpty(APPDATA_INSTALL_PATH):APPDATA_INSTALL_PATH = $appsDir/qPDFView/appdata
- 
- win32:include(qpdfview_win32.pri)
- os2:include(qpdfview_os2.pri)
--- 
-2.30.2
-
-
 From b5af672c965a1febb3521ed1875d712804fc6350 Mon Sep 17 00:00:00 2001
 From: FuRuYa7 <mymail@mydomain.org>
 Date: Fri, 29 Oct 2021 15:04:08 +0900
-Subject: [PATCH 2/2] Changed to reflect Japanese translation files
+Subject: [PATCH] Changed to reflect Japanese translation files
 
 
 diff --git a/qpdfview.pro b/qpdfview.pro

--- a/app-text/qpdfview/patches/qpdfview-0.4.18.patchset
+++ b/app-text/qpdfview/patches/qpdfview-0.4.18.patchset
@@ -149,7 +149,7 @@ index 7627a38..d631e13 100644
          <file alias="qpdfview_da.qm">translations/qpdfview_da.qm</file>
          <file alias="qpdfview_de.qm">translations/qpdfview_de.qm</file>
          <file alias="qpdfview_el.qm">translations/qpdfview_el.qm</file>
-+        <file alias="qpdfview_en_GB.qm">translations/qpdfview_en_AU.qm</file>
++        <file alias="qpdfview_en_AU.qm">translations/qpdfview_en_AU.qm</file>
          <file alias="qpdfview_en_GB.qm">translations/qpdfview_en_GB.qm</file>
          <file alias="qpdfview_eo.qm">translations/qpdfview_eo.qm</file>
          <file alias="qpdfview_es.qm">translations/qpdfview_es.qm</file>

--- a/app-text/qpdfview/patches/qpdfview-0.4.18.patchset
+++ b/app-text/qpdfview/patches/qpdfview-0.4.18.patchset
@@ -48,9 +48,6 @@ From: FuRuYa7 <mymail@mydomain.org>
 Date: Fri, 29 Oct 2021 15:03:10 +0900
 Subject: [PATCH 1/2] Fix installation path
 
----
- qpdfview.pri | 14 +++++++-------
- 1 file changed, 7 insertions(+), 7 deletions(-)
 
 diff --git a/qpdfview.pri b/qpdfview.pri
 index 6dbd353..6155ab7 100644
@@ -85,10 +82,6 @@ From: FuRuYa7 <mymail@mydomain.org>
 Date: Fri, 29 Oct 2021 15:04:08 +0900
 Subject: [PATCH 2/2] Changed to reflect Japanese translation files
 
----
- qpdfview.pro     | 14 +++++++++++++-
- translations.qrc | 12 ++++++++++++
- 2 files changed, 25 insertions(+), 1 deletion(-)
 
 diff --git a/qpdfview.pro b/qpdfview.pro
 index b9c112f..2170492 100644
@@ -195,3 +188,238 @@ index 7627a38..d631e13 100644
 -- 
 2.30.2
 
+
+From 5860cc6ebce838730c160506b701509c573e4ac0 Mon Sep 17 00:00:00 2001
+From: FuRuYa7 <mymail@mydomain.org>
+Date: Fri, 29 Oct 2021 15:06:01 +0900
+Subject: [PATCH] Fix to translate help file
+
+
+diff --git a/translations/qpdfview_az.ts b/translations/qpdfview_az.ts
+index 61e42ee..1403809 100644
+--- a/translations/qpdfview_az.ts
++++ b/translations/qpdfview_az.ts
+@@ -417,7 +417,7 @@
+         <location filename="../sources/helpdialog.cpp" line="48"/>
+         <source>help.html</source>
+         <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.</extracomment>
+-        <translation>help.html</translation>
++        <translation>help_az.html</translation>
+     </message>
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="63"/>
+diff --git a/translations/qpdfview_bg.ts b/translations/qpdfview_bg.ts
+index 2f369d4..1a67a8e 100644
+--- a/translations/qpdfview_bg.ts
++++ b/translations/qpdfview_bg.ts
+@@ -417,7 +417,7 @@
+         <location filename="../sources/helpdialog.cpp" line="48"/>
+         <source>help.html</source>
+         <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.</extracomment>
+-        <translation>help.html</translation>
++        <translation>help_bg.html</translation>
+     </message>
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="63"/>
+diff --git a/translations/qpdfview_da.ts b/translations/qpdfview_da.ts
+index 0b0e167..e440414 100644
+--- a/translations/qpdfview_da.ts
++++ b/translations/qpdfview_da.ts
+@@ -417,7 +417,7 @@
+         <location filename="../sources/helpdialog.cpp" line="48"/>
+         <source>help.html</source>
+         <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.</extracomment>
+-        <translation>help.html</translation>
++        <translation>help_da.html</translation>
+     </message>
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="63"/>
+diff --git a/translations/qpdfview_fa.ts b/translations/qpdfview_fa.ts
+index 875530e..7720023 100644
+--- a/translations/qpdfview_fa.ts
++++ b/translations/qpdfview_fa.ts
+@@ -429,9 +429,8 @@
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="48"/>
+         <source>help.html</source>
+-        <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.
+-</extracomment>
+-        <translation type="unfinished"></translation>
++        <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.</extracomment>
++        <translation>help_fa.html</translation>
+     </message>
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="63"/>
+diff --git a/translations/qpdfview_fi.ts b/translations/qpdfview_fi.ts
+index 72b8147..2f2b8f8 100644
+--- a/translations/qpdfview_fi.ts
++++ b/translations/qpdfview_fi.ts
+@@ -417,7 +417,7 @@
+         <location filename="../sources/helpdialog.cpp" line="48"/>
+         <source>help.html</source>
+         <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.</extracomment>
+-        <translation type="unfinished"></translation>
++        <translation>help_fi.html</translation>
+     </message>
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="63"/>
+diff --git a/translations/qpdfview_gl.ts b/translations/qpdfview_gl.ts
+index 6169aeb..896ea10 100644
+--- a/translations/qpdfview_gl.ts
++++ b/translations/qpdfview_gl.ts
+@@ -417,7 +417,7 @@
+         <location filename="../sources/helpdialog.cpp" line="48"/>
+         <source>help.html</source>
+         <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.</extracomment>
+-        <translation>help.html</translation>
++        <translation>help_gl.html</translation>
+     </message>
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="63"/>
+diff --git a/translations/qpdfview_ja.ts b/translations/qpdfview_ja.ts
+index c0c8d4f..88446dc 100644
+--- a/translations/qpdfview_ja.ts
++++ b/translations/qpdfview_ja.ts
+@@ -429,9 +429,8 @@
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="48"/>
+         <source>help.html</source>
+-        <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.
+-</extracomment>
+-        <translation>help.html</translation>
++        <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.</extracomment>
++        <translation>help_ja.html</translation>
+     </message>
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="63"/>
+diff --git a/translations/qpdfview_ko.ts b/translations/qpdfview_ko.ts
+index 5ab35b3..3a7b272 100644
+--- a/translations/qpdfview_ko.ts
++++ b/translations/qpdfview_ko.ts
+@@ -429,9 +429,8 @@
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="48"/>
+         <source>help.html</source>
+-        <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.
+-</extracomment>
+-        <translation type="unfinished"></translation>
++        <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.</extracomment>
++        <translation>help_ko.html</translation>
+     </message>
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="63"/>
+diff --git a/translations/qpdfview_ku.ts b/translations/qpdfview_ku.ts
+index 0e721f7..436b43b 100644
+--- a/translations/qpdfview_ku.ts
++++ b/translations/qpdfview_ku.ts
+@@ -429,9 +429,8 @@
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="48"/>
+         <source>help.html</source>
+-        <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.
+-</extracomment>
+-        <translation type="unfinished"></translation>
++        <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.</extracomment>
++        <translation>help_ku.html</translation>
+     </message>
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="63"/>
+diff --git a/translations/qpdfview_ms.ts b/translations/qpdfview_ms.ts
+index 9756691..38b4147 100644
+--- a/translations/qpdfview_ms.ts
++++ b/translations/qpdfview_ms.ts
+@@ -417,7 +417,7 @@
+         <location filename="../sources/helpdialog.cpp" line="48"/>
+         <source>help.html</source>
+         <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.</extracomment>
+-        <translation>help.html</translation>
++        <translation>help_ms.html</translation>
+     </message>
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="63"/>
+diff --git a/translations/qpdfview_pl.ts b/translations/qpdfview_pl.ts
+index 99bc54c..b9f2763 100644
+--- a/translations/qpdfview_pl.ts
++++ b/translations/qpdfview_pl.ts
+@@ -417,7 +417,7 @@
+         <location filename="../sources/helpdialog.cpp" line="48"/>
+         <source>help.html</source>
+         <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.</extracomment>
+-        <translation>help.html</translation>
++        <translation>help_pl.html</translation>
+     </message>
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="63"/>
+diff --git a/translations/qpdfview_sr.ts b/translations/qpdfview_sr.ts
+index 19c2b58..e6c387e 100644
+--- a/translations/qpdfview_sr.ts
++++ b/translations/qpdfview_sr.ts
+@@ -429,9 +429,8 @@
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="48"/>
+         <source>help.html</source>
+-        <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.
+-</extracomment>
+-        <translation>помоћ_rs.html</translation>
++        <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.</extracomment>
++        <translation>help_sr.html</translation>
+     </message>
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="63"/>
+diff --git a/translations/qpdfview_sv.ts b/translations/qpdfview_sv.ts
+index 24cdc6b..9dc9ee3 100644
+--- a/translations/qpdfview_sv.ts
++++ b/translations/qpdfview_sv.ts
+@@ -417,7 +417,7 @@
+         <location filename="../sources/helpdialog.cpp" line="48"/>
+         <source>help.html</source>
+         <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.</extracomment>
+-        <translation>help.html</translation>
++        <translation>help_sv.html</translation>
+     </message>
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="63"/>
+diff --git a/translations/qpdfview_tr.ts b/translations/qpdfview_tr.ts
+index 3c8e8a7..465b3b0 100644
+--- a/translations/qpdfview_tr.ts
++++ b/translations/qpdfview_tr.ts
+@@ -417,7 +417,7 @@
+         <location filename="../sources/helpdialog.cpp" line="48"/>
+         <source>help.html</source>
+         <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.</extracomment>
+-        <translation>yardım.html</translation>
++        <translation>help_tr.html</translation>
+     </message>
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="63"/>
+diff --git a/translations/qpdfview_vi.ts b/translations/qpdfview_vi.ts
+index 5735371..dfec310 100644
+--- a/translations/qpdfview_vi.ts
++++ b/translations/qpdfview_vi.ts
+@@ -417,7 +417,7 @@
+         <location filename="../sources/helpdialog.cpp" line="48"/>
+         <source>help.html</source>
+         <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.</extracomment>
+-        <translation>help.html</translation>
++        <translation>help_vi.html</translation>
+     </message>
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="63"/>
+diff --git a/translations/qpdfview_zh_TW.ts b/translations/qpdfview_zh_TW.ts
+index 55278e3..06152a6 100644
+--- a/translations/qpdfview_zh_TW.ts
++++ b/translations/qpdfview_zh_TW.ts
+@@ -429,9 +429,8 @@
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="48"/>
+         <source>help.html</source>
+-        <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.
+-</extracomment>
+-        <translation type="unfinished"></translation>
++        <extracomment>Please replace by file name of localized help if available, e.g. &quot;help_fr.html&quot;.</extracomment>
++        <translation>help_zh_TW.html</translation>
+     </message>
+     <message>
+         <location filename="../sources/helpdialog.cpp" line="63"/>
+-- 
+2.30.2

--- a/app-text/qpdfview/qpdfview-0.4.18.recipe
+++ b/app-text/qpdfview/qpdfview-0.4.18.recipe
@@ -77,12 +77,18 @@ INSTALL()
 	cd haiku_build
 	make install
 
+	mkdir -p $appsDir/qPDFView/data
+	cp -r ../ppsDir/qPDFView/appdata $appsDir/qPDFView/
+	cp -r ../ppsDir/qPDFView/data/* $appsDir/qPDFView/data/
+
+	#Translate Help file (Please uncomment and change the language)
+	#cp $appsDir/qPDFView/data/help_ja.html $appsDir/qPDFView/data/help.html
+	
 	mv $appsDir/qPDFView/qpdfview $appsDir/qPDFView/qPDFView
 	# Icon
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
 	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
 	local MINOR="`echo "$portVersion" | cut -d. -f3`"
-
 	sed \
 		-e "s|@MAJOR@|$MAJOR|" \
 		-e "s|@MIDDLE@|$MIDDLE|" \

--- a/app-text/qpdfview/qpdfview-0.4.18.recipe
+++ b/app-text/qpdfview/qpdfview-0.4.18.recipe
@@ -78,8 +78,9 @@ INSTALL()
 	cd haiku_build
 	make install
 
-	#Translate Help file (Please uncomment and change the language)
-	#cp $appsDir/qPDFView/data/help_ja.html $appsDir/qPDFView/data/help.html
+	#To translate the help file, modify "translations/qpdfview_??.ts".
+	#Replace the written "<translation>help.html</translation>"
+	# with "<translation>help_??.html</translation>".
 	
 	mv $appsDir/qPDFView/qpdfview $appsDir/qPDFView/qPDFView
 	# Icon

--- a/app-text/qpdfview/qpdfview-0.4.18.recipe
+++ b/app-text/qpdfview/qpdfview-0.4.18.recipe
@@ -67,6 +67,7 @@ BUILD()
 		CONFIG+="without_ps without_cups without_synctex without_dbus without_signals" \
 		TARGET_INSTALL_PATH=$appsDir/qPDFView \
 		PLUGIN_INSTALL_PATH=$appsDir/qPDFView/lib \
+		DATA_INSTALL_PATH=$appsDir/qPDFView/data \
 		MANUAL_INSTALL_PATH=$manDir
 
 	make $jobArgs
@@ -76,10 +77,6 @@ INSTALL()
 {
 	cd haiku_build
 	make install
-
-	mkdir -p $appsDir/qPDFView/data
-	cp -r ../ppsDir/qPDFView/appdata $appsDir/qPDFView/
-	cp -r ../ppsDir/qPDFView/data/* $appsDir/qPDFView/data/
 
 	#Translate Help file (Please uncomment and change the language)
 	#cp $appsDir/qPDFView/data/help_ja.html $appsDir/qPDFView/data/help.html


### PR DESCRIPTION
Translation files in some languages, including Japanese, are not reflected. 

1) Bugs that have not been translated into Japanese have been addressed in [qpdfview 0.5.0 trunk revision 2093](https://bugs.launchpad.net/qpdfview/+bug/1841048) . "qpdfview 0.5.0" is a development version and has not been released yet. So I uploaded it as a patch of "qpdfview 0.4.18".

2) For translation (switching) of help files, it is necessary to support "Haiku" on the application side. I can't expect it, so I added it as a manual switch. This feature is commented out and defaults to English.
