### PR TITLE
Add Ken's Labyrinth (LAB3D-SDL)

### DIFF
--- a/games-fps/lab3d/additional-files/lab3d-3.0.1.rdef.in
+++ b/games-fps/lab3d/additional-files/lab3d-3.0.1.rdef.in
@@ -1,0 +1,13 @@
+resource app_signature "@APP_SIGNATURE@";
+
+resource app_flags B_SINGLE_LAUNCH;
+
+resource app_version {
+	major  = @MAJOR@,
+	middle = @MIDDLE@,
+	minor  = @MINOR@,
+	variety = B_APPV_DEVELOPMENT,
+	internal = 0,
+	short_info = "Ken's Labyrinth",
+	long_info = "@LONG_INFO@"
+};

--- a/games-fps/lab3d/lab3d-3.0.1.recipe
+++ b/games-fps/lab3d/lab3d-3.0.1.recipe
@@ -1,0 +1,89 @@
+SUMMARY="A port of Ken's Labyrinth to modern systems"
+DESCRIPTION="LAB3D is a port of Ken's Labyrinth to modern operating systems, using OpenGL \
+for 3D accelerated graphics output and the SDL library to provide user input, sound output, \
+threading, unaccelerated graphics and some graphics support functions. Music output is through \
+Adlib emulation (recommended) or MIDI (MIDI only on Windows, Linux and other operating systems \
+with OSS-compatible sound APIs).
+
+As this program is provided for free, neither Ken Silverman nor Jan Lönnberg take any \
+responsibility for any effects, adverse or otherwise, resulting from the use of this program.
+
+Current version: 3.0.1 (16/12/2013).
+
+Improvements over the original Ken's Labyrinth:
+
+- Runs natively on 32-bit and 64-bit Windows or Linux (and possibly some similar systems).
+- Uses OpenGL to provide hardware accelerated, anti-aliased graphics with trilinear interpolation in true colour (where available).
+- Multiple simultaneous sound effects in stereo.
+- Many bug fixes."
+HOMEPAGE="http://icculus.org/LAB3D/"
+COPYRIGHT="1992-1993 Ken Silverman
+	2002-2014 Jan Lönnberg"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="http://icculus.org/LAB3D/LAB3D-SDL-$portVersion.tar.gz"
+CHECKSUM_SHA256="67b4bf5c5691e83ea7ac20221f8c03f6fb9a205ff6ef77f3cb70ecfa32c35738"
+SOURCE_URI_2="http://advsys.net/ken/klab/labfull.zip"
+CHECKSUM_SHA256_2="643aa0ca8d1a7d2c88afecd952da00f3b912be8b83c4c1d2f4ab9b50491fadfd"
+SOURCE_DIR="LAB3D-SDL-$portVersion"
+ADDITIONAL_FILES="lab3d-$portVersion.rdef.in"
+PATCHES="lab3d-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	KensLabyrinth$secondaryArchSuffix = $portVersion
+	app:KensLabyrinth
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libGL$secondaryArchSuffix
+	lib:libGLU$secondaryArchSuffix
+	lib:libSDL$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libGL$secondaryArchSuffix
+	devel:libGLU$secondaryArchSuffix
+	devel:libSDL$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	"
+
+BUILD()
+{
+	cd $sourceDir
+	make $jobArgs -f Makefile.Unix
+}
+
+INSTALL()
+{
+	local APP_SIGNATURE="application/x-vnd.LAB3D"
+	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
+	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
+	local MINOR="`echo "$portVersion" | cut -d. -f3`"
+	local LONG_INFO="$SUMMARY"
+	sed \
+		-e "s|@APP_SIGNATURE@|$APP_SIGNATURE|" \
+		-e "s|@MAJOR@|$MAJOR|" \
+		-e "s|@MIDDLE@|$MIDDLE|" \
+		-e "s|@MINOR@|$MINOR|" \
+		-e "s|@LONG_INFO@|$LONG_INFO|" \
+		$portDir/additional-files/lab3d-$portVersion.rdef.in > lab3d-$portVersion.rdef
+
+	addResourcesToBinaries lab3d-$portVersion.rdef $sourceDir/ken
+	mimeset -f $sourceDir/ken
+
+	mkdir -p $appsDir/KensLabyrinth
+	cp -a $sourceDir/ken $appsDir/KensLabyrinth/KensLabyrinth
+
+	cp -a $sourceDir2/* $appsDir/KensLabyrinth/
+	cp -a $sourceDir/ken.bmp $appsDir/KensLabyrinth/ken.bmp
+
+	addAppDeskbarSymlink $appsDir/KensLabyrinth/KensLabyrinth
+}

--- a/games-fps/lab3d/lab3d-3.0.1.recipe
+++ b/games-fps/lab3d/lab3d-3.0.1.recipe
@@ -81,8 +81,14 @@ INSTALL()
 	addResourcesToBinaries lab3d-$portVersion.rdef $appsDir/KensLabyrinth/KensLabyrinth
 	mimeset -f $appsDir/KensLabyrinth/KensLabyrinth
 
-	cp -a $sourceDir2/* $appsDir/KensLabyrinth/
+	mkdir -p $docDir
+	cp -a $sourceDir/!(ksmmidi).txt $docDir
+	cp -a $sourceDir2/{*.DOC,*.TXT} $docDir
+
+	cp -a $sourceDir2/{*.DAT,*.KZP} $appsDir/KensLabyrinth/
+
 	cp -a $sourceDir/ken.bmp $appsDir/KensLabyrinth/ken.bmp
+	cp -a $sourceDir/ksmmidi.txt $appsDir/KensLabyrinth/ksmmidi.txt
 
 	addAppDeskbarSymlink $appsDir/KensLabyrinth/KensLabyrinth
 }

--- a/games-fps/lab3d/lab3d-3.0.1.recipe
+++ b/games-fps/lab3d/lab3d-3.0.1.recipe
@@ -82,7 +82,7 @@ INSTALL()
 	mimeset -f $appsDir/KensLabyrinth/KensLabyrinth
 
 	mkdir -p $docDir
-	cp -a $sourceDir/!(ksmmidi).txt $docDir
+	cp -a $sourceDir/*.txt $docDir
 	cp -a $sourceDir2/{*.DOC,*.TXT} $docDir
 
 	cp -a $sourceDir2/{*.DAT,*.KZP} $appsDir/KensLabyrinth/

--- a/games-fps/lab3d/lab3d-3.0.1.recipe
+++ b/games-fps/lab3d/lab3d-3.0.1.recipe
@@ -40,14 +40,14 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libGL$secondaryArchSuffix
 	lib:libGLU$secondaryArchSuffix
-	lib:libSDL$secondaryArchSuffix
+	lib:libSDL_1.2$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libGL$secondaryArchSuffix
 	devel:libGLU$secondaryArchSuffix
-	devel:libSDL$secondaryArchSuffix
+	devel:libSDL_1.2$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
@@ -57,13 +57,12 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	cd $sourceDir
 	make $jobArgs -f Makefile.Unix
 }
 
 INSTALL()
 {
-	local APP_SIGNATURE="application/x-vnd.LAB3D"
+	local APP_SIGNATURE="application/x-vnd.KensLabyrinth"
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
 	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
 	local MINOR="`echo "$portVersion" | cut -d. -f3`"
@@ -76,11 +75,11 @@ INSTALL()
 		-e "s|@LONG_INFO@|$LONG_INFO|" \
 		$portDir/additional-files/lab3d-$portVersion.rdef.in > lab3d-$portVersion.rdef
 
-	addResourcesToBinaries lab3d-$portVersion.rdef $sourceDir/ken
-	mimeset -f $sourceDir/ken
-
 	mkdir -p $appsDir/KensLabyrinth
 	cp -a $sourceDir/ken $appsDir/KensLabyrinth/KensLabyrinth
+
+	addResourcesToBinaries lab3d-$portVersion.rdef $appsDir/KensLabyrinth/KensLabyrinth
+	mimeset -f $appsDir/KensLabyrinth/KensLabyrinth
 
 	cp -a $sourceDir2/* $appsDir/KensLabyrinth/
 	cp -a $sourceDir/ken.bmp $appsDir/KensLabyrinth/ken.bmp

--- a/games-fps/lab3d/lab3d-3.0.1.recipe
+++ b/games-fps/lab3d/lab3d-3.0.1.recipe
@@ -62,6 +62,9 @@ BUILD()
 
 INSTALL()
 {
+	mkdir -p $appsDir/KensLabyrinth
+	cp -a $sourceDir/ken $appsDir/KensLabyrinth/KensLabyrinth
+
 	local APP_SIGNATURE="application/x-vnd.KensLabyrinth"
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
 	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
@@ -74,9 +77,6 @@ INSTALL()
 		-e "s|@MINOR@|$MINOR|" \
 		-e "s|@LONG_INFO@|$LONG_INFO|" \
 		$portDir/additional-files/lab3d-$portVersion.rdef.in > lab3d-$portVersion.rdef
-
-	mkdir -p $appsDir/KensLabyrinth
-	cp -a $sourceDir/ken $appsDir/KensLabyrinth/KensLabyrinth
 
 	addResourcesToBinaries lab3d-$portVersion.rdef $appsDir/KensLabyrinth/KensLabyrinth
 	mimeset -f $appsDir/KensLabyrinth/KensLabyrinth

--- a/games-fps/lab3d/lab3d-3.0.1.recipe
+++ b/games-fps/lab3d/lab3d-3.0.1.recipe
@@ -33,7 +33,7 @@ ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	KensLabyrinth$secondaryArchSuffix = $portVersion
+	lab3d$secondaryArchSuffix = $portVersion
 	app:KensLabyrinth
 	"
 REQUIRES="

--- a/games-fps/lab3d/patches/lab3d-3.0.1.patchset
+++ b/games-fps/lab3d/patches/lab3d-3.0.1.patchset
@@ -1,0 +1,549 @@
+From 71cae173ba5fc5d8cb101b2a01a267d4b3cf4565 Mon Sep 17 00:00:00 2001
+From: Jaycie Ewald <jaycie.ewald@outlook.com>
+Date: Sat, 24 Jun 2023 10:18:30 -0500
+Subject: [PATCH] Add Haiku Support
+
+---
+ init.c     |  16 +++----
+ lab3d.c    |  28 +++++++++--
+ lab3d.h    |  11 ++++-
+ oldlab3d.c |  14 +++---
+ opengl.c   |   6 +--
+ setup.c    |   6 ++-
+ software.c |   4 +-
+ subs.c     | 134 ++++++++++++++++++++++++++++++++++++++++-------------
+ 8 files changed, 160 insertions(+), 59 deletions(-)
+
+diff --git a/init.c b/init.c
+index 99065c9..01d0316 100644
+--- a/init.c
++++ b/init.c
+@@ -102,8 +102,8 @@ void initialize()
+ 
+     if (speechstatus >= 2)
+     {	
+-	if (((i = open("sounds.kzp",O_BINARY|O_RDONLY,0)) != -1)||
+-	    ((i = open("SOUNDS.KZP",O_BINARY|O_RDONLY,0)) != -1)) {
++	if (((i = open2("sounds.kzp",O_BINARY|O_RDONLY,0)) != -1)||
++	    ((i = open2("SOUNDS.KZP",O_BINARY|O_RDONLY,0)) != -1)) {
+ 	    fstat(i, &fstats);
+ 	    sndsize = (int)(fstats.st_size);
+ 	    fprintf(stderr, "Detected %ld byte sounds.\n", sndsize);
+@@ -120,9 +120,9 @@ void initialize()
+ 	    exit(-1);
+ 	}
+ 
+-	file=fopen("sounds.kzp","rb");
++	file=fopen2("sounds.kzp","rb");
+ 	if (file==NULL) {
+-	    file=fopen("SOUNDS.KZP","rb");
++	    file=fopen2("SOUNDS.KZP","rb");
+ 	}
+ 	if (file==NULL) {
+ 	    fprintf(stderr,"Can not find sounds.kzp.\n");
+@@ -207,8 +207,8 @@ void initialize()
+     /* Shareware/registered check... */
+ 
+     if (lab3dversion) {
+-	if (((i = open("boards.dat",O_BINARY|O_RDONLY,0)) != -1)||
+-	    ((i = open("BOARDS.DAT",O_BINARY|O_RDONLY,0)) != -1)) {
++	if (((i = open2("boards.dat",O_BINARY|O_RDONLY,0)) != -1)||
++	    ((i = open2("BOARDS.DAT",O_BINARY|O_RDONLY,0)) != -1)) {
+ 	    fstat(i, &fstats);
+ 	    numboards = (int)(fstats.st_size>>13);
+ 	    fprintf(stderr, "Detected %d boards.\n", numboards);
+@@ -219,8 +219,8 @@ void initialize()
+ 	    exit(1);
+ 	}
+     } else {
+-	if (((i = open("boards.kzp",O_RDONLY|O_BINARY,0)) != -1)||
+-	    ((i = open("BOARDS.KZP",O_RDONLY|O_BINARY,0)) != -1)) {
++	if (((i = open2("boards.kzp",O_RDONLY|O_BINARY,0)) != -1)||
++	    ((i = open2("BOARDS.KZP",O_RDONLY|O_BINARY,0)) != -1)) {
+ 	    readLE16(i,&boleng[0],30*4);
+ 	    numboards = 30;
+ 	    if ((boleng[40]|boleng[41]) == 0)
+diff --git a/lab3d.c b/lab3d.c
+index 52a6fd1..0079a7a 100644
+--- a/lab3d.c
++++ b/lab3d.c
+@@ -3,6 +3,8 @@
+ #include "adlibemu.h"
+ #include "math.h"
+ 
++#include <libgen.h>
++
+ unsigned char slotable[3][16] =
+ {
+     {5,2,4,5,3,0,4,1,2,4,5,3,5,4,1,3},
+@@ -24,6 +26,24 @@ int main(int argc,char **argv)
+ 
+     clockspd=0;
+ 
++	// erysdren: get absolute base path
++	if (realpath(argv[0], __argv0) == NULL)
++	{
++		fprintf(stderr, "Failed to determine application directory\n");
++		SDL_Quit();
++		exit(-1);
++	}
++	else
++	{
++		char *temp;
++		temp = strdup(__argv0);
++		strlcpy(__argv0, dirname(temp), PATH_MAX);
++		free(temp);
++	}
++
++	// erysdren: create user dir
++	create_user_dir();
++
+     /* Initialisation... */
+ 
+     /* Initialise SDL; uncomment the NOPARACHUTE bit if the parachute
+@@ -33,14 +53,14 @@ int main(int argc,char **argv)
+     SDL_Init(SDL_INIT_TIMER|SDL_INIT_VIDEO|SDL_INIT_NOPARACHUTE|
+ 	     SDL_INIT_JOYSTICK);
+ 
+-    if (((fil = open("end.txt",O_RDONLY|O_BINARY,0)) != -1)||
+-	((fil = open("END.TXT",O_RDONLY|O_BINARY,0)) != -1)) {
++    if (((fil = open2("end.txt",O_RDONLY|O_BINARY,0)) != -1)||
++	((fil = open2("END.TXT",O_RDONLY|O_BINARY,0)) != -1)) {
+ 	close(fil);	
+ 	lab3dversion=2; /* Version 1.0 detected. */
+ 	rnumwalls=192;
+ 	fprintf(stderr, "Ken's Labyrinth version 1.0 detected.\n");
+-    } else if (((fil = open("boards.dat",O_RDONLY|O_BINARY,0)) != -1)||
+-	       ((fil = open("BOARDS.DAT",O_RDONLY|O_BINARY,0)) != -1)) {
++    } else if (((fil = open2("boards.dat",O_RDONLY|O_BINARY,0)) != -1)||
++	       ((fil = open2("BOARDS.DAT",O_RDONLY|O_BINARY,0)) != -1)) {
+ 	close(fil);	
+ 	lab3dversion=1; /* Version 1.1 detected. */
+ 	rnumwalls=0xe0;
+diff --git a/lab3d.h b/lab3d.h
+index 43fe0e9..3ba62dc 100644
+--- a/lab3d.h
++++ b/lab3d.h
+@@ -536,7 +536,7 @@ void updatebullets(K_UINT16 posxs, K_UINT16 posys, K_INT16 poszs);
+ void checkforvisiblestuff(K_UINT16 posxs, K_UINT16 posys, K_INT16 poszs, K_INT16 angs);
+ double angcan(double angle);
+ 
+-SDL_mutex *soundmutex,*timermutex;
++EXTERN SDL_mutex *soundmutex,*timermutex;
+ EXTERN int newkeydefs[numkeys],newkeystatus[SDLKEYS];
+ EXTERN int musicvolume,soundvolume;
+ EXTERN int channels;
+@@ -681,3 +681,12 @@ void openGLFlatsprite(K_UINT16 x, K_UINT16 y,K_INT16 ang,K_INT16 playerang,
+ void openGLDoordraw(K_UINT16 x,K_UINT16 y,K_INT16 walnume,K_UINT16 posxs,
+ 		    K_UINT16 posys);
+ EXTERN int paletterenderer;
++
++// erysdren
++int open2(const char *path, int openMode, ...);
++FILE *fopen2(char *name, char *mode);
++FILE *fopen3(char *name, char *mode);
++void create_user_dir(void);
++SDL_Surface *LoadBMP(char *path);
++extern char __argv0[PATH_MAX];
++extern char __userdir[PATH_MAX];
+diff --git a/oldlab3d.c b/oldlab3d.c
+index 3b47ab6..3a1c44e 100644
+--- a/oldlab3d.c
++++ b/oldlab3d.c
+@@ -2227,14 +2227,14 @@ K_INT16 oldloadgame(K_INT16 gamenum)
+     filename[6] = 'E', filename[7] = gamenum+48;
+     filename[8] = '.', filename[9] = 'D', filename[10] = 'A';
+     filename[11] = 'T', filename[12] = 0;
+-    if((fil=open(filename,O_BINARY|O_RDONLY,
++    if((fil=open2(filename,O_BINARY|O_RDONLY,
+ 		 S_IWRITE|S_IREAD|S_IRGRP|S_IROTH))==-1) {
+ 	filename[0] = 's', filename[1] = 'a', filename[2] = 'v';
+ 	filename[3] = 'g', filename[4] = 'a', filename[5] = 'm';
+ 	filename[6] = 'e', filename[7] = gamenum+48;
+ 	filename[8] = '.', filename[9] = 'd', filename[10] = 'a';
+ 	filename[11] = 't', filename[12] = 0;
+-	if((fil=open(filename,O_BINARY|O_RDONLY,
++	if((fil=open2(filename,O_BINARY|O_RDONLY,
+ 		     S_IWRITE|S_IREAD|S_IRGRP|S_IROTH))==-1)
+ 	    return(-1);
+     }
+@@ -2382,7 +2382,7 @@ K_INT16 oldsavegame(K_INT16 gamenum)
+     filename[6] = 'E', filename[7] = gamenum+48;
+     filename[8] = '.', filename[9] = 'D', filename[10] = 'A';
+     filename[11] = 'T', filename[12] = 0;
+-    if((fil=open(filename,O_BINARY|O_CREAT|O_WRONLY,
++    if((fil=open2(filename,O_BINARY|O_CREAT|O_WRONLY,
+ 		 S_IWRITE|S_IREAD|S_IRGRP|S_IROTH))==-1)
+ 	return(-1);
+     writeLE16(fil,&board[0][0],8192);
+@@ -2621,14 +2621,14 @@ K_INT16 oldintroduction(void)
+ 		    if (oldloadgame(i) != -1)
+ 		    {
+ 			if (numboards == 0)
+-			    if ((fil = open("boards.dat",O_BINARY|O_RDONLY,
++			    if ((fil = open2("boards.dat",O_BINARY|O_RDONLY,
+ 					    S_IREAD)) != -1)
+ 			    {
+ 				numboards = 27;
+ 				close(fil);
+ 			    }
+ 			if (numboards == 0)
+-			    if ((fil = open("BOARDS.DAT",O_BINARY|O_RDONLY,
++			    if ((fil = open2("BOARDS.DAT",O_BINARY|O_RDONLY,
+ 					    S_IREAD)) != -1)
+ 			    {
+ 				numboards = 27;
+@@ -2932,8 +2932,8 @@ K_INT16 oldloadstory()
+     int fil, i, k, textbufcnt, textypos;
+ 
+     ototclock = totalclock;
+-    if ((fil = open("story.kzp",O_BINARY|O_RDONLY,S_IREAD)) == -1)
+-	if ((fil = open("STORY.KZP",O_BINARY|O_RDONLY,S_IREAD)) == -1)
++    if ((fil = open2("story.kzp",O_BINARY|O_RDONLY,S_IREAD)) == -1)
++	if ((fil = open2("STORY.KZP",O_BINARY|O_RDONLY,S_IREAD)) == -1)
+ 	    return(-1);
+     read(fil,&storyoffs[0],256);
+     lseek(fil,(long)(storyoffs[boardnum+1]),SEEK_SET);
+diff --git a/opengl.c b/opengl.c
+index ff89c51..4304a05 100644
+--- a/opengl.c
++++ b/opengl.c
+@@ -84,7 +84,7 @@ void openGLInit() {
+ 
+     fprintf(stderr,"Activating video (OpenGL)...\n");
+ 
+-    icon=SDL_LoadBMP("ken.bmp");
++    icon=LoadBMP("ken.bmp");
+     if (icon==NULL) {
+ 	fprintf(stderr,"Warning: ken.bmp (icon file) not found.\n");
+     }
+@@ -1088,7 +1088,7 @@ void openGLScreencapture()
+ 	glReadPixels(0,0,screenwidth,screenheight,GL_BGR,GL_UNSIGNED_BYTE,
+ 		     screen);
+ 	unlink(filename);
+-	file=open(filename,O_CREAT|O_WRONLY|O_BINARY,
++	file=open2(filename,O_CREAT|O_WRONLY|O_BINARY,
+ 		  S_IREAD|S_IWRITE|S_IRGRP|S_IROTH);
+ 	if (file!=-1) {
+ 	    if (write(file,BMPHeader,54)==54) {
+@@ -1673,7 +1673,7 @@ void openGLInitFailsafe(void) {
+ 
+     screenwidth=360; screenheight=240;
+ 
+-    icon=SDL_LoadBMP("ken.bmp");
++    icon=LoadBMP("ken.bmp");
+     if (icon==NULL) {
+ 	fprintf(stderr,"Warning: ken.bmp (icon file) not found.\n");
+     }
+diff --git a/setup.c b/setup.c
+index 50a1c54..9725331 100644
+--- a/setup.c
++++ b/setup.c
+@@ -856,7 +856,7 @@ void configure(void) {
+ }
+ 
+ void loadsettings(void) {
+-    FILE *file=fopen("settings.ini","r");
++    FILE *file=fopen3("settings.ini","r");
+     int i;
+     SDL_Rect **modes;
+ 
+@@ -911,9 +911,11 @@ void loadsettings(void) {
+ }
+ 
+ void savesettings(void) {
+-    FILE *file=fopen("settings.ini","w");
++    FILE *file=fopen3("settings.ini","w");
+     int i;
+ 
++    if (file==NULL) printf("FUCK\n");
++
+     if (file==NULL) return;
+     fprintf(file,"%d %d %d %d %d %d\n",inputdevice,resolutionnumber,fullscr,
+ 	    nearest,music,sound);    
+diff --git a/software.c b/software.c
+index 8de8128..3ffa2e6 100644
+--- a/software.c
++++ b/software.c
+@@ -29,7 +29,7 @@ void softwareInit() {
+ 	exit(-1);
+     }
+ 
+-    icon=SDL_LoadBMP("ken.bmp");
++    icon=LoadBMP("ken.bmp");
+     if (icon==NULL) {
+ 	fprintf(stderr,"Warning: ken.bmp (icon file) not found.\n");
+     }
+@@ -979,7 +979,7 @@ void softwareInitFailsafe(void) {
+ 
+     screenwidth=360; screenheight=240;
+ 
+-    icon=SDL_LoadBMP("ken.bmp");
++    icon=LoadBMP("ken.bmp");
+     if (icon==NULL) {
+ 	fprintf(stderr,"Warning: ken.bmp (icon file) not found.\n");
+     }
+diff --git a/subs.c b/subs.c
+index 759f418..a12d4d0 100644
+--- a/subs.c
++++ b/subs.c
+@@ -128,8 +128,8 @@ void loadboard()
+ #endif
+ 
+     if (lab3dversion) {
+-	if (((fil = open("boards.dat",O_RDONLY|O_BINARY,0)) != -1)||
+-	    ((fil = open("BOARDS.DAT",O_RDONLY|O_BINARY,0)) != -1)) {
++	if (((fil = open2("boards.dat",O_RDONLY|O_BINARY,0)) != -1)||
++	    ((fil = open2("BOARDS.DAT",O_RDONLY|O_BINARY,0)) != -1)) {
+ 	    lseek(fil,((long)boardnum)<<13,SEEK_SET);
+ 	    read(fil,&board[0],8192);
+ 	    close(fil);
+@@ -141,8 +141,8 @@ void loadboard()
+ 	    exit(1);	    
+ 	}
+     } else {
+-	if (((fil = open("boards.kzp",O_RDONLY|O_BINARY,0)) != -1)||
+-	    ((fil = open("BOARDS.KZP",O_RDONLY|O_BINARY,0)) != -1))
++	if (((fil = open2("boards.kzp",O_RDONLY|O_BINARY,0)) != -1)||
++	    ((fil = open2("BOARDS.KZP",O_RDONLY|O_BINARY,0)) != -1))
+ 	{
+ 	    prepdie = 0;
+ 	    numwarps = 0;
+@@ -420,8 +420,8 @@ void loadtables()
+ {
+     K_INT16 fil;
+ 
+-    if (((fil = open("tables.dat",O_RDONLY|O_BINARY,0)) != -1)||
+-	((fil = open("TABLES.DAT",O_RDONLY|O_BINARY,0)) != -1))
++    if (((fil = open2("tables.dat",O_RDONLY|O_BINARY,0)) != -1)||
++	((fil = open2("TABLES.DAT",O_RDONLY|O_BINARY,0)) != -1))
+     {
+ 	readLE32(fil,&sintable[0],8192);
+ 	readLE32(fil,&tantable[0],4096);
+@@ -781,8 +781,8 @@ void loadwalls()
+     K_UINT16 stack[LZW_STACK_SIZE];
+     K_UINT16 stackp=0;
+ 
+-    if (((fil = open("walls.kzp",O_RDONLY|O_BINARY,0)) != -1)||
+-	((fil = open("WALLS.KZP",O_RDONLY|O_BINARY,0)) != -1))
++    if (((fil = open2("walls.kzp",O_RDONLY|O_BINARY,0)) != -1)||
++	((fil = open2("WALLS.KZP",O_RDONLY|O_BINARY,0)) != -1))
+     {
+ 	bmpkind[0] = 0;
+ 	wallheader[0] = 8;
+@@ -1081,14 +1081,14 @@ K_INT16 loadgame(K_INT16 gamenum)
+     filename[6] = 'E', filename[7] = gamenum+48;
+     filename[8] = '.', filename[9] = 'D', filename[10] = 'A';
+     filename[11] = 'T', filename[12] = 0;
+-    if((fil=open(filename,O_RDONLY|O_BINARY,0))==-1) {
++    if((fil=open2(filename,O_RDONLY|O_BINARY,0))==-1) {
+ 	filename[0] = 's', filename[1] = 'a', filename[2] = 'v';
+ 	filename[3] = 'g', filename[4] = 'a', filename[5] = 'm';
+ 	filename[6] = 'e', filename[7] = gamenum+48;
+ 	filename[8] = '.', filename[9] = 'd', filename[10] = 'a';
+ 	filename[11] = 't', filename[12] = 0;	
+ 
+-	if((fil=open(filename,O_RDONLY|O_BINARY,0))==-1)
++	if((fil=open2(filename,O_RDONLY|O_BINARY,0))==-1)
+ 	    return -1;
+     }
+     musicoff();
+@@ -1267,7 +1267,7 @@ K_INT16 savegame(K_INT16 gamenum)
+     filename[6] = 'E', filename[7] = gamenum+48;
+     filename[8] = '.', filename[9] = 'D', filename[10] = 'A';
+     filename[11] = 'T', filename[12] = 0;
+-    if((fil=open(filename,O_CREAT|O_WRONLY|O_BINARY,
++    if((fil=open2(filename,O_CREAT|O_WRONLY|O_BINARY,
+ 		 S_IWRITE|S_IREAD|S_IRGRP|S_IROTH))==-1) {
+ 	return(-1);
+     }
+@@ -1870,7 +1870,7 @@ K_INT16 loadmusic(char *filename)
+ 	{
+ 	    /* Open KSM->MIDI instrument translation table... */
+ 
+-	    file=fopen("ksmmidi.txt","rt");
++	    file=fopen2("ksmmidi.txt","rt");
+ 	    if (file==NULL) {
+ 		fprintf(stderr,"ksmmidi.txt not found; music disabled.\n");
+ 		musicsource=-1;
+@@ -1882,8 +1882,8 @@ K_INT16 loadmusic(char *filename)
+ 	}
+ 	if (musicsource == 2)
+ 	{
+-	    if(((infile=open("insts.dat",O_RDONLY|O_BINARY,0))==-1)&&
+-	       ((infile=open("INSTS.DAT",O_RDONLY|O_BINARY,0))==-1))
++	    if(((infile=open2("insts.dat",O_RDONLY|O_BINARY,0))==-1)&&
++	       ((infile=open2("INSTS.DAT",O_RDONLY|O_BINARY,0))==-1))
+ 		return(-1);
+ 	    for(i=0;i<256;i++)
+ 	    {
+@@ -1901,8 +1901,8 @@ K_INT16 loadmusic(char *filename)
+ 	    firstime = 0;
+ 	}
+     }
+-    if (((infile=open("songs.kzp",O_RDONLY|O_BINARY,0))==-1)&&
+-	((infile=open("SONGS.KZP",O_RDONLY|O_BINARY,0))==-1))
++    if (((infile=open2("songs.kzp",O_RDONLY|O_BINARY,0))==-1)&&
++	((infile=open2("SONGS.KZP",O_RDONLY|O_BINARY,0))==-1))
+ 	return(-1);
+     readLE16(infile,&numfiles,2);
+     i = 0;
+@@ -2834,31 +2834,31 @@ K_INT16 kgif(K_INT16 filenum)
+     if (filenum<0) {
+ 	switch(filenum) {
+ 	    case -1:
+-		if (((fil = open("lab3d.gif",O_RDONLY|O_BINARY,0)) == -1)&&
+-		    ((fil = open("LAB3D.GIF",O_RDONLY|O_BINARY,0)) == -1))
++		if (((fil = open2("lab3d.gif",O_RDONLY|O_BINARY,0)) == -1)&&
++		    ((fil = open2("LAB3D.GIF",O_RDONLY|O_BINARY,0)) == -1))
+ 		    return(-1);
+ 		break;
+ 	    case -2:
+-		if (((fil = open("end1.gif",O_RDONLY|O_BINARY,0)) == -1)&&
+-		    ((fil = open("END1.GIF",O_RDONLY|O_BINARY,0)) == -1))
++		if (((fil = open2("end1.gif",O_RDONLY|O_BINARY,0)) == -1)&&
++		    ((fil = open2("END1.GIF",O_RDONLY|O_BINARY,0)) == -1))
+ 		    return(-1);
+ 		break;
+ 	    case -3:
+-		if (((fil = open("end2.gif",O_RDONLY|O_BINARY,0)) == -1)&&
+-		    ((fil = open("END2.GIF",O_RDONLY|O_BINARY,0)) == -1))
++		if (((fil = open2("end2.gif",O_RDONLY|O_BINARY,0)) == -1)&&
++		    ((fil = open2("END2.GIF",O_RDONLY|O_BINARY,0)) == -1))
+ 		    return(-1);
+ 		break;
+ 	    case -4:
+-		if (((fil = open("end3.gif",O_RDONLY|O_BINARY,0)) == -1)&&
+-		    ((fil = open("END3.GIF",O_RDONLY|O_BINARY,0)) == -1))
++		if (((fil = open2("end3.gif",O_RDONLY|O_BINARY,0)) == -1)&&
++		    ((fil = open2("END3.GIF",O_RDONLY|O_BINARY,0)) == -1))
+ 		    return(-1);
+ 		break;
+ 	    default:
+ 		return(-1);
+ 	}
+     } else {
+-	if (((fil = open("lab3d.kzp",O_RDONLY|O_BINARY,0)) == -1)&&
+-	    ((fil = open("LAB3D.KZP",O_RDONLY|O_BINARY,0)) == -1))
++	if (((fil = open2("lab3d.kzp",O_RDONLY|O_BINARY,0)) == -1)&&
++	    ((fil = open2("LAB3D.KZP",O_RDONLY|O_BINARY,0)) == -1))
+ 	    return(-1);
+     }
+ 
+@@ -3115,8 +3115,8 @@ K_INT16 loadstory(K_INT16 boardnume)
+     K_INT16 fil, i, textbufcnt, textypos;
+ 
+     ototclock = totalclock;
+-    if (((fil = open("story.kzp",O_RDONLY|O_BINARY,0)) == -1)&&
+-	((fil = open("STORY.KZP",O_RDONLY|O_BINARY,0)) == -1))
++    if (((fil = open2("story.kzp",O_RDONLY|O_BINARY,0)) == -1)&&
++	((fil = open2("STORY.KZP",O_RDONLY|O_BINARY,0)) == -1))
+ 	return(-1);
+     readLE16(fil,&storyoffs[0],256);
+     lseek(fil,(long)(storyoffs[boardnume+34]),SEEK_SET);
+@@ -3388,8 +3388,8 @@ void hiscorecheck()
+     K_INT16 i, j, k, m, inse, namexist, fil;
+     K_INT32 hiscore[8], scorexist, templong;
+ 
+-    if (((fil = open("hiscore.dat",O_RDWR|O_BINARY,0)) == -1)&&
+-	((fil = open("HISCORE.DAT",O_RDWR|O_BINARY,0)) == -1))
++    if (((fil = open2("hiscore.dat",O_RDWR|O_BINARY,0)) == -1)&&
++	((fil = open2("HISCORE.DAT",O_RDWR|O_BINARY,0)) == -1))
+ 	return;
+     gfxDrawFront();
+     wipeoverlay(0,0,361,statusbaryoffset);
+@@ -4508,7 +4508,7 @@ K_INT16 loadsavegamemenu(K_INT16 whichmenu)
+ 	    filename[8] = '.', filename[9] = 'D', filename[10] = 'A';
+ 	    filename[11] = 'T', filename[12] = 0;
+ 
+-	    if((fil=open(filename,O_RDONLY|O_BINARY,0))!=-1)
++	    if((fil=open2(filename,O_RDONLY|O_BINARY,0))!=-1)
+ 	    {
+ 		gamexist[j] = 1;
+ 		read(fil,&gamehead[j][0],27);
+@@ -4520,7 +4520,7 @@ K_INT16 loadsavegamemenu(K_INT16 whichmenu)
+ 		filename[6] = 'e', filename[7] = j+48;
+ 		filename[8] = '.', filename[9] = 'd', filename[10] = 'a';
+ 		filename[11] = 't', filename[12] = 0;	
+-		if((fil=open(filename,O_RDONLY|O_BINARY,0))!=-1)
++		if((fil=open2(filename,O_RDONLY|O_BINARY,0))!=-1)
+ 		{
+ 		    gamexist[j] = 1;
+ 		    read(fil,&gamehead[j][0],27);
+@@ -5570,3 +5570,73 @@ double angcan(double angle) {
+     while(angle>=M_PI*2) angle-=M_PI*2;
+     return angle;
+ }
++
++//
++// open2
++//
++// erysdren: fix the path for haiku
++//
++
++#include <FindDirectory.h>
++#include <fs_info.h>
++
++// https://github.com/haiku/haiku/blob/master/src/system/libroot/posix/fcntl.cpp#L30-L45
++
++int __gUmask = 022;
++char __argv0[PATH_MAX];
++char __userdir[PATH_MAX];
++
++int	open2(const char *path, int openMode, ...)
++{
++	char newpath[PATH_MAX];
++	int perms = 0;
++
++	if (openMode & O_CREAT)
++	{
++		va_list args;
++		va_start(args, openMode);
++		perms = va_arg(args, int) & ~__gUmask;
++		va_end(args);
++	}
++
++	snprintf(newpath, PATH_MAX, "%s/%s", __argv0, path);
++
++	return open(newpath, openMode, perms);
++}
++
++FILE *fopen2(char *name, char *mode)
++{
++	char newname[PATH_MAX];
++	snprintf(newname, PATH_MAX, "%s/%s", __argv0, name);
++	return fopen(newname, mode);
++}
++
++FILE *fopen3(char *name, char *mode)
++{
++	char newname[PATH_MAX];
++	snprintf(newname, PATH_MAX, "%s/%s", __userdir, name);
++	return fopen(newname, mode);
++}
++
++void create_user_dir(void)
++{
++	dev_t volume = dev_for_path("/boot");
++	char buffer[PATH_MAX];
++	status_t result;
++
++	// find dir
++	result = find_directory(B_USER_NONPACKAGED_DATA_DIRECTORY, volume, false, buffer, PATH_MAX);
++
++	// copy
++	snprintf(__userdir, PATH_MAX, "%s/KensLabyrinth", buffer);
++
++	// make path
++	mkdir(__userdir, S_IWRITE|S_IREAD|S_IRGRP|S_IROTH);
++}
++
++SDL_Surface *LoadBMP(char *path)
++{
++	char newpath[PATH_MAX];
++	snprintf(newpath, PATH_MAX, "%s/%s", __argv0, path);
++	return SDL_LoadBMP(newpath);
++}
+-- 
+2.41.0
+

--- a/games-fps/lab3d/patches/lab3d-3.0.1.patchset
+++ b/games-fps/lab3d/patches/lab3d-3.0.1.patchset
@@ -1,18 +1,18 @@
-From 71cae173ba5fc5d8cb101b2a01a267d4b3cf4565 Mon Sep 17 00:00:00 2001
+From 36744b4ea79f3cbd9efe4aca7c86fce58dd65f9d Mon Sep 17 00:00:00 2001
 From: Jaycie Ewald <jaycie.ewald@outlook.com>
-Date: Sat, 24 Jun 2023 10:18:30 -0500
+Date: Sat, 24 Jun 2023 10:40:20 -0500
 Subject: [PATCH] Add Haiku Support
 
 ---
- init.c     |  16 +++----
- lab3d.c    |  28 +++++++++--
- lab3d.h    |  11 ++++-
- oldlab3d.c |  14 +++---
+ init.c     |  16 +++---
+ lab3d.c    |  28 ++++++++--
+ lab3d.h    |  12 ++++-
+ oldlab3d.c |  14 ++---
  opengl.c   |   6 +--
  setup.c    |   6 ++-
  software.c |   4 +-
- subs.c     | 134 ++++++++++++++++++++++++++++++++++++++++-------------
- 8 files changed, 160 insertions(+), 59 deletions(-)
+ subs.c     | 152 ++++++++++++++++++++++++++++++++++++++++++-----------
+ 8 files changed, 179 insertions(+), 59 deletions(-)
 
 diff --git a/init.c b/init.c
 index 99065c9..01d0316 100644
@@ -121,7 +121,7 @@ index 52a6fd1..0079a7a 100644
  	lab3dversion=1; /* Version 1.1 detected. */
  	rnumwalls=0xe0;
 diff --git a/lab3d.h b/lab3d.h
-index 43fe0e9..3ba62dc 100644
+index 43fe0e9..e1277e1 100644
 --- a/lab3d.h
 +++ b/lab3d.h
 @@ -536,7 +536,7 @@ void updatebullets(K_UINT16 posxs, K_UINT16 posys, K_INT16 poszs);
@@ -133,13 +133,14 @@ index 43fe0e9..3ba62dc 100644
  EXTERN int newkeydefs[numkeys],newkeystatus[SDLKEYS];
  EXTERN int musicvolume,soundvolume;
  EXTERN int channels;
-@@ -681,3 +681,12 @@ void openGLFlatsprite(K_UINT16 x, K_UINT16 y,K_INT16 ang,K_INT16 playerang,
+@@ -681,3 +681,13 @@ void openGLFlatsprite(K_UINT16 x, K_UINT16 y,K_INT16 ang,K_INT16 playerang,
  void openGLDoordraw(K_UINT16 x,K_UINT16 y,K_INT16 walnume,K_UINT16 posxs,
  		    K_UINT16 posys);
  EXTERN int paletterenderer;
 +
 +// erysdren
 +int open2(const char *path, int openMode, ...);
++int open3(const char *path, int openMode, ...);
 +FILE *fopen2(char *name, char *mode);
 +FILE *fopen3(char *name, char *mode);
 +void create_user_dir(void);
@@ -284,7 +285,7 @@ index 8de8128..3ffa2e6 100644
  	fprintf(stderr,"Warning: ken.bmp (icon file) not found.\n");
      }
 diff --git a/subs.c b/subs.c
-index 759f418..a12d4d0 100644
+index 759f418..b23b65f 100644
 --- a/subs.c
 +++ b/subs.c
 @@ -128,8 +128,8 @@ void loadboard()
@@ -336,7 +337,7 @@ index 759f418..a12d4d0 100644
      filename[8] = '.', filename[9] = 'D', filename[10] = 'A';
      filename[11] = 'T', filename[12] = 0;
 -    if((fil=open(filename,O_RDONLY|O_BINARY,0))==-1) {
-+    if((fil=open2(filename,O_RDONLY|O_BINARY,0))==-1) {
++    if((fil=open3(filename,O_RDONLY|O_BINARY,0))==-1) {
  	filename[0] = 's', filename[1] = 'a', filename[2] = 'v';
  	filename[3] = 'g', filename[4] = 'a', filename[5] = 'm';
  	filename[6] = 'e', filename[7] = gamenum+48;
@@ -344,7 +345,7 @@ index 759f418..a12d4d0 100644
  	filename[11] = 't', filename[12] = 0;	
  
 -	if((fil=open(filename,O_RDONLY|O_BINARY,0))==-1)
-+	if((fil=open2(filename,O_RDONLY|O_BINARY,0))==-1)
++	if((fil=open3(filename,O_RDONLY|O_BINARY,0))==-1)
  	    return -1;
      }
      musicoff();
@@ -353,7 +354,7 @@ index 759f418..a12d4d0 100644
      filename[8] = '.', filename[9] = 'D', filename[10] = 'A';
      filename[11] = 'T', filename[12] = 0;
 -    if((fil=open(filename,O_CREAT|O_WRONLY|O_BINARY,
-+    if((fil=open2(filename,O_CREAT|O_WRONLY|O_BINARY,
++    if((fil=open3(filename,O_CREAT|O_WRONLY|O_BINARY,
  		 S_IWRITE|S_IREAD|S_IRGRP|S_IROTH))==-1) {
  	return(-1);
      }
@@ -470,7 +471,7 @@ index 759f418..a12d4d0 100644
  		{
  		    gamexist[j] = 1;
  		    read(fil,&gamehead[j][0],27);
-@@ -5570,3 +5570,73 @@ double angcan(double angle) {
+@@ -5570,3 +5570,91 @@ double angcan(double angle) {
      while(angle>=M_PI*2) angle-=M_PI*2;
      return angle;
  }
@@ -490,7 +491,7 @@ index 759f418..a12d4d0 100644
 +char __argv0[PATH_MAX];
 +char __userdir[PATH_MAX];
 +
-+int	open2(const char *path, int openMode, ...)
++int open2(const char *path, int openMode, ...)
 +{
 +	char newpath[PATH_MAX];
 +	int perms = 0;
@@ -504,6 +505,24 @@ index 759f418..a12d4d0 100644
 +	}
 +
 +	snprintf(newpath, PATH_MAX, "%s/%s", __argv0, path);
++
++	return open(newpath, openMode, perms);
++}
++
++int open3(const char *path, int openMode, ...)
++{
++	char newpath[PATH_MAX];
++	int perms = 0;
++
++	if (openMode & O_CREAT)
++	{
++		va_list args;
++		va_start(args, openMode);
++		perms = va_arg(args, int) & ~__gUmask;
++		va_end(args);
++	}
++
++	snprintf(newpath, PATH_MAX, "%s/%s", __userdir, path);
 +
 +	return open(newpath, openMode, perms);
 +}

--- a/games-fps/lab3d/patches/lab3d-3.0.1.patchset
+++ b/games-fps/lab3d/patches/lab3d-3.0.1.patchset
@@ -1,6 +1,6 @@
-From 36744b4ea79f3cbd9efe4aca7c86fce58dd65f9d Mon Sep 17 00:00:00 2001
+From 7dfcf7f586396890934385b993d7ab108689bfcc Mon Sep 17 00:00:00 2001
 From: Jaycie Ewald <jaycie.ewald@outlook.com>
-Date: Sat, 24 Jun 2023 10:40:20 -0500
+Date: Sat, 24 Jun 2023 10:49:03 -0500
 Subject: [PATCH] Add Haiku Support
 
 ---
@@ -9,10 +9,10 @@ Subject: [PATCH] Add Haiku Support
  lab3d.h    |  12 ++++-
  oldlab3d.c |  14 ++---
  opengl.c   |   6 +--
- setup.c    |   6 ++-
+ setup.c    |   4 +-
  software.c |   4 +-
  subs.c     | 152 ++++++++++++++++++++++++++++++++++++++++++-----------
- 8 files changed, 179 insertions(+), 59 deletions(-)
+ 8 files changed, 177 insertions(+), 59 deletions(-)
 
 diff --git a/init.c b/init.c
 index 99065c9..01d0316 100644
@@ -237,7 +237,7 @@ index ff89c51..4304a05 100644
  	fprintf(stderr,"Warning: ken.bmp (icon file) not found.\n");
      }
 diff --git a/setup.c b/setup.c
-index 50a1c54..9725331 100644
+index 50a1c54..3c8da3e 100644
 --- a/setup.c
 +++ b/setup.c
 @@ -856,7 +856,7 @@ void configure(void) {
@@ -249,7 +249,7 @@ index 50a1c54..9725331 100644
      int i;
      SDL_Rect **modes;
  
-@@ -911,9 +911,11 @@ void loadsettings(void) {
+@@ -911,7 +911,7 @@ void loadsettings(void) {
  }
  
  void savesettings(void) {
@@ -257,11 +257,7 @@ index 50a1c54..9725331 100644
 +    FILE *file=fopen3("settings.ini","w");
      int i;
  
-+    if (file==NULL) printf("FUCK\n");
-+
      if (file==NULL) return;
-     fprintf(file,"%d %d %d %d %d %d\n",inputdevice,resolutionnumber,fullscr,
- 	    nearest,music,sound);    
 diff --git a/software.c b/software.c
 index 8de8128..3ffa2e6 100644
 --- a/software.c
@@ -285,7 +281,7 @@ index 8de8128..3ffa2e6 100644
  	fprintf(stderr,"Warning: ken.bmp (icon file) not found.\n");
      }
 diff --git a/subs.c b/subs.c
-index 759f418..b23b65f 100644
+index 759f418..5f768a8 100644
 --- a/subs.c
 +++ b/subs.c
 @@ -128,8 +128,8 @@ void loadboard()
@@ -548,7 +544,7 @@ index 759f418..b23b65f 100644
 +	status_t result;
 +
 +	// find dir
-+	result = find_directory(B_USER_NONPACKAGED_DATA_DIRECTORY, volume, false, buffer, PATH_MAX);
++	result = find_directory(B_USER_SETTINGS_DIRECTORY, volume, false, buffer, PATH_MAX);
 +
 +	// copy
 +	snprintf(__userdir, PATH_MAX, "%s/KensLabyrinth", buffer);


### PR DESCRIPTION
Add Ken's Labyrinth by Ken Silverman to Haiku, via the [LAB3D-SDL port](http://icculus.org/LAB3D/) originally created by Jan Lönnberg.

Changes:

- Add wrappers for open(), fopen() and SDL_LoadBMP() to respect Haiku user/data/etc directories.
- Pull game data from [Ken Silverman's website](http://advsys.net/ken/klab.htm) (v2.1 registered).

Issues:

- OpenGL renderer crashes for unknown reasons. The SDL fallback software renderer works, though.
- If you generate a config, there's no way to regenerate it without going to the terminal and running it with the `-setup` switch.
- No application icon.
