### PR TITLE
retawq: new recipe

### DIFF
--- a/www-client/retawq/patches/retawq-0.2.6c.patchset
+++ b/www-client/retawq/patches/retawq-0.2.6c.patchset
@@ -1,0 +1,22 @@
+From 8f6c95fdbceb74688cae88aa2b4ce00a392db55f Mon Sep 17 00:00:00 2001
+From: Al Hoang <13622+hoanga@users.noreply.github.com>
+Date: Sat, 24 Jun 2023 06:38:41 +0000
+Subject: use RAND_bytes
+
+
+diff --git a/resource.c b/resource.c
+index fe90825..b835040 100644
+--- a/resource.c
++++ b/resource.c
+@@ -2271,7 +2271,7 @@ static one_caller tBoolean tls_initialize(void)
+         my_spf_cleanup(debugstrbuf, spfbuf);
+       }
+ #endif
+-      if (RAND_egd(seedfilename) >= 0) goto rand_finish;
++      if (RAND_bytes(seedfilename, 255) >= 0) goto rand_finish;
+       debugmsg("TLS: random D\n");
+       (void) RAND_load_file(seedfilename, -1);
+         /* ("-1" is allowed for OpenSSL >= 0.9.5) */
+-- 
+2.37.3
+

--- a/www-client/retawq/retawq-0.2.6c.recipe
+++ b/www-client/retawq/retawq-0.2.6c.recipe
@@ -1,0 +1,46 @@
+SUMMARY="A multi-threaded text-based web browser"
+DESCRIPTION="an interactive, multi-threaded network client (web browser) for text \
+terminals on computers with Unix-like operating systems."
+HOMEPAGE="https://retawq.sourceforge.net/"
+COPYRIGHT="2006 Arne Thomassen"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="http://prdownloads.sourceforge.net/retawq/retawq-$portVersion.tar.gz"
+CHECKSUM_SHA256="a42e82494f00e054c2de1b065bbc8fb439d93eb69f9b97cc4868e71e48a9eae0"
+PATCHES="retawq-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	retawq$secondaryArchSuffix = $portVersion
+	cmd:retawq = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libssl$secondaryArchSuffix
+	lib:libncurses$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libssl$secondaryArchSuffix
+	devel:libncurses${secondaryArchSuffix}
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config
+	"
+
+BUILD()
+{
+	LDFLAGS="-lnetwork " ./configure --set-tls=2
+	make
+}
+
+INSTALL()
+{
+	mkdir -p $binDir
+	cp -pv retawq $binDir/
+}

--- a/www-client/retawq/retawq-0.2.6c.recipe
+++ b/www-client/retawq/retawq-0.2.6c.recipe
@@ -9,7 +9,7 @@ SOURCE_URI="http://prdownloads.sourceforge.net/retawq/retawq-$portVersion.tar.gz
 CHECKSUM_SHA256="a42e82494f00e054c2de1b065bbc8fb439d93eb69f9b97cc4868e71e48a9eae0"
 PATCHES="retawq-$portVersion.patchset"
 
-ARCHITECTURES="all !x86_gcc2"
+ARCHITECTURES="all"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="

--- a/www-client/retawq/retawq-0.2.6c.recipe
+++ b/www-client/retawq/retawq-0.2.6c.recipe
@@ -1,5 +1,5 @@
 SUMMARY="A multi-threaded text-based web browser"
-DESCRIPTION="an interactive, multi-threaded network client (web browser) for text \
+DESCRIPTION="An interactive, multi-threaded network client (web browser) for text \
 terminals on computers with Unix-like operating systems."
 HOMEPAGE="https://retawq.sourceforge.net/"
 COPYRIGHT="2006 Arne Thomassen"
@@ -18,24 +18,24 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libssl$secondaryArchSuffix
 	lib:libncurses$secondaryArchSuffix
+	lib:libssl$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libssl$secondaryArchSuffix
 	devel:libncurses${secondaryArchSuffix}
+	devel:libssl$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
-	cmd:pkg_config
+	cmd:pkg_config$secondaryArchSuffix
 	"
 
 BUILD()
 {
-	LDFLAGS="-lnetwork " ./configure --set-tls=2
+	LDFLAGS="-lnetwork -lssl" ./configure --set-tls=2
 	make
 }
 


### PR DESCRIPTION
the following recipe adds support for [retawq](https://retawq.sourceforge.net/)



```
> uname -a
Haiku shredder 1 hrev57104 Jun 22 2023 06:25:10 x86_64 x86_64 Haiku

> retawq --version
retawq 0.2.6c - Copyright (C) 2001-2006 Arne Thomassen <arne@arne-thomassen.de>
retawq is basically released under certain versions of the
GNU General Public License and WITHOUT ANY WARRANTY.
The project home page is <http://retawq.sourceforge.net/>.
```