### PR TITLE
Rust: add 1.56.0 with an additional package to support wasm32

### DIFF
--- a/dev-lang/rust_bin/rust_bin-1.56.0.recipe
+++ b/dev-lang/rust_bin/rust_bin-1.56.0.recipe
@@ -1,0 +1,99 @@
+SUMMARY="Modern and safe systems programming language"
+DESCRIPTION="Rust is a systems programming language that runs blazingly fast, \
+prevents almost all crashes*, and eliminates data races."
+HOMEPAGE="https://www.rust-lang.org/"
+COPYRIGHT="2021 The Rust Project Developers"
+LICENSE="MIT"
+REVISION="1"
+
+case "$effectiveTargetArchitecture" in
+	x86)
+SOURCE_URI="https://dl.rust-on-haiku.com/dist/$portVersion/rust-$portVersion-i686-unknown-haiku.tar.xz"
+CHECKSUM_SHA256="f624377eb414efce80e4d02e04a5b5736551e5229f8e8025f748f076ea06b42e"
+SOURCE_DIR="rust-$portVersion-i686-unknown-haiku"
+		;;
+	x86_64)
+SOURCE_URI="https://dl.rust-on-haiku.com/dist/$portVersion/rust-$portVersion-x86_64-unknown-haiku.tar.xz"
+CHECKSUM_SHA256="9ca7e5c0f0e6885efbbcf95b60ec1ca33160ea2c7cccc1dce810a3a7c0ea84f7"
+SOURCE_DIR="rust-$portVersion-x86_64-unknown-haiku"
+		;;
+	*)
+SOURCE_URI="https://dl.rust-on-haiku.com/dist/$portVersion/rustc-$portVersion-src.tar.xz"
+CHECKSUM_SHA256="2448441dc86e419917fca4ffad2b880d4449096793456919a84ed8fe815abe4f"
+SOURCE_DIR="rustc-$portVersion-src"
+		;;
+esac
+
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+DISABLE_SOURCE_PACKAGE=yes
+
+cargoVersion="0.57.0"
+rustfmtVersion="1.4.37"
+clippyVersion="0.1.56"
+
+PROVIDES="
+	rust_bin$secondaryArchSuffix = $portVersion
+	cmd:rustc$secondaryArchSuffix = $portVersion
+	cmd:rustdoc$secondaryArchSuffix = $portVersion
+	cmd:rustfmt$secondaryArchSuffix = $portVersion
+	cmd:rust_demangler$secondaryArchSuffix = $portVersion
+	cmd:rust_gdb$secondaryArchSuffix = $portVersion
+	cmd:rust_gdbgui$secondaryArchSuffix = $portVersion
+	cmd:rust_lldb$secondaryArchSuffix = $portVersion
+	cmd:cargo$secondaryArchSuffix = $cargoVersion
+	cmd:cargo_clippy$secondaryArchSuffix = $clippyVersion
+	cmd:cargo_fmt$secondaryArchSuffix = $cargoVersion
+	cmd:clippy_driver$secondaryArchSuffix = $clippyVersion
+	cmd:rustfmt = $rustfmtVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcrypto$secondaryArchSuffix
+	lib:libcurl$secondaryArchSuffix
+	lib:libssl$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+CONFLICTS="
+	rust$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+
+relativeInstallDir="develop/tools$secondaryArchSubDir/rust"
+installDir="$prefix/$relativeInstallDir"
+
+INSTALL()
+{
+	./install.sh                                   \
+		--prefix=$installDir                       \
+		--docdir=$developDocDir                    \
+		--mandir=$manDir                           \
+		--sysconfdir=$dataDir                      \
+		--disable-ldconfig
+
+	# move zsh data to the datadir
+	mv $installDir/share/zsh $dataDir
+	rm -rf $installDir/share
+
+	# clean out unneccesary files created by the rust installer
+	rm $installDir/lib/rustlib/components
+	rm $installDir/lib/rustlib/install.log
+	rm $installDir/lib/rustlib/manifest-*
+	rm $installDir/lib/rustlib/rust-installer-version
+	rm $installDir/lib/rustlib/uninstall.sh
+
+	# link the binaries in $binDir
+	mkdir -p $binDir
+	for f in cargo cargo-clippy cargo-fmt clippy-driver \
+	         rust-demangler rust-gdb rust-gdbgui rust-lldb rustc rustdoc \
+	         rustfmt; do
+		symlinkRelative -sfn $installDir/bin/$f $binDir
+	done
+
+	# make sure runtime_loader can find the libraries in the lib dir relative
+	# to the binaries
+	symlinkRelative -sfn $installDir/lib $installDir/bin/lib
+}

--- a/dev-lang/rust_wasm_bin/rust_wasm_bin-1.56.0.recipe
+++ b/dev-lang/rust_wasm_bin/rust_wasm_bin-1.56.0.recipe
@@ -1,0 +1,43 @@
+SUMMARY="Wasm target for the Rust compiler"
+DESCRIPTION="Adds support for the wasm32-unknown-unknown target for Rust."
+HOMEPAGE="https://www.rust-lang.org/"
+COPYRIGHT="2021 The Rust Project Developers"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://dl.rust-on-haiku.com/dist/$portVersion/rust-std-$portVersion-wasm32-unknown-unknown.tar.xz"
+CHECKSUM_SHA256="97c4a381d47858e0ae921dc8cc3221dd7a92d5f2051caa1a718cdfe4c7482040"
+SOURCE_DIR="rust-std-$portVersion-wasm32-unknown-unknown"
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+DISABLE_SOURCE_PACKAGE=yes
+PROVIDES="
+	rust_wasm_bin$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	rust_bin$secondaryArchSuffix == $portVersion
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+
+relativeInstallDir="develop/tools$secondaryArchSubDir/rust"
+installDir="$prefix/$relativeInstallDir"
+
+INSTALL()
+{
+	./install.sh                                   \
+		--prefix=$installDir                       \
+		--docdir=$developDocDir                    \
+		--mandir=$manDir                           \
+		--sysconfdir=$dataDir                      \
+		--disable-ldconfig
+
+	# clean out unneccesary files created by the rust installer
+	rm $installDir/lib/rustlib/components
+	rm $installDir/lib/rustlib/install.log
+	rm $installDir/lib/rustlib/manifest-*
+	rm $installDir/lib/rustlib/rust-installer-version
+	rm $installDir/lib/rustlib/uninstall.sh
+}


### PR DESCRIPTION
- This commit adds Rust 1.56.0
- It also adds the target for `wasm32-unknown-unknown` as a binary package
- The source version of Rust (dev-lang/rust) has not been updated for this release; it does not contain any patches that need to be recorded, and unfortunately builds still fail because of memory issues.
- This does not include the security fix in Rust 1.56.1 due to issues with my build setup. I find not including this acceptable (I will build an updated 1.57.0 in December).
- The wasm recipe is new and could use some scrutiny. The main recipe is a continuation of the previous stream of recipes.