### PR TITLE
dukpy: recipe clean ups.

### DIFF
--- a/dev-python/dukpy/dukpy-0.3.recipe
+++ b/dev-python/dukpy/dukpy-0.3.recipe
@@ -5,13 +5,13 @@ With dukpy, you can run JavaScript in Python."
 HOMEPAGE="https://github.com/kovidgoyal/dukpy"
 COPYRIGHT="2007-2019 Ian Bicking and contributors"
 LICENSE="GNU LGPL v3"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://github.com/kovidgoyal/dukpy/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="cc78c39ebba51f381c623b164cfb7dcf3caddf515fe7094bc53b7eca5d4e435e"
 SOURCE_FILENAME="$portName-v$portVersion.tar.gz"
 
 ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="?x86"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	$portName = $portVersion
@@ -30,19 +30,27 @@ BUILD_PREREQUIRES="
 PYTHON_PACKAGES=(python38 python39)
 PYTHON_VERSIONS=(3.8 3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_$pythonPackage+=\"
+			dukpy_$pythonPackage = $portVersion
+			\""
+	fi
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()


### PR DESCRIPTION
* Enable recipe for 32 bits.
* Provide "non _x86" package name.
* Remove unneeded \n escaping.