### PR TITLE
wxgtk: remove nonexistent include directory from wx-config

### DIFF
--- a/x11-libs/wxgtk/wxgtk-3.2.1.recipe
+++ b/x11-libs/wxgtk/wxgtk-3.2.1.recipe
@@ -9,7 +9,7 @@ open-source and mature."
 HOMEPAGE="https://www.wxwidgets.org/"
 COPYRIGHT="1998-2022 Julian Smart, Robert Roebling et al"
 LICENSE="GNU LGPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/wxWidgets/wxWidgets/releases/download/v$portVersion/wxWidgets-$portVersion.tar.bz2"
 CHECKSUM_SHA256="c229976bb413eb88e45cb5dfb68b27890d450149c09b331abd751e7ae0f5fa66"
 SOURCE_DIR="wxWidgets-$portVersion"
@@ -189,6 +189,9 @@ INSTALL()
 	# Remove the symlinked wx-config and put the real one there instead.
 	rm $binDir/wx-config
 	mv $libDir/wx/config/gtk3-unicode-3.2 $binDir/wx-config
+
+	# Remove nonexistent directory from cflags
+	sed -i 's!"-I${libdir}/wx/include/gtk3-unicode-3.2" !!' $binDir/wx-config
 
 	# Move setup.h to the main include directory.
 	mv $libDir/wx/include/gtk3-unicode-3.2/wx/setup.h $includeDir/wx-3.2/wx/


### PR DESCRIPTION
Before: wx-config returns two include directories $libDir/wx/include/gtk3-unicode-3.2 and $includeDir/wx-3.2
The first directory originally holds the setup.h but that's moved to $includeDir/wx-3.2 in line 197 of the recipe and then it's deleted. So it points to a non-existent path, resulting in CMake complaining e.g. when trying to build audacity 3.x

After the patch wx-config returns only the second include dir i.e. $includeDir/wx-3.2
With this patch I'm able to build audacity 3.1.3 and 3.2.1
