### PR TITLE
libevent: fixup, again, errors in the previous PR (#7754).

### DIFF
--- a/dev-libs/libevent/libevent-2.1.12.recipe
+++ b/dev-libs/libevent/libevent-2.1.12.recipe
@@ -55,9 +55,6 @@ REQUIRES_devel="
 	devel:libcrypto$secondaryArchSuffix
 	devel:libssl$secondaryArchSuffix
 	"
-CONFLICTS_devel="
-	libevent${secondaryArchSuffix}_devel
-	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
@@ -111,6 +108,5 @@ INSTALL()
 	# devel package
 	packageEntries devel \
 		$binDir \
-		$developDir \
-		$manDir
+		$developDir
 }


### PR DESCRIPTION
- Remove left-over "CONFLICTS_devel".
- Undo the wrongful addition of `$manDir` to the `packageEntries devel` section.


Built and test-installed on:

64 bits:
  - libevent-2.1.12-2-x86_64.hpkg

32 bits:
  - libevent-1.4.14b-3-x86_gcc2.hpkg
  - libevent_x86-2.1.12-2-x86_gcc2.hpkg

(along with their `_devel` packages)