### PR TITLE
new recipe: python-ly

### DIFF
--- a/dev-python/python-ly/python_ly-0.9.7.recipe
+++ b/dev-python/python-ly/python_ly-0.9.7.recipe
@@ -1,0 +1,79 @@
+SUMMARY="Tool and library for manipulating LilyPond files"
+DESCRIPTION="This package provides a Python library ly containing various Python modules to \
+parse, manipulate or create documents in LilyPond format. A command line program ly is also \
+provided that can be used to do various manipulations with LilyPond files.
+The LilyPond format is a plain text input format that is used by the GNU music typesetter \
+LilyPond (www.lilypond.org).
+The python-ly package is Free Software, licensed under the GPL. This package is written by the \
+Frescobaldi developers and is used extensively by the Frescobaldi project. The main author is \
+Wilbert Berendsen."
+HOMEPAGE="https://github.com/frescobaldi/python-ly/"
+COPYRIGHT="2008-2015 Wilbert Berendsen"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="https://pypi.io/packages/source/p/python-ly/python-ly-$portVersion.tar.gz"
+CHECKSUM_SHA256="d4d2b68eb0ef8073200154247cc9bd91ed7fb2671ac966ef3d2853281c15d7a8"
+SOURCE_FILENAME="python-ly-$portVersion.tar.gz"
+SOURCE_DIR="python-ly-$portVersion"
+
+ARCHITECTURES="any"
+
+PROVIDES="
+	$portName = $portVersion
+	"
+REQUIRES="
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+PYTHON_PACKAGES=(python3 python38 python39 python310)
+PYTHON_VERSIONS=(3.7 3.8 3.9 3.10)
+commandSuffixes=("" 38 39 310)
+for i in "${!PYTHON_PACKAGES[@]}"; do
+pythonPackage=${PYTHON_PACKAGES[i]}
+pythonVersion=${PYTHON_VERSIONS[$i]}
+commandSuffix=${commandSuffixes[$i]}
+eval "PROVIDES_${pythonPackage}=\"\n\
+	${portName}_$pythonPackage = $portVersion\n\
+	cmd:ly$commandSuffix = $portVersion\n\
+	cmd:ly_server$commandSuffix = $portVersion\n\
+	\"; \
+REQUIRES_$pythonPackage=\"\n\
+	haiku\n\
+	cmd:python$pythonVersion\n\
+	\""
+BUILD_REQUIRES="$BUILD_REQUIRES
+	setuptools_$pythonPackage"
+BUILD_PREREQUIRES="$BUILD_PREREQUIRES
+	cmd:python$pythonVersion"
+done
+
+INSTALL()
+{
+	for i in "${!PYTHON_PACKAGES[@]}"; do
+		pythonPackage=${PYTHON_PACKAGES[i]}
+		pythonVersion=${PYTHON_VERSIONS[$i]}
+		commandSuffix=${commandSuffixes[$i]}
+		pythonPackageName=${portName}_$pythonPackage-$portFullVersion
+		pythonLinksDir=$(dirname $portPackageLinksDir)/$pythonPackageName
+		python=python$pythonVersion
+		installLocation=$prefix/lib/$python/vendor-packages/
+		export PYTHONPATH=$installLocation:$PYTHONPATH
+		mkdir -p $installLocation
+		rm -rf build
+		$python setup.py build install \
+			--root=/ --prefix=$prefix
+
+		if [ $pythonPackage = python$commandSuffix ]; then
+			for f in $binDir/*; do
+				mv $f ${f}$commandSuffix
+			done
+		fi
+
+		packageEntries $pythonPackage \
+			$prefix/lib/python* \
+			$binDir
+	done
+}


### PR DESCRIPTION
This is another dependency for Frescobaldi.

I enabled python3 (3.7), python38, python39 and python310 versions. The python3 version uses no suffix for the commands (as it is kind of the "default" version), the others are suffixed with the version number (38, 39, 310).

The documentation is not built and packaged. Should that be added? (edit: that would require Sphinx, which seems not to be available yet ...)