### PR TITLE
libnatpmp, disable static library

### DIFF
--- a/net-libs/libnatpmp/libnatpmp-20150609.recipe
+++ b/net-libs/libnatpmp/libnatpmp-20150609.recipe
@@ -5,7 +5,7 @@ asynchronous."
 HOMEPAGE="http://miniupnp.free.fr/libnatpmp.html"
 COPYRIGHT="2007-2011 Thomas Bernard"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="http://miniupnp.free.fr/files/libnatpmp-$portVersion.tar.gz"
 CHECKSUM_SHA256="e1aa9c4c4219bc06943d6b2130f664daee213fb262fcb94dd355815b8f4536b0"
 SOURCE_FILENAME="libnatpmp-$portVersion.tar.gz"
@@ -54,9 +54,14 @@ INSTALL()
 		INSTALLDIRLIB="$libDir" \
 		INSTALLDIRBIN="$binDir"
 
-	prepareInstalledDevelLibs libnatpmp
+	prepareInstalledDevelLib libnatpmp
 
 	# devel package
 	packageEntries devel \
 		"$developDir"
+}
+
+TEST()
+{
+	./testgetgateway
 }

--- a/net-libs/libnatpmp/patches/libnatpmp-20150609.patchset
+++ b/net-libs/libnatpmp/patches/libnatpmp-20150609.patchset
@@ -1,4 +1,4 @@
-From 27c33d9ffa8503a44504bcb03d1d26b35cbd84b4 Mon Sep 17 00:00:00 2001
+From a2bd5737280d54acc6d34554f4b22d2074db9cdd Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 5 Sep 2014 15:37:36 +0000
 Subject: Haiku patch
@@ -19,10 +19,10 @@ index b67b3e8..181a9ef 100644
  HEADERS = natpmp.h
  
 -- 
-2.14.2
+2.37.3
 
 
-From 9e5a4dc47ad1e39958e874da94e5fa8fc5744a0f Mon Sep 17 00:00:00 2001
+From 38f128e94787a73dc4e133dd83d9d0a1efdbed23 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Wed, 2 Dec 2015 19:53:48 +0000
 Subject: gcc2 build fix
@@ -46,5 +46,103 @@ index 24cbe7d..5a8dbb1 100644
  	uint32_t temp = 0;
  	r = getdefaultgateway(&temp);
 -- 
-2.14.2
+2.37.3
+
+
+From 07cb2dc633008923ee29955984e607967b8cd408 Mon Sep 17 00:00:00 2001
+From: begasus <begasus@gmail.com>
+Date: Sun, 5 Feb 2023 16:15:45 +0100
+Subject: Disable static library
+
+
+diff --git a/Makefile b/Makefile
+index 181a9ef..3bb57ee 100644
+--- a/Makefile
++++ b/Makefile
+@@ -5,7 +5,7 @@
+ # http://miniupnp.free.fr/libnatpmp.html
+ 
+ OS = $(shell uname -s)
+-CC = gcc
++CC ?= gcc
+ INSTALL = install -p
+ ARCH = $(shell uname -m | sed -e s/i.86/i686/)
+ VERSION = $(shell cat VERSION)
+@@ -35,7 +35,6 @@ LIBOBJS = natpmp.o getgateway.o
+ 
+ OBJS = $(LIBOBJS) testgetgateway.o natpmpc.o natpmp-jni.o
+ 
+-STATICLIB = libnatpmp.a
+ ifeq ($(OS), Darwin)
+   SHAREDLIB = libnatpmp.dylib
+   JNISHAREDLIB = libjninatpmp.dylib
+@@ -61,7 +60,7 @@ endif
+ 
+ HEADERS = natpmp.h
+ 
+-EXECUTABLES = testgetgateway natpmpc-shared natpmpc-static
++EXECUTABLES = testgetgateway natpmpc-shared
+ 
+ INSTALLPREFIX ?= $(PREFIX)/usr
+ INSTALLDIRINC = $(INSTALLPREFIX)/include
+@@ -77,9 +76,9 @@ JNIHEADERS = fr_free_miniupnp_libnatpmp_NatPmp.h
+ 
+ .PHONY:	all clean depend install cleaninstall installpythonmodule
+ 
+-all: $(STATICLIB) $(SHAREDLIB) $(EXECUTABLES)
++all: $(SHAREDLIB) $(EXECUTABLES)
+ 
+-pythonmodule: $(STATICLIB) libnatpmpmodule.c setup.py
++pythonmodule: libnatpmpmodule.c setup.py
+ 	python setup.py build
+ 	touch $@
+ 
+@@ -87,7 +86,7 @@ installpythonmodule: pythonmodule
+ 	python setup.py install
+ 
+ clean:
+-	$(RM) $(OBJS) $(EXECUTABLES) $(STATICLIB) $(SHAREDLIB) $(JAVACLASSES) $(JNISHAREDLIB)
++	$(RM) $(OBJS) $(EXECUTABLES) $(SHAREDLIB) $(JAVACLASSES) $(JNISHAREDLIB)
+ 	$(RM) pythonmodule
+ 	$(RM) -r build/ dist/ libraries/
+ 
+@@ -98,7 +97,6 @@ install:	$(HEADERS) $(STATICLIB) $(SHAREDLIB) natpmpc-shared
+ 	$(INSTALL) -d $(INSTALLDIRINC)
+ 	$(INSTALL) -m 644 $(HEADERS) $(INSTALLDIRINC)
+ 	$(INSTALL) -d $(INSTALLDIRLIB)
+-	$(INSTALL) -m 644 $(STATICLIB) $(INSTALLDIRLIB)
+ 	$(INSTALL) -m 644 $(SHAREDLIB) $(INSTALLDIRLIB)/$(SONAME)
+ 	$(INSTALL) -d $(INSTALLDIRBIN)
+ 	$(INSTALL) -m 755 natpmpc-shared $(INSTALLDIRBIN)/natpmpc
+@@ -150,25 +148,21 @@ cleaninstall:
+ 	$(RM) $(addprefix $(INSTALLDIRINC), $(HEADERS))
+ 	$(RM) $(INSTALLDIRLIB)/$(SONAME)
+ 	$(RM) $(INSTALLDIRLIB)/$(SHAREDLIB)
+-	$(RM) $(INSTALLDIRLIB)/$(STATICLIB)
+ 
+ testgetgateway:	testgetgateway.o getgateway.o
+ 	$(CC) $(LDFLAGS) -o $@ $^ $(EXTRA_LD)
+ 
+-natpmpc-static:	natpmpc.o $(STATICLIB)
+-	$(CC) $(LDFLAGS) -o $@ $^ $(EXTRA_LD)
+-
+ natpmpc-shared:	natpmpc.o $(SHAREDLIB)
+-	$(CC) $(LDFLAGS) -o $@ $^ $(EXTRA_LD)
++	$(CC)  $(CFLAGS) $(LDFLAGS) -o $@ $^ $(EXTRA_LD)
+ 
+ $(STATICLIB):	$(LIBOBJS)
+ 	$(AR) crs $@ $?
+ 
+ $(SHAREDLIB):	$(LIBOBJS)
+ ifeq ($(OS), Darwin)
+-	$(CC) -dynamiclib -Wl,-install_name,$(SONAME) -o $@ $^
++	$(CC) $(CFLAGS) $(LDFLAGS) -dynamiclib -Wl,-install_name,$(SONAME) -o $@ $^
+ else
+-	$(CC) -shared -Wl,-soname,$(SONAME) -o $@ $^ $(EXTRA_LD)
++	$(CC) $(CFLAGS) $(LDFLAGS) -shared -Wl,-soname,$(SONAME) -o $@ $^ $(EXTRA_LD)
+ endif
+ 
+ 
+-- 
+2.37.3
 


### PR DESCRIPTION
Patch is mostly imported from Gentoo.