### PR TITLE
py: fix versioning.

### DIFF
--- a/dev-python/py/py-1.11.0.recipe
+++ b/dev-python/py/py-1.11.0.recipe
@@ -8,7 +8,7 @@ DESCRIPTION="The py lib is a Python development support library featuring the fo
 HOMEPAGE="https://pypi.org/project/py"
 COPYRIGHT="2004-2020 Holger Krekel and others."
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.io/packages/source/p/py/py-$portVersion.tar.gz"
 CHECKSUM_SHA256="51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"
 
@@ -42,12 +42,13 @@ BUILD_REQUIRES="$BUILD_REQUIRES
 	"
 BUILD_PREREQUIRES="$BUILD_PREREQUIRES
 	cmd:python$pythonVersion
-	cmd:git
 	"
 done
 
 INSTALL()
 {
+	export SETUPTOOLS_SCM_PRETEND_VERSION=$portVersion
+
 	for i in "${!PYTHON_PACKAGES[@]}"; do
 		pythonPackage=${PYTHON_PACKAGES[i]}
 		pythonVersion=${PYTHON_VERSIONS[$i]}


### PR DESCRIPTION
Removed the `cmd:git` dependency, as it is `setuptools_scm` the one that actually requires that one.