### PR TITLE
smpeg2: fix build with modern GCC.

### DIFF
--- a/media-libs/smpeg2/patches/smpeg2-2.0.0.patchset
+++ b/media-libs/smpeg2/patches/smpeg2-2.0.0.patchset
@@ -1,0 +1,81 @@
+From b485de28c08ebc0e2d302eee633a3e2cc8434072 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Wed, 28 Dec 2022 16:26:01 -0300
+Subject: Fix -Wnarroring error.
+
+error: narrowing conversion of ‘-1’ from ‘int’ to ‘unsigned int’ inside { }
+
+Patch taken from Gentoo's patch for GCC 6.
+
+diff --git a/audio/hufftable.cpp b/audio/hufftable.cpp
+index 6bc8e86..5414ae3 100644
+--- a/audio/hufftable.cpp
++++ b/audio/hufftable.cpp
+@@ -550,11 +550,11 @@ htd33[ 31][2]={{ 16,  1},{  8,  1},{  4,  1},{  2,  1},{  0,  0},{  0,  1},
+ 
+ const HUFFMANCODETABLE MPEGaudio::ht[HTN]=
+ {
+-  { 0, 0-1, 0-1, 0,  0, htd33},
++  { 0, ~0u, ~0u, 0,  0, htd33},
+   { 1, 2-1, 2-1, 0,  7,htd01},
+   { 2, 3-1, 3-1, 0, 17,htd02},
+   { 3, 3-1, 3-1, 0, 17,htd03},
+-  { 4, 0-1, 0-1, 0,  0, htd33},
++  { 4, ~0u, ~0u, 0,  0, htd33},
+   { 5, 4-1, 4-1, 0, 31,htd05},
+   { 6, 4-1, 4-1, 0, 31,htd06},
+   { 7, 6-1, 6-1, 0, 71,htd07},
+@@ -564,7 +564,7 @@ const HUFFMANCODETABLE MPEGaudio::ht[HTN]=
+   {11, 8-1, 8-1, 0,127,htd11},
+   {12, 8-1, 8-1, 0,127,htd12},
+   {13,16-1,16-1, 0,511,htd13},
+-  {14, 0-1, 0-1, 0,  0, htd33},
++  {14,~0u,  ~0u, 0,  0, htd33},
+   {15,16-1,16-1, 0,511,htd15},
+   {16,16-1,16-1, 1,511,htd16},
+   {17,16-1,16-1, 2,511,htd16},
+-- 
+2.37.3
+
+
+From b2c613327645f44bbe6049d054c2ffc95e46a82b Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Wed, 28 Dec 2022 16:40:29 -0300
+Subject: Fix smpeg2-config.in
+
+SDL_CONFIG is now SDL2_CONFIG in the new sdl2.m4
+also
+Only dump -L/-rpath if libdir is non-standard; cribbed from smpeg patche
+
+---
+
+From Gentoo's:
+    media-libs/smpeg2/files/smpeg2-2.0.0-smpeg2-config.patch
+
+diff --git a/smpeg2-config.in b/smpeg2-config.in
+index 5cce954..e734cdf 100644
+--- a/smpeg2-config.in
++++ b/smpeg2-config.in
+@@ -42,15 +42,17 @@ while test $# -gt 0; do
+       if test @includedir@ != /usr/include ; then
+         includes=-I@includedir@
+       fi
+-      echo $includes -I@includedir@/smpeg2 `@SDL_CONFIG@ --cflags`
++	  echo $includes -I@includedir@/smpeg2 `@SDL2_CONFIG@ --cflags`
+       ;;
+     --libs)
++      if [ "@libdir@" != "/usr/lib" ]; then
+       if [ "`uname`" = "SunOS" ]; then
+         libdirs="-L@libdir@ -R@libdir@"
+       else
+         libdirs="-L@libdir@ @SMPEG_RLD_FLAGS@"
+       fi
+-      echo $libdirs -lsmpeg2 `@SDL_CONFIG@ --libs`
++      fi
++      echo $libdirs -lsmpeg2 `@SDL2_CONFIG@ --libs`
+       ;;
+     *)
+       echo "${usage}" 1>&2
+-- 
+2.37.3
+

--- a/media-libs/smpeg2/smpeg2-2.0.0.recipe
+++ b/media-libs/smpeg2/smpeg2-2.0.0.recipe
@@ -6,9 +6,10 @@ software patents in the United States."
 HOMEPAGE="http://www.icculus.org/smpeg"
 COPYRIGHT="1999-2004 Sam Lantinga, Joe Tennies."
 LICENSE="GNU LGPL v2"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://www.libsdl.org/projects/smpeg/release/smpeg2-$portVersion.tar.gz"
 CHECKSUM_SHA256="979a65b211744a44fa641a9b6e4d64e64a12ff703ae776bafe3c4c4cd85494b3"
+PATCHES=""smpeg2-$portVersion.patchset""
 
 ARCHITECTURES="all"
 SECONDARY_ARCHITECTURES="x86"
@@ -22,8 +23,6 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libgl$secondaryArchSuffix
-	lib:libglu$secondaryArchSuffix
 	lib:libsdl2_2.0$secondaryArchSuffix
 	"
 
@@ -39,8 +38,6 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	#devel:libgl$secondaryArchSuffix
-	devel:libglu$secondaryArchSuffix
 	devel:libsdl2_2.0$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
@@ -56,16 +53,20 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	rm -f acinclude.m4
-	rm -f aclocal.m4
-	echo "AC_CONFIG_MACRO_DIR([acinclude]) > configure.in"
 	libtoolize --copy --force --install
 	aclocal --install -I acinclude
 	automake --foreign --add-missing
 	autoconf
 	chmod +x configure
 
-	runConfigure ./configure
+	runConfigure ./configure \
+		--disable-dependency-tracking \
+		--disable-rpath \
+		--enable-shared \
+		--disable-static \
+		--disable-debug \
+		--disable-sdltest \
+#		--enable-mmx \
 
 	make $jobArgs
 }
@@ -76,8 +77,7 @@ INSTALL()
 
 	rm $libDir/libsmpeg2.la
 
-	prepareInstalledDevelLibs libsmpeg2 \
-					libsmpeg2-2.0
+	prepareInstalledDevelLibs libsmpeg2 libsmpeg2-2.0
 	fixDevelopLibDirReferences $binDir/smpeg2-config
 	fixPkgconfig
 

--- a/media-libs/smpeg2/smpeg2-2.0.0.recipe
+++ b/media-libs/smpeg2/smpeg2-2.0.0.recipe
@@ -16,8 +16,7 @@ SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	smpeg2$secondaryArchSuffix = 2.0.0 compat >= 2
-	cmd:plaympeg$secondaryArchSuffix = 2.0.0 compat >= 2
-	cmd:smpeg2 = 2.0.0 compat >= 2
+#	cmd:plaympeg$secondaryArchSuffix = 2.0.0 compat >= 2
 	lib:libsmpeg2$secondaryArchSuffix = 2.0_0.0.0 compat >= 2.0_0
 	lib:libsmpeg2_2.0$secondaryArchSuffix = 2.0.0 compat >= 2
 	"
@@ -77,12 +76,15 @@ INSTALL()
 
 	rm $libDir/libsmpeg2.la
 
+	# Exclude from the package, for now, as it doesn't seems to work right.
+	rm $binDir/plaympeg
+	rm -rf $manDir
+
 	prepareInstalledDevelLibs libsmpeg2 libsmpeg2-2.0
 	fixDevelopLibDirReferences $binDir/smpeg2-config
 	fixPkgconfig
 
 	# devel package
 	packageEntries devel \
-		$developDir $binDir/smpeg2-config \
-		$dataDir
+		$binDir $dataDir $developDir
 }


### PR DESCRIPTION
Cleaned up the recipe somehow. The resulting "plaympeg" is still non-functional, at least with the sample files I have:

On 64 bits: Shows a white, empty window.
On 32 bits: Shows a black, empty window.

That after properly recognizing the file as a video file, give the correct details of resolution and duration, but repeating the message:

"Warning: picture block before sequence header block".

Previous revisions (smpeg2-2.0.0-4) showed same behavior. Only difference is that old version (on 64 bits at least) loads "add-ons/opengl/Software Pipe" and prints:

"GalliumContext: CreateDisplay: Using llvmpipe (LLVM 12.0.1, 128 bits) driver"