### PR TITLE
qtwebengine_web, for now depend on libevent >= 6.0.2

### DIFF
--- a/dev-qt/qtwebengine/qtwebengine_bin-5.15.2.recipe
+++ b/dev-qt/qtwebengine/qtwebengine_bin-5.15.2.recipe
@@ -5,7 +5,7 @@ HOMEPAGE="https://www.qt.io"
 COPYRIGHT="2015-2020 The Qt Company Ltd."
 LICENSE="BSD (3-clause)
 	GNU LGPL v2.1"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://github.com/threedeyes/qtwebengine-haiku/releases/download/v${portVersion}-4/qtwebengine-${portVersion}-4-x86_64.hpkg#noarchive"
 CHECKSUM_SHA256="632d0ba0dd57fa7a25033a747fd0138f3b306668739af7924b280b6ff9bf4990"
 SOURCE_URI_2="https://github.com/threedeyes/qtwebengine-haiku/releases/download/v${portVersion}-4/qtwebengine_devel-${portVersion}-4-x86_64.hpkg#noarchive"
@@ -34,7 +34,7 @@ REQUIRES="
 	lib:libdbus_1$secondaryArchSuffix
 	lib:libexecinfo$secondaryArchSuffix
 	lib:libexpat$secondaryArchSuffix
-	lib:libevent_2.1$secondaryArchSuffix
+	lib:libevent_2.1$secondaryArchSuffix >= 6.0.2
 	lib:libfontconfig$secondaryArchSuffix
 	lib:libfreetype$secondaryArchSuffix
 	lib:libgl$secondaryArchSuffix


### PR DESCRIPTION
Fixes: https://github.com/haikuports/haikuports/issues/7766