### PR TITLE
scribus: fix build for new poppler

### DIFF
--- a/app-office/scribus/scribus-1.5.7.recipe
+++ b/app-office/scribus/scribus-1.5.7.recipe
@@ -9,7 +9,7 @@ versatile PDF creation."
 HOMEPAGE="https://www.scribus.net"
 COPYRIGHT="2014-2021 Scribus Team"
 LICENSE="GNU GPL v2"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://sourceforge.net/projects/scribus/files/scribus-devel/$portVersion/scribus-$portVersion.tar.xz"
 CHECKSUM_SHA256="318316b2cfc7a76191d3e0d3f8c2265147daea0570162028e243c292d826f8ce"
 PATCHES="scribus-$portVersion.patchset"
@@ -117,7 +117,9 @@ BUILD()
 		-DSHAREDIR=$dataDir \
 		-DAPPLICATION_DATA_DIR="config/settings/Scribus" \
 		-DWANT_DISTROBUILD=1 \
-		-DLIB_SUFFIX="$secondaryArchSuffix"
+		-DLIB_SUFFIX="$secondaryArchSuffix" \
+		-DWANT_CPP17=1
+
 	make $jobArgs
 }
 


### PR DESCRIPTION
The new poppler package is using some c++17 features so we need to enable that in the scribus recipe.  Successfully packaged and installed on both x86_64 and x86.