### PR TITLE
jsonrpcclient: drop Python 3.7 support, add it for 3.9/3.10.

### DIFF
--- a/dev-python/jsonrpcclient/jsonrpcclient-3.3.5.recipe
+++ b/dev-python/jsonrpcclient/jsonrpcclient-3.3.5.recipe
@@ -5,7 +5,7 @@ HOMEPAGE="https://pypi.org/project/jsonrpcclient/
 	https://github.com/bcb/jsonrpcclient"
 COPYRIGHT="2015 Beau Barker"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://files.pythonhosted.org/packages/be/6a/0e756584a9550ff7d5f5a13a4cf325feeb5036e5ec8958617dd26321b7b6/jsonrpcclient-3.3.5.tar.gz"
 CHECKSUM_SHA256="a17d02a53061748384b15b4e9812e866d5f69771656ccf7031d6dc64d0c38099"
 
@@ -22,27 +22,43 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python3)
-PYTHON_VERSIONS=(3.7)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
+defaultVersion=3.9
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+
+	eval "PROVIDES_$pythonPackage+=\"
+		cmd:jsonrpc$pythonVersion
+		\""
+
+	if [ $pythonVersion = $defaultVersion ]; then
+		eval "PROVIDES_$pythonPackage+=\"
+			cmd:jsonrpc
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		apply_defaults_$pythonPackage
+		click_$pythonPackage
+		jsonschema_$pythonPackage
+		cmd:python$pythonVersion
+		\""
+
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
-PROVIDES_python3="$PROVIDES_python3
-	cmd:jsonrpc3.7
-	"
 
 INSTALL()
 {
@@ -53,13 +69,19 @@ INSTALL()
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
-		if [ $pythonPackage != python ]; then
-			mv $binDir/jsonrpc $binDir/jsonrpc$pythonVersion
+
+		mv $binDir/jsonrpc $binDir/jsonrpc$pythonVersion
+		# Provide non-suffixed command for the default Python version
+		if [ $pythonVersion = $defaultVersion ]; then
+			ln -s jsonrpc$pythonVersion $binDir/jsonrpc
 		fi
+
 		packageEntries  $pythonPackage \
 			$prefix/lib/python* \
 			$binDir

--- a/dev-python/jsonrpcclient/jsonrpcclient-4.0.3.recipe
+++ b/dev-python/jsonrpcclient/jsonrpcclient-4.0.3.recipe
@@ -2,12 +2,13 @@ SUMMARY="Send JSON-RPC requests in Python"
 DESCRIPTION="This library allows you to call remote procedures using the \
 JSON-RPC message format."
 HOMEPAGE="https://pypi.org/project/jsonrpcclient/
-	https://github.com/bcb/jsonrpcclient"
+	https://github.com/explodinglabs/jsonrpcclient"
 COPYRIGHT="2015 Beau Barker"
 LICENSE="MIT"
-REVISION="2"
-SOURCE_URI="https://files.pythonhosted.org/packages/be/6a/0e756584a9550ff7d5f5a13a4cf325feeb5036e5ec8958617dd26321b7b6/jsonrpcclient-3.3.5.tar.gz"
-CHECKSUM_SHA256="a17d02a53061748384b15b4e9812e866d5f69771656ccf7031d6dc64d0c38099"
+REVISION="1"
+pypiVersion="00/4b/ba54814656b155f14ae73092ae194dd04eaf7e8e9a3da4f2ee7ffc9fe98f"
+SOURCE_URI="https://files.pythonhosted.org/packages/$pypiVersion/jsonrpcclient-$portVersion-py3-none-any.whl#noarchive"
+CHECKSUM_SHA256="3cbb9e27e1be29821becf135ea183144a836215422727e1ffe5056a49a670f0d"
 
 ARCHITECTURES="any"
 
@@ -33,26 +34,13 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 		${portName}_$pythonPackage = $portVersion
 		\""
 
-	eval "PROVIDES_$pythonPackage+=\"
-		cmd:jsonrpc$pythonVersion
-		\""
-
-	if [ $pythonVersion = $defaultVersion ]; then
-		eval "PROVIDES_$pythonPackage+=\"
-			cmd:jsonrpc
-			\""
-	fi
-
 	eval "REQUIRES_$pythonPackage=\"
 		haiku
-		apply_defaults_$pythonPackage
-		click_$pythonPackage
-		jsonschema_$pythonPackage
 		cmd:python$pythonVersion
 		\""
 
 	BUILD_REQUIRES+="
-		setuptools_$pythonPackage
+		installer_$pythonPackage
 		"
 	BUILD_PREREQUIRES+="
 		cmd:python$pythonVersion
@@ -71,19 +59,10 @@ INSTALL()
 		export PYTHONPATH=$installLocation:$PYTHONPATH
 
 		mkdir -p $installLocation
-		rm -rf build
 
-		$python setup.py build install \
-			--root=/ --prefix=$prefix
-
-		mv $binDir/jsonrpc $binDir/jsonrpc$pythonVersion
-		# Provide non-suffixed command for the default Python version
-		if [ $pythonVersion = $defaultVersion ]; then
-			ln -s jsonrpc$pythonVersion $binDir/jsonrpc
-		fi
+		$python -m installer -p $prefix $portName-$portVersion-py3-none-any.whl
 
 		packageEntries  $pythonPackage \
-			$prefix/lib/python* \
-			$binDir
+			$prefix/lib/python*
 	done
 }


### PR DESCRIPTION
For the 3.3.5 version:

Also: Fixed REQUIRES. jsonrpclient still won't run as the version of the `click` package in the repos (8.1.3) is too new for this version of `jsonrpclient` (requires click < 7.x).

Updating to 4.0.3 will require either switching to install from the wheel (.whl) file provided by the project over PyPi, or having a working Poetry package in Haiku.

Packaging Poetry and its nearly 30 dependencies is still an on-going quest, so in the meantime we might want to use that .whl after all.

---

Updated it to latest 4.0.3 version (far fewer dependencies, lighter weight), using the wheel (.whl) from PyPi.