### PR TITLE
pyqt_builder: fix up recipe.

### DIFF
--- a/dev-python/pyqt_builder/pyqt_builder-1.7.0.recipe
+++ b/dev-python/pyqt_builder/pyqt_builder-1.7.0.recipe
@@ -6,7 +6,7 @@ perform the actual compilation and installation of extension modules."
 HOMEPAGE="https://www.riverbankcomputing.com/software/pyqt/"
 COPYRIGHT="2020 Riverbank Computing Limited"
 LICENSE="BSD (2-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.io/packages/source/P/PyQt-builder/PyQt-builder-$portVersion.tar.gz"
 CHECKSUM_SHA256="b6e3c826f98ff4006ecb34df491ac6062a023b63a32e9f9f50904867aff72f2e"
 SOURCE_DIR="PyQt-builder-$portVersion"
@@ -15,7 +15,6 @@ ARCHITECTURES="any"
 
 PROVIDES="
 	pyqt_builder = $portVersion
-	cmd:pyqt_bundle
 	"
 REQUIRES="
 	haiku
@@ -27,37 +26,36 @@ BUILD_REQUIRES="
 
 PYTHON_PACKAGES=(python38 python39)
 PYTHON_VERSIONS=(3.8 3.9)
+defaultVersion=3.9
+
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}
 
 	eval "PROVIDES_$pythonPackage=\"
 		${portName}_$pythonPackage = $portVersion
+		cmd:pyqt_bundle_$pythonVersion
 		\""
+
+	if [ $pythonVersion = $defaultVersion ]; then
+		eval "PROVIDES_$pythonPackage+=\"
+			cmd:pyqt_bundle
+			\""
+	fi
+
 	eval "REQUIRES_$pythonPackage=\"
 		haiku
+		sip_$pythonPackage
 		cmd:python$pythonVersion
 		\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
-BUILD()
-{
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
-		pythonVersion=${PYTHON_VERSIONS[$i]}
-
-		rm -rf "$sourceDir"-$pythonPackage
-		cp -a "$sourceDir" "$sourceDir"-$pythonPackage
-		cd "$sourceDir"-$pythonPackage
-
-		python=python$pythonVersion
-		$python setup.py build
-	done
-}
 
 INSTALL()
 {
@@ -65,15 +63,22 @@ INSTALL()
 		pythonPackage=${PYTHON_PACKAGES[i]}
 		pythonVersion=${PYTHON_VERSIONS[$i]}
 
-		cd "$sourceDir"-$pythonPackage
-
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation
+
+		rm -rf build
 		mkdir -p "$installLocation"
-		$python setup.py install --root=/ --prefix="$prefix"
+
+		$python setup.py build install --root=/ --prefix="$prefix"
+
+		mv "$prefix"/bin/pyqt-bundle $binDir/pyqt-bundle-$pythonVersion
+		if [ $pythonVersion = $defaultVersion ]; then
+			ln -sr $binDir/pyqt-bundle-$pythonVersion $binDir/pyqt-bundle
+		fi
 
 		packageEntries $pythonPackage \
-			"$prefix"/lib/$python
+			"$prefix"/lib/$python \
+			$binDir
 	done
 }


### PR DESCRIPTION
- Some clean up.
- Fix dependencies.
- Provide versioned script (pyqt-bundle), and a non-suffixed link for the default Python version.

This fixes the following problems with the previous recipe version:

- Trying to do `> python3.9 -c "import pyqtbuild; help(pyqybuild)` was failing with:
  > ModuleNotFoundError: No module named 'sipbuild'

- `> pyqt-bundle --help` (after installing `pyqt_builder-1.7.0-2-any.hpkg`) was failing with:
  > importlib.metadata.PackageNotFoundError: No package metadata was found for PyQt-builder

Note:  I haven't performed further testing than that.