### PR TITLE
qrcode: switch to "any" arch, recipe cleanups.

### DIFF
--- a/dev-python/qrcode/qrcode-7.2.recipe
+++ b/dev-python/qrcode/qrcode-7.2.recipe
@@ -73,10 +73,10 @@ INSTALL()
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		mv $prefix/bin/qr $prefix/bin/qr-$pythonVersion
+		mv $binDir/qr $binDir/qr-$pythonVersion
 		# Provide suffix-less symlinks for the default version:
 		if [ $pythonVersion = $defaultVersion ]; then
-			ln -sr $prefix/bin/qr-$pythonVersion $prefix/bin/qr
+			ln -sr $binDir/qr-$pythonVersion $binDir/qr
 		fi
 
 		mkdir -p $(dirname $manDir)


### PR DESCRIPTION
This is a pure-python package, and now that `pillow` also provides a "non _x86" package name, we can use "any" for this one.