### PR TITLE
chocolate_doom: recipe cleanups.

### DIFF
--- a/games-fps/chocolate-doom/chocolate_doom-3.0.1.recipe
+++ b/games-fps/chocolate-doom/chocolate_doom-3.0.1.recipe
@@ -8,26 +8,29 @@ COPYRIGHT="Id Software Inc. 1993-1996
 	James Haley
 	Samuel Villarreal"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://www.chocolate-doom.org/downloads/$portVersion/chocolate-doom-$portVersion.tar.gz"
 CHECKSUM_SHA256="d435d6177423491d60be706da9f07d3ab4fabf3e077ec2a3fc216e394fcfc8c7"
 SOURCE_DIR="chocolate-doom-$portVersion"
 
-ARCHITECTURES="all !x86_gcc2 ?x86"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="all !x86_gcc2"
+if [ $targetArchitecture == x86_gcc2 ]; then
+	SECONDARY_ARCHITECTURES="x86"
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
 
 PROVIDES="
 	chocolate_doom$secondaryArchSuffix = $portVersion
-	cmd:chocolate_doom$secondaryArchSuffix = $portVersion
-	cmd:chocolate_doom_setup$secondaryArchSuffix = $portVersion
-	cmd:chocolate_heretic$secondaryArchSuffix = $portVersion
-	cmd:chocolate_heretic_setup$secondaryArchSuffix = $portVersion
-	cmd:chocolate_hexen$secondaryArchSuffix = $portVersion
-	cmd:chocolate_hexen_setup$secondaryArchSuffix = $portVersion
-	cmd:chocolate_server$secondaryArchSuffix = $portVersion
-	cmd:chocolate_setup$secondaryArchSuffix = $portVersion
-	cmd:chocolate_strife$secondaryArchSuffix = $portVersion
-	cmd:chocolate_strife_setup$secondaryArchSuffix = $portVersion
+	cmd:chocolate_doom = $portVersion
+	cmd:chocolate_doom_setup = $portVersion
+	cmd:chocolate_heretic = $portVersion
+	cmd:chocolate_heretic_setup = $portVersion
+	cmd:chocolate_hexen = $portVersion
+	cmd:chocolate_hexen_setup = $portVersion
+	cmd:chocolate_server = $portVersion
+	cmd:chocolate_strife = $portVersion
+	cmd:chocolate_strife_setup = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -49,35 +52,52 @@ BUILD_REQUIRES="
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	python_imaging
 	cmd:awk
 	cmd:gcc$secondaryArchSuffix
 	cmd:install
 	cmd:ld$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:python
+	# Uncomment when updating to chocolate_doom > 3.0.1
+	# cmd:python3
 	cmd:sed
 	"
 
+defineDebugInfoPackage chocolate_doom$secondaryArchSuffix \
+	$commandBinDir/chocolate-doom \
+	$commandBinDir/chocolate-doom-setup \
+	$commandBinDir/chocolate-hexen \
+	$commandBinDir/chocolate-hexen-setup \
+	$commandBinDir/chocolate-heretic \
+	$commandBinDir/chocolate-heretic-setup \
+	$commandBinDir/chocolate-server \
+	$commandBinDir/chocolate-strife-setup \
+	$commandBinDir/chocolate-strife
+
+
 BUILD()
 {
-	runConfigure ./configure
+	# Avoid "multiple definition" linker errors under "src/hexen/"
+	export LDFLAGS="-z muldefs"
+
+	# "__dummy__" is just a placeholder, because the makefiles use "$docdir/../chocolate_xxx"
+	docdir=$prefix/documentation/packages/chocolate_doom/__dummy__
+
+	runConfigure --omit-dirs "binDir docDir" ./configure \
+		--bindir=$commandBinDir \
+		--docdir=$docdir
+		# Option available only on versions > 3.0.1, and with cmd:python3 available
+		# --with-bashcompletiondir=$dataDir/bash-completion/completions
+
 	make $jobArgs
 }
 
 INSTALL()
 {
-	cd src
-	mkdir -p $binDir
-	cp chocolate-doom \
-		chocolate-doom-setup \
-		chocolate-hexen \
-		chocolate-hexen-setup \
-		chocolate-heretic \
-		chocolate-heretic-setup \
-		chocolate-server \
-		chocolate-setup \
-		chocolate-strife-setup \
-		chocolate-strife $binDir
+	# Other install targets are: install-man install-data. Recheck when updating to > 3.0.1
+	make install install-exec
+
+	# clean-up
+	rm -rf $prefix/share
+	rm -rf $prefix/documentation/packages/chocolate_doom/__dummy__
 }


### PR DESCRIPTION
* Drop usage of Python 2.x.
* Drop python_imaging dependency.
* Drop _x86 suffixes.
* Include basic docs.
* Create _debuginfo package.

Python dependency is optional, needed for generating man pages, for example.

Those weren't included before, and to switch to Python 3, we need to update to newer versions of chocolate_doom (no new release > 3.0.1 yet), so just drop that requirement.

"python_imaging" can be replaced by "pillow" (which supports python3), but it is really only needed to re-create font files, or convert icons.

Neither is strictly needed when building under Haiku.

Instead if providing a _debuginfo package, we might want to just strip the binaries ("make install-exec-strip").