### PR TITLE
the_silver_searcher: fix build, simplify TEST_REQUIRES

### DIFF
--- a/sys-apps/the_silver_searcher/the_silver_searcher-2.2.0.recipe
+++ b/sys-apps/the_silver_searcher/the_silver_searcher-2.2.0.recipe
@@ -10,25 +10,25 @@ parallel."
 HOMEPAGE="https://github.com/ggreer/the_silver_searcher/"
 COPYRIGHT="2013-2018 Geoff Greer"
 LICENSE="Apache v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/ggreer/the_silver_searcher/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="6a0a19ca5e73b2bef9481c29a508d2413ca1a0a9a5a6b1bd9bbd695a7626cbf9"
 SOURCE_FILENAME="the_silver_searcher-$portVersion.tar.gz"
 
 ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="x86"
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	SECONDARY_ARCHITECTURES="x86"
+fi
 
 # On x86_gcc2 we don't want to install the commands in bin/<arch>/, but in bin/.
-commandSuffix=$secondaryArchSuffix
 commandBinDir=$binDir
 if [ "$targetArchitecture" = x86_gcc2 ]; then
-    commandSuffix=
     commandBinDir=$prefix/bin
 fi
 
 PROVIDES="
 	the_silver_searcher$secondaryArchSuffix = $portVersion
-	cmd:ag$commandSuffix = $portVersion
+	cmd:ag = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -48,14 +48,13 @@ BUILD_PREREQUIRES="
 	cmd:autoconf
 	cmd:autoheader
 	cmd:automake
-	cmd:clang_format
 	cmd:make
 	cmd:gcc$secondaryArchSuffix
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
 TEST_REQUIRES="
-	cmd:cram2
+	cmd:cram
 	cmd:git
 	"
 
@@ -66,14 +65,16 @@ BUILD()
 	autoheader
 	automake --add-missing
 
+	# Avoid "multiple definition of" linking errors
+	export LDFLAGS="-z muldefs"
+	# We don't care if files are wrongly formatted, and this avoids a clang_format dependency.
+	export HAS_CLANG_FORMAT_FALSE=1
+
 	runConfigure --omit-dirs binDir ./configure \
 		--bindir=$commandBinDir
 
 	# Build fix, remove if solved
 	sed --in-place '/HAVE_FOPENCOOKIE/d' src/config.h
-
-	# Test fix
-	sed -i 's/cram/cram2/g' Makefile
 
 	make $jobArgs
 }


### PR DESCRIPTION
All tests pass using newely built `cmd:cram` (Python 3.9).