### PR TITLE
smooth: add patch to fix crash in CPUID code

### DIFF
--- a/dev-libs/smooth/patches/smooth-0.9.10.patchset
+++ b/dev-libs/smooth/patches/smooth-0.9.10.patchset
@@ -1,0 +1,23 @@
+From 3d39dc4f9a3d3603ea8110e56f5fb46d518595bd Mon Sep 17 00:00:00 2001
+From: Robert Kausch <robert.kausch@freac.org>
+Date: Fri, 10 Mar 2023 01:20:01 +0000
+Subject: Fix crash querying CPU info on systems without affinity setting
+ support in libcpuid.
+
+
+diff --git a/libraries/libcpuid/cpuid_main.c b/libraries/libcpuid/cpuid_main.c
+index 39aaa57..3893f2c 100644
+--- a/libraries/libcpuid/cpuid_main.c
++++ b/libraries/libcpuid/cpuid_main.c
+@@ -1076,7 +1076,7 @@ int cpuid_get_all_raw_data(struct cpu_raw_data_array_t* data)
+ 	bool affinity_saved = save_cpu_affinity();
+ 
+ 	cpu_raw_data_array_t_constructor(data, true);
+-	while (set_cpu_affinity(logical_cpu)) {
++	while (set_cpu_affinity(logical_cpu) || logical_cpu == 0) {
+ 		debugf(2, "Getting raw dump for logical CPU %i\n", logical_cpu);
+ 		cpuid_grow_raw_data_array(data, logical_cpu + 1);
+ 		raw_ptr = &data->raw[logical_cpu];
+-- 
+2.37.3
+

--- a/dev-libs/smooth/smooth-0.9.10.recipe
+++ b/dev-libs/smooth/smooth-0.9.10.recipe
@@ -13,10 +13,11 @@ Features provided by smooth include:
 HOMEPAGE="http://www.smooth-project.org/"
 COPYRIGHT="1998-2023 Robert Kausch"
 LICENSE="Artistic v2.0"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/enzo1982/smooth/releases/download/v${portVersion/\~/-}/smooth-${portVersion/\~/-}.tar.gz"
 CHECKSUM_SHA256="c018ea09eb4e269268cb123bb5d24a813d07c985384c5384d7fa73b7173e9f1c"
 SOURCE_DIR="smooth-${portVersion/\~/-}"
+PATCHES="smooth-${portVersion}.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"


### PR DESCRIPTION
Add a patch to the smooth library to fix a crash when querying CPU information. Unfortunately, this issue was found only now and fre:ac 1.1.7 is unusable on Haiku without this.

This patch is already in the upstream smooth repository, so it will be needed only until the next release.

I have opened a PR at the libcpuid repository as well: anrieff/libcpuid#186 There is no HaikuPorts recipe for libcpuid yet, so smooth uses a bundled version of the library.