### PR TITLE
links: fix build on x86 (32 bits).

### DIFF
--- a/www-client/links/links-2.28.recipe
+++ b/www-client/links/links-2.28.recipe
@@ -78,7 +78,7 @@ BUILD()
 {
 	autoreconf -vfi
 
-	if [ "$secondaryArchSuffix" = _x86 ]; then
+	if [ $effectiveTargetArchitecture == 'x86' ]; then
 		export CFLAGS="-DTIFF_DISABLE_DEPRECATED -g -O2 -fopenmp"
 	fi
 

--- a/www-client/links/links-2.28.recipe
+++ b/www-client/links/links-2.28.recipe
@@ -77,12 +77,18 @@ defineDebugInfoPackage links$secondaryArchSuffix \
 BUILD()
 {
 	autoreconf -vfi
+
+	if [ "$secondaryArchSuffix" = _x86 ]; then
+		export CFLAGS="-DTIFF_DISABLE_DEPRECATED -g -O2 -fopenmp"
+	fi
+
 	runConfigure --omit-dirs binDir ./configure \
 		--bindir="$commandBinDir" \
 		--without-x \
 		--with-haiku \
 		--with-ssl \
 		--enable-graphics
+
 	make $jobArgs
 }
 


### PR DESCRIPTION
This seems to have been broken since the update to 2.28, as 2.21 is the last version available on the repositories.

The fix avoids errors resulting from conflicting integer types between the <tiff.h> and <SupportDefs.h> headers.

Needed to also specify "-g -O2 -fopenmp" when defining CFLAGS to avoid linking errors (and to match the default flags).

None of this is necessary on x86_64, thus the conditional on "x86".