### PR TITLE
lizard, remove static library

### DIFF
--- a/app-arch/lizard/lizard-1.0.recipe
+++ b/app-arch/lizard/lizard-1.0.recipe
@@ -12,7 +12,7 @@ HOMEPAGE="https://github.com/inikep/lizard/"
 COPYRIGHT="2011-2017, Yann Collet
 	2015-2017, Przemyslaw Skibinski"
 LICENSE="BSD (2-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="$HOMEPAGE/archive/v$portVersion.tar.gz"
 SOURCE_FILENAME="lizard-$portVersion.tar.gz"
 CHECKSUM_SHA256="6f666ed699fc15dc7fdaabfaa55787b40ac251681b50c0d8df017c671a9457e6"
@@ -22,16 +22,11 @@ SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	lizard${secondaryArchSuffix} = $portVersion
-	lib:liblizard${secondaryArchSuffix} = 1.0.0 compat >= 1
-	"
-if [ -z "$secondaryArchSuffix" ]; then
-PROVIDES="$PROVIDES
 	cmd:lizard = $portVersion
 	cmd:lizardcat = $portVersion
 	cmd:unlizard = $portVersion
+	lib:liblizard${secondaryArchSuffix} = 1.0.0 compat >= 1
 	"
-fi
-
 REQUIRES="
 	haiku$secondaryArchSuffix
 	"
@@ -64,7 +59,7 @@ BUILD()
 
 INSTALL()
 {
-	mkdir -p $includeDir $binDir $manDir/man1
+	mkdir -p $includeDir $manDir/man1
 
 	make install PREFIX=$prefix
 
@@ -78,7 +73,8 @@ INSTALL()
 	mkdir $(dirname $libDir)
 	mv $prefix/lib2 $libDir
 
-	[ -n "$secondaryArchSuffix" ] && rm -rf $prefix/bin $manDir
+	# remove static library
+	rm $libDir/liblizard.a
 
 	prepareInstalledDevelLib liblizard
 	fixPkgconfig


### PR DESCRIPTION
Keep binaries as primary target on 32bit is broken.