### PR TITLE
Add libslirp

### DIFF
--- a/net-libs/libslirp/libslirp-4.7.0.recipe
+++ b/net-libs/libslirp/libslirp-4.7.0.recipe
@@ -1,0 +1,64 @@
+SUMMARY="A TCP-IP emulator used to provide virtual networking services"
+DESCRIPTION="libslirp is a general purpose TCP-IP emulator used by virtual machine hypervisors, \
+containers, and emulation software to provide virtual networking services."
+HOMEPAGE="https://gitlab.freedesktop.org/slirp/libslirp/"
+COPYRIGHT="1995, 1996 Danny Gasparovski"
+LICENSE="BSD (3-clause)"
+REVISION="1"
+SOURCE_URI="$HOMEPAGE-/archive/v$portVersion/libslirp-v$portVersion.tar.gz"
+CHECKSUM_SHA256="9398f0ec5a581d4e1cd6856b88ae83927e458d643788c3391a39e61b75db3d3b"
+SOURCE_DIR="libslirp-v$portVersion"
+PATCHES="libslirp-$portVersion.patchset"
+
+ARCHITECTURES="all ?x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86_gcc2 x86"
+
+PROVIDES="
+	libslirp$secondaryArchSuffix = $portVersion
+	lib:libslirp$secondaryArchSuffix = 4
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libglib_2.0$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	libslirp${secondaryArchSuffix}_devel = $portVersion
+	devel:libslirp$secondaryArchSuffix = 4
+	"
+REQUIRES_devel="
+	libslirp$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libglib_2.0$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+    cmd:cmake
+	cmd:gcc$secondaryArchSuffix
+	cmd:meson
+	cmd:ninja
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	meson build --buildtype=debugoptimized \
+		--prefix=$prefix --includedir=$includeDir \
+		--libdir=$libDir --datadir=$dataDir --bindir=$binDir
+
+	ninja $jobArgs -C build
+}
+
+INSTALL()
+{
+	ninja -C build install
+
+	# prepare development lib links
+	prepareInstalledDevelLib libslirp
+	fixPkgconfig
+
+	# devel package
+	packageEntries devel $developDir
+}

--- a/net-libs/libslirp/libslirp-4.7.0.recipe
+++ b/net-libs/libslirp/libslirp-4.7.0.recipe
@@ -67,3 +67,8 @@ INSTALL()
 	# devel package
 	packageEntries devel $developDir
 }
+
+TEST()
+{
+	ninja -C build test
+}

--- a/net-libs/libslirp/libslirp-4.7.0.recipe
+++ b/net-libs/libslirp/libslirp-4.7.0.recipe
@@ -45,7 +45,7 @@ BUILD_PREREQUIRES="
 	"
 
 defineDebugInfoPackage libslirp$secondaryArchSuffix \
-	"$libDir"/libslirp.so.0.4.0
+	"$libDir"/libslirp.so.$libVersion
 
 BUILD()
 {

--- a/net-libs/libslirp/libslirp-4.7.0.recipe
+++ b/net-libs/libslirp/libslirp-4.7.0.recipe
@@ -10,8 +10,11 @@ CHECKSUM_SHA256="9398f0ec5a581d4e1cd6856b88ae83927e458d643788c3391a39e61b75db3d3
 SOURCE_DIR="libslirp-v$portVersion"
 PATCHES="libslirp-$portVersion.patchset"
 
-ARCHITECTURES="all ?x86_gcc2"
-SECONDARY_ARCHITECTURES="?x86_gcc2 x86"
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="0.4.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
 	libslirp$secondaryArchSuffix = $portVersion

--- a/net-libs/libslirp/libslirp-4.7.0.recipe
+++ b/net-libs/libslirp/libslirp-4.7.0.recipe
@@ -18,7 +18,7 @@ libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
 	libslirp$secondaryArchSuffix = $portVersion
-	lib:libslirp$secondaryArchSuffix = 4
+	lib:libslirp$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -27,7 +27,7 @@ REQUIRES="
 
 PROVIDES_devel="
 	libslirp${secondaryArchSuffix}_devel = $portVersion
-	devel:libslirp$secondaryArchSuffix = 4
+	devel:libslirp$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
 	libslirp$secondaryArchSuffix == $portVersion base
@@ -51,7 +51,7 @@ BUILD()
 {
 	meson build --buildtype=debugoptimized \
 		--prefix=$prefix --includedir=$includeDir \
-		--libdir=$libDir --datadir=$dataDir --bindir=$binDir
+		--libdir=$libDir --datadir=$dataDir
 
 	ninja $jobArgs -C build
 }

--- a/net-libs/libslirp/libslirp-4.7.0.recipe
+++ b/net-libs/libslirp/libslirp-4.7.0.recipe
@@ -35,7 +35,6 @@ BUILD_REQUIRES="
 	devel:libglib_2.0$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-    cmd:cmake
 	cmd:gcc$secondaryArchSuffix
 	cmd:meson
 	cmd:ninja

--- a/net-libs/libslirp/libslirp-4.7.0.recipe
+++ b/net-libs/libslirp/libslirp-4.7.0.recipe
@@ -44,6 +44,9 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
+defineDebugInfoPackage libslirp$secondaryArchSuffix \
+	"$libDir"/libslirp.so.0.4.0
+
 BUILD()
 {
 	meson build --buildtype=debugoptimized \

--- a/net-libs/libslirp/patches/libslirp-4.7.0.patchset
+++ b/net-libs/libslirp/patches/libslirp-4.7.0.patchset
@@ -1,0 +1,24 @@
+From 78faa99ec2886bdf8af8e8719980ed9868851ae4 Mon Sep 17 00:00:00 2001
+From: Ivan Holmes <ivan@ivanholmes.co.uk>
+Date: Wed, 4 May 2022 22:01:01 +0100
+Subject: link with network library
+
+
+diff --git a/meson.build b/meson.build
+index 5605dc9..201a5c6 100644
+--- a/meson.build
++++ b/meson.build
+@@ -66,6 +66,10 @@ elif host_system == 'darwin'
+   platform_deps += [
+     cc.find_library('resolv')
+   ]
++elif host_system == 'haiku'
++  platform_deps += [
++    cc.find_library('network')
++  ]
+ endif
+ 
+ cargs = [
+-- 
+2.30.2
+


### PR DESCRIPTION
Left untested for gcc2 because I don't have a gcc2 system.

Adding as it is a dependency of melonDS.