### PR TITLE
psutil: move to Python 3.9, add TEST().

### DIFF
--- a/dev-python/psutil/psutil-5.6.7.recipe
+++ b/dev-python/psutil/psutil-5.6.7.recipe
@@ -33,23 +33,30 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python3)
-PYTHON_VERSIONS=(3.7)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku$secondaryArchSuffix\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	eval "REQUIRES_$pythonPackage=\"
+		haiku$secondaryArchSuffix
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
+	TEST_REQUIRES+="
+		cmd:make
+		"
 done
+
 
 INSTALL()
 {
@@ -60,12 +67,29 @@ INSTALL()
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
 		packageEntries  $pythonPackage \
 			$prefix/lib/python*
+	done
+}
+
+
+TEST()
+{
+	for i in "${!PYTHON_PACKAGES[@]}"; do
+		pythonPackage=${PYTHON_PACKAGES[i]}
+		pythonVersion=${PYTHON_VERSIONS[$i]}
+
+		python=python$pythonVersion
+		installLocation=$prefix/lib/$python/vendor-packages/
+		export PYTHONPATH=$installLocation:$PYTHONPATH
+
+		make test PYTHON=$python
 	done
 }


### PR DESCRIPTION
Package is non-functional: on both 3.7 and 3.9 it gives an error when trying to "import psutil".

The patchset is WIP, so attempting to update to psutil 5.9.4 won't do much.

Still, moving away from 3.7 makes sense.