### PR TITLE
lagrange: bump to 1.11.2

### DIFF
--- a/net-misc/lagrange/lagrange-1.11.2.recipe
+++ b/net-misc/lagrange/lagrange-1.11.2.recipe
@@ -8,7 +8,7 @@ COPYRIGHT="2020-2022 Jaakko Keränen"
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="https://github.com/skyjake/lagrange/releases/download/v$portVersion/lagrange-$portVersion.tar.gz"
-CHECKSUM_SHA256="042937f466e879bd6199b4ed59b7f786b31c382918650a7a8caa1cdb75897868"
+CHECKSUM_SHA256="4e9a9ed38bcfc7b04856f0e2667d7afd535a8e06e367e2e4368ef5fb9105791f"
 SOURCE_DIR="lagrange-$portVersion"
 ADDITIONAL_FILES="lagrange.rdef.in"
 


### PR DESCRIPTION
[Changelog](https://github.com/skyjake/lagrange/releases)