### PR TITLE
gettext_devel: fix #7817 (broken links)

### DIFF
--- a/sys-devel/gettext/gettext-0.21.1.recipe
+++ b/sys-devel/gettext/gettext-0.21.1.recipe
@@ -14,7 +14,7 @@ parties in preparing these sets, or bringing them up to date."
 HOMEPAGE="https://www.gnu.org/software/gettext/"
 COPYRIGHT="1998-2020 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://ftpmirror.gnu.org/gettext/gettext-$portVersion.tar.xz"
 CHECKSUM_SHA256="50dbc8f39797950aa2c98e939947c527e5ac9ebd2c1b99dd7b06ba33a6767ae6"
 
@@ -128,10 +128,14 @@ INSTALL()
 	prepareInstalledDevelLibs \
 		libasprintf \
 		libgettextpo \
-		libgettextlib \
-		libgettextsrc \
 		libintl \
 		libtextstyle
+
+	# These two need to be handled separately from the above, due to their
+	# naming pattern: "lib<name>-<version>.so", otherwise it results on
+	# broken links in the final package.
+	prepareInstalledDevelLib libgettextlib '*.so' '*'
+	prepareInstalledDevelLib libgettextsrc '*.so' '*'
 
 	# devel package
 	packageEntries devel \


### PR DESCRIPTION
Fixes #7817

Tested on beta4 64-bits.