### PR TITLE
llvm12: adjust cmake library paths

### DIFF
--- a/sys-devel/llvm/llvm12-12.0.0.recipe
+++ b/sys-devel/llvm/llvm12-12.0.0.recipe
@@ -31,7 +31,7 @@ other than the ones listed above.
 HOMEPAGE="https://www.llvm.org/"
 COPYRIGHT="2003-2019 University of Illinois at Urbana-Champaign"
 LICENSE="Apache v2 with LLVM Exception"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/llvm/llvm-project/releases/download/llvmorg-$portVersion/llvm-$portVersion.src.tar.xz"
 CHECKSUM_SHA256="49dc47c8697a1a0abd4ee51629a696d7bfe803662f2a7252a3b16fc75f3a8b50"
 SOURCE_DIR="llvm-$portVersion.src"
@@ -550,6 +550,11 @@ INSTALL()
 		libclang* \
 		liblld* \
 		libRemarks
+
+	# adjust cmake library paths because prepareInstalledDevelLibs moved them
+	sed -i 's,\${_IMPORT_PREFIX}/lib/,\${_IMPORT_PREFIX}/develop/lib/,' \
+		$libDir/cmake/clang/ClangTargets-release.cmake \
+		$libDir/cmake/llvm/LLVMExports-release.cmake
 
 	mv $prefix/include/* $includeDir/
 	mv $prefix/libexec/* $binDir/


### PR DESCRIPTION
This is related to issue #3749. The fixed packages were tested on x86_64 by
building a couple of language servers(ccls and irony-server) which use these
library paths.