### PR TITLE
pyrsistent: style clean up, add support for Python 3.10.

### DIFF
--- a/dev-python/pyrsistent/pyrsistent-0.17.3.recipe
+++ b/dev-python/pyrsistent/pyrsistent-0.17.3.recipe
@@ -9,7 +9,7 @@ HOMEPAGE="https://pypi.org/project/pyrsistent/
 	https://github.com/tobgu/pyrsistent/"
 COPYRIGHT="2019 Tobias Gustafsson"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.org/packages/source/p/pyrsistent/pyrsistent-$portVersion.tar.gz"
 CHECKSUM_SHA256="2e636185d9eb976a18a8a8e96efce62f2905fea90041958d8cc2a189756ebf3e"
 
@@ -26,23 +26,27 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python38 python39 python310)
+PYTHON_VERSIONS=(3.8 3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
+
 
 INSTALL()
 {
@@ -53,10 +57,13 @@ INSTALL()
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
+
 		packageEntries  $pythonPackage \
 			$prefix/lib/python*
 	done


### PR DESCRIPTION
Trying to install the 3.10 version of jsonschema was complaining about no "pyrsistent_python310".

---

Tested as far as running (with Python 3.10) a test script for `jsonrpcserver`. That module needs `jsonschema`, that needs in turn this `pyrsistent`.