### PR TITLE
Disable boost versions 1.65.1 and 1.66.0, no longer installable, and …

### DIFF
--- a/dev-libs/boost/boost165-1.65.1.recipe
+++ b/dev-libs/boost/boost165-1.65.1.recipe
@@ -8,14 +8,14 @@ testing. It contains over eighty individual libraries.
 HOMEPAGE="https://www.boost.org/"
 COPYRIGHT="1998-2017 Beman Dawes, David Abrahams, Rene Rivera, et al."
 LICENSE="Boost v1.0"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://dl.bintray.com/boostorg/release/$portVersion/source/boost_${portVersion//./_}.tar.bz2"
 CHECKSUM_SHA256="9807a5d16566c57fd74fb522764e0b134a8bbe6b6e8967b83afefd30dcd3be81"
 SOURCE_DIR="boost_${portVersion//./_}"
 PATCHES="boost-$portVersion.patchset"
 
-ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="?all !x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
 
 libVersion="$portVersion compat >= 1.65.0"
 

--- a/dev-libs/boost/boost166-1.66.0.recipe
+++ b/dev-libs/boost/boost166-1.66.0.recipe
@@ -8,14 +8,14 @@ testing. It contains over eighty individual libraries.
 HOMEPAGE="https://www.boost.org/"
 SOURCE_URI="https://dl.bintray.com/boostorg/release/$portVersion/source/boost_${portVersion//./_}.tar.bz2"
 CHECKSUM_SHA256="5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9"
-REVISION="3"
+REVISION="4"
 LICENSE="Boost v1.0"
 COPYRIGHT="1998-2017 Beman Dawes, David Abrahams, Rene Rivera, et al."
 SOURCE_DIR="boost_${portVersion//./_}"
 PATCHES="boost-$portVersion.patchset"
 
-ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="?all !x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
 
 libVersion="$portVersion compat >= 1.66.0"
 


### PR DESCRIPTION
…buildmaster shouldn't try to use them.