### PR TITLE
async_timeout: drop support for Python 3.7, add it for 3.10.

### DIFF
--- a/dev-python/async-timeout/async_timeout-4.0.2.recipe
+++ b/dev-python/async-timeout/async_timeout-4.0.2.recipe
@@ -6,7 +6,7 @@ because timeout doesn't create a new task."
 HOMEPAGE="https://pypi.python.org/pypi/async_timeout"
 COPYRIGHT="2019 Andrew Svetlov"
 LICENSE="Apache v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.io/packages/source/a/async-timeout/async-timeout-$portVersion.tar.gz"
 SOURCE_DIR="async-timeout-$portVersion"
 CHECKSUM_SHA256="2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15"
@@ -24,8 +24,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python3 python38 python39)
-PYTHON_VERSIONS=(3.7 3.8 3.9)
+PYTHON_PACKAGES=(python38 python39 python310)
+PYTHON_VERSIONS=(3.8 3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}


### PR DESCRIPTION
Needed to fix the aiohttp build. (one more to go)