### PR TITLE
BeScreenCapture: bump version

### DIFF
--- a/haiku-apps/bescreencapture/bescreencapture-2.6.0.recipe
+++ b/haiku-apps/bescreencapture/bescreencapture-2.6.0.recipe
@@ -10,7 +10,7 @@ LICENSE="BSD (3-clause)
 	MIT"
 REVISION="1"
 SOURCE_URI="https://github.com/jackburton79/bescreencapture/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="0e4a6baed11253d5dece7fe2e8295f5c83db81dae96d273ec4e909a34cae882a"
+CHECKSUM_SHA256="84eb6eb5c1bf8fdf4f19951c8eb2369d26a34718e8fda7959017b63151367724"
 SOURCE_FILENAME="bescreencapture-$portVersion.tar.gz"
 
 ARCHITECTURES="all"


### PR DESCRIPTION
Add recipe for BeScreenCapture 2.6.0
Removed recipe for version 2.5.2