### PR TITLE
dulwich: support 3.10, provide 'non _x86' package name on 32 bits

### DIFF
--- a/dev-python/dulwich/dulwich-0.20.32.recipe
+++ b/dev-python/dulwich/dulwich-0.20.32.recipe
@@ -26,8 +26,8 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python38 python39 python310)
+PYTHON_VERSIONS=(3.8 3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -35,10 +35,15 @@ eval "PROVIDES_${pythonPackage}=\"\
 	${portName}_$pythonPackage = $portVersion\
 	\"; \
 REQUIRES_$pythonPackage=\"\
-	haiku\n\
+	haiku$secondaryArchSuffix\n\
 	cmd:python$pythonVersion\n\
-	urllib3_python$pythonVersion\
+	urllib3_$pythonPackage\n\
 	\""
+if [ "$targetArchitecture" = "x86_gcc2" ]; then
+	eval "PROVIDES_${pythonPackage}+=\"\n\
+		dulwich_$pythonPackage = $portVersion\
+		\""
+fi
 BUILD_REQUIRES="$BUILD_REQUIRES
 	setuptools_$pythonPackage"
 BUILD_PREREQUIRES="$BUILD_PREREQUIRES
@@ -46,18 +51,15 @@ BUILD_PREREQUIRES="$BUILD_PREREQUIRES
 	cmd:gcc$secondaryArchSuffix"
 done
 
-PROVIDES_python39="$PROVIDES_python39
-	cmd:dul_receive_pack = $portVersion
-	cmd:dul_upload_pack = $portVersion
-	cmd:dulwich = $portVersion
-	"
-
-PROVIDES_python38="$PROVIDES_python38
-	cmd:dul_receive_pack38 = $portVersion
-	cmd:dul_upload_pack38 = $portVersion
-	cmd:dulwich38 = $portVersion
-	"
-
+for i in "${!PYTHON_VERSIONS[@]}"; do
+pythonVersion=${PYTHON_VERSIONS[i]}
+pyVer=${pythonVersion//.} # remove dot from version
+eval "PROVIDES_python${pyVer}+=\"\n\
+	cmd:dul_receive_pack$pythonVersion = $portVersion\n\
+	cmd:dul_upload_pack$pythonVersion = $portVersion\n\
+	cmd:dulwich$pythonVersion = $portVersion\n\
+	\""
+done
 
 # TODO add the gpg python module when it's available
 #TEST_REQUIRES=""
@@ -77,11 +79,10 @@ INSTALL()
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		if [ $pythonPackage == python38 ]; then
-			for f in $prefix/bin/*; do
-				mv $f ${f}38
-			done
-		fi
+		for f in $prefix/bin/*; do
+			mv $f ${f}$pythonVersion
+		done
+
 		packageEntries $pythonPackage \
 			$prefix/lib/python* \
 			$prefix/bin


### PR DESCRIPTION
Fixed requires for urllib3 (should fix the build on buildmasters).

Use loops for the provides, should help when modifying the list of supported Python versions.