### PR TITLE
GCC: bump

### DIFF
--- a/sys-devel/gcc/gcc-11.2.0_2021_07_28.recipe
+++ b/sys-devel/gcc/gcc-11.2.0_2021_07_28.recipe
@@ -5,11 +5,11 @@ HOMEPAGE="https://gcc.gnu.org/"
 COPYRIGHT="1988-2021 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3
 	GNU LGPL v3"
-REVISION="2"
+REVISION="1"
 gccVersion="${portVersion%%_*}"
 SOURCE_URI="https://ftpmirror.gnu.org/gcc/gcc-$gccVersion/gcc-$gccVersion.tar.xz
 	https://ftp.gnu.org/gnu/gcc/gcc-$gccVersion/gcc-$gccVersion.tar.xz"
-CHECKSUM_SHA256="4c4a6fb8a8396059241c2e674b85b351c26a5d678274007f076957afa1cc9ddf"
+CHECKSUM_SHA256="d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b"
 SOURCE_DIR="gcc-$gccVersion"
 PATCHES="gcc-$portVersion.patchset"
 
@@ -415,9 +415,9 @@ INSTALL()
 	echo "Cleanup"
 	rm -rf $installDir/info
 	rm -rf $installDir/share
-	rm -rf $installDir/$gccLibDir/*.la
-	rm -rf $installDir/$gccLibdir/libobjc.*
-	rm -rf $installDir/$gccLibdir/include/objc
+	rm -rf $gccLibDir/*.la
+	rm -rf $gccLibdir/libobjc.*
+	rm -rf $gccLibdir/include/objc
 	rm -rf $includeDir/gcc/include/objc
 
 	### Sub Packages ##########################################

--- a/sys-devel/gcc/patches/gcc-11.2.0_2021_07_28.patchset
+++ b/sys-devel/gcc/patches/gcc-11.2.0_2021_07_28.patchset
@@ -1,4 +1,4 @@
-From b8a0d42a7696e2d7e40bdbeebc3c836e9e63ccd2 Mon Sep 17 00:00:00 2001
+From 195e64f760c95cd5e66aa4f0b3bd2b076a51f69a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Sun, 19 Jul 2015 18:55:34 +0200
 Subject: Haiku patch
@@ -1335,7 +1335,7 @@ index 0000000..587d1fb
 +LIMITS_H_TEST = [ -f $(SYSTEM_HEADER_DIR)/posix/limits.h ]
 \ No newline at end of file
 diff --git a/gcc/configure.ac b/gcc/configure.ac
-index 96a6f62..177f75e 100644
+index 162e08c..df6b36f 100644
 --- a/gcc/configure.ac
 +++ b/gcc/configure.ac
 @@ -814,6 +814,15 @@ fi
@@ -1534,7 +1534,7 @@ index 2c8be56..4e18e3c 100644
  ifneq (,$(vis_hide))
  
 diff --git a/libgcc/config.host b/libgcc/config.host
-index f808b61..2a5ee34 100644
+index 50f0006..6a497ea 100644
 --- a/libgcc/config.host
 +++ b/libgcc/config.host
 @@ -245,6 +245,14 @@ case ${host} in
@@ -2403,7 +2403,7 @@ index 17f8e5f..9c03be6 100644
 2.30.2
 
 
-From 1fabe3f3b11559db6caf31884ea1fd5ee174b2d0 Mon Sep 17 00:00:00 2001
+From 7dfded839e9667d56b9b7d6117115f72577276fd Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Mon, 27 Jul 2015 16:32:32 +0200
 Subject: Haiku: disable -fno-PIE as this fails on x86_64.
@@ -2439,7 +2439,7 @@ index 00da7f9..30fba68 100644
 2.30.2
 
 
-From 59a6a5c38d2288f08a477de7ea6a67ea531f8b23 Mon Sep 17 00:00:00 2001
+From 4b65ab73889321990069919a6f70e4dd4f4a0022 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Thu, 5 May 2016 09:03:06 +0000
 Subject: fix for libstdc++/69506
@@ -2461,7 +2461,7 @@ index 4674f7b..02c8693 100644
 2.30.2
 
 
-From e6c76e69f201c8b22ec2ae83ba305f22391b8fcb Mon Sep 17 00:00:00 2001
+From 1c1621f9b4a75e8e0f5303a482e02213355c299e Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Thu, 5 May 2016 15:52:08 +0000
 Subject: rename x86_elf_aligned_common.
@@ -2488,7 +2488,7 @@ index 76ba48e..e2fa55a 100644
 2.30.2
 
 
-From 2fb836bb4fdc90febb4c570c9392e68bb2d2427a Mon Sep 17 00:00:00 2001
+From e133e3a620bf8c6ce28f6d9dc3fa1c460173a92c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
 Date: Wed, 2 May 2018 08:37:20 +0200
 Subject: Enable libstdcxx_filesystem_ts for Haiku
@@ -2512,14 +2512,14 @@ index 1c0a4c1..8429b1a 100644
 2.30.2
 
 
-From 701f1c2fa7e41a1049e0dcb782d1d255f79d7122 Mon Sep 17 00:00:00 2001
+From a0208687b1b48264aa91f97784c2e505a6caaf18 Mon Sep 17 00:00:00 2001
 From: Jessica Hamilton <jessica.l.hamilton@gmail.com>
 Date: Fri, 12 Jul 2019 18:17:00 +0000
 Subject: gcc: fix build configuration for libgcc.
 
 
 diff --git a/libgcc/config.host b/libgcc/config.host
-index 2a5ee34..79fa44c 100644
+index 6a497ea..85d9b7f 100644
 --- a/libgcc/config.host
 +++ b/libgcc/config.host
 @@ -250,7 +250,7 @@ case ${host} in
@@ -2535,7 +2535,7 @@ index 2a5ee34..79fa44c 100644
 2.30.2
 
 
-From 6de59cf73302c0814b968f9b017a82dd40db8d1a Mon Sep 17 00:00:00 2001
+From ffd4d55c33bd851e8ef1df66865edbff70acaac1 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 12 May 2017 23:49:00 +0200
 Subject: Haiku: regenerate configure.
@@ -2641,7 +2641,7 @@ index 504f641..efdd512 100755
  fi
  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $gcc_cv_prog_cmp_skip" >&5
 diff --git a/gcc/configure b/gcc/configure
-index e8ecb3b..a1a7afe 100755
+index 9b28369..94fa995 100755
 --- a/gcc/configure
 +++ b/gcc/configure
 @@ -798,6 +798,7 @@ NETLIBS
@@ -3137,6 +3137,159 @@ index 326a279..51c46bb 100755
        mingw*)
          enable_libstdcxx_filesystem_ts=yes
          ;;
+-- 
+2.30.2
+
+
+From 068c004d09a21e772aa11e64e13e6182eb485f2d Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Thu, 6 May 2021 19:15:37 +0200
+Subject: Haiku: default to strict Dwarf4
+
+Haiku Debugger doesn't support Dwarf5.
+
+
+diff --git a/gcc/config.gcc b/gcc/config.gcc
+index d397d87..c09f7e1 100644
+--- a/gcc/config.gcc
++++ b/gcc/config.gcc
+@@ -837,6 +837,8 @@ case ${target} in
+     "" | yes | posix) thread_file='posix' ;;
+   esac
+   default_use_cxa_atexit=yes
++  tm_p_file="${tm_p_file} haiku-protos.h"
++  extra_objs="${extra_objs} haiku.o"
+   ;;
+ *-*-linux* | frv-*-*linux* | *-*-kfreebsd*-gnu | *-*-gnu* | *-*-kopensolaris*-gnu | *-*-uclinuxfdpiceabi)
+   extra_options="$extra_options gnu-user.opt"
+diff --git a/gcc/config/haiku-protos.h b/gcc/config/haiku-protos.h
+new file mode 100644
+index 0000000..22d8e59
+--- /dev/null
++++ b/gcc/config/haiku-protos.h
+@@ -0,0 +1,21 @@
++/* Operating system specific prototypes to be used when targeting GCC for Haiku.
++   Copyright (C) 2021 Free Software Foundation, Inc.
++
++This file is part of GCC.
++
++GCC is free software; you can redistribute it and/or modify
++it under the terms of the GNU General Public License as published by
++the Free Software Foundation; either version 3, or (at your option)
++any later version.
++
++GCC is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++GNU General Public License for more details.
++
++You should have received a copy of the GNU General Public License
++along with GCC; see the file COPYING3.  If not see
++<http://www.gnu.org/licenses/>.  */
++
++/* In haiku.c.  */
++extern void haiku_override_options (void);
+diff --git a/gcc/config/haiku.c b/gcc/config/haiku.c
+new file mode 100644
+index 0000000..bf62ad5
+--- /dev/null
++++ b/gcc/config/haiku.c
+@@ -0,0 +1,32 @@
++/* General Haiku system support.
++   Copyright (C) 2021 Free Software Foundation, Inc.
++
++This file is part of GCC.
++
++GCC is free software; you can redistribute it and/or modify
++it under the terms of the GNU General Public License as published by
++the Free Software Foundation; either version 3, or (at your option)
++any later version.
++
++GCC is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++GNU General Public License for more details.
++
++You should have received a copy of the GNU General Public License
++along with GCC; see the file COPYING3.  If not see
++<http://www.gnu.org/licenses/>.  */
++
++#include "config.h"
++#include "system.h"
++#include "coretypes.h"
++#include "target.h"
++
++void
++haiku_override_options (void)
++{
++  if (!global_options_set.x_dwarf_strict)
++    dwarf_strict = 1;
++  if (!global_options_set.x_dwarf_version)
++    dwarf_version = 4;
++}
+diff --git a/gcc/config/haiku.h b/gcc/config/haiku.h
+index faa34be..21e0561 100644
+--- a/gcc/config/haiku.h
++++ b/gcc/config/haiku.h
+@@ -53,6 +53,11 @@ Boston, MA 02111-1307, USA.  */
+ #undef CC1PLUS_SPEC
+ #define CC1PLUS_SPEC "%{!Wctor-dtor-privacy:-Wno-ctor-dtor-privacy}"
+ 
++#define SUBTARGET_OVERRIDE_OPTIONS			\
++  do {							\
++    haiku_override_options ();			\
++  } while (0)
++
+ /* LIB_SPEC for Haiku */
+ #undef LIB_SPEC
+ #define LIB_SPEC "-lroot"
+diff --git a/gcc/config/t-haiku b/gcc/config/t-haiku
+index 587d1fb..ba1f7f5 100644
+--- a/gcc/config/t-haiku
++++ b/gcc/config/t-haiku
+@@ -1,4 +1,9 @@
+ # There are system headers elsewhere, but these are the ones that
+ # we are most likely to want to apply any fixes to.
+ NATIVE_SYSTEM_HEADER_DIR = /boot/system/develop/headers
+-LIMITS_H_TEST = [ -f $(SYSTEM_HEADER_DIR)/posix/limits.h ]
+\ No newline at end of file
++LIMITS_H_TEST = [ -f $(SYSTEM_HEADER_DIR)/posix/limits.h ]
++
++# Haiku-specific attributes
++haiku.o: $(srcdir)/config/haiku.c
++	$(COMPILE) $<
++	$(POSTCOMPILE)
+-- 
+2.30.2
+
+
+From d3ce0f4820e7ff5daeb74fa3b6d3b3561e302081 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Wed, 13 Oct 2021 23:41:37 +0200
+Subject: linking against libssp isn't needed as it's provided by libroot
+
+but building libssp is required to be able to merge libssp_nonshared
+in libgcc.
+
+
+diff --git a/gcc/config/haiku.h b/gcc/config/haiku.h
+index 21e0561..316d384 100644
+--- a/gcc/config/haiku.h
++++ b/gcc/config/haiku.h
+@@ -210,10 +210,9 @@ Boston, MA 02111-1307, USA.  */
+ /* Haiku headers are C++-aware (and often use C++).  */
+ /* #define NO_IMPLICIT_EXTERN_C */
+ 
+-/* Only allow -lssp for SSP, as -lssp_nonshared is problematic in Haiku */
+-#ifndef TARGET_LIBC_PROVIDES_SSP
+-#define LINK_SSP_SPEC "%{fstack-protector|fstack-protector-all:-lssp}"
+-#endif
++#define LINK_SSP_SPEC "%{fstack-protector|fstack-protector-all" \
++		       "|fstack-protector-strong|fstack-protector-explicit" \
++		       ":-lssp_nonshared}"
+ 
+ /* Do not use TM clone registry in Haiku for now */
+ #define USE_TM_CLONE_REGISTRY 0
 -- 
 2.30.2
 


### PR DESCRIPTION
The missing patches were added
AFAIK libobjc not needed, but it is still in the package. Idk how to delete them. I tried this and the previous way, didnt helps.