### PR TITLE
pymupdf: cleanups, provide "non _x86" package name.

### DIFF
--- a/dev-python/pymupdf/pymupdf-1.20.2.recipe
+++ b/dev-python/pymupdf/pymupdf-1.20.2.recipe
@@ -10,10 +10,10 @@ HOMEPAGE="https://pypi.org/project/PyMuPDF/
 	https://github.com/pymupdf/PyMuPDF/"
 COPYRIGHT="2022 Jorj X. McKie and Ruikai Liu"
 LICENSE="AGPL-3.0"
-REVISION="2"
-pypi="4a/09/6afe87a8ea7acb6e4709223a704270ffe9929497add4d06b12305e229ba8"
-SOURCE_URI="https://files.pythonhosted.org/packages/$pypi/PyMuPDF-$portVersion.tar.gz"
-CHECKSUM_SHA256="02eedf01f57c6bafb5e8667cea0088a2d2522643c47100f1908bec3a68a84888"
+REVISION="3"
+SOURCE_URI="https://github.com/pymupdf/PyMuPDF/archive/refs/tags/$portVersion.tar.gz"
+CHECKSUM_SHA256="e639e5190067bc3ff599ffb09bfad7da0165c0098fe42ddc1a849715904b0ee0"
+SOURCE_FILENAME="PyMuPDF-$portVersion.tar.gz"
 SOURCE_DIR="PyMuPDF-$portVersion"
 PATCHES="pymupdf-$portVersion.patchset"
 
@@ -41,21 +41,29 @@ BUILD_PREREQUIRES="
 PYTHON_PACKAGES=(python38 python39 python310)
 PYTHON_VERSIONS=(3.8 3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\n\
-	lib:libmupdf$secondaryArchSuffix\n\
-	lib:libfreetype$secondaryArchSuffix\n\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_$pythonPackage+=\"
+			pymupdf_$pythonPackage = $portVersion
+			\""
+	fi
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cmd:python$pythonVersion
+		lib:libmupdf$secondaryArchSuffix
+		lib:libfreetype$secondaryArchSuffix
+		\""
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()


### PR DESCRIPTION
Also: switch SOURCE_URI to github. The tarball there is 7.28 MB, versus the previous 86.25 MB (due to the inclusion of mupdf.tar.gz, which we don't need here, and weights 84.36 MB).