### PR TITLE
lxml: drop Python 3.7, add 3.10.

### DIFF
--- a/dev-python/lxml/lxml-4.9.1.recipe
+++ b/dev-python/lxml/lxml-4.9.1.recipe
@@ -13,7 +13,7 @@ LICENSE="BSD (3-clause)
 	ElementTree
 	GNU GPL v2
 	PSF-2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/lxml/lxml/releases/download/lxml-$portVersion/lxml-$portVersion.tar.gz"
 CHECKSUM_SHA256="fe749b052bb7233fe5d072fcb549221a8cb1a16725c47c37e42b0b9cb3ff2c3f"
 SOURCE_DIR="lxml-$portVersion"
@@ -39,24 +39,27 @@ BUILD_PREREQUIRES="
 	cmd:ld$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES+=(python3 python38 python39 python310)
-PYTHON_VERSIONS+=(3.7 3.8 3.9 3.10)
-PYTHON_LIBSUFFIXES+=(m '' '')
+PYTHON_PACKAGES+=(python38 python39 python310)
+PYTHON_VERSIONS+=(3.8 3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
-pythonLibSuffix=${PYTHON_LIBSUFFIXES[$i]}
 eval "PROVIDES_${pythonPackage}=\"\
 	${portName}_$pythonPackage = $portVersion\
 	\"; \
 REQUIRES_$pythonPackage=\"\
 	haiku$secondaryArchSuffix\n\
 	cmd:python$pythonVersion\n\
-	lib:libpython$pythonVersion$pythonLibSuffix$secondaryArchSuffix\n\
+	lib:libpython$pythonVersion$secondaryArchSuffix\n\
 	lib:libxml2$secondaryArchSuffix\n\
 	lib:libxslt$secondaryArchSuffix\n\
 	lib:libz$secondaryArchSuffix\
 	\""
+if [ "$targetArchitecture" = "x86_gcc2" ]; then
+	eval "PROVIDES_${pythonPackage}+=\"\n\
+		lxml_$pythonPackage = $portVersion\
+		\""
+fi
 BUILD_REQUIRES+="$BUILD_REQUIRES
 	setuptools_$pythonPackage"
 BUILD_PREREQUIRES+="$BUILD_PREREQUIRES


### PR DESCRIPTION
Provide "non _x86" package name for 32 bits.
No PYTHON_LIBSUFFIXES for Python 3.8+.

Should help with the build issues of `qrcode` on 32 bits.

---

~Setting as draft~, as there's still a package recipe (`sigil` #8096) that needs to be updated/merged before this one.