### PR TITLE
pycurl: update to version 7.45.2

### DIFF
--- a/dev-python/pycurl/pycurl-7.45.2.recipe
+++ b/dev-python/pycurl/pycurl-7.45.2.recipe
@@ -10,12 +10,12 @@ COPYRIGHT="2001-2008 Kjetil Jacobsen
 	2013-2018 Oleg Pudeyev"
 LICENSE="GNU LGPL v2.1
 	MIT"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://github.com/pycurl/pycurl/archive/REL_${portVersion//./_}.tar.gz"
-CHECKSUM_SHA256="553047902a738cc2e6b1cd42783a9d0992e47086773be30027a71e1293493c39"
+CHECKSUM_SHA256="1aaaf415a5affe141593b3edf6ce187a79d99fbeb65c0b18490b03edc606394c"
 SOURCE_DIR="pycurl-REL_${portVersion//./_}"
 
-ARCHITECTURES="all"
+ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
@@ -24,17 +24,6 @@ PROVIDES="
 REQUIRES="
 	haiku$secondaryArchSuffix
 	"
-
-if [ -z "$secondaryArchSuffix" ]; then
-ARCHITECTURES_doc="any"
-SUMMARY_doc="A Python interface to the cURL library (documentation)"
-PROVIDES_doc="
-	pycurl_doc = $portVersion
-	"
-REQUIRES_doc="
-	haiku
-	"
-fi
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
@@ -49,25 +38,11 @@ BUILD_PREREQUIRES="
 	cmd:make
 	"
 
-PYTHON_PACKAGES=()
-PYTHON_VERSIONS=()
-PYTHON_LIBSUFFIXES=()
-# We don't have python2 for secondaryArch,
-if [ -z "$secondaryArchSuffix" ]; then
-	PYTHON_PACKAGES+=(python)
-	PYTHON_VERSIONS+=(2.7)
-	PYTHON_LIBSUFFIXES+=("")
-fi
-# gcc2 does not support the flags passed by python3
-if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
-	PYTHON_PACKAGES+=(python3)
-	PYTHON_VERSIONS+=(3.7)
-	PYTHON_LIBSUFFIXES+=(m)
-fi
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}
-	pythonLibSuffix=${PYTHON_LIBSUFFIXES[$i]}
 
 	eval "PROVIDES_${pythonPackage}=\"
 		${portName}_$pythonPackage = $portVersion
@@ -77,15 +52,18 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 		lib:libcrypto$secondaryArchSuffix
 		lib:libcurl$secondaryArchSuffix
 		lib:libnghttp2$secondaryArchSuffix
-		lib:libpython$pythonVersion$pythonLibSuffix$secondaryArchSuffix
+		lib:libpython$pythonVersion$secondaryArchSuffix
 		lib:libssl$secondaryArchSuffix
 		lib:libz$secondaryArchSuffix
 		\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
+
 
 INSTALL()
 {
@@ -96,24 +74,19 @@ INSTALL()
 		python=python$pythonVersion
 		installLocation="$prefix"/lib/$python/vendor-packages/
 		export PYTHONPATH="$installLocation"
+
 		rm -rf build
 		make PYTHON=$python
 		mkdir -p "$installLocation"
+
 		$python setup.py build install --root=/ --prefix="$prefix"
+
+#		mkdir -p "$docDir"
+#		mv "$prefix"/share/doc/pycurl/* "$docDir"
+		rm -rf "$prefix"/share
 
 		packageEntries $pythonPackage \
 			"$prefix"/lib/$python
+#			"$docDir"
 	done
-
-	if [ -z "$secondaryArchSuffix" ]; then
-		mkdir -p "$docDir"
-		mv "$prefix"/share/doc/pycurl/* "$docDir"
-		rmdir "$prefix"/share/doc/pycurl
-		packageEntries doc \
-			"$docDir"
-		rmdir "$prefix"/documentation/packages "$prefix"/documentation
-	else
-		rm -rf "$prefix"/share/doc/pycurl
-	fi
-	rmdir "$prefix"/share/doc "$prefix"/share
 }


### PR DESCRIPTION
- Drop support for Python 2.7/3.7.
- Add it for Python 3.9/3.10.
- Move to x86 in 32 bits.
- Disable creation of "any" pycurl_doc package (for now at least). Its content wasn't that much helpful.