### PR TITLE
argon2_cffi_bindings: recipe cleanups.

### DIFF
--- a/dev-python/argon2-cffi-bindings/argon2_cffi_bindings-21.2.0.recipe
+++ b/dev-python/argon2-cffi-bindings/argon2_cffi_bindings-21.2.0.recipe
@@ -5,7 +5,7 @@ HOMEPAGE="https://pypi.org/project/argon2-cffi-bindings/
 	https://github.com/hynek/argon2-cffi-bindings/"
 COPYRIGHT="2021 Hynek Schlawack"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 pypi="184b8ccce6683b0aa2fbb7ba5683ea4b9c5763f1356347f1312c32e3c66e"
 SOURCE_URI="https://files.pythonhosted.org/packages/b9/e9/$pypi/argon2-cffi-bindings-$portVersion.tar.gz"
 CHECKSUM_SHA256="bb89ceffa6c791807d1305ceb77dbfacc5aa499891d2c55661c6459651fc39e3"
@@ -36,42 +36,49 @@ BUILD_PREREQUIRES="
 PYTHON_PACKAGES=(python39 python310)
 PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\n\
-	cffi${secondaryArchSuffix}_$pythonPackage\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	pip_$pythonPackage
-	setuptools_scm_$pythonPackage
-	wheel_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_$pythonPackage+=\"
+			argon2_cffi_bindings_$pythonPackage = $portVersion
+			\""
+	fi
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cffi${secondaryArchSuffix}_$pythonPackage
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		cffi${secondaryArchSuffix}_$pythonPackage
+		build_$pythonPackage
+		installer_$pythonPackage
+		setuptools_scm_$pythonPackage
+		wheel_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()
 {
-	export SETUPTOOLS_SCM_PRETEND_VERSION=$portVersion
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		export ARGON2_CFFI_USE_SYSTEM=1
+	export ARGON2_CFFI_USE_SYSTEM=1
 
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_PACKAGES[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
 
 		python=python$pythonVersion
-		installLocation=$prefix/lib/$python/vendor-packages/
-		export PYTHONPATH=$installLocation:$PYTHONPATH
-		mkdir -p $installLocation
-		rm -rf build
-		$python setup.py build install \
-			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		rm -rf dist
+
+		$python -m build --wheel --skip-dependency-check --no-isolation
+		$python -m installer --p $prefix dist/*.whl
+
+		packageEntries ${PYTHON_PACKAGES[i]} \
 			$prefix/lib/python*
 	done
 }


### PR DESCRIPTION
* Build with build/installer.
* Provide "non _x86" package name.
* Remove unneded \n scaping.