### PR TITLE
ne: change default action for backspace key, and build against ncurses to fix redrawing issues.

### DIFF
--- a/app-editors/ne/ne-3.3.2.recipe
+++ b/app-editors/ne/ne-3.3.2.recipe
@@ -2,12 +2,14 @@ SUMMARY="The 'nice editor'"
 DESCRIPTION="ne is one of the few text editors which are \
 both easy to use for beginners and powerful enough for powerusers. \
 It supports UTF-8 and multi-column characters as well as syntax highlighting. \
-Is also has fully configurable key bindings and supports macros."
+Has a drop-down top menu (accesible with ESC, or F1), default keybindings like \
+CTRL+Q, CTRL+S, CTRL+O, etc, that resemble GUI editors. Keybindings are fully \
+configurable, and it also supports recording/replaying macros."
 HOMEPAGE="https://ne.di.unimi.it/"
 COPYRIGHT="1993-1998 Sebastiano Vigna
 	1999-2022 Todd M. Lewis and Sebastiano Vigna"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/vigna/ne/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="9b8b757db22bd8cb783cf063f514143a8c325e5c321af31901e0f76e77455417"
 PATCHES="ne-$portVersion.patchset"
@@ -85,12 +87,4 @@ INSTALL()
 	cp -p doc/ne.1 $manDir/man1
 	gunzip -c doc/ne.info.gz > $infoDir/ne.info
 	cp -pr doc/html doc/ne.txt doc/default.* README.md COPYING NEWS CHANGES $docDir
-
-	# Provide an optional fix to the "backspace not working" issue.
-	cat > $dataDir/ne/fix_backspace.keys <<-EOF
-		# Fix Backspace vs Delete issue. Copy this file as ~/config/settings/ne/.keys
-		# or add the following lines to that file, if it already exists.
-		KEY	0x7f BackSpace
-		KEY	0x115 DeleteChar
-	EOF
 }

--- a/app-editors/ne/ne-3.3.2.recipe
+++ b/app-editors/ne/ne-3.3.2.recipe
@@ -1,10 +1,27 @@
 SUMMARY="The 'nice editor'"
-DESCRIPTION="ne is one of the few text editors which are \
-both easy to use for beginners and powerful enough for powerusers. \
-It supports UTF-8 and multi-column characters as well as syntax highlighting. \
-Has a drop-down top menu (accesible with ESC, or F1), default keybindings like \
-CTRL+Q, CTRL+S, CTRL+O, etc, that resemble GUI editors. Keybindings are fully \
-configurable, and it also supports recording/replaying macros."
+DESCRIPTION="ne is easy to use for the beginner, but powerful and fully \
+configurable for the wizard, and most sparing in its resource usage.
+
+Some of ne's features:
+
+* Three user interfaces: control keystrokes, command line, and drop-down top menus \
+(accesible with ESC, or F1).
+* Keystrokes and menus are completely configurable (default keybindings like CTRL+Q, \
+CTRL+S, CTRL+O, etc, resemble GUI editors).
+* Syntax highlighting.
+* Full support for UTF-8 files, including multiple-column characters.
+* 64-bit file/line length.
+* Simple scripting language where scripts can be generated via an idiotproof record/play method.
+* Unlimited undo/redo capability (can be disabled with a command).
+* Automatic preferences system based on the extension of the file name being edited or \
+regex content matching.
+* Automatic completion of prefixes using words in your documents as dictionary.
+* A file requester with completion features for easy file retrieval.
+* Extended regular expression search and replace a la emacs and vi.
+* A very compact memory model—you can easily load and modify very large files, even if they \
+do not fit your core memory.
+* Editing of binary files.
+"
 HOMEPAGE="https://ne.di.unimi.it/"
 COPYRIGHT="1993-1998 Sebastiano Vigna
 	1999-2022 Todd M. Lewis and Sebastiano Vigna"
@@ -30,11 +47,12 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	lib:libncurses$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	ncurses6 # for the terminfo/termcap database
+	devel:libncurses$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
@@ -53,7 +71,7 @@ BUILD()
 	# might fail if it gets generated too late ("ne.h" can not find "enums.h").
 	cd src;
 	make CC=gcc enums.h
-	make $jobArgs CC=gcc NE_ANSI=1 NE_TERMCAP=1 NE_GLOBAL_DIR=$dataDir/ne
+	make $jobArgs CC=gcc LIBS=-lncurses NE_GLOBAL_DIR=$dataDir/ne
 
 	cd ..
 

--- a/app-editors/ne/patches/ne-3.3.2.patchset
+++ b/app-editors/ne/patches/ne-3.3.2.patchset
@@ -1,11 +1,11 @@
-From 9452565be9df0f5fdc8ca70569859ab2a06eb2ff Mon Sep 17 00:00:00 2001
+From 34b68db5988170e1b6729d517c44b9999e8f8588 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Thu, 27 Oct 2022 02:58:01 -0300
 Subject: Make PREFS_DIR be ~/config/settings/ne instead of "$HOME/.ne".
 
 
 diff --git a/src/prefs.c b/src/prefs.c
-index c02a819..38df834 100644
+index c02a819..ddfa694 100644
 --- a/src/prefs.c
 +++ b/src/prefs.c
 @@ -24,8 +24,12 @@
@@ -23,6 +23,29 @@ index c02a819..38df834 100644
  
  /* This string is appended to the filename extension. It tries to
  be enough strange to avoid clashes with macros. */
+-- 
+2.37.3
+
+
+From b356ee7cb29d0013bb1dc7fc6395c0ffea3b5a55 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Tue, 1 Nov 2022 08:16:22 -0300
+Subject: Workaround for the BACKSPACE vs DEL keys.
+
+
+diff --git a/src/inputclass.c b/src/inputclass.c
+index d1be5a5..de89aa1 100644
+--- a/src/inputclass.c
++++ b/src/inputclass.c
+@@ -95,7 +95,7 @@ const char *key_binding[NUM_KEYS] = {
+ 	NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,  /* P Q R S T U V W X Y Z [ \ ] ^ _  */
+ 	NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,  /* ` a b c d e f g h i j k l m n o  */
+ 	NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,        /* p q r s t u v w x y z { | } ~    */
+-	DELETECHAR_ABBREV,                         /*  127  7f */
++	BACKSPACE_ABBREV,                         /*  127  7f */
+ 
+ 	/* Control-meta-letter bindings (Ctrl-Alt-X)  128..159 80..9f */
+ 
 -- 
 2.37.3
 


### PR DESCRIPTION
~~A simple "is the workaround already applied" check is performed before making any change. Not ultra-sophisticated, but seems to work.~~

Should close #7333.

~~Tested with system and home package installations, without a `.keys` file in `~/config/settings/ne`, with one already containing the fix, and with an existing `.keys` with user content, but not the workaround.~~

~~Worked OK for me on these 6 cases. Albeit I've only tested these on 64 bits, I would expect it to work ok on 32 bits too.~~

~~This is my first time using post-install scripts, so... any suggestions/criticisms will be more than welcomed.~~

Thanks! 

Edit: workaround now applied directly on the executable, and not as a post-install keybinding setting.