### PR TITLE
wireshark: update to 4.0.3

### DIFF
--- a/net-analyzer/wireshark/patches/wireshark-4.0.3.patchset
+++ b/net-analyzer/wireshark/patches/wireshark-4.0.3.patchset
@@ -1,4 +1,4 @@
-From 21ad69433cebbe4b62b210b91814657c32c7d264 Mon Sep 17 00:00:00 2001
+From 789b8e700c201886b580dfaa03fa8b210a8ae698 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Tue, 25 Oct 2022 21:11:55 +0200
 Subject: fix build for cpu_info.c
@@ -21,7 +21,7 @@ index f7f0d2e..fee8651 100644
 2.37.3
 
 
-From e76a3327c7faa6d55e1b4bb63d70b2b6e799f3a9 Mon Sep 17 00:00:00 2001
+From ba9a7cc2dad9d4861859a622fc1e4938828714d0 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Tue, 25 Oct 2022 21:14:59 +0200
 Subject: fix include sys/time.h
@@ -43,17 +43,17 @@ index d12f747..80597f0 100644
 2.37.3
 
 
-From 69a204828073f2cb8bf6c0c42c6e641d1a66ac45 Mon Sep 17 00:00:00 2001
+From e7fe9972248d44c5552a82c5bd917d5b89d7244f Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Mon, 15 Nov 2021 10:26:33 +0000
 Subject: use realpath in init_progfile_dir
 
 
 diff --git a/wsutil/filesystem.c b/wsutil/filesystem.c
-index 4d749da..bde264b 100644
+index 1eca4ce..138a1bf 100644
 --- a/wsutil/filesystem.c
 +++ b/wsutil/filesystem.c
-@@ -726,6 +726,12 @@ configuration_init(
+@@ -741,6 +741,12 @@ configuration_init(
          }
      }
  
@@ -70,17 +70,17 @@ index 4d749da..bde264b 100644
 2.37.3
 
 
-From 10b5fe99f7dec64772763261a158589f8e419219 Mon Sep 17 00:00:00 2001
+From eb1955a65f48fd5e79c2aed9996cced4781866fa Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Thu, 25 Nov 2021 18:41:24 +0000
 Subject: adjust get_systemfile_dir for Haiku
 
 
 diff --git a/wsutil/filesystem.c b/wsutil/filesystem.c
-index bde264b..f89fc95 100644
+index 138a1bf..b412dbc 100644
 --- a/wsutil/filesystem.c
 +++ b/wsutil/filesystem.c
-@@ -1214,6 +1214,8 @@ get_systemfile_dir(void)
+@@ -1230,6 +1230,8 @@ get_systemfile_dir(void)
  {
  #ifdef _WIN32
      return get_datafile_dir();
@@ -93,7 +93,7 @@ index bde264b..f89fc95 100644
 2.37.3
 
 
-From ab35e5e212b297e168091a3b79a84c74664cd1af Mon Sep 17 00:00:00 2001
+From ae785bbd298a4e688cb0781a100c4ff42a7d0e66 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Thu, 25 Nov 2021 18:24:45 +0000
 Subject: remove prefix from PLUGIN_DIR, EXTCAP_DIR, DATA_DIR as they already
@@ -121,14 +121,14 @@ index a55086c..6d82b11 100644
 2.37.3
 
 
-From c327fc69fa07979d615db1cdbd7522fa7cf614c2 Mon Sep 17 00:00:00 2001
+From 7a40196ccb72165e68956031b393ad498c25263d Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Tue, 25 Oct 2022 22:00:34 +0200
 Subject: adjust user dirs for Haiku
 
 
 diff --git a/wsutil/filesystem.c b/wsutil/filesystem.c
-index f89fc95..3cb4f76 100644
+index b412dbc..30ea574 100644
 --- a/wsutil/filesystem.c
 +++ b/wsutil/filesystem.c
 @@ -39,6 +39,10 @@
@@ -142,7 +142,7 @@ index f89fc95..3cb4f76 100644
  
  #include <wsutil/report_message.h>
  #include <wsutil/privileges.h>
-@@ -1063,6 +1067,8 @@ init_plugin_pers_dir(void)
+@@ -1079,6 +1083,8 @@ init_plugin_pers_dir(void)
  #if defined(HAVE_PLUGINS) || defined(HAVE_LUA)
  #ifdef _WIN32
      plugin_pers_dir = get_persconffile_path(PLUGINS_DIR_NAME, FALSE);
@@ -151,7 +151,7 @@ index f89fc95..3cb4f76 100644
  #else
      plugin_pers_dir = g_build_filename(g_get_home_dir(), ".local/lib",
                                         CONFIGURATION_NAMESPACE_LOWER, PLUGINS_DIR_NAME, (gchar *)NULL);
-@@ -1374,6 +1380,11 @@ get_persconffile_dir_no_profile(void)
+@@ -1390,6 +1396,11 @@ get_persconffile_dir_no_profile(void)
       */
      persconffile_dir = g_build_filename("C:", persconf_namespace, NULL);
      return persconffile_dir;

--- a/net-analyzer/wireshark/wireshark-4.0.3.recipe
+++ b/net-analyzer/wireshark/wireshark-4.0.3.recipe
@@ -20,11 +20,11 @@ Wireshark is a network traffic analyzer, or \"sniffer\", for Unix \
 and Unix-like operating systems. It uses Qt, a graphical user interface \
 library, and libpcap, a packet capture and filtering library."
 HOMEPAGE="https://www.wireshark.org"
-COPYRIGHT="1998-2022 Gerald Combs"
+COPYRIGHT="1998-2023 Gerald Combs"
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://github.com/wireshark/wireshark/archive/wireshark-$portVersion.tar.gz"
-CHECKSUM_SHA256="a474957af77e160b440daf8c0e8c86a61ba169bdc624dcc8a37276757d9f9102"
+CHECKSUM_SHA256="8a4100e07211cdde616d1600a013f632b163bb2a7acf419d7e506661581b38a2"
 SOURCE_DIR="wireshark-wireshark-$portVersion"
 ADDITIONAL_FILES="wireshark.rdef.in"
 PATCHES="wireshark-$portVersion.patchset"
@@ -32,10 +32,10 @@ PATCHES="wireshark-$portVersion.patchset"
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
-libwiresharkLibVersion="16.0.2"
+libwiresharkLibVersion="16.0.3"
 libwiresharkLibVersionCompat="$libwiresharkLibVersion compat >= ${libwiresharkLibVersion%%.*}"
 
-libwiretapLibVersion="13.0.2"
+libwiretapLibVersion="13.0.3"
 libwiretapLibVersionCompat="$libwiretapLibVersion compat >= ${libwiretapLibVersion%%.*}"
 
 libwsutilLibVersion="14.0.0"


### PR DESCRIPTION
Build and smoke test successful on 32-bit&64-bit, with the same patch:
* fix build for cpu_info.c and interface_toolbar_reader.cpp - probably these could be upstreamed
* the usual hassle with paths in CMAKE which should probably not be upstreamed
* adjust directories in various places of the source code

For some strange reason i'm getting 'crash on exit' on 32-bit beta4 again. (edit: that seems to be the case also for Wireshark 4.0.2 which used to work fine on 32-bit nightly. So perhaps some difference between nightly and beta?)