### PR TITLE
u_boot: switch to Python 3.9, add missing PATCHES.

### DIFF
--- a/sys-boot/u-boot/u_boot-2022.04.rc3.recipe
+++ b/sys-boot/u-boot/u_boot-2022.04.rc3.recipe
@@ -23,7 +23,7 @@ SOURCE_DIR="u-boot-2022.04-rc3"
 CHECKSUM_SHA256="4731da5228dc35827a9d9ebc8f541b01aa6af36c27be24e10aff06e596bee2de"
 PATCHES="u_boot-2022.04.rc3.patchset"
 
-ARCHITECTURES="!any"
+ARCHITECTURES="any"
 
 PROVIDES="
 	u_boot$secondaryArchSuffix = $portVersion


### PR DESCRIPTION
* ~64 bits: no package provides: cmd:arm_none_eabi_gcc.~ builds OK now.
* 32 bits: errors related to:
  * "runtime_loader: Cannot open file libmpfr.so.4"
  * "Kconfig:66: syntax error" and " Kconfig:65: invalid option".

~Marking as broken until those get resolved.~