### PR TITLE
texlive, dblatex, lilypond: enable

### DIFF
--- a/app-text/dblatex/dblatex-0.3.12.recipe
+++ b/app-text/dblatex/dblatex-0.3.12.recipe
@@ -11,7 +11,7 @@ SOURCE_URI="https://downloads.sourceforge.net/project/dblatex/dblatex/dblatex-$p
 CHECKSUM_SHA256="16e82786272ed1806a079d37914d7ba7a594db792dc4cc34c1c3737dbd4da079"
 SOURCE_DIR="dblatex3-$portVersion"
 
-ARCHITECTURES="?any"
+ARCHITECTURES="any"
 
 PROVIDES="
 	dblatex = $portVersion

--- a/app-text/texlive/texlive-2022.recipe
+++ b/app-text/texlive/texlive-2022.recipe
@@ -26,7 +26,7 @@ ADDITIONAL_FILES="
 	texlive_update.sh
 	"
 
-ARCHITECTURES="?any"
+ARCHITECTURES="any"
 DISABLE_SOURCE_PACKAGE="yes"
 
 PROVIDES="

--- a/media-sound/lilypond/lilypond-2.24.0.recipe
+++ b/media-sound/lilypond/lilypond-2.24.0.recipe
@@ -10,8 +10,8 @@ SOURCE_URI="https://lilypond.org/download/source/v${portVersion%.*}/lilypond-$po
 CHECKSUM_SHA256="3cedbe3b92b02569e3a6f2f0674858967b3da278d70aa3e98aef5bdcd7f78b69"
 PATCHES="lilypond-$portVersion.patchset"
 
-ARCHITECTURES="?all !x86_gcc2"
-SECONDARY_ARCHITECTURES="?x86"
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
  	lilypond$secondaryArchSuffix = $portVersion
@@ -51,7 +51,7 @@ PROVIDES_doc="
 REQUIRES_doc="
 	lilypond$secondaryArchSuffix == $portVersion base
 	"
-ARCHITECTURES_doc="?any"
+ARCHITECTURES_doc="any"
 
 languages=(ca cs de es fr hu it ja nl pt zh)
 languageNames=(Catalan Czech German Spanish French Hungarian Italian Japanese Dutch Portuguese Chinese)
@@ -64,7 +64,7 @@ for i in "${!languages[@]}"; do
 		lilypond${secondaryArchSuffix}_doc == $portVersion base\
 		\"; \
 	SUMMARY_doc_${lang}=\"${SUMMARY} (${languageNames[$i]} documentation)\"\
-	ARCHITECTURES_doc_${lang}=\"?any\""
+	ARCHITECTURES_doc_${lang}=\"any\""
 done
 
 BUILD_REQUIRES="


### PR DESCRIPTION
this enables the texlive recipe and others which depend on it

I noticed that R (dev-lang/r) also has commented-out dependencies of texlive. Maybe this could be checked later as well.