### PR TITLE
portmidi: use fixed java version 11, don't require cmd:java

### DIFF
--- a/media-libs/portmidi/portmidi-2.0.3~git.recipe
+++ b/media-libs/portmidi/portmidi-2.0.3~git.recipe
@@ -4,7 +4,7 @@ HOMEPAGE="https://github.com/PortMidi/portmidi"
 COPYRIGHT="1999-2000 Ross Bencina and Phil Burk
 	2001-2009 Roger B. Dannenberg"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 srcGitRev="7db20989f1571b27bd01cf9418361e988bdcf99a"
 SOURCE_URI="https://github.com/PortMidi/portmidi/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="96872e3c89339c9cbe44d5d86de1745ced7d803563a3ef71840aa9b120497e60"
@@ -85,12 +85,11 @@ if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
 	REQUIRES_java="
 		haiku$secondaryArchSuffix
 		portmidi$secondaryArchSuffix == $portVersion base
-		cmd:java
-		java:runtime
+		java:runtime == 11
 		"
 
 	BUILD_REQUIRES+="
-		java:environment
+		java:environment == 11
 		"
 
 	BUILD_PREREQUIRES+="
@@ -127,7 +126,7 @@ INSTALL()
 		# the included pmdefaults script would need changes anyway, so we just create our own
 		cat <<- EOF > "$preferencesDir/PortMidi Setup"
 		#!/bin/sh
-		java -Djava.library.path=$libDir -jar $libDir/pmdefaults.jar > /dev/null
+		$JAVA_HOME/bin/java -Djava.library.path=$libDir -jar $libDir/pmdefaults.jar
 		EOF
 
 		chmod +x "$preferencesDir/PortMidi Setup"


### PR DESCRIPTION
OpenJDK 11 is an LTS version. This is probably the most appropriate version.