### PR TITLE
celestia, update recipe

### DIFF
--- a/sci-astronomy/celestia/celestia-1.6.3.recipe
+++ b/sci-astronomy/celestia/celestia-1.6.3.recipe
@@ -11,8 +11,8 @@ simple to navigate through the universe to the object you want to visit.
 Celestia is expandable. Celestia comes with a large catalog of stars, galaxies, \
 planets, moons, asteroids, comets, and spacecraft. If that's not enough, you \
 can download dozens of easy to install add-ons with more objects."
-HOMEPAGE="https://celestia.space"
-COPYRIGHT="2001-2021 Celestia Development Team"
+HOMEPAGE="https://celestiaproject.space"
+COPYRIGHT="2001-2023 Celestia Development Team"
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://github.com/CelestiaProject/Celestia/archive/refs/tags/$portVersion.tar.gz"


### PR DESCRIPTION
updates the copyright and homepage, since celestia.space went offline and was taken by cybersquatters, so it had to move to celestiaproject.space. not sure about the `REVISION` field though, @Begasus changed it from `2` back to `1` in #9005, so for now I'm just leaving it at `1`. is it because the `REVISION` gets reset back to `1` each time an application is updated to its' newest release or something like that?
also, is there any way that the screenshots shown on the Haiku Depot page could be updated? they look over a decade old lol