### PR TITLE
PonpokoDiff: bump to latest gitrev.

### DIFF
--- a/haiku-apps/ponpokodiff/ponpokodiff-0.2.0.recipe
+++ b/haiku-apps/ponpokodiff/ponpokodiff-0.2.0.recipe
@@ -7,10 +7,12 @@ PonpokoDiff can also be used as an external diff command of Subversion \
 HOMEPAGE="https://github.com/HaikuArchives/PonpokoDiff"
 COPYRIGHT="2008 PonpokoDiff Project Contributors"
 LICENSE="MIT"
-REVISION="6"
-SOURCE_URI="https://github.com/HaikuArchives/PonpokoDiff/archive/fca91836407a07c0c56f2410b4960e8db024130b.tar.gz"
-CHECKSUM_SHA256="0e04cbabc123bb0892aa4bd386d3e95a5d448a17357f33e55cbc5874600a3b63"
-SOURCE_DIR="PonpokoDiff-fca91836407a07c0c56f2410b4960e8db024130b/source"
+REVISION="7"
+srcGitRev="534bbe74ccecda532529315db07769f1d7fe647e"
+SOURCE_URI="https://github.com/HaikuArchives/PonpokoDiff/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="99d88cecd955bb3279e241ef16e381816a057580428fd1552461bb3682b4a89b"
+SOURCE_FILENAME="PonpokoDiff-$srcGitRev.tar.gz"
+SOURCE_DIR="PonpokoDiff-$srcGitRev/source"
 
 ARCHITECTURES="all ?x86"
 


### PR DESCRIPTION
The recipe now uses $srcGitRev.

With the latest changes (from Nov 2021) you can now select two files from Tracker, and use "Open With -> PonpokoDiff" and it will show the Diff window right away (as one might have expected) making it SO MUCH more handy!