### PR TITLE
sbcl: bump version

### DIFF
--- a/dev-lisp/sbcl/patches/sbcl-2.2.4.patchset
+++ b/dev-lisp/sbcl/patches/sbcl-2.2.4.patchset
@@ -1,0 +1,209 @@
+From 7d4bda25e68e06f85ff972718924fba3cde443a1 Mon Sep 17 00:00:00 2001
+From: Al Hoang <3811822-hoanga@users.noreply.gitlab.com>
+Date: Fri, 6 May 2022 22:49:58 -0500
+Subject: updated haiku patch
+
+
+diff --git a/contrib/sb-bsd-sockets/sockets.lisp b/contrib/sb-bsd-sockets/sockets.lisp
+index 18e94cc..0b74411 100644
+--- a/contrib/sb-bsd-sockets/sockets.lisp
++++ b/contrib/sb-bsd-sockets/sockets.lisp
+@@ -345,7 +345,9 @@ request an input stream and get an output stream in response\)."
+ (define-socket-condition sockint::EOPNOTSUPP operation-not-supported-error)
+ (define-socket-condition sockint::EPERM operation-not-permitted-error)
+ (define-socket-condition sockint::EPROTONOSUPPORT protocol-not-supported-error)
+-(define-socket-condition sockint::ESOCKTNOSUPPORT socket-type-not-supported-error)
++;; haiku hack
++#+haiku (define-socket-condition -4025 socket-type-not-supported-error)
++#-haiku (define-socket-condition sockint::ESOCKTNOSUPPORT socket-type-not-supported-error)
+ (define-socket-condition sockint::ENETUNREACH network-unreachable-error)
+ (define-socket-condition sockint::ENOTCONN not-connected-error)
+ (define-socket-condition sockint::EAFNOSUPPORT address-family-not-supported)
+diff --git a/contrib/sb-bsd-sockets/tests.lisp b/contrib/sb-bsd-sockets/tests.lisp
+index dddf316..46ac26e 100644
+--- a/contrib/sb-bsd-sockets/tests.lisp
++++ b/contrib/sb-bsd-sockets/tests.lisp
+@@ -82,6 +82,7 @@
+       ;; here, not socket-type-not-supported-error or
+       ;; protocol-not-supported-error.
+       ((or #+darwin socket-error
++        #+haiku address-family-not-supported
+         operation-not-supported-error
+         socket-type-not-supported-error
+         protocol-not-supported-error)
+@@ -100,6 +101,7 @@
+       ;; protocol-not-supported-error.
+       ((or
+         #+darwin socket-error
++        #+haiku address-family-not-supported
+         operation-not-supported-error
+         protocol-not-supported-error
+         socket-type-not-supported-error)
+@@ -497,7 +499,7 @@
+ ;; translates into an END-OF-FILE on the other end, no matter which
+ ;; end performs the shutdown and independent of the element-type of
+ ;; the stream.
+-#+ipv4-support
++#+(and ipv4-support (not haiku))
+ (macrolet
+     ((define-shutdown-test (name who-shuts-down who-reads element-type direction)
+        `(deftest ,name
+diff --git a/contrib/sb-posix/constants.lisp b/contrib/sb-posix/constants.lisp
+index 4c991ef..bdc6092 100644
+--- a/contrib/sb-posix/constants.lisp
++++ b/contrib/sb-posix/constants.lisp
+@@ -274,10 +274,11 @@
+               #-(and linux largefile) "struct dirent"
+               #-(or win32 android) (:ino-t ino "ino_t" "d_ino")
+               #+android ((unsigned 64) ino "unsigned long long" "d_ino")
+-              (:c-string name "char *" "d_name"
+-                         ;; FIXME: sunos should really have :distrust-length
+-                         ;; t, but this is currently broken. -- Jim Wise 2010-08-31
+-                         :distrust-length nil)) t)
++              ))
++              ;;(:c-string name "char *" "d_name"
++              ;;           ;; FIXME: sunos should really have :distrust-length
++              ;;           ;; t, but this is currently broken. -- Jim Wise 2010-08-31
++              ;;           :distrust-length nil)) t)
+ 
+  ;; password database
+  #-(or android win32)
+diff --git a/contrib/sb-posix/posix-tests.lisp b/contrib/sb-posix/posix-tests.lisp
+index 7c94a43..ad7ea52 100644
+--- a/contrib/sb-posix/posix-tests.lisp
++++ b/contrib/sb-posix/posix-tests.lisp
+@@ -168,6 +168,8 @@
+   #+win32
+   #.sb-posix::einval)
+ 
++;; disable for haiku
++#-haiku
+ (deftest rmdir.error.3
+   (handler-case
+       (sb-posix:rmdir #-win32 "/" #+win32 (sb-ext:posix-getenv "windir"))
+@@ -179,11 +181,11 @@
+          #.sb-posix:eisdir
+          #+win32
+          #.sb-posix::eacces
+-         #+win32
++         #+(or win32 haiku)
+          #.sb-posix::enotempty
+          #+sunos
+          #.sb-posix::einval
+-         #-(or darwin openbsd win32 sunos)
++         #-(or darwin openbsd win32 sunos haiku)
+          #.sb-posix::ebusy)))) t)
+ 
+ (deftest rmdir.error.4
+@@ -235,7 +237,7 @@
+     (logand mode (logior sb-posix::s-iread sb-posix::s-iwrite sb-posix::s-iexec)))
+   #.(logior sb-posix::s-iread sb-posix::s-iwrite sb-posix::s-iexec))
+ 
+-#-(or (and darwin x86) win32)
++#-(or (and darwin x86) win32 haiku)
+ (deftest stat.2
+   (let* ((stat (sb-posix:stat "/"))
+          (mode (sb-posix::stat-mode stat)))
+@@ -441,7 +443,7 @@
+                sb-posix::o-nonblock))
+   t)
+ 
+-#-(or win32 netbsd) ; fix: cant handle c-vargs
++#-(or win32 netbsd haiku) ; fix: cant handle c-vargs
+ (deftest fcntl.flock.1
+     (locally (declare (sb-ext:muffle-conditions sb-ext:compiler-note))
+       (let ((flock (make-instance 'sb-posix:flock
+@@ -533,7 +535,9 @@
+         (sb-posix:closedir dir))))
+   nil)
+ 
+-#-(and darwin x86)
++;;#-(and darwin x86)
++;;  disable on haiku
++#-haiku
+ (deftest readdir.1
+   (let ((dir (sb-posix:opendir "/")))
+     (unwind-protect
+@@ -546,7 +550,8 @@
+       (sb-posix:closedir dir)))
+   t)
+ 
+-#-darwin
++;;  disable on haiku as well
++#-(or darwin haiku)
+ (deftest readdir/dirent-name
+     (let ((dir (sb-posix:opendir *current-directory*)))
+       (unwind-protect
+@@ -592,7 +597,7 @@
+   (not (sb-posix:getpwuid 0))
+   nil)
+ 
+-#-(or android win32)
++#-(or android win32 haiku)
+ (deftest pwent.2
+   ;; make sure that we found something
+   (not (sb-posix:getpwnam "root"))
+@@ -665,7 +670,7 @@
+     (plusp (sb-posix:time))
+   t)
+ 
+-#-(or (and darwin x86) win32)
++#-(or (and darwin x86) win32 haiku)
+ (macrolet ((test (name posix-fun)
+              `(deftest ,name
+                 (let ((file (merge-pathnames #p"utimes.1" *test-directory*))
+@@ -713,6 +718,8 @@
+     #.(concatenate 'string "/" (make-string 255 :initial-element #\a)))
+ 
+   ;; The error tests are in the order of exposition from SUSv3.
++  ;; TERRIBLE
++  #-haiku
+   (deftest readlink.error.1
+       (let* ((subdir-pathname (merge-pathnames
+                                (make-pathname
+@@ -732,6 +739,8 @@
+             (sb-posix:unlink link-pathname)
+             (sb-posix:rmdir subdir-pathname))))
+     #.sb-posix:eacces)
++  ;; TERRIBLE
++  #-haiku
+   (deftest readlink.error.2
+       (let* ((non-link-pathname (make-pathname :name "readlink.error.2"
+                                                :defaults *test-directory*))
+@@ -762,6 +771,8 @@
+     #.sb-posix:eloop)
+   ;; Note: PATH_MAX and NAME_MAX need not be defined, and may vary, so
+   ;; failure of this test is not too meaningful.
++  ;;  TERRIBLE
++  #-haiku
+   (deftest readlink.error.4
+       (let ((pathname
+              (make-pathname :name (make-string 257 ;NAME_MAX plus some, maybe
+diff --git a/src/code/unix.lisp b/src/code/unix.lisp
+index d9858da..0a5b8c9 100644
+--- a/src/code/unix.lisp
++++ b/src/code/unix.lisp
+@@ -970,10 +970,20 @@ avoiding atexit(3) hooks, etc. Otherwise exit(2) is called."
+     (it-interval (struct timeval))      ; timer interval
+     (it-value (struct timeval))))       ; current value
+ 
++#-haiku
+ (defconstant itimer-real 0)
++#-haiku
+ (defconstant itimer-virtual 1)
++#-haiku
+ (defconstant itimer-prof 2)
+ 
++#+haiku
++(defconstant itimer-real 1)
++#+haiku
++(defconstant itimer-virtual 2)
++#+haiku
++(defconstant itimer-prof 3)
++
+ #-win32
+ (defun unix-getitimer (which)
+   "UNIX-GETITIMER returns the INTERVAL and VALUE slots of one of
+-- 
+2.30.2
+

--- a/dev-lisp/sbcl/patches/sbcl-2.2.4.patchset
+++ b/dev-lisp/sbcl/patches/sbcl-2.2.4.patchset
@@ -1,6 +1,6 @@
-From 7d4bda25e68e06f85ff972718924fba3cde443a1 Mon Sep 17 00:00:00 2001
+From 02f8cc6fdc412e9a643a7eb327e17219066efec7 Mon Sep 17 00:00:00 2001
 From: Al Hoang <3811822-hoanga@users.noreply.gitlab.com>
-Date: Fri, 6 May 2022 22:49:58 -0500
+Date: Sun, 8 May 2022 23:06:29 -0500
 Subject: updated haiku patch
 
 
@@ -69,7 +69,7 @@ index 4c991ef..bdc6092 100644
   ;; password database
   #-(or android win32)
 diff --git a/contrib/sb-posix/posix-tests.lisp b/contrib/sb-posix/posix-tests.lisp
-index 7c94a43..ad7ea52 100644
+index 0a642bd..da1b357 100644
 --- a/contrib/sb-posix/posix-tests.lisp
 +++ b/contrib/sb-posix/posix-tests.lisp
 @@ -168,6 +168,8 @@
@@ -102,9 +102,9 @@ index 7c94a43..ad7ea52 100644
 -#-(or (and darwin x86) win32)
 +#-(or (and darwin x86) win32 haiku)
  (deftest stat.2
-   (let* ((stat (sb-posix:stat "/"))
-          (mode (sb-posix::stat-mode stat)))
-@@ -441,7 +443,7 @@
+   (eql
+    (sb-posix::stat-mode (sb-posix:stat "/"))
+@@ -428,7 +430,7 @@
                 sb-posix::o-nonblock))
    t)
  
@@ -113,7 +113,7 @@ index 7c94a43..ad7ea52 100644
  (deftest fcntl.flock.1
      (locally (declare (sb-ext:muffle-conditions sb-ext:compiler-note))
        (let ((flock (make-instance 'sb-posix:flock
-@@ -533,7 +535,9 @@
+@@ -520,7 +522,9 @@
          (sb-posix:closedir dir))))
    nil)
  
@@ -124,7 +124,7 @@ index 7c94a43..ad7ea52 100644
  (deftest readdir.1
    (let ((dir (sb-posix:opendir "/")))
      (unwind-protect
-@@ -546,7 +550,8 @@
+@@ -533,7 +537,8 @@
        (sb-posix:closedir dir)))
    t)
  
@@ -134,7 +134,7 @@ index 7c94a43..ad7ea52 100644
  (deftest readdir/dirent-name
      (let ((dir (sb-posix:opendir *current-directory*)))
        (unwind-protect
-@@ -592,7 +597,7 @@
+@@ -579,7 +584,7 @@
    (not (sb-posix:getpwuid 0))
    nil)
  
@@ -143,7 +143,7 @@ index 7c94a43..ad7ea52 100644
  (deftest pwent.2
    ;; make sure that we found something
    (not (sb-posix:getpwnam "root"))
-@@ -665,7 +670,7 @@
+@@ -652,7 +657,7 @@
      (plusp (sb-posix:time))
    t)
  
@@ -152,7 +152,7 @@ index 7c94a43..ad7ea52 100644
  (macrolet ((test (name posix-fun)
               `(deftest ,name
                  (let ((file (merge-pathnames #p"utimes.1" *test-directory*))
-@@ -713,6 +718,8 @@
+@@ -700,6 +705,8 @@
      #.(concatenate 'string "/" (make-string 255 :initial-element #\a)))
  
    ;; The error tests are in the order of exposition from SUSv3.
@@ -161,7 +161,7 @@ index 7c94a43..ad7ea52 100644
    (deftest readlink.error.1
        (let* ((subdir-pathname (merge-pathnames
                                 (make-pathname
-@@ -732,6 +739,8 @@
+@@ -719,6 +726,8 @@
              (sb-posix:unlink link-pathname)
              (sb-posix:rmdir subdir-pathname))))
      #.sb-posix:eacces)
@@ -170,7 +170,7 @@ index 7c94a43..ad7ea52 100644
    (deftest readlink.error.2
        (let* ((non-link-pathname (make-pathname :name "readlink.error.2"
                                                 :defaults *test-directory*))
-@@ -762,6 +771,8 @@
+@@ -749,6 +758,8 @@
      #.sb-posix:eloop)
    ;; Note: PATH_MAX and NAME_MAX need not be defined, and may vary, so
    ;; failure of this test is not too meaningful.
@@ -180,7 +180,7 @@ index 7c94a43..ad7ea52 100644
        (let ((pathname
               (make-pathname :name (make-string 257 ;NAME_MAX plus some, maybe
 diff --git a/src/code/unix.lisp b/src/code/unix.lisp
-index d9858da..0a5b8c9 100644
+index 65cfeea..1d09ded 100644
 --- a/src/code/unix.lisp
 +++ b/src/code/unix.lisp
 @@ -970,10 +970,20 @@ avoiding atexit(3) hooks, etc. Otherwise exit(2) is called."
@@ -204,6 +204,19 @@ index d9858da..0a5b8c9 100644
  #-win32
  (defun unix-getitimer (which)
    "UNIX-GETITIMER returns the INTERVAL and VALUE slots of one of
+diff --git a/src/runtime/run-program.c b/src/runtime/run-program.c
+index 01a9f81..de74553 100644
+--- a/src/runtime/run-program.c
++++ b/src/runtime/run-program.c
+@@ -32,7 +32,7 @@
+ #include <termios.h>
+ #include <errno.h>
+ #include <dirent.h>
+-#include <sys/syscall.h>
++//#include <sys/syscall.h>
+ #include "interr.h" // for lose()
+ 
+ #ifdef LISP_FEATURE_OPENBSD
 -- 
 2.30.2
 

--- a/dev-lisp/sbcl/sbcl-2.2.4.recipe
+++ b/dev-lisp/sbcl/sbcl-2.2.4.recipe
@@ -1,0 +1,61 @@
+SUMMARY="A high performance Common Lisp compiler"
+DESCRIPTION="Steel Bank Common Lisp (SBCL) is a high performance Common \
+Lisp compiler. It is open source / free software, with a permissive license. \
+In addition to the compiler and runtime system for ANSI Common Lisp, it \
+provides an interactive environment including a debugger, a statistical \
+profiler, a code coverage tool, and many other extensions."
+HOMEPAGE="https://sbcl.org"
+COPYRIGHT="2002 Gerd Moellmann"
+LICENSE="BSD (2-clause)"
+REVISION="1"
+SOURCE_URI="git://github.com/sbcl/sbcl.git"
+CHECKSUM_SHA256="9cfd324f2a1eac2635188b945d10df428d1941c6"
+PATCHES="sbcl-2.2.4.patchset"
+
+ARCHITECTURES="!x86_gcc2 x86 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="$portVersion"
+libVersionCompat="$libVersion compat >= ${libVersion%.*}"
+portVersionCompat="$portVersion compat >= ${portVersion%%.*}"
+
+PROVIDES="
+	sbcl$secondaryArchSuffix = $portVersion
+	cmd:sbcl$secondaryArchSuffix = $portVersion
+	"
+
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libssl$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libssl$secondaryArchSuffix
+	"
+
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchPrefix
+	cmd:make
+	cmd:find
+	cmd:git
+	cmd:sed
+	cmd:sbcl
+	cmd:xargs
+	cmd:pkg_config$secondaryArchPrefix
+	"
+
+BUILD()
+{
+	echo ';;; This file is auto-generated using generate-version.sh. Every time
+;;; you re-run make.sh, this file will be overwritten if you are
+;;; working from a Git checkout.
+"2.2.4-WIP"' > version.lisp-expr
+	sh make.sh sbcl
+}
+
+INSTALL()
+{
+	INSTALL_ROOT=$prefix sh install.sh
+}
+

--- a/dev-lisp/sbcl/sbcl-2.2.4.recipe
+++ b/dev-lisp/sbcl/sbcl-2.2.4.recipe
@@ -13,8 +13,8 @@ SOURCE_DIR="sbcl-sbcl-$portVersion"
 CHECKSUM_SHA256="f9f85f1a2ab4f12068621dce5a7b7b9c43a5875b06d736b88cb1373ca2caed1f"
 PATCHES="sbcl-2.2.4.patchset"
 
-ARCHITECTURES="x86_64"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
 
 PROVIDES="
 	sbcl$secondaryArchSuffix = $portVersion
@@ -30,14 +30,14 @@ BUILD_REQUIRES="
 	devel:libssl$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:gcc$secondaryArchPrefix
+	cmd:gcc$secondaryArchSuffix
 	cmd:make
 	cmd:find
 	cmd:git
 	cmd:sed
 	cmd:sbcl
 	cmd:xargs
-	cmd:pkg_config$secondaryArchPrefix
+	cmd:pkg_config$secondaryArchSuffix
 	"
 
 BUILD()
@@ -51,6 +51,8 @@ BUILD()
 
 INSTALL()
 {
-	INSTALL_ROOT=$prefix sh install.sh
+	mkdir -p $manDir
+	mkdir -p $docDir
+	INSTALL_ROOT=$prefix MAN_DIR=$manDir DOC_DIR=$docDir INFO_DIR=$infoDir sh install.sh
 }
 

--- a/dev-lisp/sbcl/sbcl-2.2.4.recipe
+++ b/dev-lisp/sbcl/sbcl-2.2.4.recipe
@@ -23,7 +23,6 @@ PROVIDES="
 	sbcl$secondaryArchSuffix = $portVersion
 	cmd:sbcl$secondaryArchSuffix = $portVersion
 	"
-
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libssl$secondaryArchSuffix
@@ -33,7 +32,6 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libssl$secondaryArchSuffix
 	"
-
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchPrefix
 	cmd:make

--- a/dev-lisp/sbcl/sbcl-2.2.4.recipe
+++ b/dev-lisp/sbcl/sbcl-2.2.4.recipe
@@ -8,16 +8,13 @@ HOMEPAGE="https://sbcl.org"
 COPYRIGHT="2002 Gerd Moellmann"
 LICENSE="BSD (2-clause)"
 REVISION="1"
-SOURCE_URI="git://github.com/sbcl/sbcl.git"
-CHECKSUM_SHA256="9cfd324f2a1eac2635188b945d10df428d1941c6"
+SOURCE_URI="https://github.com/sbcl/sbcl/archive/refs/tags/sbcl-$portVersion.tar.gz"
+SOURCE_DIR="sbcl-sbcl-$portVersion"
+CHECKSUM_SHA256="f9f85f1a2ab4f12068621dce5a7b7b9c43a5875b06d736b88cb1373ca2caed1f"
 PATCHES="sbcl-2.2.4.patchset"
 
-ARCHITECTURES="!x86_gcc2 x86 x86_64"
+ARCHITECTURES="x86_64"
 SECONDARY_ARCHITECTURES="x86"
-
-libVersion="$portVersion"
-libVersionCompat="$libVersion compat >= ${libVersion%.*}"
-portVersionCompat="$portVersion compat >= ${portVersion%%.*}"
 
 PROVIDES="
 	sbcl$secondaryArchSuffix = $portVersion

--- a/dev-lisp/sbcl/sbcl-2.2.4.recipe
+++ b/dev-lisp/sbcl/sbcl-2.2.4.recipe
@@ -30,14 +30,14 @@ BUILD_REQUIRES="
 	devel:libssl$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:gcc$secondaryArchSuffix
-	cmd:make
 	cmd:find
+	cmd:gcc$secondaryArchSuffix
 	cmd:git
-	cmd:sed
-	cmd:sbcl
-	cmd:xargs
+	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
+	cmd:sbcl
+	cmd:sed
+	cmd:xargs
 	"
 
 BUILD()


### PR DESCRIPTION
this updates sbcl port to track the latest release. note that this release

* uses previous bootstrapped sbcl for compilation
* remove abcl and jvm bootstrap dependency for bootstrap


```
~> sbcl
This is SBCL 2.2.4-WIP, an implementation of ANSI Common Lisp.
More information about SBCL is available at <http://www.sbcl.org/>.

SBCL is free software, provided as is, with absolutely no warranty.
It is mostly in the public domain; some portions are provided under
BSD-style licenses.  See the CREDITS and COPYING files in the
distribution for more information.
WARNING: :HAIKU is no longer present in *FEATURES*
*
```