### PR TITLE
rizin: ugly hack to make it build.

### DIFF
--- a/dev-util/rizin/rizin-0.3.4.recipe
+++ b/dev-util/rizin/rizin-0.3.4.recipe
@@ -147,11 +147,42 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	# These are fixed upstream on newer versions.
+	# Remove this for rizin > 0.3.4. -->>
+	#
+	# What follows is some ugly hack, only needed to build rizin 0.3.4 with current meson.
+	# First `meson build` fails (thus the `|| true`), but pulls "tree-sitter-c", so we can
+	# patch it, and build for real. This hack is not necessary for newer rizin versions.
+
+	# This got fixed upstream for newer versions.
 	sed -i "s/project('mpc', version:/project('mpc', 'c', version:/" \
 		subprojects/mpc/meson.build
+
+	meson build \
+		--buildtype=release \
+		--wrap=default \
+		--prefix=$prefix \
+		--datadir=$dataDir \
+		--libdir=$libDir \
+		--includedir=$includeDir \
+		--mandir=$manDir \
+		-D use_sys_capstone=enabled \
+		-D use_sys_magic=enabled \
+		-D use_sys_libzip=enabled \
+		-D use_sys_zlib=enabled \
+		-D use_sys_lz4=enabled \
+		-D use_sys_xxhash=enabled \
+		-D use_sys_openssl=enabled \
+		-D use_sys_tree_sitter=enabled \
+		-D use_libuv=true \
+		-D enable_tests=false \
+		-D enable_rz_test=false \
+		-D subprojects_check=false \
+		|| true
+
+	# This got fixed upstream for newer versions.
 	sed -i "s/project('tree-sitter-c', version:/project('tree-sitter-c', 'c', version:/" \
 		subprojects/tree-sitter-c/meson.build
+	# <<-- Remove this for rizin > 0.3.4
 
 	meson build \
 		--buildtype=release \


### PR DESCRIPTION
Nothing of this is needed for newer versions, but seems like our Cutter port fails to link with newer ones for some reason.´

---

Builds OK on 32 bits (even after `hp -c rizin_x86`)