### PR TITLE
ecl: fix build, update to 21.2.1, drop old versions

### DIFF
--- a/dev-lisp/ecl/ecl-21.2.1.recipe
+++ b/dev-lisp/ecl/ecl-21.2.1.recipe
@@ -9,11 +9,12 @@ COPYRIGHT="2015 Daniel Kochmański
 	1990, 1991, 1993 Giuseppe Attardi
 	1984 Taiichi Yuasa and Masami Hagiya"
 LICENSE="GNU LGPL v2.1"
-REVISION="4"
+REVISION="1"
 SOURCE_URI="https://common-lisp.net/project/ecl/static/files/release/ecl-$portVersion.tgz"
-CHECKSUM_SHA256="76a585c616e8fa83a6b7209325a309da5bc0ca68e0658f396f49955638111254"
+CHECKSUM_SHA256="b15a75dcf84b8f62e68720ccab1393f9611c078fcd3afdd639a1086cad010900"
+PATCHES="ecl-21.2.1.patchset"
 
-ARCHITECTURES="!all x86"
+ARCHITECTURES="!all x86_64 ?x86"
 SECONDARY_ARCHITECTURES="?x86"
 
 PROVIDES="
@@ -58,8 +59,7 @@ BUILD()
 		--with-dffi=system \
 		--enable-boehm=system
 
-	# doesn't work with $jobArgs
-	make
+	make $jobArgs
 }
 
 INSTALL()
@@ -73,6 +73,5 @@ INSTALL()
 
 TEST()
 {
-	# 2 tests fail, 1 crashes in FFI
 	make check
 }

--- a/dev-lisp/ecl/ecl-21.2.1.recipe
+++ b/dev-lisp/ecl/ecl-21.2.1.recipe
@@ -14,7 +14,7 @@ SOURCE_URI="https://common-lisp.net/project/ecl/static/files/release/ecl-$portVe
 CHECKSUM_SHA256="b15a75dcf84b8f62e68720ccab1393f9611c078fcd3afdd639a1086cad010900"
 PATCHES="ecl-21.2.1.patchset"
 
-ARCHITECTURES="!all x86_64 ?x86"
+ARCHITECTURES="all ?x86_gcc2"
 SECONDARY_ARCHITECTURES="?x86"
 
 PROVIDES="

--- a/dev-lisp/ecl/patches/ecl-21.2.1.patchset
+++ b/dev-lisp/ecl/patches/ecl-21.2.1.patchset
@@ -1,0 +1,38 @@
+From 4ec558acd7258fc6d722754d43a9a81256a701cc Mon Sep 17 00:00:00 2001
+From: Estevan Castilho <estevan.cps@gmail.com>
+Date: Sun, 28 May 2023 19:30:16 +0000
+Subject: Avoid conflicting bool definitions on Haiku
+
+On Haiku, link.h indirectly includes stdbool.h, causing bool to be
+defined to _Bool, which is incompatible with ecl's own expected
+definition of int. So we just unconditionally undef bool after
+including the necessary sytem headers, which is unlikely to cause much
+trouble in any case.
+
+diff --git a/src/c/ffi/libraries.d b/src/c/ffi/libraries.d
+index 5620988..5e0fd1f 100644
+--- a/src/c/ffi/libraries.d
++++ b/src/c/ffi/libraries.d
+@@ -44,9 +44,6 @@
+ # ifdef HAVE_DLFCN_H
+ #  include <dlfcn.h>
+ #  define INIT_PREFIX "init_fas_"
+-#  ifdef bool
+-#   undef bool
+-#  endif
+ # endif
+ # ifdef HAVE_MACH_O_DYLD_H
+ #  include <mach-o/dyld.h>
+@@ -64,6 +61,9 @@
+ # else
+ #  include <unistd.h>
+ # endif
++# ifdef bool
++#  undef bool
++# endif
+ #endif /* ENABLE_DLOPEN */
+ #include <ecl/ecl-inl.h>
+ #include <ecl/internal.h>
+-- 
+2.37.3
+


### PR DESCRIPTION
I've also reenabled parallel builds, as it seems to have been fixed in the meantime. Note I've kept TEST as-is, but I don't know how it's supposed to work, as ecl's `make check` expects ecl to already be installed in the system, which doesn't seem to be the case by the time haikuporter calls TEST.