### PR TITLE
pip: update recipe to version 22.3.1

### DIFF
--- a/dev-python/pip/pip-22.3.1.recipe
+++ b/dev-python/pip/pip-22.3.1.recipe
@@ -40,6 +40,12 @@ BUILD_PREREQUIRES="$BUILD_PREREQUIRES
 	cmd:python$pythonVersion"
 done
 
+# Custom PROVIDES for the default Python version (3.9 at the moment):
+PROVIDES_python39=$PROVIDES_python39"
+	cmd:pip
+	cmd:pip3
+	"
+
 INSTALL()
 {
 	for i in "${!PYTHON_PACKAGES[@]}"; do
@@ -54,7 +60,10 @@ INSTALL()
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		rm $binDir/{pip,pip3}
+		# Do not remove pip/pip3 for the default python version (3.9 at the moment).
+		if [ $pythonPackage != python39 ]; then
+			rm $binDir/{pip,pip3}
+		fi
 
 		packageEntries  $pythonPackage \
 			$prefix/lib/python* \


### PR DESCRIPTION
~~Setting this as Draft~~, while I do some testing, and to get some feedback on some of the changes I've made. In particular:

- Keeping `pip` and `pip3` for the default Python version on Haiku (3.9 at the moment).
  This matches what I expected to find, at least based on my Python usage on Windows.

- Removal of line 67: `rm $binDir/pip${pythonVersion%%.*} || true`
  That seemed superfluous, and it was generating message like this for all the packages:
  `rm: cannot remove '/packages/pip-22.3.1/.self/bin/pip3': No such file or directory`
  Which makes sense, as `rm $binDir/{pip,pip3}` already removed that one.

Edit:

Now that I understand that `pip${pythonVersion%%.*}` leaves only `pip3` for the options in this recipe... yeah... that line can go away now.

And I think that having pip and pip3 work be the same as pip3.9 makes sense.

This one is good to go. (unless someone spots some mistake on my part).