### PR TITLE
mudlet: Use Boost 1.70

### DIFF
--- a/games-mud/mudlet/mudlet-4.0.3.recipe
+++ b/games-mud/mudlet/mudlet-4.0.3.recipe
@@ -18,7 +18,7 @@ COPYRIGHT="2008-2013 Heiko Koehn
 	2017 Tom Scheper
 	2017 Fae"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/Mudlet/Mudlet/archive/Mudlet-$portVersion.tar.gz"
 CHECKSUM_SHA256="109d542d789426f589925702a06c1793609fc10952ce5620519b02299be21c9b"
 SOURCE_DIR="Mudlet-Mudlet-$portVersion"
@@ -29,6 +29,7 @@ SOURCE_FILENAME_2="edbee-lib-$srcGitRev_2.tar.gz"
 SOURCE_DIR_2="edbee-lib-$srcGitRev_2"
 ADDITIONAL_FILES="mudlet.rdef.in"
 PATCHES="mudlet-$portVersion.patchset"
+PATCHES_2="edbee-lib-git.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -64,7 +65,7 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libboost_graph$secondaryArchSuffix
+	devel:libboost_graph$secondaryArchSuffix >= 1.70.0
 	devel:libGL$secondaryArchSuffix
 	devel:libGLU$secondaryArchSuffix
 	devel:libhunspell_1.7$secondaryArchSuffix
@@ -119,6 +120,8 @@ BUILD()
 	export HUNSPELL_DIR="$portPackageLinksDir/hunspell${secondaryArchSuffix}_devel/develop/"
 
 	cmake .. \
+		-DBUILD_SHARED_LIBS=ON \
+		-DCMAKE_BUILD_TYPE=Release \
 		-DCMAKE_INSTALL_PREFIX=$appsDir/Mudlet
 
 	make $jobArgs

--- a/games-mud/mudlet/patches/edbee-lib-git.patchset
+++ b/games-mud/mudlet/patches/edbee-lib-git.patchset
@@ -1,0 +1,24 @@
+From 18b7ce7df25b31bb61a870a144a0d5c1dfbe2a3b Mon Sep 17 00:00:00 2001
+From: robxnano <89391914+robxnano@users.noreply.github.com>
+Date: Fri, 3 Mar 2023 22:38:53 +0000
+Subject: [PATCH] Add missing QPainterPath include
+
+---
+ edbee-lib/edbee/views/components/texteditorrenderer.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/edbee-lib/edbee/views/components/texteditorrenderer.cpp b/edbee-lib/edbee/views/components/texteditorrenderer.cpp
+index bb03e34..3877b95 100644
+--- a/edbee-lib/edbee/views/components/texteditorrenderer.cpp
++++ b/edbee-lib/edbee/views/components/texteditorrenderer.cpp
+@@ -6,6 +6,7 @@
+ #include "texteditorrenderer.h"
+ 
+ #include <QPainter>
++#include <QPainterPath>
+ #include <QTextLayout>
+ 
+ #include "edbee/models/textdocument.h"
+-- 
+2.37.3
+


### PR DESCRIPTION
This builds and runs but the main screen complains about a load of missing lua modules. Not sure what needs to be done to fix it, but the old version had the same errors.