### PR TITLE
lout: fixups, include PDF docs.

### DIFF
--- a/app-text/lout/lout-3.42.1.recipe
+++ b/app-text/lout/lout-3.42.1.recipe
@@ -1,14 +1,27 @@
 SUMMARY="A document formating system"
 DESCRIPTION="Lout is a document formatting system designed and implemented by Jeffrey Kingston at \
 the Basser Department of Computer Science, University of Sydney, Australia.
+
 The system reads a high-level description of a document similar in style to LaTeX and produces a \
 PostScript file which can be printed on most laser printers and graphic display devices.
 Plain text output is also available, PDF output is limited but working (e.g. no graphics).
-Lout is inherently multilingual. Adding new languages is easy."
+Lout is inherently multilingual. Adding new languages is easy.
+
+The Lout package for Haiku includes includes documentation in PDF format, so people new to Lout \
+have an easier time learning how to use it. The files will be located under:
+
+/boot/system/documentation/packages/$portName/
+
+* slides.pdf serves as a short introduction to Lout's capabilities.
+* user.pdf offers a very complete documentation. \"Appendix A\" contains a nice quick-reference guide!
+* expert.pdf and design.pdf will serve well the more advanced users.
+
+When working with Lout files under Haiku, using the Pe editor can be convenient, as it includes \
+special supports for them (syntax coloring, content navigation, etc)."
 HOMEPAGE="https://github.com/william8000/lout"
 COPYRIGHT="1991-2010 Jeffrey H. Kingston"
 LICENSE="GNU GPL v3"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="$HOMEPAGE/archive/refs/tags/3.42.1.tar.gz"
 CHECKSUM_SHA256="b0b2f66a0f959bc80835966c69ae4d4eef2cb0def2b03e634bf1c7e55b1fe6dd"
 
@@ -27,6 +40,7 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	cmd:ps2pdf
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
@@ -40,7 +54,7 @@ BUILD()
 
 	make PDF_COMPRESSION=1 ZLIB=-lz \
 		PREFIX=$prefix \
-		LIBDIR=$dataDir/lout-$portVersion  \
+		LOUTLIBDIR=$dataDir/lout \
 		LOUTDOCDIR=$docDir \
 		MANDIR=$manDir/man1 \
 		all $jobArgs
@@ -49,11 +63,40 @@ BUILD()
 INSTALL()
 {
 	make PREFIX=$prefix \
-		LIBDIR=$dataDir/lout-$portVersion  \
+		LOUTLIBDIR=$dataDir/lout \
 		LOUTDOCDIR=$docDir \
 		MANDIR=$manDir/man1 \
 		allinstall
 
+	# Now that lout is "installed" in the chroot... use it to generate .ps files
+	# from the docs and use GhostScript's ps2pdf to generate PDF files form them.
+	cd doc
+
+	DOC_DIRS=(design expert slides user)
+	# Each "doc dir" has a README that specifies a number for "lout -rN". Those numbers are:
+	NUM_RUNS=(3 4 2 5)
+
+	# Make sure lout can find /bin/prg2lout, and that we can call "lout" without $prefix/bin/.
+	export PATH=$prefix/bin:$PATH
+
+	for i in "${!DOC_DIRS[@]}"; do
+		doc=${DOC_DIRS[i]}
+		runs=${NUM_RUNS[i]}
+
+		cd $doc
+
+		# Just in case we run repeated builds after some failure:
+		rm -f *.ld lout.li $doc.ps
+
+		lout -r$runs all > $doc.ps
+
+		ps2pdf $doc.ps $docDir/$doc.pdf
+
+		# Clean up temp files
+		rm -f *.ld lout.li $doc.ps
+		cd ..
+	done
+
 	# cleanup empty directory
-	rmdir $dataDir/lout-$portVersion/lib/locale
+	rmdir $dataDir/lout/locale
 }


### PR DESCRIPTION
* Moved data to $dataDir/lout (no version).
* Added docs in easier to use PDF format.
* Improved description a bit (mentioning docs, and Pe support).