### PR TITLE
libebml: Patch to use standard integer types

### DIFF
--- a/dev-libs/libebml/libebml-1.4.4.recipe
+++ b/dev-libs/libebml/libebml-1.4.4.recipe
@@ -3,10 +3,11 @@ DESCRIPTION="libebml is a C++ library to parse EBML content (read/write)."
 HOMEPAGE="https://github.com/Matroska-Org/libebml/"
 COPYRIGHT="2005-2023 Matroska"
 LICENSE="GNU LGPL v2.1"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="$HOMEPAGE/archive/release-$portVersion.tar.gz"
 CHECKSUM_SHA256="3b30d89a5699fef4bdf5b4d7de7a1c94d9be47fababf9caca59250282f051283"
 SOURCE_DIR="libebml-release-$portVersion"
+PATCHES="libebml-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -42,10 +43,9 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	mkdir -p build && cd build
-	cmake .. $cmakeDirArgs -DBUILD_SHARED_LIBS=TRUE \
+	cmake -B build $cmakeDirArgs -DBUILD_SHARED_LIBS=TRUE \
 		-DCMAKE_BUILD_TYPE=Release
-	make $jobArgs
+	make -C build $jobArgs
 }
 
 INSTALL()

--- a/dev-libs/libebml/patches/libebml-1.4.4.patchset
+++ b/dev-libs/libebml/patches/libebml-1.4.4.patchset
@@ -1,0 +1,1931 @@
+From 9d95a6d07fe42f542bca93f1bf3910afdc02f0ee Mon Sep 17 00:00:00 2001
+From: robxnano <89391914+robxnano@users.noreply.github.com>
+Date: Fri, 14 Jul 2023 14:54:13 +0100
+Subject: [PATCH] Use C++ std int types and remove libebml_t.h
+
+Removes dependence on conflicting non-standard integer types.
+Cherry-picked from libebml development branch.
+---
+ CMakeLists.txt                       |   5 +-
+ ebml/EbmlBinary.h                    |   4 +-
+ ebml/EbmlCrc32.h                     |  18 ++--
+ ebml/EbmlDate.h                      |  12 +--
+ ebml/EbmlElement.h                   |  48 +++++-----
+ ebml/EbmlEndian.h                    |   4 +-
+ ebml/EbmlId.h                        |   6 +-
+ ebml/EbmlMaster.h                    |   8 +-
+ ebml/EbmlSInteger.h                  |  26 +++---
+ ebml/EbmlStream.h                    |   4 +-
+ ebml/EbmlTypes.h                     |  42 ++++++---
+ ebml/EbmlUInteger.h                  |  26 +++---
+ ebml/EbmlVoid.h                      |   6 +-
+ ebml/IOCallback.h                    |   6 +-
+ ebml/MemIOCallback.h                 |  20 ++--
+ ebml/MemReadIOCallback.h             |  10 +-
+ ebml/SafeReadIOCallback.h            |  12 +--
+ ebml/StdIOCallback.h                 |   8 +-
+ ebml/c/libebml_t.h                   | 133 ---------------------------
+ src/EbmlBinary.cpp                   |   2 +-
+ src/EbmlCrc32.cpp                    |  36 ++++----
+ src/EbmlDate.cpp                     |   2 +-
+ src/EbmlElement.cpp                  |  60 ++++++------
+ src/EbmlFloat.cpp                    |   8 +-
+ src/EbmlMaster.cpp                   |   8 +-
+ src/EbmlSInteger.cpp                 |  30 +++---
+ src/EbmlStream.cpp                   |   4 +-
+ src/EbmlString.cpp                   |   2 +-
+ src/EbmlUInteger.cpp                 |  22 ++---
+ src/EbmlUnicodeString.cpp            |   4 +-
+ src/EbmlVoid.cpp                     |  14 +--
+ src/MemIOCallback.cpp                |  10 +-
+ src/MemReadIOCallback.cpp            |  14 +--
+ src/SafeReadIOCallback.cpp           |  38 ++++----
+ src/StdIOCallback.cpp                |   8 +-
+ src/platform/win32/WinIOCallback.cpp |  14 +--
+ src/platform/win32/WinIOCallback.h   |   8 +-
+ 37 files changed, 279 insertions(+), 403 deletions(-)
+ delete mode 100644 ebml/c/libebml_t.h
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 79f9375..5bf9d12 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -70,9 +70,7 @@ set(libebml_PUBLIC_HEADERS
+   ebml/SafeReadIOCallback.h
+   ebml/StdIOCallback.h)
+ 
+-set(libebml_C_PUBLIC_HEADERS ebml/c/libebml_t.h)
+-
+-add_library(ebml ${libebml_SOURCES} ${libebml_PUBLIC_HEADERS} ${libebml_C_PUBLIC_HEADERS})
++add_library(ebml ${libebml_SOURCES} ${libebml_PUBLIC_HEADERS})
+ if(WIN32)
+   include(CheckIncludeFile)
+   check_include_file(winapifamily.h HAVE_WINAPIFAMILY_H)
+@@ -114,7 +112,6 @@ install(TARGETS ebml
+   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ 
+ install(FILES ${libebml_PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ebml)
+-install(FILES ${libebml_C_PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ebml/c)
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ebml_export.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ebml)
+ 
+ if(NOT DISABLE_PKGCONFIG)
+diff --git a/ebml/EbmlBinary.h b/ebml/EbmlBinary.h
+index 4dafc6d..b5fec6d 100644
+--- a/ebml/EbmlBinary.h
++++ b/ebml/EbmlBinary.h
+@@ -69,7 +69,7 @@ class EBML_DLL_API EbmlBinary : public EbmlElement {
+     filepos_t ReadData(IOCallback & input, ScopeMode ReadFully = SCOPE_ALL_DATA) override;
+     filepos_t UpdateSize(bool bWithDefault = false, bool bForceRender = false) override;
+ 
+-    void SetBuffer(const binary *Buffer, const uint32 BufferSize) {
++    void SetBuffer(const binary *Buffer, const std::uint32_t BufferSize) {
+       Data = const_cast<binary *>(Buffer);
+       SetSize_(BufferSize);
+       SetValueIsSet();
+@@ -77,7 +77,7 @@ class EBML_DLL_API EbmlBinary : public EbmlElement {
+ 
+     binary *GetBuffer() const {return Data;}
+ 
+-    void CopyBuffer(const binary *Buffer, const uint32 BufferSize) {
++    void CopyBuffer(const binary *Buffer, const std::uint32_t BufferSize) {
+       if (Data != nullptr)
+         free(Data);
+       Data = static_cast<binary *>(malloc(BufferSize * sizeof(binary)));
+diff --git a/ebml/EbmlCrc32.h b/ebml/EbmlCrc32.h
+index 67a593f..01a99e4 100644
+--- a/ebml/EbmlCrc32.h
++++ b/ebml/EbmlCrc32.h
+@@ -64,27 +64,27 @@ DECLARE_EBML_BINARY(EbmlCrc32)
+       Use this to quickly check a CRC32 with some data
+       \return True if inputCRC matches CRC32 generated from input data
+     */
+-    static bool CheckCRC(uint32 inputCRC, const binary *input, uint32 length);
++    static bool CheckCRC(std::uint32_t inputCRC, const binary *input, std::uint32_t length);
+     /*!
+       Calls Update() and Finalize(), use to create a CRC32 in one go
+     */
+-    void FillCRC32(const binary *input, uint32 length);
++    void FillCRC32(const binary *input, std::uint32_t length);
+     /*!
+       Add data to the CRC table, in other words process some data bit by bit
+     */
+-    void Update(const binary *input, uint32 length);
++    void Update(const binary *input, std::uint32_t length);
+     /*!
+       Use this with Update() to Finalize() or Complete the CRC32
+     */
+     void Finalize();
+     /*!
+-      Returns a uint32 that has the value of the CRC32
++      Returns a std::uint32_t that has the value of the CRC32
+     */
+-    uint32 GetCrc32() const {
++    std::uint32_t GetCrc32() const {
+       return m_crc_final;
+     }
+ 
+-    void ForceCrc32(uint32 NewValue) { m_crc_final = NewValue; SetValueIsSet();}
++    void ForceCrc32(std::uint32_t NewValue) { m_crc_final = NewValue; SetValueIsSet();}
+ 
+ #if defined(EBML_STRICT_API)
+     private:
+@@ -94,9 +94,9 @@ DECLARE_EBML_BINARY(EbmlCrc32)
+     void ResetCRC();
+     void UpdateByte(binary b);
+ 
+-    static const uint32 m_tab[256];
+-    uint32 m_crc;
+-    uint32 m_crc_final;
++    static const std::uint32_t m_tab[256];
++    std::uint32_t m_crc;
++    std::uint32_t m_crc_final;
+ 
+         EBML_CONCRETE_CLASS(EbmlCrc32)
+ };
+diff --git a/ebml/EbmlDate.h b/ebml/EbmlDate.h
+index cd1d7c4..4272055 100644
+--- a/ebml/EbmlDate.h
++++ b/ebml/EbmlDate.h
+@@ -52,15 +52,15 @@ class EBML_DLL_API EbmlDate : public EbmlElement {
+       \brief set the date with a UNIX/C/EPOCH form
+       \param NewDate UNIX/C date in UTC (no timezone)
+     */
+-    void SetEpochDate(int64 NewDate) {myDate = (NewDate - UnixEpochDelay) * 1000000000; SetValueIsSet();}
+-    EbmlDate &SetValue(int64 NewValue) {SetEpochDate(NewValue); return *this;}
++    void SetEpochDate(std::int64_t NewDate) {myDate = (NewDate - UnixEpochDelay) * 1000000000; SetValueIsSet();}
++    EbmlDate &SetValue(std::int64_t NewValue) {SetEpochDate(NewValue); return *this;}
+ 
+     /*!
+       \brief get the date with a UNIX/C/EPOCH form
+       \note the date is in UTC (no timezone)
+     */
+-    int64 GetEpochDate() const {return static_cast<int64>(myDate/1000000000 + UnixEpochDelay);}
+-    int64 GetValue() const {return GetEpochDate();}
++    std::int64_t GetEpochDate() const {return static_cast<std::int64_t>(myDate/1000000000 + UnixEpochDelay);}
++    std::int64_t GetValue() const {return GetEpochDate();}
+ 
+     bool ValidateSize() const override {return IsFiniteSize() && ((GetSize() == 8) || (GetSize() == 0));}
+ 
+@@ -90,9 +90,9 @@ class EBML_DLL_API EbmlDate : public EbmlElement {
+ #endif
+     filepos_t RenderData(IOCallback & output, bool bForceRender, bool bWithDefault = false) override;
+ 
+-    int64 myDate; ///< internal format of the date
++    std::int64_t myDate; ///< internal format of the date
+ 
+-    static const uint64 UnixEpochDelay;
++    static const std::uint64_t UnixEpochDelay;
+ };
+ 
+ } // namespace libebml
+diff --git a/ebml/EbmlElement.h b/ebml/EbmlElement.h
+index 8d349f6..8c395cc 100644
+--- a/ebml/EbmlElement.h
++++ b/ebml/EbmlElement.h
+@@ -43,36 +43,36 @@ namespace libebml {
+ /*!
+   \brief The size of the EBML-coded length
+ */
+-int EBML_DLL_API CodedSizeLength(uint64 Length, unsigned int SizeLength, bool bSizeIsFinite = true);
++int EBML_DLL_API CodedSizeLength(std::uint64_t Length, unsigned int SizeLength, bool bSizeIsFinite = true);
+ 
+ /*!
+   \brief The coded value of the EBML-coded length
+   \note The size of OutBuffer must be 8 octets at least
+ */
+-int EBML_DLL_API CodedValueLength(uint64 Length, int CodedSize, binary * OutBuffer);
++int EBML_DLL_API CodedValueLength(std::uint64_t Length, int CodedSize, binary * OutBuffer);
+ 
+ /*!
+   \brief Read an EBML-coded value from a buffer
+   \return the value read
+ */
+-uint64 EBML_DLL_API ReadCodedSizeValue(const binary * InBuffer, uint32 & BufferSize, uint64 & SizeUnknown);
++std::uint64_t EBML_DLL_API ReadCodedSizeValue(const binary * InBuffer, std::uint32_t & BufferSize, std::uint64_t & SizeUnknown);
+ 
+ /*!
+   \brief The size of the EBML-coded signed length
+ */
+-int EBML_DLL_API CodedSizeLengthSigned(int64 Length, unsigned int SizeLength);
++int EBML_DLL_API CodedSizeLengthSigned(std::int64_t Length, unsigned int SizeLength);
+ 
+ /*!
+   \brief The coded value of the EBML-coded signed length
+   \note the size of OutBuffer must be 8 octets at least
+ */
+-int EBML_DLL_API CodedValueLengthSigned(int64 Length, int CodedSize, binary * OutBuffer);
++int EBML_DLL_API CodedValueLengthSigned(std::int64_t Length, int CodedSize, binary * OutBuffer);
+ 
+ /*!
+   \brief Read a signed EBML-coded value from a buffer
+   \return the value read
+ */
+-int64 EBML_DLL_API ReadCodedSizeSignedValue(const binary * InBuffer, uint32 & BufferSize, uint64 & SizeUnknown);
++std::int64_t EBML_DLL_API ReadCodedSizeSignedValue(const binary * InBuffer, std::uint32_t & BufferSize, std::uint64_t & SizeUnknown);
+ 
+ class EbmlStream;
+ class EbmlSemanticContext;
+@@ -369,20 +369,20 @@ class EBML_DLL_API EbmlSemanticContext {
+ */
+ class EBML_DLL_API EbmlElement {
+   public:
+-    EbmlElement(uint64 aDefaultSize, bool bValueSet = false);
++    EbmlElement(std::uint64_t aDefaultSize, bool bValueSet = false);
+     virtual ~EbmlElement();
+ 
+     /// Set the minimum length that will be used to write the element size (-1 = optimal)
+     void SetSizeLength(int NewSizeLength) {SizeLength = NewSizeLength;}
+     int GetSizeLength() const {return SizeLength;}
+ 
+-    static EbmlElement * FindNextElement(IOCallback & DataStream, const EbmlSemanticContext & Context, int & UpperLevel, uint64 MaxDataSize, bool AllowDummyElt, unsigned int MaxLowerLevel = 1);
+-    static EbmlElement * FindNextID(IOCallback & DataStream, const EbmlCallbacks & ClassInfos, uint64 MaxDataSize);
++    static EbmlElement * FindNextElement(IOCallback & DataStream, const EbmlSemanticContext & Context, int & UpperLevel, std::uint64_t MaxDataSize, bool AllowDummyElt, unsigned int MaxLowerLevel = 1);
++    static EbmlElement * FindNextID(IOCallback & DataStream, const EbmlCallbacks & ClassInfos, std::uint64_t MaxDataSize);
+ 
+     /*!
+       \brief find the next element with the same ID
+     */
+-    EbmlElement * FindNext(IOCallback & DataStream, uint64 MaxDataSize);
++    EbmlElement * FindNext(IOCallback & DataStream, std::uint64_t MaxDataSize);
+ 
+     EbmlElement * SkipData(EbmlStream & DataStream, const EbmlSemanticContext & Context, EbmlElement * TestReadElt = nullptr, bool AllowDummyElt = false);
+ 
+@@ -407,11 +407,11 @@ class EBML_DLL_API EbmlElement {
+ 
+     virtual bool ValidateSize() const = 0;
+ 
+-    uint64 GetElementPosition() const {
++    std::uint64_t GetElementPosition() const {
+       return ElementPosition;
+     }
+ 
+-    uint64 ElementSize(bool bWithDefault = false) const; /// return the size of the header+data, before writing
++    std::uint64_t ElementSize(bool bWithDefault = false) const; /// return the size of the header+data, before writing
+ 
+     filepos_t Render(IOCallback & output, bool bWithDefault = false, bool bKeepPosition = false, bool bForceRender = false);
+ 
+@@ -433,7 +433,7 @@ class EBML_DLL_API EbmlElement {
+     virtual bool IsDummy() const {return false;}
+     virtual bool IsMaster() const {return false;}
+ 
+-    uint8 HeadSize() const {
++    std::uint8_t HeadSize() const {
+       return EBML_ID_LENGTH((const EbmlId&)*this) + CodedSizeLength(Size, SizeLength, bSizeIsFinite);
+     } /// return the size of the head, on reading/writing
+ 
+@@ -441,7 +441,7 @@ class EBML_DLL_API EbmlElement {
+       \brief Force the size of an element
+       \warning only possible if the size is "undefined"
+     */
+-    bool ForceSize(uint64 NewSize);
++    bool ForceSize(std::uint64_t NewSize);
+ 
+     filepos_t OverwriteHead(IOCallback & output, bool bKeepPosition = false);
+     filepos_t OverwriteData(IOCallback & output, bool bKeepPosition = false);
+@@ -449,7 +449,7 @@ class EBML_DLL_API EbmlElement {
+     /*!
+       \brief void the content of the element (replace by EbmlVoid)
+     */
+-    uint64 VoidMe(IOCallback & output, bool bWithDefault = false);
++    std::uint64_t VoidMe(IOCallback & output, bool bWithDefault = false);
+ 
+     bool DefaultISset() const {return DefaultIsSet;}
+     void ForceNoDefault() {SetDefaultIsSet(false);}
+@@ -459,11 +459,11 @@ class EBML_DLL_API EbmlElement {
+     /*!
+       \brief set the default size of an element
+     */
+-    virtual void SetDefaultSize(uint64 aDefaultSize) {DefaultSize = aDefaultSize;}
++    virtual void SetDefaultSize(std::uint64_t aDefaultSize) {DefaultSize = aDefaultSize;}
+ 
+     bool ValueIsSet() const {return bValueIsSet;}
+ 
+-    inline uint64 GetEndPosition() const {
++    inline std::uint64_t GetEndPosition() const {
+       assert(bSizeIsFinite); // we don't know where the end is
+       return SizePosition + CodedSizeLength(Size, SizeLength, bSizeIsFinite) + Size;
+     }
+@@ -488,22 +488,22 @@ class EBML_DLL_API EbmlElement {
+     */
+     EbmlElement(const EbmlElement & ElementToClone) = default;
+ 
+-        inline uint64 GetDefaultSize() const {return DefaultSize;}
+-        inline void SetSize_(uint64 aSize) {Size = aSize;}
++        inline std::uint64_t GetDefaultSize() const {return DefaultSize;}
++        inline void SetSize_(std::uint64_t aSize) {Size = aSize;}
+         inline void SetValueIsSet(bool Set = true) {bValueIsSet = Set;}
+         inline void SetDefaultIsSet(bool Set = true) {DefaultIsSet = Set;}
+         inline void SetSizeIsFinite(bool Set = true) {bSizeIsFinite = Set;}
+-        inline uint64 GetSizePosition() const {return SizePosition;}
++        inline std::uint64_t GetSizePosition() const {return SizePosition;}
+ 
+ #if defined(EBML_STRICT_API)
+   private:
+ #endif
+-    uint64 Size;        ///< the size of the data to write
+-    uint64 DefaultSize; ///< Minimum data size to fill on rendering (0 = optimal)
++    std::uint64_t Size;        ///< the size of the data to write
++    std::uint64_t DefaultSize; ///< Minimum data size to fill on rendering (0 = optimal)
+     int SizeLength; /// the minimum size on which the size will be written (0 = optimal)
+     bool bSizeIsFinite;
+-    uint64 ElementPosition;
+-    uint64 SizePosition;
++    std::uint64_t ElementPosition;
++    std::uint64_t SizePosition;
+     bool bValueIsSet;
+     bool DefaultIsSet;
+     bool bLocked;
+diff --git a/ebml/EbmlEndian.h b/ebml/EbmlEndian.h
+index 23c0283..4d6e0b3 100644
+--- a/ebml/EbmlEndian.h
++++ b/ebml/EbmlEndian.h
+@@ -102,7 +102,7 @@ template<class TYPE, endianess ENDIAN> class Endian
+ #else  // _ENDIANESS_
+           if (ENDIAN == big_endian)
+ #endif // _ENDIANESS_
+-            std::reverse(reinterpret_cast<uint8*>(&endian_value),reinterpret_cast<uint8*>(&endian_value+1));
++            std::reverse(reinterpret_cast<std::uint8_t*>(&endian_value),reinterpret_cast<std::uint8_t*>(&endian_value+1));
+       }
+ 
+       inline void process_platform()
+@@ -113,7 +113,7 @@ template<class TYPE, endianess ENDIAN> class Endian
+ #else  // _ENDIANESS_
+           if (ENDIAN == big_endian)
+ #endif // _ENDIANESS_
+-            std::reverse(reinterpret_cast<uint8*>(&platform_value),reinterpret_cast<uint8*>(&platform_value+1));
++            std::reverse(reinterpret_cast<std::uint8_t*>(&platform_value),reinterpret_cast<std::uint8_t*>(&platform_value+1));
+       }
+ };
+ 
+diff --git a/ebml/EbmlId.h b/ebml/EbmlId.h
+index 33847c3..8d77862 100644
+--- a/ebml/EbmlId.h
++++ b/ebml/EbmlId.h
+@@ -65,7 +65,7 @@ class EBML_DLL_API EbmlId {
+       }
+     }
+ 
+-    EbmlId(const uint32 aValue, const unsigned int aLength)
++    EbmlId(const std::uint32_t aValue, const unsigned int aLength)
+       :Value(aValue), Length(aLength) {}
+ 
+     inline bool operator==(const EbmlId & TestId) const
+@@ -85,12 +85,12 @@ class EBML_DLL_API EbmlId {
+     }
+ 
+         inline size_t GetLength() const { return Length; }
+-        inline uint32 GetValue() const { return Value; }
++        inline std::uint32_t GetValue() const { return Value; }
+ 
+ #if defined(EBML_STRICT_API)
+     private:
+ #endif
+-    uint32 Value;
++    std::uint32_t Value;
+     size_t Length;
+ };
+ 
+diff --git a/ebml/EbmlMaster.h b/ebml/EbmlMaster.h
+index d272ecd..b70aece 100644
+--- a/ebml/EbmlMaster.h
++++ b/ebml/EbmlMaster.h
+@@ -76,13 +76,13 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
+     bool SetSizeInfinite(bool aIsInfinite = true) override {SetSizeIsFinite(!aIsInfinite); return true;}
+ 
+     bool PushElement(EbmlElement & element);
+-    uint64 GetSize() const override {
++    std::uint64_t GetSize() const override {
+       if (IsFiniteSize())
+         return EbmlElement::GetSize();
+       return (0-1);
+     }
+ 
+-    uint64 GetDataStart() const {
++    std::uint64_t GetDataStart() const {
+       return GetElementPosition() + EBML_ID_LENGTH((const EbmlId&)*this) + CodedSizeLength(EbmlElement::GetSize(), GetSizeLength(), IsFiniteSize());
+     }
+ 
+@@ -166,8 +166,8 @@ class EBML_DLL_API EbmlMaster : public EbmlElement {
+     void EnableChecksum(bool bIsEnabled = true) { bChecksumUsed = bIsEnabled; }
+     bool HasChecksum() const {return bChecksumUsed;}
+     bool VerifyChecksum() const;
+-    uint32 GetCrc32() const {return Checksum.GetCrc32();}
+-    void ForceChecksum(uint32 NewChecksum) {
++    std::uint32_t GetCrc32() const {return Checksum.GetCrc32();}
++    void ForceChecksum(std::uint32_t NewChecksum) {
+       Checksum.ForceCrc32(NewChecksum);
+       bChecksumUsed = true;
+     }
+diff --git a/ebml/EbmlSInteger.h b/ebml/EbmlSInteger.h
+index 5c079fd..ef0f664 100644
+--- a/ebml/EbmlSInteger.h
++++ b/ebml/EbmlSInteger.h
+@@ -54,15 +54,15 @@ const int DEFAULT_INT_SIZE = 1; ///< optimal size stored
+ class EBML_DLL_API EbmlSInteger : public EbmlElement {
+   public:
+     EbmlSInteger();
+-    EbmlSInteger(int64 DefaultValue);
++    EbmlSInteger(std::int64_t DefaultValue);
+     EbmlSInteger(const EbmlSInteger & ElementToClone) = default;
+ 
+-    EbmlSInteger & operator = (int64 NewValue) {Value = NewValue; SetValueIsSet(); return *this;}
++    EbmlSInteger & operator = (std::int64_t NewValue) {Value = NewValue; SetValueIsSet(); return *this;}
+ 
+     /*!
+       Set the default size of the integer (usually 1,2,4 or 8)
+     */
+-        void SetDefaultSize(uint64 nDefaultSize = DEFAULT_INT_SIZE) override {EbmlElement::SetDefaultSize(nDefaultSize); SetSize_(nDefaultSize);}
++        void SetDefaultSize(std::uint64_t nDefaultSize = DEFAULT_INT_SIZE) override {EbmlElement::SetDefaultSize(nDefaultSize); SetSize_(nDefaultSize);}
+ 
+     bool ValidateSize() const override {return IsFiniteSize() && (GetSize() <= 8);}
+     filepos_t RenderData(IOCallback & output, bool bForceRender, bool bWithDefault = false) override;
+@@ -71,17 +71,17 @@ class EBML_DLL_API EbmlSInteger : public EbmlElement {
+ 
+     bool IsSmallerThan(const EbmlElement *Cmp) const override;
+ 
+-    operator int8() const;
+-    operator int16() const;
+-    operator int32() const;
+-    operator int64() const;
++    operator std::int8_t() const;
++    operator std::int16_t() const;
++    operator std::int32_t() const;
++    operator std::int64_t() const;
+ 
+-    EbmlSInteger &SetValue(int64 NewValue);
+-    int64 GetValue() const;
++    EbmlSInteger &SetValue(std::int64_t NewValue);
++    std::int64_t GetValue() const;
+ 
+-    void SetDefaultValue(int64 aValue) {assert(!DefaultISset()); DefaultValue = aValue; SetDefaultIsSet();}
++    void SetDefaultValue(std::int64_t aValue) {assert(!DefaultISset()); DefaultValue = aValue; SetDefaultIsSet();}
+ 
+-    int64 DefaultVal() const {assert(DefaultISset()); return DefaultValue;}
++    std::int64_t DefaultVal() const {assert(DefaultISset()); return DefaultValue;}
+ 
+     bool IsDefaultValue() const override {
+       return (DefaultISset() && Value == DefaultValue);
+@@ -92,8 +92,8 @@ class EBML_DLL_API EbmlSInteger : public EbmlElement {
+ #else
+     protected:
+ #endif
+-    int64 Value; /// The actual value of the element
+-    int64 DefaultValue;
++    std::int64_t Value; /// The actual value of the element
++    std::int64_t DefaultValue;
+ };
+ 
+ } // namespace libebml
+diff --git a/ebml/EbmlStream.h b/ebml/EbmlStream.h
+index c79c7fd..0c91941 100644
+--- a/ebml/EbmlStream.h
++++ b/ebml/EbmlStream.h
+@@ -56,9 +56,9 @@ class EBML_DLL_API EbmlStream {
+       \param MaxDataSize The maximum possible of the data in the element (for sanity checks)
+       \note the user will have to delete that element later
+     */
+-    EbmlElement * FindNextID(const EbmlCallbacks & ClassInfos, uint64 MaxDataSize);
++    EbmlElement * FindNextID(const EbmlCallbacks & ClassInfos, std::uint64_t MaxDataSize);
+ 
+-    EbmlElement * FindNextElement(const EbmlSemanticContext & Context, int & UpperLevel, uint64 MaxDataSize, bool AllowDummyElt, unsigned int MaxLowerLevel = 1);
++    EbmlElement * FindNextElement(const EbmlSemanticContext & Context, int & UpperLevel, std::uint64_t MaxDataSize, bool AllowDummyElt, unsigned int MaxLowerLevel = 1);
+ 
+     inline IOCallback & I_O() {return Stream;}
+         operator IOCallback &() {return Stream;}
+diff --git a/ebml/EbmlTypes.h b/ebml/EbmlTypes.h
+index f73403a..ae2f9ad 100644
+--- a/ebml/EbmlTypes.h
++++ b/ebml/EbmlTypes.h
+@@ -33,31 +33,43 @@
+ #ifndef LIBEBML_TYPES_H
+ #define LIBEBML_TYPES_H
+ 
+-#include "ebml/c/libebml_t.h"
++#include <cstdint>
++
+ #include "ebml/EbmlConfig.h"
++
++typedef std::uint8_t  binary;
++typedef std::uint64_t filepos_t;
++
++enum open_mode {
++    MODE_READ,
++    MODE_WRITE,
++    MODE_CREATE,
++    MODE_SAFE
++};
++
+ #include "EbmlEndian.h" // binary needs to be defined
+ 
+ namespace libebml {
+ 
+ using utf16 = wchar_t;
+-using utf32 = uint32;
++using utf32 = std::uint32_t;
+ using utf8 = char;
+ 
+ using bits80 = binary[10];
+ 
+-using lil_int16 = Endian<int16, little_endian>;
+-using lil_int32 = Endian<int32, little_endian>;
+-using lil_int64 = Endian<int64, little_endian>;
+-using lil_uint16 = Endian<uint16, little_endian>;
+-using lil_uint32 = Endian<uint32, little_endian>;
+-using lil_uint64 = Endian<uint64, little_endian>;
+-using big_int16 = Endian<int16, big_endian>;
+-using big_int32 = Endian<int32, big_endian>;
+-using big_int64 = Endian<int64, big_endian>;
+-using big_uint16 = Endian<uint16, big_endian>;
+-using big_uint32 = Endian<uint32, big_endian>;
+-using big_uint64 = Endian<uint64, big_endian>;
+-using checksum = Endian<uint32, big_endian>;
++using lil_int16 = Endian<std::int16_t, little_endian>;
++using lil_int32 = Endian<std::int32_t, little_endian>;
++using lil_int64 = Endian<std::int64_t, little_endian>;
++using lil_uint16 = Endian<std::uint16_t, little_endian>;
++using lil_uint32 = Endian<std::uint32_t, little_endian>;
++using lil_uint64 = Endian<std::uint64_t, little_endian>;
++using big_int16 = Endian<std::int16_t, big_endian>;
++using big_int32 = Endian<std::int32_t, big_endian>;
++using big_int64 = Endian<std::int64_t, big_endian>;
++using big_uint16 = Endian<std::uint16_t, big_endian>;
++using big_uint32 = Endian<std::uint32_t, big_endian>;
++using big_uint64 = Endian<std::uint64_t, big_endian>;
++using checksum = Endian<std::uint32_t, big_endian>;
+ using big_80bits = Endian<bits80, big_endian>;
+ 
+ 
+diff --git a/ebml/EbmlUInteger.h b/ebml/EbmlUInteger.h
+index 999c435..7e9b3dc 100644
+--- a/ebml/EbmlUInteger.h
++++ b/ebml/EbmlUInteger.h
+@@ -52,15 +52,15 @@ const int DEFAULT_UINT_SIZE = 0; ///< optimal size stored
+ class EBML_DLL_API EbmlUInteger : public EbmlElement {
+   public:
+     EbmlUInteger();
+-    EbmlUInteger(uint64 DefaultValue);
++    EbmlUInteger(std::uint64_t DefaultValue);
+     EbmlUInteger(const EbmlUInteger & ElementToClone) = default;
+ 
+-    EbmlUInteger & operator=(uint64 NewValue) {Value = NewValue; SetValueIsSet(); return *this;}
++    EbmlUInteger & operator=(std::uint64_t NewValue) {Value = NewValue; SetValueIsSet(); return *this;}
+ 
+     /*!
+       Set the default size of the integer (usually 1,2,4 or 8)
+     */
+-    void SetDefaultSize(uint64 nDefaultSize = DEFAULT_UINT_SIZE) override {EbmlElement::SetDefaultSize(nDefaultSize); SetSize_(nDefaultSize);}
++    void SetDefaultSize(std::uint64_t nDefaultSize = DEFAULT_UINT_SIZE) override {EbmlElement::SetDefaultSize(nDefaultSize); SetSize_(nDefaultSize);}
+ 
+     bool ValidateSize() const override {return IsFiniteSize() && (GetSize() <= 8);}
+     filepos_t RenderData(IOCallback & output, bool bForceRender, bool bWithDefault = false) override;
+@@ -69,17 +69,17 @@ class EBML_DLL_API EbmlUInteger : public EbmlElement {
+ 
+     bool IsSmallerThan(const EbmlElement *Cmp) const override;
+ 
+-    operator uint8()  const;
+-    operator uint16() const;
+-    operator uint32() const;
+-    operator uint64() const;
++    operator std::uint8_t()  const;
++    operator std::uint16_t() const;
++    operator std::uint32_t() const;
++    operator std::uint64_t() const;
+ 
+-    EbmlUInteger &SetValue(uint64 NewValue);
+-    uint64 GetValue() const;
++    EbmlUInteger &SetValue(std::uint64_t NewValue);
++    std::uint64_t GetValue() const;
+ 
+-    void SetDefaultValue(uint64);
++    void SetDefaultValue(std::uint64_t);
+ 
+-    uint64 DefaultVal() const;
++    std::uint64_t DefaultVal() const;
+ 
+     bool IsDefaultValue() const override {
+       return (DefaultISset() && Value == DefaultValue);
+@@ -90,8 +90,8 @@ class EBML_DLL_API EbmlUInteger : public EbmlElement {
+ #else
+     protected:
+ #endif
+-    uint64 Value; /// The actual value of the element
+-    uint64 DefaultValue;
++    std::uint64_t Value; /// The actual value of the element
++    std::uint64_t DefaultValue;
+ };
+ 
+ } // namespace libebml
+diff --git a/ebml/EbmlVoid.h b/ebml/EbmlVoid.h
+index f35957b..0422699 100644
+--- a/ebml/EbmlVoid.h
++++ b/ebml/EbmlVoid.h
+@@ -48,7 +48,7 @@ DECLARE_EBML_BINARY(EbmlVoid)
+     /*!
+       \brief Set the size of the data (not the complete size of the element)
+     */
+-    void SetSize(uint64 aSize) {SetSize_(aSize);}
++    void SetSize(std::uint64_t aSize) {SetSize_(aSize);}
+ 
+     /*!
+       \note overwrite to write fake data
+@@ -58,12 +58,12 @@ DECLARE_EBML_BINARY(EbmlVoid)
+     /*!
+       \brief Replace the void element content (written) with this one
+     */
+-    uint64 ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output, bool ComeBackAfterward = true, bool bWithDefault = false);
++    std::uint64_t ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output, bool ComeBackAfterward = true, bool bWithDefault = false);
+ 
+     /*!
+       \brief Void the content of an element
+     */
+-    uint64 Overwrite(const EbmlElement & EltToVoid, IOCallback & output, bool ComeBackAfterward = true, bool bWithDefault = false);
++    std::uint64_t Overwrite(const EbmlElement & EltToVoid, IOCallback & output, bool ComeBackAfterward = true, bool bWithDefault = false);
+ 
+         EBML_CONCRETE_CLASS(EbmlVoid)
+ };
+diff --git a/ebml/IOCallback.h b/ebml/IOCallback.h
+index 6858f44..c9b8db2 100644
+--- a/ebml/IOCallback.h
++++ b/ebml/IOCallback.h
+@@ -59,12 +59,12 @@ public:
+   // file, the buffer and the size and the function returns the bytes read.
+   // If an error occurs or the file pointer points to the end of the file 0 is returned.
+   // Users are encouraged to throw a descriptive exception, when an error occurs.
+-  virtual uint32 read(void*Buffer,size_t Size)=0;
++  virtual std::uint32_t read(void*Buffer,size_t Size)=0;
+ 
+   // Seek to the specified position. The mode can have either SEEK_SET, SEEK_CUR
+   // or SEEK_END. The callback should return true(1) if the seek operation succeeded
+   // or false (0), when the seek fails.
+-  virtual void setFilePointer(int64 Offset,seek_mode Mode=seek_beginning)=0;
++  virtual void setFilePointer(std::int64_t Offset,seek_mode Mode=seek_beginning)=0;
+ 
+   // This callback just works like its read pendant. It returns the number of bytes written.
+   virtual size_t write(const void*Buffer,size_t Size)=0;
+@@ -74,7 +74,7 @@ public:
+   // should return -1 and the file pointer otherwise.
+   //
+   // If an error occurs, an exception should be thrown.
+-  virtual uint64 getFilePointer()=0;
++  virtual std::uint64_t getFilePointer()=0;
+ 
+   // The close callback flushes the file buffers to disk and closes the file. When using the stdio
+   // library, this is equivalent to calling fclose. When the close is not successful, an exception
+diff --git a/ebml/MemIOCallback.h b/ebml/MemIOCallback.h
+index 21dfd8c..9693d69 100644
+--- a/ebml/MemIOCallback.h
++++ b/ebml/MemIOCallback.h
+@@ -48,20 +48,20 @@ namespace libebml {
+ class EBML_DLL_API MemIOCallback : public IOCallback
+ {
+ public:
+-  MemIOCallback(uint64 DefaultSize = 128);
++  MemIOCallback(std::uint64_t DefaultSize = 128);
+   ~MemIOCallback() override;
+ 
+   /*!
+     Use this to copy some data to the Buffer from this classes data
+   */
+-  uint32 read(void *Buffer, size_t Size) override;
++  std::uint32_t read(void *Buffer, size_t Size) override;
+ 
+   /*!
+     Seek to the specified position. The mode can have either SEEK_SET, SEEK_CUR
+     or SEEK_END. The callback should return true(1) if the seek operation succeeded
+     or false (0), when the seek fails.
+   */
+-  void setFilePointer(int64 Offset, seek_mode Mode=seek_beginning) override;
++  void setFilePointer(std::int64_t Offset, seek_mode Mode=seek_beginning) override;
+ 
+   /*!
+     This callback just works like its read pendant. It returns the number of bytes written.
+@@ -75,7 +75,7 @@ public:
+ 
+     If an error occurs, an exception should be thrown.
+   */
+-  uint64 getFilePointer() override {return dataBufferPos;}
++  std::uint64_t getFilePointer() override {return dataBufferPos;}
+ 
+   /*!
+     The close callback flushes the file buffers to disk and closes the file. When using the stdio
+@@ -85,12 +85,12 @@ public:
+   void close() override {}
+ 
+   binary *GetDataBuffer() const {return dataBuffer;}
+-  uint64 GetDataBufferSize() const {return dataBufferTotalSize;}
+-  void SetDataBufferSize(uint64 newDataBufferSize) {dataBufferTotalSize = newDataBufferSize;}
++  std::uint64_t GetDataBufferSize() const {return dataBufferTotalSize;}
++  void SetDataBufferSize(std::uint64_t newDataBufferSize) {dataBufferTotalSize = newDataBufferSize;}
+   /*!
+     Use this to write some data from another IOCallback
+   */
+-  uint32 write(IOCallback & IOToRead, size_t Size);
++  std::uint32_t write(IOCallback & IOToRead, size_t Size);
+ 
+   bool IsOk() { return mOk; }
+   const std::string &GetLastErrorStr() { return mLastErrorStr; }
+@@ -102,15 +102,15 @@ protected:
+   /*!
+     Postion where we start 'writing' to the dataBuffer
+   */
+-  uint64 dataBufferPos;
++  std::uint64_t dataBufferPos;
+   /*!
+     Size of the data in the dataBuffer
+   */
+-  uint64 dataBufferTotalSize;
++  std::uint64_t dataBufferTotalSize;
+   /*!
+     Size of the memory malloc()/realloc()
+   */
+-  uint64 dataBufferMemorySize;
++  std::uint64_t dataBufferMemorySize;
+ };
+ 
+ } // namespace libebml
+diff --git a/ebml/MemReadIOCallback.h b/ebml/MemReadIOCallback.h
+index cdd5483..334b4ef 100644
+--- a/ebml/MemReadIOCallback.h
++++ b/ebml/MemReadIOCallback.h
+@@ -40,7 +40,7 @@ namespace libebml {
+ 
+ class EBML_DLL_API MemReadIOCallback : public IOCallback {
+ protected:
+-  uint8 const *mStart, *mEnd, *mPtr;
++  std::uint8_t const *mStart, *mEnd, *mPtr;
+ 
+ public:
+   MemReadIOCallback(void const *Ptr, size_t Size);
+@@ -48,13 +48,13 @@ public:
+   MemReadIOCallback(MemReadIOCallback const &Mem);
+   ~MemReadIOCallback() override = default;
+ 
+-  uint32 read(void *Buffer, size_t Size) override;
+-  void setFilePointer(int64 Offset, seek_mode Mode = seek_beginning) override;
++  std::uint32_t read(void *Buffer, size_t Size) override;
++  void setFilePointer(std::int64_t Offset, seek_mode Mode = seek_beginning) override;
+   size_t write(void const *, size_t) override { return 0; }
+-  uint64 getFilePointer() override { return mPtr - mStart; }
++  std::uint64_t getFilePointer() override { return mPtr - mStart; }
+   void close() override {}
+   binary const *GetDataBuffer() const { return mPtr; }
+-  uint64 GetDataBufferSize() const { return mEnd - mStart; }
++  std::uint64_t GetDataBufferSize() const { return mEnd - mStart; }
+ 
+ protected:
+   void Init(void const *Ptr, size_t Size);
+diff --git a/ebml/SafeReadIOCallback.h b/ebml/SafeReadIOCallback.h
+index 6b5480b..bb576c2 100644
+--- a/ebml/SafeReadIOCallback.h
++++ b/ebml/SafeReadIOCallback.h
+@@ -66,12 +66,12 @@ public:
+   size_t GetRemainingBytes() const;
+   bool IsEmpty() const;
+ 
+-  uint8  GetUInt8();
+-  uint64 GetUIntBE(size_t NumBytes);
+-  uint16 GetUInt16BE();
+-  uint32 GetUInt24BE();
+-  uint32 GetUInt32BE();
+-  uint64 GetUInt64BE();
++  std::uint8_t  GetUInt8();
++  std::uint64_t GetUIntBE(size_t NumBytes);
++  std::uint16_t GetUInt16BE();
++  std::uint32_t GetUInt24BE();
++  std::uint32_t GetUInt32BE();
++  std::uint64_t GetUInt64BE();
+ 
+   void Read(void *Dst, size_t Count);
+ 
+diff --git a/ebml/StdIOCallback.h b/ebml/StdIOCallback.h
+index 5d327ff..1b4e174 100644
+--- a/ebml/StdIOCallback.h
++++ b/ebml/StdIOCallback.h
+@@ -66,19 +66,19 @@ class EBML_DLL_API StdIOCallback:public IOCallback
+ {
+     private:
+       FILE*File;
+-    uint64 mCurrentPosition;
++    std::uint64_t mCurrentPosition;
+ 
+     public:
+ //  StdIOCallback(const char*Path,const char*Mode);
+   StdIOCallback(const char*Path, open_mode Mode);
+   ~StdIOCallback() noexcept override;
+ 
+-  uint32 read(void*Buffer,size_t Size) override;
++  std::uint32_t read(void*Buffer,size_t Size) override;
+ 
+   // Seek to the specified position. The mode can have either SEEK_SET, SEEK_CUR
+   // or SEEK_END. The callback should return true(1) if the seek operation succeeded
+   // or false (0), when the seek fails.
+-  void setFilePointer(int64 Offset,seek_mode Mode=seek_beginning) override;
++  void setFilePointer(std::int64_t Offset,seek_mode Mode=seek_beginning) override;
+ 
+   // This callback just works like its read pendant. It returns the number of bytes written.
+   size_t write(const void*Buffer,size_t Size) override;
+@@ -88,7 +88,7 @@ class EBML_DLL_API StdIOCallback:public IOCallback
+   // should return -1 and the file pointer otherwise.
+   //
+   // If an error occurs, an exception should be thrown.
+-  uint64 getFilePointer() override;
++  std::uint64_t getFilePointer() override;
+ 
+   // The close callback flushes the file buffers to disk and closes the file. When using the stdio
+   // library, this is equivalent to calling fclose. When the close is not successful, an exception
+diff --git a/ebml/c/libebml_t.h b/ebml/c/libebml_t.h
+deleted file mode 100644
+index b124369..0000000
+--- a/ebml/c/libebml_t.h
++++ /dev/null
+@@ -1,133 +0,0 @@
+-/****************************************************************************
+-** LIBEBML : parse EBML files, see http://ebml.sourceforge.net/
+-**
+-** <file/class description>
+-**
+-** Copyright (C) 2002-2003 Steve Lhomme.  All rights reserved.
+-**
+-** This file is part of LIBEBML.
+-**
+-** This library is free software; you can redistribute it and/or
+-** modify it under the terms of the GNU Lesser General Public
+-** License as published by the Free Software Foundation; either
+-** version 2.1 of the License, or (at your option) any later version.
+-**
+-** This library is distributed in the hope that it will be useful,
+-** but WITHOUT ANY WARRANTY; without even the implied warranty of
+-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+-** Lesser General Public License for more details.
+-**
+-** You should have received a copy of the GNU Lesser General Public
+-** License along with this library; if not, write to the Free Software
+-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+-**
+-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.
+-**
+-** Contact license@matroska.org if any conditions of this licensing are
+-** not clear to you.
+-**
+-**********************************************************************/
+-
+-/*!
+-    \file libebml_t.h
+-    \version \$Id: libebml_t.h 1298 2008-02-21 22:14:18Z mosu $
+-    \author Steve Lhomme     <robux4 @ users.sf.net>
+-    \author Ingo Ralf Blum   <ingoralfblum @ users.sf.net>
+-    \author Moritz Bunkus <moritz@bunkus.org>
+-
+-    \brief Misc type definitions for the C API of LIBEBML
+-
+-    \note These types should be compiler/language independant (just platform dependant)
+-    \todo recover the sized types (uint16, int32, etc) here too (or maybe here only)
+-*/
+-
+-#ifndef _LIBEBML_T_H_INCLUDED_
+-#define _LIBEBML_T_H_INCLUDED_
+-
+-#ifdef __cplusplus
+-extern "C" {
+-#endif
+-
+-// Changed char is unsigned now (signedness was causing trouble in endil)
+-#if defined(_WIN32)
+-# if !defined(__GNUC__)    // Microsoft Visual C++
+-    typedef signed __int64 int64;
+-    typedef signed __int32 int32;
+-    typedef signed __int16 int16;
+-    typedef signed __int8 int8;
+-    typedef __int8 character;
+-    typedef unsigned __int64 uint64;
+-    typedef unsigned __int32 uint32;
+-    typedef unsigned __int16 uint16;
+-    typedef unsigned __int8 uint8;
+-# else // __GNUC__, this is mingw
+-#  include <stdint.h>
+-    typedef int64_t int64;
+-    typedef int32_t int32;
+-    typedef int16_t int16;
+-    typedef int8_t int8;
+-    typedef int8_t character;
+-    typedef uint64_t uint64;
+-    typedef uint32_t uint32;
+-    typedef uint16_t uint16;
+-    typedef uint8_t uint8;
+-# endif // __GNUC__
+-#elif defined(__BEOS__) || defined(__HAIKU__)
+-#include <SupportDefs.h>
+-#elif defined(DJGPP)        /* SL : DJGPP doesn't support POSIX types ???? */
+-    typedef signed long long int64;
+-    typedef signed long int32;
+-    typedef signed short int16;
+-    typedef signed char int8;
+-    typedef char character;
+-    typedef unsigned long long uint64;
+-    typedef unsigned long uint32;
+-    typedef unsigned short uint16;
+-    typedef unsigned char uint8;
+-#elif defined(__sun) && (defined(__svr4__) || defined(__SVR4)) // SOLARIS
+-# include <inttypes.h>
+-# ifdef _NO_LONGLONG
+-#  error This compiler does not support 64bit integers.
+-# endif
+-    typedef int64_t int64;
+-    typedef int32_t int32;
+-    typedef int16_t int16;
+-    typedef int8_t int8;
+-    typedef int8_t character;
+-    typedef uint64_t uint64;
+-    typedef uint32_t uint32;
+-    typedef uint16_t uint16;
+-    typedef uint8_t uint8;
+-#elif defined(__BEOS__) || defined(__HAIKU__)
+-# include <support/SupportDefs.h>
+-#else // anything else (Linux, BSD, ...)
+-# include <inttypes.h>
+-# include <sys/types.h>
+-    typedef int64_t int64;
+-    typedef int32_t int32;
+-    typedef int16_t int16;
+-    typedef int8_t int8;
+-    typedef int8_t character;
+-    typedef uint64_t uint64;
+-    typedef uint32_t uint32;
+-    typedef uint16_t uint16;
+-    typedef uint8_t uint8;
+-#endif /* anything else */
+-
+-typedef uint8  binary;
+-typedef uint64 filepos_t;
+-
+-typedef enum open_mode {
+-    MODE_READ,
+-    MODE_WRITE,
+-    MODE_CREATE,
+-    MODE_SAFE
+-} open_mode;
+-
+-#define EBML_MIN(x,y) ((x)<(y) ? (x) : (y))
+-
+-#ifdef __cplusplus
+-}
+-#endif
+-
+-#endif /* _LIBEBML_T_H_INCLUDED_ */
+diff --git a/src/EbmlBinary.cpp b/src/EbmlBinary.cpp
+index a465c2f..7a96ec3 100644
+--- a/src/EbmlBinary.cpp
++++ b/src/EbmlBinary.cpp
+@@ -76,7 +76,7 @@ filepos_t EbmlBinary::RenderData(IOCallback & output, bool /* bForceRender */, b
+ /*!
+   \note no Default binary value handled
+ */
+-uint64 EbmlBinary::UpdateSize(bool /* bWithDefault */, bool /* bForceRender */)
++std::uint64_t EbmlBinary::UpdateSize(bool /* bWithDefault */, bool /* bForceRender */)
+ {
+   return GetSize();
+ }
+diff --git a/src/EbmlCrc32.cpp b/src/EbmlCrc32.cpp
+index 45765bf..d0c3e9a 100644
+--- a/src/EbmlCrc32.cpp
++++ b/src/EbmlCrc32.cpp
+@@ -39,20 +39,20 @@
+ #include "ebml/MemIOCallback.h"
+ 
+ #ifdef WORDS_BIGENDIAN
+-static constexpr uint32_t CRC32_INDEX(uint32_t c) { return c >> 24; }
+-static constexpr uint32_t CRC32_SHIFTED(uint32_t c) { return c << 8; }
++static constexpr std::uint32_t CRC32_INDEX(std::uint32_t c) { return c >> 24; }
++static constexpr std::uint32_t CRC32_SHIFTED(std::uint32_t c) { return c << 8; }
+ #else
+-static constexpr uint32_t CRC32_INDEX(uint32_t c) { return c & 0xFF; }
+-static constexpr uint32_t CRC32_SHIFTED(uint32_t c) { return c >> 8; }
++static constexpr std::uint32_t CRC32_INDEX(std::uint32_t c) { return c & 0xFF; }
++static constexpr std::uint32_t CRC32_SHIFTED(std::uint32_t c) { return c >> 8; }
+ #endif
+ 
+-static constexpr uint32 CRC32_NEGL = 0xffffffffL;
++static constexpr std::uint32_t CRC32_NEGL = 0xffffffffL;
+ 
+ namespace libebml {
+ 
+ DEFINE_EBML_CLASS_GLOBAL(EbmlCrc32, 0xBF, 1, "EBMLCrc32\0ratamadabapa")
+ 
+-const uint32 EbmlCrc32::m_tab[] = {
++const std::uint32_t EbmlCrc32::m_tab[] = {
+ #ifdef WORDS_BIGENDIAN
+   0x00000000L, 0x96300777L, 0x2c610eeeL, 0xba510999L, 0x19c46d07L,
+   0x8ff46a70L, 0x35a563e9L, 0xa395649eL, 0x3288db0eL, 0xa4b8dc79L,
+@@ -247,15 +247,15 @@ filepos_t EbmlCrc32::ReadData(IOCallback & input, ScopeMode ReadFully)
+   return GetSize();
+ }
+ 
+-bool EbmlCrc32::CheckCRC(uint32 inputCRC, const binary *input, uint32 length)
++bool EbmlCrc32::CheckCRC(std::uint32_t inputCRC, const binary *input, std::uint32_t length)
+ {
+-  uint32 crc = CRC32_NEGL;
++  std::uint32_t crc = CRC32_NEGL;
+ 
+-  for(; !IsAligned<uint32>(input) && length > 0; length--)
++  for(; !IsAligned<std::uint32_t>(input) && length > 0; length--)
+     crc = m_tab[CRC32_INDEX(crc) ^ *input++] ^ CRC32_SHIFTED(crc);
+ 
+   while (length >= 4) {
+-    crc ^= *reinterpret_cast<const uint32 *>(input);
++    crc ^= *reinterpret_cast<const std::uint32_t *>(input);
+     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
+     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
+     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
+@@ -273,20 +273,20 @@ bool EbmlCrc32::CheckCRC(uint32 inputCRC, const binary *input, uint32 length)
+   return crc == inputCRC;
+ }
+ 
+-void EbmlCrc32::FillCRC32(const binary *input, uint32 length)
++void EbmlCrc32::FillCRC32(const binary *input, std::uint32_t length)
+ {
+   ResetCRC();
+   Update(input, length);
+   Finalize();
+ 
+-  /*uint32 crc = CRC32_NEGL;
++  /*std::uint32_t crc = CRC32_NEGL;
+ 
+-  for(; !IsAligned<uint32>(s) && n > 0; n--)
++  for(; !IsAligned<std::uint32_t>(s) && n > 0; n--)
+     crc = m_tab[CRC32_INDEX(crc) ^ *s++] ^ CRC32_SHIFTED(crc);
+ 
+   while (n >= 4)
+   {
+-    crc ^= *(const uint32 *)s;
++    crc ^= *(const std::uint32_t *)s;
+     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
+     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
+     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
+@@ -307,15 +307,15 @@ void EbmlCrc32::FillCRC32(const binary *input, uint32 length)
+ 
+ }
+ 
+-void EbmlCrc32::Update(const binary *input, uint32 length)
++void EbmlCrc32::Update(const binary *input, std::uint32_t length)
+ {
+-  uint32 crc = m_crc;
++  std::uint32_t crc = m_crc;
+ 
+-  for(; !IsAligned<uint32>(input) && length > 0; length--)
++  for(; !IsAligned<std::uint32_t>(input) && length > 0; length--)
+     crc = m_tab[CRC32_INDEX(crc) ^ *input++] ^ CRC32_SHIFTED(crc);
+ 
+   while (length >= 4) {
+-    crc ^= *reinterpret_cast<const uint32 *>(input);
++    crc ^= *reinterpret_cast<const std::uint32_t *>(input);
+     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
+     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
+     crc = m_tab[CRC32_INDEX(crc)] ^ CRC32_SHIFTED(crc);
+diff --git a/src/EbmlDate.cpp b/src/EbmlDate.cpp
+index 53a0535..c8f3334 100644
+--- a/src/EbmlDate.cpp
++++ b/src/EbmlDate.cpp
+@@ -37,7 +37,7 @@
+ 
+ namespace libebml {
+ 
+-const uint64 EbmlDate::UnixEpochDelay = 978307200; // 2001/01/01 00:00:00 UTC
++const std::uint64_t EbmlDate::UnixEpochDelay = 978307200; // 2001/01/01 00:00:00 UTC
+ 
+ EbmlDate::EbmlDate(const EbmlDate & ElementToClone)
+ :EbmlElement(ElementToClone)
+diff --git a/src/EbmlElement.cpp b/src/EbmlElement.cpp
+index 6f974c5..b28f9e5 100644
+--- a/src/EbmlElement.cpp
++++ b/src/EbmlElement.cpp
+@@ -51,7 +51,7 @@ namespace libebml {
+ /*!
+   \todo handle more than CodedSize of 5
+ */
+-int CodedSizeLength(uint64 Length, unsigned int SizeLength, bool bSizeIsFinite)
++int CodedSizeLength(std::uint64_t Length, unsigned int SizeLength, bool bSizeIsFinite)
+ {
+   unsigned int CodedSize;
+   if (bSizeIsFinite) {
+@@ -89,7 +89,7 @@ int CodedSizeLength(uint64 Length, unsigned int SizeLength, bool bSizeIsFinite)
+ /*!
+   \todo handle more than CodedSize of 5
+ */
+-int CodedSizeLengthSigned(int64 Length, unsigned int SizeLength)
++int CodedSizeLengthSigned(std::int64_t Length, unsigned int SizeLength)
+ {
+   unsigned int CodedSize;
+   // prepare the head of the size (000...01xxxxxx)
+@@ -112,7 +112,7 @@ int CodedSizeLengthSigned(int64 Length, unsigned int SizeLength)
+   return CodedSize;
+ }
+ 
+-int CodedValueLength(uint64 Length, int CodedSize, binary * OutBuffer)
++int CodedValueLength(std::uint64_t Length, int CodedSize, binary * OutBuffer)
+ {
+   int _SizeMask = 0xFF;
+   OutBuffer[0] = 1 << (8 - CodedSize);
+@@ -126,7 +126,7 @@ int CodedValueLength(uint64 Length, int CodedSize, binary * OutBuffer)
+   return CodedSize;
+ }
+ 
+-int CodedValueLengthSigned(int64 Length, int CodedSize, binary * OutBuffer)
++int CodedValueLengthSigned(std::int64_t Length, int CodedSize, binary * OutBuffer)
+ {
+   if (Length > -64 && Length < 64) // 2^6
+     Length += 63;
+@@ -140,10 +140,10 @@ int CodedValueLengthSigned(int64 Length, int CodedSize, binary * OutBuffer)
+   return CodedValueLength(Length, CodedSize, OutBuffer);
+ }
+ 
+-uint64 ReadCodedSizeValue(const binary * InBuffer, uint32 & BufferSize, uint64 & SizeUnknown)
++std::uint64_t ReadCodedSizeValue(const binary * InBuffer, std::uint32_t & BufferSize, std::uint64_t & SizeUnknown)
+ {
+   binary SizeBitMask = 1 << 7;
+-  uint64 Result = 0x7F;
++  std::uint64_t Result = 0x7F;
+   unsigned int SizeIdx, PossibleSizeLength = 0;
+   binary PossibleSize[8];
+   memset(PossibleSize, 0, 8);
+@@ -186,9 +186,9 @@ uint64 ReadCodedSizeValue(const binary * InBuffer, uint32 & BufferSize, uint64 &
+   return 0;
+ }
+ 
+-int64 ReadCodedSizeSignedValue(const binary * InBuffer, uint32 & BufferSize, uint64 & SizeUnknown)
++std::int64_t ReadCodedSizeSignedValue(const binary * InBuffer, std::uint32_t & BufferSize, std::uint64_t & SizeUnknown)
+ {
+-  int64 Result = ReadCodedSizeValue(InBuffer, BufferSize, SizeUnknown);
++  std::int64_t Result = ReadCodedSizeValue(InBuffer, BufferSize, SizeUnknown);
+ 
+   if (BufferSize != 0) {
+     switch (BufferSize) {
+@@ -232,7 +232,7 @@ const EbmlSemantic & EbmlSemanticContext::GetSemantic(size_t i) const
+ }
+ 
+ 
+-EbmlElement::EbmlElement(uint64 aDefaultSize, bool bValueSet)
++EbmlElement::EbmlElement(std::uint64_t aDefaultSize, bool bValueSet)
+   :DefaultSize(aDefaultSize)
+   ,SizeLength(0) ///< write optimal size by default
+   ,bSizeIsFinite(true)
+@@ -254,22 +254,22 @@ EbmlElement::~EbmlElement()
+   \todo this method is deprecated and should be called FindThisID
+   \todo replace the new RawElement with the appropriate class (when known)
+ */
+-EbmlElement * EbmlElement::FindNextID(IOCallback & DataStream, const EbmlCallbacks & ClassInfos, uint64 MaxDataSize)
++EbmlElement * EbmlElement::FindNextID(IOCallback & DataStream, const EbmlCallbacks & ClassInfos, std::uint64_t MaxDataSize)
+ {
+   binary PossibleId[4];
+   int PossibleID_Length = 0;
+   binary PossibleSize[8]; // we don't support size stored in more than 64 bits
+-  uint32 PossibleSizeLength = 0;
+-  uint64 SizeUnknown = 0;
+-  uint64 SizeFound = 0;
++  std::uint32_t PossibleSizeLength = 0;
++  std::uint64_t SizeUnknown = 0;
++  std::uint64_t SizeFound = 0;
+   bool bElementFound = false;
+ 
+   binary BitMask;
+-  uint64 aElementPosition = 0, aSizePosition = 0;
++  std::uint64_t aElementPosition = 0, aSizePosition = 0;
+   while (!bElementFound) {
+     // read ID
+     aElementPosition = DataStream.getFilePointer();
+-    uint32 ReadSize = 0;
++    std::uint32_t ReadSize = 0;
+     BitMask = 1 << 7;
+     while (PossibleID_Length < 4) {
+       if (!DataStream.read(&PossibleId[PossibleID_Length], 1))
+@@ -297,7 +297,7 @@ EbmlElement * EbmlElement::FindNextID(IOCallback & DataStream, const EbmlCallbac
+ 
+     // read the data size
+     aSizePosition = DataStream.getFilePointer();
+-    uint32 _SizeLength;
++    std::uint32_t _SizeLength;
+     do {
+       if (PossibleSizeLength >= 8)
+         // Size is larger than 8 bytes
+@@ -354,19 +354,19 @@ EbmlElement * EbmlElement::FindNextID(IOCallback & DataStream, const EbmlCallbac
+   \param LowLevel Will be returned with the level of the element found compared to the context given
+ */
+ EbmlElement * EbmlElement::FindNextElement(IOCallback & DataStream, const EbmlSemanticContext & Context, int & UpperLevel,
+-                                           uint64 MaxDataSize, bool AllowDummyElt, unsigned int MaxLowerLevel)
++                                           std::uint64_t MaxDataSize, bool AllowDummyElt, unsigned int MaxLowerLevel)
+ {
+   int PossibleID_Length = 0;
+   binary PossibleIdNSize[16];
+   int PossibleSizeLength;
+-  uint64 SizeUnknown;
++  std::uint64_t SizeUnknown;
+   int ReadIndex = 0; // trick for the algo, start index at 0
+-  uint32 ReadSize = 0, IdStart = 0;
+-  uint64 SizeFound;
++  std::uint32_t ReadSize = 0, IdStart = 0;
++  std::uint64_t SizeFound;
+   int SizeIdx;
+   bool bFound;
+   int UpperLevel_original = UpperLevel;
+-  uint64 ParseStart = DataStream.getFilePointer();
++  std::uint64_t ParseStart = DataStream.getFilePointer();
+ 
+   do {
+     // read a potential ID
+@@ -412,7 +412,7 @@ EbmlElement * EbmlElement::FindNextElement(IOCallback & DataStream, const EbmlSe
+     ReadIndex -= PossibleID_Length;
+ 
+     // read the data size
+-    uint32 _SizeLength;
++    std::uint32_t _SizeLength;
+     PossibleSizeLength = ReadIndex;
+     while (true) {
+       _SizeLength = PossibleSizeLength;
+@@ -597,12 +597,12 @@ filepos_t EbmlElement::Render(IOCallback & output, bool bWithDefault, bool bKeep
+     return 0;
+   }
+ #if defined(LIBEBML_DEBUG)
+-  uint64 SupposedSize = UpdateSize(bWithDefault, bForceRender);
++  std::uint64_t SupposedSize = UpdateSize(bWithDefault, bForceRender);
+ #endif // LIBEBML_DEBUG
+   filepos_t result = RenderHead(output, bForceRender, bWithDefault, bKeepPosition);
+-  uint64 WrittenSize = RenderData(output, bForceRender, bWithDefault);
++  std::uint64_t WrittenSize = RenderData(output, bForceRender, bWithDefault);
+ #if defined(LIBEBML_DEBUG)
+-  if (static_cast<int64>(SupposedSize) != (0-1))
++  if (static_cast<std::int64_t>(SupposedSize) != (0-1))
+     assert(WrittenSize == SupposedSize);
+ #endif // LIBEBML_DEBUG
+   result += WrittenSize;
+@@ -645,7 +645,7 @@ filepos_t EbmlElement::MakeRenderHead(IOCallback & output, bool bKeepPosition)
+   return FinalHeadSize;
+ }
+ 
+-uint64 EbmlElement::ElementSize(bool bWithDefault) const
++std::uint64_t EbmlElement::ElementSize(bool bWithDefault) const
+ {
+   if (!bWithDefault && IsDefaultValue())
+     return 0; // won't be saved
+@@ -670,14 +670,14 @@ void EbmlElement::Read(EbmlStream & inDataStream, const EbmlSemanticContext & /*
+   ReadData(inDataStream.I_O(), ReadFully);
+ }
+ 
+-bool EbmlElement::ForceSize(uint64 NewSize)
++bool EbmlElement::ForceSize(std::uint64_t NewSize)
+ {
+   if (bSizeIsFinite) {
+     return false;
+   }
+ 
+   int OldSizeLen = CodedSizeLength(Size, SizeLength, bSizeIsFinite);
+-  uint64 OldSize = Size;
++  std::uint64_t OldSize = Size;
+ 
+   Size = NewSize;
+ 
+@@ -696,7 +696,7 @@ filepos_t EbmlElement::OverwriteHead(IOCallback & output, bool bKeepPosition)
+     return 0; // the element has not been written
+   }
+ 
+-  uint64 CurrentPosition = output.getFilePointer();
++  std::uint64_t CurrentPosition = output.getFilePointer();
+   output.setFilePointer(GetElementPosition());
+   filepos_t Result = MakeRenderHead(output, bKeepPosition);
+   output.setFilePointer(CurrentPosition);
+@@ -723,7 +723,7 @@ filepos_t EbmlElement::OverwriteData(IOCallback & output, bool bKeepPosition)
+ }
+ 
+ 
+-uint64 EbmlElement::VoidMe(IOCallback & output, bool bWithDefault)
++std::uint64_t EbmlElement::VoidMe(IOCallback & output, bool bWithDefault)
+ {
+   if (ElementPosition == 0) {
+     return 0; // the element has not been written
+diff --git a/src/EbmlFloat.cpp b/src/EbmlFloat.cpp
+index a6b93ae..90920b2 100644
+--- a/src/EbmlFloat.cpp
++++ b/src/EbmlFloat.cpp
+@@ -91,7 +91,7 @@ filepos_t EbmlFloat::RenderData(IOCallback & output, bool /* bForceRender */, bo
+     output.writeFully(&TmpToWrite.endian(), GetSize());
+   } else if (GetSize() == 8) {
+     double val = Value;
+-    int64 Tmp;
++    std::int64_t Tmp;
+     memcpy(&Tmp, &val, 8);
+     big_int64 TmpToWrite(Tmp);
+     output.writeFully(&TmpToWrite.endian(), GetSize());
+@@ -100,7 +100,7 @@ filepos_t EbmlFloat::RenderData(IOCallback & output, bool /* bForceRender */, bo
+   return GetSize();
+ }
+ 
+-uint64 EbmlFloat::UpdateSize(bool bWithDefault, bool  /* bForceRender */)
++std::uint64_t EbmlFloat::UpdateSize(bool bWithDefault, bool  /* bForceRender */)
+ {
+   if (!bWithDefault && IsDefaultValue())
+     return 0;
+@@ -128,7 +128,7 @@ filepos_t EbmlFloat::ReadData(IOCallback & input, ScopeMode ReadFully)
+   if (GetSize() == 4) {
+     big_int32 TmpRead;
+     TmpRead.Eval(Buffer);
+-    auto tmpp = static_cast<int32>(TmpRead);
++    auto tmpp = static_cast<std::int32_t>(TmpRead);
+     float val;
+     memcpy(&val, &tmpp, 4);
+     Value = static_cast<double>(val);
+@@ -136,7 +136,7 @@ filepos_t EbmlFloat::ReadData(IOCallback & input, ScopeMode ReadFully)
+   } else {
+     big_int64 TmpRead;
+     TmpRead.Eval(Buffer);
+-    auto tmpp = static_cast<int64>(TmpRead);
++    auto tmpp = static_cast<std::int64_t>(TmpRead);
+     double val;
+     memcpy(&val, &tmpp, 8);
+     Value = val;
+diff --git a/src/EbmlMaster.cpp b/src/EbmlMaster.cpp
+index 071eb5d..15d1dd2 100644
+--- a/src/EbmlMaster.cpp
++++ b/src/EbmlMaster.cpp
+@@ -124,7 +124,7 @@ bool EbmlMaster::PushElement(EbmlElement & element)
+   return true;
+ }
+ 
+-uint64 EbmlMaster::UpdateSize(bool bWithDefault, bool bForceRender)
++std::uint64_t EbmlMaster::UpdateSize(bool bWithDefault, bool bForceRender)
+ {
+   SetSize_(0);
+ 
+@@ -139,9 +139,9 @@ uint64 EbmlMaster::UpdateSize(bool bWithDefault, bool bForceRender)
+     if (!bWithDefault && Element->IsDefaultValue())
+       continue;
+     Element->UpdateSize(bWithDefault, bForceRender);
+-    uint64 SizeToAdd = Element->ElementSize(bWithDefault);
++    std::uint64_t SizeToAdd = Element->ElementSize(bWithDefault);
+ #if defined(LIBEBML_DEBUG)
+-    if (static_cast<int64>(SizeToAdd) == (0-1))
++    if (static_cast<std::int64_t>(SizeToAdd) == (0-1))
+       return (0-1);
+ #endif // LIBEBML_DEBUG
+     SetSize_(GetSize() + SizeToAdd);
+@@ -388,7 +388,7 @@ void EbmlMaster::Read(EbmlStream & inDataStream, const EbmlSemanticContext & sCo
+     }
+   }
+   ElementList.clear();
+-  uint64 MaxSizeToRead;
++  std::uint64_t MaxSizeToRead;
+ 
+   if (IsFiniteSize())
+     MaxSizeToRead = GetSize();
+diff --git a/src/EbmlSInteger.cpp b/src/EbmlSInteger.cpp
+index 4a4c633..d494abf 100644
+--- a/src/EbmlSInteger.cpp
++++ b/src/EbmlSInteger.cpp
+@@ -43,12 +43,12 @@
+ 
+ namespace {
+ 
+-int64
+-ToSigned(uint64 u) {
+-  if (u <= static_cast<uint64>(std::numeric_limits<int64>::max()))
+-    return static_cast<int64>(u);
++std::int64_t
++ToSigned(std::uint64_t u) {
++  if (u <= static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()))
++    return static_cast<std::int64_t>(u);
+ 
+-  return static_cast<int64>(u - std::numeric_limits<int64>::min()) + std::numeric_limits<int64>::min();
++  return static_cast<std::int64_t>(u - std::numeric_limits<std::int64_t>::min()) + std::numeric_limits<std::int64_t>::min();
+ }
+ 
+ } // namespace
+@@ -59,20 +59,20 @@ EbmlSInteger::EbmlSInteger()
+   :EbmlElement(DEFAULT_INT_SIZE, false)
+ {}
+ 
+-EbmlSInteger::EbmlSInteger(int64 aDefaultValue)
++EbmlSInteger::EbmlSInteger(std::int64_t aDefaultValue)
+   :EbmlElement(DEFAULT_INT_SIZE, true), Value(aDefaultValue)
+ {
+   SetDefaultIsSet();
+ }
+ 
+-EbmlSInteger::operator int8() const {return  static_cast<int8>(Value);}
+-EbmlSInteger::operator int16() const {return static_cast<int16>(Value);}
+-EbmlSInteger::operator int32() const {return static_cast<int32>(Value);}
+-EbmlSInteger::operator int64() const {return Value;}
++EbmlSInteger::operator std::int8_t() const {return  static_cast<std::int8_t>(Value);}
++EbmlSInteger::operator std::int16_t() const {return static_cast<std::int16_t>(Value);}
++EbmlSInteger::operator std::int32_t() const {return static_cast<std::int32_t>(Value);}
++EbmlSInteger::operator std::int64_t() const {return Value;}
+ 
+-int64 EbmlSInteger::GetValue() const {return Value;}
++std::int64_t EbmlSInteger::GetValue() const {return Value;}
+ 
+-EbmlSInteger & EbmlSInteger::SetValue(int64 NewValue) {
++EbmlSInteger & EbmlSInteger::SetValue(std::int64_t NewValue) {
+   return *this = NewValue;
+ }
+ 
+@@ -87,7 +87,7 @@ filepos_t EbmlSInteger::RenderData(IOCallback & output, bool /* bForceRender */,
+   if (GetSizeLength() > 8)
+     return 0; // integer bigger coded on more than 64 bits are not supported
+ 
+-  int64 TempValue = Value;
++  std::int64_t TempValue = Value;
+   for (i=0; i<GetSize();i++) {
+     FinalData[GetSize()-i-1] = static_cast<binary>(TempValue & 0xFF);
+     TempValue >>= 8;
+@@ -98,7 +98,7 @@ filepos_t EbmlSInteger::RenderData(IOCallback & output, bool /* bForceRender */,
+   return GetSize();
+ }
+ 
+-uint64 EbmlSInteger::UpdateSize(bool bWithDefault, bool /* bForceRender */)
++std::uint64_t EbmlSInteger::UpdateSize(bool bWithDefault, bool /* bForceRender */)
+ {
+   if (!bWithDefault && IsDefaultValue())
+     return 0;
+@@ -145,7 +145,7 @@ filepos_t EbmlSInteger::ReadData(IOCallback & input, ScopeMode ReadFully)
+   binary Buffer[8];
+   input.readFully(Buffer, GetSize());
+ 
+-  uint64 TempValue = Buffer[0] & 0x80 ? std::numeric_limits<uint64>::max() : 0;
++  std::uint64_t TempValue = Buffer[0] & 0x80 ? std::numeric_limits<std::uint64_t>::max() : 0;
+ 
+   for (unsigned int i=0; i<GetSize(); i++) {
+     TempValue <<= 8;
+diff --git a/src/EbmlStream.cpp b/src/EbmlStream.cpp
+index c3013e8..1078a9b 100644
+--- a/src/EbmlStream.cpp
++++ b/src/EbmlStream.cpp
+@@ -41,12 +41,12 @@ EbmlStream::EbmlStream(IOCallback & DataStream)
+   :Stream(DataStream)
+ {}
+ 
+-EbmlElement * EbmlStream::FindNextID(const EbmlCallbacks & ClassInfos, uint64 MaxDataSize)
++EbmlElement * EbmlStream::FindNextID(const EbmlCallbacks & ClassInfos, std::uint64_t MaxDataSize)
+ {
+   return EbmlElement::FindNextID(Stream, ClassInfos, MaxDataSize);
+ }
+ 
+-EbmlElement * EbmlStream::FindNextElement(const EbmlSemanticContext & Context, int & UpperLevel, uint64 MaxDataSize, bool AllowDummyElt, unsigned int MaxLowerLevel)
++EbmlElement * EbmlStream::FindNextElement(const EbmlSemanticContext & Context, int & UpperLevel, std::uint64_t MaxDataSize, bool AllowDummyElt, unsigned int MaxLowerLevel)
+ {
+   return EbmlElement::FindNextElement(Stream, Context, UpperLevel, MaxDataSize, AllowDummyElt, MaxLowerLevel);
+ }
+diff --git a/src/EbmlString.cpp b/src/EbmlString.cpp
+index e1f4597..27f089a 100644
+--- a/src/EbmlString.cpp
++++ b/src/EbmlString.cpp
+@@ -123,7 +123,7 @@ std::string EbmlString::GetValue() const {
+   return Value;
+ }
+ 
+-uint64 EbmlString::UpdateSize(bool bWithDefault, bool /* bForceRender */)
++std::uint64_t EbmlString::UpdateSize(bool bWithDefault, bool /* bForceRender */)
+ {
+   if (!bWithDefault && IsDefaultValue())
+     return 0;
+diff --git a/src/EbmlUInteger.cpp b/src/EbmlUInteger.cpp
+index 3cc132b..95a864f 100644
+--- a/src/EbmlUInteger.cpp
++++ b/src/EbmlUInteger.cpp
+@@ -44,33 +44,33 @@ EbmlUInteger::EbmlUInteger()
+   :EbmlElement(DEFAULT_UINT_SIZE, false)
+ {}
+ 
+-EbmlUInteger::EbmlUInteger(uint64 aDefaultValue)
++EbmlUInteger::EbmlUInteger(std::uint64_t aDefaultValue)
+   :EbmlElement(DEFAULT_UINT_SIZE, true), Value(aDefaultValue), DefaultValue(aDefaultValue)
+ {
+   SetDefaultIsSet();
+ }
+ 
+-void EbmlUInteger::SetDefaultValue(uint64 aValue)
++void EbmlUInteger::SetDefaultValue(std::uint64_t aValue)
+ {
+   assert(!DefaultISset());
+   DefaultValue = aValue;
+   SetDefaultIsSet();
+ }
+ 
+-uint64 EbmlUInteger::DefaultVal() const
++std::uint64_t EbmlUInteger::DefaultVal() const
+ {
+   assert(DefaultISset());
+   return DefaultValue;
+ }
+ 
+-EbmlUInteger::operator uint8()  const {return static_cast<uint8>(Value); }
+-EbmlUInteger::operator uint16() const {return static_cast<uint16>(Value);}
+-EbmlUInteger::operator uint32() const {return static_cast<uint32>(Value);}
+-EbmlUInteger::operator uint64() const {return Value;}
++EbmlUInteger::operator std::uint8_t()  const {return static_cast<std::uint8_t>(Value); }
++EbmlUInteger::operator std::uint16_t() const {return static_cast<std::uint16_t>(Value);}
++EbmlUInteger::operator std::uint32_t() const {return static_cast<std::uint32_t>(Value);}
++EbmlUInteger::operator std::uint64_t() const {return Value;}
+ 
+-uint64 EbmlUInteger::GetValue() const {return Value;}
++std::uint64_t EbmlUInteger::GetValue() const {return Value;}
+ 
+-EbmlUInteger & EbmlUInteger::SetValue(uint64 NewValue) {
++EbmlUInteger & EbmlUInteger::SetValue(std::uint64_t NewValue) {
+   return *this = NewValue;
+ }
+ 
+@@ -84,7 +84,7 @@ filepos_t EbmlUInteger::RenderData(IOCallback & output, bool /* bForceRender */,
+   if (GetSizeLength() > 8)
+     return 0; // integer bigger coded on more than 64 bits are not supported
+ 
+-  uint64 TempValue = Value;
++  std::uint64_t TempValue = Value;
+   for (unsigned int i=0; i<GetSize();i++) {
+     FinalData[GetSize()-i-1] = TempValue & 0xFF;
+     TempValue >>= 8;
+@@ -95,7 +95,7 @@ filepos_t EbmlUInteger::RenderData(IOCallback & output, bool /* bForceRender */,
+   return GetSize();
+ }
+ 
+-uint64 EbmlUInteger::UpdateSize(bool bWithDefault, bool /* bForceRender */)
++std::uint64_t EbmlUInteger::UpdateSize(bool bWithDefault, bool /* bForceRender */)
+ {
+   if (!bWithDefault && IsDefaultValue())
+     return 0;
+diff --git a/src/EbmlUnicodeString.cpp b/src/EbmlUnicodeString.cpp
+index 363cfe3..44444d8 100644
+--- a/src/EbmlUnicodeString.cpp
++++ b/src/EbmlUnicodeString.cpp
+@@ -235,7 +235,7 @@ const UTFstring & EbmlUnicodeString::DefaultVal() const
+ */
+ filepos_t EbmlUnicodeString::RenderData(IOCallback & output, bool /* bForceRender */, bool /* bWithDefault */)
+ {
+-  uint32 Result = Value.GetUTF8().length();
++  size_t Result = Value.GetUTF8().length();
+ 
+   if (Result != 0) {
+     output.writeFully(Value.GetUTF8().c_str(), Result);
+@@ -286,7 +286,7 @@ std::string EbmlUnicodeString::GetValueUTF8() const {
+ /*!
+ \note limited to UCS-2
+ */
+-uint64 EbmlUnicodeString::UpdateSize(bool bWithDefault, bool /* bForceRender */)
++std::uint64_t EbmlUnicodeString::UpdateSize(bool bWithDefault, bool /* bForceRender */)
+ {
+   if (!bWithDefault && IsDefaultValue())
+     return 0;
+diff --git a/src/EbmlVoid.cpp b/src/EbmlVoid.cpp
+index 0053c42..4210450 100644
+--- a/src/EbmlVoid.cpp
++++ b/src/EbmlVoid.cpp
+@@ -50,7 +50,7 @@ filepos_t EbmlVoid::RenderData(IOCallback & output, bool /* bForceRender */, boo
+   // write dummy data by 4KB chunks
+   static binary DummyBuf[4*1024];
+ 
+-  uint64 SizeToWrite = GetSize();
++  std::uint64_t SizeToWrite = GetSize();
+   while (SizeToWrite > 4*1024) {
+     output.writeFully(DummyBuf, 4*1024);
+     SizeToWrite -= 4*1024;
+@@ -59,7 +59,7 @@ filepos_t EbmlVoid::RenderData(IOCallback & output, bool /* bForceRender */, boo
+   return GetSize();
+ }
+ 
+-uint64 EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output, bool ComeBackAfterward, bool bWithDefault)
++std::uint64_t EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output, bool ComeBackAfterward, bool bWithDefault)
+ {
+   EltToReplaceWith.UpdateSize(bWithDefault);
+   if (HeadSize() + GetSize() < EltToReplaceWith.GetSize() + EltToReplaceWith.HeadSize()) {
+@@ -71,7 +71,7 @@ uint64 EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output
+     return INVALID_FILEPOS_T;
+   }
+ 
+-  uint64 CurrentPosition = output.getFilePointer();
++  std::uint64_t CurrentPosition = output.getFilePointer();
+ 
+   output.setFilePointer(GetElementPosition());
+   EltToReplaceWith.Render(output, bWithDefault);
+@@ -96,7 +96,7 @@ uint64 EbmlVoid::ReplaceWith(EbmlElement & EltToReplaceWith, IOCallback & output
+   return GetSize() + HeadSize();
+ }
+ 
+-uint64 EbmlVoid::Overwrite(const EbmlElement & EltToVoid, IOCallback & output, bool ComeBackAfterward, bool bWithDefault)
++std::uint64_t EbmlVoid::Overwrite(const EbmlElement & EltToVoid, IOCallback & output, bool ComeBackAfterward, bool bWithDefault)
+ {
+   //  EltToVoid.UpdateSize(bWithDefault);
+   if (EltToVoid.GetElementPosition() == 0) {
+@@ -108,7 +108,7 @@ uint64 EbmlVoid::Overwrite(const EbmlElement & EltToVoid, IOCallback & output, b
+     return 0;
+   }
+ 
+-  uint64 CurrentPosition = output.getFilePointer();
++  std::uint64_t CurrentPosition = output.getFilePointer();
+ 
+   output.setFilePointer(EltToVoid.GetElementPosition());
+ 
+@@ -116,8 +116,8 @@ uint64 EbmlVoid::Overwrite(const EbmlElement & EltToVoid, IOCallback & output, b
+   SetSize(EltToVoid.GetSize() + EltToVoid.HeadSize() - 1); // 1 for the ID
+   SetSize(GetSize() - CodedSizeLength(GetSize(), GetSizeLength(), IsFiniteSize()));
+   // make sure we handle even the strange cases
+-  //uint32 A1 = GetSize() + HeadSize();
+-  //uint32 A2 = EltToVoid.GetSize() + EltToVoid.HeadSize();
++  //std::uint32_t A1 = GetSize() + HeadSize();
++  //std::uint32_t A2 = EltToVoid.GetSize() + EltToVoid.HeadSize();
+   if (GetSize() + HeadSize() != EltToVoid.GetSize() + EltToVoid.HeadSize()) {
+     SetSize(GetSize()-1);
+     SetSizeLength(CodedSizeLength(GetSize(), GetSizeLength(), IsFiniteSize()) + 1);
+diff --git a/src/MemIOCallback.cpp b/src/MemIOCallback.cpp
+index 43c17e8..ee823b8 100644
+--- a/src/MemIOCallback.cpp
++++ b/src/MemIOCallback.cpp
+@@ -38,7 +38,7 @@
+ 
+ namespace libebml {
+ 
+-MemIOCallback::MemIOCallback(uint64 DefaultSize)
++MemIOCallback::MemIOCallback(std::uint64_t DefaultSize)
+ {
+   //The default size of the buffer is 128 bytes
+   dataBuffer = static_cast<binary *>(malloc(DefaultSize));
+@@ -63,7 +63,7 @@ MemIOCallback::~MemIOCallback()
+     free(dataBuffer);
+ }
+ 
+-uint32 MemIOCallback::read(void *Buffer, size_t Size)
++std::uint32_t MemIOCallback::read(void *Buffer, size_t Size)
+ {
+   if (Buffer == nullptr || Size < 1)
+     return 0;
+@@ -71,7 +71,7 @@ uint32 MemIOCallback::read(void *Buffer, size_t Size)
+   if (Size + dataBufferPos > dataBufferTotalSize) {
+     //We will only return the remaining data
+     memcpy(Buffer, dataBuffer + dataBufferPos, dataBufferTotalSize - dataBufferPos);
+-    uint64 oldDataPos = dataBufferPos;
++    std::uint64_t oldDataPos = dataBufferPos;
+     dataBufferPos = dataBufferTotalSize;
+     return dataBufferTotalSize - oldDataPos;
+   }
+@@ -83,7 +83,7 @@ uint32 MemIOCallback::read(void *Buffer, size_t Size)
+   return Size;
+ }
+ 
+-void MemIOCallback::setFilePointer(int64 Offset, seek_mode Mode)
++void MemIOCallback::setFilePointer(std::int64_t Offset, seek_mode Mode)
+ {
+   if (Mode == seek_beginning)
+     dataBufferPos = Offset;
+@@ -107,7 +107,7 @@ size_t MemIOCallback::write(const void *Buffer, size_t Size)
+   return Size;
+ }
+ 
+-uint32 MemIOCallback::write(IOCallback & IOToRead, size_t Size)
++std::uint32_t MemIOCallback::write(IOCallback & IOToRead, size_t Size)
+ {
+   if (dataBufferMemorySize < dataBufferPos + Size) {
+     //We need more memory!
+diff --git a/src/MemReadIOCallback.cpp b/src/MemReadIOCallback.cpp
+index 76dca1e..3a1d695 100644
+--- a/src/MemReadIOCallback.cpp
++++ b/src/MemReadIOCallback.cpp
+@@ -57,12 +57,12 @@ MemReadIOCallback::MemReadIOCallback(MemReadIOCallback const &Mem) {
+ void
+ MemReadIOCallback::Init(void const *Ptr,
+                         size_t Size) {
+-  mStart = reinterpret_cast<uint8 const *>(Ptr);
++  mStart = reinterpret_cast<std::uint8_t const *>(Ptr);
+   mEnd   = mStart + Size;
+   mPtr   = mStart;
+ }
+ 
+-uint32
++std::uint32_t
+ MemReadIOCallback::read(void *Buffer,
+                         size_t Size) {
+   size_t RemainingBytes = mEnd - mPtr;
+@@ -76,13 +76,13 @@ MemReadIOCallback::read(void *Buffer,
+ }
+ 
+ void
+-MemReadIOCallback::setFilePointer(int64 Offset,
++MemReadIOCallback::setFilePointer(std::int64_t Offset,
+                                   seek_mode Mode) {
+-  int64 NewPosition = Mode == seek_beginning ? Offset
+-                    : Mode == seek_end       ? static_cast<int64>(mEnd - mStart) + Offset
+-                    :                          static_cast<int64>(mPtr - mStart) + Offset;
++  std::int64_t NewPosition = Mode == seek_beginning ? Offset
++                    : Mode == seek_end       ? static_cast<std::int64_t>(mEnd - mStart) + Offset
++                    :                          static_cast<std::int64_t>(mPtr - mStart) + Offset;
+ 
+-  NewPosition = std::min<int64>(std::max<int64>(NewPosition, 0), mEnd - mStart);
++  NewPosition = std::min<std::int64_t>(std::max<std::int64_t>(NewPosition, 0), mEnd - mStart);
+   mPtr = mStart + NewPosition;
+ }
+ 
+diff --git a/src/SafeReadIOCallback.cpp b/src/SafeReadIOCallback.cpp
+index 9b7b09b..ffaf48f 100644
+--- a/src/SafeReadIOCallback.cpp
++++ b/src/SafeReadIOCallback.cpp
+@@ -73,7 +73,7 @@ SafeReadIOCallback::Init(IOCallback *IO,
+                          bool DeleteIO) {
+   mIO                = IO;
+   mDeleteIO          = DeleteIO;
+-  int64 PrevPosition = IO->getFilePointer();
++  std::int64_t PrevPosition = IO->getFilePointer();
+   IO->setFilePointer(0, seek_end);
+   mSize              = IO->getFilePointer();
+   IO->setFilePointer(PrevPosition);
+@@ -103,13 +103,13 @@ SafeReadIOCallback::IsEmpty()
+   return !GetRemainingBytes();
+ }
+ 
+-uint64
++std::uint64_t
+ SafeReadIOCallback::GetUIntBE(size_t NumBytes) {
+-  uint8 Buffer[8];
++  std::uint8_t Buffer[8];
+ 
+   NumBytes     = std::min<size_t>(std::max<size_t>(1, NumBytes), 8);
+-  uint64 Value = 0;
+-  uint8* Ptr   = &Buffer[0];
++  std::uint64_t Value = 0;
++  std::uint8_t* Ptr   = &Buffer[0];
+ 
+   Read(Buffer, NumBytes);
+ 
+@@ -119,37 +119,37 @@ SafeReadIOCallback::GetUIntBE(size_t NumBytes) {
+   return Value;
+ }
+ 
+-uint8
++std::uint8_t
+ SafeReadIOCallback::GetUInt8() {
+-  return GetUIntBE(1);
++  return static_cast<std::uint8_t>(GetUIntBE(1));
+ }
+ 
+-uint16
++std::uint16_t
+ SafeReadIOCallback::GetUInt16BE() {
+-  return GetUIntBE(2);
++  return static_cast<std::uint16_t>(GetUIntBE(2));
+ }
+ 
+-uint32
++std::uint32_t
+ SafeReadIOCallback::GetUInt24BE() {
+-  return GetUIntBE(3);
++  return static_cast<std::uint32_t>(GetUIntBE(3));
+ }
+ 
+-uint32
++std::uint32_t
+ SafeReadIOCallback::GetUInt32BE() {
+-  return GetUIntBE(4);
++  return static_cast<std::uint32_t>(GetUIntBE(4));
+ }
+ 
+-uint64
++std::uint64_t
+ SafeReadIOCallback::GetUInt64BE() {
+   return GetUIntBE(8);
+ }
+ 
+ void
+ SafeReadIOCallback::Skip(size_t Count) {
+-  int64 PrevPosition     = mIO->getFilePointer();
+-  int64 ExpectedPosition = PrevPosition + Count;
++  std::int64_t PrevPosition     = mIO->getFilePointer();
++  std::int64_t ExpectedPosition = PrevPosition + Count;
+   mIO->setFilePointer(Count, seek_current);
+-  int64 ActualPosition   = mIO->getFilePointer();
++  std::int64_t ActualPosition   = mIO->getFilePointer();
+ 
+   if (ActualPosition != ExpectedPosition)
+     throw SafeReadIOCallback::EndOfStreamX(ExpectedPosition - ActualPosition);
+@@ -158,7 +158,7 @@ SafeReadIOCallback::Skip(size_t Count) {
+ void
+ SafeReadIOCallback::Seek(size_t Position) {
+   mIO->setFilePointer(Position);
+-  uint64 ActualPosition = mIO->getFilePointer();
++  std::uint64_t ActualPosition = mIO->getFilePointer();
+   if (ActualPosition != Position)
+     throw EndOfStreamX(ActualPosition - Position);
+ }
+@@ -166,7 +166,7 @@ SafeReadIOCallback::Seek(size_t Position) {
+ void
+ SafeReadIOCallback::Read(void *Dst,
+                        size_t Count) {
+-  uint64 NumRead = mIO->read(Dst, Count);
++  std::uint64_t NumRead = mIO->read(Dst, Count);
+   if (NumRead != Count)
+     throw SafeReadIOCallback::EndOfStreamX(Count - NumRead);
+ }
+diff --git a/src/StdIOCallback.cpp b/src/StdIOCallback.cpp
+index 8b0bc34..c826bea 100644
+--- a/src/StdIOCallback.cpp
++++ b/src/StdIOCallback.cpp
+@@ -97,7 +97,7 @@ StdIOCallback::~StdIOCallback() noexcept
+ 
+ 
+ 
+-uint32 StdIOCallback::read(void*Buffer,size_t Size)
++std::uint32_t StdIOCallback::read(void*Buffer,size_t Size)
+ {
+   assert(File!=nullptr);
+ 
+@@ -106,7 +106,7 @@ uint32 StdIOCallback::read(void*Buffer,size_t Size)
+   return result;
+ }
+ 
+-void StdIOCallback::setFilePointer(int64 Offset,seek_mode Mode)
++void StdIOCallback::setFilePointer(std::int64_t Offset,seek_mode Mode)
+ {
+   assert(File!=nullptr);
+ 
+@@ -144,12 +144,12 @@ void StdIOCallback::setFilePointer(int64 Offset,seek_mode Mode)
+ size_t StdIOCallback::write(const void*Buffer,size_t Size)
+ {
+   assert(File!=nullptr);
+-  uint32 Result = fwrite(Buffer,1,Size,File);
++  std::uint32_t Result = fwrite(Buffer,1,Size,File);
+   mCurrentPosition += Result;
+   return Result;
+ }
+ 
+-uint64 StdIOCallback::getFilePointer()
++std::uint64_t StdIOCallback::getFilePointer()
+ {
+   assert(File!=nullptr);
+ 
+diff --git a/src/platform/win32/WinIOCallback.cpp b/src/platform/win32/WinIOCallback.cpp
+index 9bb979d..22265fe 100644
+--- a/src/platform/win32/WinIOCallback.cpp
++++ b/src/platform/win32/WinIOCallback.cpp
+@@ -203,7 +203,7 @@ void WinIOCallback::close()
+   }
+ }
+ 
+-uint64 WinIOCallback::getFilePointer()
++std::uint64_t WinIOCallback::getFilePointer()
+ {
+   if (!mFile) {
+     return 0;
+@@ -214,12 +214,12 @@ uint64 WinIOCallback::getFilePointer()
+   LONG High = 0;
+   DWORD Low = SetFilePointer(mFile, 0, &High, FILE_CURRENT);
+   if ( (Low==INVALID_SET_FILE_POINTER) && (GetLastError()!=NO_ERROR) )
+-    return static_cast<uint64>(-1);
+-  return ((uint64(High)<<32) | Low);
++    return static_cast<std::uint64_t>(-1);
++  return ((std::uint64_t(High)<<32) | Low);
+ #endif
+ }
+ 
+-void WinIOCallback::setFilePointer(int64 Offset, seek_mode Mode)
++void WinIOCallback::setFilePointer(std::int64_t Offset, seek_mode Mode)
+ {
+   DWORD Method;
+   switch(Mode) {
+@@ -242,13 +242,13 @@ void WinIOCallback::setFilePointer(int64 Offset, seek_mode Mode)
+   if ( mCurrentPosition == INVALID_SET_FILE_POINTER ) {
+     High = 0;
+     DWORD Low = SetFilePointer(mFile, 0, &High, FILE_CURRENT);
+-    mCurrentPosition = ((uint64(High)<<32) | Low);
++    mCurrentPosition = ((std::uint64_t(High)<<32) | Low);
+   } else {
+-    mCurrentPosition |= uint64(High)<<32;
++    mCurrentPosition |= std::uint64_t(High)<<32;
+   }
+ }
+ 
+-uint32 WinIOCallback::read(void*Buffer,size_t Size)
++std::uint32_t WinIOCallback::read(void*Buffer,size_t Size)
+ {
+   DWORD BytesRead;
+   if (!ReadFile(mFile, Buffer, Size, &BytesRead, NULL)) {
+diff --git a/src/platform/win32/WinIOCallback.h b/src/platform/win32/WinIOCallback.h
+index 349405e..37995f5 100644
+--- a/src/platform/win32/WinIOCallback.h
++++ b/src/platform/win32/WinIOCallback.h
+@@ -53,10 +53,10 @@ public:
+   bool open(const wchar_t* Path, const open_mode Mode, DWORD dwFlags=0);
+   bool open(const char* Path, const open_mode Mode, DWORD dwFlags=0);
+ 
+-  virtual uint32 read(void*Buffer,size_t Size);
++  virtual std::uint32_t read(void*Buffer,size_t Size);
+   virtual size_t write(const void*Buffer,size_t Size);
+-  virtual void setFilePointer(int64 Offset,seek_mode Mode=seek_beginning);
+-  virtual uint64 getFilePointer();
++  virtual void setFilePointer(std::int64_t Offset,seek_mode Mode=seek_beginning);
++  virtual std::uint64_t getFilePointer();
+   virtual void close();
+ 
+   bool IsOk() { return mOk; };
+@@ -65,7 +65,7 @@ public:
+ protected:
+   bool mOk;
+   std::string mLastErrorStr;
+-  uint64 mCurrentPosition;
++  std::uint64_t mCurrentPosition;
+ 
+   HANDLE mFile;
+ };
+-- 
+2.41.0
+


### PR DESCRIPTION
Pulled from upstream development version with the necessary changes to work with the stable release.