### PR TITLE
coreutils, don't provide suffix-less PROVIDES, make depending package…

### DIFF
--- a/sys-apps/coreutils/coreutils-9.3.recipe
+++ b/sys-apps/coreutils/coreutils-9.3.recipe
@@ -17,7 +17,7 @@ uptime users vdir wc who whoami yes"
 HOMEPAGE="https://www.gnu.org/software/coreutils/"
 COPYRIGHT="1994-2017 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://ftpmirror.gnu.org/coreutils/coreutils-$portVersion.tar.xz
 	https://ftp.gnu.org/gnu/coreutils/coreutils-$portVersion.tar.xz"
 CHECKSUM_SHA256="adbcfcfe899235b71e8768dcf07cd532520b7f54f9a8064843f8d199a904bbaa"
@@ -143,9 +143,6 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	"
 if [ "$targetArchitecture" = x86_gcc2 ]; then
-	PROVIDES+="
-		coreutils = $binVersionCompat
-		"
 	REPLACES="
 		coreutils
 		"


### PR DESCRIPTION
…s rely on cmd:* from the package