### PR TITLE
GCC: fix -fstack-protector on x86

### DIFF
--- a/sys-devel/gcc/gcc-11.2.0_2021_07_28.recipe
+++ b/sys-devel/gcc/gcc-11.2.0_2021_07_28.recipe
@@ -358,6 +358,15 @@ INSTALL()
 		$libDir/
 	cp $gccLibDir/libgcc*.a $developLibDir/
 
+	# merge libssp_nonshared.a in libgcc.a on x86
+	if [ "$targetArchitecture" = "x86_gcc2" ]; then
+		(mkdir temp_libgcc; cd temp_libgcc; ar x ../$gccLibDir/libssp_nonshared.a;
+			ar x ../$gccLibDir/libgcc.a; cd ..)
+		ar -qc $developLibDir/libgcc.a temp_libgcc/*.o
+		cp $developLibDir/libgcc.a $gccLibDir/libgcc.a
+		rm -rf temp_libgcc
+	fi
+
 	# gcc and c++ headers
 	mkdir -p $includeDir/gcc
 	cp -r $gccLibDir/include $includeDir/gcc/


### PR DESCRIPTION
linking stack-protected objects on x86 would fail if -fstack-protector
wasn't passed to the linker. Only one symbol is missing, provided by
libssp_nonshared. So merge it in libgcc.a, which is always linked in.