### PR TITLE
gnash: bump to current git version

### DIFF
--- a/media-video/gnash/gnash-0.8.11~git.recipe
+++ b/media-video/gnash/gnash-0.8.11~git.recipe
@@ -86,7 +86,7 @@ REQUIRES_devel="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libagg$secondaryArchSuffix
-	devel:libavcodec$secondaryArchSuffix <= 58
+	devel:libavcodec$secondaryArchSuffix >= 58
 	devel:libboost_program_options$secondaryArchSuffix >= 1.69.0
 	devel:libbz2$secondaryArchSuffix
 	devel:libcrypto$secondaryArchSuffix

--- a/media-video/gnash/gnash-0.8.11~git.recipe
+++ b/media-video/gnash/gnash-0.8.11~git.recipe
@@ -6,16 +6,16 @@ content, and programs written in ActionScript, an ECMAScript-compatible language
 HOMEPAGE="http://www.gnu.org/software/gnash/"
 COPYRIGHT="2005-2019 Free Software Foundation"
 LICENSE="GNU GPL v3"
-REVISION="1"
-srcGitRev="8a11e60585db4ed6bc4eafadfbd9b3123ced45d9"
+REVISION="2"
+srcGitRev="583ccbc1275c7701dc4843ec12142ff86bb305b4"
 SOURCE_URI="http://git.savannah.gnu.org/cgit/gnash.git/snapshot/gnash-$srcGitRev.tar.gz"
-CHECKSUM_SHA256="c2628665624a5d7b76cf68142f151da7cac61637c55052e048a3e8e958223f99"
+CHECKSUM_SHA256="8c0759c1aabd727242be8c5716341f0a7fddf242a40618815831b10cbca707f5"
 SOURCE_DIR="gnash-$srcGitRev"
 PATCHES="gnash-$portVersion.patchset"
 ADDITIONAL_FILES="gnash.rdef.in"
 
 ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="x86"
+SECONDARY_ARCHITECTURES="?x86"
 
 GLOBAL_WRITABLE_FILES="
 	settings/gnashpluginrc auto-merge
@@ -86,7 +86,7 @@ REQUIRES_devel="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libagg$secondaryArchSuffix
-	devel:libavcodec$secondaryArchSuffix
+	devel:libavcodec$secondaryArchSuffix <= 58.54.100
 	devel:libboost_program_options$secondaryArchSuffix >= 1.69.0
 	devel:libbz2$secondaryArchSuffix
 	devel:libcrypto$secondaryArchSuffix
@@ -121,7 +121,9 @@ BUILD()
 {
 	INCLUDE_DIR=`finddir B_SYSTEM_DIRECTORY`/$relativeIncludeDir
 	LIB_DIR=`finddir B_SYSTEM_DIRECTORY`/$relativeDevelopLibDir
-
+	export CXXFLAGS="-std=c++11 -D_BSD_SOURCE"
+	export LDFLAGS=" -lnetwork -lbsd"
+	
 	autogen.sh
 
 	runConfigure ./configure \
@@ -148,7 +150,7 @@ INSTALL()
 		$dataDir/{applications,icons} \
 		$libDir/gnash	
 	mv $commandBinDir/haiku-gnash $commandBinDir/gnash
-	strip $binDir/* $libDir/*.so
+	strip $commandBinDir/* $libDir/*.so
 
 	for i in $libDir/lib*.so;do
 		mv $i ${i%-*}.so

--- a/media-video/gnash/gnash-0.8.11~git.recipe
+++ b/media-video/gnash/gnash-0.8.11~git.recipe
@@ -122,8 +122,8 @@ BUILD()
 	INCLUDE_DIR=`finddir B_SYSTEM_DIRECTORY`/$relativeIncludeDir
 	LIB_DIR=`finddir B_SYSTEM_DIRECTORY`/$relativeDevelopLibDir
 	export CXXFLAGS="-std=c++11 -D_BSD_SOURCE"
-	export LDFLAGS=" -lnetwork -lbsd"
-	
+	export LDFLAGS="-lnetwork -lbsd"
+
 	autogen.sh
 
 	runConfigure ./configure \
@@ -148,7 +148,7 @@ INSTALL()
 	mv $libDir/gnash/*dev.so $libDir
 	rm -rf $commandBinDir/gnash \
 		$dataDir/{applications,icons} \
-		$libDir/gnash	
+		$libDir/gnash
 	mv $commandBinDir/haiku-gnash $commandBinDir/gnash
 	strip $commandBinDir/* $libDir/*.so
 

--- a/media-video/gnash/gnash-0.8.11~git.recipe
+++ b/media-video/gnash/gnash-0.8.11~git.recipe
@@ -86,7 +86,7 @@ REQUIRES_devel="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libagg$secondaryArchSuffix
-	devel:libavcodec$secondaryArchSuffix <= 58.54.100
+	devel:libavcodec$secondaryArchSuffix <= 58
 	devel:libboost_program_options$secondaryArchSuffix >= 1.69.0
 	devel:libbz2$secondaryArchSuffix
 	devel:libcrypto$secondaryArchSuffix


### PR DESCRIPTION

![gnash_haiku](https://user-images.githubusercontent.com/5168719/205986736-b841ead5-65ac-4af3-adef-8bedb14030f2.jpeg)

Updated to latest git revision.
1. Fixed build on R1B4 x86 and x64.
2. Disabled x86 build for now.

Closes: https://github.com/haikuports/haikuports/issues/82