### PR TITLE
pyopenssl: force rebuild.

### DIFF
--- a/dev-python/pyopenssl/pyopenssl-22.0.0.recipe
+++ b/dev-python/pyopenssl/pyopenssl-22.0.0.recipe
@@ -10,7 +10,7 @@ HOMEPAGE="https://github.com/pyca/pyopenssl
 COPYRIGHT="2008-2022 The pyOpenSSL developers"
 LICENSE="Apache v2
 	BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/pyca/pyopenssl/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="4e92f6c2f08a8d1f0d9695335037a3d50ef8f58cd326514b89104acb9abb2838"
 SOURCE_FILENAME="pyopenssl-$portVersion.tar.gz"


### PR DESCRIPTION
Repos still contain revision 1, as the buildmasters [failed to build](https://build.haiku-os.org/buildmaster/master/x86_gcc2/?buildrunDir=3993) revision 2. The issue with its build was resolved by #8090, but seems buildmasters do not auto retry when builds failed due to missing dependencies.