### PR TITLE
paramiko, bump version, add python{3.8,3.9,3.10}

### DIFF
--- a/dev-python/paramiko/paramiko-2.11.0.recipe
+++ b/dev-python/paramiko/paramiko-2.11.0.recipe
@@ -7,10 +7,10 @@ COPYRIGHT="2003-2009  Robey Pointer"
 LICENSE="GNU LGPL v2.1"
 REVISION="1"
 SOURCE_URI="https://pypi.io/packages/source/p/paramiko/paramiko-$portVersion.tar.gz"
-CHECKSUM_SHA256="7f36f4ba2c0d81d219f4595e35f70d56cc94f9ac40a6acdf51d6ca210ce65035"
+CHECKSUM_SHA256="003e6bee7c034c21fbb051bf83dc0a9ee4106204dd3c53054c71452cc4ec3938"
 
 ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="?x86"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	$portName = $portVersion
@@ -21,12 +21,11 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	devel:libffi$secondaryArchSuffix
 	"
-TEST_REQUIRES="
-	pytest
-	"
-PYTHON_PACKAGES=(python3)
-PYTHON_VERSIONS=(3.7)
+
+PYTHON_PACKAGES=(python3 python38 python39 python310)
+PYTHON_VERSIONS=(3.7 3.8 3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -35,19 +34,32 @@ eval "PROVIDES_${pythonPackage}=\"\
 	\"; \
 REQUIRES_$pythonPackage=\"\
 	haiku$secondaryArchSuffix\n\
-	bcrypt_$pythonPackage >= 3.1.7\n\
-	cryptography${secondaryArchSuffix}_$pythonPackage\n\
-	pynacl${secondaryArchSuffix}_$pythonPackage >= 1.3.0\n\
+	bcrypt_$pythonPackage\n\
+	cryptography_$pythonPackage\n\
+	pynacl_$pythonPackage\n\
+	pyasn1_$pythonPackage\n\
+	six_$pythonPackage\n\
 	cmd:python$pythonVersion\
 	\""
 BUILD_REQUIRES="$BUILD_REQUIRES
 	setuptools_$pythonPackage
 	"
 BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	cmd:python$pythonVersion
+	"
 TEST_REQUIRES="$TEST_REQUIRES
+	bcrypt_$pythonPackage
+	cryptography_$pythonPackage
+	importlib_metadata_$pythonPackage
+#	invoke_$pythonPackage
+#	pytest_relaxed_$pythonPackage
+	mock_$pythonPackage
+	pynacl_$pythonPackage
 	pytest_$pythonPackage
 	six_$pythonPackage
+	tomli_$pythonPackage
+	typing_extentions_$pythonPackage
+	lib:libsodium$secondaryArchSuffix
 	"
 done
 
@@ -77,6 +89,6 @@ TEST()
 		pythonVersion=${PYTHON_VERSIONS[$i]}
 
 		python=python$pythonVersion
-		pytest
+		pytest$pythonVersion
 	done
 }


### PR DESCRIPTION
Test still fails, but invoke/pytest_relaxed are not found, when enabled test will fail due to some known issue there.