### PR TITLE
libxml2: remove ICU dependency

### DIFF
--- a/dev-libs/libxml2/libxml2-2.9.13.recipe
+++ b/dev-libs/libxml2/libxml2-2.9.13.recipe
@@ -10,7 +10,7 @@ available in other environments."
 HOMEPAGE="http://www.xmlsoft.org/"
 COPYRIGHT="1998-2013 Daniel Veillard.  All Rights Reserved."
 LICENSE="MIT"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://download.gnome.org/sources/libxml2/2.9/libxml2-$portVersion.tar.xz"
 CHECKSUM_SHA256="276130602d12fe484ecc03447ee5e759d0465558fbc9d6bd144e3745306ebf0e"
 PATCHES="libxml2-$portVersion.patchset"
@@ -37,7 +37,6 @@ if [ -z "$secondaryArchSuffix" ]; then
 fi
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libicuuc$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
 
@@ -48,7 +47,6 @@ PROVIDES_devel="
 	"
 REQUIRES_devel="
 	libxml2$secondaryArchSuffix == $portVersion base
-	devel:libicuuc$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"
 
@@ -67,7 +65,6 @@ fi
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libicuuc$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"
 if $pythonModuleEnabled; then
@@ -123,7 +120,6 @@ BUILD()
 	runConfigure ./configure LDFLAGS="-lnetwork"  \
 		--with-html-dir=$docDir/html \
 		--with-html-subdir="" \
-		--enable-icu \
 		--disable-static \
 		$withPython
 	make $jobArgs


### PR DESCRIPTION
It wasn't used anyway because the wrong option was passed to configure.