### PR TITLE
freac: bump to 1.1.6

### DIFF
--- a/media-sound/freac/freac-1.1.6.recipe
+++ b/media-sound/freac/freac-1.1.6.recipe
@@ -15,11 +15,11 @@ Features include:
 - User interface available in 40+ languages
 - Optional command line interface"
 HOMEPAGE="https://freac.org/"
-COPYRIGHT="2001-2021 Robert Kausch"
+COPYRIGHT="2001-2022 Robert Kausch"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://github.com/enzo1982/freac/releases/download/v${portVersion}/freac-${portVersion}.tar.gz"
-CHECKSUM_SHA256="62c61840a935dba5230fb7295b508370cd4f1e861db9d479f21c858a8aac3470"
+CHECKSUM_SHA256="8269c6c733f91bbca38027375c0afd424093ac64c621871f0fe30726d6c46248"
 SOURCE_DIR="freac-${portVersion}"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -39,7 +39,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	boca$secondaryArchSuffix >= 1.0.5
+	boca$secondaryArchSuffix >= 1.0.6
 	smooth$secondaryArchSuffix >= 0.9.6
 	cmd:ffmpeg
 	cmd:mpcdec
@@ -69,7 +69,7 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	boca${secondaryArchSuffix}_devel >= 1.0.5
+	boca${secondaryArchSuffix}_devel >= 1.0.6
 	smooth${secondaryArchSuffix}_devel >= 0.9.6
 	devel:libboca_1.0$secondaryArchSuffix >= 3
 	"


### PR DESCRIPTION
This needs to be merged after BoCA 1.0.6a.