### PR TITLE
lilypond: fix secondaryArch (x86) build

### DIFF
--- a/media-sound/lilypond/lilypond-2.24.1.recipe
+++ b/media-sound/lilypond/lilypond-2.24.1.recipe
@@ -163,7 +163,7 @@ BUILD()
 
 	# CPU_COUNT=$jobs is not used because it causes hangs
 	# strip the current directory (.) from PATH, it disallows find -execdir
-	PATH=${PATH:2} make $jobArgs doc
+	PATH=${PATH/.:/} make $jobArgs doc
 }
 
 INSTALL()
@@ -171,7 +171,7 @@ INSTALL()
 	cd build
 	make install
 	make install-bytecode
-	PATH=${PATH:2} make install-doc
+	PATH=${PATH/.:/} make install-doc
 
 	# language specific doc packages
 	for lang in "${languages[@]}"; do


### PR DESCRIPTION
When building for a secondaryArch, haikuporter prepends $PATH with the secondaryArch binDir, so just removing the first 2 characters for removing '.' from $PATH doesn't work. This makes that a bit more robust. (Having '.' at the end would still not work though.)