### PR TITLE
runescape_launcher: add recipe

### DIFF
--- a/games-rpg/runescape_launcher/runescape_launcher-0.9.0.recipe
+++ b/games-rpg/runescape_launcher/runescape_launcher-0.9.0.recipe
@@ -1,0 +1,49 @@
+SUMMARY="A launcher script for old-school Runescape"
+DESCRIPTION="This is a launcher script that downloads the \
+old school Runescape launcher and starts it. \
+Please note that runescape itself is closed-source and has a \
+proprietary license.\
+\
+This script is based on https://gitlab.com/coringao/runescape/"
+HOMEPAGE="https://github.com/TheZeldakatze/haiku-oldschoolrunescape-launcher"
+COPYRIGHT="2023, Maite Gamper \
+2016-2020, Carlos Donizete Froes"
+LICENSE="BSD (2-clause)"
+REVISION="1"
+SOURCE_URI="https://github.com/TheZeldakatze/haiku-oldschoolrunescape-launcher/archive/refs/tags/v0.9.0.tar.gz"
+CHECKSUM_SHA256="92f9497095c56a74da87c5f907a57f46cee84c0ac505cb9f41e9015565354863"
+SOURCE_DIR="haiku-oldschoolrunescape-launcher-0.9.0"
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	runescape_launcher$secondaryArchSuffix
+	app:Runescape_Launcher
+	"
+
+REQUIRES="
+	haiku$secondaryArchSuffix
+	cmd:7z
+	cmd:wget
+	openjdk11${secondaryArchSuffix}_jre
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+
+BUILD_PREREQUIRES="
+	cmd:resattr
+	"
+
+BUILD() {
+	chmod +x Runescape\ Launcher
+	rc -o runescapeLogo.rsrc runescapeLogo.rdef
+	resattr -o ./Runescape\ Launcher runescapeLogo.rsrc
+}
+
+INSTALL() {
+	mkdir $appsDir
+	cp Runescape\ Launcher $appsDir
+	addAppDeskbarSymlink $appsDir/Runescape\ Launcher "Runescape Launcher"
+}


### PR DESCRIPTION
I wrote a simple launcher script for old school runescape, based on [https://gitlab.com/coringao/runescape/](https://gitlab.com/coringao/runescape/). It also has a check in it to kill the game when it's closed, as it otherwise will hang when it's quit (maybe something to do with the audio?). I hope I did everything correctly with the licensing.


Currently the game does not load when run outside of the terminal. On x86_64 it gets stuck on loading and x86_32 it cannot find the java executable. For what I could tell, the problem seems to have to do with differing environment variables when run from the terminal compared to otherwise. On x86_32 $JRE11_HOME is missing when run normally compared to the terminal. jre 11 is required as the game won't start with newer ones. I'll have a look at maybe fixing this shortly