### PR TITLE
python_ly: fix commandSuffixes

### DIFF
--- a/dev-python/python-ly/python_ly-0.9.7.recipe
+++ b/dev-python/python-ly/python_ly-0.9.7.recipe
@@ -10,7 +10,7 @@ Wilbert Berendsen."
 HOMEPAGE="https://github.com/frescobaldi/python-ly/"
 COPYRIGHT="2008-2015 Wilbert Berendsen"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.io/packages/source/p/python-ly/python-ly-$portVersion.tar.gz"
 CHECKSUM_SHA256="d4d2b68eb0ef8073200154247cc9bd91ed7fb2671ac966ef3d2853281c15d7a8"
 SOURCE_FILENAME="python-ly-$portVersion.tar.gz"
@@ -30,7 +30,7 @@ BUILD_REQUIRES="
 	"
 PYTHON_PACKAGES=(python38 python39 python310)
 PYTHON_VERSIONS=(3.8 3.9 3.10)
-commandSuffixes=("" 38 39 310)
+commandSuffixes=(38 "" 310)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}


### PR DESCRIPTION
python 3.7 was dropped, python 3.9 is the new default (with an empty suffix)