### PR TITLE
texinfo 6.7: fix gcc2 build

### DIFF
--- a/sys-apps/texinfo/patches/texinfo-6.7.patchset
+++ b/sys-apps/texinfo/patches/texinfo-6.7.patchset
@@ -1,4 +1,4 @@
-From 6e83e938550563738f6d2adc24dccc3c209b3692 Mon Sep 17 00:00:00 2001
+From 8c565d815ba2f11f772a762bf38685290b3c2171 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Tue, 22 Dec 2015 11:52:48 +0000
 Subject: Haiku patch
@@ -20,10 +20,10 @@ index 047d794..c9c6a0e 100644
  #ifndef ALSO_NULL_DEVICE
  # define ALSO_NULL_DEVICE  ""
 -- 
-2.24.0
+2.37.3
 
 
-From be44dc414443daf2275e18bbad12a2ecbdb21267 Mon Sep 17 00:00:00 2001
+From 1e83f2d47094acc0d4f0e8f3bf49818bf642cdda Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Sat, 5 Mar 2016 08:51:25 +0100
 Subject: Fix gcc2 build.
@@ -51,5 +51,50 @@ index ee666a1..64773f1 100644
  
  
 -- 
-2.24.0
+2.37.3
+
+
+From b5257a73c0441e44c86bd33dce22a4fed223c899 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
+Date: Sun, 29 Jan 2023 11:37:33 +0100
+Subject: fix gcc2 build (part 2)
+
+C11 threads are only available for the modern gcc.
+
+diff --git a/gnulib/lib/glthread/lock.h b/gnulib/lib/glthread/lock.h
+index a92c2a8..c1074db 100644
+--- a/gnulib/lib/glthread/lock.h
++++ b/gnulib/lib/glthread/lock.h
+@@ -81,7 +81,7 @@
+ #include <stdlib.h>
+ 
+ #if !defined c11_threads_in_use
+-# if HAVE_THREADS_H && USE_POSIX_THREADS_WEAK
++# if __GNUC__ > 2 && HAVE_THREADS_H && USE_POSIX_THREADS_WEAK
+ #  include <threads.h>
+ #  pragma weak thrd_exit
+ #  define c11_threads_in_use() (thrd_exit != NULL)
+diff --git a/gnulib/lib/regexec.c b/gnulib/lib/regexec.c
+index f464869..3a944b0 100644
+--- a/gnulib/lib/regexec.c
++++ b/gnulib/lib/regexec.c
+@@ -3298,6 +3298,7 @@ build_trtable (const re_dfa_t *dfa, re_dfastate_t *state)
+   re_node_set follows, *dests_node;
+   bitset_t *dests_ch;
+   bitset_t acceptable;
++  size_t ndests_max;
+ 
+   struct dests_alloc
+   {
+@@ -3348,7 +3349,7 @@ build_trtable (const re_dfa_t *dfa, re_dfastate_t *state)
+     goto out_free;
+ 
+   /* Avoid arithmetic overflow in size calculation.  */
+-  size_t ndests_max
++  ndests_max
+     = ((SIZE_MAX - (sizeof (re_node_set) + sizeof (bitset_t)) * SBC_MAX)
+        / (3 * sizeof (re_dfastate_t *)));
+   if (__glibc_unlikely (ndests_max < ndests))
+-- 
+2.37.3
 

--- a/sys-apps/texinfo/texinfo-6.7.recipe
+++ b/sys-apps/texinfo/texinfo-6.7.recipe
@@ -9,7 +9,7 @@ SOURCE_URI="http://ftp.gnu.org/gnu/texinfo/texinfo-$portVersion.tar.gz"
 CHECKSUM_SHA256="a52d05076b90032cb2523673c50e53185938746482cf3ca0213e9b4b50ac2d3e"
 PATCHES="texinfo-$portVersion.patchset"
 
-ARCHITECTURES="all ?x86_gcc2 ?x86 ?arm"
+ARCHITECTURES="all"
 
 PROVIDES="
 	texinfo = $portVersion compat >= 4


### PR DESCRIPTION
Using texinfo 6.7 fixes the `info` files build failure of lilypond reported [here](https://github.com/haikuports/haikuports/pull/7809#issuecomment-1407463711)

Should we delete texinfo-6.1 now?