### PR TITLE
ninja: fix build and add zsh subpackage

### DIFF
--- a/dev-util/ninja/ninja-1.10.2.recipe
+++ b/dev-util/ninja/ninja-1.10.2.recipe
@@ -9,7 +9,7 @@ it can build LLVM, KDE, Blender, etc."
 HOMEPAGE="https://ninja-build.org/"
 COPYRIGHT="2012-2019 Google Inc."
 LICENSE="Apache v2"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/ninja-build/ninja/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed"
 PATCHES="ninja-$portVersion.patchset"
@@ -29,7 +29,7 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel >= r1~alpha4_pm_hrev51418-1
 	"
 BUILD_PREREQUIRES="
-	haiku_devel
+	haiku${secondaryArchSuffix}_devel
 	cmd:as$secondaryArchSuffix
 	cmd:cmake
 	cmd:g++$secondaryArchSuffix
@@ -37,15 +37,30 @@ BUILD_PREREQUIRES="
 	cmd:make
 	"
 
+PROVIDES_zsh="
+	ninja_zsh$secondaryArchSuffix = $portVersion
+	"
+REQUIRES_zsh="
+	ninja$secondaryArchSuffix == $portVersion base
+	zsh >= 5.0
+	"
+
 BUILD()
 {
-	cmake -Bbuild $cmakeDirArgs .
-	cmake --build build $jobArgs
+	cmake -DCMAKE_BUILD_TYPE="Release" -Bbuild $cmakeDirArgs .
+	cd build
+	make $jobArgs
 }
 
 INSTALL()
 {
-	cmake --install build
+	cd build
+	make install
+
+	# build our zsh completion package
+	mkdir -p $dataDir/zsh/site-functions
+	cp -af $sourceDir/misc/zsh-completion $dataDir/zsh/site-functions/_ninja
+	packageEntries zsh $dataDir
 }
 
 TEST()


### PR DESCRIPTION
Maybe there is a better way to enforce CMAKE_BUILD_TYPE.  haikuporter gets very unhappy even if you use the command as a build/install tool.