### PR TITLE
lagrange: bump to 1.14.2

### DIFF
--- a/net-misc/lagrange/lagrange-1.14.2.recipe
+++ b/net-misc/lagrange/lagrange-1.14.2.recipe
@@ -8,7 +8,7 @@ COPYRIGHT="2020-2022 Jaakko Keränen"
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="https://github.com/skyjake/lagrange/releases/download/v$portVersion/lagrange-$portVersion.tar.gz"
-CHECKSUM_SHA256="56781fc948aa7d69ba76d59cbd666f79e154674255d9bb808eb21b7b0bb61e36"
+CHECKSUM_SHA256="51b05ef7fd730d77ed9571c76a1772067fcfeeb900cbe8e66ec19c6fdfe58c64"
 SOURCE_DIR="lagrange-$portVersion"
 ADDITIONAL_FILES="lagrange.rdef.in"
 


### PR DESCRIPTION
[Changelog](https://github.com/skyjake/lagrange/releases)