### PR TITLE
libpurple: switch to Python 3.9.

### DIFF
--- a/dev-libs/libpurple/libpurple-2.14.10.recipe
+++ b/dev-libs/libpurple/libpurple-2.14.10.recipe
@@ -5,7 +5,7 @@ Jabber or ICQ."
 HOMEPAGE="https://pidgin.im/"
 COPYRIGHT="1998-2021 Rob Flynn et al."
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://downloads.sourceforge.net/project/pidgin/Pidgin/$portVersion/pidgin-$portVersion.tar.bz2"
 CHECKSUM_SHA256="454b1b928bc6bcbb183353af30fbfde5595f2245a3423a1a46e6c97a2df22810"
 SOURCE_DIR="pidgin-$portVersion"
@@ -15,6 +15,8 @@ SECONDARY_ARCHITECTURES="x86"
 
 libVersion=0.14.10
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+pythonVersion=3.9
 
 PROVIDES="
 	libpurple$secondaryArchSuffix = $portVersion
@@ -40,10 +42,9 @@ REQUIRES="
 	lib:libnssdbm3$secondaryArchSuffix
 	lib:libnssutil3$secondaryArchSuffix
 	lib:libpanelw$secondaryArchSuffix
-#	lib:libperl
 	lib:libsmime3$secondaryArchSuffix
 	lib:libsoftokn3$secondaryArchSuffix
-	lib:libpython3.7m$secondaryArchSuffix
+	lib:libpython$pythonVersion$secondaryArchSuffix
 	lib:libsasl2$secondaryArchSuffix
 	lib:libssl$secondaryArchSuffix
 	lib:libssl3$secondaryArchSuffix
@@ -100,7 +101,7 @@ BUILD_REQUIRES="
 	devel:libnssutil3$secondaryArchSuffix
 	devel:libsmime3$secondaryArchSuffix
 	devel:libsoftokn3$secondaryArchSuffix
-	devel:libpython3.7m$secondaryArchSuffix
+	devel:libpython$pythonVersion$secondaryArchSuffix
 	devel:libsasl2$secondaryArchSuffix
 	devel:libssl$secondaryArchSuffix
 	devel:libssl3$secondaryArchSuffix
@@ -151,7 +152,7 @@ BUILD()
 		--with-nss-libs=$(finddir B_SYSTEM_LIB_DIRECTORY)/${secondaryArchSubDir} \
 		--with-ncurses-headers=$(finddir B_SYSTEM_HEADERS_DIRECTORY)/${secondaryArchSubDir} \
 		--with-system-ssl-certs=$(finddir B_SYSTEM_DATA_DIRECTORY)/ssl/certs \
-		--with-python3=$(finddir B_SYSTEM_HEADERS_DIRECTORY)/python3.7m
+		--with-python3=$(finddir B_SYSTEM_HEADERS_DIRECTORY)/python$pythonVersion
 	make $jobArgs
 }
 


### PR DESCRIPTION
Removed the commented out lib:perl requirement.

The warning haikuporter gives is an spurious one related to the "perl.so" this packages includes under "$libDir/purple-2/".

We might want to rev-bump the following packages that directly depend on libpurple:

- chat_o_matic
- bitlbee
- purple_discord