### PR TITLE
twisted: recipe clean up

### DIFF
--- a/dev-python/twisted/twisted-22.8.0.recipe
+++ b/dev-python/twisted/twisted-22.8.0.recipe
@@ -63,11 +63,6 @@ REQUIRES_$pythonPackage=\"\
 	incremental_$pythonPackage\n\
 	zope_interface_$pythonPackage\n\
 	\""
-if [ "$targetArchitecture" = "x86_gcc2" ]; then
-	eval "PROVIDES_${pythonPackage}+=\"\n\
-		twisted_$pythonPackage = $portVersion\
-		\""
-fi
 BUILD_REQUIRES="$BUILD_REQUIRES
 	incremental_$pythonPackage
 	setuptools_$pythonPackage"
@@ -75,34 +70,23 @@ BUILD_PREREQUIRES="$BUILD_PREREQUIRES
 	cmd:python$pythonVersion"
 done
 
-PROVIDES_python39="$PROVIDES_python39
-	cmd:cftp39
-	cmd:ckeygen39
-	cmd:conch39
-	cmd:mailmail39
-	cmd:manhole39
-	cmd:pyhtmlizer39
-	cmd:tap2deb39
-	cmd:tap2rpm39
-	cmd:tkconch39
-	cmd:trial39
-	cmd:twist39
-	cmd:twistd39
-	"
-PROVIDES_python310="$PROVIDES_python310
-	cmd:cftp310
-	cmd:ckeygen310
-	cmd:conch310
-	cmd:mailmail310
-	cmd:manhole310
-	cmd:pyhtmlizer310
-	cmd:tap2deb310
-	cmd:tap2rpm310
-	cmd:tkconch310
-	cmd:trial310
-	cmd:twist310
-	cmd:twistd310
-	"
+for i in "${!PYTHON_VERSIONS[@]}"; do
+pyVer=${PYTHON_VERSIONS[i]//.} # remove dot from version
+eval "PROVIDES_python${pyVer}+=\"\n\
+	cmd:cftp$pyVer\n\
+	cmd:ckeygen$pyVer\n\
+	cmd:conch$pyVer\n\
+	cmd:mailmail$pyVer\n\
+	cmd:manhole$pyVer\n\
+	cmd:pyhtmlizer$pyVer\n\
+	cmd:tap2deb$pyVer\n\
+	cmd:tap2rpm$pyVer\n\
+	cmd:tkconch$pyVer\n\
+	cmd:trial$pyVer\n\
+	cmd:twist$pyVer\n\
+	cmd:twistd$pyVer\n\
+	\""
+done
 
 INSTALL()
 {
@@ -118,26 +102,10 @@ INSTALL()
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		if [ $pythonPackage = python3 ]; then
-			for f in $prefix/bin/*; do
-				mv $f ${f}3
-			done
-		fi
-		if [ $pythonPackage = python38 ]; then
-			for f in $prefix/bin/*; do
-				mv $f ${f}38
-			done
-		fi
-		if [ $pythonPackage = python39 ]; then
-			for f in $prefix/bin/*; do
-				mv $f ${f}39
-			done
-		fi
-		if [ $pythonPackage = python310 ]; then
-			for f in $prefix/bin/*; do
-				mv $f ${f}310
-			done
-		fi
+		pyVer=${pythonVersion//.}
+		for f in $prefix/bin/*; do
+			mv $f ${f}$pyVer
+		done
 
 		install -m 755 -d "$docDir"
 		install -m 644 -t "$docDir" README.rst


### PR DESCRIPTION
- use loops for PROVIDES_pythonxx.
- simplify code where possible.
- remove checks related to x86_gcc2.

It should be easier to add support for newer Python versions now.

---

Tested on 64 bits. Compared contents and package info against the `twisted_python39` from the repos. Both match.

I haven't bumped the revision number, as there's no functional change. Will add it if reviewers think it's necessary.

I'm a bash newbie, so if there are suggestions regarding syntax, variables expansions, and such, please be explicit, or it will most likely go over my head.