### PR TITLE
libmatroska: update to 1.7.1

### DIFF
--- a/media-libs/libmatroska/libmatroska-1.7.1.recipe
+++ b/media-libs/libmatroska/libmatroska-1.7.1.recipe
@@ -1,14 +1,14 @@
 SUMMARY="A library to parse Matroska files"
 DESCRIPTION="libmatroska is a C++ libary to parse Matroska files."
 HOMEPAGE="https://www.matroska.org/"
-COPYRIGHT="2003-2019 Matroska"
+COPYRIGHT="2003-2023 Matroska"
 LICENSE="GNU LGPL v2.1"
 REVISION="1"
 SOURCE_URI="https://dl.matroska.org/downloads/libmatroska/libmatroska-$portVersion.tar.xz"
-CHECKSUM_SHA256="daf91a63f58dd157ca340c457871e66260cb9c3333fefb008b318befbb0e081a"
+CHECKSUM_SHA256="572a3033b8d93d48a6a858e514abce4b2f7a946fe1f02cbfeca39bfd703018b3"
 
 ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	libmatroska$secondaryArchSuffix = $portVersion
@@ -52,7 +52,7 @@ INSTALL()
 {
 	make -C build install
 
-	prepareInstalledDevelLibs libmatroska
+	prepareInstalledDevelLib libmatroska
 	fixPkgconfig
 
 	packageEntries devel $developDir $libDir/cmake


### PR DESCRIPTION
I removed the recipe for 1.6.3 since the packages that require it are the same as for libebml.