### PR TITLE
armyknife, switch so gcc11

### DIFF
--- a/haiku-apps/armyknife/armyknife-5.1.2.recipe
+++ b/haiku-apps/armyknife/armyknife-5.1.2.recipe
@@ -9,31 +9,32 @@ COPYRIGHT="2000-2001 Jason Burgess
 	2008 Jonas Sundström, Ryan Leavengood
 	2009-2022 HaikuArchives team"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="$HOMEPAGE/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="cd03e7b12122be86cfdc9663fce6c05b94437fd8f251c17d16ebd63b409fd279"
 SOURCE_DIR="ArmyKnife-$portVersion"
 
-ARCHITECTURES="all"
+ARCHITECTURES="all ?x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	armyknife = $portVersion
+	armyknife$secondaryArchSuffix = $portVersion
 	app:ArmyKnife = $portVersion
 	"
 REQUIRES="
-	haiku
-	lib:libmusicbrainz5
-	lib:libtag
+	haiku$secondaryArchSuffix
+	lib:libmusicbrainz5$secondaryArchSuffix
+	lib:libtag$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
-	devel:libmusicbrainz5
-	devel:libtag
+	haiku${secondaryArchSuffix}_devel
+	devel:libmusicbrainz5$secondaryArchSuffix
+	devel:libtag$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	makefile_engine
-	cmd:g++
+	cmd:g++$secondaryArchSuffix
 	cmd:make
 	"
 


### PR DESCRIPTION
With neon not available for primary arch on 32bit, musicbrainz needed a change.