### PR TITLE
lagrange: bump to 1.15.7

### DIFF
--- a/net-misc/lagrange/lagrange-1.15.7.recipe
+++ b/net-misc/lagrange/lagrange-1.15.7.recipe
@@ -4,11 +4,11 @@ It offers modern conveniences familiar from web browsers, \
 such as smooth scrolling, inline image viewing, multiple tabs, \
 visual themes, Unicode fonts, bookmarks, history, and page outlines."
 HOMEPAGE="https://gmi.skyjake.fi/lagrange/"
-COPYRIGHT="2020-2022 Jaakko Keränen"
+COPYRIGHT="2020-2023 Jaakko Keränen"
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="https://github.com/skyjake/lagrange/releases/download/v$portVersion/lagrange-$portVersion.tar.gz"
-CHECKSUM_SHA256="51b05ef7fd730d77ed9571c76a1772067fcfeeb900cbe8e66ec19c6fdfe58c64"
+CHECKSUM_SHA256="d556b0c596f706239ea52a8988b601d9ca06fd1f412a04d70acb5f47e7e8c097"
 SOURCE_DIR="lagrange-$portVersion"
 ADDITIONAL_FILES="lagrange.rdef.in"
 


### PR DESCRIPTION
[Changelog](https://github.com/skyjake/lagrange/releases)