### PR TITLE
gutenprint{8,9}: fix build and remove static libs.

### DIFF
--- a/net-print/gutenprint/gutenprint8-5.3.1.recipe
+++ b/net-print/gutenprint/gutenprint8-5.3.1.recipe
@@ -13,7 +13,7 @@ and beyond."
 HOMEPAGE="http://gimp-print.sourceforge.net/"
 COPYRIGHT="1999-2018 The authors of Gutenprint"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://downloads.sourceforge.net/gimp-print/gutenprint-$portVersion.tar.xz"
 CHECKSUM_SHA256="d80d8f5272d15bca5710f6ef4a2bb95e76d34e1155c5bcd5e83cb9f0a111d0d4"
 SOURCE_DIR="gutenprint-$portVersion"
@@ -56,7 +56,16 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	runConfigure ./configure
+	runConfigure ./configure \
+		--disable-dependency-tracking \
+		--disable-static \
+		--disable-testpattern \
+		CFLAGS=-D_DIRENT_HAVE_D_RECLEN=1
+
+	# Disable this test, as it a very looong time to run:
+	# (taken from Fedora's gutenprint.spec file)
+	sed -i -e 's,^\(TESTS *=.*\) run-weavetest,\1,' test/Makefile.in
+
 	make $jobArgs
 }
 
@@ -74,4 +83,11 @@ INSTALL()
 	# devel package
 	packageEntries devel \
 		$developDir
+}
+
+TEST()
+{
+	# according to test/Makefile.am: "run-weavetest" will take too long
+	# (unless it gets disabled in BUILD()) and be of little use.
+	make check
 }

--- a/net-print/gutenprint/gutenprint9-5.3.4.recipe
+++ b/net-print/gutenprint/gutenprint9-5.3.4.recipe
@@ -13,13 +13,13 @@ and beyond."
 HOMEPAGE="http://gimp-print.sourceforge.net/"
 COPYRIGHT="1999-2020 The authors of Gutenprint"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://downloads.sourceforge.net/gimp-print/gutenprint-$portVersion.tar.xz"
 CHECKSUM_SHA256="db44a701d2b8e6a8931c83cec06c91226be266d23e5c189d20a39dd175f2023b"
 SOURCE_DIR="gutenprint-$portVersion"
-PATCHES="gutenprint-$portVersion.patchset"
+PATCHES="gutenprint9-$portVersion.patchset"
 
-ARCHITECTURES="all ?x86_gcc2"
+ARCHITECTURES="all"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
@@ -56,7 +56,19 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	runConfigure ./configure --without-cups
+	runConfigure ./configure \
+		--without-cups \
+		--disable-dependency-tracking \
+		--disable-static \
+		--disable-testpattern \
+		CFLAGS=-D_DIRENT_HAVE_D_RECLEN=1
+
+	# Disable this test, as it a very looong time to run:
+	# (taken from Fedora's gutenprint.spec file)
+	# Doesn't works for gutenprint9: There's an added ".test"
+	# to the tests names (as in "run-weavetest.test").
+#	sed -i -e 's,^\(TESTS *=.*\) run-weavetest,\1,' test/Makefile.in
+
 	make $jobArgs
 }
 
@@ -74,4 +86,11 @@ INSTALL()
 	# devel package
 	packageEntries devel \
 		$developDir
+}
+
+TEST()
+{
+	# according to test/Makefile.am: "run-weavetest.test" will take too long
+	# (unless it gets disabled in BUILD()) and be of little use.
+	make check
 }

--- a/net-print/gutenprint/patches/gutenprint9-5.3.4.patchset
+++ b/net-print/gutenprint/patches/gutenprint9-5.3.4.patchset
@@ -1,4 +1,4 @@
-From d9a65c78109d122c9b8ef0a640ab782f6de70965 Mon Sep 17 00:00:00 2001
+From 18d38b5a001f9cf5b278642f8bebb71157c4d740 Mon Sep 17 00:00:00 2001
 From: Humdinger <humdingerb@gmail.com>
 Date: Fri, 20 Jan 2017 19:56:14 +0100
 Subject: undef PAGESIZE on HAIKU
@@ -76,10 +76,10 @@ index 4678949..d2ab025 100644
  
  extern int mylineno;
 -- 
-2.30.2
+2.37.3
 
 
-From bd4bfa3047ccc94b117526c21b42b087210165df Mon Sep 17 00:00:00 2001
+From 316ca9031ae06646813dabe0c17a25040006fad6 Mon Sep 17 00:00:00 2001
 From: Humdinger <humdingerb@gmail.com>
 Date: Fri, 20 Jan 2017 19:58:12 +0100
 Subject: strings.h fixes
@@ -123,10 +123,10 @@ index 751424d..2838983 100644
  #ifdef HAVE_LIMITS_H
  #include <limits.h>
 -- 
-2.30.2
+2.37.3
 
 
-From 36932888746a1317cc53372a0f0174425acf0f19 Mon Sep 17 00:00:00 2001
+From 37b46530fee8239effc5f568cdad60067b76930b Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Sat, 1 Apr 2017 15:24:54 +0200
 Subject: Make gcc2 happy.
@@ -153,10 +153,10 @@ index 2dc443b..0dffa4c 100644
  
    test_cd = 1;
 -- 
-2.30.2
+2.37.3
 
 
-From 865ca55bc93fd668aa37c6ec25e6c88a6fe639e1 Mon Sep 17 00:00:00 2001
+From 55ae17664a49a7b941f00d6bf5dc3eb94c490fd3 Mon Sep 17 00:00:00 2001
 From: Schrijvers Luc <Begasus@users.noreply.github.com>
 Date: Mon, 21 May 2018 07:42:56 +0200
 Subject: Make gcc2 happy, suite.
@@ -181,10 +181,10 @@ index 6cd4ca9..a19d6a7 100644
 +  }
  }
 -- 
-2.30.2
+2.37.3
 
 
-From 098256dc9409abd6698dc44a8069ae318b28171c Mon Sep 17 00:00:00 2001
+From 6bc1f0f9ef330ce6118d970ba32a23a6aab9c3df Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sun, 14 Apr 2019 20:56:21 +0200
 Subject: gcc2 patch for 5.3.1
@@ -800,10 +800,10 @@ index 3a6f00d..84e6375 100644
    for (c = 0; c < scount; c++)						\
      {									\
 -- 
-2.30.2
+2.37.3
 
 
-From 59e39c7ca523d276b81d2a9521c5d0cc5ed1bd20 Mon Sep 17 00:00:00 2001
+From 586b51b284fc4c8e4bcff2d085fad3a605a29f4b Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sun, 8 Sep 2019 21:24:23 +0200
 Subject: gcc build fix
@@ -878,5 +878,115 @@ index 906034c..ab5dd39 100644
      pg = 0x00;
    else if (strcmp(pd->pagesize,"A4") == 0)
 -- 
-2.30.2
+2.37.3
+
+
+From 080eb05646b833580063edb4bcd98b4239b0370b Mon Sep 17 00:00:00 2001
+From: begasus <begasus@gmail.com>
+Date: Wed, 21 Dec 2022 09:43:48 +0100
+Subject: gutenprint9, fix gcc2 build
+
+
+diff --git a/src/main/print-dyesub.c b/src/main/print-dyesub.c
+index ab5dd39..af79f96 100644
+--- a/src/main/print-dyesub.c
++++ b/src/main/print-dyesub.c
+@@ -3386,6 +3386,7 @@ kodak6900_load_parameters(const stp_vars_t *v, const char *name,
+     {
+       description->bounds.str = stp_string_list_create();
+ 
++      {
+       const dyesub_stringlist_t *mlist = &kodak6900_quality_list;
+       for (i = 0; i < mlist->n_items; i++)
+         {
+@@ -3395,6 +3396,7 @@ kodak6900_load_parameters(const stp_vars_t *v, const char *name,
+ 	}
+       description->deflt.str = stp_string_list_param(description->bounds.str, 0)->name;
+       description->is_active = 1;
++      }
+     }
+   else
+   {
+@@ -3432,6 +3434,7 @@ static void kodak_6900_printer_init(stp_vars_t *v)
+   stp_put16_le(pd->w_size, v); /* Columns */
+   stp_put16_le(pd->h_size, v); /* Rows */
+ 
++  {
+   int media = 0;
+   int overcoat = ((const char*)((pd->overcoat->seq).data))[0];
+ 
+@@ -3459,6 +3462,7 @@ static void kodak_6900_printer_init(stp_vars_t *v)
+   stp_putc(overcoat, v);  /* Options */
+   stp_putc(0, v);         /* Method XXX Multicut? */
+   dyesub_nputc(v, 0, 11); /* Reserved */
++  }
+ }
+ 
+ /* Kodak 7000/7010 */
+@@ -5620,6 +5624,7 @@ static int mitsu_cp30_load_parameters(const stp_vars_t *v, const char *name,
+     {
+       description->bounds.str = stp_string_list_create();
+ 
++      {
+       const dyesub_stringlist_t *mlist = &mitsu_cp30_quality_list;
+       for (i = 0; i < mlist->n_items; i++)
+         {
+@@ -5629,6 +5634,7 @@ static int mitsu_cp30_load_parameters(const stp_vars_t *v, const char *name,
+ 	}
+       description->deflt.str = stp_string_list_param(description->bounds.str, 0)->name;
+       description->is_active = 1;
++      }
+     }
+   else
+     {
+@@ -6603,6 +6609,7 @@ mitsu_cpm1_load_parameters(const stp_vars_t *v, const char *name,
+     {
+       description->bounds.str = stp_string_list_create();
+ 
++      {
+       const dyesub_stringlist_t *mlist = &mitsu_cpm1_quality_list;
+       for (i = 0; i < mlist->n_items; i++)
+         {
+@@ -6612,6 +6619,7 @@ mitsu_cpm1_load_parameters(const stp_vars_t *v, const char *name,
+ 	}
+       description->deflt.str = stp_string_list_param(description->bounds.str, 0)->name;
+       description->is_active = 1;
++      }
+     }
+   else if (strcmp(name, "UseLUT") == 0)
+     {
+@@ -8755,6 +8763,7 @@ qw410_load_parameters(const stp_vars_t *v, const char *name,
+     {
+       description->bounds.str = stp_string_list_create();
+ 
++      {
+       const dyesub_stringlist_t *mlist = &dnp_qw410_printspeeds_list;
+       for (i = 0; i < mlist->n_items; i++)
+         {
+@@ -8764,6 +8773,7 @@ qw410_load_parameters(const stp_vars_t *v, const char *name,
+ 	}
+       description->deflt.str = stp_string_list_param(description->bounds.str, 0)->name;
+       description->is_active = 1;
++      }
+     }
+   else if (strcmp(name, "NoCutWaste") == 0)
+     {
+@@ -9051,6 +9061,7 @@ hiti_p720l_load_parameters(const stp_vars_t *v, const char *name,
+     {
+       description->bounds.str = stp_string_list_create();
+ 
++      {
+       const dyesub_stringlist_t *mlist = &hiti_p720l_quality_list;
+       for (i = 0; i < mlist->n_items; i++)
+         {
+@@ -9060,6 +9071,7 @@ hiti_p720l_load_parameters(const stp_vars_t *v, const char *name,
+ 	}
+       description->deflt.str = stp_string_list_param(description->bounds.str, 0)->name;
+       description->is_active = 1;
++      }
+     }
+   else
+   {
+-- 
+2.37.3
 


### PR DESCRIPTION
After the changes on Haiku's dirent.h, gutenprint needs a bit of help to figure things out.

Also remove the static libs from the (devel) packages.

Fixes #7550.

Built on 64 bits.

Any simple way of testing the resulting libs?