### PR TITLE
gcc-8.3.0: fix headers after building boot libraries

### DIFF
--- a/sys-devel/gcc/gcc-8.3.0_2019_05_24.recipe
+++ b/sys-devel/gcc/gcc-8.3.0_2019_05_24.recipe
@@ -5,7 +5,7 @@ HOMEPAGE="https://gcc.gnu.org/"
 COPYRIGHT="1988-2019 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3
 	GNU LGPL v3"
-REVISION="14"
+REVISION="15"
 gccVersion="${portVersion%%_*}"
 SOURCE_URI="https://ftpmirror.gnu.org/gcc/gcc-$gccVersion/gcc-$gccVersion.tar.xz
 	https://ftp.gnu.org/gnu/gcc/gcc-$gccVersion/gcc-$gccVersion.tar.xz"
@@ -296,7 +296,6 @@ BUILD()
 		"../include/$effectiveTargetMachineTriple/bits/c++config.h" \
 		saved/
 	make clean
-	# deactivate threads and tls support
 	cp "../include/$effectiveTargetMachineTriple/bits/gthr-single.h" \
 		"../include/$effectiveTargetMachineTriple/bits/gthr-default.h"
 	sed -i -e 's,#define _GLIBCXX_HAS_GTHREADS 1,/* #undef _GLIBCXX_HAS_GTHREADS */,' \
@@ -305,7 +304,10 @@ BUILD()
 		"../include/$effectiveTargetMachineTriple/bits/c++config.h"
 	make $jobArgs CFLAGS="-O2 $bootCcFlags" CXXFLAGS="-O2 $bootCcFlags"
 	mv .libs/libsupc++.a .libs/libsupc++-boot.a
-	mv saved/* .libs/
+	mv saved/libsupc++* .libs/
+	mv saved/gthr-default.h "../include/$effectiveTargetMachineTriple/bits/"
+	mv saved/config.h ..
+	mv saved/c++config.h "../include/$effectiveTargetMachineTriple/bits/"
 	rmdir saved
 }
 


### PR DESCRIPTION
current recipe for gcc-8.3.0 has the same issue as we had on gcc11

using retroshare recipe as a "canary":
on rev.14 the build fails
on rev.15 retroshare build is successful again

if I check the package contents:
in rev.14 the files gthr-default.h and c++config.h are overwritten
this change restores these include files to their previous state
