### PR TITLE
cryptography-vectors: drop Python 2.7/3.7 support, add it for 3.9/3.10

### DIFF
--- a/dev-python/cryptography-vectors/cryptography_vectors-2.8.recipe
+++ b/dev-python/cryptography-vectors/cryptography_vectors-2.8.recipe
@@ -8,7 +8,7 @@ HOMEPAGE="https://pypi.org/project/cryptography-vectors/
 COPYRIGHT="2013-2019 The cryptography developers"
 LICENSE="Apache v2
 	BSD (3-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.io/packages/source/c/cryptography_vectors/cryptography_vectors-$portVersion.tar.gz"
 CHECKSUM_SHA256="6cd32174c56a3eca72f64af43c1daacaae758cfa5ff9d280dfcf818fa11ef116"
 
@@ -25,77 +25,54 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python python3)
-PYTHON_VERSIONS=(2.7 3.7)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
-BUILD()
-{
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
-		pythonVersion=${PYTHON_VERSIONS[$i]}
-
-		rm -rf "$sourceDir"-$pythonPackage
-		cp -a "$sourceDir" "$sourceDir"-$pythonPackage
-		cd "$sourceDir"-$pythonPackage
-
-		python=python$pythonVersion
-		$python setup.py build
-	done
-}
 
 INSTALL()
 {
-	myLicensesDir=$dataDir/licenses/packages/c/cryptography_vectors
+	licensesDir=$dataDir/licenses/cryptography_vectors
 
 	for i in "${!PYTHON_PACKAGES[@]}"; do
 		pythonPackage=${PYTHON_PACKAGES[i]}
 		pythonVersion=${PYTHON_VERSIONS[$i]}
-
-		cd "$sourceDir"-$pythonPackage
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH="$installLocation"
+
+		rm -rf build
 		mkdir -p "$installLocation"
-		$python setup.py install \
+
+		$python setup.py build install \
 			--root=/ --prefix="$prefix"
 
-		install -m 755 -d "$myLicensesDir"
-		install -m 644 -t "$myLicensesDir" LICENSE*
-		rm "$myLicensesDir"/LICENSE.APACHE
+		install -m 755 -d "$licensesDir"
+		install -m 644 -t "$licensesDir" LICENSE*
+		rm "$licensesDir"/LICENSE.APACHE
 		ln -s "`finddir B_SYSTEM_DATA_DIRECTORY`/licenses/Apache v2" \
-			"$myLicensesDir"/LICENSE.APACHE
+			"$licensesDir"/LICENSE.APACHE
 
 		packageEntries $pythonPackage \
 			"$dataDir" \
 			"$prefix"/lib/$python
-	done
-}
-
-TEST()
-{
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
-		pythonVersion=${PYTHON_VERSIONS[$i]}
-
-		cd "$sourceDir"-$pythonPackage
-
-		python=python$pythonVersion
-		$python setup.py test
 	done
 }


### PR DESCRIPTION
Did some recipe clean up as well, removed TEST() as there are no tests on the tarball.