### PR TITLE
wxqt: update to 3.2.2

### DIFF
--- a/dev-qt/wxqt/patches/wxqt-3.2.2.patchset
+++ b/dev-qt/wxqt/patches/wxqt-3.2.2.patchset
@@ -317,3 +317,32 @@ index 54eb7a7..f5e8e67 100755
 -- 
 2.37.3
 
+
+From 3000d826ad4938bf9132bf2312cee1c7d03836b9 Mon Sep 17 00:00:00 2001
+From: Gerasim Troeglazov <3dEyes@gmail.com>
+Date: Tue, 29 Nov 2022 14:31:25 +1000
+Subject: replace date formats, fix crash
+
+
+diff --git a/src/common/datetime.cpp b/src/common/datetime.cpp
+index 64168b5..9f873b0 100644
+--- a/src/common/datetime.cpp
++++ b/src/common/datetime.cpp
+@@ -281,7 +281,14 @@ wxString wxCallStrftime(const wxString& format, const tm* tm)
+     // http://sourceforge.net/tracker/?func=detail&atid=102435&aid=1046059&group_id=2435
+     wxString s;
+ 
++#ifdef __HAIKU__
++	wxString _format = format;
++	_format.Replace(wxT("%x"),wxT("%D"));
++	_format.Replace(wxT("%X"),wxT("%T"));
++    if ( !wxStrftime(buf, WXSIZEOF(buf), _format, tm) )
++#else
+     if ( !wxStrftime(buf, WXSIZEOF(buf), format, tm) )
++#endif
+     {
+         // There is one special case in which strftime() can return 0 without
+         // indicating an error: "%p" may give empty string depending on the
+-- 
+2.37.3
+

--- a/dev-qt/wxqt/wxqt-3.2.2.recipe
+++ b/dev-qt/wxqt/wxqt-3.2.2.recipe
@@ -11,7 +11,7 @@ COPYRIGHT="1998-2022 Julian Smart, Robert Roebling et al"
 LICENSE="GNU LGPL v2"
 REVISION="1"
 SOURCE_URI="https://github.com/wxWidgets/wxWidgets/releases/download/v$portVersion/wxWidgets-$portVersion.tar.bz2"
-CHECKSUM_SHA256="c229976bb413eb88e45cb5dfb68b27890d450149c09b331abd751e7ae0f5fa66"
+CHECKSUM_SHA256="8edf18672b7bc0996ee6b7caa2bee017a9be604aad1ee471e243df7471f5db5d"
 SOURCE_DIR="wxWidgets-$portVersion"
 PATCHES="wxqt-$portVersion.patchset"
 
@@ -20,7 +20,7 @@ SECONDARY_ARCHITECTURES="x86"
 
 libVersion="$portVersion"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
-libSoVersion="0.1.0"
+libSoVersion="0.2.0"
 
 PROVIDES="
 	wxqt$secondaryArchSuffix = $portVersion
@@ -191,6 +191,9 @@ INSTALL()
 	# Remove the symlinked wx-config and put the real one there instead.
 	rm $binDir/wx-config
 	mv $libDir/wx/config/qt-unicode-3.2 $binDir/wx-config
+
+	# Remove nonexistent directory from cflags
+	sed -i 's!"-I${libdir}/wx/include/qt-unicode-3.2" !!' $binDir/wx-config
 
 	# Move setup.h to the main include directory.
 	mv $libDir/wx/include/qt-unicode-3.2/wx/setup.h $includeDir/wx-3.2/wx/


### PR DESCRIPTION
similarly to wxgtk:
successful build on 32&64-bit (incl. all demos and samples)
we still need the backported patches
in addition, adopt the fix for `strftime` and `wx-config` from wxgtk