### PR TITLE
opendyslexic: new recipe

### DIFF
--- a/media-fonts/opendyslexic/opendyslexic-0.91.12.recipe
+++ b/media-fonts/opendyslexic/opendyslexic-0.91.12.recipe
@@ -1,0 +1,32 @@
+SUMMARY="Font for dyslexics that improves readability"
+DESCRIPTION="This is OpenDyslexic, recreated in SIL-OFL. \
+It is an opensource typeface that aims to help with \
+some of the symptoms of dyslexia, as defined by the DSM-V"
+HOMEPAGE="https://github.com/antijingoist/opendyslexic"
+COPYRIGHT="2019 Abbie Gonzalez"
+LICENSE="SIL Open Font License v1.1"
+REVISION="1"
+SOURCE_URI="https://github.com/antijingoist/opendyslexic/archive/refs/tags/v0.91.12.tar.gz"
+CHECKSUM_SHA256="d20d182fb7069023b8dbdf131bbe232093b4147dd4900e27c95b86d3ddfca34b"
+SOURCE_DIR="opendyslexic-0.91.12"
+
+ARCHITECTURES="any"
+DISABLE_SOURCE_PACKAGE="yes"
+
+PROVIDES="
+	opendyslexic=$portVersion
+	"
+
+REQUIRES=" "
+BUILD_PREREQUIRES="
+	coreutils
+	"
+
+BUILD() {
+	true
+}
+
+INSTALL() {
+	mkdir -p $fontsDir/otfonts
+	cp compiled/*.otf $fontsDir/otfonts
+}


### PR DESCRIPTION
I decided to use the newer
https://github.com/antijingoist/opendyslexic
repository instead of
https://github.com/antijingoist/open-dyslexic
even though the gpo recipe uses the older repository,
as the newer one is linked to by the old repository and has a different license