### PR TITLE
more_itertools: install from the .whl file

### DIFF
--- a/dev-python/more-itertools/more_itertools-8.14.0.recipe
+++ b/dev-python/more-itertools/more_itertools-8.14.0.recipe
@@ -6,10 +6,10 @@ for working with Python iterables."
 HOMEPAGE="https://pypi.python.org/pypi/more-itertools"
 COPYRIGHT="2012 Erik Rose"
 LICENSE="MIT"
-REVISION="2"
-SOURCE_URI="https://pypi.io/packages/source/m/more-itertools/more-itertools-$portVersion.tar.gz"
-CHECKSUM_SHA256="c09443cd3d5438b8dafccd867a6bc1cb0894389e90cb53d227456b0b0bccb750"
-SOURCE_DIR="more-itertools-$portVersion"
+REVISION="3"
+pypiVersion="0b/ff/1ad78678bee731ae5414ea5e97396b3f91de32186028daa614d322ac5a8b"
+SOURCE_URI="https://files.pythonhosted.org/packages/$pypiVersion/more_itertools-$portVersion-py3-none-any.whl#noarchive"
+CHECKSUM_SHA256="1bc4f91ee5b1b31ac7ceacc17c09befe6a40a503907baf9c839c229b5095cfd2"
 
 ARCHITECTURES="any"
 
@@ -37,7 +37,8 @@ REQUIRES_$pythonPackage=\"\
 	cmd:python$pythonVersion\
 	\""
 BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
+	installer_$pythonPackage
+	"
 BUILD_PREREQUIRES="$BUILD_PREREQUIRES
 	cmd:python$pythonVersion"
 done
@@ -52,9 +53,8 @@ INSTALL()
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
 		mkdir -p $installLocation
-		rm -rf build
-		$python setup.py build install \
-			--root=/ --prefix=$prefix
+
+		$python -m installer -p $prefix more_itertools-$portVersion-py3-none-any.whl
 
 		packageEntries  $pythonPackage \
 			$prefix/lib/python*


### PR DESCRIPTION
Switch to "installer" (instead of setuptools). Final package doesn't suffers the problems mentioned on #7962 (no .py files, UKNOWN-0.0.0 as package name-version).

Package can be installed, imported, and looks fine on a first inspection (tested on Python 3.10).