### PR TITLE
audacity: disable vst

### DIFF
--- a/media-sound/audacity/audacity-3.1.3.recipe
+++ b/media-sound/audacity/audacity-3.1.3.recipe
@@ -100,7 +100,8 @@ BUILD()
 		$cmakeDirArgs \
 		-DCMAKE_BUILD_TYPE=Release \
 		-Daudacity_conan_enabled=Off \
-		-Daudacity_use_pch=no
+		-Daudacity_use_pch=no \
+		-Daudacity_use_vst=no
 	cmake --build build $jobArgs
 }
 


### PR DESCRIPTION
We need to disable VST plugins to rebuild with Wayland.
After that the GUI is much better: no more flickering and the hotkeys and toolbar icons work much better.