### PR TITLE
JOSM: bump to 18543

### DIFF
--- a/sci-geosciences/josm/josm_bin-18543.recipe
+++ b/sci-geosciences/josm/josm_bin-18543.recipe
@@ -7,7 +7,7 @@ COPYRIGHT="2006-2022 Immanuel Scholz, Dirk Stöcker"
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://josm.openstreetmap.de/download/josm-snapshot-$portVersion.jar#noarchive"
-CHECKSUM_SHA256="fdeb066cb6e2750eb4f9ab8c0b55b61b01fb579a9d4d5cdb94336cb24ba1723b"
+CHECKSUM_SHA256="01099d07080e570b3c303017f22dcfedbb24debebd83bc778e10031b04566b67"
 ADDITIONAL_FILES="josm.hvif"
 
 ARCHITECTURES="any"


### PR DESCRIPTION
[2022-08-30: Stable release 18543](https://josm.openstreetmap.de/wiki/Changelog#stable-release-22.08)