### PR TITLE
filezilla: update to 3.62.2

### DIFF
--- a/net-ftp/filezilla/filezilla-3.62.2.recipe
+++ b/net-ftp/filezilla/filezilla-3.62.2.recipe
@@ -8,7 +8,7 @@ COPYRIGHT="2015-2022 Tim Kosse"
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://download.filezilla-project.org/client/FileZilla_${portVersion}_src.tar.bz2"
-CHECKSUM_SHA256="3c73c52384e366306cfd0edf75b7bb858856c7d74adecc2f0c7a28883835a4a2"
+CHECKSUM_SHA256="a76709635ca0ea474f691f6c60b191334af3079ef192c07c346504baab738c12"
 PATCHES="filezilla-$portVersion.patchset"
 
 ARCHITECTURES="?all !x86_gcc2"

--- a/net-ftp/filezilla/patches/filezilla-3.62.2.patchset
+++ b/net-ftp/filezilla/patches/filezilla-3.62.2.patchset
@@ -1,27 +1,31 @@
-From ef65d47fef4d4f6040adfa0de58bf49c829acc4e Mon Sep 17 00:00:00 2001
-From: David Karoly <david.karoly@outlook.com>
-Date: Sat, 19 Nov 2022 13:44:51 +0100
-Subject: enable build with wxgtk 3.2.x
+From c0fae6779d337a1ec5a9c367aa921dbf8a32dd4a Mon Sep 17 00:00:00 2001
+From: codesquid <codesquid>
+Date: Thu, 1 Dec 2022 10:54:16 +0100
+Subject: Allow wx3.2 across the board.
 
 
 diff --git a/configure.ac b/configure.ac
-index f5282fa..eaee0d2 100644
+index b49ae75..a8f1c1d 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -182,7 +182,7 @@ if test "$buildmain" = "yes"; then
-     AC_MSG_ERROR([You must use wxWidgets 3.0.x, development versions of wxWidgets are not supported.])
-   elif test "${WX_VERSION_MAJOR}.${WX_VERSION_MINOR}" != "3.0"; then
-     if ! echo "$WX_CPPFLAGS" | grep __WXMAC__ > /dev/null; then
+@@ -179,11 +179,7 @@ if test "$buildmain" = "yes"; then
+     ])
+   fi
+   if test "${WX_VERSION_MAJOR}.${WX_VERSION_MINOR}" = "3.1"; then
+-    AC_MSG_ERROR([You must use wxWidgets 3.0.x, development versions of wxWidgets are not supported.])
+-  elif test "${WX_VERSION_MAJOR}.${WX_VERSION_MINOR}" != "3.0"; then
+-    if ! echo "$WX_CPPFLAGS" | grep __WXMAC__ > /dev/null; then
 -      AC_MSG_ERROR([You must use wxWidgets 3.0.x, wxWidgets 3.2 or higher is not yet supported.])
-+      AC_MSG_WARN([You must use wxWidgets 3.0.x, wxWidgets 3.2 or higher is not yet supported.])
-     fi
+-    fi
++    AC_MSG_ERROR([You must use wxWidgets 3.0.x, or 3.2.x, development versions of wxWidgets are not supported.])
    fi
  
+   if test "${WX_VERSION_MAJOR}.${WX_VERSION_MINOR}" = "3.0"; then
 -- 
 2.37.3
 
 
-From 95223adc8b0c6bd69595620c2acb7a171e11af11 Mon Sep 17 00:00:00 2001
+From 67795f7fcdd9e56cb134258306f7fb85ace79293 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Sat, 19 Nov 2022 13:44:51 +0100
 Subject: stub wordexp
@@ -68,17 +72,17 @@ index a9f64f7..da7a66b 100644
 2.37.3
 
 
-From 5ca49bc0a791188227d5635141e5b6a5b66b9109 Mon Sep 17 00:00:00 2001
+From 62b3c08bd5525e0449b6adae2bff30aea50c54b0 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Sat, 19 Nov 2022 13:44:51 +0100
 Subject: configure: detect -lnetwork
 
 
 diff --git a/configure.ac b/configure.ac
-index eaee0d2..e29c784 100644
+index a8f1c1d..65b1dac 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -260,7 +260,7 @@ if test "$buildmain" = "yes"; then
+@@ -256,7 +256,7 @@ if test "$buildmain" = "yes"; then
    #include <sys/types.h>
    #include <utmp.h>])
  
@@ -91,7 +95,7 @@ index eaee0d2..e29c784 100644
 2.37.3
 
 
-From 11a84222aebaccffdf5ae25c4cd5575ba17e7813 Mon Sep 17 00:00:00 2001
+From ca3472b7a047ca97d1f176a98e60ed25c8703f19 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Sat, 19 Nov 2022 13:44:51 +0100
 Subject: adjust folders for Haiku


### PR DESCRIPTION
FileZilla 3.62.2 almost officially builds with wxWidgets 3.2.x - we need to cherry-pick only a single commit from upstream.