### PR TITLE
Update toot-0.36.0.recipe

### DIFF
--- a/net-im/toot/toot-0.36.0.recipe
+++ b/net-im/toot/toot-0.36.0.recipe
@@ -20,6 +20,7 @@ REQUIRES="
 	haiku
 	cmd:python$pythonVersion
 	beautifulsoup4_$pythonPackage
+	soupsieve_$pythonPackage
 	requests_$pythonPackage
 	urwid_$pythonPackage
 	wcwidth_$pythonPackage


### PR DESCRIPTION
Executing toot in Terminal gives an error at the beginning, that Soupieve is missing. It continued. I installed Soupsieve_python310, executed it again, and the error message at the beginning was gone. Thus, I added the line "soup sieve_...". Hope that works.