### PR TITLE
bcrypt: drop support for Python 3.7 and 3.8.

### DIFF
--- a/dev-python/bcrypt/bcrypt-3.2.0.recipe
+++ b/dev-python/bcrypt/bcrypt-3.2.0.recipe
@@ -4,7 +4,7 @@ servers."
 HOMEPAGE="https://pypi.python.org/pypi/bcrypt"
 COPYRIGHT="2013 Donald Stufft"
 LICENSE="Apache v2"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://pypi.io/packages/source/b/bcrypt/bcrypt-$portVersion.tar.gz"
 CHECKSUM_SHA256="5b93c1726e50a93a033c36e5ca7fdcd29a5c7395af50a6892f5d9e7c6cfbfb29"
 
@@ -25,8 +25,8 @@ BUILD_PREREQUIRES="
 	gcc$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python3 python38 python39 python310)
-PYTHON_VERSIONS=(3.7 3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}


### PR DESCRIPTION
Untested, but change seems straight forward enough, and the only packages depending on this one are:

- `twisted`. Already dropped support for Python < 3.9.
- `paramiko`. Should do so after #8026.