### PR TITLE
picard: release 2.8

### DIFF
--- a/media-sound/picard/patches/picard-2.8.patchset
+++ b/media-sound/picard/patches/picard-2.8.patchset
@@ -1,4 +1,4 @@
-From 66540cd5abdb49d03f2f228b2fd09ddc5b1acca5 Mon Sep 17 00:00:00 2001
+From 9f2ec058ff6cf81e08994a8c4b936e7f4496fb5d Mon Sep 17 00:00:00 2001
 From: Philipp Wolfer <ph.wolfer@gmail.com>
 Date: Tue, 29 Jan 2019 11:33:18 +0000
 Subject: [PATCH 3/3] Haiku: Avoid using locale.strxfrm
@@ -11,7 +11,7 @@ On Haiku this causes frequent core dumps
  3 files changed, 3 insertions(+), 7 deletions(-)
 
 diff --git a/picard/ui/itemviews.py b/picard/ui/itemviews.py
-index 44c5c480..56ed0810 100644
+index 03b1537f..4ead4146 100644
 --- a/picard/ui/itemviews.py
 +++ b/picard/ui/itemviews.py
 @@ -47,7 +47,6 @@ from heapq import (
@@ -22,7 +22,7 @@ index 44c5c480..56ed0810 100644
  
  from PyQt5 import (
      QtCore,
-@@ -922,7 +921,7 @@ class TreeItem(QtWidgets.QTreeWidgetItem):
+@@ -924,7 +923,7 @@ class TreeItem(QtWidgets.QTreeWidgetItem):
          elif column in MainPanel.NAT_SORT_COLUMNS:
              sortkey = natsort.natkey(self.text(column))
          else:
@@ -32,18 +32,18 @@ index 44c5c480..56ed0810 100644
          return sortkey
  
 diff --git a/picard/ui/options/interface.py b/picard/ui/options/interface.py
-index 3443c238..977ab693 100644
+index b12f5c1e..40480812 100644
 --- a/picard/ui/options/interface.py
 +++ b/picard/ui/options/interface.py
-@@ -30,7 +30,6 @@
+@@ -29,7 +29,6 @@
+ # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  
  
- from functools import partial
 -import locale
  import os.path
  
  from PyQt5 import (
-@@ -211,7 +210,7 @@ class InterfaceOptionsPage(OptionsPage):
+@@ -204,7 +203,7 @@ class InterfaceOptionsPage(OptionsPage):
          language_list = [(lang[0], lang[1], _(lang[2])) for lang in UI_LANGUAGES]
  
          def fcmp(x):
@@ -53,7 +53,7 @@ index 3443c238..977ab693 100644
              if native and native != translation:
                  name = '%s (%s)' % (translation, native)
 diff --git a/picard/ui/options/releases.py b/picard/ui/options/releases.py
-index 4a5610a8..ae5bc850 100644
+index 754c3ea8..b65d606a 100644
 --- a/picard/ui/options/releases.py
 +++ b/picard/ui/options/releases.py
 @@ -24,8 +24,6 @@
@@ -75,5 +75,5 @@ index 4a5610a8..ae5bc850 100644
          config = get_config()
          saved_data = config.setting[setting]
 -- 
-2.30.2
+2.36.1
 

--- a/media-sound/picard/picard-2.8.recipe
+++ b/media-sound/picard/picard-2.8.recipe
@@ -9,12 +9,12 @@ identified by the actual music, even if they have no metadata.
 * Plugin support - If you need a particular feature, you can choose from a \
 selection of available plugins or write your own."
 HOMEPAGE="https://picard.musicbrainz.org/"
-COPYRIGHT="2004-2021 Robert Kaye, Lukas Lalinsky, Laurent Monin, \
+COPYRIGHT="2004-2022 Robert Kaye, Lukas Lalinsky, Laurent Monin, \
 Sambhav Kothari, Philipp Wolfer and others"
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="ftp://ftp.eu.metabrainz.org/pub/musicbrainz/picard/picard-$portVersion.tar.gz"
-CHECKSUM_SHA256="73c70933f78de9a92ad8943d2e237d5f580d4f695c950d2070385f1067315e76"
+CHECKSUM_SHA256="ee6b9b160fcef12957f018410922909b21004627f67e6de637a063b877e2674e"
 SOURCE_DIR="picard-release-$portVersion"
 SOURCE_FILENAME="picard-$portVersion"
 PATCHES="picard-$portVersion.patchset"


### PR DESCRIPTION
New release of MusicBrainz Picard, see https://blog.metabrainz.org/2022/05/24/picard-2-8-released/

As usual build and tested locally on 64bit.