### PR TITLE
Update openttd, openttd_gfx, openttd_sfx, openttd_msx

### DIFF
--- a/games-simulation/openttd/openttd-12.2.recipe
+++ b/games-simulation/openttd/openttd-12.2.recipe
@@ -24,12 +24,12 @@ REQUIRES="
 	openttd_sfx
 	timgmsoundfont
 	lib:libfreetype$secondaryArchSuffix
+	lib:libGL$secondaryArchSuffix
 	lib:liblzma$secondaryArchSuffix
 	lib:liblzo2$secondaryArchSuffix
 	lib:libpng16$secondaryArchSuffix
-	lib:libsdl$secondaryArchSuffix
+	lib:libSDL_1.2$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
-	lib:libgl$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
@@ -38,7 +38,7 @@ BUILD_REQUIRES="
 	devel:liblzma$secondaryArchSuffix
 	devel:liblzo2$secondaryArchSuffix
 	devel:libpng16$secondaryArchSuffix
-	devel:libsdl$secondaryArchSuffix
+	devel:libSDL_1.2$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
@@ -52,23 +52,17 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	export includeDir=/system/$relativeIncludeDir
-	mkdir -p build ; cd build
-	cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-	-DCMAKE_INSTALL_PREFIX=$prefix \
-	-DCMAKE_INSTALL_DATADIR=$dataDir \
-	-DCMAKE_INSTALL_BINDIR=$appsDir \
-	-DCMAKE_INSTALL_DOCDIR=$docDir \
-	-DCMAKE_INSTALL_MANDIR=$manDir
+	cmake -B build -S . -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+	$cmakeDirArgs \
+	-DCMAKE_INSTALL_BINDIR=$appsDir
 
-	make $jobArgs
+	make -C build $jobArgs
 }
 
 INSTALL()
 {
 	cd build
 	make install
-	rm -r $prefix/share
 	
 	addResourcesToBinaries $portDir/additional-files/openttd.rdef $appsDir/openttd
 	addAppDeskbarSymlink $appsDir/openttd "OpenTTD"

--- a/games-simulation/openttd/openttd-12.2.recipe
+++ b/games-simulation/openttd/openttd-12.2.recipe
@@ -4,11 +4,11 @@ game \"Transport Tycoon Deluxe\", written by Chris Sawyer. It attempts to \
 mimic the original game as closely as possible while extending it with new \
 features."
 HOMEPAGE="http://www.openttd.org"
-COPYRIGHT="2005-2016 OpenTTD Team"
+COPYRIGHT="2005-2022 OpenTTD Team"
 LICENSE="GNU GPL v2"
 REVISION="2"
-SOURCE_URI="http://binaries.openttd.org/releases/$portVersion/openttd-$portVersion-source.tar.xz"
-CHECKSUM_SHA256="61190952a98d494d3fd62e395dd6c359609914d0ba8fe80eaeb585b7d62a1b36"
+SOURCE_URI="https://cdn.openttd.org/openttd-releases/$portVersion/openttd-$portVersion-source.tar.xz"
+CHECKSUM_SHA256="81508f0de93a0c264b216ef56a05f8381fff7bffa6d010121a21490b4dace95c"
 ADDITIONAL_FILES="openttd.rdef"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -29,6 +29,7 @@ REQUIRES="
 	lib:libpng16$secondaryArchSuffix
 	lib:libsdl$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
+	lib:libgl$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
@@ -45,33 +46,30 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:git
 	cmd:make
+	cmd:cmake
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
 BUILD()
 {
 	export includeDir=/system/$relativeIncludeDir
-	export CFLAGS=-O1
-	# Non-autotools script, can't use runConfigure.
-	./configure --prefix=$prefix --binary-dir=$relativeAppsDir \
-		--data-dir=$relativeDataDir/openttd --doc-dir=$relativeDocDir/openttd \
-		--man-dir=$relativeManDir --icon-dir=trash --menu-dir=trash \
-		--with-freetype=2
+	mkdir -p build ; cd build
+	cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+	-DCMAKE_INSTALL_PREFIX=$prefix \
+	-DCMAKE_INSTALL_DATADIR=$dataDir \
+	-DCMAKE_INSTALL_BINDIR=$appsDir \
+	-DCMAKE_INSTALL_DOCDIR=$docDir \
+	-DCMAKE_INSTALL_MANDIR=$manDir
+
 	make $jobArgs
 }
 
 INSTALL()
 {
+	cd build
 	make install
-	# The install script leaves some mess all around, let's clean it up...
-	rm -r $prefix/trash
-	rm -r $prefix/16x16
-	rm -r $prefix/32x32
-	rm -r $prefix/48x48
-	rm -r $prefix/64x64
-	rm -r $prefix/128x128
-	rm -r $prefix/256x256
-
+	rm -r $prefix/share
+	
 	addResourcesToBinaries $portDir/additional-files/openttd.rdef $appsDir/openttd
 	addAppDeskbarSymlink $appsDir/openttd "OpenTTD"
 }

--- a/games-simulation/openttd/openttd-12.2.recipe
+++ b/games-simulation/openttd/openttd-12.2.recipe
@@ -61,8 +61,8 @@ BUILD()
 
 INSTALL()
 {
-	cd build
-	make install
+	make -C build install
+	rm -r $dataDir/{applications,icons,pixmaps}
 	
 	addResourcesToBinaries $portDir/additional-files/openttd.rdef $appsDir/openttd
 	addAppDeskbarSymlink $appsDir/openttd "OpenTTD"

--- a/games-simulation/openttd/openttd-12.2.recipe
+++ b/games-simulation/openttd/openttd-12.2.recipe
@@ -6,7 +6,7 @@ features."
 HOMEPAGE="http://www.openttd.org"
 COPYRIGHT="2005-2022 OpenTTD Team"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://cdn.openttd.org/openttd-releases/$portVersion/openttd-$portVersion-source.tar.xz"
 CHECKSUM_SHA256="81508f0de93a0c264b216ef56a05f8381fff7bffa6d010121a21490b4dace95c"
 ADDITIONAL_FILES="openttd.rdef"
@@ -63,7 +63,7 @@ INSTALL()
 {
 	make -C build install
 	rm -r $dataDir/{applications,icons,pixmaps}
-	
+
 	addResourcesToBinaries $portDir/additional-files/openttd.rdef $appsDir/openttd
 	addAppDeskbarSymlink $appsDir/openttd "OpenTTD"
 }

--- a/games-simulation/openttd_gfx/openttd_gfx-7.1.recipe
+++ b/games-simulation/openttd_gfx/openttd_gfx-7.1.recipe
@@ -9,11 +9,11 @@ This package provides free to use graphics file. You can use them if you \
 don't have the files from the original Transport Tycoon Deluxe game.
 "
 HOMEPAGE="http://www.openttd.org"
-COPYRIGHT="2005-2013 OpenTTD Team"
+COPYRIGHT="2005-2022 OpenTTD Team"
 LICENSE="GNU GPL v2"
 REVISION="1"
-SOURCE_URI="http://bundles.openttdcoop.org/opengfx/releases/$portVersion/opengfx-$portVersion.zip#noarchive"
-CHECKSUM_SHA256="3d136d776906dbe8b5df1434cb9a68d1249511a3c4cfaca55cc24cc0028ae078"
+SOURCE_URI="https://cdn.openttd.org/opengfx-releases/$portVersion/opengfx-$portVersion-all.zip#noarchive"
+CHECKSUM_SHA256="928fcf34efd0719a3560cbab6821d71ce686b6315e8825360fba87a7a94d7846"
 
 ARCHITECTURES="any"
 
@@ -22,20 +22,17 @@ PROVIDES="
 	"
 
 BUILD_PREREQUIRES="
-	cmd:tar
 	cmd:unzip
 	"
 
 BUILD()
 {
-	rm -Rf opengfx-$portVersion
-	unzip -o opengfx-$portVersion.zip
-	tar xvf opengfx-$portVersion.tar
-	rm opengfx-$portVersion.tar
+	unzip -o opengfx-$portVersion-all.zip
+	rm opengfx-$portVersion-all.zip
 }
 
 INSTALL()
 {
-	mkdir -p $dataDir/openttd/baseset/opengfx
-	cp opengfx-$portVersion/* $dataDir/openttd/baseset/opengfx
+	mkdir -p $dataDir/openttd/baseset
+	cp opengfx-$portVersion.tar $dataDir/openttd/baseset/
 }

--- a/games-simulation/openttd_msx/openttd_msx-0.4.2.recipe
+++ b/games-simulation/openttd_msx/openttd_msx-0.4.2.recipe
@@ -10,9 +10,8 @@ HOMEPAGE="http://www.openttd.org"
 COPYRIGHT="2005-2013 OpenTTD Team"
 LICENSE="GNU GPL v2"
 REVISION="2"
-SOURCE_URI="http://binaries.openttd.org/extra/openmsx/$portVersion/openmsx-$portVersion-all.zip"
-CHECKSUM_SHA256="92e293ae89f13ad679f43185e83fb81fb8cad47fe63f4af3d3d9f955130460f5"
-SOURCE_DIR="openmsx-$portVersion"
+SOURCE_URI="https://cdn.openttd.org/openmsx-releases/$portVersion/openmsx-$portVersion-all.zip#noarchive"
+CHECKSUM_SHA256="5a4277a2e62d87f2952ea5020dc20fb2f6ffafdccf9913fbf35ad45ee30ec762"
 
 ARCHITECTURES="any"
 DISABLE_SOURCE_PACKAGE="yes"
@@ -20,21 +19,19 @@ DISABLE_SOURCE_PACKAGE="yes"
 PROVIDES="
 	openttd_msx = $portVersion
 	"
-REQUIRES="
-	"
 
-BUILD_REQUIRES="
-	"
 BUILD_PREREQUIRES="
+	cmd:unzip
 	"
 
 BUILD()
 {
-	true
+	unzip -o openmsx-$portVersion-all.zip
+	rm openmsx-$portVersion-all.zip
 }
 
 INSTALL()
 {
-	mkdir -p $dataDir/openttd/baseset/openmsx
-	cp * $dataDir/openttd/baseset/openmsx
+	mkdir -p $dataDir/openttd/baseset
+	cp openmsx-$portVersion.tar $dataDir/openttd/baseset/
 }

--- a/games-simulation/openttd_sfx/openttd_sfx-1.0.3.recipe
+++ b/games-simulation/openttd_sfx/openttd_sfx-1.0.3.recipe
@@ -11,8 +11,8 @@ HOMEPAGE="http://www.openttd.org"
 COPYRIGHT="2005-2013 OpenTTD Team"
 LICENSE="GNU GPL v2"
 REVISION="1"
-SOURCE_URI="http://binaries.openttd.org/extra/opensfx/$portVersion/opensfx-$portVersion-all.zip"
-CHECKSUM_SHA256="6831b651b3dc8b494026f7277989a1d757961b67c17b75d3c2e097451f75af02"
+SOURCE_URI="https://cdn.openttd.org/opensfx-releases/$portVersion/opensfx-$portVersion-all.zip#noarchive"
+CHECKSUM_SHA256="e0a218b7dd9438e701503b0f84c25a97c1c11b7c2f025323fb19d6db16ef3759"
 SOURCE_DIR="opensfx-$portVersion"
 
 ARCHITECTURES="any"
@@ -21,21 +21,19 @@ DISABLE_SOURCE_PACKAGE="yes"
 PROVIDES="
 	openttd_sfx = $portVersion
 	"
-REQUIRES="
-	"
 
-BUILD_REQUIRES="
-	"
 BUILD_PREREQUIRES="
+	cmd:unzip
 	"
 
 BUILD()
 {
-	true
+	unzip -o opensfx-$portVersion-all.zip
+	rm opensfx-$portVersion-all.zip
 }
 
 INSTALL()
 {
-	mkdir -p $dataDir/openttd/baseset/opensfx
-	cp * $dataDir/openttd/baseset/opensfx
+	mkdir -p $dataDir/openttd/baseset
+	cp opensfx-$portVersion.tar $dataDir/openttd/baseset/
 }


### PR DESCRIPTION
Update openttd and its asset packages to the latest version. Upstream
development switched to a new CDN and changed their build system to
CMake, so changes are somewhat more significant than just a version
bump.

Briefly tested and basic functionality seems to work. Saving/loading
games works. Downloading content through their system also works.
Did not confirm whether network play works, although I'm able to browse
the server list.

I considered fiddling with getting their SDL2 build working, but the SDL1
build seems fully functional and upstream supports both so I decided to
stop here and see if anyone here had feedback on whether that is even
desirable.

I've only been using Haiku for a week or so and this is my first time
working with the packaging system, so I look forward to feedback on
whether I'm doing it right.

Awesome project, everyone!