### PR TITLE
libatomic_ops: bump to 7.8.0

### DIFF
--- a/sys-libs/libatomic_ops/libatomic_ops-7.8.0.recipe
+++ b/sys-libs/libatomic_ops/libatomic_ops-7.8.0.recipe
@@ -2,26 +2,26 @@ SUMMARY="An atomic memory update operations portable implementation"
 DESCRIPTION="Semi-portable access to hardware-provided atomic memory update \
 operations on a number architectures."
 HOMEPAGE="https://github.com/ivmai/libatomic_ops"
-COPYRIGHT="2008-2021 Ivan Maidanski
-	1991-1994 Xerox Corporation
+COPYRIGHT="1991-1994 Xerox Corporation
 	1996-1999 Silicon Graphics
 	1999-2011 Hewlett-Packard Development Company, L.P.
 	2005, 2007 Thiemo Seufer
 	2007 NEC LE-IT
+	2008-2022 Ivan Maidanski
 	2009 Bradley Smith
-	2009 Takashi YOSHII"
+	2009 Takashi Yoshii"
 LICENSE="MIT
 	Boehm
 	GNU GPL v2"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://github.com/ivmai/libatomic_ops/releases/download/v$portVersion/libatomic_ops-$portVersion.tar.gz"
-CHECKSUM_SHA256="390f244d424714735b7050d056567615b3b8f29008a663c262fb548f1802d292"
+CHECKSUM_SHA256="15676e7674e11bda5a7e50a73f4d9e7d60452271b8acf6fd39a71fefdf89fa31"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
-libVersion="1.1.1"
-libGplVersion="1.1.3"
+libVersion="1.2.0"
+libGplVersion="1.2.0"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 libGplVersionCompat="$libGplVersion compat >= ${libGplVersion%%.*}"
 


### PR DESCRIPTION
Add new recipe version (libatomic_ops-7.8.0.recipe).