### PR TITLE
lilypond: replace texlive package requires with "tex:" ones

### DIFF
--- a/media-sound/lilypond/lilypond-2.22.2.recipe
+++ b/media-sound/lilypond/lilypond-2.22.2.recipe
@@ -43,6 +43,8 @@ REQUIRES="
 	lib:libpangoft2_1.0$secondaryArchSuffix
 	"
 
+SUMMARY_doc="${SUMMARY} (English and generic documentation)"
+
 PROVIDES_doc="
 	lilypond${secondaryArchSuffix}_doc = $portVersion
 	"
@@ -51,38 +53,23 @@ REQUIRES_doc="
 	"
 ARCHITECTURES_doc="?any"
 
-languages="ca cs de es fr hu it ja nl pt zh"
-for lang in $languages; do
+languages=(ca cs de es fr hu it ja nl pt zh)
+languageNames=(Catalan Czech German Spanish French Hungarian Italian Japanese Dutch Portuguese Chinese)
+for i in "${!languages[@]}"; do
+	lang=${languages[i]}
 	eval "PROVIDES_doc_${lang}=\"\
 		lilypond${secondaryArchSuffix}_doc_${lang} = $portVersion\
 		\"; \
 	REQUIRES_doc_${lang}=\"\
 		lilypond${secondaryArchSuffix}_doc == $portVersion base\
 		\"; \
-	SUMMARY_doc_${lang}=\"${SUMMARY} (documentation ${lang})\"\
+	SUMMARY_doc_${lang}=\"${SUMMARY} (${languageNames[$i]} documentation)\"\
 	ARCHITECTURES_doc_${lang}=\"?any\""
 done
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	tex_gyre
-	texlive_basic
-	# most of these texlive_lang* packages are needed by the tex engines
-	texlive_langchinese
-	texlive_langcyrillic # this one is specifically needed by lilypond
-	texlive_langczechslovak
-	texlive_langenglish
-	texlive_langeuropean
-	texlive_langfrench
-	texlive_langgerman
-	texlive_langgreek
-	texlive_langitalian
-	texlive_langother
-	texlive_langpolish
-	texlive_langportuguese
-	texlive_langspanish
-	texlive_metapost
-	texlive_plaingeneric
 	urw_base35_fonts
 	cmd:guile < 2
 	devel:libfreetype$secondaryArchSuffix
@@ -95,6 +82,24 @@ BUILD_REQUIRES="
 	devel:libintl$secondaryArchSuffix
 	devel:libltdl$secondaryArchSuffix
 	devel:libpangoft2_1.0$secondaryArchSuffix
+	tex:epsf
+	tex:lh
+	tex:metapost
+	# The following TeX packages are needed for creating tex formats:
+	# (because of texlive packaging, all hyphenation patterns are needed,
+	# the list contains one package from each collection)
+	tex:dehyph_exptl
+	tex:hyphen_afrikaans
+	tex:hyphen_ancientgreek
+	tex:hyphen_basque
+	tex:hyphen_catalan
+	tex:hyphen_chinese
+	tex:hyphen_croatian
+	tex:hyphen_czech
+	tex:hyphen_english
+	tex:hyphen_italian
+	tex:hyphen_polish
+	tex:hyphen_portuguese
 	"
 BUILD_PREREQUIRES="
 #	cmd:awk
@@ -165,7 +170,7 @@ INSTALL()
 	PATH=${PATH:2} make install-doc
 
 	# language specific doc packages
-	for lang in $languages; do
+	for lang in "${languages[@]}"; do
 		packageEntries doc_${lang} \
 			$(find $docDir -name "*.${lang}.*")
 	done


### PR DESCRIPTION
Also improve summaries of doc packages. For the language names, a similar technique to python packages is used.