### PR TITLE
lapack: switch to Python 3.9

### DIFF
--- a/sci-libs/lapack/lapack-3.10.0.recipe
+++ b/sci-libs/lapack/lapack-3.10.0.recipe
@@ -4,13 +4,13 @@ the most commonly occurring problems in numerical linear algebra."
 HOMEPAGE="http://www.netlib.org/lapack/"
 COPYRIGHT="1992-2021 The LAPACK Project"
 LICENSE="BSD (3-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/Reference-LAPACK/lapack/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="328c1bea493a32cac5257d84157dc686cc3ab0b004e2bea22044e0a59f6f8a19"
 SOURCE_DIR="lapack-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
+SECONDARY_ARCHITECTURES="x86"
 
 libVersion="$portVersion"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
@@ -50,9 +50,12 @@ BUILD_PREREQUIRES="
 	cmd:gfortran$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:python3.7
 	cmd:sed
 	cmd:strip$secondaryArchSuffix
+	"
+
+TEST_REQUIRES="
+	cmd:python3
 	"
 
 defineDebugInfoPackage lapack$secondaryArchSuffix \
@@ -76,7 +79,7 @@ BUILD()
 		-DBUILD_TESTING=ON \
 		-DBUILD_DEPRECATED=ON
 
-	cmake --build build
+	cmake --build build $jobArgs
 }
 
 INSTALL()


### PR DESCRIPTION
Moved cmd:python3 to TEST_REQUIRES, as even if it seems like the build needs it (for "summary tests"), it actually doesn't, and its only for "make test" we need Python3.

Added $jobArgs, as that speeds up the build quite a lot.

Testes passed 100% with or without that set, in any case.