### PR TITLE
grpc: switch to Python 3.9, drop Python 2.x, fix provides/versions.

### DIFF
--- a/net-libs/grpc/grpc-1.53.0.recipe
+++ b/net-libs/grpc/grpc-1.53.0.recipe
@@ -6,7 +6,7 @@ connected systems."
 HOMEPAGE="https://grpc.io/"
 COPYRIGHT="2015-2023 The gRPC Authors"
 LICENSE="Apache v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/grpc/grpc/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="9717ffc52120861136e478155c2ff3a9c21740e2244de52fa966f376d7471adf"
 SOURCE_FILENAME="grpc-$portVersion.tar.gz"
@@ -19,10 +19,10 @@ PATCHES="grpc-$portVersion.patchset"
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="!x86"
 
-libVersion="29.0.0"
+libVersion="30.1.0"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
-libCppVersion="1.53"
-libCppVersionCompat="$libCppVersion compat >= ${libCppVersion%%.*}"
+libCppVersion=$portVersion
+libCppVersionCompat="$libCppVersion compat >= ${libCppVersion%.*}"
 
 PROVIDES="
 	grpc$secondaryArchSuffix = $portVersion
@@ -30,6 +30,7 @@ PROVIDES="
 	lib:libaddress_sorting$secondaryArchSuffix = $libVersionCompat
 	lib:libgpr$secondaryArchSuffix = $libVersionCompat
 	lib:libgrpc$secondaryArchSuffix = $libVersionCompat
+	lib:libgrpc_authorization_provider$secondaryArchSuffix = $libCppVersionCompat
 	lib:libgrpc_plugin_support$secondaryArchSuffix = $libCppVersionCompat
 	lib:libgrpc_unsecure$secondaryArchSuffix = $libVersionCompat
 	lib:libgrpc++$secondaryArchSuffix = $libCppVersionCompat
@@ -62,6 +63,8 @@ PROVIDES_devel="
 	devel:libaddress_sorting$secondaryArchSuffix = $libVersionCompat
 	devel:libgpr$secondaryArchSuffix = $libVersionCompat
 	devel:libgrpc$secondaryArchSuffix = $libVersionCompat
+	devel:libgrpc_authorization_provider$secondaryArchSuffix = $libCppVersionCompat
+	devel:libgrpc_plugin_support$secondaryArchSuffix = $libCppVersionCompat
 	devel:libgrpc_unsecure$secondaryArchSuffix = $libVersionCompat
 	devel:libgrpc++$secondaryArchSuffix = $libCppVersionCompat
 	devel:libgrpc++_alts$secondaryArchSuffix = $libCppVersionCompat
@@ -107,9 +110,8 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 TEST_REQUIRES="
-	cmd:python2
 	cmd:python3
-	six_python3
+	six_python39
 	"
 
 BUILD()
@@ -156,9 +158,20 @@ INSTALL()
 	unset -f cmake
 	cmake --install build
 
-	prepareInstalledDevelLibs libaddress_sorting libgpr libgrpc \
-		libgrpc_unsecure libgrpc++ libgrpc++_alts libgrpc++_error_details \
-		libgrpc++_reflection libgrpc++_unsecure libgrpcpp_channelz libupb
+	prepareInstalledDevelLibs \
+		libaddress_sorting \
+		libgpr \
+		libgrpc \
+		libgrpc_authorization_provider \
+		libgrpc_plugin_support \
+		libgrpc_unsecure \
+		libgrpc++ \
+		libgrpc++_alts \
+		libgrpc++_error_details \
+		libgrpc++_reflection \
+		libgrpc++_unsecure \
+		libgrpcpp_channelz \
+		libupb
 	fixPkgconfig
 
 	packageEntries devel \


### PR DESCRIPTION
* Added a missing PROVIDES, and a couple to PROVIDES_devel (both match now).
* Fixed libVersion/libCppVersion/libVersionCppCompat variables.
~* Use -DgRPC_BUILD_TESTS=OFF, as it makes the build require far less time/storage.~