### PR TITLE
libreoffice 6.4.7: (32 bits only), remove Python build dependencies.

### DIFF
--- a/app-office/libreoffice/libreoffice-6.4.7.2.recipe
+++ b/app-office/libreoffice/libreoffice-6.4.7.2.recipe
@@ -17,7 +17,7 @@ and Open Source office suite on the market:
 HOMEPAGE="https://www.libreoffice.org/"
 COPYRIGHT="2000-2020 LibreOffice contributors"
 LICENSE="MPL v2.0"
-REVISION="10"
+REVISION="11"
 
 SOURCE_URI="https://github.com/LibreOffice/core/archive/libreoffice-$portVersion.tar.gz"
 SOURCE_DIR="core-libreoffice-$portVersion"
@@ -254,8 +254,6 @@ BUILD_PREREQUIRES="
 	cmd:patch
 	cmd:perl
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:python2.7
-	cmd:python3.7
 	cmd:ucpp
 	cmd:which
 	cmd:xz


### PR DESCRIPTION
Untested, but we don't have Python 2.7 anymore, a similar change was made for LibreOffice 7.3.7 (64 bits), and both recipes have `--enable-python=no`, so let's see if this can be rebuild, or we're stuck with the current revision.