### PR TITLE
media-sound/ocp: Version bump and general update of recipe

### DIFF
--- a/media-sound/ocp/ocp-0.2.102.recipe
+++ b/media-sound/ocp/ocp-0.2.102.recipe
@@ -1,13 +1,11 @@
 SUMMARY="Open Cubic Player"
 DESCRIPTION="ocp - Open Cubic Player, a music player ported from DOS."
 HOMEPAGE="https://stian.cubic.org/project-ocp.php"
-COPYRIGHT="1994-2016 Niklas Beisert, Stian Skjelstad and others"
+COPYRIGHT="1994-2023 Niklas Beisert, Stian Skjelstad and others"
 LICENSE="GNU GPL v2"
-REVISION="2"
-srcGitRev="835bf803f590512848282bbf74986ebfaec17da3"
-SOURCE_URI="https://sourceforge.net/code-snapshots/git/o/op/opencubicplayer/code.git/opencubicplayer-code-$srcGitRev.zip"
-CHECKSUM_SHA256="8691b9fa9f512c98307c6e4fb2723c10a4a8f212da8a3af1b9d15d2fe32764fb"
-SOURCE_DIR="opencubicplayer-code-$srcGitRev"
+REVISION="1"
+SOURCE_URI="https://stian.cubic.org/ocp/ocp-$portVersion.tar.bz2"
+CHECKSUM_SHA256="a501fe89c286c2d8ba3834dd9bb7a1b19bd3dc9349891139fc13d8de4b6e6e80"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -23,61 +21,79 @@ fi
 PROVIDES="
 	ocp$secondaryArchSuffix = $portVersion
 	cmd:ocp$commandSuffix = $portVersion
-	cmd:ocp_${portVersion#~*}$commandSuffix = $portVersion
 	cmd:ocp_curses = $portVersion
-	cmd:ocp_sdl = $portVersion
-	cmd:ultrafix.sh = $portVersion
+	cmd:ocp_sdl2 = $portVersion
+	app:OpenCubicPlayer = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	cmd:curl$secondaryArchSuffix
+	lib:libancient$secondaryArchSuffix >= 2
+	lib:libbz2$secondaryArchSuffix
+	lib:libcjson$secondaryArchSuffix
+	lib:libdiscid$secondaryArchSuffix
 	lib:libFLAC$secondaryArchSuffix
+	lib:libfreetype$secondaryArchSuffix
 	lib:libiconv$secondaryArchSuffix
+	lib:libjpeg$secondaryArchSuffix
 	lib:libncurses$secondaryArchSuffix
 	lib:libmad$secondaryArchSuffix >= 0.2.1
 	lib:libogg$secondaryArchSuffix >= 0.8.0
-	lib:libSDL_1.2$secondaryArchSuffix >= 0.11.4
+	lib:libpng$secondaryArchSuffix
+	lib:libsdl2_2.0$secondaryArchSuffix
 	lib:libvorbis$secondaryArchSuffix >= 0.4.5
+	lib:libvorbisfile$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
+	unifont
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	devel:libancient$secondaryArchSuffix >= 2
+	devel:libbz2$secondaryArchSuffix
+	devel:libcjson$secondaryArchSuffix
+	devel:libdiscid$secondaryArchSuffix
 	devel:libFLAC$secondaryArchSuffix
+	devel:libfreetype$secondaryArchSuffix
 	devel:libiconv$secondaryArchSuffix
+	devel:libjpeg$secondaryArchSuffix
 	devel:libncurses$secondaryArchSuffix
 	devel:libmad$secondaryArchSuffix >= 0.2.1
 	devel:libogg$secondaryArchSuffix >= 0.8.0
-	devel:libSDL_1.2$secondaryArchSuffix >= 0.11.4
+	devel:libpng$secondaryArchSuffix
+	devel:libSDL2_2.0$secondaryArchSuffix
 	devel:libvorbis$secondaryArchSuffix >= 0.4.5
-	devel:libz$secondaryArchSuffix >= 1.2.8
+	devel:libvorbisfile$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	unifont
 	"
 BUILD_PREREQUIRES="
 	cmd:autoconf
-	cmd:gettext$secondaryArchSuffix
 	cmd:gcc$secondaryArchSuffix
+	cmd:g++$secondaryArchSuffix
+	cmd:hexdump
 	cmd:make
 	cmd:makeinfo
 	cmd:libtoolize$secondaryArchSuffix
 	cmd:pkg_config$secondaryArchSuffix
 	cmd:sdl_config$secondaryArchSuffix
+	cmd:xa
 	"
-
-PATCH()
-{
-	# Broken, missing headers
-	sed -i '/playgmi TOPDIR/d' Makefile.in
-}
 
 BUILD()
 {
 	libtoolize -vfi
 	chmod +x configure
-	runConfigure --omit-dirs binDir ./configure --bindir=$commandBinDir
+	runConfigure --omit-dirs binDir ./configure \
+		--without-update-mime-database \
+		--bindir=$commandBinDir \
+		--with-unifontdir-ttf=/system/data/fonts/ttfonts \
+		--with-unifontdir-otf=/system/data/fonts/otfonts
 	make $jobArgs
 }
 
 INSTALL()
 {
 	make install
-	chmod +x $commandBinDir/{ocp-curses,ocp-sdl,ultrafix.sh}
+	addAppDeskbarSymlink $commandBinDir/ocp OpenCubicPlayer
 }


### PR DESCRIPTION
This depends on new version of app-arch/ancient #7793