### PR TITLE
contourpy: new recipe.

### DIFF
--- a/dev-python/contourpy/contourpy-1.1.0.recipe
+++ b/dev-python/contourpy/contourpy-1.1.0.recipe
@@ -1,0 +1,88 @@
+SUMMARY="Python library for calculating contours of 2D quadrilateral grids"
+DESCRIPTION="ContourPy is a Python library for calculating contours of 2D quadrilateral grids. \
+It is written in C++11 and wrapped using pybind11.
+
+It contains the 2005 and 2014 algorithms used in Matplotlib as well as a newer algorithm that \
+includes more features and is available in both serial and multithreaded versions. It provides \
+an easy way for Python libraries to use contouring algorithms without having to include \
+Matplotlib as a dependency."
+HOMEPAGE="https://github.com/contourpy/contourpy"
+COPYRIGHT="2021-2023, ContourPy Developers"
+LICENSE="BSD (3-clause)"
+REVISION="1"
+SOURCE_URI="https://pypi.io/packages/source/c/contourpy/contourpy-$portVersion.tar.gz"
+CHECKSUM_SHA256="e53046c3863828d21d531cc3b53786e6580eb1ba02477e8681009b6aa0870b21"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	$portName = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+PYTHON_PACKAGES=(python310)
+PYTHON_VERSIONS=(3.10)
+for i in "${!PYTHON_PACKAGES[@]}"; do
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_$pythonPackage+=\"
+			contourpy_$pythonPackage = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		numpy_$pythonPackage >= 1.16
+		\""
+	BUILD_REQUIRES+="
+		build_$pythonPackage
+		installer_$pythonPackage
+		meson_python_$pythonPackage >= 0.13.1
+		pybind11_$pythonPackage >= 2.10.4
+		wheel_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
+done
+
+
+INSTALL()
+{
+	for i in "${!PYTHON_PACKAGES[@]}"; do
+		pythonVersion=${PYTHON_VERSIONS[$i]}
+
+		python=python$pythonVersion
+
+		# Try to help pkg-config detect where our pybind11.pc is located,
+		# making sure we use the correct version of `pybind11-config`
+		export PKG_CONFIG_PATH=$(pybind11-config-$pythonVersion --pkgconfigdir)
+
+		# Without this, "installer" (see below) was erroring out when building for multiple Python
+		# versions (tested w/ 3.9/3.10). Strange, as similar recipes have no issue with that line.
+		rm -f dist/*.whl
+
+		$python -m build --wheel --skip-dependency-check --no-isolation
+		$python -m installer -p $prefix dist/*.whl
+
+		packageEntries ${PYTHON_PACKAGES[i]} \
+			$prefix/lib/python*
+	done
+}


### PR DESCRIPTION
Listed as a dependency for matplotlib.

Only providing a Python 3.10 for now, as this is a new recipe, and its only inmediate target user would be matplotlib (that should also be moved to 3.10).

In any case, I've tested the recipe works for multiple versions, by locally building it for both 3.9 and 3.10.

Note: built (and very lightly tested) on 64 bits only.

(Also: depends on the updated pybind11 from #9220)