### PR TITLE
asciidoc: use Python 3.9 also for TEST_REQUIRES.

### DIFF
--- a/app-text/asciidoc/asciidoc-10.1.3.recipe
+++ b/app-text/asciidoc/asciidoc-10.1.3.recipe
@@ -48,8 +48,8 @@ BUILD_PREREQUIRES="
 	cmd:xsltproc
 	"
 TEST_REQUIRES="
-	pytest_python3
-	pytest_mock_python3
+	pytest_python39
+	pytest_mock_python39
 	"
 
 BUILD()


### PR DESCRIPTION
No functional change for the package per se, so, no change in revision.