### PR TITLE
python3.10: cleanups, no functional changes.

### DIFF
--- a/dev-lang/python/python3.10-3.10.11.recipe
+++ b/dev-lang/python/python3.10-3.10.11.recipe
@@ -9,14 +9,18 @@ OSI-approved open source license."
 HOMEPAGE="https://www.python.org"
 LICENSE="Python"
 COPYRIGHT="1990-2023 Python Software Foundation"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://www.python.org/ftp/python/$portVersion/Python-$portVersion.tar.xz"
 CHECKSUM_SHA256="3c3bc3048303721c904a03eb8326b631e921f11cc3be2988456a42f115daf04c"
 SOURCE_DIR="Python-$portVersion"
-PATCHES="python3.10-$portVersion.patchset"
+
+pyShortVer="${portVersion%.*}"
+pyVersionCompat="$portVersion compat >= $pyShortVer"
+
+PATCHES="python${pyShortVer}-$portVersion.patchset"
 if [ "$secondaryArchSuffix" = _x86 ] ; then
 	PATCHES+="
-		python3.10_x86-$portVersion.patchset
+		python${pyShortVer}_x86-$portVersion.patchset
 	"
 fi
 
@@ -32,20 +36,20 @@ if [ "$targetArchitecture" = x86_gcc2 ]; then
 fi
 
 GLOBAL_WRITABLE_FILES="
-	non-packaged/lib/python3.10/site-packages directory keep-old
+	non-packaged/lib/python$pyShortVer/site-packages directory keep-old
 	"
 
 PROVIDES="
-	python3.10$secondaryArchSuffix = $portVersion compat >= 3.10
-	python310$secondaryArchSuffix = $portVersion compat >= 3.10
-	cmd:2to3_3.10 = $portVersion compat >= 3.10
-	cmd:idle3.10 = $portVersion compat >= 3.10
-	cmd:pydoc3.10 = $portVersion compat >= 3.10
-	cmd:python3.10 = $portVersion compat >= 3.10
-	cmd:python3.10_config = $portVersion compat >= 3.10
-	cmd:pyvenv_3.10 = $portVersion compat >= 3.10
-	devel:libpython3.10$secondaryArchSuffix = 1.0
-	lib:libpython3.10$secondaryArchSuffix = 1.0
+	python$pyShortVer$secondaryArchSuffix = $pyVersionCompat
+	python310$secondaryArchSuffix = $pyVersionCompat
+	cmd:2to3_$pyShortVer = $pyVersionCompat
+	cmd:idle$pyShortVer = $pyVersionCompat
+	cmd:pydoc$pyShortVer = $pyVersionCompat
+	cmd:python$pyShortVer = $pyVersionCompat
+	cmd:python${pyShortVer}_config = $pyVersionCompat
+	cmd:pyvenv_$pyShortVer = $pyVersionCompat
+	devel:libpython$pyShortVer$secondaryArchSuffix = 1.0
+	lib:libpython$pyShortVer$secondaryArchSuffix = 1.0
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -120,24 +124,24 @@ INSTALL()
 
 	if [ "$targetArchitecture" = x86_gcc2 ]; then
 		# On x86_gcc2, move lib-dynload to lib/python3.x/
-		mv $libDir/python3.10/lib-dynload $prefix/lib/python3.10/
+		mv $libDir/python$pyShortVer/lib-dynload $prefix/lib/python$pyShortVer/
 	fi
-	prepareInstalledDevelLibs libpython3.10
+	prepareInstalledDevelLibs libpython$pyShortVer
 	fixPkgconfig
 	if [ "$targetArchitecture" = x86_gcc2 ]; then
 		# fix pkgconfig to match configure flags
 		sed -i -e 's,headers/x86,headers,' $developLibDir/pkgconfig/python*.pc
 	fi
 
-	mkdir -p $prefix/lib/python3.10/vendor-packages
+	mkdir -p $prefix/lib/python$pyShortVer/vendor-packages
 	echo 'This directory contains packaged python modules.' \
-		>$prefix/lib/python3.10/vendor-packages/README
+		>$prefix/lib/python$pyShortVer/vendor-packages/README
 
-	mkdir -p $prefix/non-packaged/lib/python3.10
-	mv $prefix/lib/python3.10/site-packages $prefix/non-packaged/lib/python3.10/
+	mkdir -p $prefix/non-packaged/lib/python$pyShortVer
+	mv $prefix/lib/python$pyShortVer/site-packages $prefix/non-packaged/lib/python$pyShortVer/
 
 	# drop testsuite altogether; move to a separate package if needed
-	cd $prefix/lib/python3.10
+	cd $prefix/lib/python$pyShortVer
 	rm -rf ctypes/test distutils/tests idlelib/idle_test lib2to3/tests \
 		sqlite3/test test tkinter/test unittest/test
 }


### PR DESCRIPTION
This is basically #3834 (removing hard-coded version numbers), but for Python 3.10.

Only two "310" references remain, but those will go away for newer Pythons.

~Not changing the revision, as this is~ just a cleanup, no functional change intended.

(only doing it for the newest recipe, as the older ones will just be faced out eventually).