### PR TITLE
audacity: adjust folder names

### DIFF
--- a/media-sound/audacity/patches/audacity-3.2.2.patchset
+++ b/media-sound/audacity/patches/audacity-3.2.2.patchset
@@ -1,4 +1,4 @@
-From 5d09d9fad180b6aef338446569597ff8b85b6e0c Mon Sep 17 00:00:00 2001
+From e0f1c5542030ef5786dc41a9c6fe548b4095267d Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Mon, 7 Nov 2022 14:27:23 +0100
 Subject: nyquist: fix build on Haiku
@@ -34,7 +34,7 @@ index 3134849..8fd29ea 100644
 2.37.3
 
 
-From f56cbda6c6cf70e332f8677220432f46604958bc Mon Sep 17 00:00:00 2001
+From 1502ab195f721e2dc8f7b7842d29e392f3e36138 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Mon, 7 Nov 2022 14:17:48 +0100
 Subject: portmixer: fix build on Haiku
@@ -93,7 +93,7 @@ index 978f27b..eb44dce 100644
 2.37.3
 
 
-From 50f69ab7a493573559ef2947c60ebf5ac3188e7a Mon Sep 17 00:00:00 2001
+From e6629c49ead64d438a51aa72c0516d73a84fe163 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Mon, 7 Nov 2022 15:09:44 +0100
 Subject: MIDIPlay: fix build on Haiku
@@ -116,7 +116,7 @@ index 620bb85..e1ee067 100644
 2.37.3
 
 
-From 74b5477f96732953c7b6b91fe802d9ad41cbbb93 Mon Sep 17 00:00:00 2001
+From 00a1318d5b73df86dc698b3304ce5fa4ed471e61 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Mon, 7 Nov 2022 15:06:14 +0100
 Subject: fix GTK include paths and libs
@@ -140,7 +140,7 @@ index 4b35e89..e5a909c 100644
 2.37.3
 
 
-From 04c9e81eab1cf6c88ba05fe33dd94728733876f2 Mon Sep 17 00:00:00 2001
+From 44acc2ec71900e62de075ce3683dae4cb82d2ad7 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Mon, 7 Nov 2022 14:33:10 +0100
 Subject: adjust install rules for Haiku
@@ -189,7 +189,7 @@ index 154da2d..903a2d1 100644
 2.37.3
 
 
-From e71fab12e0dd15af8dee21efd78ec37bad769883 Mon Sep 17 00:00:00 2001
+From e353d83412cdeef4929d3cbb33f22a4d237a1f35 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Thu, 17 Nov 2022 20:54:07 +0100
 Subject: Adapt shm to Haiku
@@ -274,7 +274,7 @@ index 98c4a4d..0e879bd 100644
 2.37.3
 
 
-From ca400c00f31ed04070a0dfb5f490ce27264e1082 Mon Sep 17 00:00:00 2001
+From 1540f41be31b359dd69413f6503ec5efacf85d57 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Fri, 9 Dec 2022 16:36:39 +0100
 Subject: Haiku: initialize XDG vars
@@ -339,6 +339,71 @@ index 0e879bd..842ea72 100644
     return wxEntry(argc, argv);
  }
  
+-- 
+2.37.3
+
+
+From f4a7fefcafb4ade00ff91c28d726655e7c491ad7 Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Sat, 17 Dec 2022 23:26:49 +0100
+Subject: adjust paths for Haiku
+
+
+diff --git a/libraries/lib-files/PathList.cpp b/libraries/lib-files/PathList.cpp
+index 622a9eb..907dd59 100644
+--- a/libraries/lib-files/PathList.cpp
++++ b/libraries/lib-files/PathList.cpp
+@@ -29,7 +29,7 @@ void FileNames::InitializePathList()
+    const auto portablePrefix = wxPathOnly(wxPathOnly(programPath));
+ 
+    // Make sure install prefix is set so wxStandardPath resolves paths properly
+-   if (wxDirExists(portablePrefix + L"/share/audacity")) {
++   if (wxDirExists(portablePrefix + L"/data/audacity")) {
+       // use prefix relative to executable location to make Audacity portable
+       standardPaths.SetInstallPrefix(portablePrefix);
+    } else {
+@@ -95,9 +95,9 @@ void FileNames::InitializePathList()
+       audacityPathList);
+    FileNames::AddUniquePathToPathList(FileNames::ModulesDir(),
+       audacityPathList);
+-   FileNames::AddUniquePathToPathList(wxString::Format(installPrefix + L"/share/%s", wxT(AUDACITY_NAME)),
++   FileNames::AddUniquePathToPathList(wxString::Format(installPrefix + L"/data/%s", wxT(AUDACITY_NAME)),
+       audacityPathList);
+-   FileNames::AddUniquePathToPathList(wxString::Format(installPrefix + L"/share/doc/%s", wxT(AUDACITY_NAME)),
++   FileNames::AddUniquePathToPathList(wxString::Format(installPrefix + L"/data/doc/%s", wxT(AUDACITY_NAME)),
+       audacityPathList);
+ #else //AUDACITY_NAME
+    FileNames::AddUniquePathToPathList(wxString::Format(wxT("%s/.audacity-files"),
+@@ -105,13 +105,13 @@ void FileNames::InitializePathList()
+       audacityPathList);
+    FileNames::AddUniquePathToPathList(FileNames::ModulesDir(),
+       audacityPathList);
+-   FileNames::AddUniquePathToPathList(installPrefix + L"/share/audacity",
++   FileNames::AddUniquePathToPathList(installPrefix + L"/data/audacity",
+       audacityPathList);
+-   FileNames::AddUniquePathToPathList(installPrefix + L"/share/doc/audacity",
++   FileNames::AddUniquePathToPathList(installPrefix + L"/data/doc/audacity",
+       audacityPathList);
+ #endif //AUDACITY_NAME
+ 
+-   FileNames::AddUniquePathToPathList(installPrefix + L"/share/locale",
++   FileNames::AddUniquePathToPathList(installPrefix + L"/data/locale",
+       audacityPathList);
+ 
+    FileNames::AddUniquePathToPathList(wxString::Format(wxT("./locale")),
+diff --git a/libraries/lib-strings/Languages.cpp b/libraries/lib-strings/Languages.cpp
+index 6cd5775..9078693 100644
+--- a/libraries/lib-strings/Languages.cpp
++++ b/libraries/lib-strings/Languages.cpp
+@@ -220,7 +220,7 @@ void GetLanguages( FilePaths pathList,
+ 
+ #if defined(__WXGTK__)
+    {
+-      wxFileName pathNorm{ wxStandardPaths::Get().GetInstallPrefix() + L"/share/locale" };
++      wxFileName pathNorm{ wxStandardPaths::Get().GetInstallPrefix() + L"/data/locale" };
+       pathNorm.Normalize();
+       const wxString newPath{ pathNorm.GetFullPath() };
+       if (pathList.end() ==
 -- 
 2.37.3
 


### PR DESCRIPTION
This change allows audacity to find locales and plugins.
I'm not enabling this recipe yet as the crash on exit is still there unfortunately, somehow also related to locales but I couldn't find out what happens exactly.

as an example we can see nyquist plugins in the plugin list with Hungarian locale on the screenshot

![image](https://user-images.githubusercontent.com/92124087/208268209-df4b8094-4732-4177-9bbc-2844d988b520.png)
