### PR TITLE
Recipe for BeScreenCapture 2.6.2.

### DIFF
--- a/haiku-apps/bescreencapture/bescreencapture-2.6.2.recipe
+++ b/haiku-apps/bescreencapture/bescreencapture-2.6.2.recipe
@@ -5,7 +5,7 @@ to any media format supported in Haiku.
 BeScreenCapture can record either the entire screen, or just a section you \
 select."
 HOMEPAGE="https://github.com/jackburton79/bescreencapture/releases"
-COPYRIGHT="2014-2021 Stefano Ceccherini"
+COPYRIGHT="2014-2022 Stefano Ceccherini"
 LICENSE="BSD (3-clause)
 	MIT"
 REVISION="1"
@@ -21,6 +21,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku
+	ffmpeg_tools
 	"
 
 SUMMARY_inputfilter="Shortcut handler for BeScreenCapture"


### PR DESCRIPTION
Now depends on ffmpeg_tools for GIF export
Removed recipe for 2.6.0.

Minor bugfix release:

- Fixed encoding when recording more than 3000 frames.
- Improve deskbar menu using more icons from ZuMi.

