### PR TITLE
perl, texinfo-7: provide a secondaryArch package

### DIFF
--- a/dev-lang/perl/perl-5.32.1.recipe
+++ b/dev-lang/perl/perl-5.32.1.recipe
@@ -23,58 +23,59 @@ CHECKSUM_SHA256="03b693901cd8ae807231b1787798cf1f2e0b8a56218d07b7da44f784a7caeb2
 PATCHES="perl-$portVersion.patchset"
 
 ARCHITECTURES="all"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	# assume that any perl commands are backwards compatible to version 5.
-	perl = $portVersion compat >= 5
-	cmd:corelist = $portVersion compat >= 5
-	cmd:cpan = $portVersion compat >= 5
-	cmd:enc2xs = $portVersion compat >= 5
-	cmd:encguess = $portVersion compat >= 5
-	cmd:h2ph = $portVersion compat >= 5
-	cmd:h2xs = $portVersion compat >= 5
-	cmd:instmodsh = $portVersion compat >= 5
-	cmd:json_pp = $portVersion compat >= 5
-	cmd:libnetcfg = $portVersion compat >= 5
-	cmd:perl = $portVersion compat >= 5
-	cmd:perl$portVersion = $portVersion compat >= 5
-	cmd:perlbug = $portVersion compat >= 5
-	cmd:perldoc = $portVersion compat >= 5
-	cmd:perlivp = $portVersion compat >= 5
-	cmd:perlthanks = $portVersion compat >= 5
-	cmd:piconv = $portVersion compat >= 5
-	cmd:pl2pm = $portVersion compat >= 5
-	cmd:pod2html = $portVersion compat >= 5
-	cmd:pod2man = $portVersion compat >= 5
-	cmd:pod2text = $portVersion compat >= 5
-	cmd:pod2usage = $portVersion compat >= 5
-	cmd:podchecker = $portVersion compat >= 5
-	cmd:podselect = $portVersion compat >= 5
-	cmd:prove = $portVersion compat >= 5
-	cmd:ptar = $portVersion compat >= 5
-	cmd:ptardiff = $portVersion compat >= 5
-	cmd:ptargrep = $portVersion compat >= 5
-	cmd:shasum = $portVersion compat >= 5
-	cmd:splain = $portVersion compat >= 5
-	cmd:streamzip = $portVersion compat >= 5
-	cmd:xsubpp = $portVersion compat >= 5
-	cmd:zipdetails = $portVersion compat >= 5
+	perl$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:corelist$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:cpan$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:enc2xs$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:encguess$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:h2ph$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:h2xs$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:instmodsh$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:json_pp$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:libnetcfg$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:perl$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:perl$portVersion$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:perlbug$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:perldoc$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:perlivp$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:perlthanks$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:piconv$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:pl2pm$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:pod2html$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:pod2man$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:pod2text$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:pod2usage$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:podchecker$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:podselect$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:prove$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:ptar$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:ptardiff$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:ptargrep$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:shasum$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:splain$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:streamzip$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:xsubpp$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:zipdetails$secondaryArchSuffix = $portVersion compat >= 5
 	# vendor_perl refers to the path to packaged perl modules, which includes
 	# the short perl version, so it is backwards compatible up this one.
-	vendor_perl = $perlShortVersion compat >= $perlShortVersion
-	lib:libperl = $portVersion compat >= $perlShortVersion
+	vendor_perl$secondaryArchSuffix = $perlShortVersion compat >= $perlShortVersion
+	lib:libperl$secondaryArchSuffix = $portVersion compat >= $perlShortVersion
 	"
 REQUIRES="
-	haiku
+	haiku$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
+	haiku${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
 	cmd:awk
-	cmd:gcc
-	cmd:ld
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
 	cmd:make
 	cmd:sed
 	cmd:grep
@@ -83,8 +84,8 @@ BUILD_PREREQUIRES="
 perlArchName="$(uname -m)-haiku"
 
 GLOBAL_WRITABLE_FILES="
-	non-packaged/lib/perl5/site_perl/$perlShortVersion/sitecustomize.pl keep-old
-	non-packaged/lib/perl5/site_perl/$perlShortVersion/$perlArchName directory keep-old
+	non-packaged/$relativeLibDir/perl5/site_perl/$perlShortVersion/sitecustomize.pl keep-old
+	non-packaged/$relativeLibDir/perl5/site_perl/$perlShortVersion/$perlArchName directory keep-old
 	"
 
 BUILD_PACKAGE_ACTIVATION_PHASE=INSTALL
@@ -93,17 +94,19 @@ BUILD()
 {
 	./Configure \
 		-Dprefix=$prefix \
-		-Dprivlib=$prefix/lib/perl5/$portVersion \
+		-Dbin=$binDir \
+		-Dscriptdir=$binDir \
+		-Dprivlib=$libDir/perl5/$portVersion \
 		-Dsiteprefix=$prefix/non-packaged \
-		-Dsitelib=$prefix/non-packaged/lib/perl5/site_perl/$perlShortVersion \
+		-Dsitelib=$prefix/non-packaged/$relativeLibDir/perl5/site_perl/$perlShortVersion \
 		-Dvendorprefix=$prefix \
-		-Dvendorlib=$prefix/lib/perl5/vendor_perl/$perlShortVersion \
+		-Dvendorlib=$libDir/perl5/vendor_perl/$perlShortVersion \
 		-Dcf_email=zooey@hirschkaefer.de \
 		-Uusenm -Duseshrplib -Uusemymalloc \
-		-Dlibpth="$(finddir B_USER_DEVELOP_DIRECTORY)/lib $(finddir B_SYSTEM_DEVELOP_DIRECTORY)/lib" \
-		-Dusrinc="$(finddir B_SYSTEM_DEVELOP_DIRECTORY)/headers/posix" \
-		-Dlocinc="$(finddir B_USER_CONFIG_DIRECTORY)/develop/headers $(finddir B_SYSTEM_DEVELOP_DIRECTORY)/headers" \
-		-Dlibc="'$(finddir B_SYSTEM_LIB_DIRECTORY)/libroot.so'" \
+		-Dlibpth="$(finddir B_USER_DEVELOP_DIRECTORY)/lib$secondaryArchSubDir $(finddir B_SYSTEM_DEVELOP_DIRECTORY)/lib$secondaryArchSubDir" \
+		-Dusrinc="$(finddir B_SYSTEM_DEVELOP_DIRECTORY)/headers$secondaryArchSubDir/posix" \
+		-Dlocinc="$(finddir B_USER_CONFIG_DIRECTORY)/develop/headers$secondaryArchSubDir $(finddir B_SYSTEM_DEVELOP_DIRECTORY)/headers$secondaryArchSubDir" \
+		-Dlibc="'$(finddir B_SYSTEM_LIB_DIRECTORY)$secondaryArchSubDir/libroot.so'" \
 		-Dlibs=-lnetwork -Dcc=gcc -Dld=gcc \
 		-Ud_link -Ddont_use_nlink -Ud_syserrlst \
 		-Dldlibpthname=LIBRARY_PATH -Dstartperl="#! perl" \
@@ -123,7 +126,8 @@ INSTALL()
 	chmod a+x $binDir/{perl,perlthanks}
 
 	# copy script into site_perl that takes care of massaging @INC into what we need.
-	cp sitecustomize.pl $prefix/non-packaged/lib/perl5/site_perl/$perlShortVersion/
+	sed "s|/lib/|/lib$secondaryArchSubDir/|g" sitecustomize.pl > $prefix/non-packaged/$relativeLibDir/perl5/site_perl/$perlShortVersion/sitecustomize.pl
+	# TODO: maybe generate the script dynamically in the recipe (using recipe variables) instead of statically in the patchset
 }
 
 TEST()

--- a/media-sound/lilypond/lilypond-2.24.2.recipe
+++ b/media-sound/lilypond/lilypond-2.24.2.recipe
@@ -103,7 +103,7 @@ BUILD_REQUIRES="
 	tex:hyphen_portuguese
 	"
 BUILD_PREREQUIRES="
-#	cmd:awk
+	cmd:awk
 	cmd:bison
 	cmd:convert
 	cmd:dblatex
@@ -115,16 +115,15 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:kpsewhich
 	cmd:make
-	cmd:mawk # required by texindex
 	cmd:mf
 	cmd:mpost
-	cmd:perl
+	cmd:perl$secondaryArchSuffix
 	cmd:pkg_config$secondaryArchSuffix
 	cmd:rsync
 	cmd:t1asm
 	cmd:tar
 	cmd:texi2html
-	cmd:texindex
+	cmd:texindex$secondaryArchSuffix
 	cmd:tidy
 	cmd:xelatex
 	cmd:zip

--- a/sys-apps/texinfo/texinfo-7.0.3.recipe
+++ b/sys-apps/texinfo/texinfo-7.0.3.recipe
@@ -10,43 +10,46 @@ CHECKSUM_SHA256="3cc5706fb086b895e1dc2b407aade9f95a3a233ff856273e2b659b089f11768
 PATCHES="texinfo-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	texinfo = $portVersion compat >= 4
-	cmd:info = $portVersion compat >= 4
-	cmd:infokey = $portVersion compat >= 4
-	cmd:install_info = $portVersion compat >= 4
-	cmd:makeinfo = $portVersion compat >= 4
-	cmd:pdftexi2dvi = $portVersion compat >= 4
-	cmd:pod2texi = $portVersion compat >= 6
-	cmd:texi2any = $portVersion compat >= 6
-	cmd:texi2dvi = $portVersion compat >= 4
-	cmd:texi2pdf = $portVersion compat >= 4
-	cmd:texindex = $portVersion compat >= 4
+	texinfo$secondaryArchSuffix = $portVersion compat >= 4
+	cmd:info$secondaryArchSuffix = $portVersion compat >= 4
+	cmd:infokey$secondaryArchSuffix = $portVersion compat >= 4
+	cmd:install_info$secondaryArchSuffix = $portVersion compat >= 4
+	cmd:makeinfo$secondaryArchSuffix = $portVersion compat >= 4
+	cmd:pdftexi2dvi$secondaryArchSuffix = $portVersion compat >= 4
+	cmd:pod2texi$secondaryArchSuffix = $portVersion compat >= 6
+	cmd:texi2any$secondaryArchSuffix = $portVersion compat >= 6
+	cmd:texi2dvi$secondaryArchSuffix = $portVersion compat >= 4
+	cmd:texi2pdf$secondaryArchSuffix = $portVersion compat >= 4
+	cmd:texindex$secondaryArchSuffix = $portVersion compat >= 4
 	"
 REQUIRES="
-	haiku
+	haiku$secondaryArchSuffix
 	cmd:gawk
-	lib:libiconv
-	lib:libintl
-	lib:libncurses
-	lib:libperl
+	lib:libiconv$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libncurses$secondaryArchSuffix
+	lib:libperl$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
-	devel:libncurses
+	haiku${secondaryArchSuffix}_devel
+	devel:libiconv$secondaryArchSuffix
+	devel:libintl$secondaryArchSuffix
+	devel:libncurses$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:aclocal
 	cmd:autoconf
 	cmd:gawk
-	cmd:gcc
+	cmd:gcc$secondaryArchSuffix
 	cmd:gettext
 	cmd:grep
-	cmd:ld
+	cmd:ld$secondaryArchSuffix
 	cmd:make
-	cmd:perl
+	cmd:perl$secondaryArchSuffix
 	cmd:sed
 	"
 

--- a/sys-apps/texinfo/texinfo-7.0.3.recipe
+++ b/sys-apps/texinfo/texinfo-7.0.3.recipe
@@ -32,6 +32,11 @@ REQUIRES="
 	lib:libncurses$secondaryArchSuffix
 	lib:libperl$secondaryArchSuffix
 	"
+if [ -n "$secondaryArchSuffix" ]; then
+CONFLICTS="
+	texinfo
+	"
+fi
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel

--- a/sys-apps/texinfo/texinfo-7.0.3.recipe
+++ b/sys-apps/texinfo/texinfo-7.0.3.recipe
@@ -1,10 +1,9 @@
 SUMMARY="Standard GNU documentation format tool"
-DESCRIPTION="
-Texinfo is the official documentation format of the GNU project."
+DESCRIPTION="Texinfo is the official documentation format of the GNU project."
 HOMEPAGE="http://www.gnu.org/software/texinfo/"
 COPYRIGHT="1992-2008 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="http://ftp.gnu.org/gnu/texinfo/texinfo-$portVersion.tar.gz"
 CHECKSUM_SHA256="3cc5706fb086b895e1dc2b407aade9f95a3a233ff856273e2b659b089f117683"
 PATCHES="texinfo-$portVersion.patchset"
@@ -62,4 +61,7 @@ BUILD()
 INSTALL()
 {
 	make install
+
+	# remove libtool files
+	rm $libDir/texinfo/*.la
 }


### PR DESCRIPTION
LilyPond requires a newer texinfo than the 6.1 that is available for x86_gcc2. Provide a secondary architecture version of texinfo 7 to fix that.

Perl (secondary) is required for texinfo.

@Begasus @pulkomandy This needs a thorough review please. I am not sure if this is a good solution.