### PR TITLE
bash_completion: fix location of bash_completion.sh

### DIFF
--- a/app-shells/bash_completion/bash_completion-2.11.recipe
+++ b/app-shells/bash_completion/bash_completion-2.11.recipe
@@ -13,7 +13,7 @@ a daily basis."
 HOMEPAGE="https://github.com/scop/bash-completion"
 COPYRIGHT="2006-2020 Debian Project"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/scop/bash-completion/releases/download/$portVersion/bash-completion-$portVersion.tar.xz"
 CHECKSUM_SHA256="73a8894bad94dee83ab468fa09f628daffd567e8bef1a24277f1e9a0daf911ac"
 SOURCE_DIR="bash-completion-$portVersion"
@@ -41,16 +41,17 @@ BUILD_PREREQUIRES="
 	"
 
 GLOBAL_WRITABLE_FILES="
-	settings/profile.d/bash_completion.sh auto-merge
+	settings/etc/profile.d/bash_completion.sh auto-merge
 	"
 USER_SETTINGS_FILES="
-	settings/profile.d/bash_completion.sh
+	settings/etc/profile.d/bash_completion.sh
 	"
 
 BUILD()
 {
 	autoreconf -i
-	runConfigure ./configure
+	runConfigure --omit-dirs sysconfdir \
+		./configure --sysconfdir=$settingsDir/etc
 	make $jobArgs
 }
 


### PR DESCRIPTION
Make sure bash_completion.sh is placed under `settings/etc/profile.d/` and not `settings/profile.d`. Otherwise bash would not source it properly.

Fixes #7233