### PR TITLE
portmidi: bump version

### DIFF
--- a/media-libs/portmidi/portmidi-2.0.4.recipe
+++ b/media-libs/portmidi/portmidi-2.0.4.recipe
@@ -4,11 +4,10 @@ HOMEPAGE="https://github.com/PortMidi/portmidi"
 COPYRIGHT="1999-2000 Ross Bencina and Phil Burk
 	2001-2009 Roger B. Dannenberg"
 LICENSE="MIT"
-REVISION="2"
-srcGitRev="7db20989f1571b27bd01cf9418361e988bdcf99a"
-SOURCE_URI="https://github.com/PortMidi/portmidi/archive/$srcGitRev.tar.gz"
-CHECKSUM_SHA256="96872e3c89339c9cbe44d5d86de1745ced7d803563a3ef71840aa9b120497e60"
-SOURCE_DIR="portmidi-$srcGitRev"
+REVISION="1"
+SOURCE_URI="https://github.com/PortMidi/portmidi/archive/refs/tags/v$portVersion.tar.gz"
+CHECKSUM_SHA256="64893e823ae146cabd3ad7f9a9a9c5332746abe7847c557b99b2577afa8a607c"
+SOURCE_DIR="portmidi-$portVersion"
 ADDITIONAL_FILES="pmdefaults.rdef.in"
 
 ARCHITECTURES="all"
@@ -93,7 +92,7 @@ if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
 		"
 
 	BUILD_PREREQUIRES+="
-		cmd:javac
+		cmd:javac >= 11
 		"
 fi
 


### PR DESCRIPTION
also fix the requirement of cmd:javac (actually openjdk_default)