### PR TITLE
gtest: use default cmd:python3 (3.9 at the moment) to build.

### DIFF
--- a/dev-libs/gtest/gtest-1.11.0.recipe
+++ b/dev-libs/gtest/gtest-1.11.0.recipe
@@ -14,7 +14,7 @@ Features:
 HOMEPAGE="https://github.com/google/googletest"
 COPYRIGHT="2008-2019 Google Test developers"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/google/googletest/archive/release-$portVersion.tar.gz"
 CHECKSUM_SHA256="b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5"
 SOURCE_FILENAME="googletest-release-$portVersion.tar.gz"
@@ -55,7 +55,7 @@ BUILD_PREREQUIRES="
 	cmd:ld$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:python3.7
+	cmd:python3
 	"
 
 defineDebugInfoPackage gtest$secondaryArchSuffix \
@@ -99,5 +99,14 @@ INSTALL()
 
 TEST()
 {
+	# Note: lots of tests crash (intentionally it would seem), bringing up the Debugger
+	# crash dialog. Might be desirable to set Debugger's default action to "kill" before
+	# running tests, to avoid having to manually close said dialog.
+	#
+	# See https://git.haiku-os.org/haiku/commit/?id=1b744548e0a31d725a147cfeadf3eeb30a4eb84c
+	#
+	# Other than that, runnint hp --test gtest_x86 results in:
+	#
+	# 100% tests passed, 0 tests failed out of 45
 	make -C build test
 }


### PR DESCRIPTION
Passes all tests on 32 bits x86.