### PR TITLE
nnn: bump to 4.5

### DIFF
--- a/app-misc/nnn/nnn-4.5.recipe
+++ b/app-misc/nnn/nnn-4.5.recipe
@@ -12,11 +12,11 @@ Cygwin, WSL, Haiku and works seamlessly with DEs and GUI utilities.
 
 Visit the Wiki for concepts, program usage, how-tos and troubleshooting."
 HOMEPAGE="https://github.com/jarun/nnn"
-COPYRIGHT="2016-2021 Arun Prakash Jana"
+COPYRIGHT="2016-2022 Arun Prakash Jana"
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="https://github.com/jarun/nnn/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="b6df8e262e5613dd192bac610a6da711306627d56573f1a770a173ef078953bb"
+CHECKSUM_SHA256="fadc15bd6d4400c06e5ccc47845b42e60774f368570e475bd882767ee18749aa"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"


### PR DESCRIPTION
[Changelog](https://github.com/jarun/nnn/releases)