### PR TITLE
portaudio: enable build for all architectures

### DIFF
--- a/media-libs/portaudio/portaudio-19.06.00.recipe
+++ b/media-libs/portaudio/portaudio-19.06.00.recipe
@@ -10,8 +10,8 @@ CHECKSUM_SHA256="f5a21d7dcd6ee84397446fa1fa1a0675bb2e8a4a6dceb4305a8404698d8d151
 SOURCE_DIR="portaudio"
 PATCHES="portaudio-19.patchset"
 
-ARCHITECTURES="?all"
-SECONDARY_ARCHITECTURES="?x86_gcc2 x86"
+ARCHITECTURES="all"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	portaudio$secondaryArchSuffix = $portVersion


### PR DESCRIPTION
I'm currently porting the game globulation2, which requires the portaudio library (or sys/soundcard.h). Portaudio is already being built for x86_gcc4 and compiles just fine under x86_64 and x86_32_gcc2, so I think it should be safe to enable on all architectures.

For some reason the patch file used only contains some configure stuff. There is a second patch file which contains a file which contains Haiku-specific code