### PR TITLE
cryptography: restore support for Python 3.8.

### DIFF
--- a/dev-python/cryptography/cryptography-3.3.2.recipe
+++ b/dev-python/cryptography/cryptography-3.3.2.recipe
@@ -8,7 +8,7 @@ HOMEPAGE="https://cryptography.io/"
 COPYRIGHT="2013-2020 The cryptography developers"
 LICENSE="Apache v2
 	BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.io/packages/source/c/cryptography/cryptography-$portVersion.tar.gz"
 CHECKSUM_SHA256="5a60d3780149e13b7a6ff7ad6526b38846354d11a15e21068e57073e29e19bed"
 
@@ -33,8 +33,8 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
+PYTHON_PACKAGES=(python38 python39 python310)
+PYTHON_VERSIONS=(3.8 3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}


### PR DESCRIPTION
Should help fix the build for the pyopenssl packages after https://github.com/haikuports/haikuports/commit/df145a169a3a6063c7107ff4ae0e529f2f639507.