### PR TITLE
cssselect: drop Python 2.7 & 3.7, add 3.9/3.10.

### DIFF
--- a/dev-python/cssselect/cssselect-1.1.0.recipe
+++ b/dev-python/cssselect/cssselect-1.1.0.recipe
@@ -6,7 +6,7 @@ HOMEPAGE="https://pythonhosted.org/cssselect/
 	https://pypi.python.org/pypi/cssselect"
 COPYRIGHT="2007-2019 Ian Bicking and contributors"
 LICENSE="BSD (3-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/scrapy/cssselect/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="dde8c1d4a2c82de6889a3af1c1adbce1a6f3ec08b07a854d873f3f3da92960af"
 
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python python3)
-PYTHON_VERSIONS=(2.7 3.7)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}


### PR DESCRIPTION
This needs to be merged before the PR for `sigil`. Will add that next.