### PR TITLE
openal: Strip non-existent "include" directory

### DIFF
--- a/media-libs/openal/openal-1.21.1.recipe
+++ b/media-libs/openal/openal-1.21.1.recipe
@@ -8,7 +8,7 @@ HOMEPAGE="https://www.openal-soft.org/"
 COPYRIGHT="1999-2000 Loki Software
 	2005-2021 OpenAL Soft team"
 LICENSE="GNU LGPL v2.1"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://github.com/kcat/openal-soft/archive/refs/tags/1.21.1.tar.gz"
 CHECKSUM_SHA256="8ac17e4e3b32c1af3d5508acfffb838640669b4274606b7892aa796ca9d7467f"
 SOURCE_DIR="openal-soft-$portVersion"
@@ -104,6 +104,7 @@ INSTALL()
 	cd build
 	make install
 
+	sed -i 's/\${_IMPORT_PREFIX}\/include;//g' $libDir/cmake/OpenAL/OpenALConfig.cmake
 	prepareInstalledDevelLib libopenal
 	fixPkgconfig
 


### PR DESCRIPTION
This is intended to make linking against the `OpenAL::OpenAL` target work without errors. Previously attempting to link against the `OpenAL::OpenAL` target would cause an error in the generate step in CMake due to the configuration files referencing the "include" directory which doesn't exist in Haiku.