### PR TITLE
newlisp: new recipe

### DIFF
--- a/dev-lisp/newlisp/newlisp-10.7.5.recipe
+++ b/dev-lisp/newlisp/newlisp-10.7.5.recipe
@@ -46,7 +46,8 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	runConfigure ./configure-alt
+	runConfigure --omit-dirs binDir \
+		./configure-alt --bindir=$commandBinDir
 	make
 }
 

--- a/dev-lisp/newlisp/newlisp-10.7.5.recipe
+++ b/dev-lisp/newlisp/newlisp-10.7.5.recipe
@@ -12,9 +12,6 @@ PATCHES="newlisp-$portVersion.patchset"
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
-libVersion="$portVersion"
-libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
-
 PROVIDES="
 	newlisp$secondaryArchSuffix = $portVersion
 	cmd:newlisp = $portVersion
@@ -25,22 +22,30 @@ PROVIDES="
 
 REQUIRES="
 	haiku$secondaryArchSuffix
+	lib:libffi$secondaryArchSuffix
 	lib:libncursesw$secondaryArchSuffix
 	lib:libreadline$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	devel:libffi$secondaryArchSuffix
 	devel:libncursesw$secondaryArchSuffix
 	devel:libreadline$secondaryArchSuffix
 	"
 
 BUILD_PREREQUIRES="
-	cmd:gcc$secondaryArchPrefix
+	cmd:gcc$secondaryArchSuffix
 	cmd:make
-	cmd:pkg_config$secondaryArchPrefix
+	cmd:pkg_config$secondaryArchSuffix
 	"
 
+commandBinDir=$binDir
+commandSuffix=$secondaryArchSuffix
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
 
 BUILD()
 {

--- a/dev-lisp/newlisp/newlisp-10.7.5.recipe
+++ b/dev-lisp/newlisp/newlisp-10.7.5.recipe
@@ -1,0 +1,55 @@
+SUMMARY="Put the fun back in Lisp"
+DESCRIPTION="newLISP is a LISP-like scripting language for doing things"
+HOMEPAGE="https://www.newlisp.org"
+COPYRIGHT="2013 Lutz Mueller"
+LICENSE="GNU GPL v3"
+REVISION="1"
+SOURCE_URI="http://www.newlisp.org/downloads/newlisp-10.7.5.tgz"
+SOURCE_FILENAME="newlisp-$portVersion.tar.gz"
+CHECKSUM_SHA256="dc2d0ff651c2b275bc4af3af8ba59851a6fb6e1eaddc20ae75fb60b1e90126ec"
+PATCHES="newlisp-$portVersion.patchset"
+
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="$portVersion"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+       newlisp$secondaryArchSuffix = $portVersion
+       cmd:newlisp = $portVersion
+       cmd:newlisp_$portVersion = $portVersion
+       cmd:newlispdoc = $portVersion
+       "
+
+
+REQUIRES="
+       haiku$secondaryArchSuffix
+       lib:libncursesw$secondaryArchSuffix
+       lib:libreadline$secondaryArchSuffix
+       "
+
+BUILD_REQUIRES="
+       haiku${secondaryArchSuffix}_devel
+       devel:libncursesw$secondaryArchSuffix
+       devel:libreadline$secondaryArchSuffix
+       "
+
+BUILD_PREREQUIRES="
+       cmd:gcc$secondaryArchPrefix
+       cmd:make
+       cmd:pkg_config$secondaryArchPrefix
+       "
+
+
+BUILD()
+{
+       runConfigure ./configure-alt
+       make
+}
+
+INSTALL()
+{
+       mkdir -p $binDir
+       make install
+}

--- a/dev-lisp/newlisp/newlisp-10.7.5.recipe
+++ b/dev-lisp/newlisp/newlisp-10.7.5.recipe
@@ -12,14 +12,19 @@ PATCHES="newlisp-$portVersion.patchset"
 ARCHITECTURES="!x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
+commandBinDir=$binDir
+commandSuffix=$secondaryArchSuffix
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
 PROVIDES="
 	newlisp$secondaryArchSuffix = $portVersion
-	cmd:newlisp = $portVersion
+	cmd:newlisp$commandSuffix = $portVersion
 	cmd:newlisp_$portVersion = $portVersion
 	cmd:newlispdoc = $portVersion
 	"
-
-
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libffi$secondaryArchSuffix
@@ -33,19 +38,11 @@ BUILD_REQUIRES="
 	devel:libncursesw$secondaryArchSuffix
 	devel:libreadline$secondaryArchSuffix
 	"
-
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
 	"
-
-commandBinDir=$binDir
-commandSuffix=$secondaryArchSuffix
-if [ "$targetArchitecture" = x86_gcc2 ]; then
-	commandSuffix=
-	commandBinDir=$prefix/bin
-fi
 
 BUILD()
 {
@@ -55,6 +52,5 @@ BUILD()
 
 INSTALL()
 {
-	mkdir -p $binDir
 	make install
 }

--- a/dev-lisp/newlisp/newlisp-10.7.5.recipe
+++ b/dev-lisp/newlisp/newlisp-10.7.5.recipe
@@ -16,40 +16,40 @@ libVersion="$portVersion"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
-       newlisp$secondaryArchSuffix = $portVersion
-       cmd:newlisp = $portVersion
-       cmd:newlisp_$portVersion = $portVersion
-       cmd:newlispdoc = $portVersion
-       "
+	newlisp$secondaryArchSuffix = $portVersion
+	cmd:newlisp = $portVersion
+	cmd:newlisp_$portVersion = $portVersion
+	cmd:newlispdoc = $portVersion
+	"
 
 
 REQUIRES="
-       haiku$secondaryArchSuffix
-       lib:libncursesw$secondaryArchSuffix
-       lib:libreadline$secondaryArchSuffix
-       "
+	haiku$secondaryArchSuffix
+	lib:libncursesw$secondaryArchSuffix
+	lib:libreadline$secondaryArchSuffix
+	"
 
 BUILD_REQUIRES="
-       haiku${secondaryArchSuffix}_devel
-       devel:libncursesw$secondaryArchSuffix
-       devel:libreadline$secondaryArchSuffix
-       "
+	haiku${secondaryArchSuffix}_devel
+	devel:libncursesw$secondaryArchSuffix
+	devel:libreadline$secondaryArchSuffix
+	"
 
 BUILD_PREREQUIRES="
-       cmd:gcc$secondaryArchPrefix
-       cmd:make
-       cmd:pkg_config$secondaryArchPrefix
-       "
+	cmd:gcc$secondaryArchPrefix
+	cmd:make
+	cmd:pkg_config$secondaryArchPrefix
+	"
 
 
 BUILD()
 {
-       runConfigure ./configure-alt
-       make
+	runConfigure ./configure-alt
+	make
 }
 
 INSTALL()
 {
-       mkdir -p $binDir
-       make install
+	mkdir -p $binDir
+	make install
 }

--- a/dev-lisp/newlisp/patches/newlisp-10.7.5.patchset
+++ b/dev-lisp/newlisp/patches/newlisp-10.7.5.patchset
@@ -1,4 +1,4 @@
-From e5abd8984df2881d0908d4664038f6639d3e1d7a Mon Sep 17 00:00:00 2001
+From c5462b9d7ac51ab5717964cc7586145a1682c509 Mon Sep 17 00:00:00 2001
 From: Al Hoang <3811822-hoanga@users.noreply.gitlab.com>
 Date: Sat, 30 Apr 2022 00:36:55 -0500
 Subject: update configure for haiku
@@ -73,7 +73,7 @@ index 901e3bd..aafde04 100755
 2.30.2
 
 
-From ea953af16f52979e57d9f7780018356a7bcdc4f5 Mon Sep 17 00:00:00 2001
+From e218aaba59d6a7a7c9fb56876f423954c477d19a Mon Sep 17 00:00:00 2001
 From: Al Hoang <3811822-hoanga@users.noreply.gitlab.com>
 Date: Sat, 30 Apr 2022 00:37:40 -0500
 Subject: haiku makefile
@@ -110,7 +110,7 @@ index 0000000..94b631d
 2.30.2
 
 
-From 779e24fc09000e92d4180a05db002c746a0325f9 Mon Sep 17 00:00:00 2001
+From 309cb11c5077d005c488e2b66c0f0c8b06d61c19 Mon Sep 17 00:00:00 2001
 From: Al Hoang <3811822-hoanga@users.noreply.gitlab.com>
 Date: Sat, 30 Apr 2022 00:38:53 -0500
 Subject: add haiku support in interpreter
@@ -150,7 +150,7 @@ index 867908c..342d1e0 100644
 2.30.2
 
 
-From f28154042a9e2ea8f38d1cddfa46b0c26d21069d Mon Sep 17 00:00:00 2001
+From f735a712fef8448aece44a96131f9c72d34c0f1d Mon Sep 17 00:00:00 2001
 From: Al Hoang <3811822-hoanga@users.noreply.gitlab.com>
 Date: Sat, 30 Apr 2022 00:39:42 -0500
 Subject: haiku support in file and socket
@@ -206,7 +206,7 @@ index 03b8b73..c447142 100644
 2.30.2
 
 
-From 8fda848eaef5b07e31493dc9da5c709279d80b95 Mon Sep 17 00:00:00 2001
+From 20ee44a0720d2302dc74921505d0851fd4e1d7fb Mon Sep 17 00:00:00 2001
 From: Al Hoang <3811822-hoanga@users.noreply.gitlab.com>
 Date: Sat, 30 Apr 2022 00:40:51 -0500
 Subject: haiku module support
@@ -284,6 +284,131 @@ index 6bdf360..283bcdb 100644
  ))
  
  (set 'library (files (or
+-- 
+2.30.2
+
+
+From 58398a43f152116e564f17a9c89430575e09cae3 Mon Sep 17 00:00:00 2001
+From: Al Hoang <3811822-hoanga@users.noreply.gitlab.com>
+Date: Sat, 30 Apr 2022 23:50:21 -0500
+Subject: ffi support
+
+
+diff --git a/makefile_haiku b/makefile_haiku
+index 94b631d..bfdbc82 100644
+--- a/makefile_haiku
++++ b/makefile_haiku
+@@ -5,13 +5,13 @@
+ OBJS = newlisp.o nl-symbol.o nl-math.o nl-list.o nl-liststr.o nl-string.o nl-filesys.o \
+ 	nl-sock.o nl-import.o nl-xml-json.o nl-web.o nl-matrix.o nl-debug.o pcre.o
+ 
+-CFLAGS = -Wall -pedantic -Wno-uninitialized -Wno-strict-aliasing -Wno-long-long -c -O2 -s -DREADLINE -DHAIKU
++CFLAGS = -Wall -pedantic -Wno-uninitialized -Wno-strict-aliasing -Wno-long-long -c -O2 -s -DFFI -DREADLINE -DHAIKU
+ #CFLAGS = -Wall -pedantic -Wno-uninitialized -Wno-strict-aliasing -Wno-long-long -c -O2 -s -DOS2
+ 
+ CC = gcc
+ 
+ default: $(OBJS)
+-	$(CC) $(OBJS) -lm -lreadline -lncurses -lnetwork -lroot -o newlisp
++	$(CC) $(OBJS) -lm -lffi -lreadline -lncurses -lnetwork -lroot -o newlisp
+ 	#$(CC) $(OBJS) -Zomf -Zmt -lm -ldl -o newlisp.exe
+ 
+ .c.o:
+diff --git a/newlisp.h b/newlisp.h
+index 342d1e0..724347f 100644
+--- a/newlisp.h
++++ b/newlisp.h
+@@ -122,7 +122,7 @@
+ #include "win-ffi.h" 
+ #endif
+ 
+-#if defined(LINUX) || defined(_BSD) || defined(KFREEBSD) || defined(CYGWIN) 
++#if defined(LINUX) || defined(_BSD) || defined(KFREEBSD) || defined(CYGWIN) || defined(HAIKU)
+ #include <ffi.h>
+ #endif
+ 
+-- 
+2.30.2
+
+
+From 079bae5a3f03b7a74d6183d571ecebd486330e73 Mon Sep 17 00:00:00 2001
+From: Al Hoang <3811822-hoanga@users.noreply.gitlab.com>
+Date: Sat, 30 Apr 2022 23:55:28 -0500
+Subject: haiku 32bit support
+
+
+diff --git a/modules/crypto.lsp b/modules/crypto.lsp
+index 9cc15d0..8f40d58 100644
+--- a/modules/crypto.lsp
++++ b/modules/crypto.lsp
+@@ -56,6 +56,7 @@
+               "/usr/lib/libcrypto.so.18.0" ; OpenBSD 4.6
+               "/usr/lib/libcrypto.so.19.0" ; OpenBSD 5.0
+               "/usr/lib/libcrypto.dylib"
++              "/system/develop/lib/x86/libcrypto.so" ; Haiku 32bit
+               "/system/develop/lib/libcrypto.so" ; Haiku
+               ))
+ 
+diff --git a/modules/mysql.lsp b/modules/mysql.lsp
+index 94fbb2a..e8067a2 100644
+--- a/modules/mysql.lsp
++++ b/modules/mysql.lsp
+@@ -127,6 +127,7 @@
+     "/usr/local/mysql/lib/libmysqlclient.so" ; Linux, UNIX
+     "/usr/local/mysql/lib/libmysqlclient.dylib" ; MacOS X
+     "/usr/lib/libmysqlclient.dylib" ; MacOS X
++    "/system/develop/lib/x86/libmysqlclient.so" ; Haiku 32bit
+     "/system/develop/lib/libmysqlclient.so" ; Haiku
+ ))
+ 
+diff --git a/modules/postgres.lsp b/modules/postgres.lsp
+index 76783a6..0617f53 100644
+--- a/modules/postgres.lsp
++++ b/modules/postgres.lsp
+@@ -145,6 +145,7 @@
+     "/usr/lib/libpq.so.5.1" ; Debian
+     "/usr/local/pgsql/lib/libpq.dylib" ; Mac OS X
+     "c:/Program Files/PostgreSQL/8.3/bin/libpq.dll" ; Win32
++    "/system/develop/lib/x86/libpq.so" ; Haiku 32bit
+     "/system/develop/lib/libpq.so" ; Haiku
+   )))
+ 
+diff --git a/modules/sqlite3.lsp b/modules/sqlite3.lsp
+index 8f07cd6..47fe38b 100644
+--- a/modules/sqlite3.lsp
++++ b/modules/sqlite3.lsp
+@@ -100,6 +100,7 @@
+     "/usr/lib/x86_64-linux-gnu/libsqlite3.so.0"
+     "/usr/lib/i386-linux-gnu/libsqlite3.so" ; for UBUNTU 32-bit
+     "/usr/lib/i386-linux-gnu/libsqlite3.so.0"
++    "/system/develop/lib/x86/libsqlite3.so" ; Haiku 32bit
+     "/system/develop/lib/libsqlite3.so" ; Haiku
+     "sqlite3.dll" ; Windows DLL path and current directory
+     (string (env "PROGRAMFILES") "/sqlite3/sqlite3.dll") ; Windows SQLite3 std install
+diff --git a/modules/unix.lsp b/modules/unix.lsp
+index e3d159f..dafcdda 100644
+--- a/modules/unix.lsp
++++ b/modules/unix.lsp
+@@ -48,6 +48,7 @@
+     "/lib64/libc.so.6" ; CentOS 6.x
+     "/lib/libc.so.6" ; UBUNTU Linux 9.04
+     "/usr/lib/libc.so" ; Linux, BSD, Solaris
++    "/system/develop/lib/x86/libroot.so" ; Haiku 32bit
+     "/system/develop/lib/libroot.so" ; Haiku
+ ))
+ 
+diff --git a/modules/zlib.lsp b/modules/zlib.lsp
+index 283bcdb..5935990 100644
+--- a/modules/zlib.lsp
++++ b/modules/zlib.lsp
+@@ -40,6 +40,7 @@
+     "/usr/lib64/libz.so" ; for 64Bit CentOS 6 Linux
+     "/usr/lib/libz.dylib" ; Mac OSX / Darwin
+     "libz1.dll" ; MS Windows
++    "/system/develop/lib/x86/libz.so" ; Haiku 32bit
+     "/system/develop/lib/libz.so" ; Haiku
+ ))
+ 
 -- 
 2.30.2
 

--- a/dev-lisp/newlisp/patches/newlisp-10.7.5.patchset
+++ b/dev-lisp/newlisp/patches/newlisp-10.7.5.patchset
@@ -1,0 +1,289 @@
+From e5abd8984df2881d0908d4664038f6639d3e1d7a Mon Sep 17 00:00:00 2001
+From: Al Hoang <3811822-hoanga@users.noreply.gitlab.com>
+Date: Sat, 30 Apr 2022 00:36:55 -0500
+Subject: update configure for haiku
+
+
+diff --git a/configure b/configure
+index edd06f8..342e13c 100755
+--- a/configure
++++ b/configure
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ # Only LP64, LLP64 and ILP32 memory models are supported
+ echo
+@@ -21,6 +21,7 @@ case `uname` in
+ 	MINGW64_*) true ${os_type:=WINDOWS} ;;
+ 	CYGWIN*) true ${os_type:=CYGWIN} ;;
+ 	OS/2) true ${os_type:=OS2} ;;
++	Haiku) true ${os_type:=HAIKU} ;;
+ 	*)
+ 		echo Could not discover your OS platform use one of the following commands:
+ 		make help
+@@ -127,6 +128,8 @@ elif [ ${os_type} = CYGWIN ] ; then
+     fi
+ elif [ ${os_type} = OS2 ] ; then
+ 	cp makefile_os2 makefile_build
++elif [ ${os_type} = HAIKU ] ; then
++	cp makefile_haiku makefile_build
+ fi
+ 
+ 
+diff --git a/configure-alt b/configure-alt
+index 901e3bd..aafde04 100755
+--- a/configure-alt
++++ b/configure-alt
+@@ -39,6 +39,7 @@ AIX_GCCFLAGS=" -Wall -pedantic -Wno-uninitialized -Wno-long-long -fno-strict-ali
+ TRU64_CFLAGS=" -ieee -pedantic -O3 -c -D_POSIX_PII_SOCKET"
+ WIN32_CFLAGS=" -Wall -Wno-uninitialized -Wno-long-long -O1 -c"
+ OS2_CFLAGS=" -Wall -pedantic -Wno-uninitialized -Wno-long-long -Wno-strict-aliasing -O2 -c -s"
++HAIKU_CFLAGS=" -Wall -pedantic -Wno-uninitialized -Wno-long-long -Wno-strict-aliasing -O2 -c -s"
+ 
+ DEFAULT_LDFLAGS="-lm"
+ DARWIN_LDFLAGS="${DEFAULT_LDFLAGS}"
+@@ -49,6 +50,7 @@ AIX_LDFLAGS="-lm -ldl -lrt -lnsl"
+ TRU64_LDFLAGS="-lm -lrt -ldb -lbsd"
+ WIN32_LDFLAGS="-lws2_32"
+ OS2_LDFLAGS="-Zomf -Zmt -lm -ldl"
++HAIKU_LDFLAGS="-lm -lroot -lnetwork"
+ 
+ DEFAULT_OBJS="newlisp.o nl-symbol.o nl-math.o nl-list.o nl-liststr.o nl-string.o nl-filesys.o \
+ 	nl-sock.o nl-import.o nl-xml-json.o nl-web.o nl-matrix.o nl-debug.o pcre.o"
+@@ -72,6 +74,7 @@ case `uname` in
+ 	OSF1) true ${os_type:=TRU64} ;;
+ 	MINGW*) true ${os_type:=WINDOWS} ;;
+ 	OS/2) true ${os_type:=OS2} ;;
++	Haiku) true ${os_type:=HAIKU} ;;
+ 	*)
+ 		echo Could not discover your OS platform use one of the following commands:
+ 		make help
+@@ -113,6 +116,9 @@ elif [ ${os_type} = OS2 ] ; then
+ 	DEFAULT_LDFLAGS="${OS2_LDFLAGS}"
+ 	DEFAULT_TARG="${OS2_TARG}"
+ 	true ${enable_readline:=yes};
++elif [ ${os_type} = HAIKU ] ; then
++	DEFAULT_CFLAGS="${HAIKU_CFLAGS}"
++	DEFAULT_LDFLAGS="${HAIKU_LDFLAGS}"
+ fi
+ 
+ # Only LP64 and ILP32 memory models are officially supported, but we'll try to
+-- 
+2.30.2
+
+
+From ea953af16f52979e57d9f7780018356a7bcdc4f5 Mon Sep 17 00:00:00 2001
+From: Al Hoang <3811822-hoanga@users.noreply.gitlab.com>
+Date: Sat, 30 Apr 2022 00:37:40 -0500
+Subject: haiku makefile
+
+
+diff --git a/makefile_haiku b/makefile_haiku
+new file mode 100644
+index 0000000..94b631d
+--- /dev/null
++++ b/makefile_haiku
+@@ -0,0 +1,21 @@
++# makefile for newLISP v. 10.x.x on OS/2 (tested on eComstation)
++#
++#
++
++OBJS = newlisp.o nl-symbol.o nl-math.o nl-list.o nl-liststr.o nl-string.o nl-filesys.o \
++	nl-sock.o nl-import.o nl-xml-json.o nl-web.o nl-matrix.o nl-debug.o pcre.o
++
++CFLAGS = -Wall -pedantic -Wno-uninitialized -Wno-strict-aliasing -Wno-long-long -c -O2 -s -DREADLINE -DHAIKU
++#CFLAGS = -Wall -pedantic -Wno-uninitialized -Wno-strict-aliasing -Wno-long-long -c -O2 -s -DOS2
++
++CC = gcc
++
++default: $(OBJS)
++	$(CC) $(OBJS) -lm -lreadline -lncurses -lnetwork -lroot -o newlisp
++	#$(CC) $(OBJS) -Zomf -Zmt -lm -ldl -o newlisp.exe
++
++.c.o:
++	$(CC) $(CFLAGS) $<
++
++$(OBJS): primes.h protos.h makefile_build
++
+-- 
+2.30.2
+
+
+From 779e24fc09000e92d4180a05db002c746a0325f9 Mon Sep 17 00:00:00 2001
+From: Al Hoang <3811822-hoanga@users.noreply.gitlab.com>
+Date: Sat, 30 Apr 2022 00:38:53 -0500
+Subject: add haiku support in interpreter
+
+
+diff --git a/newlisp.c b/newlisp.c
+index 5d887aa..6f6f57c 100644
+--- a/newlisp.c
++++ b/newlisp.c
+@@ -96,6 +96,10 @@ int opsys = 9;
+ int opsys = 10;
+ #endif
+ 
++// todo: find proper opsys
++#ifdef HAIKU
++int opsys = 11;
++#endif
+ 
+ /* opsys = 11 taken for ANDROID; see LINUX */
+ 
+diff --git a/newlisp.h b/newlisp.h
+index 867908c..342d1e0 100644
+--- a/newlisp.h
++++ b/newlisp.h
+@@ -106,6 +106,10 @@
+ #define OSTYPE "OS/2" 
+ #endif 
+ 
++#ifdef HAIKU
++#define OSTYPE "Haiku"
++#endif 
++
+ /* include -DFFI in your makefile on the compile line 
+    and -lffi on the link line */
+ #ifdef FFI
+-- 
+2.30.2
+
+
+From f28154042a9e2ea8f38d1cddfa46b0c26d21069d Mon Sep 17 00:00:00 2001
+From: Al Hoang <3811822-hoanga@users.noreply.gitlab.com>
+Date: Sat, 30 Apr 2022 00:39:42 -0500
+Subject: haiku support in file and socket
+
+
+diff --git a/nl-filesys.c b/nl-filesys.c
+index 794e62b..bfa5037 100644
+--- a/nl-filesys.c
++++ b/nl-filesys.c
+@@ -92,7 +92,7 @@ int setenv (const char *name, const char *value, int replace);
+ #define INVALID_SOCKET -1
+ #endif
+ 
+-#if defined(LINUX) || defined(KFREEBSD) || defined(CYGWIN)
++#if defined(LINUX) || defined(KFREEBSD) || defined(CYGWIN) || defined(HAIKU)
+ char * strptime(const char * str, const char * fmt, struct tm * ttm);
+ #endif
+ 
+@@ -1730,7 +1730,7 @@ fd_set thisFdSet;
+ tv.tv_sec = 0;
+ tv.tv_usec = 892 + random() / 10000000;
+ 
+-#if defined(SUNOS) || defined(LINUX) || defined(CYGWIN) || defined(AIX) || defined(KFREEBSD)
++#if defined(SUNOS) || defined(LINUX) || defined(CYGWIN) || defined(AIX) || defined(KFREEBSD) || defined(HAIKU)
+ memcpy(&thisFdSet, &myFdSet, sizeof(fd_set));
+ #else
+ FD_COPY(&myFdSet, &thisFdSet);
+@@ -2744,7 +2744,7 @@ cell = stuffIntegerList(
+     (UINT)ttm->tm_yday + 1,
+     ((UINT)ttm->tm_wday == 0 ? 7 : (UINT)ttm->tm_wday),
+ 
+-#if defined(MAC_OSX) || defined(LINUX) || defined(_BSD) || defined(KFREEBSD) || defined(CYGWIN)
++#if defined(MAC_OSX) || defined(LINUX) || defined(_BSD) || defined(KFREEBSD) || defined(CYGWIN) || defined(HAIKU)
+     gmtoff, isdst
+ #endif
+ 
+diff --git a/nl-sock.c b/nl-sock.c
+index 03b8b73..c447142 100644
+--- a/nl-sock.c
++++ b/nl-sock.c
+@@ -2036,8 +2036,10 @@ from = alloca(sockaddr_len);
+ 
+ if(ADDR_FAMILY == AF_INET6)
+     {
++#ifndef HAIKU
+     ICMP6_FILTER_SETPASSALL (&filter);
+     setsockopt (s, IPPROTO_ICMPV6, ICMP6_FILTER, &filter, sizeof (filter));
++#endif
+     }
+ 
+ gettimeofday(&tv, NULL );
+-- 
+2.30.2
+
+
+From 8fda848eaef5b07e31493dc9da5c709279d80b95 Mon Sep 17 00:00:00 2001
+From: Al Hoang <3811822-hoanga@users.noreply.gitlab.com>
+Date: Sat, 30 Apr 2022 00:40:51 -0500
+Subject: haiku module support
+
+
+diff --git a/modules/crypto.lsp b/modules/crypto.lsp
+index 26d7bda..9cc15d0 100644
+--- a/modules/crypto.lsp
++++ b/modules/crypto.lsp
+@@ -56,6 +56,7 @@
+               "/usr/lib/libcrypto.so.18.0" ; OpenBSD 4.6
+               "/usr/lib/libcrypto.so.19.0" ; OpenBSD 5.0
+               "/usr/lib/libcrypto.dylib"
++              "/system/develop/lib/libcrypto.so" ; Haiku
+               ))
+ 
+ (set 'library (files (or
+diff --git a/modules/mysql.lsp b/modules/mysql.lsp
+index 05faded..94fbb2a 100644
+--- a/modules/mysql.lsp
++++ b/modules/mysql.lsp
+@@ -127,6 +127,7 @@
+     "/usr/local/mysql/lib/libmysqlclient.so" ; Linux, UNIX
+     "/usr/local/mysql/lib/libmysqlclient.dylib" ; MacOS X
+     "/usr/lib/libmysqlclient.dylib" ; MacOS X
++    "/system/develop/lib/libmysqlclient.so" ; Haiku
+ ))
+ 
+ (set 'library (files (or 
+diff --git a/modules/postgres.lsp b/modules/postgres.lsp
+index 0fe5ec5..76783a6 100644
+--- a/modules/postgres.lsp
++++ b/modules/postgres.lsp
+@@ -145,6 +145,7 @@
+     "/usr/lib/libpq.so.5.1" ; Debian
+     "/usr/local/pgsql/lib/libpq.dylib" ; Mac OS X
+     "c:/Program Files/PostgreSQL/8.3/bin/libpq.dll" ; Win32
++    "/system/develop/lib/libpq.so" ; Haiku
+   )))
+ 
+ ; find the library file
+diff --git a/modules/sqlite3.lsp b/modules/sqlite3.lsp
+index 0fa574d..8f07cd6 100644
+--- a/modules/sqlite3.lsp
++++ b/modules/sqlite3.lsp
+@@ -100,6 +100,7 @@
+     "/usr/lib/x86_64-linux-gnu/libsqlite3.so.0"
+     "/usr/lib/i386-linux-gnu/libsqlite3.so" ; for UBUNTU 32-bit
+     "/usr/lib/i386-linux-gnu/libsqlite3.so.0"
++    "/system/develop/lib/libsqlite3.so" ; Haiku
+     "sqlite3.dll" ; Windows DLL path and current directory
+     (string (env "PROGRAMFILES") "/sqlite3/sqlite3.dll") ; Windows SQLite3 std install
+ ))
+diff --git a/modules/unix.lsp b/modules/unix.lsp
+index 07de71e..e3d159f 100644
+--- a/modules/unix.lsp
++++ b/modules/unix.lsp
+@@ -48,6 +48,7 @@
+     "/lib64/libc.so.6" ; CentOS 6.x
+     "/lib/libc.so.6" ; UBUNTU Linux 9.04
+     "/usr/lib/libc.so" ; Linux, BSD, Solaris
++    "/system/develop/lib/libroot.so" ; Haiku
+ ))
+ 
+ (set 'library (files (or
+diff --git a/modules/zlib.lsp b/modules/zlib.lsp
+index 6bdf360..283bcdb 100644
+--- a/modules/zlib.lsp
++++ b/modules/zlib.lsp
+@@ -40,6 +40,7 @@
+     "/usr/lib64/libz.so" ; for 64Bit CentOS 6 Linux
+     "/usr/lib/libz.dylib" ; Mac OSX / Darwin
+     "libz1.dll" ; MS Windows
++    "/system/develop/lib/libz.so" ; Haiku
+ ))
+ 
+ (set 'library (files (or
+-- 
+2.30.2
+


### PR DESCRIPTION
the following recipe adds newlisp as a package.

sample run posted below:

```
> newlisp -h

newLISP v.10.7.5 Copyright (c) 2016 Lutz Mueller. All rights reserved.

usage: newlisp [file | url ...] [options ...] [file | url ...]

options:

 -h this help (no init.lsp)
 -n no init.lsp (must be first)
 -x <source> <target> link (no init.lsp)
 -v version
 -s <stacksize>
 -m <max-mem-MB> cell memory
 -e <quoted lisp expression>
 -l <path-file> log connections
 -L <path-file> log all
 -w <working dir>
 -c no prompts, net-eval, HTTP
 -C force prompts
 -t <usec-server-timeout>
 -p <port-no>
 -d <port-no> daemon mode
 -http only mode
 -http-safe safe mode
 -6 IPv6 mode

more info at http://newlisp.org

> newlisp
newLISP v.10.7.5 64-bit on Haiku IPv4/6 UTF-8, options: newlisp -h

> 
```