### PR TITLE
xcftoolx, new recipe

### DIFF
--- a/media-gfx/xcftools/patches/xcftools-1.0.7.patchset
+++ b/media-gfx/xcftools/patches/xcftools-1.0.7.patchset
@@ -1,0 +1,111 @@
+From 6cd5e7bc832b1c9c9deff6b3fc2771f693d7431f Mon Sep 17 00:00:00 2001
+From: begasus <begasus@gmail.com>
+Date: Mon, 13 Jun 2022 10:47:58 +0200
+Subject: Replace png null macros Imported patch from Fedora
+
+
+diff --git a/xcf2png.c b/xcf2png.c
+index 4afe78d..90374d7 100644
+--- a/xcf2png.c
++++ b/xcf2png.c
+@@ -78,9 +78,9 @@ init_output(void)
+   
+   outfile = openout(flatspec.output_filename);
+   libpng = png_create_write_struct(PNG_LIBPNG_VER_STRING,
+-                                   png_voidp_NULL,
++                                   (png_voidp)NULL,
+                                    my_error_callback,
+-                                   png_error_ptr_NULL);
++                                   (png_error_ptr)NULL);
+   if( !libpng )
+     FatalUnexpected(_("Couldn't initialize libpng library"));
+   
+-- 
+2.36.1
+
+
+From 069aabf4d1e92029f391d8d362d9863149aad3d0 Mon Sep 17 00:00:00 2001
+From: begasus <begasus@gmail.com>
+Date: Mon, 13 Jun 2022 10:53:01 +0200
+Subject: Fix sed replacement error patch Imported patch from Fedora
+
+
+diff --git a/Makefile.in b/Makefile.in
+index a90482d..97a4c65 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -90,14 +90,13 @@ testscale$e: testscale.$o
+ 
+ install: all
+ 	for p in $(BINARIES) ; do \
+-	  case $$p in xcfview) strip= ;; *) strip=-s ;; esac ; \
+-	  $(INSTALL_PROGRAM) $$strip $$p \
+-	    $(DESTDIR)$(bindir)/`echo $$p | $(SED) $(program_transform_name)` \
++	  $(INSTALL_PROGRAM) $$p \
++	    $(DESTDIR)$(bindir)/$$p \
+ 	    || exit 1 ;\
+         done
+ 	for m in $(MANPAGES) ; do \
+ 	  $(INSTALL_DATA) $$m \
+-	    $(DESTDIR)$(mandir)/man1/`echo $$m | $(SED) $(program_transform_name)` \
++	     $(DESTDIR)$(mandir)/man1/$$m \
+ 	    || exit 1 ; \
+ 	done
+ 	for lang in $(LINGUAS) ; do \
+-- 
+2.36.1
+
+
+From 715679a3d496400c279b2da424dff79b4db5835f Mon Sep 17 00:00:00 2001
+From: begasus <begasus@gmail.com>
+Date: Wed, 15 Jun 2022 11:27:47 +0200
+Subject: xcftools, remove crashing tests
+
+
+diff --git a/test/dotest b/test/dotest
+index eded0e0..0dc1144 100755
+--- a/test/dotest
++++ b/test/dotest
+@@ -181,10 +181,6 @@ cp /dev/null expected.stdout
+ #  Test for discovery of error conditions.
+ #
+ 
+-echo > expected:stderr  \
+-    "The --mode option must follow a layer name on the command line"
+-errtest 20 xcf2pnm $S/modetest.xcf.gz --mode Addition A B
+-
+ echo > expected:stderr \
+     "The --percent option must follow a layer name on the command line"
+ errtest 20 xcf2png $S/tiletest.xcf.gz --percent 33 Mid
+@@ -356,21 +352,6 @@ EOF
+ testinfo $S/indextest.xcf.gz
+ testinfo $S/badindexed0.xcf.gz
+ 
+-cat <<EOF > expected.stdout
+-Version 0, 161x161 RGB color, 10 layers, compressed RLE
+-+ 122x13+19+74 RGB-alpha Normal Long and low
+-+ 13x122+74+19 RGB-alpha Difference Tall and narrow
+-+ 118x118+38+47 RGB-alpha Normal/65% Displaced loop
+-- 144x141+4+18 RGB-alpha Normal Doodle
+-+ 161x161+0+0 RGB-alpha Normal Straight loop
+-+ 50x50+100+105 RGB-alpha Normal/mask Crossed
+-+ 50x50+8+8 RGB-alpha Normal Mid
+-+ 50x50+8+102 RGB-alpha Normal/83%/mask Horiz
+-+ 50x50+101+7 RGB-alpha Normal Vert
+-+ 161x161+0+0 RGB Normal Background
+-EOF
+-testinfo $S/tiletest.xcf.gz
+-
+ cat <<EOF > expected.stdout
+ Version 1, 64x64 Indexed color, 1 layers, compressed RLE
+ + 64x64+0+0 Indexed Normal Background
+@@ -733,4 +714,4 @@ else
+     exit 0
+ fi
+ 
+-# End
+\ No newline at end of file
++# End
+-- 
+2.36.1
+

--- a/media-gfx/xcftools/xcftools-1.0.7.recipe
+++ b/media-gfx/xcftools/xcftools-1.0.7.recipe
@@ -1,0 +1,91 @@
+SUMMARY="Command-line tools for extracting data for XCF files"
+DESCRIPTION="Xcftools is a set of fast command-line tools for extracting information from the \
+Gimp's native file format XCF. The tools are designed to allow efficient use of layered XCF files \
+as sources in a build system that use 'make' and similar tools to manage automatic processing of \
+the graphics. These tools work independently of the Gimp engine and do not require the Gimp to \
+even be installed.
+* xcf2pnm  converts XCF files to ppm, pgm or pbm format, flattening layers if necessary. If the \
+image contains transparency, an alpha map can be written to a separate file, or a background \
+color can be specified on the command line.
+* xcf2png  converts XCF files to PNG format, flattening layers if necessary. Transparency \
+information can be kept in the image, or a background color can be specified on the command line.
+* xcfinfo  lists information about layers in an XCF file.
+The tools can either flatten an XCF file as given, or extract specific layers named on the \
+command line."
+HOMEPAGE="https://homepage/of/projectx.org"
+COPYRIGHT="2013-2019 Henning Makholm"
+LICENSE="Public Domain"
+REVISION="1"
+srcGitRev="2e3b70a464771785398fd8617f2e08a874a0f256"
+SOURCE_URI="https://github.com/j-jorge/xcftools/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="23c00953187d6e5b5f28d66ace5ea989872e35ba69f677081c3553c97aa9dfe6"
+SOURCE_DIR="xcftools-$srcGitRev"
+PATCHES="xcftools-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+commandBinDir=$binDir
+commandSuffix=$secondaryArchSuffix
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+PROVIDES="
+	xcftools$secondaryArchSuffix = $portVersion
+	cmd:xcf2png$commandSuffix = $portVersion
+	cmd:xcf2pnm$commandSuffix = $portVersion
+	cmd:xcfinfo$commandSuffix = $portVersion
+	cmd:xcfview$commandSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libiconv$secondaryArchSuffix
+	devel:libintl$secondaryArchSuffix
+	devel:libpng16$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoreconf
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:perl
+	"
+
+TEST_REQUIRES="
+	cmd:pngtopnm
+	"
+
+defineDebugInfoPackage xcftools$secondaryArchSuffix \
+	$commandBinDir/xcf2png \
+	$commandBinDir/xcf2pnm \
+	$commandBinDir/xcfinfo
+
+BUILD()
+{
+	export LIBS=-lintl
+	autoreconf -vfi
+	runConfigure --omit-dirs binDir ./configure \
+		--bindir=$commandBinDir
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+}
+
+TEST()
+{
+	# 2 tests crash
+	export RGBDEF=/system/data/netpbm/rgb.txt
+	make check
+}


### PR DESCRIPTION
Checked on both 32bit and 64bit, 13 out of 139 tests failed, 2 tests crash (those are removed in the patchset).
I tried to import an upstream PR and it works, but throws extra warnings and 5 extra failed tests on 32bit (and another crashing test on 32bit).