### PR TITLE
pymupdf: add $secondaryArchSuffix to swig to fix 32-bit build

### DIFF
--- a/dev-python/pymupdf/pymupdf-1.20.2.recipe
+++ b/dev-python/pymupdf/pymupdf-1.20.2.recipe
@@ -31,7 +31,7 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libmupdf$secondaryArchSuffix >= 1.20
 	devel:libfreetype$secondaryArchSuffix
-	swig
+	swig$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix


### PR DESCRIPTION
This fixes one of the issues with #7125 and should allow pymupdf to build on 32-bit. 