### PR TITLE
stress-ng: bump to version 0.14.06

### DIFF
--- a/app-benchmarks/stress-ng/patches/stress_ng-0.14.06.patchset
+++ b/app-benchmarks/stress-ng/patches/stress_ng-0.14.06.patchset
@@ -1,0 +1,22 @@
+From 521487e8ee65dd3e5a636b6f037eae9718e321a5 Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Sat, 1 Oct 2022 21:04:09 +0200
+Subject: stress-touch: fix build
+
+
+diff --git a/stress-touch.c b/stress-touch.c
+index 9e412d5..2601fd0 100644
+--- a/stress-touch.c
++++ b/stress-touch.c
+@@ -185,7 +185,7 @@ static void stress_touch_dir_clean(const stress_args_t *args)
+ 	if (!dir)
+ 		return;
+ 	while ((d = readdir(dir)) != NULL) {
+-		char filename[PATH_MAX + sizeof(d->d_name) + 1];
++		char filename[PATH_MAX + 1];
+ 		struct stat statbuf;
+ 
+ 		(void)snprintf(filename, sizeof(filename), "%s/%s\n", tmp, d->d_name);
+-- 
+2.37.3
+

--- a/app-benchmarks/stress-ng/patches/stress_ng_x86-0.14.06.patchset
+++ b/app-benchmarks/stress-ng/patches/stress_ng_x86-0.14.06.patchset
@@ -1,15 +1,15 @@
-From 632e49dc6eebdbeebed5c5f91ca63ea98aa5dfc4 Mon Sep 17 00:00:00 2001
+From 23ea2d5e549bc7dab80b08cce909a3558bfbb270 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Fri, 26 Nov 2021 17:45:23 +0000
-Subject: disable 64K alignment on 32-bit Haiku
+Subject: disable too large alignment on 32-bit Haiku
 
 
 diff --git a/stress-icache.c b/stress-icache.c
-index bbff361..ed38bf7 100644
+index c53ecb3..2cc01e2 100644
 --- a/stress-icache.c
 +++ b/stress-icache.c
-@@ -161,14 +161,14 @@ static inline int icache_madvise(const stress_args_t *args, void *addr, size_t s
- 	return 0;
+@@ -169,14 +169,14 @@ func_name(const stress_args_t *args)					\
+ 	return EXIT_SUCCESS;						\
  }
  
 -#if defined(HAVE_ALIGNED_64K)
@@ -27,7 +27,7 @@ index bbff361..ed38bf7 100644
  #endif
  STRESS_ICACHE(stress_icache_16K, SIZE_16K, stress_icache_func_16K)
  STRESS_ICACHE(stress_icache_4K, SIZE_4K, stress_icache_func_4K)
-@@ -193,13 +193,13 @@ static int stress_icache(const stress_args_t *args)
+@@ -201,13 +201,13 @@ static int stress_icache(const stress_args_t *args)
  	case SIZE_16K:
  		ret = stress_icache_16K(args);
  		break;
@@ -43,6 +43,30 @@ index bbff361..ed38bf7 100644
  		pr_inf("%s: page size %zu is not %u or %u or %u, cannot test\n",
  			args->name, args->page_size,
  			SIZE_4K, SIZE_16K, SIZE_64K);
+diff --git a/stress-vecfp.c b/stress-vecfp.c
+index aa2b379..01da054 100644
+--- a/stress-vecfp.c
++++ b/stress-vecfp.c
+@@ -58,11 +58,19 @@ typedef double (*stress_vecfp_func_t)(
+ /*
+  *  float vectors, named by vfloatwN where N = number of elements width
+  */
++#ifdef __HAIKU__
++#define VEC_TYPE_T(type, elements)						\
++typedef union {									\
++	type v	 __attribute__ ((vector_size(sizeof(type) * elements)));\
++	type f[elements];						\
++} stress_vecfp_ ## type ## _ ## elements ## _t;
++#else
+ #define VEC_TYPE_T(type, elements)						\
+ typedef union {									\
+ 	type v	 ALIGNED(2048) __attribute__ ((vector_size(sizeof(type) * elements)));\
+ 	type f[elements] ALIGNED(2048);						\
+ } stress_vecfp_ ## type ## _ ## elements ## _t;
++#endif
+ 
+ VEC_TYPE_T(float, 256)
+ VEC_TYPE_T(float, 128)
 -- 
-2.30.2
+2.37.3
 

--- a/app-benchmarks/stress-ng/stress_ng-0.14.06.recipe
+++ b/app-benchmarks/stress-ng/stress_ng-0.14.06.recipe
@@ -33,13 +33,16 @@ processors as defined by sysconf(_SC_NPROCESSORS_ONLN)."
 HOMEPAGE="https://kernel.ubuntu.com/~cking/stress-ng/"
 COPYRIGHT="2013-2021 Colin Ian King"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://github.com/ColinIanKing/stress-ng/archive/V$portVersion.zip"
 SOURCE_DIR="stress-ng-$portVersion"
-CHECKSUM_SHA256="af08a8b3c434277d86eaaf7301c4dd1ff77c9e129291c754759fd86566cd49cc"
+CHECKSUM_SHA256="9af9f7ba0ea4db5d10074bb96416a7506b989a05f2b30a6eaa9d18a8da817ff6"
+PATCHES="stress_ng-$portVersion.patchset"
 
 if [ $effectiveTargetArchitecture = x86 ]; then
-	PATCHES="stress_ng_x86-$portVersion.patchset"
+	PATCHES+="
+		stress_ng_x86-$portVersion.patchset
+		"
 fi
 
 ARCHITECTURES="all !x86_gcc2"


### PR DESCRIPTION
some new alignment issues on 32-bit

otherwise the command line from trac ticket 17448 runs successfully:

`stress-ng --cpu 2 --vm 2 --hdd 1 --fork 8 --timeout 2m --metrics`