### PR TITLE
slixmpp: update to 1.8.2, switch to Python 3.9+

### DIFF
--- a/dev-python/slixmpp/slixmpp-1.8.2.recipe
+++ b/dev-python/slixmpp/slixmpp-1.8.2.recipe
@@ -11,7 +11,7 @@ LICENSE="MIT"
 REVISION="1"
 SOURCE_URI="https://github.com/poezio/slixmpp/archive/slix-$portVersion.tar.gz"
 SOURCE_DIR="slixmpp-slix-$portVersion"
-CHECKSUM_SHA256="7a855d1d3969adf7026a7c05808e80c285718f5115d944dd449a1c3f701df0c6"
+CHECKSUM_SHA256="122d7192cdc5ead5a0a65805f49f614df15a5dd16abef5c8ac440ef356d59ed1"
 
 ARCHITECTURES="any"
 
@@ -26,8 +26,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python3)
-PYTHON_VERSIONS=(3.7)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -37,6 +37,8 @@ eval "PROVIDES_${pythonPackage}=\"\
 REQUIRES_$pythonPackage=\"\
 	haiku\n\
 	aiohttp_$pythonPackage\n\
+	pyasn1_$pythonPackage\n\
+	pyasn1_modules_$pythonPackage\n\
 	cmd:python$pythonVersion\
 	\""
 BUILD_REQUIRES="$BUILD_REQUIRES
@@ -63,5 +65,3 @@ INSTALL()
 			$prefix/lib/python*
 	done
 }
-
-


### PR DESCRIPTION
`net-im/poezio` is the sole user of this in-tree. This version is needed to update poezio to 0.14 (PR for that will follow).