### PR TITLE
filezilla: update to 3.63.1

### DIFF
--- a/net-ftp/filezilla/filezilla-3.63.1.recipe
+++ b/net-ftp/filezilla/filezilla-3.63.1.recipe
@@ -4,16 +4,16 @@ FTP, FTPS and SFTP client with lots of useful features and an intuitive \
 graphical user interface."
 HOMEPAGE="https://filezilla-project.org/"
 
-COPYRIGHT="2015-2022 Tim Kosse"
+COPYRIGHT="2015-2023 Tim Kosse"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://download.filezilla-project.org/client/FileZilla_${portVersion}_src.tar.bz2"
-CHECKSUM_SHA256="a76709635ca0ea474f691f6c60b191334af3079ef192c07c346504baab738c12"
+CHECKSUM_SHA256="4e0b5c0f79f4f8bca4ba21e713ba97b86d5b45c4723de67b9c10d23bf417a37f"
 PATCHES="filezilla-$portVersion.patchset"
 ADDITIONAL_FILES="filezilla.rdef.in"
 
-ARCHITECTURES="?all !x86_gcc2"
-SECONDARY_ARCHITECTURES="?x86"
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	filezilla$secondaryArchSuffix = $portVersion
@@ -44,6 +44,7 @@ REQUIRES="
 	lib:libpango_1.0$secondaryArchSuffix
 	lib:libpugixml$secondaryArchSuffix
 	lib:libsqlite3$secondaryArchSuffix
+	lib:libX11$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="

--- a/net-ftp/filezilla/patches/filezilla-3.63.1.patchset
+++ b/net-ftp/filezilla/patches/filezilla-3.63.1.patchset
@@ -1,31 +1,4 @@
-From e5513f8a3db622f72cab6ba1144a584c1212dcb2 Mon Sep 17 00:00:00 2001
-From: codesquid <codesquid>
-Date: Thu, 1 Dec 2022 10:54:16 +0100
-Subject: Allow wx3.2 across the board.
-
-
-diff --git a/configure.ac b/configure.ac
-index b49ae75..a8f1c1d 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -179,11 +179,7 @@ if test "$buildmain" = "yes"; then
-     ])
-   fi
-   if test "${WX_VERSION_MAJOR}.${WX_VERSION_MINOR}" = "3.1"; then
--    AC_MSG_ERROR([You must use wxWidgets 3.0.x, development versions of wxWidgets are not supported.])
--  elif test "${WX_VERSION_MAJOR}.${WX_VERSION_MINOR}" != "3.0"; then
--    if ! echo "$WX_CPPFLAGS" | grep __WXMAC__ > /dev/null; then
--      AC_MSG_ERROR([You must use wxWidgets 3.0.x, wxWidgets 3.2 or higher is not yet supported.])
--    fi
-+    AC_MSG_ERROR([You must use wxWidgets 3.0.x, or 3.2.x, development versions of wxWidgets are not supported.])
-   fi
- 
-   if test "${WX_VERSION_MAJOR}.${WX_VERSION_MINOR}" = "3.0"; then
--- 
-2.37.3
-
-
-From 7d0cb381f4361f020268f357c1b4f21fd17a544c Mon Sep 17 00:00:00 2001
+From 71af5a7273990f4df8d2203878e34ac2741ed8dc Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Sat, 19 Nov 2022 13:44:51 +0100
 Subject: stub wordexp
@@ -72,14 +45,14 @@ index a9f64f7..da7a66b 100644
 2.37.3
 
 
-From fb3d46e468bc2a49ff8e8455f410f30d5dc2dacc Mon Sep 17 00:00:00 2001
+From 5e97196fea15011e400ea0bda969ca28e818de6e Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Sat, 19 Nov 2022 13:44:51 +0100
 Subject: configure: detect -lnetwork
 
 
 diff --git a/configure.ac b/configure.ac
-index a8f1c1d..65b1dac 100644
+index 4aaf93d..561cc2a 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -256,7 +256,7 @@ if test "$buildmain" = "yes"; then
@@ -95,7 +68,7 @@ index a8f1c1d..65b1dac 100644
 2.37.3
 
 
-From c3023a29746232c93f51c3b495c7b8da9b824480 Mon Sep 17 00:00:00 2001
+From 25d88e6f351187e6b300ac0188bf29882c7e6ccc Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Sat, 19 Nov 2022 13:44:51 +0100
 Subject: adjust folders for Haiku
@@ -194,7 +167,7 @@ index c7d2fc7..fac6aa7 100644
 2.37.3
 
 
-From 36f74e3cc2d12bc03c410e799ad578534a5d12ba Mon Sep 17 00:00:00 2001
+From 734b68e38cc0dd379265dd2f267457b8f46b38f6 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Sat, 3 Dec 2022 16:39:13 +0100
 Subject: Haiku: use BNotification
@@ -260,7 +233,7 @@ index 7b16d8a..8b120b6 100644
 2.37.3
 
 
-From a414cee31f8a6ab07087fe89ae2ecc3edfdbe116 Mon Sep 17 00:00:00 2001
+From 2cd24371c310fa1031c6eae77a11700ae4bebb9b Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Mon, 5 Dec 2022 23:03:41 +0100
 Subject: Haiku: initialize XDG vars


### PR DESCRIPTION
* update to latest release
* now it builds with wxWidgets 3.2 out of the box so we no longer need to patch configure.ac
* add dependency on xlibe - it is actually required
* I think now it's good enough to enable this recipe.