### PR TITLE
opencascade: switch ffmpeg requirements to use >=

### DIFF
--- a/sci-libs/opencascade/opencascade-7.7.2.recipe
+++ b/sci-libs/opencascade/opencascade-7.7.2.recipe
@@ -7,7 +7,7 @@ COPYRIGHT="1993-1999 Matra Datavision
 	1999-2020 OPEN CASCADE SAS"
 LICENSE="GNU LGPL v2.1
 	Open CASCADE exception v1.0"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=refs/tags/V${portVersion//./_};sf=tgz"
 CHECKSUM_SHA256="2fb23c8d67a7b72061b4f7a6875861e17d412d524527b2a96151ead1d9cfa2c1"
 SOURCE_DIR="occt-V${portVersion//./_}"
@@ -93,16 +93,16 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libavcodec$secondaryArchSuffix < 59
-	lib:libavformat$secondaryArchSuffix < 59
-	lib:libavutil$secondaryArchSuffix < 57
+	lib:libavcodec$secondaryArchSuffix
+	lib:libavformat$secondaryArchSuffix
+	lib:libavutil$secondaryArchSuffix
 #	lib:libEGL$secondaryArchSuffix
 	lib:libexecinfo$secondaryArchSuffix
 	lib:libfontconfig$secondaryArchSuffix
 	lib:libfreeimage$secondaryArchSuffix
 	lib:libfreetype$secondaryArchSuffix
 #	lib:libGL$secondaryArchSuffix
-	lib:libswscale$secondaryArchSuffix < 6
+	lib:libswscale$secondaryArchSuffix
 #	lib:libtbb$secondaryArchSuffix
 	lib:libX11$secondaryArchSuffix
 	"
@@ -296,9 +296,9 @@ BUILD_REQUIRES="
 	cmd:doxygen >= 1.8.4
 	cmd:lrelease$secondaryArchSuffix
 	cmd:tclsh
-	devel:libavcodec$secondaryArchSuffix < 59
-	devel:libavformat$secondaryArchSuffix < 59
-	devel:libavutil$secondaryArchSuffix < 57
+	devel:libavcodec$secondaryArchSuffix >= 58
+	devel:libavformat$secondaryArchSuffix >= 58
+	devel:libavutil$secondaryArchSuffix >= 56
 	devel:libexecinfo$secondaryArchSuffix
 #	devel:libEGL$secondaryArchSuffix
 	devel:libfontconfig$secondaryArchSuffix
@@ -312,7 +312,7 @@ BUILD_REQUIRES="
 	devel:libQt5Widgets$secondaryArchSuffix
 	devel:libQt5Xml$secondaryArchSuffix
 	devel:librapidjson$secondaryArchSuffix
-	devel:libswscale$secondaryArchSuffix < 6
+	devel:libswscale$secondaryArchSuffix >= 5
 #	devel:libtbb$secondaryArchSuffix
 	devel:libtclstub8.6$secondaryArchSuffix
 #	devel:libtk8.6$secondaryArchSuffix


### PR DESCRIPTION
Also, remove the version constraints from the lib: requirements. They should be picked up automatically by haikuporter because of the devel: requirements and the dependency of ffmpeg_devel on ffmpeg.

This is a follow-up on #9110.