### PR TITLE
stress-ng: add x86 as secondary architecture

### DIFF
--- a/app-benchmarks/stress-ng/patches/stress_ng_x86-0.13.05.patchset
+++ b/app-benchmarks/stress-ng/patches/stress_ng_x86-0.13.05.patchset
@@ -1,0 +1,33 @@
+From 2488e162f38e9b753f9d1ec0cb11258e17ae6944 Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Tue, 23 Nov 2021 10:46:52 +0000
+Subject: remove stress-icache.c
+
+
+diff --git a/Makefile b/Makefile
+index 4c163d6..4d25430 100644
+--- a/Makefile
++++ b/Makefile
+@@ -149,7 +149,6 @@ STRESS_SRC = \
+ 	stress-heapsort.c \
+ 	stress-hrtimers.c \
+ 	stress-hsearch.c \
+-	stress-icache.c \
+ 	stress-icmp-flood.c \
+ 	stress-idle-page.c \
+ 	stress-inode-flags.c \
+diff --git a/stress-ng.h b/stress-ng.h
+index 8fc5def..e12cd0d 100644
+--- a/stress-ng.h
++++ b/stress-ng.h
+@@ -2522,7 +2522,6 @@ typedef struct {
+ 	MACRO(heapsort)		\
+ 	MACRO(hrtimers)		\
+ 	MACRO(hsearch)		\
+-	MACRO(icache)		\
+ 	MACRO(icmp_flood)	\
+ 	MACRO(idle_page)	\
+ 	MACRO(inode_flags)	\
+-- 
+2.30.2
+

--- a/app-benchmarks/stress-ng/stress_ng-0.13.05.recipe
+++ b/app-benchmarks/stress-ng/stress_ng-0.13.05.recipe
@@ -38,25 +38,30 @@ SOURCE_URI="https://github.com/ColinIanKing/stress-ng/archive/V$portVersion.zip"
 SOURCE_DIR="stress-ng-$portVersion"
 CHECKSUM_SHA256="442c07327c5534566670a85dc67d50b1c643250aa09cc7129c793705d294cbeb"
 
+if [ $effectiveTargetArchitecture = x86 ]; then
+	PATCHES="stress_ng_x86-$portVersion.patchset"
+fi
+
 ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	stress_ng = $portVersion
-	cmd:stress_ng = $portVersion
+	stress_ng$secondaryArchSuffix = $portVersion
+	cmd:stress_ng$secondaryArchSuffix = $portVersion
 	"
 REQUIRES="
-	haiku
-	gcc_syslibs
-	lib:libz
+	haiku$secondaryArchSuffix
+	lib:libatomic$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
-	devel:libz
+	haiku${secondaryArchSuffix}_devel
+	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:awk
-	cmd:gcc
+	cmd:gcc$secondaryArchSuffix
 	cmd:make
 	"
 

--- a/app-benchmarks/stress-ng/stress_ng-0.13.05.recipe
+++ b/app-benchmarks/stress-ng/stress_ng-0.13.05.recipe
@@ -47,7 +47,7 @@ SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	stress_ng$secondaryArchSuffix = $portVersion
-	cmd:stress_ng$secondaryArchSuffix = $portVersion
+	cmd:stress_ng = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -74,6 +74,6 @@ BUILD()
 
 INSTALL()
 {
-	mkdir -p $binDir
-	cp stress-ng $binDir
+	mkdir -p $prefix/bin
+	cp stress-ng $prefix/bin/
 }


### PR DESCRIPTION
Disabling stress-icache on x86 as runtime_loader complains
about an "unreasonable amount of unused space."

see also issue #6428 

No such problem on x86_64 so stress-icache is still enabled there.