### PR TITLE
pybind11: update to version 2.11.1

### DIFF
--- a/dev-python/pybind11/pybind11-2.11.1.recipe
+++ b/dev-python/pybind11/pybind11-2.11.1.recipe
@@ -6,11 +6,11 @@ Its goals and syntax are similar to the excellent Boost.Python library by \
 David Abrahams: to minimize boilerplate code in traditional extension modules \
 by inferring type information using compile-time introspection."
 HOMEPAGE="https://pypi.org/project/pybind11/"
-COPYRIGHT="2015-2019 Wenzel Jakob"
+COPYRIGHT="2015-2023 Wenzel Jakob"
 LICENSE="BSD (2-clause)"
-REVISION="4"
+REVISION="1"
 SOURCE_URI="https://github.com/pybind/pybind11/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="8ff2fff22df038f5cd02cea8af56622bc67f5b64534f1b83b9f133b8366acff2"
+CHECKSUM_SHA256="d475978da0cdc2d43b73f30910786759d593a9d8ee05b1b6846d1eb16c6d2e0c"
 SOURCE_FILENAME="pybind11-v$portVersion.tar.gz"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -25,6 +25,7 @@ REQUIRES="
 
 PYTHON_PACKAGES=(python38 python39 python310)
 PYTHON_VERSIONS=(3.8 3.9 3.10)
+defaultVersion=3.10
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -33,6 +34,13 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 		${portName}_$pythonPackage = $portVersion
 		cmd:pybind11_config_$pythonVersion
 		\""
+
+	if [ $pythonVersion = $defaultVersion ]; then
+		eval "PROVIDES_${pythonPackage}+=\"
+			cmd:pybind11_config
+			\""
+	fi
+
 	if [ "$targetArchitecture" = x86_gcc2 ]; then
 		eval "PROVIDES_$pythonPackage+=\"
 			pybind11_$pythonPackage = $portVersion
@@ -48,7 +56,7 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 		devel:eigen$secondaryArchSuffix
 		"
 	BUILD_PREREQUIRES+="
-		cmd:cmake
+		cmd:cmake # setup.py calls cmake
 		cmd:gcc$secondaryArchSuffix
 		cmd:make
 		cmd:python$pythonVersion
@@ -71,7 +79,13 @@ INSTALL()
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
+		# Version suffix pybind11-config
 		mv $prefix/bin/pybind11-config $prefix/bin/pybind11-config-$pythonVersion
+
+		# Provide suffix-less symlink for the default Python version
+		if [ $pythonVersion = $defaultVersion ]; then
+			ln -sr $prefix/bin/pybind11-config-$pythonVersion $prefix/bin/pybind11-config
+		fi
 
 #		Not sure we want to run cmake build
 #		this will install the headers and cmake files double


### PR DESCRIPTION
Also, provide a non-versioned pybind11-config symlink to the 3.10 version (matching our current default Python version).

This should (might?) help with packages as `contourpy` that expect to find a non-versioned "pybind11-config".