### PR TITLE
w2c2:added Makefile patch so GCC2 can handle it

### DIFF
--- a/dev-lang/w2c2/patches/w2c2-0.1~20221219.patchset
+++ b/dev-lang/w2c2/patches/w2c2-0.1~20221219.patchset
@@ -1,0 +1,30 @@
+From dabdb794644374f24ec44b5c10c571d1466c4dad Mon Sep 17 00:00:00 2001
+From: "Samuel D. Crow" <samuraileumas@yahoo.com>
+Date: Fri, 23 Dec 2022 00:05:31 -0600
+Subject: patching makefile
+
+
+diff --git a/Makefile b/Makefile
+index 4df3a13..cdfce52 100644
+--- a/Makefile
++++ b/Makefile
+@@ -11,13 +11,15 @@ ifndef UNAME
+ 	UNAME := $(shell uname -s)
+ endif
+ 
++WARNS ?= -Wunused-result -Wall -Wpedantic -Wno-long-long -Wno-unused-function
++
+ ifeq ($(BUILD),release)
+ 	CFLAGS += -O3
+ else
+ 	CFLAGS += -g -O0
+ endif
+ 
+-CFLAGS += -std=c89 -Wunused-result -Wall -Wpedantic -Wno-long-long -Wno-unused-function
++CFLAGS += -std=c89 $(WARNS)
+ 
+ ifeq ($(UNAME),Windows)
+ 	OUTPUT := w2c2.exe
+-- 
+2.37.3
+

--- a/dev-lang/w2c2/w2c2-0.1~20221219.recipe
+++ b/dev-lang/w2c2/w2c2-0.1~20221219.recipe
@@ -13,7 +13,7 @@ Among its features are:
 HOMEPAGE="https://github.com/turbolent/w2c2"
 COPYRIGHT="2021 Bastian Mueller"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 srcGitRev="cd90cd995501d83ce41f57bfb11b1a52de092d20"
 SOURCE_URI="https://github.com/turbolent/w2c2/archive/$srcGitRev.zip"
 CHECKSUM_SHA256="8bc9699771b03f92237980e24805f74e4b866d57130089e968c038d364b0de2a"
@@ -37,10 +37,13 @@ BUILD_PREREQUIRES="
 	cmd:gcc
 	cmd:make
 	"
+PATCHES="
+	w2c2-0.1~20221219.patchset
+	"
 
 BUILD()
 {
-	make $jobArgs FEATURES="threads getopt"
+	make $jobArgs FEATURES="threads getopt strdup"  WARNS="-Wall -Wno-long-long"
 }
 
 INSTALL()

--- a/media-fonts/caligula/caligula-1.0.recipe
+++ b/media-fonts/caligula/caligula-1.0.recipe
@@ -1,0 +1,46 @@
+SUMMARY="A script font"
+DESCRIPTION="\
+Caligula is a crude representation of what was originally a \
+calligraphic bitmap script font autotraced by Fontographer 3.2. \
+There are no kerning pairs in this font and it should probably \
+be used only in sizes 24pt or larger.\
+"
+HOMEPAGE="https://github.com/FontCollection/Caligula"
+COPYRIGHT="1994 or earler"
+LICENSE="Public Domain"
+REVISION="1"
+SOURCE_URI="https://github.com/FontCollection/Caligula/releases/download/initial/Caligula.tar.xz"
+CHECKSUM_SHA256="dde42b6f09b85e92c2723d695fce907f0a07a74dff35f6b6094571fa43ac125c"
+SOURCE_FILENAME="Caligula.tar.xz"
+SOURCE_DIR="Caligula"
+
+ARCHITECTURES="any"
+DISABLE_SOURCE_PACKAGE="yes"
+
+PROVIDES="
+	caligula = $portVersion
+	"
+
+BUILD_PREREQUIRES="
+	cmd:cp
+	cmd:mkdir
+	cmd:md2html
+	"
+
+BUILD()
+{
+	md2html --github -f --fpermissive-autolinks --fstrikethrough --ftables --ftasklists --funderline --fwiki-links README.md --output=README.html
+}
+
+INSTALL()
+{
+	FONTDIR=$fontsDir/ttfonts
+	DOCDIR=$documentationDir/Caligula
+
+	mkdir -p ${FONTDIR}
+	cp caligula.ttf ${FONTDIR}/
+
+	mkdir -p $DOCDIR
+	cp README.html $DOCDIR/
+	cp caligula.gif $DOCDIR/
+}


### PR DESCRIPTION
In addition to the commit mentioned in the title, I added an indication to the build that strdup is supplied by the runtimes so even the original version for x86_64 needs updating.