### PR TITLE
mupen64plus: Disable ASLR to fix x86 build

### DIFF
--- a/games-emulation/mupen64plus/mupen64plus-2.5.9.recipe
+++ b/games-emulation/mupen64plus/mupen64plus-2.5.9.recipe
@@ -83,6 +83,8 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
+	export DISABLE_ASLR=1
+
 	APP_DIR="$appsDir/Mupen64Plus/"
 	PARAMS="\
 		PLUGINDIR=$APP_DIR/plugins \


### PR DESCRIPTION
This fixes the `lto1: out of memory` error.