### PR TITLE
BePDF: switch to latest git commit.

### DIFF
--- a/haiku-apps/bepdf/bepdf-2.1.4.recipe
+++ b/haiku-apps/bepdf/bepdf-2.1.4.recipe
@@ -8,10 +8,11 @@ COPYRIGHT="1997 Benoit Triquet
 	2013-2018 Augustin Cavalier
 	2019-2021 HaikuArchives Team"
 LICENSE="GNU GPL v2"
-REVISION="3"
-SOURCE_URI="https://github.com/HaikuArchives/BePDF/archive/${portVersion}-1.tar.gz"
-CHECKSUM_SHA256="a3f87e176ca04999f0efa4c2a325a9e4e6376fcb668a00bfad559c414973d42e"
-SOURCE_DIR="BePDF-${portVersion}-1"
+REVISION="4"
+srcGitRev="dad2e3e0fce7981eb22af5bef2f1311f0bf42e58"
+SOURCE_URI="https://github.com/HaikuArchives/BePDF/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="5464ef682fd3207c4d3be10d1680258deeb5d70ebe4b8aa86306a295e6425af4"
+SOURCE_DIR="BePDF-$srcGitRev"
 
 ARCHITECTURES="all"
 
@@ -36,10 +37,10 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	makefile_engine
-	cmd:freetype_config
 	cmd:gcc
 	cmd:htmldoc
 	cmd:make
+	cmd:pkg_config
 #	cmd:ps2pdf
 	"
 

--- a/haiku-apps/bepdf/bepdf-2.1.4.recipe
+++ b/haiku-apps/bepdf/bepdf-2.1.4.recipe
@@ -9,9 +9,9 @@ COPYRIGHT="1997 Benoit Triquet
 	2019-2021 HaikuArchives Team"
 LICENSE="GNU GPL v2"
 REVISION="4"
-srcGitRev="dad2e3e0fce7981eb22af5bef2f1311f0bf42e58"
+srcGitRev="7faf1810d975e3235c73b508c6d2c625b2c47dd4"
 SOURCE_URI="https://github.com/HaikuArchives/BePDF/archive/$srcGitRev.tar.gz"
-CHECKSUM_SHA256="5464ef682fd3207c4d3be10d1680258deeb5d70ebe4b8aa86306a295e6425af4"
+CHECKSUM_SHA256="0a792f33b17781c11315ad0a3f2198255ce8bfa8308edabfa67cc8f14b1b8f8f"
 SOURCE_DIR="BePDF-$srcGitRev"
 
 ARCHITECTURES="all"


### PR DESCRIPTION
Switching to latest git commit, and dropping freetype_config in favor of pkg_config fixes the builds on newer Haiku revisions.

Builds and runs OK on both 64 and 32 bits (hrev56584).