### PR TITLE
spice: switch to Python 3.9

### DIFF
--- a/app-emulation/spice/spice-0.15.1.recipe
+++ b/app-emulation/spice/spice-0.15.1.recipe
@@ -5,7 +5,7 @@ These components are used to provide access to a remote machine's display and de
 HOMEPAGE="https://www.spice-space.org/"
 COPYRIGHT="2009 Red Hat, Inc"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://www.spice-space.org/download/releases/spice-server/spice-$portVersion.tar.bz2"
 CHECKSUM_SHA256="ada9af67ab321916bd7eb59e3d619a4a7796c08a28c732edfc7f02fc80b1a37a"
 SOURCE_DIR="spice-$portVersion"
@@ -58,8 +58,8 @@ BUILD_REQUIRES="
 	devel:libX11$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	devel:spice_protocol
-	pyparsing_python3
-	six_python3
+	pyparsing_python39
+	six_python39
 	"
 BUILD_PREREQUIRES="
 	cmd:awk


### PR DESCRIPTION
ProTip™ (or note to myself): make sure to uninstall tk${secondaryArchSuffix}_devel before building this one. Sigh...