### PR TITLE
geos: bump to 3.11.0

### DIFF
--- a/sci-libs/geos/geos-3.11.0.recipe
+++ b/sci-libs/geos/geos-3.11.0.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="GEOS is a C++ port of the Java Topology Suite (JTS). As such, \
 it aims to contain the complete functionality of JTS in C++. This includes \
 all the OpenGIS Simple Features for SQL spatial predicate functions and \
 spatial operators, as well as specific JTS enhanced topology functions."
-HOMEPAGE="https://trac.osgeo.org/geos"
+HOMEPAGE="https://libgeos.org/"
 COPYRIGHT="2005-2006 Refractions Research Inc.
 	2012 Excensus LLC.
 	2001-2002 Vivid Solutions Inc.
@@ -13,7 +13,7 @@ COPYRIGHT="2005-2006 Refractions Research Inc.
 LICENSE="GNU LGPL v2.1"
 REVISION="1"
 SOURCE_URI="https://download.osgeo.org/geos/geos-$portVersion.tar.bz2"
-CHECKSUM_SHA256="50bbc599ac386b4c2b3962dcc411f0040a61f204aaef4eba7225ecdd0cf45715"
+CHECKSUM_SHA256="79ab8cabf4aa8604d161557b52e3e4d84575acdc0d08cb09ab3f7aaefa4d858a"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"


### PR DESCRIPTION
[Version 3.11.0 released](https://libgeos.org/posts/2022-07-01-geos-3-11-0-released/)