### PR TITLE
pypandoc: cleanup, support for Python 3.10, update to 1.11

### DIFF
--- a/dev-python/pypandoc/pypandoc-1.11.recipe
+++ b/dev-python/pypandoc/pypandoc-1.11.recipe
@@ -3,11 +3,11 @@ DESCRIPTION="thin wrapper for pandoc, a universal document converter"
 HOMEPAGE="https://pypi.org/project/pypandoc/"
 COPYRIGHT="2011-2017 Juho Vepsäläinen"
 LICENSE="MIT"
-REVISION="3"
+REVISION="1"
 SOURCE_URI="https://pypi.io/packages/source/p/pypandoc/pypandoc-$portVersion.tar.gz"
-CHECKSUM_SHA256="14a49977ab1fbc9b14ef3087dcb101f336851837fca55ca79cf33846cc4976ff"
+CHECKSUM_SHA256="7f6d68db0e57e0f6961bec2190897118c4d305fc2d31c22cd16037f22ee084a5"
 
-ARCHITECTURES="any"
+ARCHITECTURES="?any"
 
 PROVIDES="
 	$portName = $portVersion
@@ -34,6 +34,7 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 		cmd:python$pythonVersion
 		\""
 	BUILD_REQUIRES+="
+		pip_$pythonPackage
 		setuptools_$pythonPackage
 		"
 	BUILD_PREREQUIRES+="


### PR DESCRIPTION
But leave it disabled, as we don't have a working pandoc binary in the repos.