### PR TITLE
iperf3: new recipe

### DIFF
--- a/net-analyzer/iperf/iperf3-3.12.recipe
+++ b/net-analyzer/iperf/iperf3-3.12.recipe
@@ -1,0 +1,55 @@
+SUMMARY="Network bandwidth testing tool"
+DESCRIPTION="iperf3 is a tool for active measurements of the maximum \
+achievable bandwitdh on IP networks."
+HOMEPAGE="https://software.es.net/iperf/"
+COPYRIGHT="2014-2022 The Regents of the University of California, \
+through Lawrence Berkeley National Laboratory"
+LICENSE="BSD (3-clause)"
+REVISION="1"
+SOURCE_URI="https://downloads.es.net/pub/iperf/iperf-$portVersion.tar.gz"
+CHECKSUM_SHA256="72034ecfb6a7d6d67e384e19fb6efff3236ca4f7ed4c518d7db649c447e1ffd6"
+SOURCE_DIR="iperf-$portVersion"
+PATCHES="iperf3-$portVersion.patchset"
+
+if [ $effectiveTargetArchitecture = x86_gcc2 ]; then
+	PATCHES+="
+		iperf3-$portVersion.gcc2.patchset
+		"
+fi
+
+ARCHITECTURES="all"
+
+libVersion="0.0.0"
+
+PROVIDES="
+	iperf3 = $portVersion
+	cmd:iperf3 = $portVersion
+	lib:libiperf = $libVersion
+	"
+REQUIRES="
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:g++
+	cmd:gcc
+	cmd:grep
+	cmd:make
+	cmd:sed
+	"
+
+BUILD()
+{
+	runConfigure ./configure LDFLAGS="-lnetwork"
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+	rm $libDir/libiperf.a $libDir/libiperf.la
+}

--- a/net-analyzer/iperf/patches/iperf3-3.12.gcc2.patchset
+++ b/net-analyzer/iperf/patches/iperf3-3.12.gcc2.patchset
@@ -1,0 +1,271 @@
+From df494f4c930677160743252015ea35022db84480 Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Sun, 2 Oct 2022 19:42:19 +0000
+Subject: gcc2 patch
+
+
+diff --git a/src/iperf_api.c b/src/iperf_api.c
+index 16f93dc..e70d34c 100644
+--- a/src/iperf_api.c
++++ b/src/iperf_api.c
+@@ -2343,6 +2343,8 @@ send_results(struct iperf_test *test)
+ 		cJSON_AddItemReferenceToObject(j, "server_output_json", test->json_top);
+ 	    }
+ 	    else {
++		char *output;
++
+ 		/* Add textual output */
+ 		size_t buflen = 0;
+ 
+@@ -2353,7 +2355,7 @@ send_results(struct iperf_test *test)
+ 		}
+ 
+ 		/* Allocate and build it up from the component lines */
+-		char *output = calloc(buflen + 1, 1);
++		output = calloc(buflen + 1, 1);
+ 		TAILQ_FOREACH(t, &(test->server_output_list), textlineentries) {
+ 		    strncat(output, t->line, buflen);
+ 		    buflen -= strlen(t->line);
+@@ -2883,6 +2885,7 @@ iperf_free_test(struct iperf_test *test)
+ {
+     struct protocol *prot;
+     struct iperf_stream *sp;
++    struct iperf_textline *t;
+ 
+     /* Free streams */
+     while (!SLIST_EMPTY(&test->streams)) {
+@@ -2977,7 +2980,6 @@ iperf_free_test(struct iperf_test *test)
+     }
+ 
+     /* Free output line buffers, if any (on the server only) */
+-    struct iperf_textline *t;
+     while (!TAILQ_EMPTY(&test->server_output_list)) {
+ 	t = TAILQ_FIRST(&test->server_output_list);
+ 	TAILQ_REMOVE(&test->server_output_list, t, textlineentries);
+@@ -3013,6 +3015,7 @@ void
+ iperf_reset_test(struct iperf_test *test)
+ {
+     struct iperf_stream *sp;
++    struct iperf_textline *t;
+     int i;
+ 
+     /* Free streams */
+@@ -3124,7 +3127,6 @@ iperf_reset_test(struct iperf_test *test)
+     }
+ 
+     /* Free output line buffers, if any (on the server only) */
+-    struct iperf_textline *t;
+     while (!TAILQ_EMPTY(&test->server_output_list)) {
+ 	t = TAILQ_FIRST(&test->server_output_list);
+ 	TAILQ_REMOVE(&test->server_output_list, t, textlineentries);
+@@ -3295,8 +3297,9 @@ iperf_print_intermediate(struct iperf_test *test)
+     SLIST_FOREACH(sp, &test->streams, streams) {
+ 	irp = TAILQ_LAST(&sp->result->interval_results, irlisthead);
+ 	if (irp) {
++	    double interval_len;
+ 	    iperf_time_diff(&irp->interval_start_time, &irp->interval_end_time, &temp_time);
+-	    double interval_len = iperf_time_in_secs(&temp_time);
++	    interval_len = iperf_time_in_secs(&temp_time);
+ 	    if (test->debug) {
+ 		printf("interval_len %f bytes_transferred %" PRIu64 "\n", interval_len, irp->bytes_transferred);
+ 	    }
+@@ -4625,6 +4628,7 @@ iperf_json_start(struct iperf_test *test)
+ int
+ iperf_json_finish(struct iperf_test *test)
+ {
++    char *str;
+     if (test->title)
+ 	cJSON_AddStringToObject(test->json_top, "title", test->title);
+     if (test->extra_data)
+@@ -4639,7 +4643,7 @@ iperf_json_finish(struct iperf_test *test)
+     // Get ASCII rendering of JSON structure.  Then make our
+     // own copy of it and return the storage that cJSON allocated
+     // on our behalf.  We keep our own copy around.
+-    char *str = cJSON_Print(test->json_top);
++    str = cJSON_Print(test->json_top);
+     if (str == NULL)
+ 	return -1;
+     test->json_output_string = strdup(str);
+diff --git a/src/iperf_auth.c b/src/iperf_auth.c
+index 867c55f..21e575d 100644
+--- a/src/iperf_auth.c
++++ b/src/iperf_auth.c
+@@ -357,6 +357,8 @@ int decode_auth_setting(int enable_debug, const char *authtoken, EVP_PKEY *priva
+ ssize_t iperf_getpass (char **lineptr, size_t *n, FILE *stream) {
+     struct termios old, new;
+     ssize_t nread;
++    char *buf;
++    int i;
+ 
+     /* Turn echoing off and fail if we can't. */
+     if (tcgetattr (fileno (stream), &old) != 0)
+@@ -374,8 +376,7 @@ ssize_t iperf_getpass (char **lineptr, size_t *n, FILE *stream) {
+     (void) tcsetattr (fileno (stream), TCSAFLUSH, &old);
+ 
+     //strip the \n or \r\n chars
+-    char *buf = *lineptr;
+-    int i;
++    buf = *lineptr;
+     for (i = 0; buf[i] != '\0'; i++){
+         if (buf[i] == '\n' || buf[i] == '\r'){
+             buf[i] = '\0';
+diff --git a/src/iperf_client_api.c b/src/iperf_client_api.c
+index fbe1a61..c505f6a 100644
+--- a/src/iperf_client_api.c
++++ b/src/iperf_client_api.c
+@@ -54,18 +54,19 @@
+ int
+ iperf_create_streams(struct iperf_test *test, int sender)
+ {
+-    if (NULL == test)
+-    {
+-        iperf_err(NULL, "No test\n");
+-        return -1;
+-    }
+     int i, s;
+ #if defined(HAVE_TCP_CONGESTION)
+     int saved_errno;
+ #endif /* HAVE_TCP_CONGESTION */
+     struct iperf_stream *sp;
++    int orig_bind_port;
+ 
+-    int orig_bind_port = test->bind_port;
++    if (NULL == test)
++    {
++        iperf_err(NULL, "No test\n");
++        return -1;
++    }
++    orig_bind_port = test->bind_port;
+     for (i = 0; i < test->num_streams; ++i) {
+ 
+         test->bind_port = orig_bind_port;
+@@ -260,6 +261,7 @@ iperf_handle_message_client(struct iperf_test *test)
+ {
+     int rval;
+     int32_t err;
++    signed char oldstate;
+ 
+     if (NULL == test)
+     {
+@@ -327,7 +329,7 @@ iperf_handle_message_client(struct iperf_test *test)
+ 	     * Temporarily be in DISPLAY_RESULTS phase so we can get
+ 	     * ending summary statistics.
+ 	     */
+-	    signed char oldstate = test->state;
++	    oldstate = test->state;
+ 	    cpu_util(test->cpu_util);
+ 	    test->state = DISPLAY_RESULTS;
+ 	    test->reporter_callback(test);
+@@ -364,6 +366,7 @@ iperf_connect(struct iperf_test *test)
+ {
+     int opt;
+     socklen_t len;
++    int flag;
+ 
+     if (NULL == test)
+     {
+@@ -385,7 +388,7 @@ iperf_connect(struct iperf_test *test)
+     }
+ 
+     // set TCP_NODELAY for lower latency on control messages
+-    int flag = 1;
++    flag = 1;
+     if (setsockopt(test->ctrl_sck, IPPROTO_TCP, TCP_NODELAY, (char *) &flag, sizeof(int))) {
+         i_errno = IESETNODELAY;
+         return -1;
+@@ -478,12 +481,12 @@ iperf_connect(struct iperf_test *test)
+ int
+ iperf_client_end(struct iperf_test *test)
+ {
++    struct iperf_stream *sp;
+     if (NULL == test)
+     {
+         iperf_err(NULL, "No test\n");
+         return -1;
+     }
+-    struct iperf_stream *sp;
+ 
+     /* Close all stream sockets */
+     SLIST_FOREACH(sp, &test->streams, streams) {
+diff --git a/src/iperf_server_api.c b/src/iperf_server_api.c
+index d3551b0..eed846e 100644
+--- a/src/iperf_server_api.c
++++ b/src/iperf_server_api.c
+@@ -121,10 +121,11 @@ iperf_accept(struct iperf_test *test)
+     }
+ 
+     if (test->ctrl_sck == -1) {
++        int flag;
+         /* Server free, accept new client */
+         test->ctrl_sck = s;
+         // set TCP_NODELAY for lower latency on control messages
+-        int flag = 1;
++        flag = 1;
+         if (setsockopt(test->ctrl_sck, IPPROTO_TCP, TCP_NODELAY, (char *) &flag, sizeof(int))) {
+             i_errno = IESETNODELAY;
+             return -1;
+@@ -183,6 +184,7 @@ iperf_handle_message_server(struct iperf_test *test)
+ {
+     int rval;
+     struct iperf_stream *sp;
++    signed char oldstate;
+ 
+     // XXX: Need to rethink how this behaves to fit API
+     if ((rval = Nread(test->ctrl_sck, (char*) &test->state, sizeof(signed char), Ptcp)) <= 0) {
+@@ -226,7 +228,7 @@ iperf_handle_message_server(struct iperf_test *test)
+ 
+ 	    // Temporarily be in DISPLAY_RESULTS phase so we can get
+ 	    // ending summary statistics.
+-	    signed char oldstate = test->state;
++	    oldstate = test->state;
+ 	    cpu_util(test->cpu_util);
+ 	    test->state = DISPLAY_RESULTS;
+ 	    test->reporter_callback(test);
+@@ -492,6 +494,7 @@ iperf_run_server(struct iperf_test *test)
+     rcv_timeout_us = (test->settings->rcv_timeout.secs * SEC_TO_US) + test->settings->rcv_timeout.usecs;
+ 
+     while (test->state != IPERF_DONE) {
++		    iperf_size_t total_requested_rate;
+ 
+         // Check if average transfer rate was exceeded (condition set in the callback routines)
+ 	if (test->bitrate_limit_exceeded) {
+@@ -610,7 +613,6 @@ iperf_run_server(struct iperf_test *test)
+ 		    }
+ 
+                     if (!is_closed(s)) {
+-
+ #if defined(HAVE_TCP_USER_TIMEOUT)
+ 		    if (test->protocol->id == Ptcp) {
+                         int opt;
+@@ -753,7 +755,7 @@ iperf_run_server(struct iperf_test *test)
+                     test->prot_listener = -1;
+ 
+ 		    /* Ensure that total requested data rate is not above limit */
+-		    iperf_size_t total_requested_rate = test->num_streams * test->settings->rate * (test->mode == BIDIRECTIONAL? 2 : 1);
++		    total_requested_rate = test->num_streams * test->settings->rate * (test->mode == BIDIRECTIONAL? 2 : 1);
+ 		    if (test->settings->bitrate_limit > 0 && total_requested_rate > test->settings->bitrate_limit) {
+                         if (iperf_get_verbose(test))
+                             iperf_err(test, "Client total requested throughput rate of %" PRIu64 " bps exceeded %" PRIu64 " bps limit",
+diff --git a/src/t_api.c b/src/t_api.c
+index d822f55..9f13a84 100644
+--- a/src/t_api.c
++++ b/src/t_api.c
+@@ -65,6 +65,7 @@ main(int argc, char **argv)
+     const char *ver;
+     struct iperf_test *test;
+     int sint, gint;
++    int ret;
+ 
+     ver = iperf_get_iperf_version();
+     assert(strcmp(ver, IPERF_VERSION) == 0);
+@@ -79,7 +80,6 @@ main(int argc, char **argv)
+     gint = iperf_get_test_connect_timeout(test);
+     assert(sint == gint);
+ 
+-    int ret;
+     ret = test_iperf_set_test_bind_port(test);
+ 
+     ret += test_iperf_set_mss(test);
+-- 
+2.37.3
+

--- a/net-analyzer/iperf/patches/iperf3-3.12.patchset
+++ b/net-analyzer/iperf/patches/iperf3-3.12.patchset
@@ -1,0 +1,152 @@
+From b54e733f0eaedaacf4095f34560dafd9c512c794 Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Sat, 27 Nov 2021 21:24:06 +0000
+Subject: fix build on Haiku
+
+
+diff --git a/src/iperf_api.c b/src/iperf_api.c
+index 85939be..16f93dc 100644
+--- a/src/iperf_api.c
++++ b/src/iperf_api.c
+@@ -1157,7 +1157,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
+                 test->json_output = 1;
+                 break;
+             case 'v':
+-                printf("%s (cJSON %s)\n%s\n%s\n", version, cJSON_Version(), get_system_info(),
++                printf("%s (cJSON %s)\n%s\n%s\n", version, cJSON_Version(), do_get_system_info(),
+ 		       get_optional_features());
+                 exit(0);
+             case 's':
+diff --git a/src/iperf_client_api.c b/src/iperf_client_api.c
+index 5833068..fbe1a61 100644
+--- a/src/iperf_client_api.c
++++ b/src/iperf_client_api.c
+@@ -543,11 +543,11 @@ iperf_run_client(struct iperf_test * test)
+ 
+     if (test->json_output) {
+ 	cJSON_AddItemToObject(test->json_start, "version", cJSON_CreateString(version));
+-	cJSON_AddItemToObject(test->json_start, "system_info", cJSON_CreateString(get_system_info()));
++	cJSON_AddItemToObject(test->json_start, "system_info", cJSON_CreateString(do_get_system_info()));
+     } else if (test->verbose) {
+ 	iperf_printf(test, "%s\n", version);
+ 	iperf_printf(test, "%s", "");
+-	iperf_printf(test, "%s\n", get_system_info());
++	iperf_printf(test, "%s\n", do_get_system_info());
+ 	iflush(test);
+     }
+ 
+diff --git a/src/iperf_server_api.c b/src/iperf_server_api.c
+index b19cd72..d3551b0 100644
+--- a/src/iperf_server_api.c
++++ b/src/iperf_server_api.c
+@@ -470,11 +470,11 @@ iperf_run_server(struct iperf_test *test)
+ 
+     if (test->json_output) {
+ 	cJSON_AddItemToObject(test->json_start, "version", cJSON_CreateString(version));
+-	cJSON_AddItemToObject(test->json_start, "system_info", cJSON_CreateString(get_system_info()));
++	cJSON_AddItemToObject(test->json_start, "system_info", cJSON_CreateString(do_get_system_info()));
+     } else if (test->verbose) {
+ 	iperf_printf(test, "%s\n", version);
+ 	iperf_printf(test, "%s", "");
+-	iperf_printf(test, "%s\n", get_system_info());
++	iperf_printf(test, "%s\n", do_get_system_info());
+ 	iflush(test);
+     }
+ 
+diff --git a/src/iperf_util.c b/src/iperf_util.c
+index d5795ee..9179fff 100644
+--- a/src/iperf_util.c
++++ b/src/iperf_util.c
+@@ -224,7 +224,7 @@ cpu_util(double pcpu[3])
+ }
+ 
+ const char *
+-get_system_info(void)
++do_get_system_info(void)
+ {
+     static char buf[1024];
+     struct utsname  uts;
+diff --git a/src/iperf_util.h b/src/iperf_util.h
+index b109af2..251e740 100644
+--- a/src/iperf_util.h
++++ b/src/iperf_util.h
+@@ -48,7 +48,7 @@ double timeval_diff(struct timeval *tv0, struct timeval *tv1);
+ 
+ void cpu_util(double pcpu[3]);
+ 
+-const char* get_system_info(void);
++const char* do_get_system_info(void);
+ 
+ const char* get_optional_features(void);
+ 
+-- 
+2.37.3
+
+
+From 4dc5f3f923d3fdd9ae95304abeafa89d6623a263 Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Sat, 27 Nov 2021 21:58:25 +0000
+Subject: set default to IPv4
+
+
+diff --git a/src/iperf_sctp.c b/src/iperf_sctp.c
+index 1040832..7cfb061 100644
+--- a/src/iperf_sctp.c
++++ b/src/iperf_sctp.c
+@@ -171,11 +171,11 @@ iperf_sctp_listen(struct iperf_test *test)
+     memset(&hints, 0, sizeof(hints));
+     /*
+      * If binding to the wildcard address with no explicit address
+-     * family specified, then force us to get an AF_INET6 socket.
++     * family specified, then force us to get an AF_INET socket.
+      * More details in the comments in netanounce().
+      */
+     if (test->settings->domain == AF_UNSPEC && !test->bind_address) {
+-        hints.ai_family = AF_INET6;
++        hints.ai_family = AF_INET;
+     } else {
+         hints.ai_family = test->settings->domain;
+     }
+diff --git a/src/iperf_tcp.c b/src/iperf_tcp.c
+index 9620de5..f9d2828 100644
+--- a/src/iperf_tcp.c
++++ b/src/iperf_tcp.c
+@@ -178,11 +178,11 @@ iperf_tcp_listen(struct iperf_test *test)
+ 
+ 	/*
+ 	 * If binding to the wildcard address with no explicit address
+-	 * family specified, then force us to get an AF_INET6 socket.
++	 * family specified, then force us to get an AF_INET socket.
+ 	 * More details in the comments in netanounce().
+ 	 */
+ 	if (test->settings->domain == AF_UNSPEC && !test->bind_address) {
+-	    hints.ai_family = AF_INET6;
++	    hints.ai_family = AF_INET;
+ 	}
+ 	else {
+ 	    hints.ai_family = test->settings->domain;
+diff --git a/src/net.c b/src/net.c
+index 1a88155..a59ee6f 100644
+--- a/src/net.c
++++ b/src/net.c
+@@ -265,7 +265,7 @@ netannounce(int domain, int proto, const char *local, const char *bind_dev, int
+     memset(&hints, 0, sizeof(hints));
+     /*
+      * If binding to the wildcard address with no explicit address
+-     * family specified, then force us to get an AF_INET6 socket.  On
++     * family specified, then force us to get an AF_INET socket.  On
+      * CentOS 6 and MacOS, getaddrinfo(3) with AF_UNSPEC in ai_family,
+      * and ai_flags containing AI_PASSIVE returns a result structure
+      * with ai_family set to AF_INET, with the result that we create
+@@ -276,7 +276,7 @@ netannounce(int domain, int proto, const char *local, const char *bind_dev, int
+      * result structure is set to AF_INET6.
+      */
+     if (domain == AF_UNSPEC && !local) {
+-	hints.ai_family = AF_INET6;
++	hints.ai_family = AF_INET;
+     }
+     else {
+ 	hints.ai_family = domain;
+-- 
+2.37.3
+


### PR DESCRIPTION
There are a few kludges, I hope you'll still like it:
* name clash for `get_system_info()` resulting in stack overflow. I just renamed it to `do_get_system_info()`
* iperf3 uses IPv6 by default which doens't really work on Haiku so I changed default to IPv4
* the usual variable declaration issues on gcc2