### PR TITLE
Fix zziplib cmake build error

### DIFF
--- a/dev-libs/zziplib/zziplib-0.13.72.recipe
+++ b/dev-libs/zziplib/zziplib-0.13.72.recipe
@@ -5,7 +5,7 @@ HOMEPAGE="http://zziplib.sourceforge.net/"
 COPYRIGHT="1999-2010 Guido Draheim"
 LICENSE="GNU LGPL v2.1
 	MPL v1.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/gdraheim/zziplib/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="93ef44bf1f1ea24fc66080426a469df82fa631d13ca3b2e4abaeab89538518dc"
 SOURCE_FILENAME="zziplib-v$portVersion.tar.gz"

--- a/dev-libs/zziplib/zziplib-0.13.72.recipe
+++ b/dev-libs/zziplib/zziplib-0.13.72.recipe
@@ -91,7 +91,7 @@ PATCH()
 BUILD()
 {
 	mkdir -p build && cd build
-	cmake $cmakeDirArgs ..
+	cmake $cmakeDirArgs -DCMAKE_BUILD_TYPE=Release ..
 	make $jobArgs
 }
 


### PR DESCRIPTION
Fix zziplib cmake build error by specifying build type.