### PR TITLE
sc-im: new recipe

### DIFF
--- a/app-office/sc-im/patches/sc_im-0.8.3.patchset
+++ b/app-office/sc-im/patches/sc_im-0.8.3.patchset
@@ -1,0 +1,76 @@
+From 6cc2e39b78a159823f90b0fbd9a121c22563adc1 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Tue, 24 Jan 2023 02:32:55 -0300
+Subject: Initial Makefile patch for Haiku
+
+
+diff --git a/src/Makefile b/src/Makefile
+old mode 100755
+new mode 100644
+index defd77a..082a0d2
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -23,7 +23,11 @@ CONFIG_FILE=scimrc
+ #YACC = bison -y
+ #SED  = sed
+ 
++ifneq ($(shell uname -s),Haiku)
+ LDLIBS += -lm
++else
++LDLIBS += -lbsd # needed on Haiku for "strsep"
++endif
+ 
+ CFLAGS += -Wall -g
+ CFLAGS += -DNCURSES
+@@ -60,25 +64,28 @@ CFLAGS += -DMOUSE
+ #to copy to tmux clipboard:
+ #CFLAGS += -DDEFAULT_COPY_TO_CLIPBOARD_CMD=\""tmux load-buffer"\"
+ #to copy to X clipboard:
+-CFLAGS += -DDEFAULT_COPY_TO_CLIPBOARD_CMD=\""xclip -i -selection clipboard <"\"
++#CFLAGS += -DDEFAULT_COPY_TO_CLIPBOARD_CMD=\""xclip -i -selection clipboard <"\"
+ #to copy to OSX clipboard:
+ #CFLAGS += -DDEFAULT_COPY_TO_CLIPBOARD_CMD=\""pbcopy <"\"
++CFLAGS += -DDEFAULT_COPY_TO_CLIPBOARD_CMD=\""clipboard -i <"\"
+ #
+ # Choose one of the proposed commands for pasting from different clipboards:
+ # You can later change it at runtime.
+ #CFLAGS += -DDEFAULT_PASTE_FROM_CLIPBOARD_CMD=\""tmux show-buffer"\"
+-CFLAGS += -DDEFAULT_PASTE_FROM_CLIPBOARD_CMD=\""xclip -o -selection clipboard"\"
++#CFLAGS += -DDEFAULT_PASTE_FROM_CLIPBOARD_CMD=\""xclip -o -selection clipboard"\"
+ #CFLAGS += -DDEFAULT_PASTE_FROM_CLIPBOARD_CMD=\""pbpaste"\"
++CFLAGS += -DDEFAULT_PASTE_FROM_CLIPBOARD_CMD=\""clipboard -p"\"
+ 
+ # Command to open file or link under cursor
+-CFLAGS += -DDEFAULT_OPEN_FILE_UNDER_CURSOR_CMD=\""scopen"\"
++CFLAGS += -DDEFAULT_OPEN_FILE_UNDER_CURSOR_CMD=\""open"\"
+ 
+ # Autobackup. If you unset this, no backup check nor autobackup feature will be available.
+ CFLAGS += -DAUTOBACKUP
+ # Have threads? Set these two, if you want the autobackup feature to work with threads.
+ CFLAGS += -DHAVE_PTHREAD
+ 
+-ifneq ($(shell uname -s),Darwin)
++ifeq ($(shell uname -s),Haiku)
++else ifneq ($(shell uname -s),Darwin)
+   LDLIBS += -pthread
+ endif
+ 
+@@ -90,10 +97,14 @@ endif
+ # OpenBSD does not implement wordexp()
+ ifeq ($(shell uname -s),OpenBSD)
+   CFLAGS += -DNO_WORDEXP
++else ifeq ($(shell uname -s),Haiku)
++  CFLAGS += -DNO_WORDEXP
+ endif
+ 
++
+ # dynamic linking (not available in BSD)
+-ifneq ($(shell uname -s | grep -o BSD),BSD)
++ifeq ($(shell uname -s),Haiku)
++else ifneq ($(shell uname -s | grep -o BSD),BSD)
+   LDLIBS += -ldl
+ endif
+ 
+-- 
+2.37.3
+

--- a/app-office/sc-im/sc_im-0.8.3.recipe
+++ b/app-office/sc-im/sc_im-0.8.3.recipe
@@ -1,0 +1,74 @@
+SUMMARY="Spreadsheet Calculator Improvised - An ncurses spreadsheet program for terminal"
+DESCRIPTION="Spreadsheet Calculator Improvised, aka sc-im, is an ncurses based, vim-like \
+spreadsheet calculator.
+
+sc-im is based on sc, whose original authors are James Gosling and Mark Weiser, and mods \
+were later added by Chuck Martin."
+HOMEPAGE="https://github.com/andmarti1424/sc-im"
+COPYRIGHT="2013-2023 Andrés Martinelli"
+LICENSE="BSD (4-clause)"
+REVISION="1"
+SOURCE_URI="https://github.com/andmarti1424/sc-im/archive/refs/tags/v$portVersion.tar.gz"
+CHECKSUM_SHA256="5568f9987b6d26535c0e7a427158848f1bc03d829f74e41cbcf007d8704e9bd3"
+SOURCE_DIR="sc-im-$portVersion"
+PATCHES="sc_im-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	SECONDARY_ARCHITECTURES="x86"
+fi
+
+PROVIDES="
+	sc_im$secondaryArchSuffix = $portVersion
+	cmd:sc_im = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libncursesw$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	cmd:bison
+	cmd:pkg_config$secondaryArchSuffix
+	devel:libncursesw$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:make
+	cmd:gcc$secondaryArchSuffix
+	cmd:which
+	"
+
+TEST_REQUIRES="
+	cmd:bash
+	cmd:getopt
+	"
+
+PATCH()
+{
+	sed -i -e "s,^prefix  = /usr/local,prefix  = $prefix," src/Makefile
+	sed -i -e "s,^HELPDIR = .*,HELPDIR = $docDir," src/Makefile
+	sed -i -e "s,^LIBDIR  = .*,LIBDIR = $dataDir/sc-im," src/Makefile
+	sed -i -e "s,^MANDIR  = .*,MANDIR  = $manDir/man1," src/Makefile
+	sed -i -e "s,^HISTORY_DIR= .*,HISTORY_DIR= $settingsDir/sc-im," src/Makefile
+	sed -i -e "s,^CONFIG_DIR= .config/sc-im,CONFIG_DIR= $settingsDir/sc-im," src/Makefile
+}
+
+BUILD()
+{
+	make -C src $jobArgs
+}
+
+INSTALL()
+{
+	make -C src install
+	# we don't want `scopen`, we'll use Haiku's `open` instead
+	rm $prefix/bin/scopen
+}
+
+TEST()
+{
+	#  All test fail because they require "cmd:valgrind".
+	cd tests && run_all_tests.sh
+}


### PR DESCRIPTION
`sc-im` is to `sc` as `vim` is to `vi`, or so it seems.

Only enabled the basics to keep dependencies low.

In the future, could require/use `gnuplot` for "charts", `libxml2` and `libzip` for xlsx/ods import support, and/or `lua` for scripting.

----

Tested on beta4, 64 and 32 bits (x86).