### PR TITLE
lagrange: bump to 1.13.6

### DIFF
--- a/net-misc/lagrange/lagrange-1.13.6.recipe
+++ b/net-misc/lagrange/lagrange-1.13.6.recipe
@@ -8,7 +8,7 @@ COPYRIGHT="2020-2022 Jaakko Keränen"
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="https://github.com/skyjake/lagrange/releases/download/v$portVersion/lagrange-$portVersion.tar.gz"
-CHECKSUM_SHA256="f84c5fe078734df06ada747f87760ea8863369be5519d1e56992c7c5278395da"
+CHECKSUM_SHA256="7a89e4e950d14cfebd2806de07c49eeeb79368091a68ca439795d0aba9e1aaa7"
 SOURCE_DIR="lagrange-$portVersion"
 ADDITIONAL_FILES="lagrange.rdef.in"
 


### PR DESCRIPTION
[Changelog](https://github.com/skyjake/lagrange/releases)