### PR TITLE
audacity: disable networking

### DIFF
--- a/media-sound/audacity/audacity-3.2.2.recipe
+++ b/media-sound/audacity/audacity-3.2.2.recipe
@@ -103,6 +103,7 @@ BUILD()
 		$cmakeDirArgs \
 		-DCMAKE_BUILD_TYPE=Release \
 		-Daudacity_conan_enabled=Off \
+		-Daudacity_has_networking=Off \
 		-Daudacity_has_vst3=Off \
 		-Daudacity_use_pch=no \
 		-Daudacity_use_vst=no


### PR DESCRIPTION
Networking was already disabled implicitly but let's make this explicit so that we can ascertain that telemetry is not built.