### PR TITLE
Python: make Python 3.10 the main one.

### DIFF
--- a/dev-lang/python/python3.10-3.10.12.recipe
+++ b/dev-lang/python/python3.10-3.10.12.recipe
@@ -9,7 +9,7 @@ OSI-approved open source license."
 HOMEPAGE="https://www.python.org"
 LICENSE="Python"
 COPYRIGHT="1990-2023 Python Software Foundation"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://www.python.org/ftp/python/$portVersion/Python-$portVersion.tar.xz"
 CHECKSUM_SHA256="afb74bf19130e7a47d10312c8f5e784f24e0527981eab68e20546cfb865830b8"
 SOURCE_DIR="Python-$portVersion"
@@ -50,18 +50,23 @@ PROVIDES="
 	cmd:pyvenv_$pyShortVer = $pyVersionCompat
 	devel:libpython$pyShortVer$secondaryArchSuffix = 1.0
 	lib:libpython$pyShortVer$secondaryArchSuffix = 1.0
+	cmd:2to3 = $portVersion compat >= $pyShortVer
+	cmd:idle3 = $portVersion compat >= $pyShortVer
+	cmd:python3 = $portVersion compat >= $pyShortVer
+	cmd:pydoc3 = $portVersion compat >= $pyShortVer
+	cmd:python3_config = $portVersion compat >= $pyShortVer
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
 	cmd:file
 	lib:libbz2$secondaryArchSuffix
+	lib:libedit$secondaryArchSuffix
 	lib:libexpat$secondaryArchSuffix
 	lib:libffi$secondaryArchSuffix
 	lib:libintl$secondaryArchSuffix
 	lib:liblzma$secondaryArchSuffix
 	lib:libncurses$secondaryArchSuffix
 	lib:libssl$secondaryArchSuffix
-	lib:libedit$secondaryArchSuffix
 	lib:libsqlite3$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
@@ -132,8 +137,7 @@ BUILD()
 
 INSTALL()
 {
-	# altinstall avoids clobbering $prefix/bin/{2to3,idle3,pydoc3,python3,python3-config}
-	make altinstall
+	make install
 
 	rm $libDir/libpython3.so
 

--- a/dev-lang/python/python3.9-3.9.17.recipe
+++ b/dev-lang/python/python3.9-3.9.17.recipe
@@ -9,7 +9,7 @@ OSI-approved open source license."
 HOMEPAGE="https://www.python.org"
 LICENSE="Python"
 COPYRIGHT="1990-2022 Python Software Foundation"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://www.python.org/ftp/python/$portVersion/Python-$portVersion.tar.xz"
 CHECKSUM_SHA256="30ce057c44f283f8ed93606ccbdb8d51dd526bdc4c62cce5e0dc217bfa3e8cee"
 SOURCE_DIR="Python-$portVersion"
@@ -35,15 +35,10 @@ PROVIDES="
 	python3.9$secondaryArchSuffix = $portVersion compat >= 3.9
 	python39$secondaryArchSuffix = $portVersion compat >= 3.9
 	cmd:2to3_3.9 = $portVersion compat >= 3.9
-	cmd:2to3 = $portVersion compat >= 3.9
 	cmd:idle3.9 = $portVersion compat >= 3.9
-	cmd:idle3 = $portVersion compat >= 3.9
 	cmd:pydoc3.9 = $portVersion compat >= 3.9
-	cmd:pydoc3 = $portVersion compat >= 3.9
 	cmd:python3.9 = $portVersion compat >= 3.9
-	cmd:python3 = $portVersion compat >= 3.9
 	cmd:python3.9_config = $portVersion compat >= 3.9
-	cmd:python3_config = $portVersion compat >= 3.9
 	devel:libpython3.9$secondaryArchSuffix = 1.0
 	lib:libpython3.9$secondaryArchSuffix = 1.0
 	"
@@ -127,7 +122,8 @@ BUILD()
 
 INSTALL()
 {
-	make install
+	# altinstall avoids clobbering $prefix/bin/{2to3,idle3,pydoc3,python3,python3-config}
+	make altinstall
 
 	rm $libDir/libpython3.so
 


### PR DESCRIPTION
Python 3.9 is a bit broken (no readline/editline), so let's move on to 3.10 which works better.