### PR TITLE
ripgrep: fix install path for bash completions.

### DIFF
--- a/sys-apps/ripgrep/ripgrep-13.0.0.recipe
+++ b/sys-apps/ripgrep/ripgrep-13.0.0.recipe
@@ -7,7 +7,7 @@ HOMEPAGE="https://github.com/BurntSushi/ripgrep"
 COPYRIGHT="2015 Andrew Gallant"
 LICENSE="MIT
 	Unlicense"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="$HOMEPAGE/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="0fb17aaf285b3eee8ddab17b833af1e190d73de317ff9648751ab0660d763ed2"
 SOURCE_FILENAME="ripgrep-$portVersion.tar.gz"
@@ -240,7 +240,7 @@ BUILD()
 INSTALL()
 {
 	install -m 755 -d "$commandBinDir" "$docDir" "$manDir"/man1 \
-		"$dataDir"/bash-completions/completions \
+		"$dataDir"/bash-completion/completions \
 		"$dataDir"/zsh/site-functions
 
 	install -m 755 target/release/rg "$commandBinDir"
@@ -248,7 +248,7 @@ INSTALL()
 	install -m 644 target/release/build/ripgrep-*/out/rg.1 "$manDir"/man1
 
 	install -m 644 target/release/build/ripgrep-*/out/rg.bash \
-		"$dataDir"/bash-completions/completions/rg
+		"$dataDir"/bash-completion/completions/rg
 	install -m 644 complete/_rg "$dataDir"/zsh/site-functions
 }
 

--- a/sys-apps/ripgrep/ripgrep-13.0.0.recipe
+++ b/sys-apps/ripgrep/ripgrep-13.0.0.recipe
@@ -7,7 +7,7 @@ HOMEPAGE="https://github.com/BurntSushi/ripgrep"
 COPYRIGHT="2015 Andrew Gallant"
 LICENSE="MIT
 	Unlicense"
-REVISION="3"
+REVISION="2"
 SOURCE_URI="$HOMEPAGE/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="0fb17aaf285b3eee8ddab17b833af1e190d73de317ff9648751ab0660d763ed2"
 SOURCE_FILENAME="ripgrep-$portVersion.tar.gz"

--- a/sys-apps/ripgrep/ripgrep-13.0.0.recipe
+++ b/sys-apps/ripgrep/ripgrep-13.0.0.recipe
@@ -7,7 +7,7 @@ HOMEPAGE="https://github.com/BurntSushi/ripgrep"
 COPYRIGHT="2015 Andrew Gallant"
 LICENSE="MIT
 	Unlicense"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="$HOMEPAGE/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="0fb17aaf285b3eee8ddab17b833af1e190d73de317ff9648751ab0660d763ed2"
 SOURCE_FILENAME="ripgrep-$portVersion.tar.gz"


### PR DESCRIPTION
There was an final "s" on "$dataDir/bash-completion/[...]" that wasn't supposed to be there.

---

Untested (too many dependencies, + rust, for my poor PC/connection).

I didn't rev-bump it, as the fix is small, and will be pick up on future updates. Meanwhile user can manually move the files to the proper path.