### PR TITLE
move haikuporter repo update before Lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,10 @@ jobs:
           cd .. && git clone https://github.com/haikuports/haikuporter.git --depth=1 && cd haikuports
           printf 'TREE_PATH="'`pwd`'"\nPACKAGER="Nobody <server@fake>"\nTARGET_ARCHITECTURE="x86"\n' >haikuports.conf
           wget https://github.com/waddlesplash/haiku-licenses/archive/master.zip && unzip master.zip
+          echo "$(pwd)/../haikuporter" >> $GITHUB_PATH
+      - name: 'Let HaikuPorter update local repository data'
+        run: |
+          haikuporter --config=haikuports.conf --licenses=haiku-licenses-master --repository-update --quiet
       - name: 'Lint new recipes'
         run: |
-          export "PATH=$PATH:../haikuporter"
           ./.github/lint-new-recipes.sh --config=haikuports.conf --licenses=haiku-licenses-master


### PR DESCRIPTION
This makes the output of the lint job much shorter - example at https://github.com/Habbie/haikuports/actions/runs/4388705870/jobs/7685501803

(the Set up job became extra verbose because we call `--repository-update` explicitly - this will be solved by https://github.com/haikuports/haikuporter/pull/246)