### PR TITLE
openmw, fix reference to libpng16

### DIFF
--- a/games-engines/openmw/openmw-0.47.0.recipe
+++ b/games-engines/openmw/openmw-0.47.0.recipe
@@ -58,7 +58,7 @@ REQUIRES="
 	lib:liblz4$secondaryArchSuffix
 	lib:libMyGUIEngine$secondaryArchSuffix
 	lib:libopenal$secondaryArchSuffix
-	lib:libpng$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
 	lib:libQt5Gui$secondaryArchSuffix
 	lib:libQt5Widgets$secondaryArchSuffix
 	lib:libSDL2_2.0$secondaryArchSuffix


### PR DESCRIPTION
No rebuild, getting `internal compiler error` in 32bit when trying to build.