### PR TITLE
aiosignal: drop support for Python 3.7, add it for 3.10.

### DIFF
--- a/dev-python/aiosignal/aiosignal-1.2.0.recipe
+++ b/dev-python/aiosignal/aiosignal-1.2.0.recipe
@@ -36,8 +36,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python3 python38 python39)
-PYTHON_VERSIONS=(3.7 3.8 3.9)
+PYTHON_PACKAGES=(python38 python39 python310)
+PYTHON_VERSIONS=(3.8 3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -72,4 +72,3 @@ INSTALL()
 			$prefix/lib/python*
 	done
 }
-

--- a/dev-python/aiosignal/aiosignal-1.2.0.recipe
+++ b/dev-python/aiosignal/aiosignal-1.2.0.recipe
@@ -19,11 +19,11 @@ aiohttp documentation."
 HOMEPAGE="https://pypi.org/project/aiosignal/"
 COPYRIGHT="2019-2021 Nikolay Kim and Martijn Pieters"
 LICENSE="Apache v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://files.pythonhosted.org/packages/27/6b/a89fbcfae70cf53f066ec22591938296889d3cc58fec1e1c393b10e8d71d/aiosignal-$portVersion.tar.gz"
 CHECKSUM_SHA256="78ed67db6c7b7ced4f98e495e572106d5c432a93e1ddd1bf475e1dc05f5b7df2"
 
-ARCHITECTURES="all"
+ARCHITECTURES="any"
 
 PROVIDES="
 	$portName = $portVersion


### PR DESCRIPTION
Should help fix the build issue after #8049.