### PR TITLE
filezilla: use BNotification

### DIFF
--- a/net-ftp/filezilla/filezilla-3.62.2.recipe
+++ b/net-ftp/filezilla/filezilla-3.62.2.recipe
@@ -81,7 +81,7 @@ BUILD()
 	autoreconf
 	mkdir -p build
 	cd build
-	runConfigure ../configure --disable-shellext --without-dbus
+	LDFLAGS=-lbe runConfigure ../configure --disable-shellext --without-dbus
 
 	make $jobArgs
 }

--- a/net-ftp/filezilla/patches/filezilla-3.62.2.patchset
+++ b/net-ftp/filezilla/patches/filezilla-3.62.2.patchset
@@ -1,4 +1,4 @@
-From c0fae6779d337a1ec5a9c367aa921dbf8a32dd4a Mon Sep 17 00:00:00 2001
+From e5513f8a3db622f72cab6ba1144a584c1212dcb2 Mon Sep 17 00:00:00 2001
 From: codesquid <codesquid>
 Date: Thu, 1 Dec 2022 10:54:16 +0100
 Subject: Allow wx3.2 across the board.
@@ -25,7 +25,7 @@ index b49ae75..a8f1c1d 100644
 2.37.3
 
 
-From 67795f7fcdd9e56cb134258306f7fb85ace79293 Mon Sep 17 00:00:00 2001
+From 7d0cb381f4361f020268f357c1b4f21fd17a544c Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Sat, 19 Nov 2022 13:44:51 +0100
 Subject: stub wordexp
@@ -72,7 +72,7 @@ index a9f64f7..da7a66b 100644
 2.37.3
 
 
-From 62b3c08bd5525e0449b6adae2bff30aea50c54b0 Mon Sep 17 00:00:00 2001
+From fb3d46e468bc2a49ff8e8455f410f30d5dc2dacc Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Sat, 19 Nov 2022 13:44:51 +0100
 Subject: configure: detect -lnetwork
@@ -95,7 +95,7 @@ index a8f1c1d..65b1dac 100644
 2.37.3
 
 
-From ca3472b7a047ca97d1f176a98e60ed25c8703f19 Mon Sep 17 00:00:00 2001
+From c3023a29746232c93f51c3b495c7b8da9b824480 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Sat, 19 Nov 2022 13:44:51 +0100
 Subject: adjust folders for Haiku
@@ -190,6 +190,72 @@ index c7d2fc7..fac6aa7 100644
  			if (!file.empty()) {
  				return file;
  			}
+-- 
+2.37.3
+
+
+From 36f74e3cc2d12bc03c410e799ad578534a5d12ba Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Sat, 3 Dec 2022 16:39:13 +0100
+Subject: Haiku: use BNotification
+
+
+diff --git a/src/interface/QueueView.cpp b/src/interface/QueueView.cpp
+index 9a319ca..2582fb0 100644
+--- a/src/interface/QueueView.cpp
++++ b/src/interface/QueueView.cpp
+@@ -29,7 +29,9 @@
+ 
+ #include <libfilezilla/glue/wxinvoker.hpp>
+ 
+-#if WITH_LIBDBUS
++#if defined(__HAIKU__)
++#include <Notification.h>
++#elif WITH_LIBDBUS
+ #include "../dbus/desktop_notification.h"
+ #elif defined(__WXGTK__) || defined(__WXMSW__)
+ #include <wx/notifmsg.h>
+@@ -2689,7 +2691,13 @@ void CQueueView::ActionAfter(bool warned)
+ 				msg = _("All files have been successfully transferred");
+ 			}
+ 
+-#if WITH_LIBDBUS
++#if defined(__HAIKU__)
++			BNotification notification((failed_count > 0) ? B_ERROR_NOTIFICATION : B_INFORMATION_NOTIFICATION);
++			notification.SetGroup("FileZilla");
++			notification.SetTitle(BString(title));
++			notification.SetContent(BString(msg));
++			notification.Send();
++#elif WITH_LIBDBUS
+ 			if (!m_desktop_notification) {
+ 				m_desktop_notification = std::make_unique<CDesktopNotification>();
+ 			}
+diff --git a/src/interface/QueueView.h b/src/interface/QueueView.h
+index 7b16d8a..8b120b6 100644
+--- a/src/interface/QueueView.h
++++ b/src/interface/QueueView.h
+@@ -86,7 +86,9 @@ class CMainFrame;
+ class CStatusLineCtrl;
+ class CAsyncRequestQueue;
+ class CQueue;
+-#if WITH_LIBDBUS
++#if defined(__HAIKU__)
++// empty
++#elif WITH_LIBDBUS
+ class CDesktopNotification;
+ #elif defined(__WXGTK__) || defined(__WXMSW__)
+ class wxNotificationMessage;
+@@ -271,7 +273,9 @@ protected:
+ 
+ 	void ReleaseExclusiveEngineLock(CFileZillaEngine* pEngine);
+ 
+-#if WITH_LIBDBUS
++#if defined(__HAIKU__)
++	// empty
++#elif WITH_LIBDBUS
+ 	std::unique_ptr<CDesktopNotification> m_desktop_notification;
+ #elif defined(__WXGTK__) || defined(__WXMSW__)
+ 	std::unique_ptr<wxNotificationMessage> m_desktop_notification;
 -- 
 2.37.3
 


### PR DESCRIPTION
Use BNotification instead of wxNotificationMessage as the latter one misbehaves (causes GUI lockups)

I'm not removing the untested flag yet - preferrably it should be tested by more users before we enable this recipe in HaikuDepot.