### PR TITLE
multidict: switch to x86, drop support for Python 3.7, add it for 3.10.

### DIFF
--- a/dev-python/multidict/multidict-4.5.2.recipe
+++ b/dev-python/multidict/multidict-4.5.2.recipe
@@ -4,28 +4,29 @@ might be occurred more than once in the container."
 HOMEPAGE="https://pypi.python.org/pypi/multidict"
 COPYRIGHT="2016-2017 Andrew Svetlov"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.io/packages/source/m/multidict/multidict-$portVersion.tar.gz"
 CHECKSUM_SHA256="024b8129695a952ebd93373e45b5d341dbb87c17ce49637b34000093f243dd4f"
 
-ARCHITECTURES="all"
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	$portName = $portVersion
 	"
 REQUIRES="
-	haiku
+	haiku$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
+	haiku${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
 	gcc$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python3 python38 python39)
-PYTHON_VERSIONS=(3.7 3.8 3.9)
+PYTHON_PACKAGES=(python38 python39 python310)
+PYTHON_VERSIONS=(3.8 3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -36,6 +37,11 @@ REQUIRES_$pythonPackage=\"\
 	haiku\n\
 	cmd:python$pythonVersion\
 	\""
+if [ "$targetArchitecture" = "x86_gcc2" ]; then
+	eval "PROVIDES_${pythonPackage}+=\"\n\
+		multidict_$pythonPackage = $portVersion\
+		\""
+fi
 BUILD_REQUIRES="$BUILD_REQUIRES
 	cython_$pythonPackage
 	setuptools_$pythonPackage"

--- a/dev-python/multidict/multidict-4.5.2.recipe
+++ b/dev-python/multidict/multidict-4.5.2.recipe
@@ -34,7 +34,7 @@ eval "PROVIDES_${pythonPackage}=\"\
 	${portName}_$pythonPackage = $portVersion\
 	\"; \
 REQUIRES_$pythonPackage=\"\
-	haiku\n\
+	haiku$secondaryArchSuffix\n\
 	cmd:python$pythonVersion\
 	\""
 if [ "$targetArchitecture" = "x86_gcc2" ]; then


### PR DESCRIPTION
Build was broken on x86_gcc2 (requires compiler with C99 support).