### PR TITLE
haikuporter: updated to latest 1.2.x-revision

### DIFF
--- a/haiku-apps/haikuporter/haikuporter-1.2.7.recipe
+++ b/haiku-apps/haikuporter/haikuporter-1.2.7.recipe
@@ -8,12 +8,13 @@ patches, builds the software, and packages it according to so-called 'recipes'.
 See the wiki on the HaikuPorter website for more information on its usage \
 and details on how to create those recipes."
 HOMEPAGE="https://github.com/haikuports/haikuporter"
-COPYRIGHT="2013-2022 Haiku, Inc."
+COPYRIGHT="2013-2023 Haiku, Inc."
 LICENSE="MIT"
 REVISION="1"
-SOURCE_URI="https://github.com/haikuports/haikuporter/archive/$portVersion.tar.gz"
-CHECKSUM_SHA256="13e00cd4f170d7604a689b733536d511ed52864a38d7b4907fea00e20ce7898b"
-
+SrcGitRev="cac0903d0f2c1f1dccb7f7af88185ebfef398bee"
+SOURCE_URI="https://github.com/haikuports/haikuporter/archive/$SrcGitRev.tar.gz"
+CHECKSUM_SHA256="9c9950fc2cc02c34bca8bb2f13428d299bb56b953f83ed244b8f191be0907962"
+SOURCE_DIR="haikuporter-$SrcGitRev"
 ARCHITECTURES="any"
 
 GLOBAL_WRITABLE_FILES="
@@ -27,7 +28,7 @@ PROVIDES="
 REQUIRES="
 	haiku
 	cmd:git
-	cmd:python3.9
+	cmd:python3.10
 	"
 
 BUILD_REQUIRES="


### PR DESCRIPTION
- Updated to latest git-cac0903 - 26 Jul 2023.
- Updated for Python 3.10 transition.