### PR TITLE
BeBook: fix mime types

### DIFF
--- a/haiku-data/be_book/be_book-2008_10_26.recipe
+++ b/haiku-data/be_book/be_book-2008_10_26.recipe
@@ -5,7 +5,7 @@ familiarize themselves with the BeAPI and Haiku programming in general."
 HOMEPAGE="https://www.haiku-os.org/documents"
 COPYRIGHT="ACCESS Co., Ltd."
 LICENSE="Attribution-NonCommercial-NoDerivs 3.0 Unported"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="http://haiku-files.org/files/data/bebook_20081026.zip#noarchive"
 CHECKSUM_SHA256="8bd4836744c2542567b95b3b1cacf60333562e178d5cbcf3aa0a69a02d2f7a28"
 SOURCE_DIR="bebook"
@@ -26,4 +26,5 @@ INSTALL()
 	mkdir -p $documentationDir
 	unzip $sourceDir/bebook_20081026.zip -d $documentationDir
 	mv $documentationDir/bebook $documentationDir/BeBook
+	mimeset -F $documentationDir/BeBook
 }


### PR DESCRIPTION
The original files have the type attribute set already, with CSS files taken as text/x-source-code.