### PR TITLE
ddnet: fix recipe

### DIFF
--- a/games-action/ddnet/ddnet-2023.03.12~git.recipe
+++ b/games-action/ddnet/ddnet-2023.03.12~git.recipe
@@ -12,7 +12,7 @@ COPYRIGHT="2007-2014 Magnus Auvinen
 LICENSE="Zlib
 	CC-BY-SA-3.0
 	SIL Open Font License v1.1"
-REVISION="1"
+REVISION="2"
 srcGitRev="9878ca25f5b04909d44dc5509e30ec8acaac9abd"
 SOURCE_URI="https://github.com/ddnet/ddnet/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="fa309fe6c529bbadf58378073c3f72a296ac3dce9c028608ce436f7712b6d331"
@@ -113,6 +113,8 @@ EOF
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
 	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
 	local MINOR="`echo "$portVersion" | cut -d. -f3`"
+	# Remove ~git suffix, if it exists
+	local MINOR="`echo "$MINOR" | cut -d~ -f1`"
 	local LONG_INFO="$SUMMARY"
 	sed \
 		-e "s|@APP_SIGNATURE@|$APP_SIGNATURE|" \


### PR DESCRIPTION
recipe unexpectedly broke because of ~git suffix, tested on x86_64

See: https://github.com/haikuports/haikuports/pull/7951
Build logs of build mysteriously failing: https://build.haiku-os.org/buildmaster/master/x86_64/logviewer.html?buildruns/8219/builds/78935.log