### PR TITLE
icu70: enable for x86_64 and x86

### DIFF
--- a/dev-libs/icu/icu70-70.1.recipe
+++ b/dev-libs/icu/icu70-70.1.recipe
@@ -41,7 +41,7 @@ wrapping when displaying the text."
 HOMEPAGE="http://www.icu-project.org"
 COPYRIGHT="1995-2020 IBM Corporation and others."
 LICENSE="ICU"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/unicode-org/icu/releases/download/release-70-1/icu4c-70_1-src.tgz"
 SOURCE_URI_2="https://github.com/unicode-org/icu/releases/download/release-70-1/icu4c-70_1-data.zip#noarchive"
 #SOURCE_URI_3="http://www.iana.org/time-zones/repository/releases/tzdata2019c.tar.gz#noarchive"
@@ -50,9 +50,8 @@ CHECKSUM_SHA256_2="c72723ddba3300ffb231d6b09e2a728ea6e89de10ed5927f74bacbd770423
 SOURCE_DIR="icu"
 PATCHES="icu70-70.1.patchset"
 
-ARCHITECTURES="!all ?x86 ?arm ?sparc ?arm64 ?riscv64"
-# leave inactive until full testing can be done
-SECONDARY_ARCHITECTURES="!x86"
+ARCHITECTURES="!all ?x86 ?arm ?sparc ?arm64 ?riscv64 x86_64"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	icu70$secondaryArchSuffix = $portVersion compat >= 70
@@ -80,6 +79,9 @@ PROVIDES_devel="
 REQUIRES_devel="
 	icu70${secondaryArchSuffix} == $portVersion base
 	"
+CONFLICTS_devel="
+	icu66${secondaryArchSuffix}_devel
+	"
 
 if [ -z "$secondaryArchSuffix" ]; then
 	SUMMARY_tools="The ICU support tools"
@@ -96,6 +98,7 @@ if [ -z "$secondaryArchSuffix" ]; then
 		cmd:gennorm2
 		cmd:genrb
 		cmd:gensprep
+		cmd:icuexportdata
 		cmd:icuinfo
 		cmd:icupkg
 		cmd:makeconv


### PR DESCRIPTION
This is needed for texlive_core 2023 (#8113).

Also add a conflict for the devel package with icu66_devel. Others, like icu67 should be added as well, when they are made available.