### PR TITLE
portsmf: fix 32-bit build

### DIFF
--- a/media-libs/portsmf/portsmf-239.recipe
+++ b/media-libs/portsmf/portsmf-239.recipe
@@ -4,7 +4,7 @@ C++ library for reading and writing Standard MIDI Files."
 HOMEPAGE="https://codeberg.org/tenacityteam/portsmf"
 COPYRIGHT="2022 Tenacity Team"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://codeberg.org/tenacityteam/portsmf/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="fe7aee61453e398aa360608fe34bc26a6af612bce987cdacbc0fc40b18e01d58"
 SOURCE_DIR="portsmf"
@@ -28,7 +28,7 @@ PROVIDES_devel="
 	devel:libportsmf$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
-	portsmf == $portVersion base
+	portsmf$secondaryArchSuffix == $portVersion base
 	"
 
 BUILD_REQUIRES="


### PR DESCRIPTION
32-bit builder failed because of a typo, fixing it with this PR