### PR TITLE
apply_defaults: update to 0.1.6

### DIFF
--- a/dev-python/apply_defaults/apply_defaults-0.1.6.recipe
+++ b/dev-python/apply_defaults/apply_defaults-0.1.6.recipe
@@ -6,8 +6,8 @@ HOMEPAGE="https://pypi.org/project/apply-defaults/
 COPYRIGHT="2015 Beau Barker"
 LICENSE="MIT"
 REVISION="1"
-SOURCE_URI="https://files.pythonhosted.org/packages/f6/da/badf3e4dbefdcfd911c07c542782e7f31fcd232a7d081ea78261561c73e5/apply_defaults-0.1.4.tar.gz"
-CHECKSUM_SHA256="1ce26326a61d8773d38a9726a345c6525a91a6120d7333af79ad792dacb6246c"
+SOURCE_URI="https://files.pythonhosted.org/packages/42/31/7daf0d1111b29405d25b7677c8c681f6de7aff19d44b54f57ce5c789af24/apply_defaults-0.1.6.tar.gz"
+CHECKSUM_SHA256="3773de3491b94c0fe44310f1a85888389cdc71e1544b343bce0d2bd6991acea5"
 
 ARCHITECTURES="any"
 
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python3)
-PYTHON_VERSIONS=(3.7)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}


### PR DESCRIPTION
Drop support for Python 3.7, add it for 3.9 and 3.10.