### PR TITLE
hstr: fix configuration instructions and other minor changes.

### DIFF
--- a/app-shells/hstr/hstr-2.5.recipe
+++ b/app-shells/hstr/hstr-2.5.recipe
@@ -1,10 +1,10 @@
 SUMMARY="Shell history suggest box"
 DESCRIPTION="Easily view, navigate, search and use your command history with \
-shell history suggest box for Bash and ZSH."
+shell history suggest box for Bash."
 HOMEPAGE="http://me.mindforger.com/projects/hh.html"
 COPYRIGHT="2014-2021 Martin Dvorak"
 LICENSE="Apache v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/dvorka/hstr/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="7f5933fc07d55d09d5f7f9a6fbfdfc556d8a7d8575c3890ac1e672adabd2bec4"
 PATCHES="hstr-$portVersion.patchset"
@@ -13,11 +13,11 @@ ARCHITECTURES="all ?x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 # On x86_gcc2 we don't want to install the commands in bin/<arch>/, but in bin/.
-commandSuffix=$secondaryArchSuffix
 commandBinDir=$binDir
+commandSuffix=$secondaryArchSuffix
 if [ "$targetArchitecture" = x86_gcc2 ]; then
-	commandSuffix=
 	commandBinDir=$prefix/bin
+	commandSuffix=
 fi
 
 PROVIDES="
@@ -47,13 +47,12 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
-defineDebugInfoPackage hstr$secondaryArchSuffix \
-	"$commandBinDir"/hh
+defineDebugInfoPackage hstr$secondaryArchSuffix $commandBinDir/hstr
 
 BUILD()
 {
 	libtoolize --force --copy --install
-	aclocal -I m4
+	aclocal
 	autoconf
 	automake --add-missing --force-missing
 
@@ -67,9 +66,6 @@ BUILD()
 INSTALL()
 {
 	make install
-}
-
-TEST()
-{
-	make check
+	# Remove the "hh" symlink to "hstr". The user can create an alias if needed.
+	rm $commandBinDir/hh
 }

--- a/app-shells/hstr/patches/hstr-2.5.patchset
+++ b/app-shells/hstr/patches/hstr-2.5.patchset
@@ -1,4 +1,4 @@
-From 4b5cdd73ba59aed4ecbd6cfcff56edec73e01624 Mon Sep 17 00:00:00 2001
+From 727dd4c7f6459ff37d7f5f62f305de38d794c11c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
 Date: Sat, 27 Oct 2018 12:51:57 +0200
 Subject: Haiku supporting patches
@@ -68,7 +68,7 @@ index 8a50ab9..de92e58 100644
 2.37.3
 
 
-From d2c81bf97bfce27b2baa764f91ffef4097dbb729 Mon Sep 17 00:00:00 2001
+From 6099e00c93c0b98ba4ecc3a57fa5e1323830a82d Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Mon, 3 Oct 2022 06:59:40 -0300
 Subject: Updated Haiku support patch.
@@ -99,18 +99,114 @@ index eb5c80a..15c0b60 100644
 2.37.3
 
 
-From 5af8c31ff4012a93814580994478b66302dfeae8 Mon Sep 17 00:00:00 2001
+From 72755e1794ab4c4c139450e509a39ee36cc06d1f Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
-Date: Mon, 3 Oct 2022 07:04:35 -0300
-Subject: No dotfiles on Haiku
+Date: Sun, 9 Oct 2022 10:43:02 -0300
+Subject: Fix configuration instructions under Haiku.
+
+* Use the proper configuration instructions for bash in Haiu.
+  Big thanks to madmax for finding the issue!.
+* Show the correct locations for config files under Haiku.
+
+The issue was that, on platforms that lack the TIOCSTI ioctl, a
+workaround is needed to be able to insert text on the shell's command
+line. The workaround relies on defining a shell function,
+and keybinding said function so it gets handled by readline.
+
+Now, following the "hstr --show-configuration" instructions will
+result in C-r working as expected, at least for bash.
+
+It still won't under zsh (for the lack of a similar workaround,
+but implemented as a zsh function).
+
+diff --git a/src/hstr.c b/src/hstr.c
+index b0ee33f..cefe572 100644
+--- a/src/hstr.c
++++ b/src/hstr.c
+@@ -158,7 +158,11 @@ static const char* HSTR_CASE_LABELS[]={
+ };
+ 
+ static const char* INSTALL_BASH_STRING=
++#if defined(__HAIKU__)
++        "\n# HSTR configuration - add this to ~/config/settings/profile"
++#else
+         "\n# HSTR configuration - add this to ~/.bashrc"
++#endif
+         "\nalias hh=hstr                    # hh to be alias for hstr"
+         "\nexport HSTR_CONFIG=hicolor       # get more colors"
+         "\nshopt -s histappend              # append new history items to .bash_history"
+@@ -190,24 +194,28 @@ static const char* INSTALL_BASH_STRING=
+         "\n  READLINE_POINT=${#READLINE_LINE}"
+         "\n}"
+         "\nif [[ $- =~ .*i.* ]]; then bind -x '\"\\C-r\": \"hstrwsl\"'; fi"
+-#elif defined(__CYGWIN__)
+-        "\nfunction hstrcygwin {"
++#elif defined(__CYGWIN__) || defined(__HAIKU__)
++        "\nfunction hstr_helper {"
+         "\n  offset=${READLINE_POINT}"
+         "\n  READLINE_POINT=0"
+         "\n  { READLINE_LINE=$(</dev/tty hstr ${READLINE_LINE:0:offset} 2>&1 1>&$hstrout); } {hstrout}>&1"
+         "\n  READLINE_POINT=${#READLINE_LINE}"
+         "\n}"
+-        "\nif [[ $- =~ .*i.* ]]; then bind -x '\"\\C-r\": \"hstrcygwin\"'; fi"
++        "\nif [[ $- =~ .*i.* ]]; then bind -x '\"\\C-r\": \"hstr_helper\"'; fi"
+ #else
+         "\nif [[ $- =~ .*i.* ]]; then bind '\"\\C-r\": \"\\C-a hstr -- \\C-j\"'; fi"
++#endif
+         "\n# if this is interactive shell, then bind 'kill last command' to Ctrl-x k"
+         "\nif [[ $- =~ .*i.* ]]; then bind '\"\\C-xk\": \"\\C-a hstr -k \\C-j\"'; fi"
+-#endif
+         "\n\n";
+ 
+ // zsh doc: http://zsh.sourceforge.net/Guide/zshguide.html
+ static const char* INSTALL_ZSH_STRING=
++#if defined(__HAIKU__)
++        "\n# HSTR configuration - add this to ~/config/settings/zsh/.zshrc"
++#else
+         "\n# HSTR configuration - add this to ~/.zshrc"
++#endif
+         "\nalias hh=hstr                    # hh to be alias for hstr"
+         "\nsetopt histignorespace           # skip cmds w/ leading space from history"
+         // HISTFILE should not be needed - HSTR must work on blank environment as well
+@@ -228,7 +236,7 @@ static const char* INSTALL_ZSH_STRING=
+         "\n#bindkey -s \"\\C-r\" \"\\eqhstr_winwsl\\n\""
+         "\n"
+         "\nbindkey -s \"\\C-r\" \"\\eqhstr\\n\"     # bind hstr to Ctrl-r (for Vi mode check doc)"
+-#elif defined(__CYGWIN__)
++#elif defined(__CYGWIN__) || defined(__HAIKU__)
+         // TODO binding to be rewritten for zsh@Cygwin as it's done for bash - hstr_cygwin() like function to be implemented to make it work under Cygwin
+ 
+         "\n# Function and binding below is bash script that makes command completion work under Cygwin."
+@@ -260,8 +268,13 @@ static const char* HELP_STRING=
+         "\n  --favorites              -f ... show favorites view"
+         "\n  --kill-last-command      -k ... delete last command in history"
+         "\n  --non-interactive        -n ... print filtered history and exit"
++#if defined(__HAIKU__)
++        "\n  --show-configuration     -s ... show configuration to be added to ~/config/settings/profile"
++        "\n  --show-zsh-configuration -z ... show zsh configuration to be added to ~/config/settings/zsh/.zshrc"
++#else
+         "\n  --show-configuration     -s ... show configuration to be added to ~/.bashrc"
+         "\n  --show-zsh-configuration -z ... show zsh configuration to be added to ~/.zshrc"
++#endif
+         "\n  --show-blacklist         -b ... show commands to skip on history indexation"
+         "\n  --insert-in-terminal=[c] -i ... insert command c in terminal prompt and exit"
+         "\n  --version                -V ... show version details"
+-- 
+2.37.3
+
+
+From c079ab287f685d1ba01988c0c8c8944d6b9e59a6 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Sun, 9 Oct 2022 18:19:00 -0300
+Subject: Adjust location of history files.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 
-Based on the previous 2.0 patch from Zoltán Mizsei.
+Idea taken from the previous v2.0 patch by Zoltán Mizsei.
 
 diff --git a/src/include/hstr_history.h b/src/include/hstr_history.h
-index f715672..adffc64 100644
+index f715672..ea4bf23 100644
 --- a/src/include/hstr_history.h
 +++ b/src/include/hstr_history.h
 @@ -32,9 +32,15 @@
@@ -126,8 +222,8 @@ index f715672..adffc64 100644
 +    #define FILE_ZSH_ZHISTORY ".zhistory"
 +#else
 +    #define FILE_DEFAULT_HISTORY "bash_history"
-+    #define FILE_ZSH_HISTORY "zsh_history"
-+    #define FILE_ZSH_ZHISTORY "zhistory"
++    #define FILE_ZSH_HISTORY "zsh/.zsh_history"
++    #define FILE_ZSH_ZHISTORY "zsh/.zhistory"
 +#endif
  
  #define ZSH_HISTORY_EXT_DIGITS 10


### PR DESCRIPTION
* Use the proper configuration instructions for bash in Haiku. Big thanks to madmax for finding the issue!
* Reworked the patch about the history files locations.
* Removed the TEST() section, as "make check" had "nothing to do".
* Removed "-I m4" from aclocal, as it was not necessary.

The issue was that, on platforms that lack the TIOCSTI ioctl, a workaround is needed to be able to insert text on the shell's command line. The workaround relies on defining a shell function, and keybinding said function so it gets handled by readline.

Now, following the "hstr --show-configuration" instructions will result in C-r working as expected, at least for bash.

It still won't under zsh (for the lack of a similar workaround, but implemented as a zsh function).