### PR TITLE
wasm3: new recipe

### DIFF
--- a/app-emulation/wasm3/patches/wasm3-0.5.0.patchset
+++ b/app-emulation/wasm3/patches/wasm3-0.5.0.patchset
@@ -1,0 +1,21 @@
+From bd74b8afee6a878fdce3214ca550fb790cfbad84 Mon Sep 17 00:00:00 2001
+From: Al Hoang <3811822-hoanga@users.noreply.gitlab.com>
+Date: Thu, 23 Dec 2021 12:59:15 -0600
+Subject: link network lib
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 92ba950..3ddf73c 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -180,6 +180,7 @@ else()
+   set(CMAKE_EXE_LINKER_FLAGS_RELEASE "-O3")
+ 
+   target_link_libraries(${OUT_FILE} m)
++  target_link_libraries(${OUT_FILE} network)
+ 
+ endif()
+ 
+-- 
+2.30.2
+

--- a/app-emulation/wasm3/wasm3-0.5.0.recipe
+++ b/app-emulation/wasm3/wasm3-0.5.0.recipe
@@ -8,7 +8,6 @@ LICENSE="MIT"
 REVISION="1"
 SOURCE_URI="https://github.com/wasm3/wasm3/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="b778dd72ee2251f4fe9e2666ee3fe1c26f06f517c3ffce572416db067546536c"
-SOURCE_DIR="wasm3-$portVersion"
 PATCHES="wasm3-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -30,14 +29,13 @@ BUILD_PREREQUIRES="
 	cmd:cmake
 	cmd:make
 	cmd:gcc
-	cmd:git
 	"
 
 BUILD()
 {
 	mkdir -p build 
 	cd build 
-	cmake .. -DCMAKE_BUILD_TYPE=Release
+	cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_WASI=simple
 	make
 }
 

--- a/app-emulation/wasm3/wasm3-0.5.0.recipe
+++ b/app-emulation/wasm3/wasm3-0.5.0.recipe
@@ -1,0 +1,52 @@
+SUMMARY="The fastest WebAssembly interpreter, and the most universal runtime"
+DESCRIPTION="Wasm3 started as a research project and remains \
+so by many means. Evaluating the engine in different \
+environments is part of the research."
+HOMEPAGE="http://github.com/wasm3/wasm3"
+COPYRIGHT="2019 Steven Massey, Volodymyr Shymanskyy"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://github.com/wasm3/wasm3/archive/refs/tags/v$portVersion.tar.gz"
+CHECKSUM_SHA256="b778dd72ee2251f4fe9e2666ee3fe1c26f06f517c3ffce572416db067546536c"
+SOURCE_DIR="wasm3-$portVersion"
+PATCHES="wasm3-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
+
+PROVIDES="
+	wasm3$secondaryArchSuffix = $portVersion
+	cmd:wasm3$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:make
+	cmd:gcc
+	cmd:git
+	"
+
+BUILD()
+{
+	mkdir -p build 
+	cd build 
+	cmake .. -DCMAKE_BUILD_TYPE=Release
+	make
+}
+
+INSTALL()
+{
+
+	# install runtime
+	mkdir -p $binDir
+
+	cd build
+	cp -p wasm3 $binDir/
+}


### PR DESCRIPTION
the following recipe adds the [wasm3](https://github.com/wasm3/wasm3) interpreter. tested that package built and was able to install and uninstall on x86-64 Haiku (hrev55602)

sample test run (borrowed from [cookbook](
https://github.com/wasm3/wasm3/blob/main/docs/Cookbook.md))

```
~/hellowasm> uname -a
Haiku shredder 1 hrev55602 Oct 29 2021 07:10:38 x86_64 x86_64 Haiku
~/hellowasm> cat hello.zig 
const std = @import("std");

pub fn main() !void {
    const stdout = std.io.getStdOut().writer();
    try stdout.print("Hello, {s}!\n", .{"world"});
}
~/hellowasm> zig build-exe -O ReleaseSmall -target wasm32-wasi hello.zig
~/hellowasm> wasm3 hello.wasm
Hello, world!
~/hellowasm> 
```