### PR TITLE
fonttools: recipe cleanup.

### DIFF
--- a/dev-python/fonttools/fonttools-4.39.2.recipe
+++ b/dev-python/fonttools/fonttools-4.39.2.recipe
@@ -5,7 +5,7 @@ Mac-specific formats."
 HOMEPAGE="https://github.com/behdad/fonttools"
 COPYRIGHT="1999-2004 Just van Rossum, Letterror, The Netherlands."
 LICENSE="FONTTOOLS"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/fonttools/fonttools/archive/$portVersion.tar.gz"
 SOURCE_FILENAME="fonttools-$portVersion.tar.gz"
 CHECKSUM_SHA256="f49a6d3cf67c44a2e8da4435f42e736cbc96591c7033f86ab9f778b11b266b17"
@@ -25,36 +25,43 @@ BUILD_REQUIRES="
 
 PYTHON_PACKAGES=(python310)
 PYTHON_VERSIONS=(3.10)
+defaultVersion=3.10
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\n\
-	setuptools_$pythonPackage\n\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage
-	wheel_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	build_$pythonPackage
-	installer_$pythonPackage
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		cmd:fonttools_$pythonVersion = $portVersion
+		cmd:pyftmerge_$pythonVersion = $portVersion
+		cmd:pyftsubset_$pythonVersion = $portVersion
+		cmd:ttx_$pythonVersion = $portVersion
+		\""
+
+	if [ $pythonVersion = $defaultVersion ]; then
+		eval "PROVIDES_${pythonPackage}+=\"
+			cmd:fonttools = $portVersion
+			cmd:pyftmerge = $portVersion
+			cmd:pyftsubset = $portVersion
+			cmd:ttx = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage+=\"
+		haiku
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		build_$pythonPackage
+		installer_$pythonPackage
+		setuptools_$pythonPackage
+		wheel_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
-PROVIDES_python310="$PROVIDES_python310
-	cmd:fonttools
-	cmd:pyftinspect
-	cmd:pyftmerge
-	cmd:pyftsubset
-	cmd:ttx
-	"
-REPLACES_python310="
-	fonttools_python3
-	"
 
 INSTALL()
 {
@@ -64,15 +71,29 @@ INSTALL()
 
 		python=python$pythonVersion
 		rm -rf build
+
 		$python -m build -wn
 		$python -m installer -p $prefix dist/*.whl
 
+		# Version suffix all the scripts
+		for f in $binDir/*; do
+			mv $f $f-$pythonVersion
+		done
+
+		# And provide suffix-less symlinks for the default version
+		if [ $pythonVersion = $defaultVersion ]; then
+			for f in $binDir/*; do
+				ln -sr $f ${f%-$pythonVersion}
+			done
+		fi
+
+		mkdir -p $manDir
+		mv $prefix/share/man/* $manDir
+		rm -rf $prefix/share
+
 		packageEntries  $pythonPackage \
 			$prefix/lib/python* \
-			$binDir
+			$binDir \
+			$manDir
 	done
-
-	mkdir -p $(dirname $manDir)
-	mv $prefix/share/man $manDir
-	rmdir $prefix/share
 }


### PR DESCRIPTION
No functional change intended. Just aligning the recipe with what has been done on others lately.

Dropping the "REPLACES_*" as nothing in-tree was requiring either "fonttools_python3", nor any of the commands it provides, and that replaces seems to have been there for ages already.