### PR TITLE
chrpath: new recipe

### DIFF
--- a/app-admin/chrpath/chrpath-0.16.recipe
+++ b/app-admin/chrpath/chrpath-0.16.recipe
@@ -1,0 +1,53 @@
+SUMMARY="Modifies the dynamic library load path"
+DESCRIPTION="'chrpath' allows you to modify the dynamic library load path (rpath and runpath) of \
+compiled programs and libraries."
+HOMEPAGE="https://directory.fsf.org/wiki/Chrpath"
+COPYRIGHT="2001-2014 Petter Reinholdtsen"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="https://alioth-archive.debian.org/releases/chrpath/chrpath/$portVersion/chrpath-$portVersion.tar.gz"
+CHECKSUM_SHA256="bb0d4c54bac2990e1bdf8132f2c9477ae752859d523e141e72b3b11a12c26e7b"
+PATCHES="chrpath-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandBinDir=$prefix/bin
+fi
+
+
+PROVIDES="
+	chrpath$secondaryArchSuffix = $portVersion
+	cmd:chrpath = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:make
+	cmd:gcc$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	runConfigure --omit-dirs binDir ./configure --bindir=$commandBinDir
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+	rm -rf $prefix/doc
+}
+
+TEST()
+{
+	make check
+}

--- a/app-admin/chrpath/patches/chrpath-0.16.patchset
+++ b/app-admin/chrpath/patches/chrpath-0.16.patchset
@@ -1,0 +1,39 @@
+From 5ce86fd44694055d87e2cc2a3e1500f293bfe3ed Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Sat, 13 May 2023 16:47:24 -0300
+Subject: Fix build on Haiku
+
+
+diff --git a/protos.h b/protos.h
+index f24bc06..b16b1cc 100644
+--- a/protos.h
++++ b/protos.h
+@@ -1,7 +1,14 @@
+ #ifndef PROTOS_H
+ #define PROTOS_H
+ 
++#ifdef __HAIKU__
++	#include <ByteOrder.h>
++	#define bswap_16 B_SWAP_INT16
++	#define bswap_32 B_SWAP_INT32
++	#define bswap_64 B_SWAP_INT64
++#else
+ #include <byteswap.h>
++#endif
+ #include <elf.h>
+ #include "config.h"
+ 
+@@ -25,6 +32,10 @@ typedef union {
+   Elf64_Shdr e64;
+ } Elf_Shdr;
+ 
++#ifdef __HAIKU__
++	#undef Elf_Phdr
++#endif
++
+ typedef union {
+   Elf32_Phdr e32;
+   Elf64_Phdr e64;
+-- 
+2.37.3
+


### PR DESCRIPTION
Tested (*very* lightly) only on beta4 64 bits (now also lightly tested on 32 bits).

----

I assume we're supposed to use stuff as `CMAKE_SKIP_RPATH` instead if that's available, or disable `rpath` via some `sed` patching if the build system doesn't provides an easier mechanism.

I just had a "complex to build" project (still no proper .recipe for it), and I'll probably need either this `chrpath` thing, or some serious `sed` scripts :-D.

~Leaving it as Draft for now,~ as I'm not sure my .patchset is correct, or if this `chrpath` is something we actually want/need.

----

Drop Draft status:

If we have `cmd:patchelf`, I guess having this one also available can't hurt that much :-)