### PR TITLE
innoextract: Update to 1.9, Use Boost 1.70

### DIFF
--- a/app-arch/innoextract/innoextract-1.9.recipe
+++ b/app-arch/innoextract/innoextract-1.9.recipe
@@ -2,16 +2,16 @@ SUMMARY="A tool to unpack installers created by Inno Setup"
 DESCRIPTION="Inno Setup is a tool to create installers for Microsoft Windows \
 applications. innoextract allows to extract such installers under non-Windows \
 systems without running the actual installer using wine. innoextract currently\
- supports installers created by Inno Setup 1.2.10 to 5.6.0.
+ supports installers created by Inno Setup 1.2.10 to 6.0.5.
 In addition to standard Inno Setup installers, innoextract also supports some \
 modified Inno Setup variants including Martijn Laan's My Inno Setup Extensions\
  3.0.6.1 as well as GOG.com's Inno Setup-based game installers."
 HOMEPAGE="https://constexpr.org/innoextract/"
-COPYRIGHT="2011-2019 Daniel Scharrer"
+COPYRIGHT="2011-2020 Daniel Scharrer"
 LICENSE="Zlib"
 REVISION="1"
 SOURCE_URI="http://constexpr.org/innoextract/files/innoextract-$portVersion.tar.gz"
-CHECKSUM_SHA256="5e78f6295119eeda08a54dcac75306a1a4a40d0cb812ff3cd405e9862c285269"
+CHECKSUM_SHA256="6344a69fc1ed847d4ed3e272e0da5998948c6b828cb7af39c6321aba6cf88126"
 
 ARCHITECTURES="all !x86_gcc2 ?x86"
 SECONDARY_ARCHITECTURES="x86"
@@ -38,9 +38,9 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libboost_filesystem$secondaryArchSuffix
-	devel:libboost_iostreams$secondaryArchSuffix
-	devel:libboost_program_options$secondaryArchSuffix
+	devel:libboost_filesystem$secondaryArchSuffix >= 1.70.0
+	devel:libboost_iostreams$secondaryArchSuffix >= 1.70.0
+	devel:libboost_program_options$secondaryArchSuffix >= 1.70.0
 	devel:libiconv$secondaryArchSuffix
 	devel:liblzma$secondaryArchSuffix
 	"
@@ -54,12 +54,14 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	export CXXFLAGS="-D_BSD_SOURCE"
-	cmake . $cmakeDirArgs \
-		-DCMAKE_INSTALL_BINDIR=$commandBinDir
-	make $jobArgs
+	cmake -Bbuild -S. $cmakeDirArgs \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_BINDIR=$commandBinDir \
+		-DBoost_NO_BOOST_CMAKE=ON
+	make -C build $jobArgs
 }
 
 INSTALL()
 {
-	make install
+	make -C build install
 }


### PR DESCRIPTION
Using Boost 1.69 as 1.70 failed to work. EDIT: Found an alternative solution to use 1.70.