### PR TITLE
tcl: update to version 8.16.13

### DIFF
--- a/dev-lang/tcl/patches/tcl-8.6.13.patchset
+++ b/dev-lang/tcl/patches/tcl-8.6.13.patchset
@@ -1,11 +1,11 @@
-From f1281718cfb8a9e92bcc3d03961424043f281735 Mon Sep 17 00:00:00 2001
+From bdc9c01ab8290a624bf326fbf70731f8ec0eb012 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sat, 11 Apr 2020 14:33:00 -0400
 Subject: import patch from previous version
 
 
 diff --git a/tests/env.test b/tests/env.test
-index 036c7a2..ab8fe59 100644
+index bc1d7e9..d91cfbf 100644
 --- a/tests/env.test
 +++ b/tests/env.test
 @@ -101,7 +101,7 @@ variable keep {
@@ -14,14 +14,14 @@ index 036c7a2..ab8fe59 100644
      DYLD_NEW_LOCAL_SHARED_REGIONS DYLD_NO_FIX_PREBINDING MSYSTEM
 -    __CF_USER_TEXT_ENCODING SECURITYSESSIONID LANG WINDIR TERM
 +    __CF_USER_TEXT_ENCODING SECURITYSESSIONID LANG WINDIR TERM LIBRARY_PATH
-     CommonProgramFiles ProgramFiles CommonProgramW6432 ProgramW6432
- }
- 
+     CommonProgramFiles CommonProgramFiles(x86) ProgramFiles
+     ProgramFiles(x86) CommonProgramW6432 ProgramW6432
+     PROCESSOR_ARCHITECTURE PROCESSOR_ARCHITEW6432 USERPROFILE
 diff --git a/unix/tcl.m4 b/unix/tcl.m4
-index 27b7540..1091ee0 100644
+index ca94abd..eae2f72 100644
 --- a/unix/tcl.m4
 +++ b/unix/tcl.m4
-@@ -628,7 +628,13 @@ AC_DEFUN([SC_ENABLE_THREADS], [
+@@ -630,7 +630,13 @@ AC_DEFUN([SC_ENABLE_THREADS], [
  	    # The space is needed
  	    THREADS_LIBS=" -lpthread"
  	else
@@ -36,7 +36,7 @@ index 27b7540..1091ee0 100644
  		tcl_ok=yes, tcl_ok=no)
  	    if test "$tcl_ok" = "yes"; then
  		# The space is needed
-@@ -647,6 +653,7 @@ AC_DEFUN([SC_ENABLE_THREADS], [
+@@ -649,6 +655,7 @@ AC_DEFUN([SC_ENABLE_THREADS], [
  			AC_MSG_WARN([Don't know how to find pthread lib on your system - you must disable thread support or edit the LIBS in the Makefile...])
  		    fi
  		fi
@@ -44,7 +44,7 @@ index 27b7540..1091ee0 100644
  	    fi
  	fi
  
-@@ -1238,6 +1245,7 @@ AC_DEFUN([SC_CONFIG_CFLAGS], [
+@@ -1241,6 +1248,7 @@ AC_DEFUN([SC_CONFIG_CFLAGS], [
  	    SHLIB_LD='${CC} ${CFLAGS} ${LDFLAGS} -shared'
  	    DL_OBJS="tclLoadDl.o"
  	    DL_LIBS="-lroot"
@@ -53,5 +53,5 @@ index 27b7540..1091ee0 100644
  	    ;;
  	HP-UX-*.11.*)
 -- 
-2.30.0
+2.37.3
 

--- a/dev-lang/tcl/tcl-8.6.13.recipe
+++ b/dev-lang/tcl/tcl-8.6.13.recipe
@@ -9,7 +9,7 @@ COPYRIGHT="Regents of the University of California, Sun Microsystems, Inc., Scri
 LICENSE="TCL"
 REVISION="1"
 SOURCE_URI="https://sourceforge.net/projects/tcl/files/Tcl/$portVersion/tcl$portVersion-src.tar.gz"
-CHECKSUM_SHA256="26c995dd0f167e48b11961d891ee555f680c175f7173ff8cb829f4ebcde4c1a6"
+CHECKSUM_SHA256="43a1fae7412f61ff11de2cfd05d28cfc3a73762f354a417c62370a54e2caf066"
 SOURCE_DIR="tcl$portVersion"
 PATCHES="tcl-$portVersion.patchset"
 
@@ -71,7 +71,7 @@ BUILD()
 	export CFLAGS="-USQLITE_API -USQLITE_EXTERN"
 	cd unix
 	autoconf -f
-	runConfigure --omit-dirs binDit ./configure \
+	runConfigure --omit-dirs binDir ./configure \
 		--bindir=$commandBinDir \
 		--enable-man-symlinks \
 		--with-system-sqlite \


### PR DESCRIPTION
The so version is the same as in 8.6.12 therefore the recipe was just renamed. OpenCASCADE's DRAW still runs.
Should I remove version 8.6.11?

Tests don't run successfully. Some tests hang, and one test even crashes with an assertion in free.