### PR TITLE
wireshark: update to 4.0.5

### DIFF
--- a/net-analyzer/wireshark/patches/wireshark-4.0.5.patchset
+++ b/net-analyzer/wireshark/patches/wireshark-4.0.5.patchset
@@ -1,4 +1,4 @@
-From 789b8e700c201886b580dfaa03fa8b210a8ae698 Mon Sep 17 00:00:00 2001
+From 455dd0f50fac170f11a460c0da84c67c7e630e36 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Tue, 25 Oct 2022 21:11:55 +0200
 Subject: fix build for cpu_info.c
@@ -21,7 +21,7 @@ index f7f0d2e..fee8651 100644
 2.37.3
 
 
-From ba9a7cc2dad9d4861859a622fc1e4938828714d0 Mon Sep 17 00:00:00 2001
+From 77270532c5f24643437df84f3d88ebb8309b2dc6 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Tue, 25 Oct 2022 21:14:59 +0200
 Subject: fix include sys/time.h
@@ -43,7 +43,7 @@ index d12f747..80597f0 100644
 2.37.3
 
 
-From e7fe9972248d44c5552a82c5bd917d5b89d7244f Mon Sep 17 00:00:00 2001
+From 1c5916889b834f74c02e59e516cd3fdf982d000e Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Mon, 15 Nov 2021 10:26:33 +0000
 Subject: use realpath in init_progfile_dir
@@ -70,7 +70,7 @@ index 1eca4ce..138a1bf 100644
 2.37.3
 
 
-From eb1955a65f48fd5e79c2aed9996cced4781866fa Mon Sep 17 00:00:00 2001
+From 0c6e5da70e407e82c0bee26ec1fc1b35d1df65a5 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Thu, 25 Nov 2021 18:41:24 +0000
 Subject: adjust get_systemfile_dir for Haiku
@@ -93,27 +93,29 @@ index 138a1bf..b412dbc 100644
 2.37.3
 
 
-From ae785bbd298a4e688cb0781a100c4ff42a7d0e66 Mon Sep 17 00:00:00 2001
+From 97fed6ab10ed30ebe314be8e4a4886374cdf464f Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Thu, 25 Nov 2021 18:24:45 +0000
-Subject: remove prefix from PLUGIN_DIR, EXTCAP_DIR, DATA_DIR as they already
- contain full path
+Subject: use full path for PLUGIN_DIR, EXTCAP_DIR, DATA_DIR
 
 
 diff --git a/wsutil/CMakeLists.txt b/wsutil/CMakeLists.txt
-index a55086c..6d82b11 100644
+index a55086c..3b51243 100644
 --- a/wsutil/CMakeLists.txt
 +++ b/wsutil/CMakeLists.txt
-@@ -7,9 +7,9 @@
+@@ -7,9 +7,12 @@
  # SPDX-License-Identifier: GPL-2.0-or-later
  #
  
 -add_definitions(-DPLUGIN_DIR=\"${CMAKE_INSTALL_PREFIX}/${PLUGIN_INSTALL_LIBDIR}\")
 -add_definitions(-DEXTCAP_DIR=\"${CMAKE_INSTALL_PREFIX}/${EXTCAP_INSTALL_LIBDIR}\")
 -add_definitions(-DDATA_DIR=\"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}\")
-+add_definitions(-DPLUGIN_DIR=\"${PLUGIN_INSTALL_LIBDIR}\")
-+add_definitions(-DEXTCAP_DIR=\"${EXTCAP_INSTALL_LIBDIR}\")
-+add_definitions(-DDATA_DIR=\"${CMAKE_INSTALL_DATADIR}\")
++GNUInstallDirs_get_absolute_install_dir(PLUGIN_INSTALL_FULL_LIBDIR PLUGIN_INSTALL_LIBDIR LIBDIR)
++GNUInstallDirs_get_absolute_install_dir(EXTCAP_INSTALL_FULL_LIBDIR EXTCAP_INSTALL_LIBDIR LIBDIR)
++
++add_definitions(-DPLUGIN_DIR=\"${PLUGIN_INSTALL_FULL_LIBDIR}\")
++add_definitions(-DEXTCAP_DIR=\"${EXTCAP_INSTALL_FULL_LIBDIR}\")
++add_definitions(-DDATA_DIR=\"${CMAKE_INSTALL_FULL_DATADIR}\")
  
  add_subdirectory(wmem)
  
@@ -121,7 +123,7 @@ index a55086c..6d82b11 100644
 2.37.3
 
 
-From 7a40196ccb72165e68956031b393ad498c25263d Mon Sep 17 00:00:00 2001
+From 342b5ec5eb7bf588f05011e4931aa15fbc73f6be Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Tue, 25 Oct 2022 22:00:34 +0200
 Subject: adjust user dirs for Haiku
@@ -163,6 +165,55 @@ index b412dbc..30ea574 100644
  #else
      char *xdg_path, *path;
      struct passwd *pwd;
+-- 
+2.37.3
+
+
+From 609f2159bf94ab871a2bcc2b98548099cc32314b Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Tue, 7 Mar 2023 15:42:01 +0100
+Subject: Haiku: adjust default value for INSTALL_DATADIR
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 271fee9..b70b051 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -240,6 +240,12 @@ if(WIN32)
+ 	set(CMAKE_INSTALL_INCLUDEDIR "include")
+ 	set(CMAKE_INSTALL_DATADIR ".")
+ 	set(CMAKE_INSTALL_DOCDIR ".")
++elseif(CMAKE_SYSTEM_NAME MATCHES "Haiku")
++	# By default INSTALL_DATADIR is set to INSTALL_DATAROOTDIR, set the
++	# proper value here.
++	set(CMAKE_INSTALL_DATADIR "data/${PROJECT_NAME}"
++		CACHE PATH "Read-only architecture-independent data"
++	)
+ else()
+ 	# By default INSTALL_DATADIR is set to INSTALL_DATAROOTDIR, set the
+ 	# proper value here.
+-- 
+2.37.3
+
+
+From 8c52a01cc6c82a735a1d9f77fd0f2d18656e7803 Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Sun, 23 Apr 2023 19:18:49 +0000
+Subject: deregister log writer on exit
+
+
+diff --git a/ui/qt/main.cpp b/ui/qt/main.cpp
+index 87c02a9..e27a8af 100644
+--- a/ui/qt/main.cpp
++++ b/ui/qt/main.cpp
+@@ -128,6 +128,7 @@ void exit_application(int status) {
+     if (wsApp) {
+         wsApp->quit();
+     }
++    qInstallMessageHandler(0);
+     exit(status);
+ }
+ 
 -- 
 2.37.3
 

--- a/net-analyzer/wireshark/wireshark-4.0.5.recipe
+++ b/net-analyzer/wireshark/wireshark-4.0.5.recipe
@@ -23,19 +23,18 @@ HOMEPAGE="https://www.wireshark.org"
 COPYRIGHT="1998-2023 Gerald Combs"
 LICENSE="GNU GPL v2"
 REVISION="1"
-SOURCE_URI="https://github.com/wireshark/wireshark/archive/wireshark-$portVersion.tar.gz"
-CHECKSUM_SHA256="8a4100e07211cdde616d1600a013f632b163bb2a7acf419d7e506661581b38a2"
-SOURCE_DIR="wireshark-wireshark-$portVersion"
+SOURCE_URI="https://www.wireshark.org/download/src/all-versions/wireshark-$portVersion.tar.xz"
+CHECKSUM_SHA256="71b67346935fea4968c68efcae0371c06b30770d6396419c10bc443aac196b29"
 ADDITIONAL_FILES="wireshark.rdef.in"
 PATCHES="wireshark-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
-libwiresharkLibVersion="16.0.3"
+libwiresharkLibVersion="16.0.5"
 libwiresharkLibVersionCompat="$libwiresharkLibVersion compat >= ${libwiresharkLibVersion%%.*}"
 
-libwiretapLibVersion="13.0.3"
+libwiretapLibVersion="13.0.5"
 libwiretapLibVersionCompat="$libwiretapLibVersion compat >= ${libwiretapLibVersion%%.*}"
 
 libwsutilLibVersion="14.0.0"
@@ -126,7 +125,17 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	cmake -S . -B build -G Ninja \
-		$cmakeDirArgs \
+		-DCMAKE_INSTALL_PREFIX=$prefix \
+		-DCMAKE_INSTALL_DATAROOTDIR=data \
+		-DCMAKE_INSTALL_DOCDIR=documentation/packages/wireshark \
+		-DCMAKE_INSTALL_INCLUDEDIR=develop/headers$secondaryArchSubDir \
+		-DCMAKE_INSTALL_INFODIR=documentation/info \
+		-DCMAKE_INSTALL_LIBEXECDIR=lib$secondaryArchSubDir \
+		-DCMAKE_INSTALL_LIBDIR=lib$secondaryArchSubDir \
+		-DCMAKE_INSTALL_MANDIR=documentation/man \
+		-DCMAKE_INSTALL_OLDINCLUDEDIR=develop/headers$secondaryArchSubDir \
+		-DCMAKE_INSTALL_SBINDIR=bin \
+		-DCMAKE_INSTALL_SYSCONFDIR=$sysconfDir \
 		-DCMAKE_EXE_LINKER_FLAGS="-lnetwork" \
 		-DCMAKE_BUILD_TYPE=Release
 	cmake --build build $jobArgs
@@ -138,10 +147,6 @@ INSTALL()
 
 	prepareInstalledDevelLibs libwireshark libwiretap libwsutil
 	fixPkgconfig
-
-	if [ $effectiveTargetArchitecture = x86 ]; then
-		mv $binDir/* $prefix/bin/
-	fi
 
 	mkdir -p $appsDir
 	ln -s $prefix/bin/wireshark $appsDir/Wireshark


### PR DESCRIPTION
folder structure wasn't entirely right either with absolute or relative cmakeDirArgs so I changed the recipe to use hand-crafted args

there was also one more potential crash on exit so I added some code to deregister the log writer on exit.