### PR TITLE
lilypond: require libgs >= 9

### DIFF
--- a/media-sound/lilypond/lilypond-2.24.0.recipe
+++ b/media-sound/lilypond/lilypond-2.24.0.recipe
@@ -36,7 +36,7 @@ REQUIRES="
 	lib:libgmp$secondaryArchSuffix
 	lib:libgobject_2.0$secondaryArchSuffix
 	lib:libguile_2.2$secondaryArchSuffix
-	lib:libgs$secondaryArchSuffix # TODO: replace with cmd:gs?
+	lib:libgs$secondaryArchSuffix >= 9 # TODO: replace with cmd:gs?
 	lib:libharfbuzz$secondaryArchSuffix
 	lib:libintl$secondaryArchSuffix
 	lib:libltdl$secondaryArchSuffix
@@ -77,7 +77,7 @@ BUILD_REQUIRES="
 	devel:libgmp$secondaryArchSuffix
 	devel:libgobject_2.0$secondaryArchSuffix
 	devel:libguile_2.2$secondaryArchSuffix
-	devel:libgs$secondaryArchSuffix
+	devel:libgs$secondaryArchSuffix >= 9
 	devel:libharfbuzz$secondaryArchSuffix
 	devel:libintl$secondaryArchSuffix
 	devel:libltdl$secondaryArchSuffix


### PR DESCRIPTION
Ghostscript >= 9.03 is actually [required](http://lilypond.org/doc/v2.24/Documentation/contributor/requirements-for-running-lilypond).

This is untested, but a rather trivial change.

A revision bump shouldn't be needed here, correct?