### PR TITLE
BePodder: switch to using srcGitRev (and latest git-rev).

### DIFF
--- a/haiku-apps/bepodder/bepodder-1.5.0.recipe
+++ b/haiku-apps/bepodder/bepodder-1.5.0.recipe
@@ -23,11 +23,12 @@ HOMEPAGE="https://github.com/HaikuArchives/BePodder"
 COPYRIGHT="2006-2014 Funky Idea Software
 	2015-2018 HaikuArchives Team"
 LICENSE="MIT"
-REVISION="2"
-SOURCE_URI="$HOMEPAGE/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="c63b1ed184c6425ec42f32c08a02c22ea7b3aa8625ef33c6577b5639a9e5b45f"
-SOURCE_FILENAME="bepodder-$portVersion.tar.gz"
-SOURCE_DIR="BePodder-$portVersion"
+REVISION="3"
+srcGitRev="17a9e0d3f74d8399974585bdfa9b03dfd82eb1dd"
+SOURCE_URI="$HOMEPAGE/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="b4cb279abdb3451c6ebfdd6c7cbafae89939ded9b742e3dc2ed479aefc57b607"
+SOURCE_FILENAME="bepodder-$srcGitRev.tar.gz"
+SOURCE_DIR="BePodder-$srcGitRev"
 
 ARCHITECTURES="all"
 


### PR DESCRIPTION
This solves the missing symbol and build issues, and will also enable the use of the newer/updated translations.

Edit: Tested on both 32 and 64 bits installs.