### PR TITLE
pytest: fix versioning, cleanup dependencies.

### DIFF
--- a/dev-python/pytest/pytest-7.1.3.recipe
+++ b/dev-python/pytest/pytest-7.1.3.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="The pytest framework makes it easy to write small tests, yet scales
 HOMEPAGE="https://pytest.org"
 COPYRIGHT="2010-2020 Holger Krekel and others."
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.io/packages/source/p/pytest/pytest-$portVersion.tar.gz"
 CHECKSUM_SHA256="4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"
 
@@ -33,31 +33,27 @@ eval "PROVIDES_${pythonPackage}=\"\
 REQUIRES_$pythonPackage=\"\
 	haiku\n\
 	cmd:python$pythonVersion\n\
-	atomicwrites_$pythonPackage\n\
 	attrs_$pythonPackage\n\
-	iniconfig_$pythonPackage\n\
 	importlib_metadata_$pythonPackage\n\
-	pluggy_$pythonPackage\n\
-	more_itertools_$pythonPackage\n\
+	iniconfig_$pythonPackage\n\
 	packaging_$pythonPackage\n\
-	pyparsing_$pythonPackage\n\
-	toml_$pythonPackage\n\
+	pluggy_$pythonPackage\n\
+	py_$pythonPackage\n\
+	tomli_$pythonPackage\n\
 	zipp_$pythonPackage\n\
-	py_$pythonPackage\
 	\""
 BUILD_REQUIRES="$BUILD_REQUIRES
 	setuptools_scm_$pythonPackage
 	"
 BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:git
 	cmd:python$pythonVersion
-	pip_$pythonPackage
-	wheel_$pythonPackage\n\
 	"
 done
 
 INSTALL()
 {
+	export SETUPTOOLS_SCM_PRETEND_VERSION=$portVersion
+
 	for i in "${!PYTHON_PACKAGES[@]}"; do
 		pythonPackage=${PYTHON_PACKAGES[i]}
 		pythonVersion=${PYTHON_VERSIONS[$i]}


### PR DESCRIPTION
Only list as dependencies those packages that are listed in pytest's setup.cfg.