### PR TITLE
pynacl: drop support for Python 3.7 and 3.8.

### DIFF
--- a/dev-python/pynacl/pynacl-1.5.0.recipe
+++ b/dev-python/pynacl/pynacl-1.5.0.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="PyNaCl provides Python binding to the libsodium library."
 HOMEPAGE="https://pypi.python.org/pypi/PyNaCl"
 COPYRIGHT="2013,2018 Donald Stufft and individual contributors"
 LICENSE="Apache v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.io/packages/source/p/pynacl/PyNaCl-$portVersion.tar.gz"
 CHECKSUM_SHA256="8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba"
 SOURCE_DIR="PyNaCl-$portVersion"
@@ -30,8 +30,8 @@ BUILD_PREREQUIRES="
 	cmd:make
 	"
 
-PYTHON_PACKAGES=(python3 python38 python39 python310)
-PYTHON_VERSIONS=(3.7 3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -39,9 +39,8 @@ eval "PROVIDES_${pythonPackage}=\"\
 	${portName}_$pythonPackage = $portVersion\
 	\"; \
 REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cffi${secondaryArchSuffix}_$pythonPackage\n\
-	six_$pythonPackage\n\
+	haiku$secondaryArchSuffix\n\
+	cffi_$pythonPackage\n\
 	cmd:python$pythonVersion\n\
 	lib:libsodium$secondaryArchSuffix\
 	\""
@@ -51,10 +50,12 @@ if [ "$targetArchitecture" = "x86_gcc2" ]; then
 		\""
 fi
 BUILD_REQUIRES="$BUILD_REQUIRES
-	cffi${secondaryArchSuffix}_$pythonPackage
-	setuptools_$pythonPackage"
+	cffi_$pythonPackage
+	setuptools_$pythonPackage
+	"
 BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	cmd:python$pythonVersion
+	"
 done
 
 INSTALL()
@@ -79,4 +80,3 @@ INSTALL()
 			$prefix/lib/python*
 	done
 }
-


### PR DESCRIPTION
Also removed unneded dependency on six.

Only package that depended on this one is `paramiko` (see #8026), so it's safe to merge.