### PR TITLE
ocp: bump version

### DIFF
--- a/media-sound/ocp/ocp-0.2.106.recipe
+++ b/media-sound/ocp/ocp-0.2.106.recipe
@@ -5,7 +5,7 @@ COPYRIGHT="1994-2023 Niklas Beisert, Stian Skjelstad and others"
 LICENSE="GNU GPL v2"
 REVISION="2"
 SOURCE_URI="https://stian.cubic.org/ocp/ocp-$portVersion.tar.bz2"
-CHECKSUM_SHA256="d45d93ee3e95371116b449df7633e926f6c429d6ce1e60912884473b85288277"
+CHECKSUM_SHA256="600cbc10cff1ed1926b2e6fce04ab9fd6f9a8ab9e39895a78829966dfd42758c"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -34,6 +34,7 @@ REQUIRES="
 	lib:libdiscid$secondaryArchSuffix
 	lib:libFLAC$secondaryArchSuffix
 	lib:libfreetype$secondaryArchSuffix
+	lib:libgme$secondaryArchSuffix
 	lib:libiconv$secondaryArchSuffix
 	lib:libjpeg$secondaryArchSuffix
 	lib:libncurses$secondaryArchSuffix
@@ -55,6 +56,7 @@ BUILD_REQUIRES="
 	devel:libdiscid$secondaryArchSuffix
 	devel:libFLAC$secondaryArchSuffix
 	devel:libfreetype$secondaryArchSuffix
+	devel:libgme$secondaryArchSuffix
 	devel:libiconv$secondaryArchSuffix
 	devel:libjpeg$secondaryArchSuffix
 	devel:libncurses$secondaryArchSuffix


### PR DESCRIPTION
Version 0.2.106 adds support for libgme (game-music-emu)