### PR TITLE
libdrm: add recipe

### DIFF
--- a/sys-libs/libdrm/libdrm-2.4.109.recipe
+++ b/sys-libs/libdrm/libdrm-2.4.109.recipe
@@ -11,24 +11,24 @@ libdrm is a low-level library, typically used by graphics drivers such as \
 the Mesa drivers, the X drivers, libva and similar projects."
 HOMEPAGE="https://dri.freedesktop.org"
 COPYRIGHT="
-		1998-2003 VIA Technologies, Inc.
-		1999 Precision Insight
-		2000 VA Linux Systems, Inc
-		2000 Gareth Hughes
-		2001-2003 S3 Graphics, Inc.
-		2002 Frank C. Earl
-		2002-2003 Leif Delgass
-		2002, 2003, 2006, 2007-2008 Tungsten Graphics, Inc.
-		2004  Felix Kuehling
-		2005 Eric Anholt
-		2007 Dave Airlie
-		2007 Jakob Bornecrantz
-		2007-2008, 2011 Intel Corporation
-		2009-2015 VMware, Inc.
-		2008, 2013 Red Hat
-		2014-2015 Broadcom
-		2014 Advanced Micro Devices, Inc.
-		"
+	1998-2003 VIA Technologies, Inc.
+	1999 Precision Insight
+	2000 VA Linux Systems, Inc
+	2000 Gareth Hughes
+	2001-2003 S3 Graphics, Inc.
+	2002 Frank C. Earl
+	2002-2003 Leif Delgass
+	2002, 2003, 2006, 2007-2008 Tungsten Graphics, Inc.
+	2004 Felix Kuehling
+	2005 Eric Anholt
+	2007 Dave Airlie
+	2007 Jakob Bornecrantz
+	2007-2008, 2011 Intel Corporation
+	2009-2015 VMware, Inc.
+	2008, 2013 Red Hat
+	2014-2015 Broadcom
+	2014 Advanced Micro Devices, Inc.
+	"
 LICENSE="MIT"
 REVISION="1"
 SOURCE_URI="https://dri.freedesktop.org/libdrm/libdrm-${portVersion}.tar.xz"
@@ -89,18 +89,14 @@ defineDebugInfoPackage libdrm$secondaryArchSuffix \
 
 BUILD()
 {
-	if [ -n "$secondaryArchSuffix" ]; then
-		export HAIKU_SECONDARY_ARCH="$effectiveTargetArchitecture"
-	fi
-
 	mkdir -p build
 	meson build -Dintel=false -Dlibkms=true \
 		-Dinstall-test-programs=true \
 		--buildtype=debugoptimized \
 		--prefix=$prefix \
 		--bindir=$binDir \
-       	--libdir=$libDir \
-       	--datadir=$dataDir \
+       		--libdir=$libDir \
+       		--datadir=$dataDir \
 		--includedir=$includeDir
 	ninja -C build $jobArgs
 }

--- a/sys-libs/libdrm/libdrm-2.4.109.recipe
+++ b/sys-libs/libdrm/libdrm-2.4.109.recipe
@@ -11,24 +11,24 @@ libdrm is a low-level library, typically used by graphics drivers such as \
 the Mesa drivers, the X drivers, libva and similar projects."
 HOMEPAGE="https://dri.freedesktop.org"
 COPYRIGHT="
-	1998-2003 VIA Technologies, Inc.
-	1999 Precision Insight
-	2000 VA Linux Systems, Inc
-	2000 Gareth Hughes
-	2001-2003 S3 Graphics, Inc.
-	2002 Frank C. Earl
-	2002-2003 Leif Delgass
-	2002, 2003, 2006, 2007-2008 Tungsten Graphics, Inc.
-	2004  Felix Kuehling
-	2005 Eric Anholt
-	2007 Dave Airlie
-	2007 Jakob Bornecrantz
-	2007-2008, 2011 Intel Corporation
-	2009-2015 VMware, Inc.
-	2008, 2013 Red Hat
-	2014-2015 Broadcom
-	2014 Advanced Micro Devices, Inc.
-	"
+		1998-2003 VIA Technologies, Inc.
+		1999 Precision Insight
+		2000 VA Linux Systems, Inc
+		2000 Gareth Hughes
+		2001-2003 S3 Graphics, Inc.
+		2002 Frank C. Earl
+		2002-2003 Leif Delgass
+		2002, 2003, 2006, 2007-2008 Tungsten Graphics, Inc.
+		2004  Felix Kuehling
+		2005 Eric Anholt
+		2007 Dave Airlie
+		2007 Jakob Bornecrantz
+		2007-2008, 2011 Intel Corporation
+		2009-2015 VMware, Inc.
+		2008, 2013 Red Hat
+		2014-2015 Broadcom
+		2014 Advanced Micro Devices, Inc.
+		"
 LICENSE="MIT"
 REVISION="1"
 SOURCE_URI="https://dri.freedesktop.org/libdrm/libdrm-${portVersion}.tar.xz"
@@ -49,10 +49,12 @@ PROVIDES="
 	lib:libdrm_intel$secondaryArchSuffix = 1.0.0
 	lib:libdrm_nouveau$secondaryArchSuffix = 2.0.0
 	lib:libdrm_radeon$secondaryArchSuffix = 1.0.1
+	lib:libkms$secondaryArchSuffix = 1.0.0
 	cmd:amdgpu_stress$secondaryArchSuffix
 	cmd:drmdevice$secondaryArchSuffix
 	cmd:kms_steal_crtc$secondaryArchSuffix
 	cmd:kms_universal_planes$secondaryArchSuffix
+	cmd:kmstest$secondaryArchSuffix
 	cmd:modeprint$secondaryArchSuffix
 	cmd:modetest$secondaryArchSuffix
 	cmd:proptest$secondaryArchSuffix
@@ -65,6 +67,7 @@ REQUIRES="
 PROVIDES_devel="
 	libdrm${secondaryArchSuffix}_devel = $portVersion
 	devel:libdrm$secondaryArchSuffix = $libVersionCompat
+	devel:libkms$secondaryArchSuffix
 	"
 REQUIRES_devel="
 	libdrm$secondaryArchSuffix == $portVersion base
@@ -86,14 +89,18 @@ defineDebugInfoPackage libdrm$secondaryArchSuffix \
 
 BUILD()
 {
+	if [ -n "$secondaryArchSuffix" ]; then
+		export HAIKU_SECONDARY_ARCH="$effectiveTargetArchitecture"
+	fi
+
 	mkdir -p build
-	meson build -Dintel=false \
+	meson build -Dintel=false -Dlibkms=true \
 		-Dinstall-test-programs=true \
 		--buildtype=debugoptimized \
 		--prefix=$prefix \
 		--bindir=$binDir \
-		--libdir=$libDir \
-		--datadir=$dataDir \
+       	--libdir=$libDir \
+       	--datadir=$dataDir \
 		--includedir=$includeDir
 	ninja -C build $jobArgs
 }
@@ -103,7 +110,7 @@ INSTALL()
 	ninja -C build install
 
 	prepareInstalledDevelLibs \
-		libdrm
+		libdrm libkms
 	fixPkgconfig
 
 	# devel package

--- a/sys-libs/libdrm/libdrm-2.4.109.recipe
+++ b/sys-libs/libdrm/libdrm-2.4.109.recipe
@@ -91,7 +91,7 @@ BUILD()
 	fi
 
 	mkdir -p build
-	meson build -Dnouveau=false -Dintel=false \
+	meson build -Dintel=false \
 		-Dinstall-test-programs=true \
 		--buildtype=debugoptimized \
 		--prefix=$prefix \

--- a/sys-libs/libdrm/libdrm-2.4.109.recipe
+++ b/sys-libs/libdrm/libdrm-2.4.109.recipe
@@ -11,24 +11,24 @@ libdrm is a low-level library, typically used by graphics drivers such as \
 the Mesa drivers, the X drivers, libva and similar projects."
 HOMEPAGE="https://dri.freedesktop.org"
 COPYRIGHT="
-		1998-2003 VIA Technologies, Inc.
-		1999 Precision Insight
-		2000 VA Linux Systems, Inc
-		2000 Gareth Hughes
-		2001-2003 S3 Graphics, Inc.
-		2002 Frank C. Earl
-		2002-2003 Leif Delgass
-		2002, 2003, 2006, 2007-2008 Tungsten Graphics, Inc.
-		2004  Felix Kuehling
-		2005 Eric Anholt
-		2007 Dave Airlie
-		2007 Jakob Bornecrantz
-		2007-2008, 2011 Intel Corporation
-		2009-2015 VMware, Inc.
-		2008, 2013 Red Hat
-		2014-2015 Broadcom
-		2014 Advanced Micro Devices, Inc.
-		"
+	1998-2003 VIA Technologies, Inc.
+	1999 Precision Insight
+	2000 VA Linux Systems, Inc
+	2000 Gareth Hughes
+	2001-2003 S3 Graphics, Inc.
+	2002 Frank C. Earl
+	2002-2003 Leif Delgass
+	2002, 2003, 2006, 2007-2008 Tungsten Graphics, Inc.
+	2004  Felix Kuehling
+	2005 Eric Anholt
+	2007 Dave Airlie
+	2007 Jakob Bornecrantz
+	2007-2008, 2011 Intel Corporation
+	2009-2015 VMware, Inc.
+	2008, 2013 Red Hat
+	2014-2015 Broadcom
+	2014 Advanced Micro Devices, Inc.
+	"
 LICENSE="MIT"
 REVISION="1"
 SOURCE_URI="https://dri.freedesktop.org/libdrm/libdrm-${portVersion}.tar.xz"
@@ -96,8 +96,8 @@ BUILD()
 		--buildtype=debugoptimized \
 		--prefix=$prefix \
 		--bindir=$binDir \
-       	--libdir=$libDir \
-       	--datadir=$dataDir \
+		--libdir=$libDir \
+		--datadir=$dataDir \
 		--includedir=$includeDir
 	ninja -C build $jobArgs
 }

--- a/sys-libs/libdrm/libdrm-2.4.109.recipe
+++ b/sys-libs/libdrm/libdrm-2.4.109.recipe
@@ -86,10 +86,6 @@ defineDebugInfoPackage libdrm$secondaryArchSuffix \
 
 BUILD()
 {
-	if [ -n "$secondaryArchSuffix" ]; then
-		export HAIKU_SECONDARY_ARCH="$effectiveTargetArchitecture"
-	fi
-
 	mkdir -p build
 	meson build -Dintel=false \
 		-Dinstall-test-programs=true \

--- a/sys-libs/libdrm/libdrm-2.4.109.recipe
+++ b/sys-libs/libdrm/libdrm-2.4.109.recipe
@@ -95,8 +95,9 @@ BUILD()
 		-Dinstall-test-programs=true \
 		--buildtype=debugoptimized \
 		--prefix=$prefix \
-			--bindir=$binDir \
-       		--libdir=$libDir \
+		--bindir=$binDir \
+       	--libdir=$libDir \
+       	--datadir=$dataDir \
 		--includedir=$includeDir
 	ninja -C build $jobArgs
 }
@@ -105,13 +106,6 @@ INSTALL()
 {
 	ninja -C build install
 
-	# Do a little cleanup
-	rm -rf $prefix/share
-
-	# Set some nice version info
-#	appVersion=${portVersion//\./ }
-#	setversion "$libDir/libGL.so" -app $appVersion -long "Haiku OpenGL kit"
-
 	prepareInstalledDevelLibs \
 		libdrm
 	fixPkgconfig
@@ -119,7 +113,6 @@ INSTALL()
 	# devel package
 	packageEntries devel \
 		$developDir
-
 }
 
 TEST()

--- a/sys-libs/libdrm/libdrm-2.4.109.recipe
+++ b/sys-libs/libdrm/libdrm-2.4.109.recipe
@@ -1,0 +1,128 @@
+SUMMARY="Userspace interface to kernel Direct Rendering Module services"
+DESCRIPTION="a userspace library for accessing the Direct Rendering \
+Manager (DRM). DRM is a framework to manage *Graphics Processing Units* \
+(GPUs) designed to support the needs of complex graphics \
+devices, usually containing programmable pipelines well suited \
+to 3D graphics acceleration. Furthermore, DRM is responsible for \
+memory management, interrupt handling and DMA to provide a uniform \
+interface to applications.
+
+libdrm is a low-level library, typically used by graphics drivers such as \
+the Mesa drivers, the X drivers, libva and similar projects."
+HOMEPAGE="https://dri.freedesktop.org"
+COPYRIGHT="
+		1998-2003 VIA Technologies, Inc.
+		1999 Precision Insight
+		2000 VA Linux Systems, Inc
+		2000 Gareth Hughes
+		2001-2003 S3 Graphics, Inc.
+		2002 Frank C. Earl
+		2002-2003 Leif Delgass
+		2002, 2003, 2006, 2007-2008 Tungsten Graphics, Inc.
+		2004  Felix Kuehling
+		2005 Eric Anholt
+		2007 Dave Airlie
+		2007 Jakob Bornecrantz
+		2007-2008, 2011 Intel Corporation
+		2009-2015 VMware, Inc.
+		2008, 2013 Red Hat
+		2014-2015 Broadcom
+		2014 Advanced Micro Devices, Inc.
+		"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://dri.freedesktop.org/libdrm/libdrm-${portVersion}.tar.xz"
+CHECKSUM_SHA256="629352e08c1fe84862ca046598d8a08ce14d26ab25ee1f4704f993d074cb7f26"
+SOURCE_DIR="libdrm-${portVersion}"
+PATCHES="libdrm-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion=2.4.0
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	libdrm$secondaryArchSuffix = $portVersion
+	lib:libdrm$secondaryArchSuffix = $libVersionCompat
+	lib:libdrm_amdgpu$secondaryArchSuffix = 1.0.0 
+	lib:libdrm_intel$secondaryArchSuffix = 1.0.0
+	lib:libdrm_nouveau$secondaryArchSuffix = 2.0.0
+	lib:libdrm_radeon$secondaryArchSuffix = 1.0.1
+	cmd:amdgpu_stress$secondaryArchSuffix
+	cmd:drmdevice$secondaryArchSuffix
+	cmd:kms_steal_crtc$secondaryArchSuffix
+	cmd:kms_universal_planes$secondaryArchSuffix
+	cmd:modeprint$secondaryArchSuffix
+	cmd:modetest$secondaryArchSuffix
+	cmd:proptest$secondaryArchSuffix
+	cmd:vbltest$secondaryArchSuffix
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	libdrm${secondaryArchSuffix}_devel = $portVersion
+	devel:libdrm$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	libdrm$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	python3$secondaryArchSuffix
+	cmd:ninja
+	cmd:meson
+	cmd:gcc$secondaryArchSuffix
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+defineDebugInfoPackage libdrm$secondaryArchSuffix \
+	"$libDir"/libdrm.so.$libVersion 
+
+BUILD()
+{
+	if [ -n "$secondaryArchSuffix" ]; then
+		export HAIKU_SECONDARY_ARCH="$effectiveTargetArchitecture"
+	fi
+
+	mkdir -p build
+	meson build -Dnouveau=false -Dintel=false \
+		-Dinstall-test-programs=true \
+		--buildtype=debugoptimized \
+		--prefix=$prefix \
+			--bindir=$binDir \
+       		--libdir=$libDir \
+		--includedir=$includeDir
+	ninja -C build $jobArgs
+}
+
+INSTALL()
+{
+	ninja -C build install
+
+	# Do a little cleanup
+	rm -rf $prefix/share
+
+	# Set some nice version info
+#	appVersion=${portVersion//\./ }
+#	setversion "$libDir/libGL.so" -app $appVersion -long "Haiku OpenGL kit"
+
+	prepareInstalledDevelLibs \
+		libdrm
+	fixPkgconfig
+
+	# devel package
+	packageEntries devel \
+		$developDir
+
+}
+
+TEST()
+{
+	ninja -C build test
+}

--- a/sys-libs/libdrm/patches/libdrm-2.4.109.patchset
+++ b/sys-libs/libdrm/patches/libdrm-2.4.109.patchset
@@ -1,4 +1,4 @@
-From 13ef84b90884c06765eab06ec1edab3964fa13f0 Mon Sep 17 00:00:00 2001
+From 8759acf44c921a5d98d978b02f557d7b6fc1807c Mon Sep 17 00:00:00 2001
 From: Ken Mays <kmays2000@gmail.com>
 Date: Fri, 26 Nov 2021 08:21:14 +1000
 Subject: Fix MAKEDEV for Haiku
@@ -26,22 +26,26 @@ index 5933e4b..9f25d3a 100644
 2.30.2
 
 
-From dc8ac7a9fcf8073cb45ef790d8d98fa618e820b0 Mon Sep 17 00:00:00 2001
+From 9a444283f2e9ecb67fb7c79a30c25a4e634a9952 Mon Sep 17 00:00:00 2001
 From: Ken Mays <kmays2000@gmail.com>
 Date: Fri, 26 Nov 2021 08:21:14 +1000
 Subject: Fix Nouveau IOCTL for Haiku
 
 
 diff --git a/tests/nouveau/threaded.c b/tests/nouveau/threaded.c
-index ddbac74..a4b54cd 100644
+index ddbac74..bd36785 100644
 --- a/tests/nouveau/threaded.c
 +++ b/tests/nouveau/threaded.c
-@@ -38,6 +38,8 @@ static int import_fd;
+@@ -36,8 +36,11 @@ static int failed;
  
- #if defined(__GLIBC__) || defined(__FreeBSD__)
+ static int import_fd;
+ 
+-#if defined(__GLIBC__) || defined(__FreeBSD__)
++#if defined(__GLIBC__) || defined(__FreeBSD__)||defined(__HAIKU__)
++#if defined(__HAIKU__)
++#undef ioctl
  int ioctl(int fd, unsigned long request, ...)
-+#elif defined(__HAIKU__)
-+int fcntl(int fd, int request, ...)
++#endif
  #else
  int ioctl(int fd, int request, ...)
  #endif

--- a/sys-libs/libdrm/patches/libdrm-2.4.109.patchset
+++ b/sys-libs/libdrm/patches/libdrm-2.4.109.patchset
@@ -24,3 +24,4 @@ index 5933e4b..9f25d3a 100644
  /* Not all systems have MAP_FAILED defined */
 -- 
 2.30.2
+

--- a/sys-libs/libdrm/patches/libdrm-2.4.109.patchset
+++ b/sys-libs/libdrm/patches/libdrm-2.4.109.patchset
@@ -1,4 +1,4 @@
-From e2ab214b7ce934aac490119e1654e6d61081184c Mon Sep 17 00:00:00 2001
+From 13ef84b90884c06765eab06ec1edab3964fa13f0 Mon Sep 17 00:00:00 2001
 From: Ken Mays <kmays2000@gmail.com>
 Date: Fri, 26 Nov 2021 08:21:14 +1000
 Subject: Fix MAKEDEV for Haiku
@@ -22,6 +22,29 @@ index 5933e4b..9f25d3a 100644
  #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
  
  /* Not all systems have MAP_FAILED defined */
+-- 
+2.30.2
+
+
+From dc8ac7a9fcf8073cb45ef790d8d98fa618e820b0 Mon Sep 17 00:00:00 2001
+From: Ken Mays <kmays2000@gmail.com>
+Date: Fri, 26 Nov 2021 08:21:14 +1000
+Subject: Fix Nouveau IOCTL for Haiku
+
+
+diff --git a/tests/nouveau/threaded.c b/tests/nouveau/threaded.c
+index ddbac74..a4b54cd 100644
+--- a/tests/nouveau/threaded.c
++++ b/tests/nouveau/threaded.c
+@@ -38,6 +38,8 @@ static int import_fd;
+ 
+ #if defined(__GLIBC__) || defined(__FreeBSD__)
+ int ioctl(int fd, unsigned long request, ...)
++#elif defined(__HAIKU__)
++int fcntl(int fd, int request, ...)
+ #else
+ int ioctl(int fd, int request, ...)
+ #endif
 -- 
 2.30.2
 

--- a/sys-libs/libdrm/patches/libdrm-2.4.109.patchset
+++ b/sys-libs/libdrm/patches/libdrm-2.4.109.patchset
@@ -1,0 +1,26 @@
+From e2ab214b7ce934aac490119e1654e6d61081184c Mon Sep 17 00:00:00 2001
+From: Ken Mays <kmays2000@gmail.com>
+Date: Fri, 26 Nov 2021 08:21:14 +1000
+Subject: Fix MAKEDEV for Haiku
+
+
+diff --git a/xf86drm.c b/xf86drm.c
+index 5933e4b..9f25d3a 100644
+--- a/xf86drm.c
++++ b/xf86drm.c
+@@ -68,6 +68,13 @@
+ #include <sys/pciio.h>
+ #endif
+ 
++#if !defined(HAVE_MAJOR) && !defined(major)
++/* Replacement for major/minor/makedev. */
++#define	major(x) ((int)(0x00ff & ((x) >> 8)))
++#define	minor(x) ((int)(0xffff00ff & (x)))
++#define	makedev(maj,min) ((0xff00 & ((maj)<<8)) | (0xffff00ff & (min)))
++#endif
++
+ #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+ 
+ /* Not all systems have MAP_FAILED defined */
+-- 
+2.30.2

--- a/sys-libs/libdrm/patches/libdrm-2.4.109.patchset
+++ b/sys-libs/libdrm/patches/libdrm-2.4.109.patchset
@@ -1,4 +1,4 @@
-From 8759acf44c921a5d98d978b02f557d7b6fc1807c Mon Sep 17 00:00:00 2001
+From 264848145262e0d3d20d3c11b3e3688bde07ab26 Mon Sep 17 00:00:00 2001
 From: Ken Mays <kmays2000@gmail.com>
 Date: Fri, 26 Nov 2021 08:21:14 +1000
 Subject: Fix MAKEDEV for Haiku
@@ -26,7 +26,7 @@ index 5933e4b..9f25d3a 100644
 2.30.2
 
 
-From 9a444283f2e9ecb67fb7c79a30c25a4e634a9952 Mon Sep 17 00:00:00 2001
+From b51d58487dd964d68e934a549b552cb8b9d3cd83 Mon Sep 17 00:00:00 2001
 From: Ken Mays <kmays2000@gmail.com>
 Date: Fri, 26 Nov 2021 08:21:14 +1000
 Subject: Fix Nouveau IOCTL for Haiku
@@ -49,6 +49,59 @@ index ddbac74..bd36785 100644
  #else
  int ioctl(int fd, int request, ...)
  #endif
+-- 
+2.30.2
+
+
+From 52e625d5786926a1d797da77f43175b1cf2554c8 Mon Sep 17 00:00:00 2001
+From: Ken Mays <kmays2000@gmail.com>
+Date: Fri, 26 Nov 2021 08:45:05 +1000
+Subject: Fix libkms for Haiku
+
+
+diff --git a/libkms/linux.c b/libkms/linux.c
+index 5620505..ec6be68 100644
+--- a/libkms/linux.c
++++ b/libkms/linux.c
+@@ -49,6 +49,13 @@
+ 
+ #define PATH_SIZE 512
+ 
++#if !defined(HAVE_MAJOR) && !defined(major)
++/* Replacement for major/minor/makedev. */
++#define	major(x) ((int)(0x00ff & ((x) >> 8)))
++#define	minor(x) ((int)(0xffff00ff & (x)))
++#define	makedev(maj,min) ((0xff00 & ((maj)<<8)) | (0xffff00ff & (min)))
++#endif
++
+ static int
+ linux_name_from_sysfs(int fd, char **out)
+ {
+-- 
+2.30.2
+
+
+From ba71f19c817a867d842961f3e991a365992eaaa5 Mon Sep 17 00:00:00 2001
+From: Ken Mays <kmays2000@gmail.com>
+Date: Fri, 26 Nov 2021 08:45:05 +1000
+Subject: Fix Haiku ERESTART for libkms
+
+
+diff --git a/libkms/vmwgfx.c b/libkms/vmwgfx.c
+index 1984399..20fde63 100644
+--- a/libkms/vmwgfx.c
++++ b/libkms/vmwgfx.c
+@@ -38,6 +38,10 @@
+ #include "libdrm_macros.h"
+ #include "vmwgfx_drm.h"
+ 
++#ifndef ERESTART and defined __HAIKU__
++#define ERESTART (B_ERRORS_END +1)
++#endif
++
+ struct vmwgfx_bo
+ {
+ 	struct kms_bo base;
 -- 
 2.30.2
 


### PR DESCRIPTION
Tested on Haiku R1B3 x86 and x86_64 platforms.
Supports:
- AMD Radeon HD 2000 series through Radeon RX 6000 series (Radeon RX 6900 XT)
- Intel GPUs up to Gen 12 (Tiger Lake, Rocket Lake, (Alder Lake processors))
- Nvidia Riva TNT through GeForce GTX 1070 (GeForce RTX 2060 (W-I-P))