### PR TITLE
luabind: Use Boost 1.70, enable building on x86_64

### DIFF
--- a/dev-cpp/luabind/luabind-0.9.1.recipe
+++ b/dev-cpp/luabind/luabind-0.9.1.recipe
@@ -17,12 +17,12 @@ recommended that you register everything in the same cpp-file."
 HOMEPAGE="https://github.com/luabind/luabind"
 COPYRIGHT="2005 Rasterbar software"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/luabind/luabind/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="0e5ead50a07668d29888f2fa6f53220f900c886e46a2c99c7e8656842f05ff2d"
 PATCHES="luabind-$portVersion.patchset"
 
-ARCHITECTURES="?all"
+ARCHITECTURES="all ?x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
@@ -45,31 +45,26 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libboost_config$secondaryArchSuffix >= 1.66
-	devel:liblua5.1$secondaryArchSuffix
+	devel:libboost_config$secondaryArchSuffix >= 1.70.0
+	devel:liblua$secondaryArchSuffix >= 5.1
 	"
 BUILD_PREREQUIRES="
-	cmd:bjam
+	cmd:b2
 	cmd:gcc$secondaryArchSuffix
 	"
 
 BUILD()
 {
-	bjam $jobArgs
+	if [ "$targetArchitecture" = "x86_gcc2" ]; then
+		export HAIKU_ARCH=x86
+	fi
+
+	b2 $jobArgs
 }
 
 INSTALL()
 {
-	bjam install --prefix=$prefix
-
-	# Fix include dir
-	mkdir -p $includeDir
-	mv $prefix/include/luabind $includeDir
-	rmdir $prefix/include
-
-	# Fix lib dir
-	mkdir -p $libDir
-	mv $prefix/lib/*.so* $libDir
+	b2 install --includedir=$includeDir --libdir=$libDir
 
 	prepareInstalledDevelLib libluabindd
 	packageEntries devel $developDir

--- a/dev-cpp/luabind/patches/luabind-0.9.1.patchset
+++ b/dev-cpp/luabind/patches/luabind-0.9.1.patchset
@@ -1,29 +1,40 @@
-From 8f20d43747b1967317c6beea4a075cc93af93410 Mon Sep 17 00:00:00 2001
-From: Adrien Destugues <pulkomandy@pulkomandy.tk>
-Date: Sat, 24 Mar 2018 09:59:56 +0100
-Subject: Hack in Haiku support in Jamfile
+From f0645dbfc26638759634fd55ace2b5052b1ccdf3 Mon Sep 17 00:00:00 2001
+From: robxnano <89391914+robxnano@users.noreply.github.com>
+Date: Fri, 3 Mar 2023 15:03:51 +0000
+Subject: [PATCH] Hack in Haiku support in Jamroot (updated)
 
+---
+ Jamroot | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
 
 diff --git a/Jamroot b/Jamroot
-index 94494bf..2a468d1 100755
+index 94494bf..f20e57e 100755
 --- a/Jamroot
 +++ b/Jamroot
-@@ -112,6 +112,13 @@ else if [ os.name ] in LINUX MACOSX FREEBSD
+@@ -112,6 +112,21 @@ else if [ os.name ] in LINUX MACOSX FREEBSD
      }
      lib lua : m dl : <name>$(lib-name) <search>$(library:D) : : <include>$(includes) ;
  }
 +if [ os.name ] = HAIKU
 +{
-+	includes = /system/develop/headers/x86/lua5.1 ;
-+	library = /system/develop/lib/x86/liblua.so ;
-+    lib-name = [ MATCH "lib(.*)" : $(library[1]:B) ] ;
++    if [ os.environ HAIKU_ARCH ] = "x86"
++    {
++        includes = /boot/system/develop/headers/x86/lua5.1 ;
++        library = /boot/system/lib/x86/liblua.so.5.1 ;
++    }
++    else
++    {
++        includes = /boot/system/develop/headers/lua5.1 ;
++        library = /boot/system/lib/liblua.so.5.1 ;
++    }
++    lib-name = lua ;
 +    lib lua : : <name>$(lib-name) <search>$(library:D) : : <include>$(includes) ;
 +}
  
  rule tag-names ( name : type ? : property-set )
  {
 -- 
-2.16.1
+2.37.3
 
 
 From adccca31f5bb3b37c9e3d23cc006971e181e6f91 Mon Sep 17 00:00:00 2001


### PR DESCRIPTION
I believe this is the last remaining package that requires boost 1.66.