### PR TITLE
wireshark: update rdef, enable ninja build

### DIFF
--- a/net-analyzer/wireshark/additional-files/wireshark.rdef.in
+++ b/net-analyzer/wireshark/additional-files/wireshark.rdef.in
@@ -2,15 +2,15 @@
 resource app_flags B_SINGLE_LAUNCH | B_ARGV_ONLY;
 
 resource app_version {
-       major  = 2,
-       middle = 0,
-       minor  = 0,
+       major  = @MAJOR@,
+       middle = @MIDDLE@,
+       minor  = @MINOR@,
 
        variety = B_APPV_FINAL,
        internal = 0,
 
        short_info = "Wireshark",
-       long_info = "A network protocol analyzer formerly known as ethereal."
+       long_info = "@LONG_INFO@"
 };
 
 resource app_signature "application/x-vnd.Wireshark";

--- a/net-analyzer/wireshark/wireshark-4.0.1.recipe
+++ b/net-analyzer/wireshark/wireshark-4.0.1.recipe
@@ -22,11 +22,11 @@ library, and libpcap, a packet capture and filtering library."
 HOMEPAGE="https://www.wireshark.org"
 COPYRIGHT="1998-2022 Gerald Combs"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/wireshark/wireshark/archive/wireshark-$portVersion.tar.gz"
 CHECKSUM_SHA256="87b0f41a8158f27a695936c5fdd14bd0c85544dcd584313deea404215d62561c"
 SOURCE_DIR="wireshark-wireshark-$portVersion"
-ADDITIONAL_FILES="wireshark.rdef"
+ADDITIONAL_FILES="wireshark.rdef.in"
 PATCHES="wireshark-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -147,8 +147,17 @@ INSTALL()
 	mkdir -p $appsDir
 	ln -s $prefix/bin/wireshark $appsDir/Wireshark
 
-	addResourcesToBinaries $portDir/additional-files/wireshark.rdef \
-		$appsDir/Wireshark
+	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
+	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
+	local MINOR="`echo "$portVersion" | cut -d. -f3`"
+	local LONG_INFO="$SUMMARY"
+	sed \
+		-e "s|@MAJOR@|$MAJOR|" \
+		-e "s|@MIDDLE@|$MIDDLE|" \
+		-e "s|@MINOR@|$MINOR|" \
+		-e "s|@LONG_INFO@|$LONG_INFO|" \
+		$portDir/additional-files/wireshark.rdef.in > $sourceDir/wireshark.rdef
+	addResourcesToBinaries $sourceDir/wireshark.rdef $appsDir/Wireshark
 
 	addAppDeskbarSymlink $appsDir/Wireshark
 

--- a/net-analyzer/wireshark/wireshark-4.0.1.recipe
+++ b/net-analyzer/wireshark/wireshark-4.0.1.recipe
@@ -117,7 +117,7 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:libtoolize
 	cmd:lrelease$secondaryArchSuffix >= 5
-	cmd:make
+	cmd:ninja
 	cmd:pkg_config$secondaryArchSuffix
 	cmd:python
 	cmd:strip$secondaryArchSuffix
@@ -125,17 +125,16 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	mkdir -p build
-	cd build
-	cmake .. $cmakeDirArgs \
+	cmake -S . -B build -G Ninja \
+		$cmakeDirArgs \
 		-DCMAKE_EXE_LINKER_FLAGS="-lnetwork" \
 		-DCMAKE_BUILD_TYPE=Release
-	make $jobArgs
+	cmake --build build $jobArgs
 }
 
 INSTALL()
 {
-	make -C build install
+	cmake --install build
 
 	prepareInstalledDevelLibs libwireshark libwiretap libwsutil
 	fixPkgconfig


### PR DESCRIPTION
* rdef used to have hard-coded version 2.0.0 let's replace it with automatically generated version number
* build with ninja
* revbump to trigger rebuild (especially needed for x86_64 as previously the builder was lost)