### PR TITLE
pydispatcher: update version to 2.0.7

### DIFF
--- a/dev-python/pydispatcher/pydispatcher-2.0.7.recipe
+++ b/dev-python/pydispatcher/pydispatcher-2.0.7.recipe
@@ -4,12 +4,12 @@ multiple-producer-multiple-consumer, signal-registration and routing infrastruct
 use in multiple contexts. The mechanism of PyDispatcher started life as a highly rated \
 recipe in the Python Cookbook. The SourceForge project aims to include various \
 enhancements to the recipe developed during use in various applications."
-HOMEPAGE="http://pydispatcher.sourceforge.net/"
+HOMEPAGE="https://github.com/mcfletch/pydispatcher"
 COPYRIGHT="2001-2006, Patrick K. O'Brien and Contributors"
 LICENSE="BSD (3-clause)"
 REVISION="1"
-SOURCE_URI="https://downloads.sourceforge.net/pydispatcher/PyDispatcher-$portVersion.tar.gz"
-CHECKSUM_SHA256="a126561446cd1c9fdee0d43a32cae4413831dc017a64baf2f2fecd1597203898"
+SOURCE_URI="https://pypi.io/packages/source/p/pydispatcher/PyDispatcher-$portVersion.tar.gz"
+CHECKSUM_SHA256="b777c6ad080dc1bad74a4c29d6a46914fa6701ac70f94b0d66fbcfde62f5be31"
 SOURCE_DIR="PyDispatcher-$portVersion"
 
 ARCHITECTURES="any"
@@ -25,23 +25,30 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python)
-PYTHON_VERSIONS=(2.7)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_$pythonPackage=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_$pythonPackage=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		build_$pythonPackage
+		installer_$pythonPackage
+		setuptools_$pythonPackage
+		wheel_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
+
 
 INSTALL()
 {
@@ -52,10 +59,12 @@ INSTALL()
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
-		$python setup.py build install \
-			--root=/ --prefix=$prefix
+
+		$python -m build --wheel --no-isolation
+		$python -m installer -p $prefix dist/*.whl
 
 		packageEntries  $pythonPackage \
 			$prefix/lib/python*


### PR DESCRIPTION
- Drops support for Python 2.7, adds it for 3.9/3.10.
- Switched build system from "python3 setup.py" to using the  `build` and `installer` modules (was having versioning issues, otherwise).