### PR TITLE
glew, fixes and use libVersionCompat

### DIFF
--- a/media-libs/glew/glew-2.2.0.recipe
+++ b/media-libs/glew/glew-2.2.0.recipe
@@ -10,7 +10,7 @@ COPYRIGHT="2007 The Kronos Group Inc.
 	2002 Lev Povalahev
 	1999-2007 Brian Paul"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="http://downloads.sourceforge.net/project/glew/glew/${portVersion}/glew-${portVersion}.tgz"
 CHECKSUM_SHA256="d4fc82893cfb00109578d0a1a2337fb8ca335b3ceccf97b97e5cc7f08e4353e1"
 PATCHES="glew-$portVersion.patchset"
@@ -18,11 +18,14 @@ PATCHES="glew-$portVersion.patchset"
 ARCHITECTURES="all"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
+libVersion="$portVersion"
+libVersionCompat="$libVersion compat >= ${libVersion%.**}"
+
 PROVIDES="
 	glew$secondaryArchSuffix = $portVersion
 	cmd:glewinfo = $portVersion
 	cmd:visualinfo = $portVersion
-	lib:libglew$secondaryArchSuffix = $portVersion compat >= 2.2
+	lib:libglew$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -31,7 +34,7 @@ REQUIRES="
 
 PROVIDES_devel="
 	glew${secondaryArchSuffix}_devel = $portVersion
-	devel:libglew$secondaryArchSuffix = $portVersion compat >= 2.2
+	devel:libglew$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
 	glew$secondaryArchSuffix == $portVersion base
@@ -65,14 +68,14 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	make $jobArgs GLEW_DEST=$prefix BINDIR=$binDir LIBDIR=$libDir \
-		INCDIR=$includeDir/GL PKGDIR=$developLibDir/pkgconfig
+	make $jobArgs GLEW_PREFIX=$prefix BINDIR=$binDir LIBDIR=$libDir \
+		INCDIR=$includeDir/GL PKGDIR=$libDir/pkgconfig
 }
 
 INSTALL()
 {
-	make install.all GLEW_DEST=$prefix BINDIR=$binDir LIBDIR=$libDir \
-		INCDIR=$includeDir/GL PKGDIR=$developLibDir/pkgconfig
+	make install.all GLEW_PREFIX=$prefix BINDIR=$binDir LIBDIR=$libDir \
+		INCDIR=$includeDir/GL PKGDIR=$libDir/pkgconfig
 
 	rm $libDir/libGLEW.a
 

--- a/media-libs/glew/glew1-1.13.0.recipe
+++ b/media-libs/glew/glew1-1.13.0.recipe
@@ -9,7 +9,7 @@ COPYRIGHT="2007 The Kronos Group Inc.
 	2002-2007 Marcelo E. Magallon
 	2002 Lev Povalahev"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="http://downloads.sourceforge.net/project/glew/glew/${portVersion}/glew-${portVersion}.tgz"
 CHECKSUM_SHA256="aa25dc48ed84b0b64b8d41cdd42c8f40f149c37fa2ffa39cd97f42c78d128bc7"
 SOURCE_DIR="glew-$portVersion"
@@ -58,15 +58,16 @@ BUILD()
 {
 	cp /system/data/libtool/config/config.guess config/ \
 		|| cp /system/data/libtool/build-aux/config.guess config/
-	make $jobArgs GLEW_DEST=$prefix BINDIR=$binDir LIBDIR=$libDir INCDIR=$includeDir/GL
+	make $jobArgs GLEW_PREFIX=$prefix BINDIR=$binDir LIBDIR=$libDir INCDIR=$includeDir/GL
 }
 
 INSTALL()
 {
-	make install.all GLEW_DEST=$prefix BINDIR=$binDir LIBDIR=$libDir INCDIR=$includeDir/GL
+	make install.all GLEW_PREFIX=$prefix BINDIR=$binDir LIBDIR=$libDir INCDIR=$includeDir/GL
 
-	prepareInstalledDevelLib libGLEW
-	prepareInstalledDevelLib libGLEWmx
+	rm $libDir/*.a
+
+	prepareInstalledDevelLibs libGLEW libGLEWmx
 	fixPkgconfig
 
 	packageEntries devel $developDir

--- a/media-libs/glew/glew21-2.1.0.recipe
+++ b/media-libs/glew/glew21-2.1.0.recipe
@@ -10,7 +10,7 @@ COPYRIGHT="2007 The Kronos Group Inc.
 	2002 Lev Povalahev
 	1999-2007 Brian Paul"
 LICENSE="BSD (3-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://downloads.sourceforge.net/project/glew/glew/${portVersion}/glew-${portVersion}.tgz"
 CHECKSUM_SHA256="04de91e7e6763039bc11940095cd9c7f880baba82196a7765f727ac05a993c95"
 SOURCE_DIR="glew-$portVersion"
@@ -19,9 +19,12 @@ PATCHES="glew-$portVersion.patchset"
 ARCHITECTURES="all"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
+libVersion="$portVersion"
+libVersionCompat="$libVersion compat >= ${libVersion%.**}"
+
 PROVIDES="
 	glew21$secondaryArchSuffix = $portVersion
-	lib:libglew$secondaryArchSuffix = $portVersion compat >= 2.1
+	lib:libglew$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix


### PR DESCRIPTION
GLEW_PREFIX is being used to set the path in pkgconfig file, moving the pkgconfig file to $libDir instead of $developLibDir enables fixPkgconfig to do it's work to set the correct path for the headers.