### PR TITLE
nim: bump version

### DIFF
--- a/dev-lang/nim/nim-1.6.12.recipe
+++ b/dev-lang/nim/nim-1.6.12.recipe
@@ -1,0 +1,143 @@
+SUMMARY="An imperative, multi-paradigm, compiled programming language"
+DESCRIPTION="Nim is a systems and applications programming language. \
+Statically typed and compiled, it provides unparalleled performance in an \
+elegant package.
+
+Features:
+* High-performance garbage-collected language
+* Compiles to C, C++ or JavaScript
+* Produces dependency-free binaries
+* Runs on Windows, macOS, Linux, and more"
+HOMEPAGE="https://nim-lang.org/"
+COPYRIGHT="2006-2021 Andreas Rumpf
+	2017-2021 Nim contributors"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://nim-lang.org/download/nim-$portVersion.tar.xz"
+SOURCE_DIR="nim-$portVersion"
+CHECKSUM_SHA256="acef0b0ab773604d4d7394b68519edb74fb30f46912294b28bc27e0c7b4b4dc2"
+ADDITIONAL_FILES="
+	config.nims
+	nim.rdef.in
+	"
+PATCHES="nim-1.6.12.patchset"
+
+ARCHITECTURES="all !x86_gcc2 ?x86"
+if [ "$targetArchitecture" = "x86_gcc2" ]; then
+	# There is no point in having secondaryArch package except for gcc2.
+	# The compiler can already target different architectures effortlessly.
+	SECONDARY_ARCHITECTURES="x86"
+fi
+
+GLOBAL_WRITABLE_FILES="
+	settings/nim directory auto-merge
+	settings/nim/config.nims auto-merge
+	settings/nim/nim.cfg auto-merge
+	settings/nim/nimdoc.cfg auto-merge
+	settings/nim/nimdoc.tex.cfg auto-merge
+	"
+USER_SETTINGS_FILES="
+	settings/nim directory
+	settings/nim/config.nims
+	settings/nim/nim.cfg
+	settings/nim/nimdoc.cfg
+	settings/nim/nimdoc.tex.cfg
+	"
+
+PROVIDES="
+	nim$secondaryArchSuffix = $portVersion
+	cmd:nim$secondaryArchSuffix = $portVersion
+	cmd:nimble$secondaryArchSuffix = $portVersion
+	cmd:nimgrep$secondaryArchSuffix = $portVersion
+	cmd:nimpretty$secondaryArchSuffix = $portVersion
+	cmd:nimsuggest$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+PROVIDES_doc="
+	nim_doc = $portVersion
+	"
+
+# git and NodeJS are for js docs
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libpcre$secondaryArchSuffix >= 1
+	cmd:git
+	cmd:node >= 16
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	"
+
+TEST_REQUIRES="
+	lib:libcrypto$secondaryArchSuffix
+	lib:libgc$secondaryArchSuffix
+	cmd:node >= 16
+	"
+
+BUILD()
+{
+	export XDG_CACHE_HOME="$sourceDir/cache"
+	sh build.sh
+	bin/nim c koch
+	./koch boot -d:release
+	./koch tools
+
+	# Docs
+	./koch docs
+}
+
+INSTALL()
+{
+	install -d -m 755 "$binDir" "$docDir" "$libDir" "$settingsDir" \
+		"$developDocDir"
+	./koch install "$libDir"
+
+	install -t "$libDir/nim/bin" -m 755 bin/{nimsuggest,nimgrep,nimpretty,nimble}
+	ln -st "$binDir" "$libDir/nim/bin"/*
+
+	mv "$libDir/nim/config" "$settingsDir/nim"
+	ln -s "$sysconfDir/nim" "$libDir/nim/config"
+
+	mv -T "$libDir/nim/doc" "$docDir"
+
+	complierPkgDir="$dataDir/nimble/pkgs/compiler-$portVersion"
+	install -d -m 755 "$complierPkgDir"
+	mv -t "$complierPkgDir" "$libDir/nim"/compiler
+	# Apparantly you need some files in docDir for the compiler sources to work
+	ln -s "$docDir" "$complierPkgDir/doc"
+
+	install -t "$settingsDir/nim" -m 644 "$portDir/additional-files/config.nims"
+	# Completions
+	install -d -m 755 "$dataDir/bash-completion/completions" \
+		"$dataDir/zsh/site-functions"
+	install -m 644 tools/nim.bash-completion \
+		"$dataDir/bash-completion/completions/nim"
+	install -m 644 tools/nim.zsh-completion \
+		"$dataDir/zsh/site-functions/_nim"
+
+	rm -rf "$docDir/html"
+	install -t "$developDocDir" -m 644 doc/html/*.html doc/html/*.js
+
+	# Add Haiku resources
+	local MAJOR="$(echo ${portVersion%%_*} | cut -d. -f1)"
+	local MIDDLE="$(echo ${portVersion%%_*} | cut -d. -f2)"
+	local MINOR="$(echo ${portVersion%%_*} | cut -d. -f3)"
+	sed \
+		-e "s|@MAJOR@|$MAJOR|" \
+		-e "s|@MIDDLE@|$MIDDLE|" \
+		-e "s|@MINOR@|$MINOR|" \
+		"$portDir/additional-files/nim.rdef.in" > nim.rdef
+
+	addResourcesToBinaries nim.rdef "$libDir/nim/bin/nim"
+
+	packageEntries doc "$developDir"
+}
+
+TEST()
+{
+	PATH="$sourceDir/bin:$PATH" ./koch tests --targets:"c c++" all
+}

--- a/dev-lang/nim/patches/nim-1.6.12.patchset
+++ b/dev-lang/nim/patches/nim-1.6.12.patchset
@@ -1,0 +1,42 @@
+From 7188243e4ca17e3e30d24a75923afedf4acff967 Mon Sep 17 00:00:00 2001
+From: Al Hoang <13622+hoanga@users.noreply.github.com>
+Date: Thu, 20 Apr 2023 05:14:10 +0000
+Subject: build fix for maxDescriptors
+
+
+diff --git a/lib/pure/asyncdispatch.nim b/lib/pure/asyncdispatch.nim
+index 04dbf4e..ed6531b 100644
+--- a/lib/pure/asyncdispatch.nim
++++ b/lib/pure/asyncdispatch.nim
+@@ -1974,7 +1974,7 @@ when defined(posix):
+   import posix
+ 
+ when defined(linux) or defined(windows) or defined(macosx) or defined(bsd) or
+-       defined(zephyr) or defined(freertos):
++       defined(zephyr) or defined(freertos) or defined(haiku):
+   proc maxDescriptors*(): int {.raises: OSError.} =
+     ## Returns the maximum number of active file descriptors for the current
+     ## process. This involves a system call. For now `maxDescriptors` is
+@@ -1987,4 +1987,4 @@ when defined(linux) or defined(windows) or defined(macosx) or defined(bsd) or
+       var fdLim: RLimit
+       if getrlimit(RLIMIT_NOFILE, fdLim) < 0:
+         raiseOSError(osLastError())
+-      result = int(fdLim.rlim_cur) - 1
+\ No newline at end of file
++      result = int(fdLim.rlim_cur) - 1
+diff --git a/lib/pure/selectors.nim b/lib/pure/selectors.nim
+index ec441f6..a377069 100644
+--- a/lib/pure/selectors.nim
++++ b/lib/pure/selectors.nim
+@@ -324,7 +324,7 @@ else:
+     doAssert(timeout >= -1, "Cannot select with a negative value, got: " & $timeout)
+ 
+   when defined(linux) or defined(windows) or defined(macosx) or defined(bsd) or
+-       defined(zephyr) or defined(freertos):
++       defined(zephyr) or defined(freertos) or defined(haiku):
+     template maxDescriptors*(): int =
+       ## Returns the maximum number of active file descriptors for the current
+       ## process. This involves a system call. For now `maxDescriptors` is
+-- 
+2.37.3
+


### PR DESCRIPTION
this updates the nim to the latest release

* patched to fix a compilation failure that has cropped up in more recent nim releases

```
~> nim --version
Nim Compiler Version 1.6.12 [Haiku: amd64]
Compiled at 2023-04-20
Copyright (c) 2006-2023 by Andreas Rumpf

git hash: c924167414fa6071fdc1ff8dd807b02fb36e3a75
active boot switches: -d:release
```