### PR TITLE
ranger. update to version 1.9.3

### DIFF
--- a/app-misc/ranger/ranger-1.9.3.recipe
+++ b/app-misc/ranger/ranger-1.9.3.recipe
@@ -32,28 +32,28 @@ COPYRIGHT="2009-2018 Roman Zimbelmann
 	2015-2018 Wojciech Siewierski
 	2016-2018 Toon Nolten"
 LICENSE="GNU GPL v3"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://ranger.github.io/$portVersionedName.tar.gz"
-CHECKSUM_SHA256="0e1d1b1d3f78c227a6cfa783822e98591ca76a35c643d4814f40f73515d66b8a"
+CHECKSUM_SHA256="ce088a04c91c25263a9675dc5c43514b7ec1b38c8ea43d9a9d00923ff6cdd251"
 
 ARCHITECTURES="any"
+
+# It only makes sense to package this one just for the default Python version.
+pythonVersion=3.9
+pythonPackage=python${pythonVersion//.}
 
 PROVIDES="
 	$portName = $portVersion
 	"
 REQUIRES="
 	haiku
+	${portName}_$pythonPackage
 	"
 
 BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python python3)
-PYTHON_VERSIONS=(2.7 3.7)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
 eval "PROVIDES_$pythonPackage='
 	${portName}_$pythonPackage = $portVersion
 	cmd:ranger = $portVersion
@@ -63,35 +63,32 @@ eval "REQUIRES_$pythonPackage='
 	haiku
 	cmd:python$pythonVersion
 	'"
-eval "CONFLICTS_$pythonPackage='
-	cmd:ranger
-	cmd:rifle
-	'"
-
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
-done
+BUILD_REQUIRES+="
+	setuptools_$pythonPackage
+	"
+BUILD_PREREQUIRES+="
+	cmd:python$pythonVersion
+	"
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
-		pythonVersion=${PYTHON_VERSIONS[$i]}
+	python=python$pythonVersion
+	installLocation=$prefix/lib/$python/vendor-packages/
+	export PYTHONPATH=$installLocation:$PYTHONPATH
 
-		python=python$pythonVersion
-		pkgPrefix=$(getPackagePrefix $pythonPackage)
-		installLocation=$pkgPrefix/lib/$python/vendor-packages/
-		export PYTHONPATH=$installLocation:$PYTHONPATH
-		mkdir -p $installLocation
-		rm -rf build
-		$python setup.py build install \
-			--root=/ --prefix=$pkgPrefix
+	mkdir -p $installLocation
 
-		install -d -m 755 $pkgPrefix/$relativeDocDir $pkgPrefix/$relativeManDir
-		mv $pkgPrefix/share/doc/ranger/* $pkgPrefix/$relativeDocDir
-		mv $pkgPrefix/share/man/* $pkgPrefix/$relativeManDir
-		rm -rf $pkgPrefix/share
-	done
+	$python setup.py build install --root=/ --prefix=$prefix
+
+	install -d -m 755 $docDir $manDir
+
+	mv $prefix/share/doc/ranger/* $docDir
+	mv $prefix/share/man/* $manDir
+	rm -rf $prefix/share
+
+	packageEntries $pythonPackage \
+		$prefix/lib/python* \
+		$docDir \
+		$manDir \
+		$binDir
 }

--- a/app-misc/ranger/ranger-1.9.3.recipe
+++ b/app-misc/ranger/ranger-1.9.3.recipe
@@ -44,29 +44,19 @@ pythonPackage=python${pythonVersion//.}
 
 PROVIDES="
 	$portName = $portVersion
+	cmd:ranger = $portVersion
+	cmd:rifle = $portVersion
 	"
 REQUIRES="
 	haiku
-	${portName}_$pythonPackage
+	cmd:python$pythonVersion
 	"
 
 BUILD_REQUIRES="
 	haiku_devel
-	"
-
-eval "PROVIDES_$pythonPackage='
-	${portName}_$pythonPackage = $portVersion
-	cmd:ranger = $portVersion
-	cmd:rifle = $portVersion
-	'"
-eval "REQUIRES_$pythonPackage='
-	haiku
-	cmd:python$pythonVersion
-	'"
-BUILD_REQUIRES+="
 	setuptools_$pythonPackage
 	"
-BUILD_PREREQUIRES+="
+BUILD_PREREQUIRES="
 	cmd:python$pythonVersion
 	"
 
@@ -85,10 +75,4 @@ INSTALL()
 	mv $prefix/share/doc/ranger/* $docDir
 	mv $prefix/share/man/* $manDir
 	rm -rf $prefix/share
-
-	packageEntries $pythonPackage \
-		$prefix/lib/python* \
-		$docDir \
-		$manDir \
-		$binDir
 }


### PR DESCRIPTION
Only build it for the default Python version (3.9 at the moment), as this is just intended to be used as a command line utility.