### PR TITLE
speex/speexdsp: bump to 1.2.1

### DIFF
--- a/media-libs/speex/patches/speex-1.2.1.patchset
+++ b/media-libs/speex/patches/speex-1.2.1.patchset
@@ -1,0 +1,22 @@
+From c451ca1806f4b64d214e25474ea9d2632fc65c61 Mon Sep 17 00:00:00 2001
+From: Robert Kausch <robert.kausch@freac.org>
+Date: Wed, 12 Oct 2022 23:14:39 +0000
+Subject: gcc2 fixes
+
+
+diff --git a/libspeex/stack_alloc.h b/libspeex/stack_alloc.h
+index f6eb3f6..dcea2f6 100644
+--- a/libspeex/stack_alloc.h
++++ b/libspeex/stack_alloc.h
+@@ -100,7 +100,7 @@
+ 
+ #endif
+ 
+-#if defined(VAR_ARRAYS)
++#if defined(VAR_ARRAYS) && 0
+ #define VARDECL(var) 
+ #define ALLOC(var, size, type) type var[size]
+ #elif defined(USE_ALLOCA)
+-- 
+2.37.3
+

--- a/media-libs/speex/speex-1.2.1.recipe
+++ b/media-libs/speex/speex-1.2.1.recipe
@@ -16,9 +16,10 @@ COPYRIGHT="2002-2009 Xiph.org Foundation
 	2003 EpicGames
 	1992-1994 Jutta Degener, Carsten Bormann"
 LICENSE="Speex"
-REVISION="4"
+REVISION="1"
 SOURCE_URI="http://downloads.xiph.org/releases/speex/speex-$portVersion.tar.gz"
-CHECKSUM_SHA256="eaae8af0ac742dc7d542c9439ac72f1f385ce838392dc849cae4536af9210094"
+CHECKSUM_SHA256="4b44d4f2b38a370a2d98a78329fefc56a0cf93d1c1be70029217baae6628feea"
+PATCHES="speex-$portVersion.patchset"
 
 ARCHITECTURES="all"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
@@ -36,6 +37,7 @@ fi
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libogg$secondaryArchSuffix
+	lib:libspeexdsp$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
@@ -49,6 +51,7 @@ REQUIRES_devel="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libogg$secondaryArchSuffix
+	devel:libspeexdsp$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix

--- a/media-libs/speexdsp/speexdsp-1.2.1.recipe
+++ b/media-libs/speexdsp/speexdsp-1.2.1.recipe
@@ -18,13 +18,13 @@ COPYRIGHT="2002-2009 Xiph.org Foundation
 LICENSE="Speex"
 REVISION="1"
 SOURCE_URI="https://downloads.xiph.org/releases/speex/speexdsp-${portVersion/\~/}.tar.gz"
-CHECKSUM_SHA256="682042fc6f9bee6294ec453f470dadc26c6ff29b9c9e9ad2ffc1f4312fd64771"
+CHECKSUM_SHA256="8c777343e4a6399569c72abc38a95b24db56882c83dbdb6c6424a5f4aeb54d3d"
 SOURCE_DIR="speexdsp-${portVersion/\~/}"
 
 ARCHITECTURES="all"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
-libVersion="1.5.1"
+libVersion="1.5.2"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="


### PR DESCRIPTION
Adds a patch for GCC 2.95 compatibility (the definition of ALLOC for variable length arrays generated non-top-of-block variable declarations).

Also adds libspeexdsp as a dependency of speex. This enables two processing options in speexenc that were missing on Haiku.