### PR TITLE
Rust: add version 1.60.0

### DIFF
--- a/dev-lang/rust_bin/rust_bin-1.60.0.recipe
+++ b/dev-lang/rust_bin/rust_bin-1.60.0.recipe
@@ -1,0 +1,100 @@
+SUMMARY="Modern and safe systems programming language"
+DESCRIPTION="Rust is a systems programming language that runs blazingly fast, \
+prevents almost all crashes*, and eliminates data races."
+HOMEPAGE="https://www.rust-lang.org/"
+COPYRIGHT="2022 The Rust Project Developers"
+LICENSE="MIT"
+REVISION="1"
+
+case "$effectiveTargetArchitecture" in
+	x86)
+SOURCE_URI="https://dl.rust-on-haiku.com/dist/$portVersion/rust-$portVersion-i686-unknown-haiku.tar.xz"
+CHECKSUM_SHA256="5da4cc89f01efa281b5d8684c87248abab052d69bf310157e5c19e9f15677a66"
+SOURCE_DIR="rust-$portVersion-i686-unknown-haiku"
+		;;
+	x86_64)
+SOURCE_URI="https://dl.rust-on-haiku.com/dist/$portVersion/rust-$portVersion-x86_64-unknown-haiku.tar.xz"
+CHECKSUM_SHA256="ffa6aef075780978dc46ed718261ea7f70953e1c64cae62155d39a3aa559de0a"
+SOURCE_DIR="rust-$portVersion-x86_64-unknown-haiku"
+		;;
+	*)
+SOURCE_URI="https://dl.rust-on-haiku.com/dist/$portVersion/rustc-$portVersion-src.tar.xz"
+CHECKSUM_SHA256="0f8533a0d73210d0843c42cdb9df599b886451bf4b48d11a91374d32becc0b05"
+SOURCE_DIR="rustc-$portVersion-src"
+		;;
+esac
+
+ARCHITECTURES="!x86_gcc2 ?x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+DISABLE_SOURCE_PACKAGE=yes
+
+cargoVersion="0.61.0"
+rustfmtVersion="1.4.38"
+clippyVersion="0.1.60"
+
+PROVIDES="
+	rust_bin$secondaryArchSuffix = $portVersion
+	cmd:rustc$secondaryArchSuffix = $portVersion
+	cmd:rustdoc$secondaryArchSuffix = $portVersion
+	cmd:rustfmt$secondaryArchSuffix = $portVersion
+	cmd:rust_demangler$secondaryArchSuffix = $portVersion
+	cmd:rust_gdb$secondaryArchSuffix = $portVersion
+	cmd:rust_gdbgui$secondaryArchSuffix = $portVersion
+	cmd:rust_lldb$secondaryArchSuffix = $portVersion
+	cmd:cargo$secondaryArchSuffix = $cargoVersion
+	cmd:cargo_clippy$secondaryArchSuffix = $clippyVersion
+	cmd:cargo_fmt$secondaryArchSuffix = $cargoVersion
+	cmd:clippy_driver$secondaryArchSuffix = $clippyVersion
+	cmd:rustfmt = $rustfmtVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcrypto$secondaryArchSuffix
+	lib:libcurl$secondaryArchSuffix
+	lib:libssh2$secondaryArchSuffix
+	lib:libssl$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+CONFLICTS="
+	rust$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+
+relativeInstallDir="develop/tools$secondaryArchSubDir/rust"
+installDir="$prefix/$relativeInstallDir"
+
+INSTALL()
+{
+	./install.sh                                   \
+		--prefix=$installDir                       \
+		--docdir=$developDocDir                    \
+		--mandir=$manDir                           \
+		--sysconfdir=$dataDir                      \
+		--disable-ldconfig
+
+	# move zsh data to the datadir
+	mv $installDir/share/zsh $dataDir
+	rm -rf $installDir/share
+
+	# clean out unneccesary files created by the rust installer
+	rm $installDir/lib/rustlib/components
+	rm $installDir/lib/rustlib/install.log
+	rm $installDir/lib/rustlib/manifest-*
+	rm $installDir/lib/rustlib/rust-installer-version
+	rm $installDir/lib/rustlib/uninstall.sh
+
+	# link the binaries in $binDir
+	mkdir -p $binDir
+	for f in cargo cargo-clippy cargo-fmt clippy-driver \
+	         rust-demangler rust-gdb rust-gdbgui rust-lldb rustc rustdoc \
+	         rustfmt; do
+		symlinkRelative -sfn $installDir/bin/$f $binDir
+	done
+
+	# make sure runtime_loader can find the libraries in the lib dir relative
+	# to the binaries
+	symlinkRelative -sfn $installDir/lib $installDir/bin/lib
+}


### PR DESCRIPTION
Add Rust 1.60.0. Unfortunately the wasm target does not build, so no updated recipe for that this time.