### PR TITLE
libguess, fix build

### DIFF
--- a/app-i18n/libguess/libguess-1.2_20150906.recipe
+++ b/app-i18n/libguess/libguess-1.2_20150906.recipe
@@ -3,13 +3,15 @@ DESCRIPTION="Libguess is a high speed, open source character set encoding \
 detector. Libguess employs discrete-finite automata to deduce the character \
 set of the input buffer. The advantage of this is that all character sets can \
 be checked in parallel, and quickly."
-HOMEPAGE="https://atheme.org/projects/libguess.html"
+HOMEPAGE="https://github.com/kaniini/libguess"
 COPYRIGHT="2000-2003 Shiro Kawai
 	2009-2013 Tony Vroon"
 LICENSE="BSD (3-clause)"
-REVISION="2"
-SOURCE_URI="http://rabbit.dereferenced.org/~nenolod/distfiles/libguess-$portVersion.tar.bz2"
-CHECKSUM_SHA256="8019a16bdc7ca9d2efbdcc1429d48d033d5053d42e45fccea10abf98074f05f8"
+REVISION="3"
+srcGitRev="b44a240c57ddce98f772ae7d9f2cf11a5972d8c2"
+SOURCE_URI="https://github.com/kaniini/libguess/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="ae110f2fe4f93837720f04232348498d8c84af32db352d01a02e50609c643e22"
+SOURCE_DIR="libguess-$srcGitRev"
 
 ARCHITECTURES="all"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"


### PR DESCRIPTION
Upstream doesn't exist anymore, no releases or tags on github so used latest commit date.