### PR TITLE
lilypond: bump version

### DIFF
--- a/media-sound/lilypond/lilypond-2.24.0.recipe
+++ b/media-sound/lilypond/lilypond-2.24.0.recipe
@@ -3,11 +3,11 @@ DESCRIPTION="LilyPond is a music engraving program, devoted to producing the hig
 sheet music possible. It brings the aesthetics of traditionally engraved music to computer \
 printouts. LilyPond is free software and part of the GNU Project."
 HOMEPAGE="https://lilypond.org/"
-COPYRIGHT="1993-2020 The LilyPond development team"
+COPYRIGHT="1993-2022 The LilyPond development team"
 LICENSE="GNU GPL v3"
 REVISION="1"
 SOURCE_URI="https://lilypond.org/download/source/v${portVersion%.*}/lilypond-$portVersion.tar.gz"
-CHECKSUM_SHA256="dde90854fa7de1012f4e1304a68617aea9ab322932ec0ce76984f60d26aa23be"
+CHECKSUM_SHA256="3cedbe3b92b02569e3a6f2f0674858967b3da278d70aa3e98aef5bdcd7f78b69"
 PATCHES="lilypond-$portVersion.patchset"
 
 ARCHITECTURES="?all !x86_gcc2"
@@ -29,13 +29,13 @@ PROVIDES="
 REQUIRES="
 	haiku$secondaryArchSuffix
 	cmd:fc_list$secondaryArchSuffix
-	cmd:guile < 2
 	cmd:python3
 	lib:libfreetype$secondaryArchSuffix
+	lib:libgc$secondaryArchSuffix
 	lib:libglib_2.0$secondaryArchSuffix
 	lib:libgmp$secondaryArchSuffix
 	lib:libgobject_2.0$secondaryArchSuffix
-	lib:libguile$secondaryArchSuffix
+	lib:libguile_2.2$secondaryArchSuffix
 	lib:libgs$secondaryArchSuffix # TODO: replace with cmd:gs?
 	lib:libharfbuzz$secondaryArchSuffix
 	lib:libintl$secondaryArchSuffix
@@ -71,18 +71,19 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	tex_gyre
 	urw_base35_fonts
-	cmd:guile < 2
 	devel:libfreetype$secondaryArchSuffix
+	devel:libgc$secondaryArchSuffix
 	devel:libglib_2.0$secondaryArchSuffix
 	devel:libgmp$secondaryArchSuffix
 	devel:libgobject_2.0$secondaryArchSuffix
-	devel:libguile$secondaryArchSuffix
+	devel:libguile_2.2$secondaryArchSuffix
 	devel:libgs$secondaryArchSuffix
 	devel:libharfbuzz$secondaryArchSuffix
 	devel:libintl$secondaryArchSuffix
 	devel:libltdl$secondaryArchSuffix
 	devel:libpangoft2_1.0$secondaryArchSuffix
 	tex:epsf
+	tex:fontinst
 	tex:lh
 	tex:metapost
 	# The following TeX packages are needed for creating tex formats:
@@ -127,6 +128,7 @@ BUILD_PREREQUIRES="
 	cmd:tidy
 	cmd:xelatex
 	cmd:zip
+	lib:libreadline$secondaryArchSuffix >= 7 # required by fontforge, remove this when fixed
 	"
 
 TEST_REQUIRES="
@@ -157,6 +159,7 @@ BUILD()
 		--with-localedir=$dataDir/locale \
 		--enable-gs-api # needed because of broken ghostscript (gs)
 	make $jobArgs
+	make $jobArgs bytecode
 
 	# CPU_COUNT=$jobs is not used because it causes hangs
 	# strip the current directory (.) from PATH, it disallows find -execdir
@@ -167,6 +170,7 @@ INSTALL()
 {
 	cd build
 	make install
+	make install-bytecode
 	PATH=${PATH:2} make install-doc
 
 	# language specific doc packages

--- a/media-sound/lilypond/patches/lilypond-2.24.0.patchset
+++ b/media-sound/lilypond/patches/lilypond-2.24.0.patchset
@@ -1,32 +1,31 @@
-From 23fe51375c6aa281488168144108a012e330d7fa Mon Sep 17 00:00:00 2001
+From 26897ab6bba690fe026cddbba5452191b04e3425 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
 Date: Thu, 14 Apr 2022 15:21:58 +0200
 Subject: don't use hard links
 
 
 diff --git a/Documentation/po/GNUmakefile b/Documentation/po/GNUmakefile
-index 340e9ea..d4d1395 100644
+index 3a8e9ad..0b67652 100644
 --- a/Documentation/po/GNUmakefile
 +++ b/Documentation/po/GNUmakefile
-@@ -14,11 +14,11 @@ TELY_FILES += $(foreach l, $(LANGS), $(shell ls $(depth)/Documentation/$(l)/*.te
+@@ -13,10 +13,10 @@ TELY_FILES += $(foreach l, $(LANGS), $(shell ls $(depth)/Documentation/$(l)/*.te
  messages: $(outdir)/messages
  
  $(outdir)/messages: $(MO_FILES)
 -	$(call ly_progress,Making,$@,(hard links))
 +	$(call ly_progress,Making,$@,(symbolic links))
  	for i in $(CATALOGS); do \
- 	  rm -rf $(doc-localedir)/$$i/LC_MESSAGES; \
  	  mkdir -p $(doc-localedir)/$$i/LC_MESSAGES; \
--	  $(LN) $(outdir)/$$i.mo $(doc-localedir)/$$i/LC_MESSAGES/lilypond-doc.mo; \
-+	  $(LN) -s ../../$$i.mo $(doc-localedir)/$$i/LC_MESSAGES/lilypond-doc.mo; \
+-	  $(LN) -f $(outdir)/$$i/LC_MESSAGES/lilypond.mo $(doc-localedir)/$$i/LC_MESSAGES/lilypond-doc.mo; \
++	  $(LN) -sf ../../$$i/LC_MESSAGES/lilypond.mo $(doc-localedir)/$$i/LC_MESSAGES/lilypond-doc.mo; \
  	done
  	touch $@
  
 diff --git a/GNUmakefile.in b/GNUmakefile.in
-index d796004..2ae8f72 100644
+index 00ea581..603df70 100644
 --- a/GNUmakefile.in
 +++ b/GNUmakefile.in
-@@ -141,13 +141,13 @@ $(outdir)/%-root/index.html: doc-build
+@@ -153,13 +153,13 @@ $(outdir)/%-root/index.html: doc-build
  	mkdir -p $(dir $@)/Documentation/
  	for d in . musicxml abc2ly lilypond-book ; do \
  		mkdir -p $(dir $@)/input/regression/$${d}; \
@@ -44,10 +43,10 @@ index d796004..2ae8f72 100644
  	cp $(addprefix $(src-dir)/,$(README_FILES)) $(dir $@)
  	$(PYTHON) $(buildscript-dir)/www_post.py $(PACKAGE_NAME) $(TOPLEVEL_VERSION) $(dir $@) "$*"
 diff --git a/configure.ac b/configure.ac
-index 720f329..cd19c9e 100644
+index 16f6591..b421e5d 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -433,7 +433,7 @@ touch local.make
+@@ -320,7 +320,7 @@ touch local.make
  STEPMAKE_END
  
  if make top-doc 1>/dev/null 2>&1; then
@@ -57,10 +56,10 @@ index 720f329..cd19c9e 100644
  
  cat <<EOF
 diff --git a/python/book_snippets.py b/python/book_snippets.py
-index 3cd2270..3693e9f 100644
+index 576573f..a156ed1 100644
 --- a/python/book_snippets.py
 +++ b/python/book_snippets.py
-@@ -676,10 +676,7 @@ printing diff against existing file." % filename)
+@@ -723,10 +723,7 @@ printing diff against existing file." % filename)
                      content = content.replace(basename, final_basename)
                      open(dst, 'wb').write(content)
                  else:
@@ -70,13 +69,13 @@ index 3cd2270..3693e9f 100644
 -                        shutil.copyfile(src, dst)
 +                    shutil.copyfile(src, dst)
              except (IOError, OSError):
-                 error(_('Could not overwrite file %s') % dst)
+                 ly.error(_('Could not overwrite file %s') % dst)
                  raise CompileError(self.basename())
 -- 
-2.30.2
+2.37.3
 
 
-From 3c3bddf4c2117190cac3f0e53f344b6b746b97f1 Mon Sep 17 00:00:00 2001
+From e7353c043e2e95a00512c582ffef9cd9b516fce9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
 Date: Sat, 16 Apr 2022 14:04:41 +0200
 Subject: use perl globbing instead of shell globbing to avoid a too long
@@ -85,10 +84,10 @@ Subject: use perl globbing instead of shell globbing to avoid a too long
 the increase in hrev55899 is still not enough for this command, apparently.
 
 diff --git a/GNUmakefile.in b/GNUmakefile.in
-index 2ae8f72..bc5f4ba 100644
+index 603df70..4300f7a 100644
 --- a/GNUmakefile.in
 +++ b/GNUmakefile.in
-@@ -154,7 +154,7 @@ $(outdir)/%-root/index.html: doc-build
+@@ -166,7 +166,7 @@ $(outdir)/%-root/index.html: doc-build
  	find $(outdir)/$*-root -type l | xargs rm -f
  	cd $(outdir)/$*-root && find -name \*.html -execdir $(buildscript-dir)/fix-docsize.sh {} +
  	$(PERL) -i -pe 's#(href)="\.\./Documentation/#\1="#g' $(dir $@)/Documentation/*html
@@ -98,20 +97,20 @@ index 2ae8f72..bc5f4ba 100644
  	$(PERL) -i -pe 's#(href)="css/#\1="../../Documentation/css/#g' $(dir $@)/input/regression/*html
  	$(PERL) -i -pe 's#(href)="css/#\1="../../../Documentation/css/#g' $(dir $@)/input/regression/*/*html
 -- 
-2.30.2
+2.37.3
 
 
-From cd6c4eb018001e1975ccbb4ae3f628cda34e7428 Mon Sep 17 00:00:00 2001
+From 45f510deb1937eaba2afd976c68d73f4d86061fd Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
 Date: Sat, 16 Apr 2022 16:59:07 +0200
 Subject: fix docdir configure argument not being honoured
 
 
 diff --git a/config.make.in b/config.make.in
-index 2b8c636..582708a 100644
+index b89016e..60b6c82 100644
 --- a/config.make.in
 +++ b/config.make.in
-@@ -77,7 +77,7 @@ configure-builddir = @abs_builddir@
+@@ -74,7 +74,7 @@ configure-builddir = @abs_builddir@
  configure-srcdir = @abs_srcdir@
  datadir = @datadir@
  datarootdir = @datarootdir@
@@ -121,37 +120,10 @@ index 2b8c636..582708a 100644
  exec_prefix = @exec_prefix@
  includedir = @includedir@
 -- 
-2.30.2
+2.37.3
 
 
-From e03900f64ac990454af339ecd2174f92ea684b51 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
-Date: Sun, 17 Apr 2022 12:45:41 +0200
-Subject: fix installing info symlink
-
-python's os.getcwd() returns the normalized path with all symlinks resolved,
-which is a problem with the symlinked packaging paths of Haiku.
-
-diff --git a/scripts/build/relative.py b/scripts/build/relative.py
-index 7bd700d..b8dba56 100644
---- a/scripts/build/relative.py
-+++ b/scripts/build/relative.py
-@@ -3,8 +3,8 @@ import sys
- 
- 
- def relative(dir, r=os.getcwd()):
--    dir = os.path.normpath(dir) + '/'
--    r = os.path.normpath(r) + '/'
-+    dir = os.path.realpath(os.path.normpath(dir)) + '/'
-+    r = os.path.realpath(os.path.normpath(r)) + '/'
-     prefix = len(os.path.commonprefix((dir, r)))
-     if prefix == len(dir):
-         return './'
--- 
-2.30.2
-
-
-From 750cb8af980433616b8dc23e82782126e798aea5 Mon Sep 17 00:00:00 2001
+From 24541f3c8d769c9b69d4eee27e0120977213b4bc Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
 Date: Mon, 18 Apr 2022 11:14:49 +0200
 Subject: some fixes for tests
@@ -160,20 +132,10 @@ tests have not yet run successfully because of missing extractbb (should be prov
 texlive_core)
 
 diff --git a/scripts/build/output-distance.py b/scripts/build/output-distance.py
-index be9626c..50aa97e 100644
+index 9980b87..5841cbb 100644
 --- a/scripts/build/output-distance.py
 +++ b/scripts/build/output-distance.py
-@@ -99,7 +99,8 @@ def system_allow_exit1(x):
-     log_verbose('invoking %s' % x)
-     stat = os.system(x)
-     # This return value convention is sick.
--    assert (stat == 0) or (stat == 256)
-+    # this assert fails on Haiku, disable it
-+    # assert (stat == 0) or (stat == 256)
- 
- 
- def shorten_string(s, threshold=15):
-@@ -1278,7 +1279,7 @@ def link_file(x, y):
+@@ -1036,7 +1036,7 @@ def link_file(x, y):
      mkdir(os.path.split(y)[0])
      try:
          log_verbose('%s -> %s' % (x, y))
@@ -183,5 +145,5 @@ index be9626c..50aa97e 100644
          if z.errno == errno.ENOENT:
              pass
 -- 
-2.30.2
+2.37.3
 


### PR DESCRIPTION
Note: the recipe is still disabled because it requires texlive to build. I will rebase #7316 when this is merged.