### PR TITLE
picard: bump version to 2.9

### DIFF
--- a/media-sound/picard/picard-2.9.recipe
+++ b/media-sound/picard/picard-2.9.recipe
@@ -9,12 +9,12 @@ identified by the actual music, even if they have no metadata.
 * Plugin support - If you need a particular feature, you can choose from a \
 selection of available plugins or write your own."
 HOMEPAGE="https://picard.musicbrainz.org/"
-COPYRIGHT="2004-2022 Robert Kaye, Lukas Lalinsky, Laurent Monin, \
+COPYRIGHT="2004-2023 Robert Kaye, Lukas Lalinsky, Laurent Monin, \
 Sambhav Kothari, Philipp Wolfer and others"
 LICENSE="GNU GPL v2"
-REVISION="4"
+REVISION="1"
 SOURCE_URI="ftp://ftp.eu.metabrainz.org/pub/musicbrainz/picard/picard-$portVersion.tar.gz"
-CHECKSUM_SHA256="b1c1f76d5fe92cb481f4362142c6a84f1cf45948e42cfd7c3d3beffd703c54ce"
+CHECKSUM_SHA256="89eb2d299f40eac9de7166593733c57942583dd1118f5c7a0b58278255fcd129"
 SOURCE_DIR="picard-release-$portVersion"
 SOURCE_FILENAME="picard-$portVersion"
 ADDITIONAL_FILES="


### PR DESCRIPTION
New release, see https://blog.metabrainz.org/2023/07/26/picard-2-9-released/

Haikuporter build tested locally (64 bit build)