### PR TITLE
fusesmb_haiku: require userland_fs >= hrev56446

### DIFF
--- a/sys-fs/fusesmb_haiku/fusesmb_haiku-0.9.recipe
+++ b/sys-fs/fusesmb_haiku/fusesmb_haiku-0.9.recipe
@@ -13,7 +13,7 @@ COPYRIGHT="2003-2006 Vincent Wagelaar
 	2017 Julian Harnath"
 LICENSE="GNU GPL v2
 	MIT"
-REVISION="4"
+REVISION="5"
 srcGirRev="62fb2fd9d00d9f9f08a828e251f4061d1e0a89e1"
 SOURCE_URI="https://github.com/HaikuArchives/fusesmb-haiku/archive/$srcGirRev.tar.gz"
 CHECKSUM_SHA256="282dba466ba9818d45fb5de4c58b4cb48673d01fae01eb2a4878e252fc28ef8b"
@@ -32,14 +32,14 @@ PROVIDES="
 REQUIRES="
 	haiku
 	samba
-	userland_fs
+	userland_fs >= r1~beta3_hrev56446
 	"
 
 BUILD_REQUIRES="
 	haiku
 	haiku_devel
 	samba_devel
-	userland_fs
+	userland_fs >= r1~beta3_hrev56446
 	"
 BUILD_PREREQUIRES="
 	cmd:gcc


### PR DESCRIPTION
The newer code (fusesmb_haiku-0.9) relies on code changes not available on Haiku versions older than hrev56446.

This means the package will remain broken on buildmaster until the switch to beta4. Thankfully, that'll be "Real Soon Now (tm)". :-D