### PR TITLE
glu, remove static library

### DIFF
--- a/sys-libs/glu/glu-9.0.0.recipe
+++ b/sys-libs/glu/glu-9.0.0.recipe
@@ -5,16 +5,20 @@ higher-level drawing routines from the more primitive routines that OpenGL provi
 HOMEPAGE="http://freedesktop.org"
 COPYRIGHT="1999-2012 Brian Paul and others"
 LICENSE="MIT"
-REVISION="7"
+REVISION="8"
 SOURCE_URI="ftp://freedesktop.org/pub/mesa/glu/glu-9.0.0.tar.gz"
 CHECKSUM_SHA256="4387476a1933f36fec1531178ea204057bbeb04cc2d8396c9ea32720a1f7e264"
+PATCHES="glu-$portVersion.patchset"
 
 ARCHITECTURES="all"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
+libVersion="1.3.1"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
 PROVIDES="
 	glu$secondaryArchSuffix = $portVersion
-	lib:libGLU$secondaryArchSuffix = 1.3.1 compat >= 1
+	lib:libGLU$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -23,7 +27,7 @@ REQUIRES="
 
 PROVIDES_devel="
 	glu${secondaryArchSuffix}_devel = $portVersion
-	devel:libGLU$secondaryArchSuffix = 1.3.1 compat >= 1
+	devel:libGLU$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
 	glu$secondaryArchSuffix == $portVersion base
@@ -46,7 +50,7 @@ defineDebugInfoPackage glu$secondaryArchSuffix \
 
 BUILD()
 {
-	runConfigure ./configure
+	runConfigure ./configure --disable-static
 	make $jobArgs
 }
 
@@ -54,6 +58,7 @@ INSTALL()
 {
 	make install
 
+	# remove libtool file
 	rm $libDir/libGLU.la
 
 	prepareInstalledDevelLibs libGLU

--- a/sys-libs/glu/patches/glu-9.0.0.patchset
+++ b/sys-libs/glu/patches/glu-9.0.0.patchset
@@ -1,0 +1,21 @@
+From 382d5000a146add98d1b6f92b0da00b8e89e8170 Mon Sep 17 00:00:00 2001
+From: begasus <begasus@gmail.com>
+Date: Tue, 13 Dec 2022 10:52:55 +0100
+Subject: Fix NULL undeclared
+
+
+diff --git a/src/libutil/error.c b/src/libutil/error.c
+index 7212748..513f455 100644
+--- a/src/libutil/error.c
++++ b/src/libutil/error.c
+@@ -31,6 +31,7 @@
+ #include "gluos.h"
+ #include "gluint.h"
+ #include <GL/glu.h>
++#include <stddef.h>
+ 
+ 
+ struct token_string
+-- 
+2.37.3
+


### PR DESCRIPTION
Added patchset for: `error: 'NULL' undeclared here (not in a function)` on secondary architecture.