### PR TITLE
GCC 13: add gcc_jit and other fixes

### DIFF
--- a/sys-devel/gcc/gcc-13.1.0_2023_06_20.recipe
+++ b/sys-devel/gcc/gcc-13.1.0_2023_06_20.recipe
@@ -25,6 +25,9 @@ libgccLibVersion="1"
 libgfortranSoVersion="5"
 libgfortranLibVersion="5.0.0"
 
+libgccjitSoVersion="0"
+libgccjitLibVersion="0.0.1"
+
 libgompSoVersion="1"
 libgompLibVersion="1.0.0"
 
@@ -76,6 +79,30 @@ PROVIDES_fortran="
 REQUIRES_fortran="
 	haiku$secondaryArchSuffix
 	gcc${secondaryArchSuffix}_syslibs == $portVersion base
+	"
+
+SUMMARY_jit="Library for embedding GCC inside programs and libraries"
+DESCRIPTION_jit="This package contains the shared library with the GCC JIT front-end"
+PROVIDES_jit="
+	gcc${secondaryArchSuffix}_jit = $portVersion
+	lib:libgccjit$secondaryArchSuffix = $libgccjitLibVersion compat >= $libgccjitSoVersion
+	"
+REQUIRES_jit="
+	haiku$secondaryArchSuffix
+	lib:libgmp$secondaryArchSuffix
+	lib:libmpc$secondaryArchSuffix
+	lib:libmpfr$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+SUMMARY_jit_devel="Libraries and headers for embedding GCC inside programs and libraries"
+DESCRIPTION_jit_devel="This package contains the header files for GCC JIT"
+PROVIDES_jit_devel="
+	gcc${secondaryArchSuffix}_jit_devel = $portVersion
+	devel:libgccjit$secondaryArchSuffix = $libgccjitLibVersion compat >= $libgccjitSoVersion
+	"
+REQUIRES_jit_devel="
+	gcc${secondaryArchSuffix}_jit == $portVersion base
 	"
 
 SUMMARY_syslibs="C/C++-runtime shared libraries, needed to execute C/C++ programs"
@@ -174,6 +201,7 @@ defineDebugInfoPackage gcc$secondaryArchSuffix \
 	"$installDir/bin"/lto-dump \
 	"$(getPackagePrefix fortran)/$relativeInstallDir"/bin/gfortran \
 	"$(getPackagePrefix fortran)/$relativeInstallDir/$gccLibDir"/f951 \
+	"$(getPackagePrefix jit)/$relativeLibDir"/libgccjit.so.$libgccjitLibVersion \
 	"$(getPackagePrefix syslibs)/$relativeLibDir"/libatomic.so.$libatomicLibVersion \
 	"$(getPackagePrefix syslibs)/$relativeLibDir"/libgcc_s.so.$libgccSoVersion \
 	"$(getPackagePrefix syslibs)/$relativeLibDir"/libgfortran.so.$libgfortranLibVersion \
@@ -210,13 +238,13 @@ BUILD()
 		--docdir=$docDir --enable-threads=posix \
 		--disable-nls --enable-shared --with-gnu-ld --with-gnu-as \
 		--enable-version-specific-runtime-libs \
-		--enable-languages=c,c++,fortran,objc --enable-lto \
+		--enable-languages=c,c++,fortran,jit,objc --enable-lto \
 		--enable-frame-pointer \
 		--with-pkgversion=$(echo $portVersion | cut -d_ -f2-) \
 		--enable-__cxa-atexit --with-system-zlib --enable-checking=release \
 		--with-bug-url=http://dev.haiku-os.org/ \
 		--with-default-libstdcxx-abi=gcc4-compatible \
-		--enable-libssp \
+		--enable-libssp --enable-host-shared \
 		$additionalConfigureFlags
 
 	make $jobArgs
@@ -349,6 +377,12 @@ INSTALL()
 		$gccLibDir
 	rm $gccLibDir/libatomic*.a
 
+	# libgccjit
+	mv $installDir/lib/libgccjit.so \
+		$installDir/lib/libgccjit.so.$libgccjitSoVersion \
+		$installDir/lib/libgccjit.so.$libgccjitLibVersion \
+		$libDir/
+
 	# libgfortran
 	mv $gccLibDir/libgfortran.so \
 		$gccLibDir/libgfortran.so.$libgfortranSoVersion \
@@ -439,10 +473,12 @@ INSTALL()
 		rm -rf temp_libgcc
 	fi
 
-	# gcc and c++ headers
+	# gcc, gccjit and c++ headers
 	mkdir -p $includeDir/gcc
 	cp -r $gccLibDir/include $includeDir/gcc/
 	cp -r $gccLibDir/include-fixed $includeDir/gcc/
+	mv $installDir/include/libgccjit*.h $includeDir/
+	rmdir $installDir/include
 	mv $includeDir/gcc/include/c++ $includeDir/
 
 	### Strip #################################################
@@ -484,7 +520,7 @@ INSTALL()
 
 	# symlink all libraries from libDir -> developLibDir
 	mkdir -p $developLibDir
-	for l in libatomic libgomp libquadmath libssp libgcc_s libstdc++ \
+	for l in libatomic libgccjit libgomp libquadmath libssp libgcc_s libstdc++ \
 			libsupc++; do
 		for f in $libDir/$l*; do
 			symlinkRelative -sfn $f $developLibDir/
@@ -513,6 +549,16 @@ INSTALL()
 		$installDir/$gccLibDir/libgfortran.spec
 
 	rm -rf $installDir/$gccLibDir/{f951, finclude, libcaf_single*, libgfortran*}
+
+	packageEntries "jit" \
+		$relativeLibDir/libgccjit.so \
+		$relativeLibDir/libgccjit.so.$libgccjitSoVersion \
+		$relativeLibDir/libgccjit.so.$libgccjitLibVersion
+
+	packageEntries "jit_devel" \
+		$developLibDir/libgccjit.so* \
+		$relativeIncludeDir/libgccjit.h \
+		$relativeIncludeDir/libgccjit++.h
 
 	packageEntries "syslibs" \
 		$relativeLibDir/libatomic.so \

--- a/sys-devel/gcc/gcc-13.1.0_2023_06_20.recipe
+++ b/sys-devel/gcc/gcc-13.1.0_2023_06_20.recipe
@@ -54,6 +54,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	gcc${secondaryArchSuffix}_syslibs == $portVersion base
 	cmd:as$secondaryArchSuffix
 	lib:libgmp$secondaryArchSuffix
 	lib:libmpc$secondaryArchSuffix
@@ -122,7 +123,9 @@ PROVIDES_syslibs_devel="
 	devel:libsupc++_boot$secondaryArchSuffix = $portVersion compat >= 7
 	devel:libsupc++_kernel$secondaryArchSuffix = $portVersion compat >= 7
 	"
-REQUIRES_syslibs_devel=""
+REQUIRES_syslibs_devel="
+	gcc${secondaryArchSuffix}_syslibs == $portVersion base
+	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
@@ -157,13 +160,6 @@ defineDebugInfoPackage gcc$secondaryArchSuffix \
 	"$gccLibDir"/cc1plus \
 	"$gccLibDir"/collect2 \
 	"$gccLibDir"/g++-mapper-server \
-	"$gccLibDir"/libatomic.so.$libatomicLibVersion \
-	"$gccLibDir"/libgcc_s.so.$libgccSoVersion \
-	"$gccLibDir"/libgfortran.so.$libgfortranLibVersion \
-	"$gccLibDir"/libgomp.so.$libgompLibVersion \
-	"$gccLibDir"/libquadmath.so.$libquadmathLibVersion \
-	"$gccLibDir"/libssp.so.$libsspLibVersion \
-	"$gccLibDir"/libstdc++.so.$libstdcxxLibVersion \
 	"$gccLibDir"/lto1 \
 	"$gccLibDir"/lto-wrapper \
 	"$installDir/bin"/cpp \
@@ -184,8 +180,7 @@ defineDebugInfoPackage gcc$secondaryArchSuffix \
 	"$(getPackagePrefix syslibs)/$relativeLibDir"/libgomp.so.$libgompLibVersion \
 	"$(getPackagePrefix syslibs)/$relativeLibDir"/libquadmath.so.$libquadmathLibVersion \
 	"$(getPackagePrefix syslibs)/$relativeLibDir"/libssp.so.$libsspLibVersion \
-	"$(getPackagePrefix syslibs)/$relativeLibDir"/libstdc++.so.$libstdcxxLibVersion \
-	"$(getPackagePrefix syslibs)/$relativeLibDir"/libsupc++.so
+	"$(getPackagePrefix syslibs)/$relativeLibDir"/libstdc++.so.$libstdcxxLibVersion
 
 BUILD()
 {
@@ -344,48 +339,72 @@ INSTALL()
 	cd $installDir
 
 	# libatomic
-	cp -d $gccLibDir/libatomic.so \
+	mv $gccLibDir/libatomic.so \
 		$gccLibDir/libatomic.so.$libatomicSoVersion \
 		$gccLibDir/libatomic.so.$libatomicLibVersion \
 		$libDir/
+	ln -s $libDir/libatomic.so \
+		$libDir/libatomic.so.$libatomicSoVersion \
+		$libDir/libatomic.so.$libatomicLibVersion \
+		$gccLibDir
 	rm $gccLibDir/libatomic*.a
 
 	# libgfortran
-	cp -d $gccLibDir/libgfortran.so \
+	mv $gccLibDir/libgfortran.so \
 		$gccLibDir/libgfortran.so.$libgfortranSoVersion \
 		$gccLibDir/libgfortran.so.$libgfortranLibVersion \
 		$libDir/
-	cp $gccLibDir/libgfortran*.a $developLibDir/
+	ln -s $libDir/libgfortran.so \
+		$libDir/libgfortran.so.$libgfortranSoVersion \
+		$libDir/libgfortran.so.$libgfortranLibVersion \
+		$gccLibDir
+	mv $gccLibDir/libgfortran*.a $developLibDir/
 
 	# libgomp
-	cp -d $gccLibDir/libgomp.so \
+	mv $gccLibDir/libgomp.so \
 		$gccLibDir/libgomp.so.$libgompSoVersion \
 		$gccLibDir/libgomp.so.$libgompLibVersion \
 		$libDir/
+	ln -s $libDir/libgomp.so \
+		$libDir/libgomp.so.$libgompSoVersion \
+		$libDir/libgomp.so.$libgompLibVersion\
+		$gccLibDir
 	rm $gccLibDir/libgomp*.a
 
 	# libquadmath
-	cp -d $gccLibDir/libquadmath.so \
+	mv $gccLibDir/libquadmath.so \
 		$gccLibDir/libquadmath.so.$libquadmathSoVersion \
 		$gccLibDir/libquadmath.so.$libquadmathLibVersion \
 		$libDir/
+	ln -s $libDir/libquadmath.so \
+		$libDir/libquadmath.so.$libquadmathSoVersion \
+		$libDir/libquadmath.so.$libquadmathLibVersion \
+		$gccLibDir
 	rm $gccLibDir/libquadmath*.a
 
 	# libssp
-	cp -d $gccLibDir/libssp.so \
+	mv $gccLibDir/libssp.so \
 		$gccLibDir/libssp.so.$libsspSoVersion \
 		$gccLibDir/libssp.so.$libsspLibVersion \
 		$libDir/
+	ln -s $libDir/libssp.so \
+		$libDir/libssp.so.$libsspSoVersion \
+		$libDir/libssp.so.$libsspLibVersion \
+		$gccLibDir
 	rm $gccLibDir/libssp.a
-	cp $gccLibDir/libssp_nonshared.a $developLibDir
+	mv $gccLibDir/libssp_nonshared.a $developLibDir
 
 	# libstdc++
-	cp -d $gccLibDir/libstdc++.so \
+	mv $gccLibDir/libstdc++.so \
 		$gccLibDir/libstdc++.so.$libstdcxxSoVersion \
 		$gccLibDir/libstdc++.so.$libstdcxxLibVersion \
 		$libDir/
+	ln -s $libDir/libstdc++.so \
+		$libDir/libstdc++.so.$libstdcxxSoVersion \
+		$libDir/libstdc++.so.$libstdcxxLibVersion \
+		$gccLibDir
 	rm $gccLibDir/libstdc++.a
-	cp $gccLibDir/libstdc++exp.a $developLibDir
+	mv $gccLibDir/libstdc++exp.a $developLibDir
 
 	# libsupc++
 	libstdcxxDir=$objectsDir/$effectiveTargetMachineTriple/libstdc++-v3
@@ -393,8 +412,8 @@ INSTALL()
 		$gccLibDir/
 	cp $libstdcxxDir/libsupc++/.libs/libsupc++-boot.a \
 		$gccLibDir/
-	ln -s libstdc++.so $libDir/libsupc++.so
-	cp $gccLibDir/libsupc++*.a $developLibDir/
+	ln -s $libDir/libstdc++.so $libDir/libsupc++.so
+	mv $gccLibDir/libsupc++*.a $developLibDir/
 
 	# libgcc
 	cp $objectsDir/$effectiveTargetMachineTriple/libgcc/libgcc-kernel.a \
@@ -403,9 +422,12 @@ INSTALL()
 	cp $objectsDir/$effectiveTargetMachineTriple/libgcc/libgcc-boot.a \
 		$objectsDir/$effectiveTargetMachineTriple/libgcc/libgcc_eh-boot.a \
 		$gccLibDir/
-	cp -d $gccLibDir/libgcc_s.so \
+	mv $gccLibDir/libgcc_s.so \
 		$gccLibDir/libgcc_s.so.$libgccSoVersion \
 		$libDir/
+	ln -s $libDir/libgcc_s.so \
+		$libDir/libgcc_s.so.$libgccSoVersion \
+		$gccLibDir
 	cp $gccLibDir/libgcc*.a $developLibDir/
 
 	# merge libssp_nonshared.a in libgcc.a on x86
@@ -487,7 +509,7 @@ INSTALL()
 		$installDir/$gccLibDir/f951 \
 		$installDir/$gccLibDir/finclude \
 		$installDir/$gccLibDir/libcaf_single.a \
-		$installDir/$gccLibDir/libgfortran.a \
+		$developLibDir/libgfortran.a \
 		$installDir/$gccLibDir/libgfortran.spec
 
 	rm -rf $installDir/$gccLibDir/{f951, finclude, libcaf_single*, libgfortran*}

--- a/sys-devel/gcc/gcc-13.1.0_2023_06_20.recipe
+++ b/sys-devel/gcc/gcc-13.1.0_2023_06_20.recipe
@@ -54,6 +54,7 @@ PROVIDES="
 	cmd:gcov_dump$secondaryArchSuffix = $portVersion compat >= 7
 	cmd:gcov_tool$secondaryArchSuffix = $portVersion compat >= 7
 	cmd:lto_dump$secondaryArchSuffix = $portVersion compat >= 7
+	cmd:${effectiveTargetMachineTriple//-/_}_gcc_$gccVersion$secondaryArchSuffix = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -89,6 +90,7 @@ PROVIDES_jit="
 	"
 REQUIRES_jit="
 	haiku$secondaryArchSuffix
+	gcc${secondaryArchSuffix} == $portVersion base
 	lib:libgmp$secondaryArchSuffix
 	lib:libmpc$secondaryArchSuffix
 	lib:libmpfr$secondaryArchSuffix
@@ -517,6 +519,11 @@ INSTALL()
 		gcov-tool gfortran lto-dump ; do
 		symlinkRelative -sfn $installDir/bin/$f $binDir
 	done
+
+	# make the ${effectiveTargetMachineTriple}-gcc-${$gccVersion} accessible in the libdir; this is
+	# the driver for gcc jit and it needs to be able to find it in PATH
+	symlinkRelative -sfn $installDir/bin/gcc \
+		$binDir/$effectiveTargetMachineTriple-gcc-$gccVersion
 
 	# symlink all libraries from libDir -> developLibDir
 	mkdir -p $developLibDir

--- a/sys-devel/gcc/gcc-13.1.0_2023_06_20.recipe
+++ b/sys-devel/gcc/gcc-13.1.0_2023_06_20.recipe
@@ -468,7 +468,7 @@ INSTALL()
 
 	# merge libssp_nonshared.a in libgcc.a on x86
 	if [ "$targetArchitecture" = "x86_gcc2" ]; then
-		(mkdir temp_libgcc; cd temp_libgcc; ar x ../$gccLibDir/libssp_nonshared.a;
+		(mkdir temp_libgcc; cd temp_libgcc; ar x $developLibDir/libssp_nonshared.a;
 			ar x ../$gccLibDir/libgcc.a; cd ..)
 		ar -qc $developLibDir/libgcc.a temp_libgcc/*.o
 		cp $developLibDir/libgcc.a $gccLibDir/libgcc.a


### PR DESCRIPTION
I spread the changes out over two commits so that they can be reviewed independently.

Initially this PR as following the GCC JIT packaging instructions to build GCC twice, once for JIT, and once for the rest of the languages. This was based on the assumption that the second build would be without position independent code. However, on Haiku all executables are PIE, so there is no advantage in building twice.

Previous note.
~~Note that the recipe for building GCC became more complex than it was, due to the packaging instructions. I do want to note that FreeBSD chose not to build GCC twice, and instead also builds the main compiler with `--enable-host-shared`. ~~
