### PR TITLE
cargo-c, try to fix build for 64bit

### DIFF
--- a/dev-rust/cargo_c/cargo_c-0.9.8.recipe
+++ b/dev-rust/cargo_c/cargo_c-0.9.8.recipe
@@ -57,6 +57,10 @@ BUILD()
 
 INSTALL()
 {
+	export LIBSSH2_SYS_USE_PKG_CONFIG=1
+	export LIBGIT2_SYS_USE_PKG_CONFIG=1
+	export PKG_CONFIG_ALLOW_CROSS=1
+
 	cargo install --locked --root $prefix --path .
 
 	rm -f $prefix/{.crates.toml,.crates2.json}


### PR DESCRIPTION
Only needed for 64bit, 32bit already fine (no revbump).