### PR TITLE
zstd, bump version, drop x86_gcc2

### DIFF
--- a/app-arch/zstd/patches/zstd-1.5.5-gcc2.patchset
+++ b/app-arch/zstd/patches/zstd-1.5.5-gcc2.patchset
@@ -1,0 +1,31 @@
+From 8117537ace9e497a4ae63c0f71ab13298e9a92e2 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Wed, 29 Sep 2021 17:14:40 -0400
+Subject: Various GCC2 fixes.
+
+
+diff --git a/lib/common/compiler.h b/lib/common/compiler.h
+index 73f8d01..a419389 100644
+--- a/lib/common/compiler.h
++++ b/lib/common/compiler.h
+@@ -142,7 +142,7 @@
+ /* vectorization
+  * older GCC (pre gcc-4.3 picked as the cutoff) uses a different syntax,
+  * and some compilers, like Intel ICC and MCST LCC, do not support it at all. */
+-#if !defined(__INTEL_COMPILER) && !defined(__clang__) && defined(__GNUC__) && !defined(__LCC__)
++#if !defined(__INTEL_COMPILER) && !defined(__clang__) && defined(__GNUC__) && (__GNUC__ >= 3) && !defined(__LCC__)
+ #  if (__GNUC__ == 4 && __GNUC_MINOR__ > 3) || (__GNUC__ >= 5)
+ #    define DONT_VECTORIZE __attribute__((optimize("no-tree-vectorize")))
+ #  else
+@@ -157,7 +157,7 @@
+  * If you can remove a LIKELY/UNLIKELY annotation without speed changes in gcc
+  * and clang, please do.
+  */
+-#if defined(__GNUC__)
++#if defined(__GNUC__) && (__GNUC__ >= 3)
+ #define LIKELY(x) (__builtin_expect((x), 1))
+ #define UNLIKELY(x) (__builtin_expect((x), 0))
+ #else
+-- 
+2.37.3
+

--- a/app-arch/zstd/patches/zstd-1.5.5.patchset
+++ b/app-arch/zstd/patches/zstd-1.5.5.patchset
@@ -1,0 +1,21 @@
+From 343d422acde80402cbd7730c74005e29a8f7fade Mon Sep 17 00:00:00 2001
+From: Begasus <begasus@gmail.com>
+Date: Fri, 26 May 2023 13:32:39 +0200
+Subject: Include stdio.h for FILE
+
+
+diff --git a/programs/util.h b/programs/util.h
+index 8234646..0404999 100644
+--- a/programs/util.h
++++ b/programs/util.h
+@@ -21,6 +21,7 @@ extern "C" {
+ ******************************************/
+ #include "platform.h"     /* PLATFORM_POSIX_VERSION, ZSTD_NANOSLEEP_SUPPORT, ZSTD_SETPRIORITY_SUPPORT */
+ #include <stddef.h>       /* size_t, ptrdiff_t */
++#include <stdio.h>   /* FILE */
+ #include <sys/types.h>    /* stat, utime */
+ #include <sys/stat.h>     /* stat, chmod */
+ #include "../lib/common/mem.h"          /* U64 */
+-- 
+2.37.3
+

--- a/app-arch/zstd/zstd-1.5.5.recipe
+++ b/app-arch/zstd/zstd-1.5.5.recipe
@@ -1,0 +1,160 @@
+SUMMARY="Zstandard, a fast real-time compression algorithm"
+SUMMARY_bin="Command line tools to compress/decompress .zst files"
+DESCRIPTION="Zstd, short for Zstandard, is a fast lossless compression \
+algorithm, targeting real-time compression scenarios at zlib-level and better \
+compression ratios. The zstd compression library provides in-memory \
+compression and decompression functions. It offers a very wide range of \
+compression / speed trade-off, while being backed by a very fast decoder. It \
+also offers a special mode for small data, called dictionary compression, and \
+can create dictionaries from any sample set."
+HOMEPAGE="https://facebook.github.io/zstd/"
+COPYRIGHT="2016-2023 Facebook, Inc.
+	Meta Platforms, Inc. and affiliates"
+LICENSE="BSD (2-clause)
+	GNU GPL v2"
+REVISION="1"
+SOURCE_URI="https://github.com/facebook/zstd/archive/v$portVersion.tar.gz"
+CHECKSUM_SHA256="98e9c3d949d1b924e28e01eccb7deed865eefebf25c2f21c702e5cd5b63b85e1"
+SOURCE_FILENAME="zstd-v$portVersion.tar.gz"
+PATCHES="zstd-$portVersion.patchset"
+if [ "$effectiveTargetArchitecture" = x86_gcc2 ]; then
+PATCHES="$PATCHES
+	zstd-$portVersion-gcc2.patchset
+	"
+fi
+
+ARCHITECTURES="all"
+SECONDARY_ARCHITECTURES="x86"
+
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ -n "$secondaryArchSuffix" ]; then
+# Comment out this block if you wish to co-install zstd_bin & e.g. zstd_x86_bin.
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+libVersion="$portVersion"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	zstd$secondaryArchSuffix = $portVersion
+	lib:libzstd$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+SUMMARY_bin="Command line tools to compress/decompress .zst files"
+PROVIDES_bin="
+	zstd${secondaryArchSuffix}_bin = $portVersion
+	cmd:unzstd$commandSuffix = $portVersion
+	cmd:zstd$commandSuffix = $portVersion
+	cmd:zstdcat$commandSuffix = $portVersion
+	cmd:zstdgrep$commandSuffix = $portVersion
+	cmd:zstdless$commandSuffix = $portVersion
+	cmd:zstdmt$commandSuffix = $portVersion
+	"
+if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+PROVIDES_bin="$PROVIDES_bin
+	cmd:pzstd$commandSuffix = $portVersion
+	"
+fi
+REQUIRES_bin="
+	haiku$secondaryArchSuffix
+	zstd$secondaryArchSuffix == $portVersion base
+	cmd:grep
+	cmd:less
+	lib:liblz4$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+REQUIRES_bin="$REQUIRES_bin
+	lib:liblzma$secondaryArchSuffix
+	"
+fi
+if [ -n "$secondaryArchSuffix" -a "$commandBinDir" = "$prefix"/bin ]; then
+CONFLICTS_bin="
+	zstd_bin
+	"
+fi
+
+PROVIDES_devel="
+	zstd${secondaryArchSuffix}_devel = $portVersion
+	devel:libzstd$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	zstd$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:liblz4$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+BUILD_REQUIRES="$BUILD_REQUIRES
+	devel:liblzma$secondaryArchSuffix
+	"
+fi
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:cmake
+	cmd:make
+	cmd:sed
+	cmd:find
+	"
+
+TEST_REQUIRES="
+	cmd:python3
+	"
+
+PATCH()
+{
+	# avoid error on tests without static libs, we use LD_LIBRARY_PATH
+	sed '/build static library to build tests/d' -i build/cmake/CMakeLists.txt
+	sed 's/libzstd_static/libzstd_shared/g' -i build/cmake/tests/CMakeLists.txt
+}
+
+BUILD()
+{
+	cmake -B bld -S build/cmake -DCMAKE_BUILD_TYPE=Release \
+		$cmakeDirArgs \
+		-DCMAKE_INSTALL_BINDIR=$commandBinDir \
+		-DZSTD_BUILD_STATIC=OFF \
+		-DZSTD_BUILD_TESTS=ON \
+		-DZSTD_PROGRAMS_LINK_SHARED=ON
+	make -C bld $jobArgs
+}
+
+INSTALL()
+{
+	make -C bld install
+
+	mkdir -p $docDir
+	cp doc/zstd_manual.html $docDir
+
+	prepareInstalledDevelLib libzstd
+	fixPkgconfig
+	fixCMake
+
+	sed "s|$libDir|$developLibDir|g" \
+		-i $developLibDir/cmake/zstd/zstdTargets-release.cmake
+
+	packageEntries bin \
+		$commandBinDir \
+		$manDir/man1
+
+	packageEntries devel \
+		$developDir \
+		$docDir/zstd_manual.html
+
+	rmdir $manDir
+
+	install -t $docDir -m 444 LICENSE
+}
+
+TEST()
+{
+	make -C bld test
+}


### PR DESCRIPTION
Maybe remove older recipes here too (only keep 1.5.2 for x86_gcc2)?

x86_gcc2 build fails with at least parse errors, didn't investigate further.