### PR TITLE
icu: enable icu67 for all non-gcc2 architectures

### DIFF
--- a/dev-libs/icu/icu67-67.1.recipe
+++ b/dev-libs/icu/icu67-67.1.recipe
@@ -41,18 +41,18 @@ wrapping when displaying the text."
 HOMEPAGE="http://www.icu-project.org"
 COPYRIGHT="1995-2020 IBM Corporation and others."
 LICENSE="ICU"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/unicode-org/icu/releases/download/release-67-1/icu4c-67_1-src.tgz"
 SOURCE_URI_2="https://github.com/unicode-org/icu/releases/download/release-67-1/icu4c-67_1-data.zip#noarchive"
-#SOURCE_URI_3="http://www.iana.org/time-zones/repository/releases/tzdata2019c.tar.gz#noarchive"
+SOURCE_URI_3="http://www.iana.org/time-zones/repository/releases/tzdata2022f.tar.gz#noarchive"
 CHECKSUM_SHA256="94a80cd6f251a53bd2a997f6f1b5ac6653fe791dfab66e1eb0227740fb86d5dc"
 CHECKSUM_SHA256_2="7c16a59cc8c06128b7ecc1dc4fc056b36b17349312829b17408b9e67b05c4a7e"
+CHECKSUM_SHA256_3="9990d71f675d212567b931fe8aae1cab7027f89fefb8a79d808a6933a67af000"
 SOURCE_DIR="icu"
 PATCHES="icu66-66.1.patchset"
 
-ARCHITECTURES="!all ?x86 arm sparc arm64 riscv64"
-# leave inactive until full testing can be done
-SECONDARY_ARCHITECTURES="!x86"
+ARCHITECTURES="all !x86_gcc2 ?x86"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	icu67$secondaryArchSuffix = $portVersion compat >= 67
@@ -102,7 +102,7 @@ if [ -z "$secondaryArchSuffix" ]; then
 		cmd:pkgdata
 		"
 	REQUIRES_tools="
-		icu == $portVersion base
+		icu67 == $portVersion base
 		haiku
 		"
 fi
@@ -129,8 +129,8 @@ BUILD()
 	cd source
 
 	# Created during build and prevent rebuilds.
-	#rm -rf tools/tzcode/vanguard
-	#cp ../../../sources-3/tzdata*.tar.gz tools/tzcode/
+	rm -rf tools/tzcode/vanguard
+	cp ../../../sources-3/tzdata*.tar.gz tools/tzcode/
 
 	unzip -oq ../../../sources-2/icu4c-*-data.zip
 	rm -f data/in/icudt??l.dat

--- a/dev-libs/libxml2/libxml2-2.9.13.recipe
+++ b/dev-libs/libxml2/libxml2-2.9.13.recipe
@@ -10,7 +10,7 @@ available in other environments."
 HOMEPAGE="http://www.xmlsoft.org/"
 COPYRIGHT="1998-2013 Daniel Veillard.  All Rights Reserved."
 LICENSE="MIT"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://download.gnome.org/sources/libxml2/2.9/libxml2-$portVersion.tar.xz"
 CHECKSUM_SHA256="276130602d12fe484ecc03447ee5e759d0465558fbc9d6bd144e3745306ebf0e"
 PATCHES="libxml2-$portVersion.patchset"
@@ -19,10 +19,13 @@ ARCHITECTURES="all"
 SECONDARY_ARCHITECTURES="?x86_gcc2 x86"
 
 
-# build the python module only for the primary architecture
-pythonModuleEnabled=false
-if [ -z "$secondaryArchSuffix" ]; then
+# build the python module only for the architectures where python 3 is available
+if [ "$effectiveTargetArchitecture" == x86_gcc2 ]; then
+	pythonModuleEnabled=false
+	icu="libicuuc$secondaryArchSuffix >= 57"
+else
 	pythonModuleEnabled=true
+	icu="libicuuc$secondaryArchSuffix >= 67"
 fi
 
 PROVIDES="
@@ -37,7 +40,7 @@ if [ -z "$secondaryArchSuffix" ]; then
 fi
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libicuuc$secondaryArchSuffix
+	lib:$icu
 	lib:libz$secondaryArchSuffix
 	"
 
@@ -48,7 +51,7 @@ PROVIDES_devel="
 	"
 REQUIRES_devel="
 	libxml2$secondaryArchSuffix == $portVersion base
-	devel:libicuuc$secondaryArchSuffix
+	devel:$icu
 	devel:libz$secondaryArchSuffix
 	"
 
@@ -61,21 +64,19 @@ if $pythonModuleEnabled; then
 		libxml2 == $portVersion base
 		haiku$secondaryArchSuffix
 		lib:libz$secondaryArchSuffix
-		cmd:python
+		cmd:python3
 		"
 fi
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libicuuc$secondaryArchSuffix
+	devel:$icu
 	devel:libz$secondaryArchSuffix
 	"
 if $pythonModuleEnabled; then
 	BUILD_REQUIRES="$BUILD_REQUIRES
-		python >= 2.7
-		"
-		# Note: We don't use "cmd:python" here to avoid issues with the
-		# python search path.
+		cmd:python3.9
+	"
 fi
 BUILD_PREREQUIRES="
 	lib:libicudata$secondaryArchSuffix
@@ -117,13 +118,13 @@ BUILD()
 		# installation directory for the python module is determined.
 		pythonDir="$portPackageLinksDir/python"
 		ln -s $pythonDir/bin $pythonDir/develop $pythonDir/lib $prefix
-		withPython="--with-python=$prefix"
+		withPython="--with-python=`which python3.9`"
 	fi
 
 	runConfigure ./configure LDFLAGS="-lnetwork"  \
 		--with-html-dir=$docDir/html \
 		--with-html-subdir="" \
-		--enable-icu \
+		--with-icu \
 		--disable-static \
 		$withPython
 	make $jobArgs
@@ -144,6 +145,11 @@ INSTALL()
 	else
 		make install
 	fi
+
+	mv $prefix/non-packaged/lib/* $prefix/lib/
+
+	rmdir $prefix/non-packaged/lib
+	rmdir $prefix/non-packaged
 
 	rm $libDir/libxml2.la
 	# prepare develop/lib

--- a/haiku-libs/haikuwebkit/haikuwebkit-1.9.2.recipe
+++ b/haiku-libs/haikuwebkit/haikuwebkit-1.9.2.recipe
@@ -9,7 +9,7 @@ COPYRIGHT="1998-2022 Apple Inc., Google Inc., et al"
 LICENSE="GNU LGPL v2
 	GNU LGPL v2.1
 	MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/haiku/haikuwebkit/archive/HaikuWebKit-$portVersion.tar.gz"
 SOURCE_FILENAME="haikuwebkit-$portVersion.tar.gz"
 SOURCE_DIR="haikuwebkit-HaikuWebKit-$portVersion"
@@ -31,7 +31,7 @@ REQUIRES="
 	lib:libcurl$secondaryArchSuffix
 	lib:libexecinfo$secondaryArchSuffix
 	lib:libgl$secondaryArchSuffix
-	lib:libicuuc$secondaryArchSuffix >= 66
+	lib:libicuuc$secondaryArchSuffix >= 67
 	lib:libidn2$secondaryArchSuffix
 	lib:libgpg_error$secondaryArchSuffix
 	lib:libjpeg$secondaryArchSuffix
@@ -66,7 +66,7 @@ BUILD_REQUIRES="
 	devel:libexecinfo$secondaryArchSuffix
 	devel:libgl$secondaryArchSuffix
 	devel:libpng16$secondaryArchSuffix
-	devel:libicuuc$secondaryArchSuffix >= 66
+	devel:libicuuc$secondaryArchSuffix >= 67
 	devel:libidn2$secondaryArchSuffix
 	devel:libjpeg$secondaryArchSuffix
 	devel:libpng16$secondaryArchSuffix

--- a/media-libs/harfbuzz/harfbuzz-4.0.0.recipe
+++ b/media-libs/harfbuzz/harfbuzz-4.0.0.recipe
@@ -16,7 +16,7 @@ COPYRIGHT="2004-2018 Behdad Esfahbod
 	2004,2007,2008,2009,2010 Red Hat, Inc.
 	1998-2004 David Turner and Werner Lemberg"
 LICENSE="MIT"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/harfbuzz/harfbuzz/releases/download/$portVersion/harfbuzz-$portVersion.tar.xz"
 CHECKSUM_SHA256="ab61d4e3fc0c30072e98b46aa7727fc3eed36a85d2b6b9274cec7eaadea97cb7"
 PATCHES="harfbuzz-$portVersion.patchset"
@@ -46,7 +46,7 @@ REQUIRES="
 	lib:libfreetype$secondaryArchSuffix
 	lib:libgraphite2$secondaryArchSuffix
 	lib:libiconv$secondaryArchSuffix
-	lib:libicuuc$secondaryArchSuffix >= 66
+	lib:libicuuc$secondaryArchSuffix >= 67
 	lib:libintl$secondaryArchSuffix
 	lib:libpng16$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
@@ -71,7 +71,7 @@ REQUIRES_glib="
 	lib:libgraphite2$secondaryArchSuffix
 	lib:libharfbuzz$secondaryArchSuffix
 	lib:libiconv$secondaryArchSuffix
-	lib:libicuuc$secondaryArchSuffix >= 66
+	lib:libicuuc$secondaryArchSuffix >= 67
 	lib:libintl$secondaryArchSuffix
 	lib:libpng16$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
@@ -102,7 +102,7 @@ BUILD_REQUIRES="
 	devel:libglib_2.0$secondaryArchSuffix
 	devel:libgraphite2$secondaryArchSuffix
 	devel:libiconv$secondaryArchSuffix
-	devel:libicuuc$secondaryArchSuffix >= 66
+	devel:libicuuc$secondaryArchSuffix >= 67
 	devel:libintl$secondaryArchSuffix
 	devel:libpng16$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix


### PR DESCRIPTION
Currently the x86 architectures use icu66 while other architectures (arm, sparc, risc-v) are already migrated to icu 67. This complicates icu version management in Haiku. To make things simpler, enable icu 67 for everyone.

Confirmed booting without problems on x86_64 after doing the corresponding changes on Haiku side.