### PR TITLE
mutagen: cleanup, add support for Python 3.10.

### DIFF
--- a/dev-python/mutagen/mutagen-1.45.1.recipe
+++ b/dev-python/mutagen/mutagen-1.45.1.recipe
@@ -9,7 +9,7 @@ Ogg streams on an individual packet/page level."
 HOMEPAGE="https://github.com/quodlibet/mutagen"
 COPYRIGHT="Joe Wreschnig, Michael Urman, Lukáš Lalinský, Christoph Reiter, Ben Ockmore & others"
 LICENSE="GNU GPL v2"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/m/$portName/$portName-$portVersion.tar.gz"
 CHECKSUM_SHA256="6397602efb3c2d7baebd2166ed85731ae1c1d475abca22090b7141ff5034b3e1"
 SOURCE_DIR="mutagen-$portVersion"
@@ -27,13 +27,21 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python38 python39 python310)
+PYTHON_VERSIONS=(3.8 3.9 3.10)
+commandSuffixes=(3.8 "" 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
+commandSuffix=${commandSuffixes[$i]}
 eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
+	${portName}_$pythonPackage = $portVersion\n\
+	cmd:mid3cp$commandSuffix\n\
+	cmd:mid3iconv$commandSuffix\n\
+	cmd:mid3v2$commandSuffix\n\
+	cmd:moggsplit$commandSuffix\n\
+	cmd:mutagen_inspect$commandSuffix\n\
+	cmd:mutagen_pony$commandSuffix\n\
 	\"; \
 REQUIRES_$pythonPackage=\"\
 	haiku\n\
@@ -45,38 +53,33 @@ BUILD_PREREQUIRES="$BUILD_PREREQUIRES
 	cmd:python$pythonVersion"
 done
 
-PROVIDES_python39="$PROVIDES_python39
-	cmd:mid3cp
-	cmd:mid3iconv
-	cmd:mid3v2
-	cmd:moggsplit
-	cmd:mutagen_inspect
-	cmd:mutagen_pony
-	"
 
 INSTALL()
 {
 	for i in "${!PYTHON_PACKAGES[@]}"; do
 		pythonPackage=${PYTHON_PACKAGES[i]}
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		commandSuffix=${commandSuffixes[$i]}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix \
 			--install-data=$dataDir
 
-		if [ $pythonPackage == python39 ]; then
-			packageEntries $pythonPackage \
-				$prefix/lib/python* \
-				$binDir
-		else
-			rm -rf $binDir
-			packageEntries $pythonPackage \
-				$prefix/lib/python*
+		if [ "$pythonVersion" = "$commandSuffix" ]; then
+			for f in $binDir/*; do
+				mv $f ${f}$commandSuffix
+			done
 		fi
+
+		packageEntries  $pythonPackage \
+			$prefix/lib/python* \
+			$binDir
 	done
 }


### PR DESCRIPTION
- Use loops to generate the package/version specific PROVIDES.
- Use version suffixes for the provided cmds, except for the ones from the package for the default Python version (3.9 currently).