### PR TITLE
qrcode: support 3.10, provide non _x86 package name.

### DIFF
--- a/dev-python/qrcode/qrcode-7.2.recipe
+++ b/dev-python/qrcode/qrcode-7.2.recipe
@@ -27,8 +27,8 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python38 python39 python310)
+PYTHON_VERSIONS=(3.8 3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -39,6 +39,11 @@ REQUIRES_$pythonPackage=\"\
 	haiku\n\
 	cmd:python$pythonVersion\
 	\""
+if [ "$targetArchitecture" = "x86_gcc2" ]; then
+	eval "PROVIDES_${pythonPackage}+=\"\n\
+		qrcode_$pythonPackage = $portVersion\
+		\""
+fi
 BUILD_REQUIRES="$BUILD_REQUIRES
 	lxml_$pythonPackage
 	pillow${secondaryArchSuffix}_$pythonPackage
@@ -47,12 +52,14 @@ BUILD_PREREQUIRES="$BUILD_PREREQUIRES
 	cmd:python$pythonVersion"
 done
 
-PROVIDES_python38="$PROVIDES_python38
-	cmd:qr3.8
-	"
-PROVIDES_python39="$PROVIDES_python39
-	cmd:qr3.9
-	"
+for i in "${!PYTHON_VERSIONS[@]}"; do
+pyversion=${PYTHON_VERSIONS[i]}
+pyVer=${PYTHON_VERSIONS[i]//.} # remove dot from version
+eval "PROVIDES_python${pyVer}+=\"\n\
+	cmd:qr$pyversion\n\
+	\""
+done
+
 
 INSTALL()
 {


### PR DESCRIPTION
Minor clean up to the provides. Should easy modifying supported python versions in the future.

----

~Opening as draft~, as it sould be able to fix qrcode build on 32 bits, once #8093 gets merged.