### PR TITLE
chardet: clean up.

### DIFF
--- a/dev-python/chardet/chardet-4.0.0.recipe
+++ b/dev-python/chardet/chardet-4.0.0.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="Python module for character encoding auto-detection."
 HOMEPAGE="https://github.com/chardet/chardet"
 COPYRIGHT="2011-2022 Mark Pilgrim, Dan Blanchard"
 LICENSE="GNU LGPL v2.1"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://pypi.io/packages/source/${portName:0:1}/$portName/${portName}-$portVersion.tar.gz"
 CHECKSUM_SHA256="0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"
 
@@ -22,11 +22,14 @@ BUILD_REQUIRES="
 
 PYTHON_PACKAGES=(python38 python39 python310)
 PYTHON_VERSIONS=(3.8 3.9 3.10)
+commandSuffixes=(3.8 "" 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
+commandSuffix=${commandSuffixes[$i]}
 eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
+	${portName}_$pythonPackage = $portVersion\n\
+	cmd:chardetect$commandSuffix = $portVersion\n\
 	\"; \
 REQUIRES_$pythonPackage=\"\
 	haiku\n\
@@ -38,39 +41,27 @@ BUILD_PREREQUIRES="$BUILD_PREREQUIRES
 	cmd:python$pythonVersion"
 done
 
-PROVIDES_python38="$PROVIDES_python38
-	cmd:chardetect3.8
-	"
-PROVIDES_python39="$PROVIDES_python39
-	cmd:chardetect
-	"
-PROVIDES_python310="$PROVIDES_python310
-	cmd:chardetect3.10
-	"
 
 INSTALL()
 {
 	for i in "${!PYTHON_PACKAGES[@]}"; do
 		pythonPackage=${PYTHON_PACKAGES[i]}
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		commandSuffix=${commandSuffixes[$i]}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		if [ $pythonPackage = python38 ]; then
+		if [ "$pythonVersion" = "$commandSuffix" ]; then
 			for f in $binDir/*; do
-				mv $f ${f}3.8
-			done
-		fi
-
-		if [ $pythonPackage = python310 ]; then
-			for f in $binDir/*; do
-				mv $f ${f}3.10
+				mv $f ${f}$commandSuffix
 			done
 		fi
 


### PR DESCRIPTION
- Use loops to generate the package/version specific PROVIDES.
- Version all the scripts that will end on /bin (except for the one from the default Python version, 3.9 at the moment).