### PR TITLE
GCC 13: enable recipe

### DIFF
--- a/sys-devel/gcc/gcc-13.1.0_2023_06_20.recipe
+++ b/sys-devel/gcc/gcc-13.1.0_2023_06_20.recipe
@@ -13,8 +13,8 @@ CHECKSUM_SHA256="61d684f0aa5e76ac6585ad8898a2427aade8979ed5e7f85492286c4dfc13ee8
 SOURCE_DIR="gcc-$gccVersion"
 PATCHES="gcc-$portVersion.patchset"
 
-ARCHITECTURES="?all !x86_gcc2"
-SECONDARY_ARCHITECTURES="?x86"
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 libatomicSoVersion="1"
 libatomicLibVersion="1.2.0"


### PR DESCRIPTION
It is now time to enable the recipe, everything is set to continue the build and merge process.