### PR TITLE
fluidlite, re-enable and rename static library used by Haiku builds

### DIFF
--- a/media-sound/fluidlite/fluidlite-1.0.9.recipe
+++ b/media-sound/fluidlite/fluidlite-1.0.9.recipe
@@ -37,6 +37,7 @@ REQUIRES="
 PROVIDES_devel="
 	fluidlite${secondaryArchSuffix}_devel = $portVersion
 	devel:libfluidlite$secondaryArchSuffix = $portVersion compat >= 1
+	devel:libfluidlite_static$secondaryArchSuffix
 	"
 REQUIRES_devel="
 	fluidlite$secondaryArchSuffix == $portVersion base
@@ -64,7 +65,6 @@ BUILD()
 	cmake -Bbuild -S. \
 		-DCMAKE_BUILD_TYPE=Release \
 		$cmakeDirArgs \
-		-DFLUIDLITE_BUILD_STATIC:BOOL=OFF \
 		-DENABLE_SF3=YES \
 		-DSTB_VORBIS=NO
  	make -C build $jobArgs
@@ -74,7 +74,11 @@ INSTALL()
 {
 	make -C build install
 
-	prepareInstalledDevelLib libfluidlite
+	# fluidlite static library is used by the Haiku build
+	# rename so it doesn't produce an error for the same static/shared library
+	mv $libDir/libfluidlite.a $libDir/libfluidlite-static.a
+
+	prepareInstalledDevelLibs libfluidlite libfluidlite-static
 	fixPkgconfig
 
 	# devel package


### PR DESCRIPTION
This addresses: https://github.com/haikuports/haikuports/pull/7697#issuecomment-1367583768