### PR TITLE
libmatroska: Use libVersionCompat

### DIFF
--- a/media-libs/libmatroska/libmatroska-1.7.1.recipe
+++ b/media-libs/libmatroska/libmatroska-1.7.1.recipe
@@ -3,16 +3,19 @@ DESCRIPTION="libmatroska is a C++ libary to parse Matroska files."
 HOMEPAGE="https://www.matroska.org/"
 COPYRIGHT="2003-2023 Matroska"
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://dl.matroska.org/downloads/libmatroska/libmatroska-$portVersion.tar.xz"
 CHECKSUM_SHA256="572a3033b8d93d48a6a858e514abce4b2f7a946fe1f02cbfeca39bfd703018b3"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
+libVersion="7.0.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
 PROVIDES="
 	libmatroska$secondaryArchSuffix = $portVersion
-	lib:libmatroska$secondaryArchSuffix = 7.0.0 compat >= 7
+	lib:libmatroska$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku${secondaryArchSuffix}
@@ -21,7 +24,7 @@ REQUIRES="
 
 PROVIDES_devel="
 	libmatroska${secondaryArchSuffix}_devel = $portVersion
-	devel:libmatroska$secondaryArchSuffix = 7.0.0 compat >= 7
+	devel:libmatroska$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
 	libmatroska$secondaryArchSuffix == $portVersion base


### PR DESCRIPTION
The rebuild should also fix an issue with mkvtoolnix on x86.