### PR TITLE
torrentor: mark as broken for all platforms.

### DIFF
--- a/haiku-apps/torrentor/torrentor-0.0.5.recipe
+++ b/haiku-apps/torrentor/torrentor-0.0.5.recipe
@@ -12,8 +12,8 @@ SOURCE_URI="https://github.com/HaikuArchives/Torrentor/archive/$srcGitRev.tar.gz
 CHECKSUM_SHA256="08e47eefe98e08360f63262548b43ea39995e2ca6514a7178ea9cc7afd7cdf8f"
 SOURCE_DIR="Torrentor-$srcGitRev"
 
-ARCHITECTURES="?all !x86_gcc2 x86"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="!all !x86_gcc2"
+SECONDARY_ARCHITECTURES="!x86"
 
 PROVIDES="
 	torrentor${secondaryArchSuffix} = $portVersion


### PR DESCRIPTION
Broken since long ago (no packages on Haiku Depot).

Disable until builds gets fixed upstream (might require "transplanting" code from transmission and its .patchset for Haiku.