### PR TITLE
unicorn: provide Python bindings in a separate recipe.

### DIFF
--- a/dev-libs/unicorn/unicorn-2.0.1.recipe
+++ b/dev-libs/unicorn/unicorn-2.0.1.recipe
@@ -4,7 +4,7 @@ CPU emulator framework written in pure C, and based on QEMU."
 HOMEPAGE="https://www.unicorn-engine.org/"
 COPYRIGHT="2015-2018, Nguyen Anh Quynh"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/unicorn-engine/unicorn/archive/$portVersion.post1.tar.gz"
 CHECKSUM_SHA256="6b276c857c69ee5ec3e292c3401c8c972bae292e0e4cb306bb9e5466c0f14737"
 SOURCE_FILENAME="unicorn-$portVersion.post1.tar.gz"
@@ -36,26 +36,15 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
-	cmd:python3
 	cmd:gcc$secondaryArchSuffix
 	cmd:cmake
 	cmd:make
-	cmd:pkg_config
+	cmd:pkg_config$secondaryArchSuffix
 	"
 
 defineDebugInfoPackage unicorn$secondaryArchSuffix \
 	"$libDir"/libunicorn.so.2
 
-SUMMARY_python3="The python 3 bindings for unicorn"
-PROVIDES_python3="
-	unicorn_python3 = $portVersion
-	"
-REQUIRES_python3="
-	unicorn == $portVersion base
-	haiku$secondaryArchSuffix
-	lib:libunicorn$secondaryArchSuffix
-	cmd:python3
-	"
 
 BUILD()
 {
@@ -64,31 +53,22 @@ BUILD()
 	cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		$cmakeDirArgs \
 		-DCMAKE_INSTALL_LIBDIR="$libDir" \
-		-DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=OFF
+		-DBUILD_SHARED_LIBS=ON -DUNICORN_BUILD_TESTS=OFF
 	make $jobArgs
-
-	cd ../bindings/python
-	make
 }
+
 
 INSTALL()
 {
 	cd build
 	make PREFIX=$prefix install
 
+	# remove static library
+	rm -f $libDir/libunicorn.a
+
 	prepareInstalledDevelLib libunicorn
 	fixPkgconfig
 
 	packageEntries devel \
 		"$developDir"
-
-	# Install python 3 module
-	cd ../bindings/python
-	installLocation=$libDir/python3/vendor-packages/
-	mkdir -p $installLocation
-	cp -R unicorn $installLocation/
-
-	packageEntries python3 \
-		$libDir/python*
 }
-

--- a/dev-python/unicorn/patches/unicorn_py-2.0.1.patchset
+++ b/dev-python/unicorn/patches/unicorn_py-2.0.1.patchset
@@ -1,0 +1,23 @@
+From a6e09e3fac6c277e433a43b73555136f312405c0 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Sun, 26 Mar 2023 01:55:40 -0300
+Subject: Use libunicorn.so.2 as fallback path
+
+Same patch is already applied in upstream's dev branch.
+
+diff --git a/bindings/python/unicorn/unicorn.py b/bindings/python/unicorn/unicorn.py
+index 2e6a938..0aacfb1 100644
+--- a/bindings/python/unicorn/unicorn.py
++++ b/bindings/python/unicorn/unicorn.py
+@@ -94,7 +94,7 @@ _path_list = [os.getenv('LIBUNICORN_PATH', None),
+ 
+ for _path in _path_list:
+     if _path is None: continue
+-    _uc = _load_lib(_path, _lib.get(sys.platform, "libunicorn.so"))
++    _uc = _load_lib(_path, _lib.get(sys.platform, "libunicorn.so.2"))
+     if _uc is not None:
+         break
+ 
+-- 
+2.37.3
+

--- a/dev-python/unicorn/unicorn_py-2.0.1.recipe
+++ b/dev-python/unicorn/unicorn_py-2.0.1.recipe
@@ -1,0 +1,81 @@
+SUMMARY="The Python bindings for unicorn"
+DESCRIPTION="Unicorn is a lightweight, thread-safe, multi-platform, multi-architecture \
+CPU emulator framework written in pure C, and based on QEMU.\
+\n\
+This package provides Python bindings for libunicorn.so.2."
+HOMEPAGE="https://www.unicorn-engine.org/"
+COPYRIGHT="2015-2018, Nguyen Anh Quynh"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="https://github.com/unicorn-engine/unicorn/archive/$portVersion.post1.tar.gz"
+CHECKSUM_SHA256="6b276c857c69ee5ec3e292c3401c8c972bae292e0e4cb306bb9e5466c0f14737"
+SOURCE_FILENAME="unicorn-$portVersion.post1.tar.gz"
+SOURCE_DIR="unicorn-$portVersion.post1"
+
+# Should be safe to remove after 2.0.1 (upstreamed)
+PATCHES="unicorn_py-$portVersion.patchset"
+
+ARCHITECTURES="any"
+
+PROVIDES="
+	$portName = $portVersion
+	"
+REQUIRES="
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+
+PYTHON_PACKAGES=(python38 python39 python310)
+PYTHON_VERSIONS=(3.8 3.9 3.10)
+for i in "${!PYTHON_PACKAGES[@]}"; do
+pythonPackage=${PYTHON_PACKAGES[i]}
+pythonVersion=${PYTHON_VERSIONS[$i]}
+eval "PROVIDES_${pythonPackage}=\"\
+	${portName}_$pythonPackage = $portVersion\
+	\"; \
+REQUIRES_$pythonPackage=\"\
+	haiku\n\
+	cmd:python$pythonVersion\
+	\""
+if [ "$targetArchitecture" = "x86_gcc2" ]; then
+	eval "REQUIRES_${pythonPackage}+=\"\n\
+		lib:libunicorn_x86 >= 2.0.1\n\
+		\""
+else
+	eval "REQUIRES_${pythonPackage}+=\"\n\
+		lib:libunicorn >= 2.0.1\n\
+		\""
+fi
+BUILD_REQUIRES="$BUILD_REQUIRES
+	setuptools_$pythonPackage"
+BUILD_PREREQUIRES="$BUILD_PREREQUIRES
+	cmd:python$pythonVersion"
+done
+
+INSTALL()
+{
+	cd bindings/python
+
+	for i in "${!PYTHON_PACKAGES[@]}"; do
+		pythonPackage=${PYTHON_PACKAGES[i]}
+		pythonVersion=${PYTHON_VERSIONS[$i]}
+
+		python=python$pythonVersion
+		installLocation=$prefix/lib/$python/vendor-packages/
+		export PYTHONPATH=$installLocation:$PYTHONPATH
+		mkdir -p $installLocation
+		rm -rf build
+
+		# Make sure the bindings use the system-wide libunicorn.so.2
+		export LIBUNICORN_PATH=$libDir
+
+		$python setup.py build install \
+			--root=/ --prefix=$prefix
+
+		packageEntries  $pythonPackage \
+			$prefix/lib/python*
+	done
+}


### PR DESCRIPTION
This change allows to:

- Decouple the building of the Python bindings (otherwise needs to rebuild full libunicorn.so for each build of the bindings).
- Be able to provide bindings for multiple Python versions.

The tiny patch is the same as one already applied upstream 3 weeks ago, so it could be dropped on next release/update.

Also:

- Removed static library.
- Disabled building of tests.