### PR TITLE
texlive: add notification when post-installing

### DIFF
--- a/app-text/texlive/additional-files/texlive_update.sh
+++ b/app-text/texlive/additional-files/texlive_update.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+notify --group "TexLive" --title "Installation in progress" --messageID texliveInstallID --timeout 10000 "Updating TeXLive filename database…"
 mktexlsr
+
+notify --group "TexLive" --title "Installation in progress" --messageID texliveInstallID --timeout 10000 "Updating TeXLive format files…"
 fmtutil-sys --all
+
 #mtxrun --generate
+notify --group "TexLive" --title "Installation in progress" --messageID texliveInstallID --timeout 10000 "Updating TeXLive font maps…"
 updmap-sys
 
+notify --group "TexLive" --title "Installation finished" --messageID texliveInstallID  "Took long enough...!"


### PR DESCRIPTION
As it was mentioned on the forums that running the post-install script can take a while. Let's not make the user wonder if installation has failed and show a notification.

I did **not** test this by actually building/installing texlive...