### PR TITLE
plee_the_bear, fix references to libpng16 and libSDL*

### DIFF
--- a/games-arcade/plee_the_bear/plee_the_bear-0.7.1.recipe
+++ b/games-arcade/plee_the_bear/plee_the_bear-0.7.1.recipe
@@ -13,7 +13,7 @@ skills and the details of the game."
 HOMEPAGE="http://www.stuff-o-matic.com/plee-the-bear/"
 COPYRIGHT="2012 Stuff O Matic"
 LICENSE="GNU GPL v3"
-REVISION="2"
+REVISION="1"
 srcGitRev="8b08a7a49fa74d59dbfcbf0f2d77dcfee1642f7c"
 SOURCE_URI="https://github.com/j-jorge/plee-the-bear/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="1353f37d392966e58cb976ad031af4e4aecfd032d6994d22fb08af0a219417bc"
@@ -64,8 +64,8 @@ REQUIRES="
 	lib:libintl$secondaryArchSuffix
 	lib:libjpeg$secondaryArchSuffix
 	lib:libpng16$secondaryArchSuffix
-	lib:libsdl2_2.0$secondaryArchSuffix
-	lib:libsdl2_mixer_2.0$secondaryArchSuffix
+	lib:libSDL2_2.0$secondaryArchSuffix
+	lib:libSDL2_mixer_2.0$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
 
@@ -80,9 +80,9 @@ BUILD_REQUIRES="
 	devel:libGL$secondaryArchSuffix
 	devel:libintl$secondaryArchSuffix
 	devel:libjpeg$secondaryArchSuffix
-	devel:libpng$secondaryArchSuffix
-	devel:libsdl2_2.0$secondaryArchSuffix
-	devel:libsdl2_mixer_2.0$secondaryArchSuffix
+	devel:libpng16$secondaryArchSuffix
+	devel:libSDL2_2.0$secondaryArchSuffix
+	devel:libSDL2_mixer_2.0$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
@@ -110,7 +110,9 @@ include( uninstall )
 subdirs( bear plee-the-bear-$portVersion )
 EOF
 
-	cmake .. -DBEAR_EDITORS_ENABLED=FALSE -DCMAKE_INSTALL_PREFIX=$prefix \
+	cmake .. -DCMAKE_BUILD_TYPE=Release \
+		-DBEAR_EDITORS_ENABLED=FALSE \
+		-DCMAKE_INSTALL_PREFIX=$prefix \
 		-DCMAKE_CXX_FLAGS="-DNDEBUG"
 	make $jobArgs
 }


### PR DESCRIPTION
No need for revbump (recipe still disabled, crashes on launch), addresses issue: https://github.com/haikuports/haikuports/issues/3779