### PR TITLE
twisted: clean up

### DIFF
--- a/dev-python/twisted/twisted-22.8.0.recipe
+++ b/dev-python/twisted/twisted-22.8.0.recipe
@@ -22,7 +22,7 @@ Twisted-based code."
 HOMEPAGE="https://twistedmatrix.com"
 COPYRIGHT="2001-2022 Twisted project members"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/twisted/twisted/archive/twisted-$portVersion.tar.gz"
 CHECKSUM_SHA256="3d17049da4b7c66b11359ff29eeea103ef8356f2aec2e4fc3d78c1920fc622a1"
 SOURCE_DIR="twisted-twisted-$portVersion"
@@ -52,7 +52,7 @@ eval "PROVIDES_${pythonPackage}=\"\
 	${portName}_$pythonPackage = $portVersion\
 	\"; \
 REQUIRES_$pythonPackage=\"\
-	haiku\n\
+	haiku$secondaryArchSuffix\n\
 	cmd:python$pythonVersion\n\
 	attrs_$pythonPackage\n\
 	automat_$pythonPackage\n\
@@ -63,6 +63,11 @@ REQUIRES_$pythonPackage=\"\
 	incremental_$pythonPackage\n\
 	zope_interface_$pythonPackage\n\
 	\""
+if [ "$targetArchitecture" = "x86_gcc2" ]; then
+	eval "PROVIDES_${pythonPackage}+=\"\n\
+		twisted_$pythonPackage = $portVersion\
+		\""
+fi
 BUILD_REQUIRES="$BUILD_REQUIRES
 	incremental_$pythonPackage
 	setuptools_$pythonPackage"


### PR DESCRIPTION
Restored erroneously removed (by me, sorry) PROVIDES for the "non _x86" package name.

Fixed REQUIRES.