### PR TITLE
openscenegraph, fix references for lib:libsdl

### DIFF
--- a/games-engines/openscenegraph/openscenegraph-3.6.5.recipe
+++ b/games-engines/openscenegraph/openscenegraph-3.6.5.recipe
@@ -56,7 +56,7 @@ REQUIRES="
 	lib:libfreetype$secondaryArchSuffix
 	lib:libgdal$secondaryArchSuffix
 	lib:libgif$secondaryArchSuffix
-	lib:libgl$secondaryArchSuffix
+	lib:libGL$secondaryArchSuffix
 	lib:libglib_2.0$secondaryArchSuffix
 #	lib:libgstreamer_1.0$secondaryArchSuffix
 	lib:libhalf$secondaryArchSuffix
@@ -67,7 +67,7 @@ REQUIRES="
 #	lib:libOpenCOLLADABaseUtils$secondaryArchSuffix
 	lib:libpng16$secondaryArchSuffix
 	lib:libpoppler${secondaryArchSuffix}_glib
-	lib:libsdl$secondaryArchSuffix
+	lib:libSDL_1.2$secondaryArchSuffix
 	lib:libtiff$secondaryArchSuffix
 #	lib:libTKGeomBase$secondaryArchSuffix #opencascade
 	lib:libxml2$secondaryArchSuffix
@@ -108,7 +108,7 @@ BUILD_REQUIRES="
 	devel:libfreetype$secondaryArchSuffix
 	devel:libgdal$secondaryArchSuffix >= 28
 	devel:libgif$secondaryArchSuffix >= 7
-	devel:libgl$secondaryArchSuffix
+	devel:libGL$secondaryArchSuffix
 	devel:libglib_2.0$secondaryArchSuffix
 #	devel:libgstreamer_1.0$secondaryArchSuffix
 	devel:libilmimf_2_4$secondaryArchSuffix
@@ -118,7 +118,7 @@ BUILD_REQUIRES="
 #	devel:libOpenCOLLADABaseUtils$secondaryArchSuffix
 	devel:libpng16$secondaryArchSuffix
 	devel:libpoppler${secondaryArchSuffix}_glib >= 8.12
-	devel:libsdl$secondaryArchSuffix
+	devel:libSDL_1.2$secondaryArchSuffix
 	devel:libtiff$secondaryArchSuffix >= 5
 #	devel:libTKGeomBase$secondaryArchSuffix #opencascade
 	devel:libxml2$secondaryArchSuffix


### PR DESCRIPTION
No revbump, recipe is marked broken on all architectures.