### PR TITLE
gcc: Pass --eh-frame-hdr to linker by default

### DIFF
--- a/sys-devel/gcc/gcc-11.2.0_2021_07_28.recipe
+++ b/sys-devel/gcc/gcc-11.2.0_2021_07_28.recipe
@@ -5,7 +5,7 @@ HOMEPAGE="https://gcc.gnu.org/"
 COPYRIGHT="1988-2021 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3
 	GNU LGPL v3"
-REVISION="7"
+REVISION="8"
 gccVersion="${portVersion%%_*}"
 SOURCE_URI="https://ftpmirror.gnu.org/gcc/gcc-$gccVersion/gcc-$gccVersion.tar.xz
 	https://ftp.gnu.org/gnu/gcc/gcc-$gccVersion/gcc-$gccVersion.tar.xz"

--- a/sys-devel/gcc/patches/gcc-11.2.0_2021_07_28.patchset
+++ b/sys-devel/gcc/patches/gcc-11.2.0_2021_07_28.patchset
@@ -3627,3 +3627,38 @@ index 000000000..efa187289
 -- 
 2.35.1
 
+
+From 4dfaf5b96eaa934b487a83f9deb9eee0dde3a100 Mon Sep 17 00:00:00 2001
+From: Trung Nguyen <trungnt282910@gmail.com>
+Date: Wed, 6 Jul 2022 23:57:55 +0700
+Subject: [PATCH] gcc: Pass --eh-frame-hdr to linker by default
+
+This creates a PT_EH_FRAME section in Haiku binaries,
+allowing 3rd party unwind libraries (libunwind) to obtain
+frame information for unwind procedures.
+
+Change-Id: If475909d182bcac11024ebbc8220456733330fe8
+---
+ gcc/config/haiku.h | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/gcc/config/haiku.h b/gcc/config/haiku.h
+index 316d38469..37adf4081 100644
+--- a/gcc/config/haiku.h
++++ b/gcc/config/haiku.h
+@@ -67,6 +67,12 @@ Boston, MA 02111-1307, USA.  */
+ #define USE_LD_AS_NEEDED 1
+ #endif
+
++/* Pass --eh-frame-hdr to provide a PT_EH_FRAME section, allowing unwind
++   libraries to get frame information. */
++#if defined(HAVE_LD_EH_FRAME_HDR)
++#define LINK_EH_SPEC "%{!static|static-pie:--eh-frame-hdr} "
++#endif
++
+ #undef  STARTFILE_SPEC
+ #define STARTFILE_SPEC "crti.o%s crtbeginS.o%s %{!shared:%{!nostart:start_dyn.o%s}} init_term_dyn.o%s"
+
+--
+2.34.1
+


### PR DESCRIPTION
This commit adds the patch submitted [here](https://review.haiku-os.org/c/buildtools/+/5434) to Haiku's GCC toolchain on HaikuPorts.

It has been tested. On the terminal is the output of `readelf --headers test`, where `test` is a binary compiled using a `gcc` built with this recipe.

![image](https://user-images.githubusercontent.com/57174311/177781024-9840c20a-5f8d-4ad7-b7a1-96e1c4edf8e2.png)
