### PR TITLE
charset_normalizer: drop support for Python 3.7, add it for 3.10.

### DIFF
--- a/dev-python/charset-normalizer/charset_normalizer-2.1.1.recipe
+++ b/dev-python/charset-normalizer/charset_normalizer-2.1.1.recipe
@@ -6,12 +6,12 @@ All IANA character set names for which the Python core library provides codecs a
 HOMEPAGE="https://pypi.org/project/charset-normalizer/"
 COPYRIGHT="2019-2022 Ahmed TAHRI"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://files.pythonhosted.org/packages/a1/34/44964211e5410b051e4b8d2869c470ae8a68ae274953b1c7de6d98bbcf94/charset-normalizer-$portVersion.tar.gz"
 SOURCE_DIR="charset-normalizer-$portVersion"
 CHECKSUM_SHA256="5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845"
 
-ARCHITECTURES="all"
+ARCHITECTURES="any"
 
 PROVIDES="
 	$portName = $portVersion
@@ -25,8 +25,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python3 python38 python39)
-PYTHON_VERSIONS=(3.7 3.8 3.9)
+PYTHON_PACKAGES=(python38 python39 python310)
+PYTHON_VERSIONS=(3.8 3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -62,4 +62,3 @@ INSTALL()
 			$prefix/lib/python*
 	done
 }
-


### PR DESCRIPTION
Switch arch to "any".

Needed to fix aiohttp build (two more PRs also for that will follow).