### PR TITLE
zsh: rev-bump to fix libgdbm dependency

### DIFF
--- a/app-shells/zsh/zsh-5.8.1.recipe
+++ b/app-shells/zsh/zsh-5.8.1.recipe
@@ -7,7 +7,7 @@ HOMEPAGE="https://www.zsh.org/"
 COPYRIGHT="1992-2020 The Zsh Development Group"
 LICENSE="ZSH
 	GNU GPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://downloads.sf.net/zsh/zsh-$portVersion.tar.xz"
 CHECKSUM_SHA256="b6973520bace600b4779200269b1e5d79e5f505ac4952058c11ad5bbf0dd9919"
 SOURCE_URI_2="https://downloads.sf.net/zsh/zsh-$portVersion-doc.tar.xz"


### PR DESCRIPTION
Needed after the update on the libgdbm recipe (#7704).

Tested on 64 bits.

~Not sure if this change is enough, or specifying that the compat is with "4.0" version only.~

~If that's the case, suggestions (or links to a good example) on what's the right syntax for that... are more than welcome.~