### PR TITLE
pygments: cleanup, update to version 2.14.0

### DIFF
--- a/dev-python/pygments/pygments-2.11.2.recipe
+++ b/dev-python/pygments/pygments-2.11.2.recipe
@@ -14,7 +14,7 @@ ANSI sequences
 HOMEPAGE="https://pygments.org/"
 COPYRIGHT="2006-2022 by the Pygments team"
 LICENSE="BSD (2-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://pypi.org/packages/source/P/Pygments/Pygments-$portVersion.tar.gz"
 CHECKSUM_SHA256="4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"
 SOURCE_DIR="Pygments-$portVersion"
@@ -34,11 +34,14 @@ BUILD_REQUIRES="
 
 PYTHON_PACKAGES=(python38 python39 python310)
 PYTHON_VERSIONS=(3.8 3.9 3.10)
+commandSuffixes=(3.8 "" 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}
+commandSuffix=${commandSuffixes[$i]}
 eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
+	${portName}_$pythonPackage = $portVersion\n\
+	cmd:pygmentize$commandSuffix = $portVersion\n\
 	\"; \
 REQUIRES_$pythonPackage=\"\
 	haiku\n\
@@ -50,30 +53,30 @@ BUILD_PREREQUIRES="$BUILD_PREREQUIRES
 	cmd:python$pythonVersion"
 done
 
-PROVIDES_python38="$PROVIDES_python38
-	cmd:pygmentize3.8 = $portVersion
-	"
-PROVIDES_python39="$PROVIDES_python39
-	cmd:pygmentize = $portVersion
-	"
 
 INSTALL()
 {
 	for i in "${!PYTHON_PACKAGES[@]}"; do
 		pythonPackage=${PYTHON_PACKAGES[i]}
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		commandSuffix=${commandSuffixes[$i]}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		if [ $pythonPackage = python38 ]; then
-			mv $binDir/pygmentize $binDir/pygmentize3.8
+		if [ "$pythonVersion" = "$commandSuffix" ]; then
+			for f in $binDir/*; do
+				mv $f ${f}$commandSuffix
+			done
 		fi
+
 		packageEntries  $pythonPackage \
 			$prefix/lib/python* \
 			$binDir

--- a/dev-python/pygments/pygments-2.14.0.recipe
+++ b/dev-python/pygments/pygments-2.14.0.recipe
@@ -12,11 +12,11 @@ ANSI sequences
 * it is usable as a command-line tool and as a library
 * ... and it highlights even Brainf*ck!"
 HOMEPAGE="https://pygments.org/"
-COPYRIGHT="2006-2022 by the Pygments team"
+COPYRIGHT="2006-2023 by the Pygments team"
 LICENSE="BSD (2-clause)"
-REVISION="4"
+REVISION="1"
 SOURCE_URI="https://pypi.org/packages/source/P/Pygments/Pygments-$portVersion.tar.gz"
-CHECKSUM_SHA256="4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"
+CHECKSUM_SHA256="b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297"
 SOURCE_DIR="Pygments-$portVersion"
 
 ARCHITECTURES="any"

--- a/dev-python/pygments/pygments-2.14.0.recipe
+++ b/dev-python/pygments/pygments-2.14.0.recipe
@@ -71,14 +71,18 @@ INSTALL()
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
+		mkdir -p $manDir/man1
+		cp doc/pygmentize.1 $manDir/man1
+
 		if [ "$pythonVersion" = "$commandSuffix" ]; then
 			for f in $binDir/*; do
 				mv $f ${f}$commandSuffix
 			done
 		fi
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python* \
-			$binDir
+			$binDir \
+			$manDir
 	done
 }


### PR DESCRIPTION
Move the PROVIDES_* inside the loop, fix script suffixes for 3.10.

Install from the wheel file instead of using the tarball for faster package buids (1.1 MB vs 4.4 MB file download).