### PR TITLE
aiohttp: switch to x86, drop support for Python 3.7, add it for 3.10.

### DIFF
--- a/dev-python/aiohttp/aiohttp-3.8.1.recipe
+++ b/dev-python/aiohttp/aiohttp-3.8.1.recipe
@@ -6,25 +6,26 @@ Provides Web-server with middlewares and pluggable routing."
 HOMEPAGE="https://pypi.python.org/pypi/aiohttp"
 COPYRIGHT="2013-2021 Nikolay Kim and Andrew Svetlov"
 LICENSE="Apache v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.org/packages/source/a/aiohttp/aiohttp-$portVersion.tar.gz"
 CHECKSUM_SHA256="fc5471e1a54de15ef71c1bc6ebe80d4dc681ea600e68bfd1cbce40427f0b7578"
 
-ARCHITECTURES="all"
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	$portName = $portVersion
 	"
 REQUIRES="
-	haiku
+	haiku$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
+	haiku${secondaryArchSuffix}_devel
 	"
 
-PYTHON_PACKAGES=(python3 python38 python39)
-PYTHON_VERSIONS=(3.7 3.8 3.9)
+PYTHON_PACKAGES=(python38 python39 python310)
+PYTHON_VERSIONS=(3.8 3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -32,7 +33,7 @@ eval "PROVIDES_${pythonPackage}=\"\
 	${portName}_$pythonPackage = $portVersion\
 	\"; \
 REQUIRES_$pythonPackage=\"\
-	haiku\n\
+	haiku$secondaryArchSuffix\n\
 	aiosignal_$pythonPackage\n\
 	attrs_$pythonPackage\n\
 	asynctest_$pythonPackage\n\
@@ -44,6 +45,11 @@ REQUIRES_$pythonPackage=\"\
 	yarl_$pythonPackage\n\
 	cmd:python$pythonVersion\
 	\""
+if [ "$targetArchitecture" = "x86_gcc2" ]; then
+	eval "PROVIDES_${pythonPackage}+=\"\n\
+		aiohttp_$pythonPackage = $portVersion\
+		\""
+fi
 BUILD_REQUIRES="$BUILD_REQUIRES
 	setuptools_$pythonPackage"
 BUILD_PREREQUIRES="$BUILD_PREREQUIRES
@@ -69,4 +75,3 @@ INSTALL()
 			$prefix/lib/python*
 	done
 }
-


### PR DESCRIPTION
Build was broken for x86_gcc2.

Provide also the "non _x86" package name. This should fix the build failure for slixmpp after #8036.