### PR TITLE
jsonrpcserver: drop support for Python 3.7, add it for 3.9/3.10.

### DIFF
--- a/dev-python/jsonrpcserver/jsonrpcserver-4.1.2.recipe
+++ b/dev-python/jsonrpcserver/jsonrpcserver-4.1.2.recipe
@@ -4,7 +4,7 @@ HOMEPAGE="https://pypi.org/project/jsonrpcserver/
 	https://github.com/bcb/jsonrpcserver"
 COPYRIGHT="2015 Beau Barker"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://files.pythonhosted.org/packages/bf/c9/5309715a98f87e05afcd942082f5e6361048436de1518431ee329b0c9add/jsonrpcserver-4.1.2.tar.gz"
 CHECKSUM_SHA256="73db55d1cf245ebdfb96ca05c4cce01c51b61be845a2a981f539ea1e6a4e0c4a"
 SOURCE_FILENAME="jsonrpcserver-$portVersion.tar.gz"
@@ -23,23 +23,29 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python3)
-PYTHON_VERSIONS=(3.7)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		apply_defaults_$pythonPackage
+		jsonschema_$pythonPackage
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
+
 
 INSTALL()
 {
@@ -50,8 +56,10 @@ INSTALL()
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 


### PR DESCRIPTION
Added the needed REQUIRES.

I was able to import the module, and run a test server now.

---

The `_python310` version of this will require #8202 merged to work (due to the jsonschema->pyrsistent, dependencies).