### PR TITLE
trackgit: require libgit2 >= 1.5.0

### DIFF
--- a/haiku-apps/trackgit/trackgit-1.0.0~git.recipe
+++ b/haiku-apps/trackgit/trackgit-1.0.0~git.recipe
@@ -6,7 +6,7 @@ HOMEPAGE="https://github.com/Hrily/TrackGit"
 COPYRIGHT="2018 Hrishi Hiraskar
 	2021 HaikuArchives Team"
 LICENSE="MIT"
-REVISION="3"
+REVISION="4"
 srcGitRev="b676c5e0ed241a88ed358f0dc73cfa3fa065d76e"
 SOURCE_URI="https://github.com/HaikuArchives/TrackGit/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="e5dbef35b28e6dfffd86ccc26f9582fdb9ae64325c09483d56b27e52ae303a23"
@@ -27,7 +27,7 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku_devel
-	devel:libgit2
+	devel:libgit2 >= 1.5.0
 	"
 BUILD_PREREQUIRES="
 	makefile_engine


### PR DESCRIPTION
When trying to `pkgman install trackgit`, I was getting the error:

> problem 1: nothing provides lib:libgit2>=1.4.3 needed by trackgit-1.0.0~git-3

Additionally, attempting to rebuild locally, build was failing with an error about the `git_status_options` struct not having a "baseline" field (it was pulling in the `libgit2_25-0.25.1-3` packages).

----

Also, seems to me like `dev-libs/libgit2` could use a clean up of the older recipes. Task for someone more experienced than me :-)