### PR TITLE
bind_utils, build fix

### DIFF
--- a/net-dns/bind_utils/bind_utils-9.16.36.recipe
+++ b/net-dns/bind_utils/bind_utils-9.16.36.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="bind_utils is a collection of DNS troubleshooting applications"
 HOMEPAGE="https://isc.org"
 COPYRIGHT="Internet Systems Consortium, Inc. ('ISC')"
 LICENSE="MPL v2.0"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="ftp://ftp.isc.org/isc/bind9/$portVersion/bind-$portVersion.tar.xz"
 CHECKSUM_SHA256="508c94e8c9884f6075fa820a51efae04a1758dbdd157b01695ea6cd07049c221"
 SOURCE_DIR="bind-$portVersion"
@@ -47,14 +47,16 @@ BUILD_PREREQUIRES="
 	cmd:ld$secondaryArchSuffix
 	cmd:make
 	cmd:makeinfo
-	cmd:pkg_config
+	cmd:pkg_config$secondaryArchSuffix
 	cmd:find
 	cmd:xargs
 	"
 
 BUILD()
 {
-	runConfigure ./configure --without-python
+	runConfigure --omit-dirs binDir ./configure \
+		--bindir=$commandBinDir \
+		--without-python
 
 	make -C lib/dns $jobArgs
 	make -C lib/isc $jobArgs


### PR DESCRIPTION
On 32bit (couldn't find libuv for wrong pkg-config command and wrong install dir for the binaries.