### PR TITLE
pyopengl: update to version 3.1.6

### DIFF
--- a/dev-python/pyopengl/pyopengl-3.1.6.recipe
+++ b/dev-python/pyopengl/pyopengl-3.1.6.recipe
@@ -6,9 +6,9 @@ under an extremely liberal BSD-style Open-Source license."
 HOMEPAGE="https://pypi.org/project/PyOpenGL/"
 COPYRIGHT="1997-1998, 2004-2020 Mike C. Fletcher"
 LICENSE="BSD (3-clause)"
-REVISION="1"
-SOURCE_URI="https://files.pythonhosted.org/packages/b8/73/31c8177f3d236e9a5424f7267659c70ccea604dab0585bfcd55828397746/PyOpenGL-$portVersion.tar.gz"
-CHECKSUM_SHA256="4107ba0d0390da5766a08c242cf0cf3404c377ed293c5f6d701e457c57ba3424"
+REVISION="2"
+SOURCE_URI="https://files.pythonhosted.org/packages/5b/01/f8fd986bc7f456f1a925ee0239f0391838ade92cdb6e5b674ffb8b86cfd6/PyOpenGL-3.1.6.tar.gz"
+CHECKSUM_SHA256="8ea6c8773927eda7405bffc6f5bb93be81569a7b05c8cac50cd94e969dce5e27"
 SOURCE_DIR="PyOpenGL-$portVersion"
 
 ARCHITECTURES="any"
@@ -24,23 +24,27 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python3)
-PYTHON_VERSIONS=(3.7)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+	"
 done
+
 
 INSTALL()
 {
@@ -51,8 +55,10 @@ INSTALL()
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 


### PR DESCRIPTION
Also:
- Drop support for Python 3.7
- Add it for 3.9 and 3.10.
- Style clean up.