### PR TITLE
hoedown: new recipe

### DIFF
--- a/app-text/hoedown/hoedown-3.0.7.recipe
+++ b/app-text/hoedown/hoedown-3.0.7.recipe
@@ -39,7 +39,7 @@ BUILD_PREREQUIRES="
 TEST_REQUIRES="
 	cmd:python3
 	cmd:tidy
-"
+	"
 
 BUILD()
 {

--- a/app-text/hoedown/hoedown-3.0.7.recipe
+++ b/app-text/hoedown/hoedown-3.0.7.recipe
@@ -20,7 +20,6 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	"
 
-SUMMARY_devel="The hoedown development files"
 PROVIDES_devel="
 	hoedown${secondaryArchSuffix}_devel = $portVersion compat >= 1
 	devel:libhoedown$secondaryArchSuffix = $portVersion compat >= 1

--- a/app-text/hoedown/hoedown-3.0.7.recipe
+++ b/app-text/hoedown/hoedown-3.0.7.recipe
@@ -32,8 +32,8 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
-	cmd:make
 	cmd:gcc$secondaryArchSuffix 
+	cmd:make
 	"
 
 TEST_REQUIRES="

--- a/app-text/hoedown/hoedown-3.0.7.recipe
+++ b/app-text/hoedown/hoedown-3.0.7.recipe
@@ -8,21 +8,21 @@ SOURCE_URI="https://github.com/hoedown/hoedown/archive/refs/tags/$portVersion.ta
 CHECKSUM_SHA256="01b6021b1ec329b70687c0d240b12edcaf09c4aa28423ddf344d2bd9056ba920"
 
 ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="?x86"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	hoedown$secondaryArchSuffix = $portVersion
-	lib:libhoedown$secondaryArchSuffix = $portVersion
 	cmd:hoedown$secondaryArchSuffix = $portVersion
 	cmd:smartypants$secondaryArchSuffix = $portVersion
+	lib:libhoedown$secondaryArchSuffix = ${portVersion%%.*}
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
-	hoedown${secondaryArchSuffix}_devel = $portVersion compat >= 1
-	devel:libhoedown$secondaryArchSuffix = $portVersion compat >= 1
+	hoedown${secondaryArchSuffix}_devel
+	devel:libhoedown$secondaryArchSuffix = ${portVersion%%.*}
 	"
 REQUIRES_devel="
 	hoedown$secondaryArchSuffix == $portVersion base
@@ -31,11 +31,15 @@ REQUIRES_devel="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
-
 BUILD_PREREQUIRES="
 	cmd:make
 	cmd:gcc
 	"
+
+TEST_REQUIRES="
+	cmd:python3
+	cmd:tidy
+"
 
 BUILD()
 {
@@ -46,8 +50,8 @@ INSTALL()
 {
 	# update install paths
 	sed -i 's,PREFIX = /usr/local',"PREFIX = $prefix", Makefile
-	sed -i 's,BINDIR = $(PREFIX)/include',"BINDIR = $binDir", Makefile
-	sed -i 's,LIBDIR = $(PREFIX)/include',"LIBDIR = $libDir", Makefile
+	sed -i 's,BINDIR = $(PREFIX)/bin',"BINDIR = $binDir", Makefile
+	sed -i 's,LIBDIR = $(PREFIX)/lib',"LIBDIR = $libDir", Makefile
 	sed -i 's,INCLUDEDIR = $(PREFIX)/include',"INCLUDEDIR = $includeDir", Makefile
 	make DESTDIR=$installDestDir install
 
@@ -55,4 +59,10 @@ INSTALL()
 
 	packageEntries devel \
 		$developDir
+}
+
+TEST()
+{
+	sed -i 's,python test',"python3 test", Makefile
+	make test
 }

--- a/app-text/hoedown/hoedown-3.0.7.recipe
+++ b/app-text/hoedown/hoedown-3.0.7.recipe
@@ -33,7 +33,7 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	cmd:make
-	cmd:gcc
+	cmd:gcc$secondaryArchSuffix 
 	"
 
 TEST_REQUIRES="

--- a/app-text/hoedown/hoedown-3.0.7.recipe
+++ b/app-text/hoedown/hoedown-3.0.7.recipe
@@ -1,0 +1,59 @@
+SUMMARY="Standards compliant, fast, secure markdown processing library in C"
+DESCRIPTION="Hoedown is a revived fork of Sundown, the Markdown parser"
+HOMEPAGE="https://github.com/hoedown/hoedown"
+COPYRIGHT="2014 Xaier Mendez, Devin Torres, and Hoedown authors"
+LICENSE="ISC"
+REVISION="1"
+SOURCE_URI="https://github.com/hoedown/hoedown/archive/refs/tags/$portVersion.tar.gz"
+CHECKSUM_SHA256="01b6021b1ec329b70687c0d240b12edcaf09c4aa28423ddf344d2bd9056ba920"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
+
+PROVIDES="
+	hoedown$secondaryArchSuffix = $portVersion
+	lib:libhoedown$secondaryArchSuffix = $portVersion
+	cmd:hoedown$secondaryArchSuffix = $portVersion
+	cmd:smartypants$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+SUMMARY_devel="The hoedown development files"
+PROVIDES_devel="
+	hoedown${secondaryArchSuffix}_devel = $portVersion compat >= 1
+	devel:libhoedown$secondaryArchSuffix = $portVersion compat >= 1
+	"
+REQUIRES_devel="
+	hoedown$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+
+BUILD_PREREQUIRES="
+	cmd:make
+	cmd:gcc
+	"
+
+BUILD()
+{
+	make
+}
+
+INSTALL()
+{
+	# update install paths
+	sed -i 's,PREFIX = /usr/local',"PREFIX = $prefix", Makefile
+	sed -i 's,BINDIR = $(PREFIX)/include',"BINDIR = $binDir", Makefile
+	sed -i 's,LIBDIR = $(PREFIX)/include',"LIBDIR = $libDir", Makefile
+	sed -i 's,INCLUDEDIR = $(PREFIX)/include',"INCLUDEDIR = $includeDir", Makefile
+	make DESTDIR=$installDestDir install
+
+	prepareInstalledDevelLib libhoedown
+
+	packageEntries devel \
+		$developDir
+}


### PR DESCRIPTION
the following recipe adds support for [hoedown](https://github.com/hoedown/hoedown) which includes the hoedown and smartypants utility as well.

sample run:

```
> uname -a
Haiku shredder 1 hrev55910 Feb 26 2022 07:26:08 x86_64 x86_64 Haiku

> hoedown --version
Built with Hoedown 3.0.7.

> smartypants --version
Built with Hoedown 3.0.7.
```
