### PR TITLE
twisted: swith to "any" arch, recipe clean ups.

### DIFF
--- a/dev-python/twisted/twisted-22.8.0.recipe
+++ b/dev-python/twisted/twisted-22.8.0.recipe
@@ -22,76 +22,86 @@ Twisted-based code."
 HOMEPAGE="https://twistedmatrix.com"
 COPYRIGHT="2001-2022 Twisted project members"
 LICENSE="MIT"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/twisted/twisted/archive/twisted-$portVersion.tar.gz"
 CHECKSUM_SHA256="3d17049da4b7c66b11359ff29eeea103ef8356f2aec2e4fc3d78c1920fc622a1"
 SOURCE_DIR="twisted-twisted-$portVersion"
 
-ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="any"
 
 PROVIDES="
 	$portName = $portVersion
 	"
 REQUIRES="
-	haiku$secondaryArchSuffix
+	haiku
 	"
 
 BUILD_REQUIRES="
-	haiku${secondaryArchSuffix}_devel
+	haiku_devel
 	"
-BUILD_PREREQUIRES="
-	cmd:gcc$secondaryArchSuffix
-	"
+
 PYTHON_PACKAGES=(python39 python310)
 PYTHON_VERSIONS=(3.9 3.10)
+defaultVersion=3.9
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku$secondaryArchSuffix\n\
-	cmd:python$pythonVersion\n\
-	attrs_$pythonPackage\n\
-	automat_$pythonPackage\n\
-	bcrypt_$pythonPackage\n\
-	constantly_$pythonPackage\n\
-	cryptography_$pythonPackage\n\
-	hyperlink_$pythonPackage\n\
-	incremental_$pythonPackage\n\
-	zope_interface_$pythonPackage\n\
-	\""
-if [ "$targetArchitecture" = "x86_gcc2" ]; then
-	eval "PROVIDES_${pythonPackage}+=\"\n\
-		twisted_$pythonPackage = $portVersion\
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_$pythonPackage=\"
+		${portName}_$pythonPackage = $portVersion
+		cmd:cftp_$pythonVersion = $portVersion
+		cmd:ckeygen_$pythonVersion = $portVersion
+		cmd:conch_$pythonVersion = $portVersion
+		cmd:mailmail_$pythonVersion = $portVersion
+		cmd:manhole_$pythonVersion = $portVersion
+		cmd:pyhtmlizer_$pythonVersion = $portVersion
+		cmd:tap2deb_$pythonVersion = $portVersion
+		cmd:tap2rpm_$pythonVersion = $portVersion
+		cmd:tkconch_$pythonVersion = $portVersion
+		cmd:trial_$pythonVersion = $portVersion
+		cmd:twist_$pythonVersion = $portVersion
+		cmd:twistd_$pythonVersion = $portVersion
 		\""
-fi
-BUILD_REQUIRES="$BUILD_REQUIRES
-	incremental_$pythonPackage
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	# Provide non-suffixed cmd only for the default Python version
+	if [ $pythonVersion = $defaultVersion ]; then
+		eval "PROVIDES_$pythonPackage+=\"
+			cmd:cftp = $portVersion
+			cmd:ckeygen = $portVersion
+			cmd:conch = $portVersion
+			cmd:mailmail = $portVersion
+			cmd:manhole = $portVersion
+			cmd:pyhtmlizer = $portVersion
+			cmd:tap2deb = $portVersion
+			cmd:tap2rpm = $portVersion
+			cmd:tkconch = $portVersion
+			cmd:trial = $portVersion
+			cmd:twist = $portVersion
+			cmd:twistd = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		attrs_$pythonPackage
+		automat_$pythonPackage
+		bcrypt_$pythonPackage
+		constantly_$pythonPackage
+		cryptography_$pythonPackage
+		hyperlink_$pythonPackage
+		incremental_$pythonPackage
+		typing_extensions_$pythonPackage
+		zope_interface_$pythonPackage
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		incremental_$pythonPackage
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
-for i in "${!PYTHON_VERSIONS[@]}"; do
-pyVer=${PYTHON_VERSIONS[i]//.} # remove dot from version
-eval "PROVIDES_python${pyVer}+=\"\n\
-	cmd:cftp$pyVer\n\
-	cmd:ckeygen$pyVer\n\
-	cmd:conch$pyVer\n\
-	cmd:mailmail$pyVer\n\
-	cmd:manhole$pyVer\n\
-	cmd:pyhtmlizer$pyVer\n\
-	cmd:tap2deb$pyVer\n\
-	cmd:tap2rpm$pyVer\n\
-	cmd:tkconch$pyVer\n\
-	cmd:trial$pyVer\n\
-	cmd:twist$pyVer\n\
-	cmd:twistd$pyVer\n\
-	\""
-done
 
 INSTALL()
 {
@@ -102,15 +112,24 @@ INSTALL()
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		pyVer=${pythonVersion//.}
-		for f in $prefix/bin/*; do
-			mv $f ${f}$pyVer
+		# Version suffix all the scripts
+		for f in $binDir/*; do
+			mv $f $f-$pythonVersion
 		done
+
+		# And provide suffix-less symlinks for the default version
+		if [ $pythonVersion = $defaultVersion ]; then
+			for f in $binDir/*; do
+				ln -sr $f ${f%-$pythonVersion}
+			done
+		fi
 
 		install -m 755 -d "$docDir"
 		install -m 644 -t "$docDir" README.rst


### PR DESCRIPTION
* Remove some clutter.
* Provide non-suffixed "cmd:"s for default Python version.
* Drop unnecessary gcc BUILD_PREQUIRES, and switch recipe to "any".
* Add missing typing_extensions dependency.

All "cmd:" now work at least with "--version" parameter, except for `tkconch`, that deadlocks (known issue for Python + Tk: #6967).