### PR TITLE
R, disable X11 for now

### DIFF
--- a/dev-lang/r/r-4.2.2.recipe
+++ b/dev-lang/r/r-4.2.2.recipe
@@ -13,7 +13,7 @@ variety of specific purposes but are not distributed with this package."
 HOMEPAGE="https://www.r-project.org/"
 COPYRIGHT="2022 The R Foundation for Statistical Computing"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://cloud.r-project.org/src/base/R-4/R-$portVersion.tar.gz"
 CHECKSUM_SHA256="0ff62b42ec51afa5713caee7c4fde7a0c45940ba39bef8c5c9487fef0c953df5"
 SOURCE_DIR="R-$portVersion"
@@ -152,7 +152,7 @@ BUILD()
 		--bindir=$commandBinDir \
 		--sysconfdir="$sysconfDir/R" \
 		--enable-R-shlib \
-		--with-x \
+		--with-x=no \
 		rdocdir="$docDir" \
 		rincludedir=$includeDir \
 		rsharedir="$dataDir/R"


### PR DESCRIPTION
Last build on buildmaster failed, issue with cairo vs xcairo? https://build.haiku-os.org/buildmaster/master/x86_gcc2/logviewer.html?buildruns/3659/builds/79370.log