### PR TITLE
documentviewer: add version requirement for mupdf

### DIFF
--- a/haiku-apps/documentviewer/documentviewer-0.3~git.recipe
+++ b/haiku-apps/documentviewer/documentviewer-0.3~git.recipe
@@ -22,7 +22,7 @@ REQUIRES="
 	lib:libfreetype$secondaryArchSuffix
 	lib:libjbig2dec$secondaryArchSuffix
 	lib:libjpeg$secondaryArchSuffix
-	lib:libmupdf$secondaryArchSuffix >= 1.20
+	lib:libmupdf$secondaryArchSuffix
 	lib:libopenjp2$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"

--- a/haiku-apps/documentviewer/documentviewer-0.3~git.recipe
+++ b/haiku-apps/documentviewer/documentviewer-0.3~git.recipe
@@ -22,7 +22,7 @@ REQUIRES="
 	lib:libfreetype$secondaryArchSuffix
 	lib:libjbig2dec$secondaryArchSuffix
 	lib:libjpeg$secondaryArchSuffix
-	lib:libmupdf$secondaryArchSuffix
+	lib:libmupdf$secondaryArchSuffix >= 1.20
 	lib:libopenjp2$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
@@ -33,7 +33,7 @@ BUILD_REQUIRES="
 	devel:libfreetype$secondaryArchSuffix
 	devel:libjbig2dec$secondaryArchSuffix
 	devel:libjpeg$secondaryArchSuffix
-	devel:libmupdf$secondaryArchSuffix
+	devel:libmupdf$secondaryArchSuffix >= 1.20
 	devel:libopenjp2$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"

--- a/haiku-apps/documentviewer/documentviewer-0.3~git.recipe
+++ b/haiku-apps/documentviewer/documentviewer-0.3~git.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="DocumentViewer is a viewer that supports PDF and DJVU files."
 HOMEPAGE="https://github.com/HaikuArchives/DocumentViewer"
 COPYRIGHT="2010-2018 Haiku, Inc"
 LICENSE="MIT"
-REVISION="17"
+REVISION="18"
 srcGitRev="d1eab70bbbcfa22049d711f520a1f58c02459623"
 SOURCE_URI="$HOMEPAGE/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="628b8fc9498f3d23210145e3388a241aeb38517cb16d3f53a1c7e24e6a91c3c0"
@@ -33,7 +33,7 @@ BUILD_REQUIRES="
 	devel:libfreetype$secondaryArchSuffix
 	devel:libjbig2dec$secondaryArchSuffix
 	devel:libjpeg$secondaryArchSuffix
-	devel:libmupdf$secondaryArchSuffix >= 1.20
+	devel:libmupdf$secondaryArchSuffix
 	devel:libopenjp2$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"


### PR DESCRIPTION
This adds a version requirement for libmupdf to the DocumentViewer recipe, which should force it to rebuild as per @korli's advice on #7125.