### PR TITLE
sc: new recipe

### DIFF
--- a/app-office/sc/sc-7.16_1.1.2.recipe
+++ b/app-office/sc/sc-7.16_1.1.2.recipe
@@ -1,0 +1,62 @@
+SUMMARY="Spreadsheet Calculator - A spreadsheet program for the terminal"
+DESCRIPTION="sc is a free curses-based spreadsheet program that uses key bindings \
+similar to vi and less."
+HOMEPAGE="https://github.com/n-t-roff/sc"
+COPYRIGHT="1981-2018 sc authors"
+LICENSE="Public Domain"
+REVISION="1"
+SOURCE_URI="https://github.com/n-t-roff/sc/archive/refs/tags/$portVersion.tar.gz"
+CHECKSUM_SHA256="1802c9d3d60dac85feb783adf967bc0d2fd7e5f592d9d1df15e4e87d83efcf14"
+SOURCE_DIR="sc-$portVersion"
+
+ARCHITECTURES="all !x86_gcc2"
+
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	SECONDARY_ARCHITECTURES="x86"
+fi
+
+PROVIDES="
+	sc$secondaryArchSuffix = $portVersion
+	cmd:sc = $portVersion
+	cmd:psc = $portVersion
+	cmd:scqref = $portVersion
+	cmd:xsc = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libncursesw$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	cmd:bison
+	devel:libncursesw$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:make
+	cmd:gcc$secondaryArchSuffix
+	"
+
+PATCH()
+{
+	sed -i -e "s,^prefix=/usr/local,prefix=$prefix," "Makefile.in"
+	sed -i -e "s,^MANDIR=.*,MANDIR=$manDir/man1," "Makefile.in"
+	sed -i -e "s,^LIBDIR=.*,LIBDIR=$dataDir/sc," "Makefile.in"
+
+	# Use symlinks (the order of the sed calls here matters)
+	sed -i -e "s,^LN=ln,#LN=ln," "Makefile.in"
+	sed -i -e "s,^#LN=ln -s,LN=ln -s," "Makefile.in"
+}
+
+BUILD()
+{
+	# This is NOT an autotools "configure" script, but a custom one.
+	./configure
+	# not using parallel builds, as it may break if bison/yacc files are generated to late.
+	make
+}
+
+INSTALL()
+{
+	make install
+}

--- a/app-office/sc/sc-7.16_1.1.2.recipe
+++ b/app-office/sc/sc-7.16_1.1.2.recipe
@@ -15,12 +15,13 @@ if [ "$targetArchitecture" = x86_gcc2 ]; then
 	SECONDARY_ARCHITECTURES="x86"
 fi
 
+GLOBAL_WRITABLE_FILES="settings/sc directory keep-old"
+
 PROVIDES="
 	sc$secondaryArchSuffix = $portVersion
 	cmd:sc = $portVersion
 	cmd:psc = $portVersion
 	cmd:scqref = $portVersion
-	cmd:xsc = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -29,19 +30,19 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	cmd:bison
 	devel:libncursesw$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:make
+	cmd:bison
 	cmd:gcc$secondaryArchSuffix
+	cmd:make
 	"
 
 PATCH()
 {
 	sed -i -e "s,^prefix=/usr/local,prefix=$prefix," "Makefile.in"
 	sed -i -e "s,^MANDIR=.*,MANDIR=$manDir/man1," "Makefile.in"
-	sed -i -e "s,^LIBDIR=.*,LIBDIR=$dataDir/sc," "Makefile.in"
+	sed -i -e "s,^LIBDIR=.*,LIBDIR=$settingsDir/sc," "Makefile.in"
 
 	# Use symlinks (the order of the sed calls here matters)
 	sed -i -e "s,^LN=ln,#LN=ln," "Makefile.in"
@@ -50,13 +51,17 @@ PATCH()
 
 BUILD()
 {
-	# This is NOT an autotools "configure" script, but a custom one.
+	# This is not an autotools "configure" script, but a custom one.
 	./configure
-	# not using parallel builds, as it may break if bison/yacc files are generated to late.
+	# don't use parallel builds, as it may break if bison/yacc files are processed too late.
 	make
 }
 
 INSTALL()
 {
 	make install
+
+	# These are not really that useful to have around.
+	rm $prefix/bin/xsc
+	rm $manDir/man1/xsc.1
 }


### PR DESCRIPTION
Tested on beta4, 64 and 32 bits (x86).

Placed it under `app-office` following the example from Gentoo, that, despite not having `sc` proper, it does has [sc-im](https://gitweb.gentoo.org/repo/gentoo.git/tree/app-office/sc-im) (will submit a PR for that one later).