### PR TITLE
fish: bump version

### DIFF
--- a/app-shells/fish/fish-3.5.1.recipe
+++ b/app-shells/fish/fish-3.5.1.recipe
@@ -42,9 +42,9 @@ BUILD_REQUIRES="
 	devel:libpcre2_32$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
+	cmd:cmake
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
-	cmd:cmake
 	"
 
 defineDebugInfoPackage fish$secondaryArchSuffix \
@@ -57,12 +57,7 @@ BUILD()
 	mkdir -p build && cd build
 	cmake .. \
 		-DCMAKE_BUILD_TYPE=Release \
-		-DCMAKE_INSTALL_PREFIX=$prefix \
-		-DCMAKE_INSTALL_DATADIR=$dataDir \
-		-DCMAKE_INSTALL_SYSCONFDIR=$settingsDir \
-		-DCMAKE_INSTALL_DOCDIR=$docDir \
-		-DCMAKE_INSTALL_MANDIR=$manDir \
-		-DCMAKE_INSTALL_LOCALEDIR=$dataDir/locale
+		$cmakeDirArgs
 
 	make $jobArgs
 }

--- a/app-shells/fish/fish-3.5.1.recipe
+++ b/app-shells/fish/fish-3.5.1.recipe
@@ -5,13 +5,13 @@ is simple but incompatible with other shell languages."
 HOMEPAGE="https://ridiculousfish.com/shell/"
 COPYRIGHT="2005-2018 Axel Liljencrantz"
 LICENSE="GNU GPL v2"
-REVISION="3"
-SOURCE_URI="https://github.com/fish-shell/fish-shell/releases/download/$portVersion/fish-$portVersion.tar.gz"
-CHECKSUM_SHA256="e42bb19c7586356905a58578190be792df960fa81de35effb1ca5a5a981f0c5a"
+REVISION="1"
+SOURCE_URI="https://github.com/fish-shell/fish-shell/releases/download/$portVersion/fish-$portVersion.tar.xz"
+CHECKSUM_SHA256="a6d45b3dc5a45dd31772e7f8dfdfecabc063986e8f67d60bd7ca60cc81db6928"
 PATCHES="fish-$portVersion.patchset"
 
-ARCHITECTURES="?all !x86_gcc2"
-SECONDARY_ARCHITECTURES="?x86"
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 GLOBAL_WRITABLE_FILES="
 	settings/fish/config.fish keep-old
@@ -26,8 +26,6 @@ PROVIDES="
 REQUIRES="
 	haiku$secondaryArchSuffix
 	cmd:gettext$secondaryArchSuffix
-	cmd:python
-	cmd:ul
 	lib:libexecinfo$secondaryArchSuffix
 	lib:libiconv$secondaryArchSuffix
 	lib:libintl$secondaryArchSuffix
@@ -44,9 +42,9 @@ BUILD_REQUIRES="
 	devel:libpcre2_32$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:awk
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
+	cmd:cmake
 	"
 
 defineDebugInfoPackage fish$secondaryArchSuffix \
@@ -56,12 +54,15 @@ defineDebugInfoPackage fish$secondaryArchSuffix \
 
 BUILD()
 {
-	export CFLAGS="-D_BSD_SOURCE"
-	export CXXFLAGS=$CFLAGS
-	export LIBS="-lnetwork -lexecinfo"
-
-	runConfigure ./configure \
-		--without-included-pcre2
+	mkdir -p build && cd build
+	cmake .. \
+		-DCMAKE_BUILD_TYPE=Debug \
+		-DCMAKE_INSTALL_PREFIX=$prefix \
+		-DCMAKE_INSTALL_DATADIR=$dataDir \
+		-DCMAKE_INSTALL_SYSCONFDIR=$settingsDir \
+		-DCMAKE_INSTALL_DOCDIR=$docDir \
+		-DCMAKE_INSTALL_MANDIR=$manDir \
+		-DCMAKE_INSTALL_LOCALEDIR=$dataDir/locale
 
 	make $jobArgs
 }

--- a/app-shells/fish/fish-3.5.1.recipe
+++ b/app-shells/fish/fish-3.5.1.recipe
@@ -34,7 +34,7 @@ REQUIRES="
 	"
 
 BUILD_REQUIRES="
-	haiku${secondaryArchSuffix}_devel >= r1~alpha4_pm_hrev51519-1
+	haiku${secondaryArchSuffix}_devel
 	devel:libexecinfo$secondaryArchSuffix
 	devel:libgettextlib$secondaryArchSuffix
 	devel:libiconv$secondaryArchSuffix
@@ -56,7 +56,7 @@ BUILD()
 {
 	mkdir -p build && cd build
 	cmake .. \
-		-DCMAKE_BUILD_TYPE=Debug \
+		-DCMAKE_BUILD_TYPE=Release \
 		-DCMAKE_INSTALL_PREFIX=$prefix \
 		-DCMAKE_INSTALL_DATADIR=$dataDir \
 		-DCMAKE_INSTALL_SYSCONFDIR=$settingsDir \

--- a/app-shells/fish/patches/fish-3.5.1.patchset
+++ b/app-shells/fish/patches/fish-3.5.1.patchset
@@ -1,0 +1,59 @@
+From 21ae0a493f309006033103a44f31be43cc78ef08 Mon Sep 17 00:00:00 2001
+From: Ivan Holmes <ivan@ivanholmes.co.uk>
+Date: Wed, 17 Aug 2022 19:30:18 +0100
+Subject: Don't include mount.h on Haiku
+
+
+diff --git a/src/path.cpp b/src/path.cpp
+index d5a649e..b920d7a 100644
+--- a/src/path.cpp
++++ b/src/path.cpp
+@@ -6,7 +6,9 @@
+ #include "path.h"
+ 
+ #include <errno.h>
++#ifndef __HAIKU__
+ #include <sys/mount.h>
++#endif
+ #include <sys/param.h>
+ #include <sys/stat.h>
+ #if defined(__linux__)
+diff --git a/src/wutil.cpp b/src/wutil.cpp
+index 21ec26d..1848948 100644
+--- a/src/wutil.cpp
++++ b/src/wutil.cpp
+@@ -11,7 +11,9 @@
+ #include <limits.h>
+ #include <stdio.h>
+ #include <stdlib.h>
++#ifndef __HAIKU__
+ #include <sys/mount.h>
++#endif
+ #include <sys/stat.h>
+ #include <sys/statvfs.h>
+ #include <sys/types.h>
+-- 
+2.36.1
+
+
+From 74736c3a8584cc05327804cbb13e666dc94efe7b Mon Sep 17 00:00:00 2001
+From: Ivan Holmes <ivan@ivanholmes.co.uk>
+Date: Wed, 17 Aug 2022 19:30:41 +0100
+Subject: remove assertion that exit codes are less than 256
+
+
+diff --git a/src/proc.h b/src/proc.h
+index 6ac42c7..7d9b719 100644
+--- a/src/proc.h
++++ b/src/proc.h
+@@ -90,7 +90,6 @@ class proc_status_t {
+         constexpr int zerocode = w_exitcode(0, 0);
+         static_assert(WIFEXITED(zerocode), "Synthetic exit status not reported as exited");
+ 
+-        assert(ret < 256);
+         return proc_status_t(w_exitcode(ret, 0 /* sig */));
+     }
+ 
+-- 
+2.36.1
+


### PR DESCRIPTION
Thanks to the good work recently by waddlesplash on FIFOs and trungnt2910 on locale_t, the latest version of fish shell now compiles and runs on Haiku with minimal changes.

I tried porting extrowerk's patch to fix the crash on exit from fish 2.7.1, but it doesn't seem to work so I removed it.

I'm submitting this recipe anyway in case someone else can fix it, or it can be lived with for now.