### PR TITLE
tuxpaint, bump version, use SDL2 now

### DIFF
--- a/media-gfx/tuxpaint/patches/tuxpaint_sdl2-0.9.28.patchset
+++ b/media-gfx/tuxpaint/patches/tuxpaint_sdl2-0.9.28.patchset
@@ -1,0 +1,22 @@
+From c1a1b144eb2b3bf1356d529f569c0789fe3e7aae Mon Sep 17 00:00:00 2001
+From: begasus <begasus@gmail.com>
+Date: Mon, 6 Jun 2022 13:48:55 +0200
+Subject: Fix build on Haiku
+
+
+diff --git a/src/BeOS_print.cpp b/src/BeOS_print.cpp
+index 6bfed5c..f019c11 100644
+--- a/src/BeOS_print.cpp
++++ b/src/BeOS_print.cpp
+@@ -82,8 +82,6 @@ BBitmap *SurfaceToBBitmap(SDL_Surface * surf)
+   pixfmt.Gloss = 0;
+   pixfmt.Bloss = 0;
+   pixfmt.Aloss = 0;
+-  pixfmt.colorkey = 0;
+-  pixfmt.alpha = 0;
+ 
+   surf32 = SDL_ConvertSurface(surf, &pixfmt, SDL_SWSURFACE);
+ 
+-- 
+2.36.1
+

--- a/media-gfx/tuxpaint/tuxpaint_sdl2-0.9.28.recipe
+++ b/media-gfx/tuxpaint/tuxpaint_sdl2-0.9.28.recipe
@@ -1,0 +1,91 @@
+SUMMARY="Drawing program designed for young children"
+DESCRIPTION="Tux Paint is a free, award-winning drawing program for children \
+ages 3 to 12 (for example, preschool and K-6). Tux Paint is used \
+in schools and around the world as a computer literacy drawing activity. \
+It combines an easy-to-use interface, fun sound effects, and an \
+encouraging cartoon mascot who guides children as they use the program."
+HOMEPAGE="http://www.tuxpaint.org/"
+COPYRIGHT="2002-2022 Bill Kendrick and others"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="https://downloads.sourceforge.net/tuxpaint/tuxpaint-$portVersion-sdl2.tar.gz"
+CHECKSUM_SHA256="4f1ed9330feab324070b93630d79ced50ccc4816ab76750119f012b5d904709d"
+SOURCE_DIR="tuxpaint-$portVersion-sdl2"
+PATCHES="tuxpaint_sdl2-$portVersion.patchset"
+
+ARCHITECTURES="?all !x86_gcc2 x86_64"
+SECONDARY_ARCHITECTURES="x86"
+
+USER_SETTINGS_FILES="
+	settings/TuxPaint directory
+	"
+
+PROVIDES="
+	tuxpaint_sdl2$secondaryArchSuffix = $portVersion
+	app:TuxPaint
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcairo$secondaryArchSuffix
+	lib:libfribidi$secondaryArchSuffix
+	lib:libgdk_pixbuf_2.0$secondaryArchSuffix
+	lib:libgio_2.0$secondaryArchSuffix
+	lib:libglib_2.0$secondaryArchSuffix
+	lib:libgobject_2.0$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libimagequant$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libpaper$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
+	lib:librsvg_2$secondaryArchSuffix
+	lib:libSDL2_2.0$secondaryArchSuffix
+	lib:libSDL2_gfx$secondaryArchSuffix
+	lib:libSDL2_image_2.0$secondaryArchSuffix
+	lib:libSDL2_mixer_2.0$secondaryArchSuffix
+	lib:libSDL2_pango$secondaryArchSuffix
+	lib:libSDL2_ttf_2.0$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libcairo$secondaryArchSuffix
+	devel:libfribidi$secondaryArchSuffix
+	devel:libgdk_pixbuf_2.0$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
+	devel:libimagequant$secondaryArchSuffix
+	devel:libintl$secondaryArchSuffix
+	devel:libpaper$secondaryArchSuffix
+	devel:libpng16$secondaryArchSuffix
+	devel:librsvg_2$secondaryArchSuffix
+	devel:libSDL2_2.0$secondaryArchSuffix
+	devel:libSDL2_gfx$secondaryArchSuffix
+	devel:libSDL2_image_2.0$secondaryArchSuffix
+	devel:libSDL2_mixer_2.0$secondaryArchSuffix
+	devel:libSDL2_pango$secondaryArchSuffix
+	devel:libSDL2_ttf_2.0$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:convert$secondaryArchSuffix
+	cmd:gcc$secondaryArchSuffix
+	cmd:gperf
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	make PREFIX=$appsDir/TuxPaint
+}
+
+INSTALL()
+{
+	mkdir -p $appsDir/TuxPaint
+
+	make install PREFIX=$appsDir/TuxPaint
+	ln -s $appsDir/TuxPaint/bin/tuxpaint $appsDir/TuxPaint/TuxPaint
+
+	addAppDeskbarSymlink $appsDir/TuxPaint/bin/tuxpaint TuxPaint
+}


### PR DESCRIPTION
Keeping the older version that still uses SDL1.2, current version has issues with SDL1.2 and support for that will end at some point.