### PR TITLE
perl: enable recipe for arm

### DIFF
--- a/dev-lang/perl/perl-5.32.1.recipe
+++ b/dev-lang/perl/perl-5.32.1.recipe
@@ -22,7 +22,7 @@ SOURCE_URI="http://www.cpan.org/src/perl-$portVersion.tar.gz"
 CHECKSUM_SHA256="03b693901cd8ae807231b1787798cf1f2e0b8a56218d07b7da44f784a7caeb2c"
 PATCHES="perl-$portVersion.patchset"
 
-ARCHITECTURES="all ?arm"
+ARCHITECTURES="all"
 
 PROVIDES="
 	# assume that any perl commands are backwards compatible to version 5.


### PR DESCRIPTION
this is needed for building the 'rigged' source packages during bootstrap