### PR TITLE
tar, revbump for 32bit, use --disable-year2038

### DIFF
--- a/app-arch/tar/tar-1.35.recipe
+++ b/app-arch/tar/tar-1.35.recipe
@@ -12,7 +12,7 @@ archives)."
 HOMEPAGE="https://www.gnu.org/software/tar/"
 COPYRIGHT="1990-2018 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://ftpmirror.gnu.org/tar/tar-$portVersion.tar.bz2
 	https://ftp.gnu.org/gnu/tar/tar-$portVersion.tar.bz2"
 CHECKSUM_SHA256="7edb8886a3dc69420a1446e1e2d061922b642f1cf632d2cd0f9ee7e690775985"
@@ -71,11 +71,17 @@ defineDebugInfoPackage tar$secondaryArchSuffix $commandBinDir/tar
 
 BUILD()
 {
+	local yearArg
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		yearArg="--disable-year2038"
+	fi
+
 	runConfigure --omit-dirs binDir ./configure --bindir=$commandBinDir \
 		--disable-nls \
 		--disable-gcc-warnings \
 		LDFLAGS="-lnetwork" CFLAGS="-D_BSD_SOURCE" \
-		FORCE_UNSAFE_CONFIGURE=1
+		FORCE_UNSAFE_CONFIGURE=1 \
+		$yearArg
 	make $jobArgs YACC=:
 }
 


### PR DESCRIPTION
Shouldn't be needed for 64bit, but I guess it will be fixed by 2038? :)