### PR TITLE
pyopenssl: switch to "any" arch, add Python 3.10

### DIFF
--- a/dev-python/pyopenssl/pyopenssl-22.0.0.recipe
+++ b/dev-python/pyopenssl/pyopenssl-22.0.0.recipe
@@ -10,42 +10,43 @@ HOMEPAGE="https://github.com/pyca/pyopenssl
 COPYRIGHT="2008-2022 The pyOpenSSL developers"
 LICENSE="Apache v2
 	BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/pyca/pyopenssl/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="4e92f6c2f08a8d1f0d9695335037a3d50ef8f58cd326514b89104acb9abb2838"
 SOURCE_FILENAME="pyopenssl-$portVersion.tar.gz"
 
-ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="any"
 
 PROVIDES="
 	$portName = $portVersion
 	"
 REQUIRES="
-	haiku$secondaryArchSuffix
+	haiku
 	"
 
 BUILD_REQUIRES="
-	haiku${secondaryArchSuffix}_devel
+	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python38 python39 python310)
+PYTHON_VERSIONS=(3.8 3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_$pythonPackage=\"
-	${portName}_$pythonPackage = $portVersion
-	\""
-eval "REQUIRES_$pythonPackage=\"
-	haiku$secondaryArchSuffix
-	cryptography${secondaryArchSuffix}_$pythonPackage
-	six_$pythonPackage
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_$pythonPackage=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cryptography_$pythonPackage
+		\""
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()


### PR DESCRIPTION
I guess this could use REPLACES, at least for 32 bits, but I didn't find anything in-tree actually requiring `pyopenssl`, so I think we can do without it.