### PR TITLE
BeCJK: cleanup requirements, dropping Python 2.x.

### DIFF
--- a/app-i18n/becjk/becjk-1.0.1.recipe
+++ b/app-i18n/becjk/becjk-1.0.1.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="BeCJK was an input method for legacy BeOS, now works on Haiku."
 HOMEPAGE="https://github.com/HaikuArchives/BeCJK"
 COPYRIGHT="2001-2002 Anthony Lee"
 LICENSE="GNU LGPL v2"
-REVISION="4"
+REVISION="5"
 srcGitRev="e0df819cb872ef790374a33608177afd73c6dc38"
 SOURCE_URI="https://github.com/HaikuArchives/BeCJK/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="f5c0732c53ada4c210a4bbf99258899548894d73996211d4d1f3b7ee34fe99d6"
@@ -24,9 +24,7 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 BUILD_PREREQUIRES="
-	cmd:gcc
-	cmd:ld
-	cmd:python
+	cmd:g++
 	cmd:scons
 	"
 


### PR DESCRIPTION
SCons will pull the version it needs (3.9 currently).