### PR TITLE
x265: fix detection of cpu cores

### DIFF
--- a/media-libs/x265/patches/x265-3.4.patchset
+++ b/media-libs/x265/patches/x265-3.4.patchset
@@ -108,7 +108,7 @@ index 0df90c8..e07fa91 100644
       * uses only one processor as the scheduler doesn't have enough work to utilize all processors */
      return sysconf(_SC_NPROCESSORS_CONF);
 -#elif __unix__
-+#elif __unix__ || __HAIKU__
++#elif defined(__unix__) || defined(__HAIKU__)
      return sysconf(_SC_NPROCESSORS_ONLN);
  #elif MACOS && __MACH__
      int nm[2];

--- a/media-libs/x265/patches/x265-3.4.patchset
+++ b/media-libs/x265/patches/x265-3.4.patchset
@@ -91,3 +91,27 @@ index 2db7a14..0df90c8 100644
 -- 
 2.28.0
 
+
+
+From f2377573876ff155dc7b04d7f05a92a414589b94 Mon Sep 17 00:00:00 2001
+From: Elio Blanca <eblanca76@users.sourceforge.net>
+Date: Mon, 28 Feb 2022 23:29:47 +0000
+Subject: fix detection of cpu cores
+
+
+diff --git a/source/common/threadpool.cpp b/source/common/threadpool.cpp
+index 0df90c8..e07fa91 100644
+--- a/source/common/threadpool.cpp
++++ b/source/common/threadpool.cpp
+@@ -636,7 +636,7 @@ int ThreadPool::getCpuCount()
+     /* Return the number of processors configured by OS. Because, most embedded linux distributions
+      * uses only one processor as the scheduler doesn't have enough work to utilize all processors */
+     return sysconf(_SC_NPROCESSORS_CONF);
+-#elif __unix__
++#elif __unix__ || __HAIKU__
+     return sysconf(_SC_NPROCESSORS_ONLN);
+ #elif MACOS && __MACH__
+     int nm[2];
+-- 
+2.30.2
+

--- a/media-libs/x265/x265-3.4.recipe
+++ b/media-libs/x265/x265-3.4.recipe
@@ -7,7 +7,7 @@ the bit rate. x265 is a free software project implementing that standard."
 HOMEPAGE="http://x265.org/"
 COPYRIGHT="2013-2020 x265 Project"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://bitbucket.org/multicoreware/x265_git/get/$portVersion.tar.gz"
 CHECKSUM_SHA256="7f2771799bea0f53b5ab47603d5bea46ea2a221e047a7ff398115e9976fd5f86"
 # BitBucket sucks


### PR DESCRIPTION
Allow for x265 proper detection of actual number of cpu cores, instead of using default (2).