### PR TITLE
pyproject_hooks: new recipe.

### DIFF
--- a/dev-python/pyproject_hooks/pyproject_hooks-1.0.0.recipe
+++ b/dev-python/pyproject_hooks/pyproject_hooks-1.0.0.recipe
@@ -1,0 +1,77 @@
+SUMMARY="Low-level replacement for pep517"
+DESCRIPTION="This is a low-level library for calling build-backends in 'pyproject.toml'-based \
+project. It provides the basic functionality to help write tooling that generates distribution files \
+from Python projects.
+
+If you want a tool that builds Python packages, you’ll want to use https://github.com/pypa/build \
+instead. This is an underlying piece for pip, build and other “build frontends” use to call \
+“build backends” within them.
+
+Note: The 'pep517' project has been replaced by this project (low level) and the 'build' project \
+(high level)."
+HOMEPAGE="https://pypi.org/project/pyproject_hooks/"
+COPYRIGHT="2017 Thomas Kluyver"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://github.com/pypa/pyproject-hooks/archive/refs/tags/v$portVersion.tar.gz"
+CHECKSUM_SHA256="d45c52f9af6bce94755eecf9dbfe6b3c89ef9a50088a8809f5bbec4ed0f9be0b"
+SOURCE_DIR="pyproject-hooks-$portVersion"
+
+ARCHITECTURES="any"
+
+PROVIDES="
+	$portName = $portVersion
+	"
+REQUIRES="
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+
+PYTHON_PACKAGES=(python38 python39 python310)
+PYTHON_VERSIONS=(3.8 3.9 3.10)
+for i in "${!PYTHON_PACKAGES[@]}"; do
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		tomli_$pythonPackage # only for python < 3.11.
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		flit_core_$pythonPackage
+		installer_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
+done
+
+
+INSTALL()
+{
+	for i in "${!PYTHON_PACKAGES[@]}"; do
+		pythonPackage=${PYTHON_PACKAGES[i]}
+		pythonVersion=${PYTHON_VERSIONS[$i]}
+
+		python=python$pythonVersion
+		installLocation=$prefix/lib/$python/vendor-packages/
+		export PYTHONPATH=$installLocation:$PYTHONPATH
+
+		mkdir -p $installLocation
+		rm -rf dist
+
+		$python -m flit_core.wheel
+		$python -m installer -p $prefix dist/*.whl
+
+		packageEntries  $pythonPackage \
+			$prefix/lib/python*
+	done
+}


### PR DESCRIPTION
This will be needed when updating the `build` package to version 0.10.0, as it changes dependencies from `pep517` to this one.