### PR TITLE
libdiscid 0.6.4

### DIFF
--- a/media-libs/libdiscid/libdiscid-0.6.4.recipe
+++ b/media-libs/libdiscid/libdiscid-0.6.4.recipe
@@ -9,7 +9,7 @@ COPYRIGHT="2006-2023 MetaBrainz Foundation"
 LICENSE="GNU LGPL v2.1"
 REVISION="1"
 SOURCE_URI="http://ftp.eu.metabrainz.org/pub/musicbrainz/libdiscid/libdiscid-$portVersion.tar.gz"
-CHECKSUM_SHA256="0f9efc7ab65f24da57673547304b0143ee89f33638beadcc20a8401e077b3c25"
+CHECKSUM_SHA256="dd5e8f1c9aead442e23b749a9cc9336372e62e88ad7079a2b62895b0390cb282"
 
 ARCHITECTURES="all"
 SECONDARY_ARCHITECTURES="x86"


### PR DESCRIPTION
The 0.6.3 release broke compilation with C++ in some cases due to a type change in discid.h. The update fixes this again.