### PR TITLE
libsndfile: bump revision to rebuild with FLAC 1.4.2

### DIFF
--- a/media-libs/libsndfile/libsndfile-1.0.25.recipe
+++ b/media-libs/libsndfile/libsndfile-1.0.25.recipe
@@ -4,7 +4,7 @@ files containing sampled audio data."
 HOMEPAGE="http://www.mega-nerd.com/libsndfile"
 COPYRIGHT="1999-2011 Erik de Castro Lopo"
 LICENSE="GNU LGPL v2.1"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="http://www.mega-nerd.com/libsndfile/files/libsndfile-$portVersion.tar.gz"
 CHECKSUM_SHA256="59016dbd326abe7e2366ded5c344c853829bebfd1702ef26a07ef662d6aa4882"
 PATCHES="libsndfile-$portVersion.patchset"
@@ -52,8 +52,7 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	cmd:aclocal
-	cmd:autoconf
-	cmd:automake
+	cmd:autoreconf
 	cmd:find
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
@@ -64,10 +63,7 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	libtoolize --force --copy --install
-	aclocal -I M4
-	autoconf
-	automake
+	autoreconf -i
 	if [ $effectiveTargetArchitecture = x86_gcc2 ]; then
 		export CFLAGS=-O1
 	fi

--- a/media-libs/libsndfile/libsndfile-1.0.25.recipe
+++ b/media-libs/libsndfile/libsndfile-1.0.25.recipe
@@ -46,7 +46,7 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libflac$secondaryArchSuffix
+	devel:libflac$secondaryArchSuffix >= 12
 	devel:libogg$secondaryArchSuffix
 	devel:libvorbis$secondaryArchSuffix
 	"

--- a/media-libs/libsndfile/libsndfile-1.1.0.recipe
+++ b/media-libs/libsndfile/libsndfile-1.1.0.recipe
@@ -4,7 +4,7 @@ files containing sampled audio data."
 HOMEPAGE="http://libsndfile.github.io/libsndfile/"
 COPYRIGHT="1999-2021 Erik de Castro Lopo"
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/libsndfile/libsndfile/releases/download/$portVersion/libsndfile-$portVersion.tar.xz"
 CHECKSUM_SHA256="0f98e101c0f7c850a71225fb5feaf33b106227b3d331333ddc9bacee190bcf41"
 

--- a/media-libs/libsndfile/libsndfile-1.1.0.recipe
+++ b/media-libs/libsndfile/libsndfile-1.1.0.recipe
@@ -48,7 +48,7 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libflac$secondaryArchSuffix
+	devel:libflac$secondaryArchSuffix >= 12
 	devel:libogg$secondaryArchSuffix
 	devel:libopus$secondaryArchSuffix
 	devel:libspeex$secondaryArchSuffix


### PR DESCRIPTION
Bump revisions of libsndfile recipes to rebuild with FLAC 1.4.2.

**Should be merged after #7292.**

Needed because devel:libsndfile depends on devel:libflac and will be broken after the libFLAC soname change.