### PR TITLE
x265: enabled assembly for 10bit & 12bit encoding libs

### DIFF
--- a/media-libs/x265/x265-3.5.recipe
+++ b/media-libs/x265/x265-3.5.recipe
@@ -7,7 +7,7 @@ the bit rate. x265 is a free software project implementing that standard."
 HOMEPAGE="http://x265.org/"
 COPYRIGHT="2013-2021 x265 Project"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://bitbucket.org/multicoreware/x265_git/get/$portVersion.tar.gz"
 CHECKSUM_SHA256="5ca3403c08de4716719575ec56c686b1eb55b078c0fe50a064dcf1ac20af1618"
 # BitBucket sucks
@@ -89,8 +89,7 @@ BUILD()
 		-DEXPORT_C_API=OFF \
 		-DENABLE_SHARED=OFF \
 		-DENABLE_CLI=OFF \
-		-DMAIN12=ON \
-		-DENABLE_ASSEMBLY=OFF
+		-DMAIN12=ON
 	make $jobArgs -C build/12bit
 	cp ./build/12bit/libx265.a ./libx265_12b.a
 
@@ -104,8 +103,7 @@ BUILD()
 		-DEXPORT_C_API=OFF \
 		-DENABLE_SHARED=OFF \
 		-DENABLE_CLI=OFF \
-		-DENABLE_HDR10_PLUS=ON \
-		-DENABLE_ASSEMBLY=OFF
+		-DENABLE_HDR10_PLUS=ON
 	make $jobArgs -C build/10bit
 	cp ./build/10bit/libx265.a ./libx265_10b.a
 	cp ./build/10bit/libhdr10plus.a ./libhdr10plus.a


### PR DESCRIPTION
The recipe for x265 3.5 contained a statement -DENABLE_ASSEMBLY=OFF which caused encoding libraries for both 10 bit and 12 bit to be built without assembly optimizations.
I removed that statement and now nasm is used to build faster versions of the libs.