### PR TITLE
armadillo, bump version

### DIFF
--- a/sci-libs/armadillo/armadillo-12.2.0.recipe
+++ b/sci-libs/armadillo/armadillo-12.2.0.recipe
@@ -1,0 +1,111 @@
+SUMMARY="A C++ linear algebra library"
+DESCRIPTION="The library provides efficient classes for vectors, matrices and \
+cubes, as well as 200+ associated functions (eg. contiguous and non-contiguous \
+submatrix views). Various matrix decompositions are provided through \
+integration with LAPACK, or one of its high performance drop-in replacements."
+HOMEPAGE="http://arma.sourceforge.net/"
+COPYRIGHT="2008-2020 Conrad Sanderson
+	2008-2016 National ICT Australia (NICTA)
+	2017-2020 Arroyo Consortium
+	2017-2020 Data61, CSIRO"
+LICENSE="Apache v2"
+REVISION="2"
+SOURCE_URI="https://downloads.sourceforge.net/arma/armadillo-$portVersion.tar.xz"
+CHECKSUM_SHA256="b0dce042297e865add3351dad77f78c2c7638d6632f58357b015e50edcbd2186"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="$portVersion"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	armadillo$secondaryArchSuffix = $portVersion
+	lib:libarmadillo$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libarpack$secondaryArchSuffix
+	lib:libhdf5$secondaryArchSuffix
+	lib:liblapack$secondaryArchSuffix
+	lib:libopenblas$secondaryArchSuffix
+	lib:libsuperlu$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	armadillo${secondaryArchSuffix}_devel = $portVersion
+	devel:libarmadillo$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	armadillo$secondaryArchSuffix == $portVersion base
+	"
+CONFLICTS_devel="
+	armadillo${secondaryArchSuffix}_devel
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libarpack$secondaryArchSuffix
+	devel:libhdf5$secondaryArchSuffix
+	devel:liblapack$secondaryArchSuffix
+	devel:libopenblas$secondaryArchSuffix
+	devel:libsuperlu$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:g++$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:sed
+	"
+
+defineDebugInfoPackage armadillo$secondaryArchSuffix \
+	"$libDir"/libarmadillo.so.$libVersion
+
+PATCH()
+{
+	# Enable some optional features
+	sed --regexp-extended -i '/ARMA_USE_(SUPERLU|ARPACK)/s/^\/\///g' include/armadillo_bits/config.hpp
+}
+
+BUILD()
+{
+	cmake -Bbuild -S. -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		$cmakeDirArgs \
+		-DBUILD_SHARED_LIBS=ON
+	make -C build $jobArgs
+}
+
+INSTALL()
+{
+	make -C build install
+
+	mkdir -p $libDir/cmake/
+	cp -r $dataDir/Armadillo/CMake/. $libDir/cmake/.
+	rm -rf $dataDir/Armadillo/
+
+	prepareInstalledDevelLib libarmadillo
+
+	sed  -i "1i prefix=$prefix" \
+		$libDir/pkgconfig/armadillo.pc
+
+	fixPkgconfig
+
+	packageEntries devel \
+		$developDir \
+		$libDir/cmake
+}
+
+TEST()
+{
+	export LIBRARY_PATH=$LIBRARY_PATH:$sourceDir/build
+	export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:$sourceDir/include
+
+	sed -i "s|LIB_FLAGS = -larmadillo|LIB_FLAGS = -lopenblas -llapack -larpack -lsuperlu -larmadillo -L$sourceDir/build|g" tests/Makefile
+
+	make -C tests all $jobArgs
+
+	./tests/main
+}

--- a/sci-libs/armadillo/armadillo10-10.8.2.recipe
+++ b/sci-libs/armadillo/armadillo10-10.8.2.recipe
@@ -21,7 +21,7 @@ libVersion="$portVersion"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
-	armadillo$secondaryArchSuffix = $portVersion
+	armadillo10$secondaryArchSuffix = $portVersion
 	lib:libarmadillo$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
@@ -35,11 +35,11 @@ REQUIRES="
 	"
 
 PROVIDES_devel="
-	armadillo${secondaryArchSuffix}_devel = $portVersion
+	armadillo10${secondaryArchSuffix}_devel = $portVersion
 	devel:libarmadillo$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
-	armadillo$secondaryArchSuffix == $portVersion base
+	armadillo10$secondaryArchSuffix == $portVersion base
 	"
 CONFLICTS_devel="
 	armadillo${secondaryArchSuffix}_devel
@@ -62,7 +62,7 @@ BUILD_PREREQUIRES="
 	cmd:sed
 	"
 
-defineDebugInfoPackage armadillo$secondaryArchSuffix \
+defineDebugInfoPackage armadillo10$secondaryArchSuffix \
 	"$libDir"/libarmadillo.so.$libVersion
 
 PATCH()
@@ -76,7 +76,7 @@ BUILD()
 	cmake -Bbuild -S. -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		$cmakeDirArgs \
 		-DDETECT_HDF5=ON \
-		-DBUILD_SHARED_LIBS=ON
+		-DBUILD_SHARED_LIBS=ON -L
 	make -C build $jobArgs
 }
 


### PR DESCRIPTION
This moves the older armadillo into the armadillo10 package so libraries are kept around for depending packages.