### PR TITLE
keepassxc, revbump for qrencode

### DIFF
--- a/app-admin/keepassxc/keepassxc-2.6.2.recipe
+++ b/app-admin/keepassxc/keepassxc-2.6.2.recipe
@@ -28,7 +28,7 @@ COPYRIGHT="
 	2016-2020, KeePassXC Team
 	"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/keepassxreboot/keepassxc/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="9387caeadabb5e66190f1ccae4eb26887ba872125620e22bba8c79615349cf81"
 PATCHES="keepassxc-$portVersion.patchset"


### PR DESCRIPTION
Needs https://github.com/haikuports/haikuports/pull/9103 to be merged first.