### PR TITLE
x265: fix build on 32 bit & version string

### DIFF
--- a/media-libs/x265/x265-3.5.recipe
+++ b/media-libs/x265/x265-3.5.recipe
@@ -130,7 +130,7 @@ BUILD()
 		-DLINKED_12BIT=ON \
 		-DCMAKE_INSTALL_PREFIX:PATH=$prefix	\
 		-DLIB_INSTALL_DIR:PATH=$relativeLibDir	\
-		-DBIN_INSTALL_DIR:PATH=$relativeBinDir	\
+		-DBIN_INSTALL_DIR:PATH=bin	\
 		-DINCLUDE_INSTALL_DIR:PATH=$relativeIncludeDir
 	make $jobArgs
 }

--- a/media-libs/x265/x265-3.5.recipe
+++ b/media-libs/x265/x265-3.5.recipe
@@ -38,7 +38,7 @@ REQUIRES_devel="
 
 PROVIDES_bin="
 	x265${secondaryArchSuffix}_bin = $portVersion
-	cmd:x265$secondaryArchSuffix = $portVersion
+	cmd:x265 = $portVersion
 	"
 REQUIRES_bin="
 	x265$secondaryArchSuffix == $portVersion base

--- a/media-libs/x265/x265-3.5.recipe
+++ b/media-libs/x265/x265-3.5.recipe
@@ -7,7 +7,7 @@ the bit rate. x265 is a free software project implementing that standard."
 HOMEPAGE="http://x265.org/"
 COPYRIGHT="2013-2021 x265 Project"
 LICENSE="GNU GPL v2"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://bitbucket.org/multicoreware/x265_git/get/$portVersion.tar.gz"
 CHECKSUM_SHA256="5ca3403c08de4716719575ec56c686b1eb55b078c0fe50a064dcf1ac20af1618"
 # BitBucket sucks
@@ -38,7 +38,7 @@ REQUIRES_devel="
 
 PROVIDES_bin="
 	x265${secondaryArchSuffix}_bin = $portVersion
-	cmd:x265 = $portVersion
+	cmd:x265$secondaryArchSuffix = $portVersion
 	"
 REQUIRES_bin="
 	x265$secondaryArchSuffix == $portVersion base
@@ -62,6 +62,12 @@ defineDebugInfoPackage x265$secondaryArchSuffix \
 
 BUILD()
 {
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		enableAsmHdr="OFF"
+	else
+		enableAsmHdr="ON"
+	fi
+
 	# Can't put this in SOURCE_DIR as cmake uses a file in the root
 	# directory to find out the version of x265
 	cd source
@@ -85,11 +91,13 @@ BUILD()
 		-S. \
 		-B build/12bit \
 		-DCMAKE_BUILD_TYPE=Release \
+		-DGIT_ARCHETYPE=1 \
 		-DHIGH_BIT_DEPTH=ON \
 		-DEXPORT_C_API=OFF \
 		-DENABLE_SHARED=OFF \
 		-DENABLE_CLI=OFF \
-		-DMAIN12=ON
+		-DMAIN12=ON \
+		-DENABLE_ASSEMBLY=$enableAsmHdr
 	make $jobArgs -C build/12bit
 	cp ./build/12bit/libx265.a ./libx265_12b.a
 
@@ -99,11 +107,13 @@ BUILD()
 		-S. \
 		-B build/10bit \
 		-DCMAKE_BUILD_TYPE=Release \
+		-DGIT_ARCHETYPE=1 \
 		-DHIGH_BIT_DEPTH=ON \
 		-DEXPORT_C_API=OFF \
 		-DENABLE_SHARED=OFF \
 		-DENABLE_CLI=OFF \
-		-DENABLE_HDR10_PLUS=ON
+		-DENABLE_HDR10_PLUS=ON \
+		-DENABLE_ASSEMBLY=$enableAsmHdr
 	make $jobArgs -C build/10bit
 	cp ./build/10bit/libx265.a ./libx265_10b.a
 	cp ./build/10bit/libhdr10plus.a ./libhdr10plus.a


### PR DESCRIPTION
This PR fixes build in 32 bit haiku, where asm is now disabled for hdr libraries - on 64 bit asm is enabled for all libraries.
Further, fixed the missing version number for those hdr libs.