### PR TITLE
ruby: use global gemrc to make --user-install the default

### DIFF
--- a/dev-lang/ruby/additional-files/gemrc
+++ b/dev-lang/ruby/additional-files/gemrc
@@ -1,0 +1,5 @@
+# Read about the gemrc format at http://guides.rubygems.org/command-reference/#gem-environment
+
+# --user-install is used to install to $HOME/.gem by default since we want to separate
+#                pkgman installed gems and gem installed gems
+gem: --user-install

--- a/dev-lang/ruby/ruby-2.7.4.recipe
+++ b/dev-lang/ruby/ruby-2.7.4.recipe
@@ -50,6 +50,7 @@ REQUIRES="
 	lib:libcrypto$secondaryArchSuffix
 	lib:libedit$secondaryArchSuffix
 	lib:libffi$secondaryArchSuffix
+	lib:libgdbm$secondaryArchSuffix
 	lib:libgmp$secondaryArchSuffix
 	lib:libiconv$secondaryArchSuffix
 	lib:libncursesw$secondaryArchSuffix
@@ -70,6 +71,7 @@ BUILD_REQUIRES="
 	devel:libcrypto$secondaryArchSuffix
 	devel:libedit$secondaryArchSuffix
 	devel:libffi$secondaryArchSuffix
+	devel:libgdbm$secondaryArchSuffix
 	devel:libgmp$secondaryArchSuffix
 	devel:libiconv$secondaryArchSuffix
 	devel:libncursesw$secondaryArchSuffix
@@ -112,7 +114,8 @@ BUILD()
 		--enable-shared \
 		--disable-silent-rules \
 		--enable-debug-env \
-		--bindir=$prefix/bin
+		--bindir=$prefix/bin \
+		--with-dbm-type=gdbm_compat
 
 	# The build process needs to run ruby, and without this it fails to find
 	# libruby.so.

--- a/dev-lang/ruby/ruby-2.7.4.recipe
+++ b/dev-lang/ruby/ruby-2.7.4.recipe
@@ -13,14 +13,17 @@ HOMEPAGE="https://www.ruby-lang.org/"
 COPYRIGHT="1993-2021 Yukihiro Matsumoto"
 LICENSE="Ruby
 	BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://cache.ruby-lang.org/pub/ruby/2.7/ruby-$portVersion.tar.bz2"
 CHECKSUM_SHA256="bffa8aec9da392eda98f1c561071bb6e71d217d541c617fc6e3282d79f4e7d48"
 SOURCE_DIR="ruby-$portVersion"
 PATCHES="ruby-$portVersion.patchset"
+ADDITIONAL_FILES="gemrc"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
+
+GLOBAL_WRITABLE_FILES="settings/gemrc keep-old"
 
 libVersion="$portVersion"
 libVersionCompat="$libVersion compat >= ${libVersion%.*}"
@@ -124,6 +127,8 @@ INSTALL()
 	prepareInstalledDevelLib libruby
 	fixPkgconfig
 	packageEntries devel $developDir
+
+	cp -f $portDir/additional-files/gemrc $settingsDir/gemrc
 }
 
 TEST()


### PR DESCRIPTION
This is how some Linux distros like Arch handle `gem install`.