### PR TITLE
pycares: drop support for 3.7, add it for 3.9 and 3.10.

### DIFF
--- a/dev-python/pycares/pycares-3.1.1.recipe
+++ b/dev-python/pycares/pycares-3.1.1.recipe
@@ -5,12 +5,12 @@ asynchronously."
 HOMEPAGE="https://pypi.python.org/pypi/pycares"
 COPYRIGHT="2017 Saúl Ibarra Corretgé"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.io/packages/source/p/pycares/pycares-$portVersion.tar.gz"
 CHECKSUM_SHA256="18dfd4fd300f570d6c4536c1d987b7b7673b2a9d14346592c5d6ed716df0d104"
 PATCHES="pycares-$portVersion.patchset"
 
-ARCHITECTURES="all"
+ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
@@ -30,8 +30,8 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python3)
-PYTHON_VERSIONS=(3.7)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -69,5 +69,3 @@ INSTALL()
 			$prefix/lib/python*
 	done
 }
-
-


### PR DESCRIPTION
Only `net-im/poezio` depends on this in HaikuPorts. Following PRs will update that too.

(tested on beta4 64 bits).