### PR TITLE
argh: update to 0.28.1. Drop support for Python 2.7 & 3.7. Add 3.10.

### DIFF
--- a/dev-python/argh/argh-0.28.1.recipe
+++ b/dev-python/argh/argh-0.28.1.recipe
@@ -5,11 +5,12 @@ Don't like the complexity but need the power?
 Argh is a smart wrapper for argparse. Argparse is a very powerful tool; \
 Argh just makes it easy to use."
 HOMEPAGE="https://pypi.python.org/pypi/argh"
-COPYRIGHT="2010-2014 Andrey Mikhaylenko and contributors"
+COPYRIGHT="2010-2023 Andrey Mikhaylenko and contributors"
 LICENSE="GNU LGPL v3"
-REVISION="3"
-SOURCE_URI="https://github.com/neithere/argh/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="eb5476ac788e5c4f5e01825455630218aba055c29240637988f4c99532e7bdb6"
+REVISION="1"
+pypiVersion="b2/03/7cad222e3aed5ed668c3c93c35f7ee866bc1da5cdcac945275f45e8caf80"
+SOURCE_URI="https://files.pythonhosted.org/packages/$pypiVersion/$portName-$portVersion-py3-none-any.whl#noarchive"
+CHECKSUM_SHA256="10e7311f3ea54a78a366e5456900d8b81049f44d8d653b524eb90cf7d29a71ee"
 
 ARCHITECTURES="any"
 
@@ -24,8 +25,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python python3 python38 python39)
-PYTHON_VERSIONS=(2.7 3.7 3.8 3.9)
+PYTHON_PACKAGES=(python38 python39 python310)
+PYTHON_VERSIONS=(3.8 3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -34,10 +35,11 @@ eval "PROVIDES_${pythonPackage}=\"\
 	\"; \
 REQUIRES_$pythonPackage=\"\
 	haiku\n\
-	cmd:python$pythonVersion\
+	cmd:python$pythonVersion\n\
 	\""
 BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
+	installer_$pythonPackage
+	"
 BUILD_PREREQUIRES="$BUILD_PREREQUIRES
 	cmd:python$pythonVersion"
 done
@@ -52,9 +54,8 @@ INSTALL()
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
 		mkdir -p $installLocation
-		rm -rf build
-		$python setup.py build install \
-			--root=/ --prefix=$prefix
+
+		$python -m installer -p $prefix $portName-$portVersion-py3-none-any.whl
 
 		packageEntries  $pythonPackage \
 			$prefix/lib/python*


### PR DESCRIPTION
Only `orphilia-dropbox` depended on this one, so... Good to merge after #8084.