### PR TITLE
paramiko: drop support for Python 3.7 and 3.8.

### DIFF
--- a/dev-python/paramiko/paramiko-2.11.0.recipe
+++ b/dev-python/paramiko/paramiko-2.11.0.recipe
@@ -5,7 +5,7 @@ remote machines."
 HOMEPAGE="https://www.lag.net/paramiko/"
 COPYRIGHT="2003-2009  Robey Pointer"
 LICENSE="GNU LGPL v2.1"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.io/packages/source/p/paramiko/paramiko-$portVersion.tar.gz"
 CHECKSUM_SHA256="003e6bee7c034c21fbb051bf83dc0a9ee4106204dd3c53054c71452cc4ec3938"
 
@@ -24,8 +24,8 @@ BUILD_REQUIRES="
 	devel:libffi$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python3 python38 python39 python310)
-PYTHON_VERSIONS=(3.7 3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -51,8 +51,6 @@ TEST_REQUIRES="$TEST_REQUIRES
 	bcrypt_$pythonPackage
 	cryptography_$pythonPackage
 	importlib_metadata_$pythonPackage
-#	invoke_$pythonPackage
-#	pytest_relaxed_$pythonPackage
 	mock_$pythonPackage
 	pynacl_$pythonPackage
 	pytest_$pythonPackage


### PR DESCRIPTION
Untested, but change seems straight forward enough, and nothing depends on this package.