### PR TITLE
requests-futures: source URI out of date, changed python 3.7 to 3.9

### DIFF
--- a/dev-python/requests-futures/requests_futures-1.0.0.recipe
+++ b/dev-python/requests-futures/requests_futures-1.0.0.recipe
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python python3)
-PYTHON_VERSIONS=(2.7 3.9)
+PYTHON_PACKAGES=(python3)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/requests-futures/requests_futures-1.0.0.recipe
+++ b/dev-python/requests-futures/requests_futures-1.0.0.recipe
@@ -6,7 +6,7 @@ HOMEPAGE="https://pypi.org/project/requests-futures/"
 COPYRIGHT="2013-2016 Ross McFarland"
 LICENSE="Apache v2"
 REVISION="1"
-SOURCE_URI="https://pypi.io/packages/source/r/requests-futures/requests-futures-$portVersion.tar.gz"
+SOURCE_URI="https://files.pythonhosted.org/packages/47/c4/fd48d1ac5110a5457c71ac7cc4caa93da10a80b8de71112430e439bdee22/requests-futures-$portVersion.tar.gz"
 SOURCE_DIR="requests-futures-$portVersion"
 CHECKSUM_SHA256="35547502bf1958044716a03a2f47092a89efe8f9789ab0c4c528d9c9c30bc148"
 ARCHITECTURES="any"
@@ -23,7 +23,7 @@ BUILD_REQUIRES="
 	"
 
 PYTHON_PACKAGES=(python python3)
-PYTHON_VERSIONS=(2.7 3.7)
+PYTHON_VERSIONS=(2.7 3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}


### PR DESCRIPTION
pypi.org now hosts this file at files.pythonhosted.org, updated to use version 3.9 of python