### PR TITLE
x265: enable asm

### DIFF
--- a/media-libs/x265/x265-3.4.recipe
+++ b/media-libs/x265/x265-3.4.recipe
@@ -7,7 +7,7 @@ the bit rate. x265 is a free software project implementing that standard."
 HOMEPAGE="http://x265.org/"
 COPYRIGHT="2013-2020 x265 Project"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://bitbucket.org/multicoreware/x265_git/get/$portVersion.tar.gz"
 CHECKSUM_SHA256="7f2771799bea0f53b5ab47603d5bea46ea2a221e047a7ff398115e9976fd5f86"
 # BitBucket sucks

--- a/media-libs/x265/x265-3.4.recipe
+++ b/media-libs/x265/x265-3.4.recipe
@@ -41,7 +41,7 @@ BUILD_PREREQUIRES="
 	cmd:cmake
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
-	cmd:yasm
+	cmd:nasm
 	"
 
 BUILD()
@@ -51,6 +51,7 @@ BUILD()
 	cd source
 
 	cmake	-DCMAKE_INSTALL_PREFIX:PATH=$prefix	\
+		-DCMAKE_BUILD_TYPE=Release				\
 		-DLIB_INSTALL_DIR:PATH=$relativeLibDir	\
 		-DBIN_INSTALL_DIR:PATH=bin	\
 		-DINCLUDE_INSTALL_DIR:PATH=$relativeIncludeDir


### PR DESCRIPTION
The recipe for x265-3.4 needed a fix for enabling asm optimizations using nasm.
This PR fixes this.