### PR TITLE
mac: bump to 9.20

### DIFF
--- a/media-sound/mac/mac-9.20.recipe
+++ b/media-sound/mac/mac-9.20.recipe
@@ -3,11 +3,11 @@ DESCRIPTION="Monkey's Audio is a lossless audio format. This package provides \
 the mac command line utility for compressing and decompressing Monkey's Audio \
 files."
 HOMEPAGE="https://www.monkeysaudio.com/"
-COPYRIGHT="2000-2022 Matthew T. Ashland"
+COPYRIGHT="2000-2023 Matthew T. Ashland"
 LICENSE="Monkey's Audio SDK and Source Code License Agreement"
 REVISION="1"
 SOURCE_URI="https://www.monkeysaudio.com/files/MAC_${portVersion/./}_SDK.zip"
-CHECKSUM_SHA256="ada511b5fe58e05a12440646a7d568f47aa9f6ec69f42b30f1f6e97084e241d3"
+CHECKSUM_SHA256="54a99ff50b589d4afdb0e38aa86dba2c6a9fe1a086330209ecd563f09e46fd66"
 SOURCE_DIR=""
 
 ARCHITECTURES="all !x86_gcc2"
@@ -20,7 +20,7 @@ if [ "$targetArchitecture" = x86_gcc2 ]; then
 	commandBinDir=$prefix/bin
 fi
 
-libVersion="8"
+libVersion="9"
 
 PROVIDES="
 	mac$secondaryArchSuffix = $portVersion
@@ -43,6 +43,7 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
+	cmd:cmake
 	cmd:g++$secondaryArchSuffix
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
@@ -56,14 +57,15 @@ defineDebugInfoPackage mac$secondaryArchSuffix \
 BUILD()
 {
 	export CXXFLAGS="$CXXFLAGS -fpermissive"
-	make -f Source/Projects/NonWindows/Makefile $jobArgs
+	cmake . $cmakeDirArgs \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_BINDIR=$commandBinDir
+	make $jobArgs
 }
 
 INSTALL()
 {
-	make -f Source/Projects/NonWindows/Makefile \
-		prefix="$prefix" bindir="$commandBinDir" \
-		libdir="$libDir" includedir="$includeDir" install
+	make install
 
 	install -m 755 -d "$developDocDir"
 	install -m 644 -t "$developDocDir" Readme.txt


### PR DESCRIPTION
Attention: SONAME change!

However, fre:ac appears to be the only package using libMAC and I will open a pull request to update it too. So I think the SONAME change shouldn't matter.