### PR TITLE
jsonschema: drop support for Python 3.7, add it for 3.9/3.10.

### DIFF
--- a/dev-python/jsonschema/jsonschema-3.2.0.recipe
+++ b/dev-python/jsonschema/jsonschema-3.2.0.recipe
@@ -5,7 +5,7 @@ HOMEPAGE="https://pypi.org/project/jsonschema/
 	https://github.com/Julian/jsonschema"
 COPYRIGHT="2013 Julian Berman"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://files.pythonhosted.org/packages/69/11/a69e2a3c01b324a77d3a7c0570faa372e8448b666300c4117a516f8b1212/jsonschema-3.2.0.tar.gz"
 CHECKSUM_SHA256="c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"
 
@@ -22,30 +22,47 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python3)
-PYTHON_VERSIONS=(3.7)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
+defaultVersion=3.9
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	eval "PROVIDES_$pythonPackage+=\"
+		cmd:jsonschema$pythonVersion
+		\""
+
+	if [ $pythonVersion = $defaultVersion ]; then
+		eval "PROVIDES_$pythonPackage+=\"
+			cmd:jsonschema
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		attrs_$pythonPackage
+		pyrsistent_$pythonPackage
+		six_$pythonPackage
+		cmd:python$pythonVersion
+		\""
+
+	BUILD_REQUIRES+="
+		setuptools_scm_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
-PROVIDES_python3="$PROVIDES_python3
-	cmd:jsonschema3.7
-	"
 
 INSTALL()
 {
+	export SETUPTOOLS_SCM_PRETEND_VERSION=$portVersion
+
 	for i in "${!PYTHON_PACKAGES[@]}"; do
 		pythonPackage=${PYTHON_PACKAGES[i]}
 		pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -53,11 +70,19 @@ INSTALL()
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
+
 		mv $binDir/jsonschema $binDir/jsonschema$pythonVersion
+		# Provide non-suffixed command for the default Python version
+		if [ $pythonVersion = $defaultVersion ]; then
+			ln -s jsonschema$pythonVersion $binDir/jsonschema
+		fi
+
 		packageEntries  $pythonPackage \
 			$prefix/lib/python* \
 			$binDir


### PR DESCRIPTION
Fixed dependencies. Now the jsonchema script actually runs.