### PR TITLE
speedtest_cli: update to latest release, and switch to Python 3.9.

### DIFF
--- a/net-analyzer/speedtest-cli/speedtest_cli-2.1.3.recipe
+++ b/net-analyzer/speedtest-cli/speedtest_cli-2.1.3.recipe
@@ -10,11 +10,11 @@ the application being written in Python, \
 differing performance between Python versions, \
 and CPU and Memory capacity and speed."
 HOMEPAGE="https://github.com/sivel/speedtest-cli"
-COPYRIGHT="2012-2018 Matt Martz"
+COPYRIGHT="2012-2021 Matt Martz"
 LICENSE="Apache v2"
 REVISION="1"
 SOURCE_URI="$HOMEPAGE/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="5e22f2dcce1c9020f33faf559b22727483f022008a2912b85d573e578374b6a0"
+CHECKSUM_SHA256="45e3ca21c3ce3c339646100de18db8a26a27d240c29f1c9e07b6c13995a969be"
 SOURCE_FILENAME="speedtest-cli-$portVersion.tar.gz"
 SOURCE_DIR="speedtest-cli-$portVersion"
 
@@ -30,11 +30,11 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python python3)
-PYTHON_VERSIONS=(2.7 3.6)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersions=${PYTHON_VERSIONS[$i]}
+pythonVersion=${PYTHON_VERSIONS[$i]}
 eval "PROVIDES_${pythonPackage}=\"\
 	${portName}_$pythonPackage = $portVersion\n\
 	cmd:speedtest_cli_$pythonPackage


### PR DESCRIPTION
Also: drop unsupported Python versions (and only provide a package for the default Python on beta4).

I saw a commit related to Python 3.10 support on the speedtest-cli repo, but it were newer than the 2.1.3 release, so... let this recipe update stick to 3.9 (works for me on beta4 with Python 3.9).