### PR TITLE
rizin: switch to Python 3.9

### DIFF
--- a/dev-util/rizin/rizin-0.3.4.recipe
+++ b/dev-util/rizin/rizin-0.3.4.recipe
@@ -16,7 +16,7 @@ LICENSE="Apache v2
 	MPL v1.1
 	NCSA
 	RSA-MD"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/rizinorg/rizin/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="b81279e5335f0167efaecdc31225c1b432d3d3c69e002c75dc01f4390b1c99a9"
 SOURCE_FILENAME="rizin-v$portVersion.tar.gz"
@@ -75,7 +75,7 @@ REQUIRES="
 	lib:liblz4$secondaryArchSuffix
 	lib:liblzma$secondaryArchSuffix
 	lib:libmagic$secondaryArchSuffix
-	lib:libpython3.7m$secondaryArchSuffix
+	lib:libpython3.9$secondaryArchSuffix
 	lib:libssl$secondaryArchSuffix
 	lib:libtree_sitter$secondaryArchSuffix
 	lib:libuv$secondaryArchSuffix
@@ -117,14 +117,14 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	pyyaml_python3
+	pyyaml_python39
 	devel:libcapstone$secondaryArchSuffix
 	devel:libbz2$secondaryArchSuffix
 	devel:libexecinfo$secondaryArchSuffix
 	devel:liblz4$secondaryArchSuffix
 	devel:liblzma$secondaryArchSuffix
 	devel:libmagic$secondaryArchSuffix
-	devel:libpython3.7m$secondaryArchSuffix
+	devel:libpython3.9$secondaryArchSuffix
 	devel:libssl$secondaryArchSuffix
 	devel:libtree_sitter$secondaryArchSuffix
 	devel:libuv$secondaryArchSuffix
@@ -147,6 +147,12 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
+	# These are fixed upstream on newer versions.
+	sed -i "s/project('mpc', version:/project('mpc', 'c', version:/" \
+		subprojects/mpc/meson.build
+	sed -i "s/project('tree-sitter-c', version:/project('tree-sitter-c', 'c', version:/" \
+		subprojects/tree-sitter-c/meson.build
+
 	meson build \
 		--buildtype=release \
 		--wrap=default \
@@ -165,7 +171,8 @@ BUILD()
 		-D use_sys_tree_sitter=enabled \
 		-D use_libuv=true \
 		-D enable_tests=false \
-		-D enable_rz_test=false
+		-D enable_rz_test=false \
+		-D subprojects_check=false
 	ninja -C build
 }
 


### PR DESCRIPTION
Added a temp workaround to fix the build. Shouldn't be necessary anymore once we update rizin to a newer release.