### PR TITLE
plee_the_bear, use boost169

### DIFF
--- a/games-arcade/plee_the_bear/plee_the_bear-0.7.0.recipe
+++ b/games-arcade/plee_the_bear/plee_the_bear-0.7.0.recipe
@@ -20,8 +20,8 @@ SOURCE_FILENAME="plee-the-bear-0.7.0.tgz"
 SOURCE_DIR="plee-the-bear-0.7.0-light"
 PATCHES="plee_the_bear-$portVersion.patchset"
 
-ARCHITECTURES="?all !x86_gcc2 x86_64"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="?all !x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
 
 PROVIDES="
 	plee_the_bear$secondaryArchSuffix = $portVersion

--- a/games-arcade/plee_the_bear/plee_the_bear-0.7.0.recipe
+++ b/games-arcade/plee_the_bear/plee_the_bear-0.7.0.recipe
@@ -13,15 +13,15 @@ skills and the details of the game."
 HOMEPAGE="http://www.stuff-o-matic.com/plee-the-bear/"
 COPYRIGHT="2012 Stuff O Matic"
 LICENSE="GNU GPL v3"
-REVISION="7"
+REVISION="8"
 SOURCE_URI="https://src.fedoraproject.org/lookaside/extras/plee-the-bear/plee-the-bear_0.7.0-light.tar.gz/d6f6b2c4c51021747398eaaff3b6031c/plee-the-bear_0.7.0-light.tar.gz"
 CHECKSUM_SHA256="41dfe864fe2d791d6f99ba7cd330e22c94fce19d82909054eeac594aa4f2924e"
 SOURCE_FILENAME="plee-the-bear-0.7.0.tgz"
 SOURCE_DIR="plee-the-bear-0.7.0-light"
 PATCHES="plee_the_bear-$portVersion.patchset"
 
-ARCHITECTURES="!x86_gcc2 x86"
-SECONDARY_ARCHITECTURES="!x86_gcc2 x86"
+ARCHITECTURES="?all !x86_gcc2 x86_64"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	plee_the_bear$secondaryArchSuffix = $portVersion
@@ -56,27 +56,31 @@ REQUIRES="
 	lib:libintl$secondaryArchSuffix
 	lib:libjpeg$secondaryArchSuffix
 	lib:libpng$secondaryArchSuffix
-	lib:libsdl$secondaryArchSuffix
-	lib:libsdl2_2.0$secondaryArchSuffix
-	lib:libsdl2_mixer_2.0$secondaryArchSuffix
+	lib:libSDL_1.2$secondaryArchSuffix
+	lib:libSDL2_2.0$secondaryArchSuffix
+	lib:libSDL2_mixer_2.0$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
-	boost${secondaryArchSuffix}_devel
+	haiku${secondaryArchSuffix}_devel
+	devel:libboost_filesystem$secondaryArchSuffix >= 1.69.0
+	devel:libboost_regex$secondaryArchSuffix >= 1.69.0
+	devel:libboost_system$secondaryArchSuffix >= 1.69.0
+	devel:libboost_thread$secondaryArchSuffix >= 1.69.0
 	devel:libclaw_application$secondaryArchSuffix
 	devel:libfreetype$secondaryArchSuffix
+	devel:libGL$secondaryArchSuffix
 	devel:libintl$secondaryArchSuffix
 	devel:libjpeg$secondaryArchSuffix
 	devel:libpng$secondaryArchSuffix
-	devel:libsdl$secondaryArchSuffix
-	devel:libsdl2_2.0$secondaryArchSuffix
-	devel:libsdl2_mixer_2.0$secondaryArchSuffix
+	devel:libSDL_1.2$secondaryArchSuffix
+	devel:libSDL_mixer_1.2$secondaryArchSuffix
+	devel:libSDL2_2.0$secondaryArchSuffix
+	devel:libSDL2_mixer_2.0$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
-	devel:sdl_mixer$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	haiku${secondaryArchSuffix}_devel
 	cmd:cmake >= 3.0
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
@@ -85,14 +89,16 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	cmake . -DBEAR_EDITORS_ENABLED=FALSE -DCMAKE_INSTALL_PREFIX=$prefix \
+	cmake -Bbuild -S. -DCMAKE_BUILD_TYPE=Release \
+		-DBEAR_EDITORS_ENABLED=FALSE \
+		-DCMAKE_INSTALL_PREFIX=$prefix \
 		-DCMAKE_CXX_FLAGS="-DNDEBUG"
-	make $jobArgs
+	make -C build $jobArgs
 }
 
 INSTALL()
 {
-	make install
+	make -C build install
 	rm -r $prefix/share
 
 	addAppDeskbarSymlink $binDir/plee-the-bear "Plee the Bear"


### PR DESCRIPTION
Solves:

```
plee_the_bear_x86-0.7.0-7-x86_gcc2.hpkg:
	requires "lib:libboost_filesystem_x86 >= 1.57.0" of package "plee_the_bear_x86-0.7.0-7" could not be resolved
```

Crashes on launch though (not sure how it did before because I never tested it).