### PR TITLE
lagrange: disable use of SSE4.1. Give older PCs a chance.

### DIFF
--- a/net-misc/lagrange/lagrange-1.15.7.recipe
+++ b/net-misc/lagrange/lagrange-1.15.7.recipe
@@ -6,7 +6,7 @@ visual themes, Unicode fonts, bookmarks, history, and page outlines."
 HOMEPAGE="https://gmi.skyjake.fi/lagrange/"
 COPYRIGHT="2020-2023 Jaakko Keränen"
 LICENSE="BSD (2-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/skyjake/lagrange/releases/download/v$portVersion/lagrange-$portVersion.tar.gz"
 CHECKSUM_SHA256="d556b0c596f706239ea52a8988b601d9ca06fd1f412a04d70acb5f47e7e8c097"
 SOURCE_DIR="lagrange-$portVersion"
@@ -60,7 +60,8 @@ BUILD()
 	cmake .. \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DCMAKE_INSTALL_PREFIX=$appsDir/Lagrange \
-		-DENABLE_POPUP_MENUS=NO
+		-DENABLE_POPUP_MENUS=NO \
+		-DTFDN_ENABLE_SSE41=NO
 	make $jobArgs
 }
 


### PR DESCRIPTION
This is a light-weight protocol, right? Older PCs should be able to enjoy it too :-)

Fixes #8114

(according to Lagrange's own [debian/rules](https://github.com/skyjake/lagrange/blob/7fa7024ec5be671afc3190a70734fe807d862cbd/debian/rules#L8) file, seems like the same is done in Debian)