### PR TITLE
Build libiconv with --enable-extra-encodings

### DIFF
--- a/dev-libs/libiconv/libiconv-1.17.recipe
+++ b/dev-libs/libiconv/libiconv-1.17.recipe
@@ -97,7 +97,7 @@ HOMEPAGE="https://www.gnu.org/software/libiconv/"
 COPYRIGHT="2000-2022 Free Software Foundation, Inc."
 LICENSE="GNU LGPL v2
 	GNU GPL v3"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://ftpmirror.gnu.org/libiconv/libiconv-$portVersion.tar.gz"
 CHECKSUM_SHA256="8f74213b56238c85a50a5329f77e06198771e70dd9a739779f4c02f65d971313"
 PATCHES="libiconv-$portVersion.patchset"
@@ -165,7 +165,8 @@ BUILD()
 		--enable-relocatable \
 		--enable-shared \
 		--disable-static \
-		--disable-nls
+		--disable-nls \
+		--enable-extra-encodings
 	make $jobArgs
 }
 


### PR DESCRIPTION
libiconv should be built with **--enable-extra-encodings**, so that standard items like CP437 used by open cubic player is included.

Fixes #7781