### PR TITLE
yarl: switch to x86, drop support for Python 3.7, add it for 3.10.

### DIFF
--- a/dev-python/yarl/yarl-1.6.3.recipe
+++ b/dev-python/yarl/yarl-1.6.3.recipe
@@ -3,28 +3,29 @@ DESCRIPTION="The module provides handy URL class for URL parsing and changing."
 HOMEPAGE="https://pypi.python.org/pypi/yarl"
 COPYRIGHT="2016-2018 Andrew Svetlov and aio-libs team"
 LICENSE="Apache v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.io/packages/source/y/yarl/yarl-$portVersion.tar.gz"
 CHECKSUM_SHA256="8a9066529240171b68893d60dca86a763eae2139dd42f42106b03cf4b426bf10"
 
-ARCHITECTURES="all"
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	$portName = $portVersion
 	"
 REQUIRES="
-	haiku
+	haiku$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
+	haiku${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
-	gcc
+	gcc$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python3 python38 python39)
-PYTHON_VERSIONS=(3.7 3.8 3.9)
+PYTHON_PACKAGES=(python38 python39 python310)
+PYTHON_VERSIONS=(3.8 3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -36,6 +37,11 @@ REQUIRES_$pythonPackage=\"\
 	idna_$pythonPackage\n\
 	cmd:python$pythonVersion\
 	\""
+if [ "$targetArchitecture" = "x86_gcc2" ]; then
+	eval "PROVIDES_${pythonPackage}+=\"\n\
+		yarl_$pythonPackage = $portVersion\
+		\""
+fi
 BUILD_REQUIRES="$BUILD_REQUIRES
 	setuptools_$pythonPackage"
 BUILD_PREREQUIRES="$BUILD_PREREQUIRES


### PR DESCRIPTION
Build was broken for x86_gcc2.