### PR TITLE
libass: update to 0.17.1, enable assembly and cleanup

### DIFF
--- a/media-libs/libass/libass-0.16.0.recipe
+++ b/media-libs/libass/libass-0.16.0.recipe
@@ -76,7 +76,7 @@ defineDebugInfoPackage libass$secondaryArchSuffix \
 BUILD()
 {
 	autoreconf -fi
-	runConfigure ./configure --with-pic
+	runConfigure ./configure --with-pic --disable-static
 	make $jobArgs
 }
 

--- a/media-libs/libass/libass-0.16.0.recipe
+++ b/media-libs/libass/libass-0.16.0.recipe
@@ -33,7 +33,7 @@ REQUIRES="
 	lib:libgraphite2$secondaryArchSuffix # required by harfbuzz
 	lib:libharfbuzz$secondaryArchSuffix
 	lib:libiconv$secondaryArchSuffix
-	lib:libintl$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix # required by fontconfig
 	lib:libpng16$secondaryArchSuffix # required by freetype
 	lib:libxml2$secondaryArchSuffix # required by fontconfig
 	lib:libz$secondaryArchSuffix # required by freetype
@@ -52,16 +52,11 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libbz2$secondaryArchSuffix # required by freetype
 	devel:libfontconfig$secondaryArchSuffix
 	devel:libfreetype$secondaryArchSuffix
 	devel:libfribidi$secondaryArchSuffix
-	devel:libgraphite2$secondaryArchSuffix # required by harfbuzz
 	devel:libharfbuzz$secondaryArchSuffix
 	devel:libiconv$secondaryArchSuffix
-	devel:libpng16$secondaryArchSuffix # required by freetype
-	devel:libxml2$secondaryArchSuffix # required by fontconfig
-	devel:libz$secondaryArchSuffix # required by freetype
 	"
 BUILD_PREREQUIRES="
 	cmd:aclocal

--- a/media-libs/libass/libass-0.16.0.recipe
+++ b/media-libs/libass/libass-0.16.0.recipe
@@ -66,6 +66,7 @@ BUILD_PREREQUIRES="
 	cmd:ld$secondaryArchSuffix
 	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
+	cmd:nasm
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
@@ -75,7 +76,7 @@ defineDebugInfoPackage libass$secondaryArchSuffix \
 BUILD()
 {
 	autoreconf -fi
-	runConfigure ./configure
+	runConfigure ./configure --with-pic
 	make $jobArgs
 }
 

--- a/media-libs/libass/libass-0.16.0.recipe
+++ b/media-libs/libass/libass-0.16.0.recipe
@@ -27,7 +27,6 @@ PROVIDES="
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libbz2$secondaryArchSuffix # required by freetype
-	lib:libenca$secondaryArchSuffix
 	lib:libfontconfig$secondaryArchSuffix
 	lib:libfreetype$secondaryArchSuffix
 	lib:libfribidi$secondaryArchSuffix
@@ -54,7 +53,6 @@ REQUIRES_devel="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libbz2$secondaryArchSuffix # required by freetype
-	devel:libenca$secondaryArchSuffix
 	devel:libfontconfig$secondaryArchSuffix
 	devel:libfreetype$secondaryArchSuffix
 	devel:libfribidi$secondaryArchSuffix

--- a/media-libs/libass/libass-0.17.1.recipe
+++ b/media-libs/libass/libass-0.17.1.recipe
@@ -12,12 +12,12 @@ COPYRIGHT="2006-2021 libass contributors
 LICENSE="ISC"
 REVISION="1"
 SOURCE_URI="https://github.com/libass/libass/releases/download/$portVersion/libass-$portVersion.tar.xz"
-CHECKSUM_SHA256="5dbde9e22339119cf8eed59eea6c623a0746ef5a90b689e68a090109078e3c08"
+CHECKSUM_SHA256="f0da0bbfba476c16ae3e1cfd862256d30915911f7abaa1b16ce62ee653192784"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
-libVersion="9.1.4"
+libVersion="9.2.1"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="


### PR DESCRIPTION
- cleanup dependencies
- enable x86 assembly usage in builds
- disable static library build *(apparently required for all packages now?)*
- update to 0.17.1