### PR TITLE
lagrange: bump to 1.14.1

### DIFF
--- a/net-misc/lagrange/lagrange-1.14.1.recipe
+++ b/net-misc/lagrange/lagrange-1.14.1.recipe
@@ -8,7 +8,7 @@ COPYRIGHT="2020-2022 Jaakko Keränen"
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="https://github.com/skyjake/lagrange/releases/download/v$portVersion/lagrange-$portVersion.tar.gz"
-CHECKSUM_SHA256="7a89e4e950d14cfebd2806de07c49eeeb79368091a68ca439795d0aba9e1aaa7"
+CHECKSUM_SHA256="56781fc948aa7d69ba76d59cbd666f79e154674255d9bb808eb21b7b0bb61e36"
 SOURCE_DIR="lagrange-$portVersion"
 ADDITIONAL_FILES="lagrange.rdef.in"
 
@@ -24,7 +24,7 @@ REQUIRES="
 	lib:libfribidi$secondaryArchSuffix
 	lib:libharfbuzz$secondaryArchSuffix
 	lib:libmpg123$secondaryArchSuffix
-	lib:libpcre$secondaryArchSuffix
+	lib:libpcre2_8$secondaryArchSuffix
 	lib:libSDL2_2.0$secondaryArchSuffix
 	lib:libssl$secondaryArchSuffix
 	lib:libunistring$secondaryArchSuffix
@@ -37,7 +37,7 @@ BUILD_REQUIRES="
 	devel:libfribidi$secondaryArchSuffix
 	devel:libharfbuzz$secondaryArchSuffix
 	devel:libmpg123$secondaryArchSuffix
-	devel:libpcre$secondaryArchSuffix
+	devel:libpcre2_8$secondaryArchSuffix
 	devel:libSDL2_2.0$secondaryArchSuffix
 	devel:libssl$secondaryArchSuffix
 	devel:libunistring$secondaryArchSuffix


### PR DESCRIPTION
[Changelog](https://github.com/skyjake/lagrange/releases)