### PR TITLE
neo: new recipe

### DIFF
--- a/app-misc/neo/neo-0.6.1.recipe
+++ b/app-misc/neo/neo-0.6.1.recipe
@@ -1,0 +1,44 @@
+SUMMARY="Recreates the digital rain effect"
+DESCRIPTION="neo recreates the digital rain effect \
+from \"The Matrix\". Streams of random characters will \
+endlessly scroll down your terminal screen."
+HOMEPAGE="https://github.com/visit1985/neo"
+COPYRIGHT="2021 Stewart Reive"
+LICENSE="GNU GPL v3"
+REVISION="1"
+SOURCE_URI="https://github.com/st3w/neo/releases/download/v$portVersion/neo-$portVersion.tar.gz"
+CHECKSUM_SHA256="a55e4ed5efd0a4af248d16018a7aaad3b617ef1d3ac05d292a258a38aaf46a79"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	neo$secondaryArchSuffix = $portVersion
+	cmd:neo = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libncursesw$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libncursesw$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	"
+
+BUILD()
+{
+	./configure --prefix=$prefix --mandir=$manDir
+	make
+}
+
+INSTALL()
+{
+
+	make install
+}

--- a/app-misc/neo/neo-0.6.1.recipe
+++ b/app-misc/neo/neo-0.6.1.recipe
@@ -1,8 +1,8 @@
-SUMMARY="Recreates the digital rain effect"
+SUMMARY="Recreates Matrix' falling characters in Terminal"
 DESCRIPTION="neo recreates the digital rain effect \
 from \"The Matrix\". Streams of random characters will \
 endlessly scroll down your terminal screen."
-HOMEPAGE="https://github.com/visit1985/neo"
+HOMEPAGE="https://github.com/st3w/neo"
 COPYRIGHT="2021 Stewart Reive"
 LICENSE="GNU GPL v3"
 REVISION="1"
@@ -39,6 +39,5 @@ BUILD()
 
 INSTALL()
 {
-
 	make install
 }


### PR DESCRIPTION
the following adds the neo program as a port. sample run below:

```
> uname -a
Haiku shredder 1 hrev56137 May 27 2022 06:24:51 x86_64 x86_64 Haiku



> neo --help
Usage: neo [OPTIONS]

Simulate the digital rain from "The Matrix"

Options:
  -a, --async            asynchronous scroll speed
  -b, --bold=NUM         control character boldness
  -C, --colorfile=FILE   read the colors from a file
  -c, --color=COLOR      select the foreground text color
  -D, --defaultbg        use the default terminal background color
  -d, --density=NUM      set the density of droplets
  -F, --fullwidth        use two columns per character
  -f, --fps=NUM          set the frames per second target/limit
  -G, --glitchpct=NUM    set the percentage of screen chars that glitch
  -g, --glitchms=NUM1,2  control how often characters glitch
  -h, --help             show this help message
  -l, --lingerms=NUM1,2  control how long characters linger after scrolling
  -M, --shadingmode=NUM  set the shading mode
  -m, --message=STR      display a message
  -p, --profile          enable profiling mode
  -r, --rippct=NUM       set the percentage of droplets that die early
  -S, --speed=NUM        set the scroll speed in chars per second
  -s, --screensaver      exit on the first key press
  -V, --version          print the version
      --chars=NUM1,2     use a range of unicode chars
      --charset=STR      set the character set
      --colormode=NUM    set the color mode
      --maxdpc=NUM       set the maximum droplets per column
      --noglitch         disable character glitching
      --shortpct=NUM     set the percentage of shortened droplets

See the manual page for more info: man neo
```