### PR TITLE
psutil, pycurl: provide "non _x86" package name.

### DIFF
--- a/dev-python/psutil/psutil-5.6.7.recipe
+++ b/dev-python/psutil/psutil-5.6.7.recipe
@@ -42,6 +42,11 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 	eval "PROVIDES_${pythonPackage}=\"
 		${portName}_$pythonPackage = $portVersion
 		\""
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_$pythonPackage+=\"
+			psutil_$pythonPackage = $portVersion
+			\""
+	fi
 	eval "REQUIRES_$pythonPackage=\"
 		haiku$secondaryArchSuffix
 		cmd:python$pythonVersion

--- a/dev-python/pycurl/pycurl-7.45.2.recipe
+++ b/dev-python/pycurl/pycurl-7.45.2.recipe
@@ -10,7 +10,7 @@ COPYRIGHT="2001-2008 Kjetil Jacobsen
 	2013-2018 Oleg Pudeyev"
 LICENSE="GNU LGPL v2.1
 	MIT"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://github.com/pycurl/pycurl/archive/REL_${portVersion//./_}.tar.gz"
 CHECKSUM_SHA256="1aaaf415a5affe141593b3edf6ce187a79d99fbeb65c0b18490b03edc606394c"
 SOURCE_DIR="pycurl-REL_${portVersion//./_}"
@@ -47,6 +47,11 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 	eval "PROVIDES_${pythonPackage}=\"
 		${portName}_$pythonPackage = $portVersion
 		\""
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_$pythonPackage+=\"
+			pycurl_$pythonPackage = $portVersion
+			\""
+	fi
 	eval "REQUIRES_$pythonPackage=\"
 		haiku$secondaryArchSuffix
 		lib:libcrypto$secondaryArchSuffix


### PR DESCRIPTION
The psutil recipe remains disabled (so no rev-bump there).