### PR TITLE
asynctest: drop support for Python 3.7, add it for 3.10.

### DIFF
--- a/dev-python/asynctest/asynctest-0.13.0.recipe
+++ b/dev-python/asynctest/asynctest-0.13.0.recipe
@@ -7,11 +7,11 @@ Windows’ proactor."
 HOMEPAGE="https://pypi.org/project/asynctest/"
 COPYRIGHT="2015-2019 Martin Richard"
 LICENSE="Apache v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://files.pythonhosted.org/packages/0c/0f/6056f4435923d2f8c89ac9ef2d18506a569348d8f9cc827b0dd7a4c8acc4/asynctest-$portVersion.tar.gz"
 CHECKSUM_SHA256="c27862842d15d83e6a34eb0b2866c323880eb3a75e4485b079ea11748fd77fac"
 
-ARCHITECTURES="all"
+ARCHITECTURES="any"
 
 PROVIDES="
 	$portName = $portVersion
@@ -24,8 +24,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python3 python38 python39)
-PYTHON_VERSIONS=(3.7 3.8 3.9)
+PYTHON_PACKAGES=(python38 python39 python310)
+PYTHON_VERSIONS=( 3.8 3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -60,4 +60,3 @@ INSTALL()
 			$prefix/lib/python*
 	done
 }
-

--- a/dev-python/asynctest/asynctest-0.13.0.recipe
+++ b/dev-python/asynctest/asynctest-0.13.0.recipe
@@ -25,7 +25,7 @@ BUILD_REQUIRES="
 	"
 
 PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=( 3.8 3.9 3.10)
+PYTHON_VERSIONS=(3.8 3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}


### PR DESCRIPTION
Also, switch arch to "any".

This is 3 of 3 of the changes to hopefully fix aiohttp's build for good.
(/me crosses fingers).