### PR TITLE
cryptography: fix build

### DIFF
--- a/dev-python/cryptography/cryptography-3.3.2.recipe
+++ b/dev-python/cryptography/cryptography-3.3.2.recipe
@@ -35,23 +35,21 @@ BUILD_PREREQUIRES="
 
 PYTHON_PACKAGES=(python39 python310)
 PYTHON_VERSIONS=(3.9 3.10)
-PYTHON_LIBSUFFIXES+=(m)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
-pythonLibSuffix=${PYTHON_LIBSUFFIXES[$i]}
 eval "PROVIDES_$pythonPackage=\"
 	${portName}_$pythonPackage = $portVersion
 	\""
 eval "REQUIRES_$pythonPackage=\"
 	haiku$secondaryArchSuffix
 	asn1crypto_$pythonPackage
-	cffi${secondaryArchSuffix}_$pythonPackage
+	cffi_$pythonPackage
 	idna_$pythonPackage
 	pyasn1_$pythonPackage
 	six_$pythonPackage
 	lib:libcrypto$secondaryArchSuffix
-	lib:libpython$pythonVersion$pythonLibSuffix$secondaryArchSuffix
+	lib:libpython$pythonVersion$secondaryArchSuffix
 	lib:libssl$secondaryArchSuffix
 	\""
 if [ "$targetArchitecture" = "x86_gcc2" ]; then


### PR DESCRIPTION
No need for PYTHON_LIBSUFFIXES for Python > 3.7.

Fixed cffi requirement on 32 bits.