### PR TITLE
texlive: fix references to texlive_core package links directory

### DIFF
--- a/app-text/texlive/texlive-2023.recipe
+++ b/app-text/texlive/texlive-2023.recipe
@@ -6,7 +6,7 @@ are free software, including support for many languages around the world."
 HOMEPAGE="http://tug.org/texlive/"
 COPYRIGHT="1996 by collaboration between the TeX user groups."
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 fullVersion=20230313
 SOURCE_URI="ftp://tug.org/historic/systems/texlive/$portVersion/install-tl-unx.tar.gz"
 SOURCE_URI_2="ftp://tug.org/historic/systems/texlive/$portVersion/texlive-$fullVersion-texmf.tar.xz"
@@ -256,8 +256,11 @@ INSTALL()
 	install-tl --custom-bin=$customBinDir --profile=texlive.profile
 
 	# somewhere along the way, a texmf.cnf gets created with ALL the wrong paths...
-	# replace it with the known working version from the main texlive_core package
-	cp -f /boot/system/data/texmf-dist/web2c/texmf.cnf $dataDir/texlive/texmf-dist/web2c/texmf.cnf
+	# replace it with the known working version from the main texlive_core package,
+	# but replace package links with our own ones
+	sed -e "s@/packages/texlive_core.*/\.self@$prefix@g" \
+		-e "s@/packages/texlive_core.*/\.settings@$sysconfDir@g" \
+		/boot/system/data/texmf-dist/web2c/texmf.cnf > $dataDir/texlive/texmf-dist/web2c/texmf.cnf
 
 	rm -rf $dataDir/texlive/bin
 


### PR DESCRIPTION
This would bind the texlive packages to a fixed version (and revision!) of texlive_core. Also, they couldn't be shared between x86 and other architectures, because the packages are named `texlive_core_x86` on x86 because of secondaryArch.

Revbump for rebuild (texlive was built against texlive_core 2022 before and is therefore broken right now.)