### PR TITLE
tcpdump: update to 4.99.3

### DIFF
--- a/net-analyzer/tcpdump/patches/tcpdump-4.99.3.gcc2.patchset
+++ b/net-analyzer/tcpdump/patches/tcpdump-4.99.3.gcc2.patchset
@@ -1,14 +1,84 @@
-From 429ca8b7b35b724c8e9690f00eaa76638d9442fb Mon Sep 17 00:00:00 2001
+From 8c3732c93f123f7d2f02fd2c4fed06416c590385 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
-Date: Mon, 1 Nov 2021 11:06:20 +0100
+Date: Fri, 13 Jan 2023 18:56:10 +0000
 Subject: fix build with gcc2
 
 
+diff --git a/print-802_15_4.c b/print-802_15_4.c
+index 1895be7..e3b4e03 100644
+--- a/print-802_15_4.c
++++ b/print-802_15_4.c
+@@ -2093,9 +2093,10 @@ ieee802_15_4_std_frames(netdissect_options *ndo,
+ 
+ 	/* Print MIC */
+ 	if (ndo->ndo_vflag > 2 && miclen != 0) {
++		u_int micoffset;
+ 		ND_PRINT("\n\tMIC ");
+ 
+-		for (u_int micoffset = 0; micoffset < miclen; micoffset++) {
++		for (micoffset = 0; micoffset < miclen; micoffset++) {
+ 			ND_PRINT("%02x", GET_U_1(mic_start + micoffset));
+ 		}
+ 		ND_PRINT(" ");
+@@ -2416,9 +2417,10 @@ ieee802_15_4_mp_frame(netdissect_options *ndo,
+ 
+ 	/* Print MIC */
+ 	if (ndo->ndo_vflag > 2 && miclen != 0) {
++		u_int micoffset;
+ 		ND_PRINT("\n\tMIC ");
+ 
+-		for (u_int micoffset = 0; micoffset < miclen; micoffset++) {
++		for (micoffset = 0; micoffset < miclen; micoffset++) {
+ 			ND_PRINT("%02x", GET_U_1(mic_start + micoffset));
+ 		}
+ 		ND_PRINT(" ");
+diff --git a/print-arista.c b/print-arista.c
+index 039a1ff..da9b20e 100644
+--- a/print-arista.c
++++ b/print-arista.c
+@@ -124,6 +124,8 @@ arista_ethertype_print(netdissect_options *ndo, const u_char *bp, u_int len _U_)
+ 
+ 	// TapAgg Header Timestamping
+ 	if (subTypeId == ARISTA_SUBTYPE_TIMESTAMP) {
++		uint8_t ts_format;
++		uint8_t hw_info;
+ 		uint64_t seconds;
+ 		uint32_t nanoseconds;
+ 		uint8_t ts_timescale = GET_U_1(bp);
+@@ -133,8 +135,8 @@ arista_ethertype_print(netdissect_options *ndo, const u_char *bp, u_int len _U_)
+ 		         tok2str(ts_timescale_str, "Unknown", ts_timescale),
+ 		         ts_timescale);
+ 
+-		uint8_t ts_format = GET_U_1(bp) >> 4;
+-		uint8_t hw_info = GET_U_1(bp) & 0x0f;
++		ts_format = GET_U_1(bp) >> 4;
++		hw_info = GET_U_1(bp) & 0x0f;
+ 		bp += 1;
+ 		bytesConsumed += 1;
+ 
+diff --git a/print-bgp.c b/print-bgp.c
+index e13fdd9..207fab0 100644
+--- a/print-bgp.c
++++ b/print-bgp.c
+@@ -2980,9 +2980,11 @@ bgp_notification_print(netdissect_options *ndo,
+         if ((bgpn_minor == BGP_NOTIFY_MINOR_CEASE_SHUT ||
+              bgpn_minor == BGP_NOTIFY_MINOR_CEASE_RESET) &&
+              length >= BGP_NOTIFICATION_SIZE + 1) {
++            uint8_t shutdown_comm_length;
++            uint8_t remainder_offset;
+             tptr = dat + BGP_NOTIFICATION_SIZE;
+-            uint8_t shutdown_comm_length = GET_U_1(tptr);
+-            uint8_t remainder_offset = 0;
++            shutdown_comm_length = GET_U_1(tptr);
++            remainder_offset = 0;
+             /* garbage, hexdump it all */
+             if (shutdown_comm_length > length - (BGP_NOTIFICATION_SIZE + 1)) {
+                 ND_PRINT(", invalid Shutdown Communication length");
 diff --git a/print-ether.c b/print-ether.c
-index da95862..6682678 100644
+index cd623f9..d306fd7 100644
 --- a/print-ether.c
 +++ b/print-ether.c
-@@ -210,6 +210,7 @@ recurse:
+@@ -211,6 +211,7 @@ recurse:
  	 */
  	printed_length = 0;
  	if (length_type == ETHERTYPE_MACSEC) {
@@ -16,16 +86,16 @@ index da95862..6682678 100644
  		/*
  		 * MACsec, aka IEEE 802.1AE-2006
  		 * Print the header, and try to print the payload if it's not encrypted
-@@ -220,7 +221,7 @@ recurse:
+@@ -221,7 +222,7 @@ recurse:
  			printed_length = 1;
  		}
  
 -		int ret = macsec_print(ndo, &p, &length, &caplen, &hdrlen,
 +		ret = macsec_print(ndo, &p, &length, &caplen, &hdrlen,
- 		    &src, &dst);
+ 				       &src, &dst);
  
  		if (ret == 0) {
-@@ -345,6 +346,7 @@ recurse:
+@@ -350,6 +351,7 @@ recurse:
  		}
  		hdrlen += llc_hdrlen;
  	} else if (length_type == ETHERTYPE_ARISTA) {
@@ -33,7 +103,7 @@ index da95862..6682678 100644
  		if (caplen < 2) {
  			ND_PRINT("[|arista]");
  			return hdrlen + caplen;
-@@ -355,7 +357,7 @@ recurse:
+@@ -360,7 +362,7 @@ recurse:
  		}
  		ether_type_print(ndo, length_type);
  		ND_PRINT(", length %u: ", orig_length);
@@ -63,6 +133,27 @@ index ddd5595..2ad598d 100644
                      tptr++;
                      subtlv_len--;
                      subtlv_sum_len--;
+diff --git a/print-juniper.c b/print-juniper.c
+index 2fc0b55..77aeaa5 100644
+--- a/print-juniper.c
++++ b/print-juniper.c
+@@ -1275,6 +1275,7 @@ juniper_parse_header(netdissect_options *ndo,
+ #endif
+     int tlv_value;
+     const u_char *tptr;
++    const struct juniper_cookie_table_t *table_lp;
+ 
+ 
+     l2info->header_len = 0;
+@@ -1405,7 +1406,7 @@ juniper_parse_header(netdissect_options *ndo,
+ 
+     /* search through the cookie table for one matching our PIC type */
+     lp = NULL;
+-    for (const struct juniper_cookie_table_t *table_lp = juniper_cookie_table;
++    for (table_lp = juniper_cookie_table;
+          table_lp->s != NULL; table_lp++) {
+         if (table_lp->pictype == l2info->pictype) {
+             lp = table_lp;
 diff --git a/print-openflow-1.0.c b/print-openflow-1.0.c
 index 1d7f247..67f537a 100644
 --- a/print-openflow-1.0.c
@@ -85,10 +176,10 @@ index 1d7f247..67f537a 100644
  	ether_print(ndo, cp, len, ND_BYTES_AVAILABLE_AFTER(cp), NULL, NULL);
  	ndo->ndo_snapend = snapend_save;
 diff --git a/print-ospf.c b/print-ospf.c
-index c370bda..916b279 100644
+index e6bebed..7f8f817 100644
 --- a/print-ospf.c
 +++ b/print-ospf.c
-@@ -643,14 +643,15 @@ ospf_print_lsa(netdissect_options *ndo,
+@@ -645,14 +645,15 @@ ospf_print_lsa(netdissect_options *ndo,
  
  	switch (GET_U_1(lsap->ls_hdr.ls_type)) {
  
@@ -106,7 +197,7 @@ index c370bda..916b279 100644
  			ND_TCHECK_SIZE(rlp);
  			switch (GET_U_1(rlp->un_tos.link.link_type)) {
  
-@@ -690,7 +691,7 @@ ospf_print_lsa(netdissect_options *ndo,
+@@ -692,7 +693,7 @@ ospf_print_lsa(netdissect_options *ndo,
  			    (GET_U_1(rlp->un_tos.link.link_tos_count) * sizeof(union un_tos)));
  		}
  		break;
@@ -115,7 +206,7 @@ index c370bda..916b279 100644
  	case LS_TYPE_NETWORK:
  		ND_PRINT("\n\t    Mask %s\n\t    Connected Routers:",
  		    GET_IPADDR_STRING(lsap->lsa_un.un_nla.nla_mask));
-@@ -799,10 +800,11 @@ ospf_print_lsa(netdissect_options *ndo,
+@@ -800,10 +801,11 @@ ospf_print_lsa(netdissect_options *ndo,
  	case LS_TYPE_OPAQUE_DW:
  
  	    switch (GET_U_1(lsap->ls_hdr.un_lsa_id.opaque_field.opaque_type)) {
@@ -129,7 +220,7 @@ index c370bda..916b279 100644
  		while (ls_length_remaining != 0) {
                      ND_TCHECK_4(tptr);
  		    if (ls_length_remaining < 4) {
-@@ -847,7 +849,7 @@ ospf_print_lsa(netdissect_options *ndo,
+@@ -848,7 +850,7 @@ ospf_print_lsa(netdissect_options *ndo,
                      ls_length_remaining-=tlv_length;
                  }
                  break;
@@ -165,7 +256,7 @@ index 23b6d5a..c52ca43 100644
                  hexdump=TRUE;
              }
 diff --git a/print.c b/print.c
-index bfc35d9..b4709bf 100644
+index 9c0ab86..b0d2930 100644
 --- a/print.c
 +++ b/print.c
 @@ -327,6 +327,7 @@ void
@@ -185,5 +276,5 @@ index bfc35d9..b4709bf 100644
  	tvbuf.tv_usec = h->ts.tv_usec;
  	ts_print(ndo, &tvbuf);
 -- 
-2.30.2
+2.37.3
 

--- a/net-analyzer/tcpdump/patches/tcpdump-4.99.3.patchset
+++ b/net-analyzer/tcpdump/patches/tcpdump-4.99.3.patchset
@@ -1,14 +1,14 @@
-From 5fc466d76d9e5f599f9a3c2ae0aade7eece6d486 Mon Sep 17 00:00:00 2001
+From e33cbe01f9a0cc763a4699ff2a1792f1cd46f9ec Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Tue, 28 Apr 2015 20:22:20 +0000
 Subject: Haiku patch
 
 
 diff --git a/aclocal.m4 b/aclocal.m4
-index ef5efe0..a618dcd 100644
+index c67e572..7dfa4ce 100644
 --- a/aclocal.m4
 +++ b/aclocal.m4
-@@ -1072,7 +1072,7 @@ AC_DEFUN(AC_LBL_LIBRARY_NET, [
+@@ -1174,7 +1174,7 @@ AC_DEFUN(AC_LBL_LIBRARY_NET, [
  	AC_CHECK_LIB(socket, gethostbyname,
                       LIBS="-lsocket -lnsl $LIBS", , -lnsl)
      fi
@@ -18,5 +18,5 @@ index ef5efe0..a618dcd 100644
      # DLPI needs putmsg under HPUX so test for -lstr while we're at it
      AC_SEARCH_LIBS(putmsg, str)
 -- 
-2.30.2
+2.37.3
 

--- a/net-analyzer/tcpdump/tcpdump-4.99.3.recipe
+++ b/net-analyzer/tcpdump/tcpdump-4.99.3.recipe
@@ -34,11 +34,13 @@ COPYRIGHT="
 LICENSE="BSD (3-clause)"
 REVISION="1"
 SOURCE_URI="http://www.tcpdump.org/release/tcpdump-${portVersion}.tar.gz"
-CHECKSUM_SHA256="79b36985fb2703146618d87c4acde3e068b91c553fb93f021a337f175fd10ebe"
+CHECKSUM_SHA256="ad75a6ed3dc0d9732945b2e5483cb41dc8b4b528a169315e499c6861952e73b3"
 PATCHES="tcpdump-$portVersion.patchset"
 
 if [ $effectiveTargetArchitecture = x86_gcc2 ]; then
-	PATCHES="tcpdump-$portVersion.gcc2.patchset"
+	PATCHES+="
+		tcpdump-$portVersion.gcc2.patchset
+		"
 fi
 
 ARCHITECTURES="all"


### PR DESCRIPTION
The patch for `aclocal.m4` is still needed - could be upstreamed.

make check: 1 failed test case `nflog-e`, this is better test result than on any previous version so far.