### PR TITLE
kristall: Move to 0.4 release

### DIFF
--- a/www-client/kristall/kristall-0.4.recipe
+++ b/www-client/kristall/kristall-0.4.recipe
@@ -7,11 +7,11 @@ HOMEPAGE="https://kristall.random-projects.net/"
 COPYRIGHT="2020 Felix Queißner"
 LICENSE="GNU GPL v3"
 REVISION="6"
-srcGitRev="bca592adf686b11321b7185f234525674d7d474c"
-SOURCE_URI="https://github.com/MasterQ32/kristall/archive/$srcGitRev.tar.gz"
-CHECKSUM_SHA256="326d3f3785ba5faf3caf12df1caf99e801816658b79881106e6b39204dfddfc5"
-SOURCE_FILENAME="kristall-$portVersion-tar.gz"
-SOURCE_DIR="kristall-$srcGitRev"
+# srcGitRev="bca592adf686b11321b7185f234525674d7d474c"
+SOURCE_URI="https://github.com/MasterQ32/kristall/archive/V$portVersion.tar.gz"
+CHECKSUM_SHA256="1547e60978c73783d0737af3ccea6abfcf7ec214e8dedc91157ef3f88453be8f"
+SOURCE_FILENAME="kristall-v$portVersion.tar.gz"
+SOURCE_DIR="kristall-$portVersion"
 ADDITIONAL_FILES="kristall.rdef.in"
 
 ARCHITECTURES="!x86_gcc2 x86_64"
@@ -61,7 +61,7 @@ PATCH()
 
 BUILD()
 {
-	make -j1
+	make $jobArgs
 }
 
 INSTALL()


### PR DESCRIPTION
Updates Kristall to the [0.4 release](https://github.com/MasterQ32/kristall/releases/tag/V0.4) tagged back in September of 2022. Some of the most notable additions of the release since the last commit this recipe was based on are:

* [Improved caching api related to urls and implemented fragment handling](https://github.com/MasterQ32/kristall/commit/9dd660d66e23f02716d4b2bad84ac86764de71a6) (fixes [non-working HTML anchor links](https://github.com/MasterQ32/kristall/issues/237))
* [Option to exit Kristall when the last tab is closed](https://github.com/MasterQ32/kristall/commit/6b39f24484bb0796f3f383401f95904f85b74d7b) (requested in [this issue](https://github.com/MasterQ32/kristall/issues/245))

This PR is also intended to switch the package to tracking tagged releases, instead of Git revisions. Should there be any future commits intended explicitly for Haiku, exceptions can be made to switch back.