### PR TITLE
filezilla: new recipe

### DIFF
--- a/net-ftp/filezilla/filezilla-3.62.1.recipe
+++ b/net-ftp/filezilla/filezilla-3.62.1.recipe
@@ -1,0 +1,95 @@
+SUMMARY="The free FTP solution"
+DESCRIPTION="FileZilla Client is a fast and reliable cross-platform \
+FTP, FTPS and SFTP client with lots of useful features and an intuitive \
+graphical user interface."
+HOMEPAGE="https://filezilla-project.org/"
+
+COPYRIGHT="2015-2022 Tim Kosse"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="https://download.filezilla-project.org/client/FileZilla_${portVersion}_src.tar.bz2"
+CHECKSUM_SHA256="3c73c52384e366306cfd0edf75b7bb858856c7d74adecc2f0c7a28883835a4a2"
+PATCHES="filezilla-$portVersion.patchset"
+
+ARCHITECTURES="?all !x86_gcc2"
+
+PROVIDES="
+	filezilla = $portVersion
+	app:FileZilla = $portVersion
+	cmd:filezilla
+	cmd:fzputtygen
+	cmd:fzsftp
+	lib:libfzclient_commonui_private
+	lib:libfzclient_commonui_private_$portVersion
+	lib:libfzclient_private
+	lib:libfzclient_private_$portVersion
+	"
+
+REQUIRES="
+	haiku
+	wxgtk
+	lib:libatk_1.0
+	lib:libcairo
+	lib:libfilezilla
+	lib:libgdk_pixbuf_2.0
+	lib:libglib_2.0
+	lib:libgtk_3
+	lib:libharfbuzz
+	lib:libiconv
+	lib:libidn
+	lib:libintl
+	lib:libnettle
+	lib:libpango_1.0
+	lib:libpugixml
+	lib:libsqlite3
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	wxgtk_Devel
+	xdg_utils
+	xz_utils_devel
+	devel:libfilezilla
+	devel:libgnutls
+	devel:libiconv
+	devel:libidn
+	devel:libnettle
+	devel:libpugixml
+	devel:libsqlite3
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:awk
+	cmd:diff
+	cmd:gcc
+	cmd:make
+	cmd:pkg_config
+	cmd:wx_config
+	cmd:xgettext
+	"
+
+defineDebugInfoPackage filezilla \
+	"$libDir"/libfzclient-commonui-private.so \
+	"$libDir"/libfzclient-private.so \
+	"$binDir"/filezilla
+
+BUILD()
+{
+	mkdir -p src/fzshellext/32
+	mkdir -p src/fzshellext/64
+	autoreconf
+	mkdir -p build
+	cd build
+	runConfigure ../configure --disable-shellext --without-dbus
+
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make -C build install
+
+	mkdir -p $developLibDir
+	mv $libDir/*.la $developLibDir/
+}

--- a/net-ftp/filezilla/patches/filezilla-3.62.1.patchset
+++ b/net-ftp/filezilla/patches/filezilla-3.62.1.patchset
@@ -1,0 +1,191 @@
+From ef65d47fef4d4f6040adfa0de58bf49c829acc4e Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Sat, 19 Nov 2022 13:44:51 +0100
+Subject: enable build with wxgtk 3.2.x
+
+
+diff --git a/configure.ac b/configure.ac
+index f5282fa..eaee0d2 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -182,7 +182,7 @@ if test "$buildmain" = "yes"; then
+     AC_MSG_ERROR([You must use wxWidgets 3.0.x, development versions of wxWidgets are not supported.])
+   elif test "${WX_VERSION_MAJOR}.${WX_VERSION_MINOR}" != "3.0"; then
+     if ! echo "$WX_CPPFLAGS" | grep __WXMAC__ > /dev/null; then
+-      AC_MSG_ERROR([You must use wxWidgets 3.0.x, wxWidgets 3.2 or higher is not yet supported.])
++      AC_MSG_WARN([You must use wxWidgets 3.0.x, wxWidgets 3.2 or higher is not yet supported.])
+     fi
+   fi
+ 
+-- 
+2.37.3
+
+
+From 95223adc8b0c6bd69595620c2acb7a171e11af11 Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Sat, 19 Nov 2022 13:44:51 +0100
+Subject: stub wordexp
+
+
+diff --git a/src/commonui/fz_paths.cpp b/src/commonui/fz_paths.cpp
+index a9f64f7..da7a66b 100644
+--- a/src/commonui/fz_paths.cpp
++++ b/src/commonui/fz_paths.cpp
+@@ -15,8 +15,10 @@
+ 	#include <objbase.h>
+ #else
+ 	#include <unistd.h>
++#ifndef __HAIKU__
+ 	#include <wordexp.h>
+ #endif
++#endif
+ 
+ using namespace std::literals;
+ 
+@@ -487,6 +489,8 @@ char const* GetDownloadDirImpl();
+ #elif !defined(FZ_WINDOWS)
+ 
+ namespace {
++
++#ifndef __HAIKU__
+ std::string ShellUnescape(std::string const& path)
+ {
+ 	std::string ret;
+@@ -500,6 +504,12 @@ std::string ShellUnescape(std::string const& path)
+ 
+ 	return ret;
+ }
++#else
++std::string ShellUnescape(std::string const& path)
++{
++	return path;
++}
++#endif
+ 
+ size_t next_line(fz::file& f, fz::buffer& buf, size_t maxlen = 16 * 1024)
+ {
+-- 
+2.37.3
+
+
+From 5ca49bc0a791188227d5635141e5b6a5b66b9109 Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Sat, 19 Nov 2022 13:44:51 +0100
+Subject: configure: detect -lnetwork
+
+
+diff --git a/configure.ac b/configure.ac
+index eaee0d2..e29c784 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -260,7 +260,7 @@ if test "$buildmain" = "yes"; then
+   #include <sys/types.h>
+   #include <utmp.h>])
+ 
+-  AC_SEARCH_LIBS([socket], [xnet])
++  AC_SEARCH_LIBS([socket], [network xnet])
+   AC_SEARCH_LIBS([getaddrinfo], [xnet])
+   AC_SEARCH_LIBS([in6addr_loopback], [socket])
+ 
+-- 
+2.37.3
+
+
+From 11a84222aebaccffdf5ae25c4cd5575ba17e7813 Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Sat, 19 Nov 2022 13:44:51 +0100
+Subject: adjust folders for Haiku
+
+
+diff --git a/src/commonui/Makefile.am b/src/commonui/Makefile.am
+index dbd9a00..c6ea81a 100644
+--- a/src/commonui/Makefile.am
++++ b/src/commonui/Makefile.am
+@@ -5,6 +5,7 @@ lib_LTLIBRARIES = libfzclient-commonui-private.la
+ libfzclient_commonui_private_la_CPPFLAGS = -I$(top_builddir)/config
+ libfzclient_commonui_private_la_CPPFLAGS += $(LIBFILEZILLA_CFLAGS)
+ libfzclient_commonui_private_la_CPPFLAGS += -DBUILDING_FZ_COMMONUI
++libfzclient_commonui_private_la_CPPFLAGS += -DDATADIR='L"$(datadir)"'
+ 
+ libfzclient_commonui_private_la_CXXFLAGS = -fvisibility=hidden
+ libfzclient_commonui_private_la_LDFLAGS = -no-undefined -release $(PACKAGE_VERSION_MAJOR).$(PACKAGE_VERSION_MINOR).$(PACKAGE_VERSION_MICRO)
+diff --git a/src/commonui/fz_paths.cpp b/src/commonui/fz_paths.cpp
+index da7a66b..9199cbf 100644
+--- a/src/commonui/fz_paths.cpp
++++ b/src/commonui/fz_paths.cpp
+@@ -287,6 +287,19 @@ CLocalPath GetFZDataDir(std::vector<std::wstring> const& fileToFind, std::wstrin
+ 		}
+ 	}
+ 
++#ifdef DATADIR
++	std::wstring dataDir(DATADIR);
++	if (testPath(dataDir)) {
++		return ret;
++	}
++
++	if (!prefixSub.empty()) {
++		if (testPath(dataDir + L_DIR_SEP + prefixSub)) {
++			return ret;
++		}
++	}
++#endif
++
+ 	std::wstring selfDir = GetOwnExecutableDir();
+ 	if (!selfDir.empty()) {
+ 		if (searchSelfDir && testPath(selfDir)) {
+@@ -349,7 +362,7 @@ CLocalPath GetDefaultsDir()
+ 
+ #endif
+ 		if (path.empty()) {
+-			path = GetFZDataDir({ L"fzdefaults.xml" }, L"share/filezilla");
++			path = GetFZDataDir({ L"fzdefaults.xml" }, L"filezilla");
+ 		}
+ 		return path;
+ 	}();
+diff --git a/src/interface/FileZilla.cpp b/src/interface/FileZilla.cpp
+index df54eeb..9652cac 100644
+--- a/src/interface/FileZilla.cpp
++++ b/src/interface/FileZilla.cpp
+@@ -294,7 +294,7 @@ int CFileZillaApp::OnExit()
+ bool CFileZillaApp::LoadResourceFiles()
+ {
+ 	AddStartupProfileRecord("CFileZillaApp::LoadResourceFiles");
+-	m_resourceDir = GetFZDataDir({L"resources/defaultfilters.xml"}, L"share/filezilla");
++	m_resourceDir = GetFZDataDir({L"resources/defaultfilters.xml"}, L"filezilla");
+ 
+ 	wxImage::AddHandler(new wxPNGHandler());
+ 
+@@ -322,7 +322,7 @@ bool CFileZillaApp::LoadLocales()
+ 	}
+ #ifndef __WXMAC__
+ 	else {
+-		m_localesDir = GetFZDataDir({L"de/filezilla.mo", L"de/LC_MESSAGES/filezilla.mo"}, L"share/locale", false);
++		m_localesDir = GetFZDataDir({L"de/filezilla.mo", L"de/LC_MESSAGES/filezilla.mo"}, L"locale", false);
+ 	}
+ #endif
+ 	if (!m_localesDir.empty()) {
+diff --git a/src/interface/locale_initializer.cpp b/src/interface/locale_initializer.cpp
+index c7d2fc7..fac6aa7 100644
+--- a/src/interface/locale_initializer.cpp
++++ b/src/interface/locale_initializer.cpp
+@@ -204,7 +204,7 @@ std::string CInitializer::GetDefaultsXmlFile()
+ 	std::string selfPath = fz::to_string(GetOwnExecutableDir());
+ 	file = CheckPathForDefaults(selfPath, 0, "fzdefaults.xml");
+ 	if (selfPath.size() > 5 && fz::ends_with(selfPath, std::string("/bin/"))) {
+-		file = CheckPathForDefaults(selfPath.substr(0, selfPath.size() - 4), 0, "share/filezilla/fzdefaults.xml");
++		file = CheckPathForDefaults(selfPath.substr(0, selfPath.size() - 4), 0, "data/filezilla/fzdefaults.xml");
+ 		if (!file.empty()) {
+ 			return file;
+ 		}
+@@ -225,7 +225,7 @@ std::string CInitializer::GetDefaultsXmlFile()
+ 			path += '/';
+ 		}
+ 		if (segment.size() > 5 && fz::ends_with(segment, std::string("/bin/"))) {
+-			file = CheckPathForDefaults(segment.substr(0, segment.size() - 4), 0, "share/filezilla/fzdefaults.xml");
++			file = CheckPathForDefaults(segment.substr(0, segment.size() - 4), 0, "data/filezilla/fzdefaults.xml");
+ 			if (!file.empty()) {
+ 				return file;
+ 			}
+-- 
+2.37.3
+


### PR DESCRIPTION
We need a few kludges:
* enable build with wxWidgets 3.2 - by default filezilla requires 3.0
* stub function ShellUnescape as we don't have `wordexp`
* adjust folder names

With these changes, it's possible to build filezilla without any policy warnings (in haikupoter strict mode as well), filezilla starts up succesfully. I tested connecting to localhost and retrieving directory listing, not much else.

![image](https://user-images.githubusercontent.com/92124087/204638152-a86c765b-0de2-4648-a56f-cb478ec21891.png)
