### PR TITLE
pyqt_builder: drop support for Python 3.8.

### DIFF
--- a/dev-python/pyqt_builder/pyqt_builder-1.7.0.recipe
+++ b/dev-python/pyqt_builder/pyqt_builder-1.7.0.recipe
@@ -6,7 +6,7 @@ perform the actual compilation and installation of extension modules."
 HOMEPAGE="https://www.riverbankcomputing.com/software/pyqt/"
 COPYRIGHT="2020 Riverbank Computing Limited"
 LICENSE="BSD (2-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://pypi.io/packages/source/P/PyQt-builder/PyQt-builder-$portVersion.tar.gz"
 CHECKSUM_SHA256="b6e3c826f98ff4006ecb34df491ac6062a023b63a32e9f9f50904867aff72f2e"
 SOURCE_DIR="PyQt-builder-$portVersion"
@@ -24,8 +24,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 defaultVersion=3.9
 
 for i in "${!PYTHON_PACKAGES[@]}"; do


### PR DESCRIPTION
We don't have a sip_python38 anymore, and all users of this recipe are using the 3.9 version already.