### PR TITLE
gcc/config: Drop cdecl and stdcall built-in defines

### DIFF
--- a/sys-devel/gcc/gcc-11.2.0_2021_07_28.recipe
+++ b/sys-devel/gcc/gcc-11.2.0_2021_07_28.recipe
@@ -5,7 +5,7 @@ HOMEPAGE="https://gcc.gnu.org/"
 COPYRIGHT="1988-2021 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3
 	GNU LGPL v3"
-REVISION="8"
+REVISION="9"
 gccVersion="${portVersion%%_*}"
 SOURCE_URI="https://ftpmirror.gnu.org/gcc/gcc-$gccVersion/gcc-$gccVersion.tar.xz
 	https://ftp.gnu.org/gnu/gcc/gcc-$gccVersion/gcc-$gccVersion.tar.xz"

--- a/sys-devel/gcc/patches/gcc-11.2.0_2021_07_28.patchset
+++ b/sys-devel/gcc/patches/gcc-11.2.0_2021_07_28.patchset
@@ -3627,7 +3627,6 @@ index 000000000..efa187289
 -- 
 2.35.1
 
-
 From 4dfaf5b96eaa934b487a83f9deb9eee0dde3a100 Mon Sep 17 00:00:00 2001
 From: Trung Nguyen <trungnt282910@gmail.com>
 Date: Wed, 6 Jul 2022 23:57:55 +0700
@@ -3662,3 +3661,100 @@ index 316d38469..37adf4081 100644
 --
 2.34.1
 
+From 20ef1c8d76f40b53411a4828239538631659fd0e Mon Sep 17 00:00:00 2001
+From: Trung Nguyen <trungnt282910@gmail.com>
+Date: Mon, 8 May 2023 18:49:58 +1000
+Subject: [PATCH] gcc/config: Drop cdecl and stdcall built-in defines
+
+---
+ gcc/gcc/config/aarch64/aarch64-haiku.h | 2 --
+ gcc/gcc/config/arm/haiku.h             | 2 --
+ gcc/gcc/config/i386/haiku64.h          | 4 ++--
+ gcc/gcc/config/m68k/haiku.h            | 2 --
+ gcc/gcc/config/mips/haiku.h            | 2 --
+ gcc/gcc/config/rs6000/haiku.h          | 2 --
+ 6 files changed, 2 insertions(+), 12 deletions(-)
+
+diff --git a/gcc/gcc/config/aarch64/aarch64-haiku.h b/gcc/gcc/config/aarch64/aarch64-haiku.h
+index 2305a55755..6ab98a4a02 100644
+--- a/gcc/gcc/config/aarch64/aarch64-haiku.h
++++ b/gcc/gcc/config/aarch64/aarch64-haiku.h
+@@ -26,8 +26,6 @@
+   do									\
+     {									\
+       builtin_define ("__HAIKU__");					\
+-      builtin_define ("__stdcall=__attribute__((__stdcall__))");	\
+-      builtin_define ("__cdecl=__attribute__((__cdecl__))");		\
+       builtin_define ("__STDC_ISO_10646__=201103L"); 			\
+       builtin_assert ("system=haiku");					\
+     }									\
+diff --git a/gcc/gcc/config/arm/haiku.h b/gcc/gcc/config/arm/haiku.h
+index e0e56cd2df..543ba9dd4f 100644
+--- a/gcc/gcc/config/arm/haiku.h
++++ b/gcc/gcc/config/arm/haiku.h
+@@ -53,8 +53,6 @@
+       builtin_define ("__HAIKU__");					\
+       builtin_define ("__ARM__");					\
+       builtin_define ("__arm__");					\
+-      builtin_define ("__stdcall=__attribute__((__stdcall__))");	\
+-      builtin_define ("__cdecl=__attribute__((__cdecl__))");		\
+       builtin_define ("__STDC_ISO_10646__=201103L"); \
+       builtin_assert ("system=haiku");					\
+       TARGET_BPABI_CPP_BUILTINS();					\
+diff --git a/gcc/gcc/config/i386/haiku64.h b/gcc/gcc/config/i386/haiku64.h
+index e2fa55a345..1b56931492 100644
+--- a/gcc/gcc/config/i386/haiku64.h
++++ b/gcc/gcc/config/i386/haiku64.h
+@@ -42,9 +42,9 @@ Boston, MA 02111-1307, USA.  */
+         {								\
+           builtin_define ("__INTEL__");					\
+           builtin_define ("__X86__");					\
++          builtin_define ("__stdcall=__attribute__((__stdcall__))");	\
++          builtin_define ("__cdecl=__attribute__((__cdecl__))");		\
+         }								\
+-      builtin_define ("__stdcall=__attribute__((__stdcall__))");	\
+-      builtin_define ("__cdecl=__attribute__((__cdecl__))");		\
+       builtin_define ("__STDC_ISO_10646__=201103L");			\
+       builtin_assert ("system=haiku");					\
+     }									\
+diff --git a/gcc/gcc/config/m68k/haiku.h b/gcc/gcc/config/m68k/haiku.h
+index ce43a66656..2b117fcb13 100644
+--- a/gcc/gcc/config/m68k/haiku.h
++++ b/gcc/gcc/config/m68k/haiku.h
+@@ -69,8 +69,6 @@ Boston, MA 02110-1301, USA.  */
+ 	builtin_define ("__M68K__");					\
+ 	builtin_define_std ("mc68000");					\
+ 	builtin_define_std ("mc68020");					\
+-	builtin_define ("__stdcall=__attribute__((__stdcall__))");	\
+-	builtin_define ("__cdecl=__attribute__((__cdecl__))");		\
+     builtin_define ("__STDC_ISO_10646__=201103L"); \
+ 	builtin_assert ("system=haiku");				\
+     }									\
+diff --git a/gcc/gcc/config/mips/haiku.h b/gcc/gcc/config/mips/haiku.h
+index 870173d2e2..aa3dcded9f 100644
+--- a/gcc/gcc/config/mips/haiku.h
++++ b/gcc/gcc/config/mips/haiku.h
+@@ -27,8 +27,6 @@ Boston, MA 02111-1307, USA.  */
+ 	builtin_define ("__MIPS__");					\
+ 	builtin_define ("__MIPSEL__");					\
+ 	builtin_define ("_MIPSEL_");					\
+-	builtin_define ("__stdcall=__attribute__((__stdcall__))");	\
+-	builtin_define ("__cdecl=__attribute__((__cdecl__))");		\
+     builtin_define ("__STDC_ISO_10646__=201103L"); \
+ 	builtin_assert ("system=haiku");					\
+ 	if (flag_pic)							\
+diff --git a/gcc/gcc/config/rs6000/haiku.h b/gcc/gcc/config/rs6000/haiku.h
+index fee7c3c28f..8c2e8054b8 100644
+--- a/gcc/gcc/config/rs6000/haiku.h
++++ b/gcc/gcc/config/rs6000/haiku.h
+@@ -35,8 +35,6 @@ Boston, MA 02111-1307, USA.  */
+ 	builtin_define ("__HAIKU__");					\
+ 	builtin_define ("__POWERPC__");					\
+ 	builtin_define ("__powerpc__");					\
+-	builtin_define ("__stdcall=__attribute__((__stdcall__))");	\
+-	builtin_define ("__cdecl=__attribute__((__cdecl__))");		\
+     builtin_define ("__STDC_ISO_10646__=201103L"); \
+ 	builtin_assert ("system=haiku");					\
+ 	builtin_assert ("cpu=powerpc");					\
+-- 
+2.37.3


### PR DESCRIPTION
Synchronized GCC recipe with changes from https://review.haiku-os.org/c/buildtools/+/6384.