### PR TITLE
ruby: add 3.2.2 (disabled)

### DIFF
--- a/dev-lang/ruby/patches/ruby-3.2.2.patchset
+++ b/dev-lang/ruby/patches/ruby-3.2.2.patchset
@@ -1,0 +1,27 @@
+From 7da8402f9742580188f62cabee8ba01eacb9151d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
+Date: Mon, 29 May 2023 02:09:14 -0600
+Subject: We don't allow unsetting O_NONBLOCK or O_NDELAY on packaged FS
+
+
+diff --git a/ruby.c b/ruby.c
+index c27f44e..537454e 100644
+--- a/ruby.c
++++ b/ruby.c
+@@ -2416,11 +2416,11 @@ open_load_file(VALUE fname_v, int *xflag)
+         /* open(2) may block if fname is point to FIFO and it's empty. Let's
+            use O_NONBLOCK. */
+         const int MODE_TO_LOAD = O_RDONLY | (
+-#if defined O_NONBLOCK && HAVE_FCNTL
++#if defined O_NONBLOCK && HAVE_FCNTL && !defined(__HAIKU__)
+         /* TODO: fix conflicting O_NONBLOCK in ruby/win32.h */
+             !(O_NONBLOCK & O_ACCMODE) ? O_NONBLOCK :
+ #endif
+-#if defined O_NDELAY && HAVE_FCNTL
++#if defined O_NDELAY && HAVE_FCNTL && !defined(__HAIKU__)
+             !(O_NDELAY & O_ACCMODE) ? O_NDELAY :
+ #endif
+             0);
+-- 
+2.39.2
+

--- a/dev-lang/ruby/ruby-3.2.2.recipe
+++ b/dev-lang/ruby/ruby-3.2.2.recipe
@@ -1,0 +1,137 @@
+SUMMARY="A programming language focused on simplicity and productivity"
+DESCRIPTION="Ruby is a dynamic, reflective, object-oriented, general-purpose \
+programming language. It was designed and developed in the mid-1990s \
+by Yukihiro 'Matz' Matsumoto in Japan.
+
+Ruby embodies syntax inspired by Perl with Smalltalk-like features and \
+was also influenced by Eiffel and Lisp. It supports multiple \
+programming paradigms, including functional, object oriented, and \
+imperative. It also has a dynamic type system and automatic memory \
+management. Therefore, it is similar in varying degrees to, Smalltalk, \
+Python, Perl, Lisp, Dylan, and CLU."
+HOMEPAGE="https://www.ruby-lang.org/"
+COPYRIGHT="1993-2023 Yukihiro Matsumoto"
+LICENSE="Ruby
+	BSD (3-clause)"
+REVISION="1"
+SOURCE_URI="https://cache.ruby-lang.org/pub/ruby/3.2/ruby-$portVersion.tar.gz"
+CHECKSUM_SHA256="96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc"
+SOURCE_DIR="ruby-$portVersion"
+PATCHES="ruby-$portVersion.patchset"
+ADDITIONAL_FILES="gemrc"
+
+ARCHITECTURES="?all !x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
+
+GLOBAL_WRITABLE_FILES="settings/gemrc keep-old"
+
+libVersion="$portVersion"
+libVersionCompat="$libVersion compat >= ${libVersion%.*}"
+
+PROVIDES="
+	ruby$secondaryArchSuffix = $libVersionCompat
+	cmd:bundle = $libVersionCompat
+	cmd:bundler = $libVersionCompat
+	cmd:erb = $libVersionCompat
+	cmd:gem = $libVersionCompat
+	cmd:irb = $libVersionCompat
+	cmd:racc = $libVersionCompat
+	cmd:racc2y = $libVersionCompat
+	cmd:rake = $libVersionCompat
+	cmd:rbs = $libVersionCompat
+	cmd:rdbg = $libVersionCompat
+	cmd:rdoc = $libVersionCompat
+	cmd:ri = $libVersionCompat
+	cmd:ruby = $libVersionCompat
+	cmd:testrb = $libVersionCompat
+	cmd:typeprof = $libVersionCompat
+	cmd:y2racc = $libVersionCompat
+	lib:libruby$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcrypto$secondaryArchSuffix
+	lib:libedit$secondaryArchSuffix
+	lib:libffi$secondaryArchSuffix
+	lib:libgdbm$secondaryArchSuffix
+	lib:libgmp$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libncursesw$secondaryArchSuffix
+	lib:libssl$secondaryArchSuffix
+	lib:libyaml_0$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	ruby${secondaryArchSuffix}_devel = $portVersion
+	devel:libruby$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	ruby$secondaryArchSuffix == $portVersion base
+	"
+
+PROVIDES_docs="
+	ruby${secondaryArchSuffix}_docs = $portVersion
+	"
+REQUIRES_docs="
+	ruby$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libcrypto$secondaryArchSuffix
+	devel:libedit$secondaryArchSuffix
+	devel:libffi$secondaryArchSuffix
+	devel:libgdbm$secondaryArchSuffix
+	devel:libgmp$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
+	devel:libncursesw$secondaryArchSuffix
+	devel:libssl$secondaryArchSuffix
+	devel:libyaml_0$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:bison
+	cmd:g++$secondaryArchSuffix
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+defineDebugInfoPackage ruby$secondaryArchSuffix \
+	"$libDir"/libruby.so.$libVersion
+
+BUILD()
+{
+	export CFLAGS="-D_BSD_SOURCE"
+
+	runConfigure --omit-dirs binDir ./configure \
+		--bindir=$prefix/bin \
+		--enable-shared \
+		--enable-debug-env \
+		--with-ridir=$docDir/ri \
+		--with-dbm-type=gdbm_compat
+
+	# The build process needs to run ruby, and without this it fails to find
+	# libruby.so.
+	export LIBRARY_PATH=$LIBRARY_PATH:%A
+	make $jobArgs
+}
+
+INSTALL()
+{
+	export LIBRARY_PATH=$LIBRARY_PATH:%A
+	make install
+	prepareInstalledDevelLib libruby
+	fixPkgconfig
+	packageEntries devel $developDir
+	packageEntries docs $docDir/ri
+	cp -f $portDir/additional-files/gemrc $settingsDir/gemrc
+}
+
+TEST()
+{
+	export LIBRARY_PATH=$LIBRARY_PATH:%A
+	make check
+}

--- a/dev-lang/ruby/ruby-3.2.2.recipe
+++ b/dev-lang/ruby/ruby-3.2.2.recipe
@@ -20,8 +20,8 @@ SOURCE_DIR="ruby-$portVersion"
 PATCHES="ruby-$portVersion.patchset"
 ADDITIONAL_FILES="gemrc"
 
-ARCHITECTURES="?all !x86_gcc2"
-SECONDARY_ARCHITECTURES="?x86"
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 GLOBAL_WRITABLE_FILES="settings/gemrc keep-old"
 
@@ -104,8 +104,8 @@ defineDebugInfoPackage ruby$secondaryArchSuffix \
 
 BUILD()
 {
-	export CFLAGS="-D_BSD_SOURCE"
-
+	CFLAGS="-D_BSD_SOURCE" \
+	LDFLAGS="-lbsd" \
 	runConfigure --omit-dirs binDir ./configure \
 		--bindir=$prefix/bin \
 		--enable-shared \


### PR DESCRIPTION
The port appears to be working as well as the ruby-2.7 version but I haven't tried to run the test suite.  I'm not sure if we want to go the same path as the python recipes and call this one `ruby32-3.2.2.recipe` since there are very few things using ruby and most of them will probably support 3.x.  The [Arch package information](https://archlinux.org/packages/extra/x86_64/ruby2.7/) only shows a couple of things depending on 2.x