### PR TITLE
glances: switch to Python 3.9, disable recipe.

### DIFF
--- a/sys-process/glances/glances-3.1.3.recipe
+++ b/sys-process/glances/glances-3.1.3.recipe
@@ -12,8 +12,8 @@ CHECKSUM_SHA256="e3e8f9362b82c74427522e82501b47696945251035b35282f9ee4bc53399622
 #SOURCE_DIR="psutil-release-$portVersion"
 #PATCHES="psutil-$portVersion.patchset"
 
-ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="?all !x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
 
 PROVIDES="
 	$portName = $portVersion
@@ -31,8 +31,8 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python3)
-PYTHON_VERSIONS=(3.7)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}


### PR DESCRIPTION
This requires psutil, which is currently broken WIP.

Still, we're dropping Python 3.7.