### PR TITLE
nnn: bump to 4.3

### DIFF
--- a/app-misc/nnn/nnn-4.3.recipe
+++ b/app-misc/nnn/nnn-4.3.recipe
@@ -16,7 +16,7 @@ COPYRIGHT="2016-2021 Arun Prakash Jana"
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="https://github.com/jarun/nnn/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="5675f9fe53bddfd92681ef88bf6c0fab3ad897f9e74dd6cdff32fe1fa62c687f"
+CHECKSUM_SHA256="b6df8e262e5613dd192bac610a6da711306627d56573f1a770a173ef078953bb"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"


### PR DESCRIPTION
[Changelog](https://github.com/jarun/nnn/releases)