### PR TITLE
cargo_c: revbumped, updated cargo_c-0.9.8.recipe

### DIFF
--- a/dev-rust/cargo_c/cargo_c-0.9.8.recipe
+++ b/dev-rust/cargo_c/cargo_c-0.9.8.recipe
@@ -5,7 +5,7 @@ C-compatible) software."
 HOMEPAGE="https://github.com/lu-zero/cargo-c"
 COPYRIGHT="2020 Luca Barbato"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/lu-zero/cargo-c/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="7c649061826e0ad3c2c8735718f4a0c4afd12eed9b9fdc5fe59e34582902e1c5"
 SOURCE_URI_2="https://github.com/lu-zero/cargo-c/releases/download/v$portVersion/Cargo.lock#noarchive"
@@ -13,7 +13,7 @@ CHECKSUM_SHA256_2="11f23a09ef06ca2125027e24574124a99089863fb4226570b6adbe317848b
 SOURCE_DIR="cargo-c-$portVersion"
 PATCHES="cargo_c-$portVersion.patchset"
 
-ARCHITECTURES="?all !x86_gcc2 x86_64"
+ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="


### PR DESCRIPTION
Rebuilt for openssl 1.1.1t on x86.