### PR TITLE
new recipe: lilypond

### DIFF
--- a/media-sound/lilypond/lilypond-2.22.2.recipe
+++ b/media-sound/lilypond/lilypond-2.22.2.recipe
@@ -1,0 +1,178 @@
+SUMMARY="A typesetting system for music notation"
+DESCRIPTION="LilyPond is a music engraving program, devoted to producing the highest-quality \
+sheet music possible. It brings the aesthetics of traditionally engraved music to computer \
+printouts. LilyPond is free software and part of the GNU Project."
+HOMEPAGE="https://lilypond.org/"
+COPYRIGHT="1993-2020 The LilyPond development team"
+LICENSE="GNU GPL v3"
+REVISION="1"
+SOURCE_URI="https://lilypond.org/download/source/v${portVersion%.*}/lilypond-$portVersion.tar.gz"
+CHECKSUM_SHA256="dde90854fa7de1012f4e1304a68617aea9ab322932ec0ce76984f60d26aa23be"
+PATCHES="lilypond-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+ 	lilypond$secondaryArchSuffix = $portVersion
+	cmd:abc2ly
+	cmd:convert_ly
+	cmd:etf2ly
+	cmd:lilymidi
+ 	cmd:lilypond
+	cmd:lilypond_book
+	cmd:lilypond_invoke_editor
+	cmd:lilysong
+	cmd:midi2ly
+	cmd:musicxml2ly
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	cmd:fc_list$secondaryArchSuffix
+	cmd:guile < 2
+	cmd:python3
+	lib:libfreetype$secondaryArchSuffix
+	lib:libglib_2.0$secondaryArchSuffix
+	lib:libgmp$secondaryArchSuffix
+	lib:libgobject_2.0$secondaryArchSuffix
+	lib:libguile$secondaryArchSuffix
+	lib:libgs$secondaryArchSuffix # TODO: replace with cmd:gs?
+	lib:libharfbuzz$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libltdl$secondaryArchSuffix
+	lib:libpangoft2_1.0$secondaryArchSuffix
+	"
+
+PROVIDES_doc="
+	lilypond${secondaryArchSuffix}_doc = $portVersion
+	"
+REQUIRES_doc="
+	lilypond$secondaryArchSuffix == $portVersion base
+	"
+ARCHITECTURES_doc="any"
+
+languages="ca cs de es fr hu it ja nl pt zh"
+for lang in $languages; do
+	eval "PROVIDES_doc_${lang}=\"\
+		lilypond${secondaryArchSuffix}_doc_${lang} = $portVersion\
+		\"; \
+	REQUIRES_doc_${lang}=\"\
+		lilypond${secondaryArchSuffix}_doc == $portVersion base\
+		\"; \
+	SUMMARY_doc_${lang}=\"${SUMMARY} (documentation ${lang})\"\
+	ARCHITECTURES_doc_${lang}=\"any\""
+done
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	tex_gyre
+	texlive_basic
+	# most of these texlive_lang* packages are needed by the tex engines
+	texlive_langchinese
+	texlive_langcyrillic # this one is specifically needed by lilypond
+	texlive_langczechslovak
+	texlive_langenglish
+	texlive_langeuropean
+	texlive_langfrench
+	texlive_langgerman
+	texlive_langgreek
+	texlive_langitalian
+	texlive_langother
+	texlive_langpolish
+	texlive_langportuguese
+	texlive_langspanish
+	texlive_metapost
+	texlive_plaingeneric
+	urw_base35_fonts
+	cmd:guile < 2
+	devel:libfreetype$secondaryArchSuffix
+	devel:libglib_2.0$secondaryArchSuffix
+	devel:libgmp$secondaryArchSuffix
+	devel:libgobject_2.0$secondaryArchSuffix
+	devel:libguile$secondaryArchSuffix
+	devel:libgs$secondaryArchSuffix
+	devel:libharfbuzz$secondaryArchSuffix
+	devel:libintl$secondaryArchSuffix
+	devel:libltdl$secondaryArchSuffix
+	devel:libpangoft2_1.0$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+#	cmd:awk
+	cmd:bison
+	cmd:convert$secondaryArchSuffix
+	cmd:dblatex
+#	cmd:extractpdfmark # broken, requires working ghostscript
+	cmd:fc_list$secondaryArchSuffix
+	cmd:find
+	cmd:flex
+	cmd:fontforge
+	cmd:gcc$secondaryArchSuffix
+	cmd:kpsewhich
+	cmd:make
+	cmd:mawk # required by texindex
+	cmd:mf
+	cmd:mpost
+	cmd:perl
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:rsync
+	cmd:t1asm
+	cmd:tar
+	cmd:texi2html
+	cmd:texindex
+	cmd:tidy$secondaryArchSuffix
+	cmd:xelatex
+	cmd:zip
+	"
+
+TEST_REQUIRES="
+	cmd:git
+	"
+
+defineDebugInfoPackage lilypond$secondaryArchSuffix \
+	$prefix/bin/lilypond
+
+PATCH()
+{
+	./autogen.sh --noconfigure
+}
+
+BUILD()
+{
+	mkdir -p build
+	cd build
+
+	# the build system already installs documentation in a subdirectory of docdir
+	runConfigure --omit-dirs "binDir docDir" $sourceDir/configure \
+		--bindir=$prefix/bin \
+		--docdir=$documentationDir/packages \
+		--with-localedir=$dataDir/locale \
+		--enable-gs-api # needed because of broken ghostscript (gs)
+	make $jobArgs
+
+	# CPU_COUNT=$jobs is not used because it causes hangs
+	# strip the current directory (.) from PATH, it disallows find -execdir
+	PATH=${PATH:2} make $jobArgs doc
+}
+
+INSTALL()
+{
+	cd build
+	make install
+	PATH=${PATH:2} make install-doc
+
+	# language specific doc packages
+	for lang in $languages; do
+		packageEntries doc_${lang} \
+			$(find $docDir -name "*.${lang}.*")
+	done
+
+	# generic and english doc package
+	packageEntries doc \
+		$docDir $infoDir
+}
+
+TEST()
+{
+	cd build
+	make $jobArgs test
+}

--- a/media-sound/lilypond/lilypond-2.22.2.recipe
+++ b/media-sound/lilypond/lilypond-2.22.2.recipe
@@ -125,7 +125,12 @@ BUILD_PREREQUIRES="
 	"
 
 TEST_REQUIRES="
+	# either one of these is required (don't know which yet, it doesn't work yet)
+#	dejavu
+#	texlive_fontsextra
+	texlive_xetex
 	cmd:git
+	cmd:xsltproc
 	"
 
 defineDebugInfoPackage lilypond$secondaryArchSuffix \

--- a/media-sound/lilypond/lilypond-2.22.2.recipe
+++ b/media-sound/lilypond/lilypond-2.22.2.recipe
@@ -127,6 +127,7 @@ BUILD_PREREQUIRES="
 TEST_REQUIRES="
 	dejavu
 	texlive_xetex
+	cmd:fc_cache$secondaryArchSuffix
 	cmd:git
 	cmd:xsltproc
 	"
@@ -176,6 +177,9 @@ INSTALL()
 
 TEST()
 {
+	# update the fontconfig cache to make sure it knows of all installed fonts (needed by xetex)
+	fc-cache -f
+
 	cd build
 	make $jobArgs test
 }

--- a/media-sound/lilypond/lilypond-2.22.2.recipe
+++ b/media-sound/lilypond/lilypond-2.22.2.recipe
@@ -101,7 +101,7 @@ BUILD_PREREQUIRES="
 	cmd:bison
 	cmd:convert$secondaryArchSuffix
 	cmd:dblatex
-#	cmd:extractpdfmark # broken, requires working ghostscript
+	cmd:extractpdfmark
 	cmd:fc_list$secondaryArchSuffix
 	cmd:find
 	cmd:flex

--- a/media-sound/lilypond/lilypond-2.22.2.recipe
+++ b/media-sound/lilypond/lilypond-2.22.2.recipe
@@ -10,8 +10,8 @@ SOURCE_URI="https://lilypond.org/download/source/v${portVersion%.*}/lilypond-$po
 CHECKSUM_SHA256="dde90854fa7de1012f4e1304a68617aea9ab322932ec0ce76984f60d26aa23be"
 PATCHES="lilypond-$portVersion.patchset"
 
-ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="?all !x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
 
 PROVIDES="
  	lilypond$secondaryArchSuffix = $portVersion
@@ -49,7 +49,7 @@ PROVIDES_doc="
 REQUIRES_doc="
 	lilypond$secondaryArchSuffix == $portVersion base
 	"
-ARCHITECTURES_doc="any"
+ARCHITECTURES_doc="?any"
 
 languages="ca cs de es fr hu it ja nl pt zh"
 for lang in $languages; do
@@ -60,7 +60,7 @@ for lang in $languages; do
 		lilypond${secondaryArchSuffix}_doc == $portVersion base\
 		\"; \
 	SUMMARY_doc_${lang}=\"${SUMMARY} (documentation ${lang})\"\
-	ARCHITECTURES_doc_${lang}=\"any\""
+	ARCHITECTURES_doc_${lang}=\"?any\""
 done
 
 BUILD_REQUIRES="
@@ -119,7 +119,7 @@ BUILD_PREREQUIRES="
 	cmd:tar
 	cmd:texi2html
 	cmd:texindex
-	cmd:tidy$secondaryArchSuffix
+	cmd:tidy
 	cmd:xelatex
 	cmd:zip
 	"

--- a/media-sound/lilypond/lilypond-2.22.2.recipe
+++ b/media-sound/lilypond/lilypond-2.22.2.recipe
@@ -125,9 +125,7 @@ BUILD_PREREQUIRES="
 	"
 
 TEST_REQUIRES="
-	# either one of these is required (don't know which yet, it doesn't work yet)
-#	dejavu
-#	texlive_fontsextra
+	dejavu
 	texlive_xetex
 	cmd:git
 	cmd:xsltproc

--- a/media-sound/lilypond/patches/lilypond-2.22.2.patchset
+++ b/media-sound/lilypond/patches/lilypond-2.22.2.patchset
@@ -1,0 +1,187 @@
+From 23fe51375c6aa281488168144108a012e330d7fa Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
+Date: Thu, 14 Apr 2022 15:21:58 +0200
+Subject: don't use hard links
+
+
+diff --git a/Documentation/po/GNUmakefile b/Documentation/po/GNUmakefile
+index 340e9ea..d4d1395 100644
+--- a/Documentation/po/GNUmakefile
++++ b/Documentation/po/GNUmakefile
+@@ -14,11 +14,11 @@ TELY_FILES += $(foreach l, $(LANGS), $(shell ls $(depth)/Documentation/$(l)/*.te
+ messages: $(outdir)/messages
+ 
+ $(outdir)/messages: $(MO_FILES)
+-	$(call ly_progress,Making,$@,(hard links))
++	$(call ly_progress,Making,$@,(symbolic links))
+ 	for i in $(CATALOGS); do \
+ 	  rm -rf $(doc-localedir)/$$i/LC_MESSAGES; \
+ 	  mkdir -p $(doc-localedir)/$$i/LC_MESSAGES; \
+-	  $(LN) $(outdir)/$$i.mo $(doc-localedir)/$$i/LC_MESSAGES/lilypond-doc.mo; \
++	  $(LN) -s ../../$$i.mo $(doc-localedir)/$$i/LC_MESSAGES/lilypond-doc.mo; \
+ 	done
+ 	touch $@
+ 
+diff --git a/GNUmakefile.in b/GNUmakefile.in
+index d796004..2ae8f72 100644
+--- a/GNUmakefile.in
++++ b/GNUmakefile.in
+@@ -141,13 +141,13 @@ $(outdir)/%-root/index.html: doc-build
+ 	mkdir -p $(dir $@)/Documentation/
+ 	for d in . musicxml abc2ly lilypond-book ; do \
+ 		mkdir -p $(dir $@)/input/regression/$${d}; \
+-		cp --link -a input/regression/$${d}/out-www/*  $(dir $@)/input/regression/$${d}/ ; \
++		cp -a input/regression/$${d}/out-www/*  $(dir $@)/input/regression/$${d}/ ; \
+ 	done
+ 	find $(dir $@)/input/regression/ -type f -not -name '*.png' \
+ 		-not -name '*.ly' -not -name '*.html' -not -name 'collated-files.pdf' \
+ 		-delete
+-	cp --link -a Documentation/out-www/webdoc/* $(dir $@)/Documentation/
+-	cp --link $(TOPDOC_TXT_FILES) $(dir $@)
++	cp -a Documentation/out-www/webdoc/* $(dir $@)/Documentation/
++	cp $(TOPDOC_TXT_FILES) $(dir $@)
+ 	# No link because the files come from the source directory.
+ 	cp $(addprefix $(src-dir)/,$(README_FILES)) $(dir $@)
+ 	$(PYTHON) $(buildscript-dir)/www_post.py $(PACKAGE_NAME) $(TOPLEVEL_VERSION) $(dir $@) "$*"
+diff --git a/configure.ac b/configure.ac
+index 720f329..cd19c9e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -433,7 +433,7 @@ touch local.make
+ STEPMAKE_END
+ 
+ if make top-doc 1>/dev/null 2>&1; then
+-    rm -f INSTALL.txt && ln Documentation/out/topdocs/INSTALL.txt .
++    rm -f INSTALL.txt && ln -s Documentation/out/topdocs/INSTALL.txt .
+ fi
+ 
+ cat <<EOF
+diff --git a/python/book_snippets.py b/python/book_snippets.py
+index 3cd2270..3693e9f 100644
+--- a/python/book_snippets.py
++++ b/python/book_snippets.py
+@@ -676,10 +676,7 @@ printing diff against existing file." % filename)
+                     content = content.replace(basename, final_basename)
+                     open(dst, 'wb').write(content)
+                 else:
+-                    try:
+-                        os.link(src, dst)
+-                    except AttributeError:
+-                        shutil.copyfile(src, dst)
++                    shutil.copyfile(src, dst)
+             except (IOError, OSError):
+                 error(_('Could not overwrite file %s') % dst)
+                 raise CompileError(self.basename())
+-- 
+2.30.2
+
+
+From 3c3bddf4c2117190cac3f0e53f344b6b746b97f1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
+Date: Sat, 16 Apr 2022 14:04:41 +0200
+Subject: use perl globbing instead of shell globbing to avoid a too long
+ argument list
+
+the increase in hrev55899 is still not enough for this command, apparently.
+
+diff --git a/GNUmakefile.in b/GNUmakefile.in
+index 2ae8f72..bc5f4ba 100644
+--- a/GNUmakefile.in
++++ b/GNUmakefile.in
+@@ -154,7 +154,7 @@ $(outdir)/%-root/index.html: doc-build
+ 	find $(outdir)/$*-root -type l | xargs rm -f
+ 	cd $(outdir)/$*-root && find -name \*.html -execdir $(buildscript-dir)/fix-docsize.sh {} +
+ 	$(PERL) -i -pe 's#(href)="\.\./Documentation/#\1="#g' $(dir $@)/Documentation/*html
+-	$(PERL) -i -pe 's#(href)="\.\./\.\./Documentation/#\1="../#g' $(dir $@)/Documentation/*/*html
++	$(PERL) -i -pe 'BEGIN{ @ARGV = glob(pop) } s#(href)="\.\./\.\./Documentation/#\1="../#g' "$(dir $@)/Documentation/*/*html"
+ 	# Fixup links to CSS files.
+ 	$(PERL) -i -pe 's#(href)="css/#\1="../../Documentation/css/#g' $(dir $@)/input/regression/*html
+ 	$(PERL) -i -pe 's#(href)="css/#\1="../../../Documentation/css/#g' $(dir $@)/input/regression/*/*html
+-- 
+2.30.2
+
+
+From cd6c4eb018001e1975ccbb4ae3f628cda34e7428 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
+Date: Sat, 16 Apr 2022 16:59:07 +0200
+Subject: fix docdir configure argument not being honoured
+
+
+diff --git a/config.make.in b/config.make.in
+index 2b8c636..582708a 100644
+--- a/config.make.in
++++ b/config.make.in
+@@ -77,7 +77,7 @@ configure-builddir = @abs_builddir@
+ configure-srcdir = @abs_srcdir@
+ datadir = @datadir@
+ datarootdir = @datarootdir@
+-docdir = $(datadir)/doc
++docdir = @docdir@
+ elispdir = $(datadir)/emacs/site-lisp
+ exec_prefix = @exec_prefix@
+ includedir = @includedir@
+-- 
+2.30.2
+
+
+From e03900f64ac990454af339ecd2174f92ea684b51 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
+Date: Sun, 17 Apr 2022 12:45:41 +0200
+Subject: fix installing info symlink
+
+python's os.getcwd() returns the normalized path with all symlinks resolved,
+which is a problem with the symlinked packaging paths of Haiku.
+
+diff --git a/scripts/build/relative.py b/scripts/build/relative.py
+index 7bd700d..b8dba56 100644
+--- a/scripts/build/relative.py
++++ b/scripts/build/relative.py
+@@ -3,8 +3,8 @@ import sys
+ 
+ 
+ def relative(dir, r=os.getcwd()):
+-    dir = os.path.normpath(dir) + '/'
+-    r = os.path.normpath(r) + '/'
++    dir = os.path.realpath(os.path.normpath(dir)) + '/'
++    r = os.path.realpath(os.path.normpath(r)) + '/'
+     prefix = len(os.path.commonprefix((dir, r)))
+     if prefix == len(dir):
+         return './'
+-- 
+2.30.2
+
+
+From 750cb8af980433616b8dc23e82782126e798aea5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
+Date: Mon, 18 Apr 2022 11:14:49 +0200
+Subject: some fixes for tests
+
+tests have not yet run successfully because of missing extractbb (should be provided by
+texlive_core)
+
+diff --git a/scripts/build/output-distance.py b/scripts/build/output-distance.py
+index be9626c..50aa97e 100644
+--- a/scripts/build/output-distance.py
++++ b/scripts/build/output-distance.py
+@@ -99,7 +99,8 @@ def system_allow_exit1(x):
+     log_verbose('invoking %s' % x)
+     stat = os.system(x)
+     # This return value convention is sick.
+-    assert (stat == 0) or (stat == 256)
++    # this assert fails on Haiku, disable it
++    # assert (stat == 0) or (stat == 256)
+ 
+ 
+ def shorten_string(s, threshold=15):
+@@ -1278,7 +1279,7 @@ def link_file(x, y):
+     mkdir(os.path.split(y)[0])
+     try:
+         log_verbose('%s -> %s' % (x, y))
+-        os.link(x, y)
++        os.symlink(x, y)
+     except OSError as z:
+         if z.errno == errno.ENOENT:
+             pass
+-- 
+2.30.2
+


### PR DESCRIPTION
~Tests fail because of missing `extractbb` command (which should be provided by `texlive_core`).~ fixed in 29e1618 in #6818 

It also cannot be built right now as long as `texlive` is not available (should it be marked as untested?). Texlive is only required for building, not at runtime.

The libgs API is used instead of the GhostScript executable because that crashes on Lilypond's PostScript output (see #6284).