### PR TITLE
Calendar: update to latest git-rev.

### DIFF
--- a/haiku-apps/calendar/calendar-0.1.recipe
+++ b/haiku-apps/calendar/calendar-0.1.recipe
@@ -13,12 +13,13 @@ Calendar'.
 preferences change but GUI string still needs to be localized."
 HOMEPAGE="https://github.com/HaikuArchives/Calendar"
 COPYRIGHT="2017 Akshay Agarwal
-	2017-2021 HaikuArchives Team"
+	2017-2022 HaikuArchives Team"
 LICENSE="MIT"
-REVISION="2"
-SOURCE_URI="$HOMEPAGE/archive/$portVersion.tar.gz"
-CHECKSUM_SHA256="c3d42cbd4554dda4e65cd5d8bb234ccfa2659cf5405046049d8528d3f86165ee"
-SOURCE_DIR="Calendar-$portVersion"
+REVISION="3"
+srcGitRev="97ebe6faa1cfd1954fc9a1dfd949305bc2817f8c"
+SOURCE_URI="$HOMEPAGE/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="1c655c6fa43a09df13441dbff175064458bcaa3d68ada6f514e49f1eeb672845"
+SOURCE_DIR="Calendar-$srcGitRev"
 
 ARCHITECTURES="all"
 
@@ -43,6 +44,7 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
+	cd main
 	make OBJ_DIR=objects $jobArgs
 	make OBJ_DIR=objects bindcatalogs
 }
@@ -51,7 +53,7 @@ INSTALL()
 {
 	mkdir -p "$appsDir"
 
-	cp objects/Calendar $appsDir
+	cp main/objects/Calendar $appsDir
 
 	addAppDeskbarSymlink "$appsDir"/Calendar
 }


### PR DESCRIPTION
Fixes the latest "missing symbols" issue, and also makes it possible to build on Haiku after hrev55770 (changes on BBitmap's ImportBits() methods).

Tested on x86_64.