### PR TITLE
requests: removed python 2.7

### DIFF
--- a/dev-python/requests/requests-2.27.1.recipe
+++ b/dev-python/requests/requests-2.27.1.recipe
@@ -4,7 +4,7 @@ HOMEPAGE="http://python-requests.org/
 	http://pypi.python.org/pypi/requests"
 COPYRIGHT="2022 Kenneth Reitz"
 LICENSE="Apache v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.io/packages/source/${portName:0:1}/$portName/$portName-$portVersion.tar.gz"
 CHECKSUM_SHA256="68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"
 SOURCE_FILENAME="requests-$portVersion.tar.gz"
@@ -21,8 +21,8 @@ REQUIRES="
 BUILD_REQUIRES="
 	haiku_devel
 	"
-PYTHON_PACKAGES=(python python3 python38 python39 python310)
-PYTHON_VERSIONS=(2.7 3.7 3.8 3.9 3.10)
+PYTHON_PACKAGES=(python3 python38 python39 python310)
+PYTHON_VERSIONS=(3.7 3.8 3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}


### PR DESCRIPTION
Fixes build on buildbot as Python 2.7 support is being removed.