### PR TITLE
sane_backends: switch to Python 3.9, fix x86_32 build.

### DIFF
--- a/media-gfx/sane_backends/sane_backends-1.2.1.recipe
+++ b/media-gfx/sane_backends/sane_backends-1.2.1.recipe
@@ -16,18 +16,20 @@ documentation."
 HOMEPAGE="http://www.sane-project.org"
 COPYRIGHT="David Mosberger-Tang, Andy Beck"
 LICENSE="GNU LGPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://gitlab.com/sane-project/backends/uploads/110fc43336d0fb5e514f1fdc7360dd87/sane-backends-$portVersion.tar.gz"
 CHECKSUM_SHA256="f832395efcb90bb5ea8acd367a820c393dda7e0dd578b16f48928b8f5bdd0524"
 SOURCE_DIR="sane-backends-$portVersion"
 PATCHES="sane_backends-$portVersion.patchset"
 
-ARCHITECTURES="all ?x86_gcc2"
+ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 GLOBAL_WRITABLE_FILES="
 	settings/sane.d directory keep-old
 	"
+
+pythonVersion=3.9
 
 PROVIDES="
 	sane_backends$secondaryArchSuffix = $portVersion
@@ -44,7 +46,7 @@ REQUIRES="
 	lib:libcurl$secondaryArchSuffix
 	lib:libjpeg$secondaryArchSuffix
 	lib:libpng16$secondaryArchSuffix
-	lib:libpython3.7m$secondaryArchSuffix
+	lib:libpython$pythonVersion$secondaryArchSuffix
 	lib:libtiff$secondaryArchSuffix
 	lib:libusb_1.0$secondaryArchSuffix
 	lib:libxml2$secondaryArchSuffix
@@ -63,7 +65,7 @@ BUILD_REQUIRES="
 	devel:libcurl$secondaryArchSuffix
 	devel:libjpeg$secondaryArchSuffix
 	devel:libpng16$secondaryArchSuffix
-	devel:libpython3.7m$secondaryArchSuffix
+	devel:libpython$pythonVersion$secondaryArchSuffix
 	devel:libtiff$secondaryArchSuffix
 	devel:libusb_1.0$secondaryArchSuffix
 	devel:libxml2$secondaryArchSuffix
@@ -87,6 +89,10 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
+	if [ $effectiveTargetArchitecture == 'x86' ]; then
+		export CFLAGS="-DTIFF_DISABLE_DEPRECATED"
+	fi
+
 	export LIBS="-lnetwork"
 	runConfigure configure \
 		--prefix=$prefix \
@@ -104,7 +110,7 @@ BUILD()
 		--enable-rpath \
 		--enable-pnm-backend
 
-	make
+	make $jobArgs
 }
 
 INSTALL()


### PR DESCRIPTION
Also enabled parallel build via $jobArgs.

Fixes #8489.

(similar issue in the past was fixed for Links on #7764)