### PR TITLE
libbson, mark x86_gcc2 as broken (parse error(s)), not installable on…

### DIFF
--- a/dev-libs/libbson/libbson-1.1.10.recipe
+++ b/dev-libs/libbson/libbson-1.1.10.recipe
@@ -6,11 +6,11 @@ languages such as python, ruby, or perl."
 HOMEPAGE="https://github.com/mongodb/libbson"
 COPYRIGHT="2013-2015 Christian Hergert, MongoDB and others"
 LICENSE="Apache v2"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/mongodb/libbson/releases/download/1.1.10/libbson-1.1.10.tar.gz"
 CHECKSUM_SHA256="211a62a7a6f93ba21b85afc1522c3a367a264be09626ea15f7be3a0fbe084a70"
 
-ARCHITECTURES="all"
+ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="


### PR DESCRIPTION
… primary 32bit