### PR TITLE
markdown: clean up, support Python 3.10.

### DIFF
--- a/dev-python/markdown/markdown-3.1.1.recipe
+++ b/dev-python/markdown/markdown-3.1.1.recipe
@@ -8,7 +8,7 @@ COPYRIGHT="2007, 2008 The Python Markdown Project
 	2004, 2005, 2006 Yuri Takhteyev
 	2004 Manfred Stienstra"
 LICENSE="BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/M/Markdown/Markdown-$portVersion.tar.gz"
 CHECKSUM_SHA256="2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a"
 SOURCE_DIR="Markdown-$portVersion"
@@ -26,13 +26,16 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python38 python39 python310)
+PYTHON_VERSIONS=(3.8 3.9 3.10)
+commandSuffixes=(3.8 "" 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
+commandSuffix=${commandSuffixes[$i]}
 eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
+	${portName}_$pythonPackage = $portVersion\n\
+	cmd:markdown_py$commandSuffix\n\
 	\"; \
 REQUIRES_$pythonPackage=\"\
 	haiku\n\
@@ -44,30 +47,30 @@ BUILD_PREREQUIRES="$BUILD_PREREQUIRES
 	cmd:python$pythonVersion"
 done
 
-PROVIDES_python38="$PROVIDES_python38
-	cmd:markdown_py38
-	"
-PROVIDES_python39="$PROVIDES_python39
-	cmd:markdown_py
-	"
 
 INSTALL()
 {
 	for i in "${!PYTHON_PACKAGES[@]}"; do
 		pythonPackage=${PYTHON_PACKAGES[i]}
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		commandSuffix=${commandSuffixes[$i]}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		if [ $pythonPackage = python38 ]; then
-			mv $binDir/markdown_py $binDir/markdown_py38
+		if [ "$pythonVersion" = "$commandSuffix" ]; then
+			for f in $binDir/*; do
+				mv $f ${f}$commandSuffix
+			done
 		fi
+
 		packageEntries  $pythonPackage \
 			$prefix/lib/python* \
 			$binDir


### PR DESCRIPTION
- Use loops to generate the package/version specific PROVIDES.
- Use version suffixes for the provided cmds, except for the ones from the package for the default Python version (3.9 currently).