### PR TITLE
cffi: Drop Python 3.7. Provide "non _x86" package name on x86_gcc2.

### DIFF
--- a/dev-python/cffi/cffi-1.15.1.recipe
+++ b/dev-python/cffi/cffi-1.15.1.recipe
@@ -4,7 +4,7 @@ HOMEPAGE="https://cffi.readthedocs.io/
 	https://pypi.org/project/cffi/"
 COPYRIGHT="2012-2021 Armin Rigo, Maciej Fijalkowski"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/c/cffi/cffi-$portVersion.tar.gz"
 CHECKSUM_SHA256="d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"
 
@@ -27,8 +27,8 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python3 python38 python39 python310)
-PYTHON_VERSIONS=(3.7 3.8 3.9 3.10)
+PYTHON_PACKAGES=(python38 python39 python310)
+PYTHON_VERSIONS=(3.8 3.9 3.10)
 PYTHON_LIBSUFFIXES+=(m)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
@@ -44,6 +44,11 @@ REQUIRES_$pythonPackage=\"\
 	pycparser_$pythonPackage\n\
 	cmd:python$pythonVersion\
 	\""
+if [ "$targetArchitecture" = "x86_gcc2" ]; then
+	eval "PROVIDES_${pythonPackage}+=\"\n\
+		cffi_$pythonPackage = $portVersion\
+		\""
+fi
 BUILD_REQUIRES="$BUILD_REQUIRES
 	setuptools_$pythonPackage
 	pycparser_$pythonPackage"


### PR DESCRIPTION
Should fix the 32 bits build of pycares after #8035.