### PR TITLE
dtc: re-add libfdt symlink

### DIFF
--- a/sys-apps/dtc/dtc-1.6.1.recipe
+++ b/sys-apps/dtc/dtc-1.6.1.recipe
@@ -4,7 +4,7 @@ device tree source files (*.dts) into the binary format (*.dtb)."
 HOMEPAGE="https://git.kernel.org/cgit/utils/dtc/dtc.git"
 COPYRIGHT="2005 David Gibson, IBM Corporation"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://www.kernel.org/pub/software/utils/dtc/dtc-$portVersion.tar.xz"
 CHECKSUM_SHA256="65cec529893659a49a89740bb362f507a3b94fc8cd791e76a8d6a2b6f3203473"
 PATCHES="dtc-$portVersion.patchset"
@@ -98,6 +98,9 @@ INSTALL()
 	packageEntries devel $developDir
 
 	packageEntries tools $commandBinDir
+
+	ln -r -s $libDir/libfdt-$portVersion.so \
+		$libDir/libfdt.so.$libVersionCompat
 }
 
 TEST()


### PR DESCRIPTION
We need to reapply this workaround unfortunately. I was a bit too enthusiastic with #7607 and #7674 - while it's true that I was able to get a sucessful qemu build with new libfdt but I tested it only on old libfdt :disappointed: 
