### PR TITLE
python-poppler-qt5: new recipe

### DIFF
--- a/dev-python/python-poppler-qt5/patches/python_poppler_qt5-21.1.0.patchset
+++ b/dev-python/python-poppler-qt5/patches/python_poppler_qt5-21.1.0.patchset
@@ -1,0 +1,113 @@
+From 2964f4f4796cfcd7b900ae5c46fccec38d7e0f73 Mon Sep 17 00:00:00 2001
+From: Ben Greiner <code@bnavigator.de>
+Date: Tue, 23 Feb 2021 17:59:33 +0100
+Subject: map type QVector< QPair<TYPE, TYPE> > for
+ FormFieldChoice::choicesWithExportValues()
+
+
+diff --git a/types.sip b/types.sip
+index 239b8c9..81cb283 100644
+--- a/types.sip
++++ b/types.sip
+@@ -331,5 +331,98 @@ template <TYPE>
+ };
+ 
+ 
++/**
++ * Convert QVector< QPair<TYPE, TYPE> >
++ * from and to a Python list of a 2-item tuple
++ */
++
++template<TYPE>
++%MappedType QVector< QPair<TYPE, TYPE> >
++{
++%TypeHeaderCode
++#include <qvector.h>
++#include <qpair.h>
++%End
++
++%ConvertFromTypeCode
++  // Create the list.
++  PyObject *l;
++
++  if ((l = PyList_New(sipCpp->size())) == NULL)
++      return NULL;
++
++  // Set the list elements.
++  for (int i = 0; i < sipCpp->size(); ++i)
++  {
++    QPair<TYPE, TYPE>* p = new QPair<TYPE, TYPE>(sipCpp->at(i));
++    PyObject *ptuple = PyTuple_New(2);
++    PyObject *pfirst;
++    PyObject *psecond;
++
++    TYPE *sfirst = new TYPE(p->first);
++    if ((pfirst = sipConvertFromType(sfirst, sipType_TYPE, sipTransferObj)) == NULL)
++    {
++      Py_DECREF(l);
++      Py_DECREF(ptuple);
++      return NULL;
++    }
++    PyTuple_SET_ITEM(ptuple, 0, pfirst);
++
++    TYPE *ssecond = new TYPE(p->second);
++    if ((psecond = sipConvertFromType(ssecond, sipType_TYPE, sipTransferObj)) == NULL)
++    {
++      Py_DECREF(l);
++      Py_DECREF(ptuple);
++      Py_DECREF(pfirst);
++      return NULL;
++    }
++    PyTuple_SET_ITEM(ptuple, 1, psecond);
++
++    PyList_SET_ITEM(l, i, ptuple);
++  }
++
++  return l;
++%End
++
++%ConvertToTypeCode
++  const sipTypeDef* qpair_type = sipFindType("QPair<TYPE, TYPE>");
++
++  // Check the type if that is all that is required.
++  if (sipIsErr == NULL)
++  {
++    if (!PySequence_Check(sipPy))
++      return 0;
++
++    for (int i = 0; i < PySequence_Size(sipPy); ++i)
++      if (!sipCanConvertToType(PySequence_ITEM(sipPy, i), qpair_type, SIP_NOT_NONE))
++        return 0;
++
++    return 1;
++  }
++
++
++  QVector< QPair<TYPE, TYPE> > *qv = new QVector< QPair<TYPE, TYPE> >;
++
++  for (int i = 0; i < PySequence_Size(sipPy); ++i)
++  {
++    int state;
++    QPair<TYPE, TYPE> * p = reinterpret_cast< QPair<TYPE, TYPE> * >(sipConvertToType(PySequence_ITEM(sipPy, i), qpair_type, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
++
++    if (*sipIsErr)
++    {
++      sipReleaseType(p, qpair_type, state);
++      delete qv;
++      return 0;
++    }
++    qv->append(*p);
++    sipReleaseType(p, qpair_type, state);
++  }
++
++  *sipCppPtr = qv;
++  return sipGetState(sipTransferObj);
++%End
++
++};
++
+ 
+ /* kate: indent-width 4; space-indent on; hl c++; indent-mode cstyle; */
+-- 
+2.30.2
+

--- a/dev-python/python-poppler-qt5/python_poppler_qt5-21.1.0.recipe
+++ b/dev-python/python-poppler-qt5/python_poppler_qt5-21.1.0.recipe
@@ -1,0 +1,122 @@
+SUMMARY="A Python binding to Poppler-Qt5"
+DESCRIPTION="A Python binding for libpoppler-qt5 that aims for completeness and for being \
+actively maintained.
+Using this module you can access the contents of PDF files inside PyQt5 applications."
+HOMEPAGE="https://github.com/frescobaldi/python-poppler-qt5/"
+COPYRIGHT="2009-2021 Wilbert Berendsen"
+LICENSE="GNU LGPL v2.1"
+REVISION="1"
+SOURCE_URI="https://pypi.python.org/packages/source/p/python-poppler-qt5/python-poppler-qt5-$portVersion.tar.gz"
+CHECKSUM_SHA256="add766db2c04026a6087f38f2044e66c8b053c81002f3753d8059713497d022d"
+SOURCE_DIR="python-poppler-qt5-$portVersion"
+PYTHON3_VERSION="3.8"
+PATCHES="python_poppler_qt5-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	python_poppler_qt5$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libpoppler_qt5$secondaryArchSuffix
+	"
+PROVIDES_python38="
+	python_poppler_qt5${secondaryArchSuffix}_python38 = $portVersion
+	"
+REQUIRES_python38="
+	haiku$secondaryArchSuffix
+	python_poppler_qt5$secondaryArchSuffix == $portVersion base
+	pyqt5_python38
+	pyqt5_sip_python38
+	cmd:python$PYTHON3_VERSION
+	$REQUIRES
+	"
+
+if [ "$targetArchitecture" = "x86_gcc2" ]; then
+	PROVIDES_python38+="
+		python_poppler_qt5_python38 = $portVersion
+		"
+fi
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	pyqt_builder_python38
+	pyqt5_python38
+	setuptools_python38
+	sip_python38 >= 6
+	devel:libpoppler_qt5$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:python$PYTHON3_VERSION
+	cmd:gcc${secondaryArchSuffix}
+	cmd:make
+	cmd:ld${secondaryArchSuffix}
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:sed
+	cmd:sip >= 6
+	cmd:qmake${secondaryArchSuffix} >= 5
+	"
+
+BUILD()
+{
+	OLDPYTHONPATH=$PYTHONPATH
+
+	local packageLinksDir=$(dirname $portPackageLinksDir)
+	local python3PackageName="${portName}_python38-$portFullVersion"
+
+	# GENERIC: all python_setuptools-based installs need this
+	python=$packageLinksDir/$python3PackageName/cmd~python$PYTHON3_VERSION/bin/python$PYTHON3_VERSION
+	pythonVersion=$($python --version 2>&1 | sed 's/Python //' | head -c3)
+	installLocation=$prefix/lib/python$pythonVersion/vendor-packages/
+	export PYTHONPATH=$installLocation:$OLDPYTHONPATH
+
+	# this seems to be not needed
+	#BINDINGS_DIR=$portPackageLinksDir/pyqt5_python38/lib/python$pythonVersion/vendor-packages/PyQt5/bindings/
+	#sed -i -e "s|BINDINGS_DIR|$BINDINGS_DIR|g" pyproject.toml
+
+	sip-build \
+		--no-make \
+		--target-dir=$installLocation \
+		--api-dir=$dataDir/sip/PyQt5
+
+	cd build
+
+	## BUILD HACK ##
+	# what is this for? is this needed at all? ".5" is probably not correct in our case anyway ...
+	#sed -i "s|libpopplerqt5.so|libpopplerqt5.so.5|g" popplerqt5/Makefile
+	## BUILD HACK ##
+
+	make $jobArgs
+}
+
+INSTALL()
+{
+	OLDPYTHONPATH=$PYTHONPATH
+
+	local packageLinksDir=$(dirname $portPackageLinksDir)
+	local python3PackageName="${portName}_python38-$portFullVersion"
+
+	# GENERIC: all python_setuptools-based installs need this
+	python=$packageLinksDir/$python3PackageName/cmd~python$PYTHON3_VERSION/bin/python$PYTHON3_VERSION
+	pythonVersion=$($python --version 2>&1 | sed 's/Python //' | head -c3)
+	installLocation=lib/python$pythonVersion/vendor-packages/
+	export PYTHONPATH=$installLocation:$OLDPYTHONPATH
+
+	mkdir -p $installLocation
+	cd build
+	make install INSTALL_ROOT=
+
+	$python -m compileall -d / $prefix/lib/python$pythonVersion
+	$python -O -m compileall -d / $prefix/lib/python$pythonVersion
+
+	packageEntries python38 \
+		$installLocation
+
+	rmdir $prefix/lib/python$pythonVersion
+
+	### PACKAGING HACK ###
+	rm -rf $prefix/packages
+	### PACKAGING HACK ###
+}


### PR DESCRIPTION
This is one of the dependencies of [Frescobaldi](https://www.frescobaldi.org/), a GUI editor for Lilypond based on PyQt5.

I modelled the recipe after pyqtwebengine5. It contained a few statements that are not clear to me, maybe @extrowerk can explain that. I left them in as comments for now.

The included patch is a build fix and is taken directly from an upstream pull request (https://github.com/frescobaldi/python-poppler-qt5/pull/45).

I haven't tested this in any way right now, it just builds successfully on x86_64. The real test will be Frescobaldi, once that is running, but that is still multiple steps away ...