### PR TITLE
docutils: clean up, support Python 3.10.

### DIFF
--- a/dev-python/docutils/docutils-0.18.1.recipe
+++ b/dev-python/docutils/docutils-0.18.1.recipe
@@ -11,7 +11,7 @@ LICENSE="Public Domain
 	BSD (2-clause)
 	GNU GPL v3
 	Python"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.io/packages/source/${portName:0:1}/$portName/$portName-$portVersion.tar.gz"
 CHECKSUM_SHA256="679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06"
 
@@ -28,13 +28,28 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python38 python39 python310)
+PYTHON_VERSIONS=(3.8 3.9 3.10)
+commandSuffixes=(3.8 "" 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
+commandSuffix=${commandSuffixes[$i]}
 eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
+	${portName}_$pythonPackage = $portVersion\n\
+	cmd:rst2html.py$commandSuffix = $portVersion\n\
+	cmd:rst2html4.py$commandSuffix = $portVersion\n\
+	cmd:rst2html5.py$commandSuffix = $portVersion\n\
+	cmd:rst2latex.py$commandSuffix = $portVersion\n\
+	cmd:rst2man.py$commandSuffix = $portVersion\n\
+	cmd:rst2newlatex.py$commandSuffix = $portVersion\n\
+	cmd:rst2odt_prepstyles.py$commandSuffix = $portVersion\n\
+	cmd:rst2odt.py$commandSuffix = $portVersion\n\
+	cmd:rst2pseudoxml.py$commandSuffix = $portVersion\n\
+	cmd:rst2s5.py$commandSuffix = $portVersion\n\
+	cmd:rst2xetex.py$commandSuffix = $portVersion\n\
+	cmd:rst2xml.py$commandSuffix = $portVersion\n\
+	cmd:rstpep2html.py$commandSuffix = $portVersion\n\
 	\"; \
 REQUIRES_$pythonPackage=\"\
 	haiku\n\
@@ -46,56 +61,30 @@ BUILD_PREREQUIRES="$BUILD_PREREQUIRES
 	cmd:python$pythonVersion"
 done
 
-PROVIDES_python39="$PROVIDES_python39
-	cmd:rst2html.py = $portVersion
-	cmd:rst2html4.py = $portVersion
-	cmd:rst2html5.py = $portVersion
-	cmd:rst2latex.py = $portVersion
-	cmd:rst2man.py = $portVersion
-	cmd:rst2newlatex.py = $portVersion
-	cmd:rst2odt_prepstyles.py = $portVersion
-	cmd:rst2odt.py = $portVersion
-	cmd:rst2pseudoxml.py = $portVersion
-	cmd:rst2s5.py = $portVersion
-	cmd:rst2xetex.py = $portVersion
-	cmd:rst2xml.py = $portVersion
-	cmd:rstpep2html.py = $portVersion
-	"
-PROVIDES_python38="$PROVIDES_python38
-	cmd:rst2html38.py = $portVersion
-	cmd:rst2html438.py = $portVersion
-	cmd:rst2html538.py = $portVersion
-	cmd:rst2latex38.py = $portVersion
-	cmd:rst2man38.py = $portVersion
-	cmd:rst2newlatex38.py = $portVersion
-	cmd:rst2odt_prepstyles38.py = $portVersion
-	cmd:rst2odt38.py = $portVersion
-	cmd:rst2pseudoxml38.py = $portVersion
-	cmd:rst2s538.py = $portVersion
-	cmd:rst2xetex38.py = $portVersion
-	cmd:rst2xml38.py = $portVersion
-	cmd:rstpep2html38.py = $portVersion
-	"
 
 INSTALL()
 {
 	for i in "${!PYTHON_PACKAGES[@]}"; do
 		pythonPackage=${PYTHON_PACKAGES[i]}
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		commandSuffix=${commandSuffixes[$i]}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		if [ $pythonPackage == python38 ]; then
-			for f in $binDir/*.py; do
-				mv $f ${f%.py}38.py
+		if [ "$pythonVersion" = "$commandSuffix" ]; then
+			for f in $binDir/*; do
+				mv $f ${f}$commandSuffix
 			done
 		fi
+
 		packageEntries  $pythonPackage \
 			$prefix/lib/python* \
 			$binDir

--- a/dev-python/docutils/docutils-0.18.1.recipe
+++ b/dev-python/docutils/docutils-0.18.1.recipe
@@ -30,35 +30,57 @@ BUILD_REQUIRES="
 
 PYTHON_PACKAGES=(python38 python39 python310)
 PYTHON_VERSIONS=(3.8 3.9 3.10)
-commandSuffixes=("_3.8" "" "_3.10")
+defaultVersion=3.9
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-commandSuffix=${commandSuffixes[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\n\
-	cmd:rst2html$commandSuffix.py = $portVersion\n\
-	cmd:rst2html4$commandSuffix.py = $portVersion\n\
-	cmd:rst2html5$commandSuffix.py = $portVersion\n\
-	cmd:rst2latex$commandSuffix.py = $portVersion\n\
-	cmd:rst2man$commandSuffix.py = $portVersion\n\
-	cmd:rst2newlatex$commandSuffix.py = $portVersion\n\
-	cmd:rst2odt_prepstyles$commandSuffix.py = $portVersion\n\
-	cmd:rst2odt$commandSuffix.py = $portVersion\n\
-	cmd:rst2pseudoxml$commandSuffix.py = $portVersion\n\
-	cmd:rst2s5$commandSuffix.py = $portVersion\n\
-	cmd:rst2xetex$commandSuffix.py = $portVersion\n\
-	cmd:rst2xml$commandSuffix.py = $portVersion\n\
-	cmd:rstpep2html$commandSuffix.py = $portVersion\n\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+	commandSuffix=${commandSuffixes[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		cmd:rst2html_$pythonVersion.py = $portVersion
+		cmd:rst2html4_$pythonVersion.py = $portVersion
+		cmd:rst2html5_$pythonVersion.py = $portVersion
+		cmd:rst2latex_$pythonVersion.py = $portVersion
+		cmd:rst2man_$pythonVersion.py = $portVersion
+		cmd:rst2newlatex_$pythonVersion.py = $portVersion
+		cmd:rst2odt_prepstyles_$pythonVersion.py = $portVersion
+		cmd:rst2odt_$pythonVersion.py = $portVersion
+		cmd:rst2pseudoxml_$pythonVersion.py = $portVersion
+		cmd:rst2s5_$pythonVersion.py = $portVersion
+		cmd:rst2xetex_$pythonVersion.py = $portVersion
+		cmd:rst2xml_$pythonVersion.py = $portVersion
+		cmd:rstpep2html_$pythonVersion.py = $portVersion
+		\""
+
+	if [ $pythonVersion = $defaultVersion ]; then
+		eval "PROVIDES_${pythonPackage}+=\"
+			cmd:rst2html = $portVersion
+			cmd:rst2html4 = $portVersion
+			cmd:rst2html5 = $portVersion
+			cmd:rst2latex = $portVersion
+			cmd:rst2man = $portVersion
+			cmd:rst2newlatex = $portVersion
+			cmd:rst2odt_prepstyles = $portVersion
+			cmd:rst2odt = $portVersion
+			cmd:rst2pseudoxml = $portVersion
+			cmd:rst2s5 = $portVersion
+			cmd:rst2xetex = $portVersion
+			cmd:rst2xml = $portVersion
+			cmd:rstpep2html = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
 
@@ -67,7 +89,6 @@ INSTALL()
 	for i in "${!PYTHON_PACKAGES[@]}"; do
 		pythonPackage=${PYTHON_PACKAGES[i]}
 		pythonVersion=${PYTHON_VERSIONS[$i]}
-		commandSuffix=${commandSuffixes[$i]}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
@@ -79,10 +100,16 @@ INSTALL()
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		# "rst2html-3.10.py" script, "rst2html_3.10.py" in PROVIDES_*
-		if [ "$pythonVersion" = "${commandSuffix//_}" ]; then
+		# Version suffix all the scripts
+		for f in $binDir/*; do
+			mv $f ${f%.py}-${pythonVersion}.py
+		done
+
+		# And provide suffix-less symlinks for the default version
+		if [ $pythonVersion = $defaultVersion ]; then
 			for f in $binDir/*; do
-				mv $f ${f%.py}${commandSuffix/_/-}.py
+				scriptName=`basename "$f"`
+				ln -s $scriptName $binDir/${scriptName%-$pythonVersion.py}
 			done
 		fi
 

--- a/dev-python/docutils/docutils-0.18.1.recipe
+++ b/dev-python/docutils/docutils-0.18.1.recipe
@@ -30,26 +30,26 @@ BUILD_REQUIRES="
 
 PYTHON_PACKAGES=(python38 python39 python310)
 PYTHON_VERSIONS=(3.8 3.9 3.10)
-commandSuffixes=(3.8 "" 3.10)
+commandSuffixes=("_3.8" "" "_3.10")
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
 commandSuffix=${commandSuffixes[$i]}
 eval "PROVIDES_${pythonPackage}=\"\
 	${portName}_$pythonPackage = $portVersion\n\
-	cmd:rst2html.py$commandSuffix = $portVersion\n\
-	cmd:rst2html4.py$commandSuffix = $portVersion\n\
-	cmd:rst2html5.py$commandSuffix = $portVersion\n\
-	cmd:rst2latex.py$commandSuffix = $portVersion\n\
-	cmd:rst2man.py$commandSuffix = $portVersion\n\
-	cmd:rst2newlatex.py$commandSuffix = $portVersion\n\
-	cmd:rst2odt_prepstyles.py$commandSuffix = $portVersion\n\
-	cmd:rst2odt.py$commandSuffix = $portVersion\n\
-	cmd:rst2pseudoxml.py$commandSuffix = $portVersion\n\
-	cmd:rst2s5.py$commandSuffix = $portVersion\n\
-	cmd:rst2xetex.py$commandSuffix = $portVersion\n\
-	cmd:rst2xml.py$commandSuffix = $portVersion\n\
-	cmd:rstpep2html.py$commandSuffix = $portVersion\n\
+	cmd:rst2html$commandSuffix.py = $portVersion\n\
+	cmd:rst2html4$commandSuffix.py = $portVersion\n\
+	cmd:rst2html5$commandSuffix.py = $portVersion\n\
+	cmd:rst2latex$commandSuffix.py = $portVersion\n\
+	cmd:rst2man$commandSuffix.py = $portVersion\n\
+	cmd:rst2newlatex$commandSuffix.py = $portVersion\n\
+	cmd:rst2odt_prepstyles$commandSuffix.py = $portVersion\n\
+	cmd:rst2odt$commandSuffix.py = $portVersion\n\
+	cmd:rst2pseudoxml$commandSuffix.py = $portVersion\n\
+	cmd:rst2s5$commandSuffix.py = $portVersion\n\
+	cmd:rst2xetex$commandSuffix.py = $portVersion\n\
+	cmd:rst2xml$commandSuffix.py = $portVersion\n\
+	cmd:rstpep2html$commandSuffix.py = $portVersion\n\
 	\"; \
 REQUIRES_$pythonPackage=\"\
 	haiku\n\
@@ -79,9 +79,10 @@ INSTALL()
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		if [ "$pythonVersion" = "$commandSuffix" ]; then
+		# "rst2html-3.10.py" script, "rst2html_3.10.py" in PROVIDES_*
+		if [ "$pythonVersion" = "${commandSuffix//_}" ]; then
 			for f in $binDir/*; do
-				mv $f ${f}$commandSuffix
+				mv $f ${f%.py}${commandSuffix/_/-}.py
 			done
 		fi
 

--- a/dev-python/docutils/docutils-0.19.recipe
+++ b/dev-python/docutils/docutils-0.19.recipe
@@ -110,8 +110,7 @@ INSTALL()
 		# And provide suffix-less symlinks for the default version
 		if [ $pythonVersion = $defaultVersion ]; then
 			for f in $binDir/*; do
-				scriptName=`basename "$f"`
-				ln -s $scriptName $binDir/${scriptName%-$pythonVersion.py}
+				ln -sr $f ${f%-$pythonVersion.py}
 			done
 		fi
 

--- a/dev-python/docutils/docutils-0.19.recipe
+++ b/dev-python/docutils/docutils-0.19.recipe
@@ -11,9 +11,9 @@ LICENSE="Public Domain
 	BSD (2-clause)
 	GNU GPL v3
 	Python"
-REVISION="3"
+REVISION="1"
 SOURCE_URI="https://pypi.io/packages/source/${portName:0:1}/$portName/$portName-$portVersion.tar.gz"
-CHECKSUM_SHA256="679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06"
+CHECKSUM_SHA256="33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6"
 
 ARCHITECTURES="any"
 
@@ -38,6 +38,7 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 
 	eval "PROVIDES_${pythonPackage}=\"
 		${portName}_$pythonPackage = $portVersion
+		cmd:docutils_$pythonVersion.py = $portVersion
 		cmd:rst2html_$pythonVersion.py = $portVersion
 		cmd:rst2html4_$pythonVersion.py = $portVersion
 		cmd:rst2html5_$pythonVersion.py = $portVersion
@@ -55,6 +56,7 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 
 	if [ $pythonVersion = $defaultVersion ]; then
 		eval "PROVIDES_${pythonPackage}+=\"
+			cmd:docutils = $portVersion
 			cmd:rst2html = $portVersion
 			cmd:rst2html4 = $portVersion
 			cmd:rst2html5 = $portVersion


### PR DESCRIPTION
- Use loops to generate the package/version specific PROVIDES.
- Use version suffixes for the provided cmds, except for the ones from the package for the default Python version (3.9 currently).

Note:

~Moved suffixes after the ".py", as names like "rst2html4310.py" looked weird, and we can't use "rst2html4-3.10.py" due to the "no dashes in PROVIDES or REQUIRES" rule.~

As names like `rst2html4310.py` look weird, use the easier to read: `rst2html4-3.10.py` naming style. See comments below.