### PR TITLE
LibreOffice: fix building with newer bison

### DIFF
--- a/app-office/libreoffice/libreoffice-7.2.0.4.recipe
+++ b/app-office/libreoffice/libreoffice-7.2.0.4.recipe
@@ -17,7 +17,7 @@ and Open Source office suite on the market:
 HOMEPAGE="https://www.libreoffice.org/"
 COPYRIGHT="2000-2021 LibreOffice contributors"
 LICENSE="MPL v2.0"
-REVISION="3"
+REVISION="4"
 
 SOURCE_URI="https://github.com/LibreOffice/core/archive/libreoffice-$portVersion.tar.gz"
 SOURCE_DIR="core-libreoffice-$portVersion"

--- a/app-office/libreoffice/patches/libreoffice-7.2.0.4.patchset
+++ b/app-office/libreoffice/patches/libreoffice-7.2.0.4.patchset
@@ -1,4 +1,4 @@
-From 2c83f2d6504b192a0fa0832ee2a97b94fde6a795 Mon Sep 17 00:00:00 2001
+From 5ab0e302b5319c27292b49eeec9877582f1f77e3 Mon Sep 17 00:00:00 2001
 From: Sergei Reznikov <diver@gelios.net>
 Date: Sat, 15 Feb 2020 14:52:59 +0300
 Subject: Make Elementary the default on Haiku
@@ -22,7 +22,7 @@ index 253242b..6b55799 100644
 2.30.2
 
 
-From a73eb5ed50cbb7cae46fecd18317a3bc4433edde Mon Sep 17 00:00:00 2001
+From 1bedbb1c2eaa36d0e1d2b875b5e125c90045fd47 Mon Sep 17 00:00:00 2001
 From: Sergei Reznikov <diver@gelios.net>
 Date: Fri, 7 Aug 2020 12:14:40 +0300
 Subject: Show used vcl backend in About window on Haiku
@@ -45,7 +45,7 @@ index 79d6dfa..6071ffe 100644
 2.30.2
 
 
-From 93355f10e60eadabe8459212452786e5eed14f54 Mon Sep 17 00:00:00 2001
+From 7c49d4b9b8e1b6669d0739318321c71e4e4c4efd Mon Sep 17 00:00:00 2001
 From: Sergei Reznikov <diver@gelios.net>
 Date: Wed, 24 Oct 2018 17:01:34 +0300
 Subject: Identify Haiku in about window
@@ -88,7 +88,7 @@ index 0093f64..04042bd 100644
 2.30.2
 
 
-From 9da1a2cc3a16ca855051142053bb5c501d304ec3 Mon Sep 17 00:00:00 2001
+From dd1936ff5962dfcd89a0a9fd972d7675cc846623 Mon Sep 17 00:00:00 2001
 From: Sergei Reznikov <diver@gelios.net>
 Date: Sat, 15 Feb 2020 15:04:53 +0300
 Subject: Implement ShellExec on Haiku
@@ -112,7 +112,7 @@ index 87b78fe..7588126 100644
 2.30.2
 
 
-From 5fc4fecefd59105d00f3169265cc76081d4d583d Mon Sep 17 00:00:00 2001
+From dfec624de1fc74f21a29fcb3b7ef322ceb90a845 Mon Sep 17 00:00:00 2001
 From: Sergei Reznikov <diver@gelios.net>
 Date: Sat, 20 Jul 2019 01:18:50 +0300
 Subject: Comment out linking with pthread
@@ -139,7 +139,7 @@ index 4a96547..49f872b 100644
 2.30.2
 
 
-From 023d1c8a0b93d69300a28261ea480189b2bbd060 Mon Sep 17 00:00:00 2001
+From baae0c588fc4ccf6d9e02ce1b615ce09fe56fb9c Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Sun, 11 Aug 2019 11:47:40 +1000
 Subject: Add XP_HAIKU defs for xmlsec
@@ -183,7 +183,7 @@ index 450e19b..568ff83 100644
 2.30.2
 
 
-From 7c3aaa13ad15dbfcafd3b1d899bb29025e459cf9 Mon Sep 17 00:00:00 2001
+From ee13859a22ee1df556c28afe1d71f7e28ac88e85 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Fri, 7 Aug 2020 12:37:45 +0300
 Subject: Cast to boolean
@@ -274,7 +274,7 @@ index 8807927..c570173 100644
 2.30.2
 
 
-From 71c4d0955b51728ea771cb9adc62ec58f9ed53fd Mon Sep 17 00:00:00 2001
+From c6d997672800388b766a33b1855c568935abe761 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Mon, 8 Feb 2021 15:50:11 +1000
 Subject: Use dpi=100 for qt5 backend
@@ -299,7 +299,7 @@ index a2730be..9be0a6e 100644
 2.30.2
 
 
-From 55411bced7c261727bc45b297fa6416af86b591a Mon Sep 17 00:00:00 2001
+From 117aec49dfca2c4be21e16539e40824fe1f91ea9 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Mon, 8 Feb 2021 15:52:13 +1000
 Subject: Disable hidpi for Haiku
@@ -326,7 +326,7 @@ index bf8d529..e8dca9a 100644
 2.30.2
 
 
-From fe6d8e4802857fca553b3aad7221be3b2d7eba0a Mon Sep 17 00:00:00 2001
+From afd76d862076e22b2e042065bb9bf426687ffd67 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Mon, 8 Feb 2021 21:47:12 +1000
 Subject: Don't use fontconfig
@@ -353,7 +353,7 @@ index b429485..0719575 100644
 2.30.2
 
 
-From ea647dec913ffcf242b96d6f94c5873508a8b596 Mon Sep 17 00:00:00 2001
+From 560b63239cf935af041793ed25e7115b9bb0337a Mon Sep 17 00:00:00 2001
 From: Sergei Reznikov <diver@gelios.net>
 Date: Fri, 7 Aug 2020 12:47:56 +0300
 Subject: Revert fstack-protector check removal in
@@ -437,7 +437,7 @@ index 09ca90a..9248195 100644
 2.30.2
 
 
-From 756a5adb7dec21c27d655c265a7bd2f32f6721b1 Mon Sep 17 00:00:00 2001
+From bf6d867eb750ebe9e5d1b3464f0b775807a71172 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Fri, 20 Aug 2021 23:33:13 +1000
 Subject: Revert Qt::Popup window handling
@@ -486,6 +486,60 @@ index ebb11ce..dcbc2cc 100644
  }
  
  static ExtTextInputAttr lcl_MapUndrelineStyle(QTextCharFormat::UnderlineStyle us)
+-- 
+2.30.2
+
+
+From 1123e2cb9c5754f813da94ddfbf36fe0d35dfcbb Mon Sep 17 00:00:00 2001
+From: Stephan Bergmann <sbergman@redhat.com>
+Date: Tue, 14 Sep 2021 12:20:48 +0200
+Subject: Adapt to Bison 3.8 internal yyn -> yyrule rename
+
+see
+<https://git.savannah.gnu.org/cgit/bison.git/commit/?id=f30067ed51f23802fc91761ede1506dfa72b2865>
+"glr2.cc: log the execution of deferred actions" including "Rename argument yyn
+as yyrule for clarity."
+
+YYBISON was defined as 1 rather than as a representation of the Bison version
+prior to
+<https://git.savannah.gnu.org/cgit/bison.git/commit/?id=21c147b6e5372563b7c4741deadaddb9354f4b09>
+"yacc.c: provide the Bison version as an integral macro", which shouldn't be a
+problem here.  And YYBISON is apparently completely undefined with
+/usr/bin/bison on macOS.
+
+(The preceding comment always mentioned "yyi" and "yyrmap" in apparent mismatch
+with the actually used "yyn" and "yyr1" ever since
+c25ec0608a167bcf1d891043f02273761c351701 "initial import", so just leave it
+untouched.)
+
+Change-Id: I4f901407aa21ed4abec84e661d813ee7599f02f0
+Reviewed-on: https://gerrit.libreoffice.org/c/core/+/122082
+Tested-by: Jenkins
+Reviewed-by: Stephan Bergmann <sbergman@redhat.com>
+(cherry picked from commit 45227d9b79dc4f2a2aa6874cd4e3c02b7934b197)
+Reviewed-on: https://gerrit.libreoffice.org/c/core/+/122069
+Reviewed-by: Michael Stahl <michael.stahl@allotropia.de>
+
+diff --git a/connectivity/source/parse/sqlbison.y b/connectivity/source/parse/sqlbison.y
+index d14f36e..c4be0bc 100644
+--- a/connectivity/source/parse/sqlbison.y
++++ b/connectivity/source/parse/sqlbison.y
+@@ -74,9 +74,15 @@ inline connectivity::OSQLInternalNode* newNode(const OUString& _newValue,
+ 
+ // yyi is the internal number of the rule that is currently being reduced
+ // This can be mapped to external rule number via the yyrmap.
++#if defined YYBISON && YYBISON >= 30800
++#define SQL_NEW_RULE 			newNode("", SQLNodeType::Rule, yyr1[yyrule])
++#define SQL_NEW_LISTRULE 		newNode("", SQLNodeType::ListRule, yyr1[yyrule])
++#define SQL_NEW_COMMALISTRULE   newNode("", SQLNodeType::CommaListRule, yyr1[yyrule])
++#else
+ #define SQL_NEW_RULE 			newNode("", SQLNodeType::Rule, yyr1[yyn])
+ #define SQL_NEW_LISTRULE 		newNode("", SQLNodeType::ListRule, yyr1[yyn])
+ #define SQL_NEW_COMMALISTRULE   newNode("", SQLNodeType::CommaListRule, yyr1[yyn])
++#endif
+ 
+ 
+ extern connectivity::OSQLParser* xxx_pGLOBAL_SQLPARSER;
 -- 
 2.30.2
 


### PR DESCRIPTION
patch was taken directly from the upstream 7.2 branch of the libreoffice repo

I was able to successfully build, package, install, and run on x86_64.  I can also look into the x86 build issues but I'm not sure when I'll have the time.  Could be tomorrow or later in the week.
