### PR TITLE
btanks: fix build issues related to lua.

### DIFF
--- a/games-action/btanks/btanks-0.9.8083.recipe
+++ b/games-action/btanks/btanks-0.9.8083.recipe
@@ -32,7 +32,7 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libexpat$secondaryArchSuffix
 	lib:libGLU$secondaryArchSuffix
-	lib:liblua$secondaryArchSuffix
+	lib:liblua$secondaryArchSuffix >= 5.3
 	lib:libSDL$secondaryArchSuffix
 	lib:libSDL_image$secondaryArchSuffix
 	lib:libsmpeg$secondaryArchSuffix
@@ -44,7 +44,7 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libexpat$secondaryArchSuffix
 	devel:libglu$secondaryArchSuffix
-	devel:liblua$secondaryArchSuffix
+	devel:liblua$secondaryArchSuffix >= 5.3
 	devel:libSDL$secondaryArchSuffix
 	devel:libSDL_image$secondaryArchSuffix
 	devel:libsmpeg$secondaryArchSuffix

--- a/games-action/btanks/patches/btanks-0.9.8083.patchset
+++ b/games-action/btanks/patches/btanks-0.9.8083.patchset
@@ -339,25 +339,3 @@ index dfc672f..8881eaa 100644
 2.37.3
 
 
-From 631ff04a413b21e7bf6908d13f17177b967b804e Mon Sep 17 00:00:00 2001
-From: Oscar Lesta <oscar.lesta@gmail.com>
-Date: Sun, 30 Apr 2023 05:20:41 -0300
-Subject: Fix for Lua 5.3
-
-
-diff --git a/engine/luaxx/state.cpp b/engine/luaxx/state.cpp
-index ddaf0fd..a350386 100644
---- a/engine/luaxx/state.cpp
-+++ b/engine/luaxx/state.cpp
-@@ -63,7 +63,7 @@ static const char * chunk_reader(lua_State *L, void *data, size_t *size) {
- void State::load(const std::string &fname, const mrt::Chunk &data) {
- 	//throw_ex(("implement me[%s]", fname.c_str()));
- 	reader_state x(data);
--	int err = lua_load(state, chunk_reader, &x, fname.c_str(), NULL);
-+	int err = lua_load(state, chunk_reader, &x, fname.c_str());
- 	check_error(state, err);
- }
- 
--- 
-2.37.3
-


### PR DESCRIPTION
Ensure we're pulling lua 5.3 (wasn't the case for some reason on my machine).