### PR TITLE
botan: use $prefix during configure

### DIFF
--- a/dev-libs/botan/botan-2.19.2.recipe
+++ b/dev-libs/botan/botan-2.19.2.recipe
@@ -8,7 +8,7 @@ languages."
 HOMEPAGE="https://botan.randombit.net/"
 COPYRIGHT="1999-2022 The Botan Authors"
 LICENSE="BSD (2-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/randombit/botan/archive/refs/tags/$portVersion.tar.gz"
 CHECKSUM_SHA256="47bb0330255cf1a439db3f2bc91894b2f41788e58eb71d27e0abf36038d93f1e"
 PATCHES="botan-$portVersion.patchset"
@@ -68,7 +68,7 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	runConfigure --omit-buildspec --omit-dirs binDir ./configure.py \
-		--prefix=/ --bindir="$commandBinDir" \
+		--prefix="$prefix" --bindir="$commandBinDir" \
 		--enable-shared-library \
 		--disable-static \
 		--with-bzip2 --with-lzma --with-zlib \

--- a/dev-libs/botan/patches/botan-2.19.2.patchset
+++ b/dev-libs/botan/patches/botan-2.19.2.patchset
@@ -1,4 +1,4 @@
-From 36ed1edcafba861515a6d5bac1b00f3306f98671 Mon Sep 17 00:00:00 2001
+From cc19bf72f5eb7adabcb8e5e6b1d8d525e404dde6 Mon Sep 17 00:00:00 2001
 From: begasus <begasus@gmail.com>
 Date: Sun, 13 Nov 2022 08:42:34 +0100
 Subject: botan, add configure.py patch for cmd:python3
@@ -15,5 +15,28 @@ index 72e02c3..7208e3f 100755
  """
  Configuration program for botan
 -- 
-2.37.3
+2.39.2
+
+
+From e1fe04bbebab5dfac011d520f021980e3587106a Mon Sep 17 00:00:00 2001
+From: Chris Roberts <cpr420@gmail.com>
+Date: Wed, 3 May 2023 00:16:42 -0600
+Subject: Don't mkdir prefix during install
+
+
+diff --git a/src/scripts/install.py b/src/scripts/install.py
+index 32a7a7e..50ab4d7 100755
+--- a/src/scripts/install.py
++++ b/src/scripts/install.py
+@@ -163,7 +163,7 @@ def main(args):
+                                       'botan-%d' % (ver_major),
+                                       'botan')
+ 
+-    for d in [options.prefix, lib_dir, bin_dir, target_include_dir]:
++    for d in [lib_dir, bin_dir, target_include_dir]:
+         makedirs(prepend_destdir(d))
+ 
+     build_include_dir = os.path.join(options.build_dir, 'include', 'botan')
+-- 
+2.39.2
 


### PR DESCRIPTION
This fixes bad paths in the botan-2.pc file