### PR TITLE
cram: switch to Python 3.9.

### DIFF
--- a/dev-util/cram/cram-0.7.recipe
+++ b/dev-util/cram/cram-0.7.recipe
@@ -6,60 +6,48 @@ the command's actual output."
 HOMEPAGE="https://bitheap.org/cram/"
 COPYRIGHT="2010-2016 Rafael G. Martins"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://bitheap.org/cram/cram-$portVersion.tar.gz"
 CHECKSUM_SHA256="7da7445af2ce15b90aad5ec4792f857cef5786d71f14377e9eb994d8b8337f2f"
 
 ARCHITECTURES="any"
 
+# It only makes sense to package this one just for the default Python version.
+pythonVersion=3.9
+pythonPackage=python${pythonVersion//.}
+
 PROVIDES="
 	$portName = $portVersion
+	cmd:cram = $portVersion
 	"
 REQUIRES="
 	haiku
+	cmd:python$pythonVersion
 	"
 
 BUILD_REQUIRES="
 	haiku_devel
+	setuptools_$pythonPackage
 	"
-
-PYTHON_PACKAGES=(python python3)
-PYTHON_VERSIONS=(2.7 3.7)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\n\
-	cmd:${portName}${pythonVersion%%.*} = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
-done
+BUILD_PREREQUIRES="
+	cmd:python$pythonVersion
+	"
+TEST_REQUIRES="
+	cmd:cram
+	"
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
-		pythonVersion=${PYTHON_VERSIONS[$i]}
+	python=python$pythonVersion
+	installLocation=$prefix/lib/$python/vendor-packages/
+	export PYTHONPATH=$installLocation:$PYTHONPATH
 
-		python=python$pythonVersion
-		installLocation=$prefix/lib/$python/vendor-packages/
-		export PYTHONPATH=$installLocation:$PYTHONPATH
-		mkdir -p $installLocation
-		rm -rf build
-		$python setup.py build install \
-			--root=/ --prefix=$prefix
+	mkdir -p $installLocation
 
-		mv $prefix/bin/cram $prefix/bin/cram${pythonVersion%%.*}
+	$python setup.py build install --root=/ --prefix=$prefix
+}
 
-		packageEntries  $pythonPackage \
-			$prefix/bin \
-			$prefix/lib/python*
-	done
+TEST()
+{
+	cram tests/*.t
 }


### PR DESCRIPTION
- Dropped Python2 version.
- No need to version-suffix `cmd:cram`.

Notice: upstream repo has been archived in 2022, and while the repo mentions an 0.8 release, the link for that is broken, and no 0.8 tag exists on its git repo.

Considering only one package in HaikuPorts needs `cmd:cram` (the silver searcher, and only for its `TEST()`)... impact of these changes is pretty minimal.

(Will fix "the silver searcher"'s  recipe next).