### PR TITLE
libunibreak, bump version, keep old around

### DIFF
--- a/dev-libs/libunibreak/libunibreak-5.1.recipe
+++ b/dev-libs/libunibreak/libunibreak-5.1.recipe
@@ -1,0 +1,80 @@
+SUMMARY="Line and word breaking library"
+DESCRIPTION="An implementation of the line breaking and word breaking \
+algorithms as described in Unicode Standard Annex 14 and Unicode Standard \
+Annex 29."
+HOMEPAGE="http://vimgadgets.sourceforge.net/libunibreak/"
+COPYRIGHT="2022 Andreas Röver"
+LICENSE="Zlib"
+REVISION="1"
+SOURCE_URI="https://github.com/adah1972/libunibreak/releases/download/libunibreak_${portVersion//./_}/libunibreak-$portVersion.tar.gz"
+CHECKSUM_SHA256="dd1a92d4c5646aa0e457ff41d89812ec5243863be6c20bbcb5ee380f3dd78377"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="5.0.1"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	libunibreak$secondaryArchSuffix = $portVersion
+	lib:libunibreak$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku${secondaryArchSuffix}
+	"
+
+PROVIDES_devel="
+	libunibreak${secondaryArchSuffix}_devel = $portVersion
+	devel:libunibreak$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	libunibreak$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:cmp
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+TEST_REQUIRES="
+	cmd:wget
+	"
+
+defineDebugInfoPackage libunibreak$secondaryArchSuffix \
+	"$libDir"/libunibreak.so.$libVersion
+
+BUILD()
+{
+	runConfigure ./configure --disable-static
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	# remove libtool file
+	rm $libDir/*.la
+
+	# prepare develop/lib
+	prepareInstalledDevelLib libunibreak
+
+	fixPkgconfig
+
+	# devel package
+	packageEntries devel \
+		$developDir
+}
+
+TEST()
+{
+	make check
+}

--- a/dev-libs/libunibreak/libunibreak4.0-4.0.recipe
+++ b/dev-libs/libunibreak/libunibreak4.0-4.0.recipe
@@ -5,9 +5,10 @@ Annex 29."
 HOMEPAGE="http://vimgadgets.sourceforge.net/libunibreak/"
 COPYRIGHT="2016 Andreas Röver"
 LICENSE="Zlib"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/adah1972/libunibreak/releases/download/libunibreak_${portVersion//./_}/libunibreak-$portVersion.tar.gz"
 CHECKSUM_SHA256="f7329bef1eb169d3363f040cefcc323cfd0a0bc53290a35a395e1d1adc849539"
+SOURCE_DIR="libunibreak-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -16,7 +17,7 @@ libVersion="3.1.0"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
-	libunibreak$secondaryArchSuffix = $portVersion
+	libunibreak4.0$secondaryArchSuffix = $portVersion
 	lib:libunibreak$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
@@ -24,12 +25,14 @@ REQUIRES="
 	"
 
 PROVIDES_devel="
-	libunibreak${secondaryArchSuffix}_devel = $portVersion
-	devel:liblinebreak$secondaryArchSuffix = $libVersionCompat
+	libunibreak4.0${secondaryArchSuffix}_devel = $portVersion
 	devel:libunibreak$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
-	libunibreak$secondaryArchSuffix == $portVersion base
+	libunibreak4.0$secondaryArchSuffix == $portVersion base
+	"
+CONFLICTS_devel="
+	libunibreak${secondaryArchSuffix}_devel
 	"
 
 BUILD_REQUIRES="
@@ -45,12 +48,16 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
-defineDebugInfoPackage libunibreak$secondaryArchSuffix \
+TEST_REQUIRES="
+	cmd:wget
+	"
+
+defineDebugInfoPackage libunibreak4.0$secondaryArchSuffix \
 	"$libDir"/libunibreak.so.$libVersion
 
 BUILD()
 {
-	runConfigure ./configure
+	runConfigure ./configure --disable-static
 	make $jobArgs
 }
 
@@ -58,13 +65,11 @@ INSTALL()
 {
 	make install
 
-	# remove libtool library files
+	# remove libtool file
 	rm $libDir/*.la
-	rm $libDir/liblinebreak.a
 
 	# prepare develop/lib
-	prepareInstalledDevelLibs libunibreak
-	ln -s libunibreak.a $developLibDir/liblinebreak.a
+	prepareInstalledDevelLib libunibreak
 
 	fixPkgconfig
 


### PR DESCRIPTION
Tuxpain-config and FBReader are still using the older library, FBReader download link is broken so can't be rebuild, hence keeping the older recipe around (renamed).