### PR TITLE
python3.11: new recipe for Python 3.11

### DIFF
--- a/dev-lang/python/patches/python3.11-3.11.5.patchset
+++ b/dev-lang/python/patches/python3.11-3.11.5.patchset
@@ -1,0 +1,900 @@
+From 5d191a7773513212c1b4ca8e496a36f6776d75ad Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Thu, 10 Apr 2014 16:03:33 +0000
+Subject: initial Haiku patch
+
+
+diff --git a/Include/pyport.h b/Include/pyport.h
+index 93250f4..d170ac9 100644
+--- a/Include/pyport.h
++++ b/Include/pyport.h
+@@ -685,7 +685,7 @@ extern char * _getpty(int *, int, mode_t, int);
+ #  define _Py_FORCE_UTF8_LOCALE
+ #endif
+ 
+-#if defined(_Py_FORCE_UTF8_LOCALE) || defined(__APPLE__)
++#if defined(_Py_FORCE_UTF8_LOCALE) || defined(__APPLE__) || defined(__HAIKU__)
+    // Use UTF-8 as the filesystem encoding.
+    // See PyUnicode_DecodeFSDefaultAndSize(), PyUnicode_EncodeFSDefault(),
+    // Py_DecodeLocale() and Py_EncodeLocale().
+diff --git a/Lib/distutils/command/install.py b/Lib/distutils/command/install.py
+index 01d5331..b109392 100644
+--- a/Lib/distutils/command/install.py
++++ b/Lib/distutils/command/install.py
+@@ -33,13 +33,15 @@ SCHEME_KEYS = ('purelib', 'platlib', 'headers', 'scripts', 'data')
+ # alter locations for packages installations in a single place.
+ # Note that this module is deprecated (PEP 632); all consumers
+ # of this information should switch to using sysconfig directly.
+-INSTALL_SCHEMES = {"unix_prefix": {}, "unix_home": {}, "nt": {}}
++INSTALL_SCHEMES = {"unix_prefix": {}, "unix_home": {}, "nt": {},
++    "haiku": {}, "haiku_vendor": {}, "haiku_home": {}}
+ 
+ # Copy from sysconfig._INSTALL_SCHEMES
+ for key in SCHEME_KEYS:
+     for distutils_scheme_name, sys_scheme_name in (
+             ("unix_prefix", "posix_prefix"), ("unix_home", "posix_home"),
+-            ("nt", "nt")):
++            ("nt", "nt"), ("haiku", "haiku"), ("haiku_vendor", "haiku_vendor"),
++            ("haiku_home", "haiku_home")):
+         sys_key = key
+         sys_scheme = sysconfig._INSTALL_SCHEMES[sys_scheme_name]
+         if key == "headers" and key not in sys_scheme:
+@@ -86,6 +88,13 @@ if HAS_USER_SITE:
+         'data'   : '$userbase',
+         }
+ 
++    INSTALL_SCHEMES['haiku_user'] = {
++        'purelib': '$usersite',
++        'platlib': '$usersite',
++        'headers': '$userbase/develop/headers/python$py_version_short/$dist_name',
++        'scripts': '$userbase/bin',
++        'data'   : '$userbase',
++        }
+ 
+ class install(Command):
+ 
+@@ -431,10 +440,16 @@ class install(Command):
+                 raise DistutilsPlatformError(
+                     "User base directory is not specified")
+             self.install_base = self.install_platbase = self.install_userbase
+-            self.select_scheme("unix_user")
++            if sys.platform.startswith('haiku'):
++                self.select_scheme("haiku_user")
++            else:
++                self.select_scheme("unix_user")
+         elif self.home is not None:
+             self.install_base = self.install_platbase = self.home
+-            self.select_scheme("unix_home")
++            if sys.platform.startswith('haiku'):
++                self.select_scheme("haiku_home")
++            else:
++                self.select_scheme("unix_home")
+         else:
+             if self.prefix is None:
+                 if self.exec_prefix is not None:
+@@ -450,7 +465,13 @@ class install(Command):
+ 
+             self.install_base = self.prefix
+             self.install_platbase = self.exec_prefix
+-            self.select_scheme("unix_prefix")
++            if sys.platform.startswith('haiku'):
++                if os.environ.get('HAIKU_USE_VENDOR_DIRECTORIES') == '1':
++                    self.select_scheme("haiku_vendor")
++                else:
++                    self.select_scheme("haiku")
++            else:
++                self.select_scheme("unix_prefix")
+ 
+     def finalize_other(self):
+         """Finalizes options for non-posix platforms"""
+diff --git a/Lib/distutils/sysconfig.py b/Lib/distutils/sysconfig.py
+index 03b8558..a7253b6 100644
+--- a/Lib/distutils/sysconfig.py
++++ b/Lib/distutils/sysconfig.py
+@@ -287,7 +287,8 @@ def get_python_inc(plat_specific=0, prefix=None):
+                 incdir = os.path.join(get_config_var('srcdir'), 'Include')
+                 return os.path.normpath(incdir)
+         python_dir = 'python' + get_python_version() + build_flags
+-        return os.path.join(prefix, "include", python_dir)
++        inc_dir = "include" if sys.platform != "haiku1" else "develop/headers"
++        return os.path.join(prefix, inc_dir, python_dir)
+     elif os.name == "nt":
+         if python_build:
+             # Include both the include and PC dir to ensure we can find
+@@ -322,19 +323,27 @@ def get_python_lib(plat_specific=0, standard_lib=0, prefix=None):
+             prefix = plat_specific and EXEC_PREFIX or PREFIX
+ 
+     if os.name == "posix":
+-        if plat_specific or standard_lib:
+-            # Platform-specific modules (any module from a non-pure-Python
+-            # module distribution) or standard Python library modules.
+-            libdir = sys.platlibdir
++        if sys.platform.startswith('haiku'):
++            if standard_lib:
++                return os.path.join(prefix,
++                                    "lib", "python" + get_python_version())
++            return os.path.join(prefix, "non-packaged",
++                                "lib", "python" + get_python_version(),
++                                "site-packages")
+         else:
+-            # Pure Python
+-            libdir = "lib"
+-        libpython = os.path.join(prefix, libdir,
+-                                 "python" + get_python_version())
+-        if standard_lib:
+-            return libpython
+-        else:
+-            return os.path.join(libpython, "site-packages")
++            if plat_specific or standard_lib:
++                # Platform-specific modules (any module from a non-pure-Python
++                # module distribution) or standard Python library modules.
++                libdir = sys.platlibdir
++
++                # Pure Python
++                libdir = "lib"
++            libpython = os.path.join(prefix, libdir,
++                                     "python" + get_python_version())
++            if standard_lib:
++                return libpython
++            else:
++                return os.path.join(libpython, "site-packages")
+     elif os.name == "nt":
+         if standard_lib:
+             return os.path.join(prefix, "Lib")
+diff --git a/Lib/plat-haiku1/regen b/Lib/plat-haiku1/regen
+new file mode 100644
+index 0000000..4372ee2
+--- /dev/null
++++ b/Lib/plat-haiku1/regen
+@@ -0,0 +1,4 @@
++#! /bin/sh
++HEADERS=/boot/develop/headers
++set -v
++eval $PYTHON_FOR_BUILD ../../Tools/scripts/h2py.py -i "'(u_long)'" $HEADERS/posix/netinet/in.h
+diff --git a/Lib/site.py b/Lib/site.py
+index 69670d9..82ca5af 100644
+--- a/Lib/site.py
++++ b/Lib/site.py
+@@ -281,6 +281,14 @@ def _getuserbase():
+         return joinuser("~", "Library", sys._framework,
+                         "%d.%d" % sys.version_info[:2])
+ 
++    if sys.platform.startswith('haiku'):
++        try:
++            import subprocess
++            return subprocess.run(['finddir', 'B_USER_NONPACKAGED_DIRECTORY'],
++                stdout=subprocess.PIPE, check=True).stdout.rstrip().decode('utf-8')
++        except:
++            pass
++
+     return joinuser("~", ".local")
+ 
+ 
+@@ -361,7 +369,14 @@ def getsitepackages(prefixes=None):
+             continue
+         seen.add(prefix)
+ 
+-        if os.sep == '/':
++        if sys.platform.startswith('haiku'):
++           sitepackages.append(os.path.join(prefix, "non-packaged", "lib",
++                                       "python%d.%d" % sys.version_info[:2],
++                                       "site-packages"))
++           sitepackages.append(os.path.join(prefix, "lib",
++                                       "python%d.%d" % sys.version_info[:2],
++                                       "vendor-packages"))
++        elif os.sep == '/':
+             libdirs = [sys.platlibdir]
+             if sys.platlibdir != "lib":
+                 libdirs.append("lib")
+@@ -470,8 +485,16 @@ def enablerlcompleter():
+             # each interpreter exit when readline was already configured
+             # through a PYTHONSTARTUP hook, see:
+             # http://bugs.python.org/issue5845#msg198636
+-            history = os.path.join(os.path.expanduser('~'),
+-                                   '.python_history')
++            import subprocess
++            try:
++                history = os.path.join(subprocess.run(['finddir', 'B_USER_VAR_DIRECTORY'],
++                            check=True, stdout=subprocess.PIPE).stdout.rstrip().decode('utf-8'),
++                            'python', 'history')
++                if not os.path.exists(os.path.dirname(history)):
++                    os.makedirs(os.path.dirname(history))
++            except subprocess.CalledProcessError:
++                history = os.path.join(os.path.expanduser('~'),
++                                       '.python_history')
+             try:
+                 readline.read_history_file(history)
+             except OSError:
+diff --git a/Lib/test/test_fileio.py b/Lib/test/test_fileio.py
+index 5cc3d4b..6f53287 100644
+--- a/Lib/test/test_fileio.py
++++ b/Lib/test/test_fileio.py
+@@ -391,6 +391,7 @@ class OtherFileTests:
+                     self.assertEqual(f.writable(), True)
+                     if sys.platform != "darwin" and \
+                        'bsd' not in sys.platform and \
++                       'haiku' not in sys.platform and \
+                        not sys.platform.startswith(('sunos', 'aix')):
+                         # Somehow /dev/tty appears seekable on some BSDs
+                         self.assertEqual(f.seekable(), False)
+diff --git a/Makefile.pre.in b/Makefile.pre.in
+index 3ea8653..1b16bda 100644
+--- a/Makefile.pre.in
++++ b/Makefile.pre.in
+@@ -146,7 +146,7 @@ BINDIR=		@bindir@
+ LIBDIR=		@libdir@
+ MANDIR=		@mandir@
+ INCLUDEDIR=	@includedir@
+-CONFINCLUDEDIR=	$(exec_prefix)/include
++CONFINCLUDEDIR=	$(INCLUDEDIR)
+ PLATLIBDIR=	@PLATLIBDIR@
+ SCRIPTDIR=	$(prefix)/$(PLATLIBDIR)
+ ABIFLAGS=	@ABIFLAGS@
+diff --git a/Modules/resource.c b/Modules/resource.c
+index d8bba2e..f010e09 100644
+--- a/Modules/resource.c
++++ b/Modules/resource.c
+@@ -113,6 +113,7 @@ resource_getrusage_impl(PyObject *module, int who)
+                     PyFloat_FromDouble(doubletime(ru.ru_utime)));
+     PyStructSequence_SET_ITEM(result, 1,
+                     PyFloat_FromDouble(doubletime(ru.ru_stime)));
++#ifndef __HAIKU__
+     PyStructSequence_SET_ITEM(result, 2, PyLong_FromLong(ru.ru_maxrss));
+     PyStructSequence_SET_ITEM(result, 3, PyLong_FromLong(ru.ru_ixrss));
+     PyStructSequence_SET_ITEM(result, 4, PyLong_FromLong(ru.ru_idrss));
+@@ -127,7 +128,22 @@ resource_getrusage_impl(PyObject *module, int who)
+     PyStructSequence_SET_ITEM(result, 13, PyLong_FromLong(ru.ru_nsignals));
+     PyStructSequence_SET_ITEM(result, 14, PyLong_FromLong(ru.ru_nvcsw));
+     PyStructSequence_SET_ITEM(result, 15, PyLong_FromLong(ru.ru_nivcsw));
+-
++#else
++    PyStructSequence_SET_ITEM(result, 2, PyLong_FromLong(0));
++    PyStructSequence_SET_ITEM(result, 3, PyLong_FromLong(0));
++    PyStructSequence_SET_ITEM(result, 4, PyLong_FromLong(0));
++    PyStructSequence_SET_ITEM(result, 5, PyLong_FromLong(0));
++    PyStructSequence_SET_ITEM(result, 6, PyLong_FromLong(0));
++    PyStructSequence_SET_ITEM(result, 7, PyLong_FromLong(0));
++    PyStructSequence_SET_ITEM(result, 8, PyLong_FromLong(0));
++    PyStructSequence_SET_ITEM(result, 9, PyLong_FromLong(0));
++    PyStructSequence_SET_ITEM(result, 10, PyLong_FromLong(0));
++    PyStructSequence_SET_ITEM(result, 11, PyLong_FromLong(0));
++    PyStructSequence_SET_ITEM(result, 12, PyLong_FromLong(0));
++    PyStructSequence_SET_ITEM(result, 13, PyLong_FromLong(0));
++    PyStructSequence_SET_ITEM(result, 14, PyLong_FromLong(0));
++    PyStructSequence_SET_ITEM(result, 15, PyLong_FromLong(0));
++#endif
+     if (PyErr_Occurred()) {
+         Py_DECREF(result);
+         return NULL;
+@@ -378,19 +394,19 @@ resource_exec(PyObject *module)
+     }
+ 
+     /* insert constants */
+-#ifdef RLIMIT_CPU
++#if !defined(__HAIKU__) && defined(RLIMIT_CPU)
+     ADD_INT(module, RLIMIT_CPU);
+ #endif
+ 
+-#ifdef RLIMIT_FSIZE
++#if !defined(__HAIKU__) && defined(RLIMIT_FSIZE)
+     ADD_INT(module, RLIMIT_FSIZE);
+ #endif
+ 
+-#ifdef RLIMIT_DATA
++#if !defined(__HAIKU__) && defined(RLIMIT_DATA)
+     ADD_INT(module, RLIMIT_DATA);
+ #endif
+ 
+-#ifdef RLIMIT_STACK
++#if !defined(__HAIKU__) && defined(RLIMIT_STACK)
+     ADD_INT(module, RLIMIT_STACK);
+ #endif
+ 
+@@ -402,31 +418,31 @@ resource_exec(PyObject *module)
+     ADD_INT(module, RLIMIT_NOFILE);
+ #endif
+ 
+-#ifdef RLIMIT_OFILE
++#if !defined(__HAIKU__) && defined(RLIMIT_OFILE)
+     ADD_INT(module, RLIMIT_OFILE);
+ #endif
+ 
+-#ifdef RLIMIT_VMEM
++#if !defined(__HAIKU__) && defined(RLIMIT_VMEM)
+     ADD_INT(module, RLIMIT_VMEM);
+ #endif
+ 
+-#ifdef RLIMIT_AS
++#if !defined(__HAIKU__) && defined(RLIMIT_AS)
+     ADD_INT(module, RLIMIT_AS);
+ #endif
+ 
+-#ifdef RLIMIT_RSS
++#if !defined(__HAIKU__) && defined(RLIMIT_RSS)
+     ADD_INT(module, RLIMIT_RSS);
+ #endif
+ 
+-#ifdef RLIMIT_NPROC
++#if !defined(__HAIKU__) && defined(RLIMIT_NPROC)
+     ADD_INT(module, RLIMIT_NPROC);
+ #endif
+ 
+-#ifdef RLIMIT_MEMLOCK
++#if !defined(__HAIKU__) && defined(RLIMIT_MEMLOCK)
+     ADD_INT(module, RLIMIT_MEMLOCK);
+ #endif
+ 
+-#ifdef RLIMIT_SBSIZE
++#if !defined(__HAIKU__) && defined(RLIMIT_SBSIZE)
+     ADD_INT(module, RLIMIT_SBSIZE);
+ #endif
+ 
+diff --git a/Modules/socketmodule.h b/Modules/socketmodule.h
+index 1b35b11..f230057 100644
+--- a/Modules/socketmodule.h
++++ b/Modules/socketmodule.h
+@@ -102,6 +102,10 @@ typedef int socklen_t;
+ #  undef AF_QIPCRTR
+ #endif
+ 
++#if defined(__HAIKU__)
++#undef HAVE_BLUETOOTH_BLUETOOTH_H
++#endif
++
+ #ifdef HAVE_BLUETOOTH_BLUETOOTH_H
+ #include <bluetooth/bluetooth.h>
+ #include <bluetooth/rfcomm.h>
+diff --git a/Modules/spwdmodule.c b/Modules/spwdmodule.c
+index 42123c9..60de40a 100644
+--- a/Modules/spwdmodule.c
++++ b/Modules/spwdmodule.c
+@@ -9,6 +9,7 @@
+ #ifdef HAVE_SHADOW_H
+ #include <shadow.h>
+ #endif
++#include <errno.h>
+ 
+ #include "clinic/spwdmodule.c.h"
+ 
+@@ -148,7 +149,12 @@ spwd_getspnam_impl(PyObject *module, PyObject *arg)
+     if (PyBytes_AsStringAndSize(bytes, &name, NULL) == -1)
+         goto out;
+     if ((p = getspnam(name)) == NULL) {
++// Haiku sets ENOENT if invalid user is specified. Ignore it to make KeyError is set.
++#ifdef __HAIKU__
++        if (errno != 0 && errno != ENOENT)
++#else
+         if (errno != 0)
++#endif
+             PyErr_SetFromErrno(PyExc_OSError);
+         else
+             PyErr_SetString(PyExc_KeyError, "getspnam(): name not found");
+-- 
+2.37.3
+
+
+From 10a9824ed8ac63d5cf0b0ef6543c3d01ebaada49 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Sun, 16 Apr 2017 10:05:42 +0200
+Subject: fix for negative errnos
+
+
+diff --git a/Lib/subprocess.py b/Lib/subprocess.py
+index fbc76b8..d719f09 100644
+--- a/Lib/subprocess.py
++++ b/Lib/subprocess.py
+@@ -1938,6 +1938,8 @@ class Popen:
+                         SubprocessError)
+                 if issubclass(child_exception_type, OSError) and hex_errno:
+                     errno_num = int(hex_errno, 16)
++                    if sys.platform.startswith('haiku'):
++                        errno_num = -errno_num;
+                     child_exec_never_called = (err_msg == "noexec")
+                     if child_exec_never_called:
+                         err_msg = ""
+diff --git a/Modules/_posixsubprocess.c b/Modules/_posixsubprocess.c
+index ad9daae..f4d9702 100644
+--- a/Modules/_posixsubprocess.c
++++ b/Modules/_posixsubprocess.c
+@@ -724,6 +724,10 @@ error:
+         char *cur;
+         _Py_write_noraise(errpipe_write, "OSError:", 8);
+         cur = hex_errno + sizeof(hex_errno);
++#ifdef __HAIKU__
++        if (saved_errno < 0)
++            saved_errno = -saved_errno;
++#endif
+         while (saved_errno != 0 && cur != hex_errno) {
+             *--cur = Py_hexdigits[saved_errno % 16];
+             saved_errno /= 16;
+-- 
+2.37.3
+
+
+From 3f8dc4f41ab07c615a9638d6669a65f2897f7143 Mon Sep 17 00:00:00 2001
+From: Philippe Houdoin <philippe.houdoin@gmail.com>
+Date: Wed, 24 May 2017 11:09:43 +0000
+Subject: Implement CTypes's find_library for Haiku
+
+
+diff --git a/Lib/ctypes/util.py b/Lib/ctypes/util.py
+index 0c2510e..2b4f04c 100644
+--- a/Lib/ctypes/util.py
++++ b/Lib/ctypes/util.py
+@@ -265,6 +265,56 @@ elif os.name == "posix":
+         def find_library(name, is64 = False):
+             return _get_soname(_findLib_crle(name, is64) or _findLib_gcc(name))
+ 
++    elif sys.platform.startswith("haiku"):
++
++        def _num_version(libname):
++            # "libxyz.so.MAJOR.MINOR" => [ MAJOR, MINOR ]
++            parts = libname.split('.')
++            nums = []
++            try:
++                while parts:
++                    nums.insert(0, int(parts.pop()))
++            except ValueError:
++                pass
++            return nums or [sys.maxint]
++
++        def find_library(name):
++            if name in ('c', 'm'):
++                return find_library('root')
++            for directory in os.environ['LIBRARY_PATH'].split(os.pathsep):
++                if directory.startswith("%A/"):
++                    directory = directory.replace('%A',
++                        os.path.dirname(os.path.abspath(sys.argv[0] or os.getcwd())))
++
++                if not os.path.isdir(directory):
++                    continue
++
++                # try direct match
++                fname = os.path.join(directory, name)
++                if os.path.isfile(fname):
++                    return fname
++
++                fname = os.path.join(directory, 'lib%s.so' % name)
++                if os.path.isfile(fname):
++                    return fname
++
++                # no exact matching in this directroy
++                # collect versioned candidates, if any
++                candidates = []
++                pattern = re.compile(r'lib%s\.so\.\S+' % re.escape(name))
++                for entry in os.listdir(directory):
++                    if not os.path.isfile(os.path.join(directory, entry)):
++                        continue
++
++                    if re.match(pattern, entry):
++                        candidates.append(os.path.join(directory, entry))
++
++                if candidates:
++                    # return latest version found
++                    candidates.sort(key=_num_version)
++                    return candidates[-1]
++
++            return None
+     else:
+ 
+         def _findSoname_ldconfig(name):
+@@ -367,6 +417,12 @@ def test():
+             print(f"crypt\t:: {cdll.LoadLibrary(find_library('crypt'))}")
+             print(f"crypto\t:: {find_library('crypto')}")
+             print(f"crypto\t:: {cdll.LoadLibrary(find_library('crypto'))}")
++        elif sys.platform.startswith("haiku"):
++            print(find_library("libbz2.so.1.0"))
++            print(find_library("tracker"))
++            print(find_library("media"))
++            print(cdll.LoadLibrary(find_library("tracker")))
++            print(cdll.LoadLibrary("libmedia.so"))
+         else:
+             print(cdll.LoadLibrary("libm.so"))
+             print(cdll.LoadLibrary("libcrypt.so"))
+-- 
+2.37.3
+
+
+From 47b3e011cfc9808b6f7f126f5c74ed923c50f79f Mon Sep 17 00:00:00 2001
+From: Philipp Wolfer <phil@parolu.io>
+Date: Mon, 23 Sep 2019 09:14:58 +0200
+Subject: webbrowser: Support for default browsers on Haiku
+
+
+diff --git a/Lib/webbrowser.py b/Lib/webbrowser.py
+index 44974d4..ce78f41 100755
+--- a/Lib/webbrowser.py
++++ b/Lib/webbrowser.py
+@@ -549,6 +549,11 @@ def register_standard_browsers():
+                         "netscape", "opera", iexplore):
+             if shutil.which(browser):
+                 register(browser, None, BackgroundBrowser(browser))
++    elif sys.platform[:5] == "haiku":
++        # First try to use the default configured browser
++        register("haiku-default", None, GenericBrowser("open"))
++        # Fall back to WebPositive as the standard browser of Haiku
++        register("webpositive", None, BackgroundBrowser("WebPositive"))
+     else:
+         # Prefer X browsers if present
+         if os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"):
+-- 
+2.37.3
+
+
+From 71113b3e83a9efeef8b19eee1a4dbe1e99370ef9 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Fri, 4 Oct 2019 22:02:35 +0200
+Subject: since 3.8, don't reinit locks on fork.
+
+
+diff --git a/Lib/logging/__init__.py b/Lib/logging/__init__.py
+index bcee2ba..46630a4 100644
+--- a/Lib/logging/__init__.py
++++ b/Lib/logging/__init__.py
+@@ -244,7 +244,7 @@ def _releaseLock():
+ 
+ # Prevent a held logging lock from blocking a child from logging.
+ 
+-if not hasattr(os, 'register_at_fork'):  # Windows and friends.
++if sys.platform.startswith('haiku') or not hasattr(os, 'register_at_fork'):  # Windows and friends.
+     def _register_at_fork_reinit_lock(instance):
+         pass  # no-op when os.register_at_fork does not exist.
+ else:
+-- 
+2.37.3
+
+
+From 1e76f9a4a07888e29233765205dabc3bc1e7df08 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Fri, 15 May 2020 15:20:57 +0200
+Subject: handle errors returned by internal_connect()
+
+upstream bug #40628 by Ryan C. Gordon
+
+diff --git a/Modules/socketmodule.c b/Modules/socketmodule.c
+index 65d0e10..6b88397 100644
+--- a/Modules/socketmodule.c
++++ b/Modules/socketmodule.c
+@@ -3325,7 +3325,7 @@ sock_connect(PySocketSockObject *s, PyObject *addro)
+     }
+ 
+     res = internal_connect(s, SAS2SA(&addrbuf), addrlen, 1);
+-    if (res < 0)
++    if (res == -1)
+         return NULL;
+ 
+     Py_RETURN_NONE;
+@@ -3356,7 +3356,7 @@ sock_connect_ex(PySocketSockObject *s, PyObject *addro)
+     }
+ 
+     res = internal_connect(s, SAS2SA(&addrbuf), addrlen, 0);
+-    if (res < 0)
++    if (res == -1)
+         return NULL;
+ 
+     return PyLong_FromLong((long) res);
+-- 
+2.37.3
+
+
+From 5c37732a4d4ba06beb9414d2b74380dd93650829 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Mon, 19 Oct 2020 18:03:09 +0200
+Subject: ttyname_r can use MAXPATHLEN
+
+
+diff --git a/Modules/posixmodule.c b/Modules/posixmodule.c
+index a01662d..681b833 100644
+--- a/Modules/posixmodule.c
++++ b/Modules/posixmodule.c
+@@ -3091,11 +3091,14 @@ static PyObject *
+ os_ttyname_impl(PyObject *module, int fd)
+ /*[clinic end generated code: output=c424d2e9d1cd636a input=9ff5a58b08115c55]*/
+ {
+-
++#ifndef __HAIKU__
+     long size = sysconf(_SC_TTY_NAME_MAX);
+     if (size == -1) {
+         return posix_error();
+     }
++#else
++    long size = MAXPATHLEN;
++#endif
+     char *buffer = (char *)PyMem_RawMalloc(size);
+     if (buffer == NULL) {
+         return PyErr_NoMemory();
+-- 
+2.37.3
+
+
+From 2bb7e5696dd15014215aa238bcb0ecff6956ee5d Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Wed, 5 Oct 2022 16:09:41 -0300
+Subject: The rest of korli's "initial Haiku patch".
+
+Parts of that original patch did not applied cleanly anymore.
+Manually massaged them for 3.11.0rc2.
+
+diff --git a/Lib/sysconfig.py b/Lib/sysconfig.py
+index ebe3711..63e2742 100644
+--- a/Lib/sysconfig.py
++++ b/Lib/sysconfig.py
+@@ -56,6 +56,27 @@ _INSTALL_SCHEMES = {
+         'scripts': '{base}/Scripts',
+         'data': '{base}',
+         },
++    'haiku': {
++        'purelib': '{base}/non-packaged/lib/python{py_version_short}/site-packages',
++        'platlib': '{platbase}/non-packaged/lib/python{py_version_short}/site-packages',
++        'headers': '{base}/non-packaged/develop/headers/python{py_version_short}',
++        'scripts': '{base}/non-packaged/bin',
++        'data'   : '{base}/non-packaged',
++        },
++    'haiku_vendor': {
++        'purelib': '{base}/lib/python{py_version_short}/vendor-packages',
++        'platlib': '{platbase}/lib/python{py_version_short}/vendor-packages',
++        'headers': '{base}/develop/headers/python{py_version_short}',
++        'scripts': '{base}/bin',
++        'data'   : '{base}',
++        },
++    'haiku_home': {
++        'purelib': '{base}/lib/python',
++        'platlib': '{base}/lib/python',
++        'headers': '{base}/develop/headers/python/',
++        'scripts': '{base}/bin',
++        'data'   : '{base}',
++        },
+     # Downstream distributors can overwrite the default install scheme.
+     # This is done to support downstream modifications where distributors change
+     # the installation layout (eg. different site-packages directory).
+diff --git a/configure.ac b/configure.ac
+index 1c25abd..ce5ab17 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1495,6 +1495,16 @@ if test $enable_shared = "yes"; then
+ 	      PY3LIBRARY=libpython3.so
+ 	  fi
+ 	  ;;
++    Haiku*)
++	  LDLIBRARY='libpython$(LDVERSION).so'
++	  BLDLIBRARY='-L. -lpython$(LDVERSION)'
++	  RUNSHARED=LIBRARY_PATH=`pwd`${LIBRARY_PATH:+:${LIBRARY_PATH}}
++	  INSTSONAME="$LDLIBRARY".$SOVERSION
++	  if test "$with_pydebug" != yes
++          then
++	      PY3LIBRARY=libpython3.so
++	  fi
++	  ;;
+     hp*|HP*)
+ 	  case `uname -m` in
+ 		ia64)
+@@ -1651,6 +1661,7 @@ AC_PROG_MKDIR_P
+ AC_SUBST(LN)
+ if test -z "$LN" ; then
+ 	case $ac_sys_system in
++		Haiku*) LN="ln -s";;
+ 		CYGWIN*) LN="ln -s";;
+ 		*) LN=ln;;
+ 	esac
+@@ -3252,7 +3263,7 @@ then
+ 		 else CCSHARED="+z";
+ 		 fi;;
+ 	Linux-android*) ;;
+-	Linux*|GNU*) CCSHARED="-fPIC";;
++	Linux*|GNU*|Haiku*) CCSHARED="-fPIC";;
+ 	Emscripten*|WASI*)
+ 		AS_VAR_IF([enable_wasm_dynamic_linking], [yes], [
+ 			CCSHARED="-fPIC"
+@@ -3285,7 +3296,7 @@ then
+ 	    LINKFORSHARED="-Wl,-E -Wl,+s";;
+ #	    LINKFORSHARED="-Wl,-E -Wl,+s -Wl,+b\$(BINLIBDEST)/lib-dynload";;
+ 	Linux-android*) LINKFORSHARED="-pie -Xlinker -export-dynamic";;
+-	Linux*|GNU*) LINKFORSHARED="-Xlinker -export-dynamic";;
++	Linux*|GNU*|Haiku*) LINKFORSHARED="-Xlinker -export-dynamic";;
+ 	# -u libsys_s pulls in all symbols in libsys
+ 	Darwin/*)
+ 		LINKFORSHARED="$extra_undefs -framework CoreFoundation"
+@@ -5340,6 +5351,7 @@ AC_CHECK_FUNC(__fpu_control,
+ AC_SUBST(LIBM)
+ case $ac_sys_system in
+ Darwin) ;;
++Haiku) ;;
+ *) LIBM=-lm
+ esac
+ AC_MSG_CHECKING(for --with-libm=STRING)
+diff --git a/setup.py b/setup.py
+index 4f122b6..dc42f39 100644
+--- a/setup.py
++++ b/setup.py
+@@ -84,6 +84,7 @@ CYGWIN = (HOST_PLATFORM == 'cygwin')
+ MACOS = (HOST_PLATFORM == 'darwin')
+ AIX = (HOST_PLATFORM.startswith('aix'))
+ VXWORKS = ('vxworks' in HOST_PLATFORM)
++HAIKU = (HOST_PLATFORM == 'haiku1')
+ EMSCRIPTEN = HOST_PLATFORM == 'emscripten-wasm32'
+ CC = os.environ.get("CC")
+ if not CC:
+@@ -890,6 +891,11 @@ class PyBuildExt(build_ext):
+         with open(config_h) as file:
+             self.config_h_vars = sysconfig.parse_config_h(file)
+ 
++        # Haiku-specific library locations
++        if HAIKU:
++            self.inc_dirs += ['/boot/develop/headers/posix',
++                         '/boot/system/develop/headers']
++            self.lib_dirs += ['/boot/system/develop/lib']
+         # OSF/1 and Unixware have some stuff in /usr/ccs/lib (like -ldb)
+         if HOST_PLATFORM in ['osf1', 'unixware7', 'openunix8']:
+             self.lib_dirs += ['/usr/ccs/lib']
+-- 
+2.37.3
+
+
+From 980960bf6f76ccbc15e87613fafead38bc585ec8 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Mon, 24 Oct 2022 20:04:10 -0300
+Subject: Lib/test: require the "largefile" usage flag for I/O heavy tests.
+
+The same is done for Windows and macOS already.
+
+This avoids needing several GBs of storage to run the tests
+(unless the "largefile" resource usage flag is enabled).
+
+diff --git a/Lib/test/test_io.py b/Lib/test/test_io.py
+index 79aa2da..b45826b 100644
+--- a/Lib/test/test_io.py
++++ b/Lib/test/test_io.py
+@@ -609,7 +609,7 @@ class IOTest(unittest.TestCase):
+         # On Windows and Mac OSX this test consumes large resources; It takes
+         # a long time to build the >2 GiB file and takes >2 GiB of disk space
+         # therefore the resource must be enabled to run this test.
+-        if sys.platform[:3] == 'win' or sys.platform == 'darwin':
++        if sys.platform[:3] == 'win' or sys.platform == 'darwin' or sys.platform == 'haiku1':
+             support.requires(
+                 'largefile',
+                 'test requires %s bytes and a long time to run' % self.LARGE)
+diff --git a/Lib/test/test_largefile.py b/Lib/test/test_largefile.py
+index 3c11c59..512db2f 100644
+--- a/Lib/test/test_largefile.py
++++ b/Lib/test/test_largefile.py
+@@ -253,7 +253,7 @@ def setUpModule():
+     # takes a long time to build the >2 GiB file and takes >2 GiB of disk
+     # space therefore the resource must be enabled to run this test.
+     # If not, nothing after this line stanza will be executed.
+-    if sys.platform[:3] == 'win' or sys.platform == 'darwin':
++    if sys.platform[:3] == 'win' or sys.platform == 'darwin' or sys.platform == 'haiku1':
+         requires('largefile',
+                  'test requires %s bytes and a long time to run' % str(size))
+     else:
+diff --git a/Lib/test/test_mmap.py b/Lib/test/test_mmap.py
+index 517cbe0..dc41464 100644
+--- a/Lib/test/test_mmap.py
++++ b/Lib/test/test_mmap.py
+@@ -981,7 +981,7 @@ class LargeMmapTests(unittest.TestCase):
+         unlink(TESTFN)
+ 
+     def _make_test_file(self, num_zeroes, tail):
+-        if sys.platform[:3] == 'win' or sys.platform == 'darwin':
++        if sys.platform[:3] == 'win' or sys.platform == 'darwin' or sys.platform == 'haiku1':
+             requires('largefile',
+                 'test requires %s bytes and a long time to run' % str(0x180000000))
+         f = open(TESTFN, 'w+b')
+-- 
+2.37.3
+
+
+From 8348d6bcc81947db02a8323706b22387b7875278 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Tue, 7 Mar 2023 18:29:29 +0100
+Subject: default schemes for Haiku
+
+
+diff --git a/Lib/sysconfig.py b/Lib/sysconfig.py
+index 63e2742..6ba9d18 100644
+--- a/Lib/sysconfig.py
++++ b/Lib/sysconfig.py
+@@ -57,25 +57,32 @@ _INSTALL_SCHEMES = {
+         'data': '{base}',
+         },
+     'haiku': {
++        'stdlib': '{installed_base}/{platlibdir}/python{py_version_short}',
++        'platstdlib': '{platbase}/{platlibdir}/python{py_version_short}',
+         'purelib': '{base}/non-packaged/lib/python{py_version_short}/site-packages',
+-        'platlib': '{platbase}/non-packaged/lib/python{py_version_short}/site-packages',
+-        'headers': '{base}/non-packaged/develop/headers/python{py_version_short}',
++        'platlib': '{platbase}/non-packaged/{platlibdir}/python{py_version_short}/site-packages',
++        'include': '{base}/non-packaged/develop/headers/python{py_version_short}',
+         'scripts': '{base}/non-packaged/bin',
+         'data'   : '{base}/non-packaged',
+         },
+     'haiku_vendor': {
++        'stdlib': '{installed_base}/{platlibdir}/python{py_version_short}',
++        'platstdlib': '{platbase}/{platlibdir}/python{py_version_short}',
+         'purelib': '{base}/lib/python{py_version_short}/vendor-packages',
+         'platlib': '{platbase}/lib/python{py_version_short}/vendor-packages',
+-        'headers': '{base}/develop/headers/python{py_version_short}',
++        'include': '{base}/develop/headers/python{py_version_short}',
+         'scripts': '{base}/bin',
+         'data'   : '{base}',
+         },
+     'haiku_home': {
++        'stdlib': '{installed_base}/lib/python',
++        'platstdlib': '{base}/lib/python',
+         'purelib': '{base}/lib/python',
+         'platlib': '{base}/lib/python',
+-        'headers': '{base}/develop/headers/python/',
++        'include': '{installed_base}/develop/headers/python',
++        'platinclude': '{installed_base}/develop/headers/python',
+         'scripts': '{base}/bin',
+-        'data'   : '{base}',
++        'data': '{base}',
+         },
+     # Downstream distributors can overwrite the default install scheme.
+     # This is done to support downstream modifications where distributors change
+@@ -172,6 +179,15 @@ if _HAS_USER_BASE:
+             'scripts': '{userbase}/bin',
+             'data': '{userbase}',
+             },
++        'haiku_user': {
++            'stdlib': '{userbase}/{platlibdir}/python{py_version_short}',
++            'platstdlib': '{userbase}/{platlibdir}/python{py_version_short}',
++            'purelib': '{userbase}/lib/python{py_version_short}/site-packages',
++            'platlib': '{userbase}/lib/python{py_version_short}/site-packages',
++            'include': '{userbase}/develop/headers/python{py_version_short}',
++            'scripts': '{userbase}/bin',
++            'data': '{userbase}',
++            },
+         'osx_framework_user': {
+             'stdlib': '{userbase}/lib/python',
+             'platstdlib': '{userbase}/lib/python',
+@@ -298,6 +314,18 @@ def _expand_vars(scheme, vars):
+ 
+ 
+ def _get_preferred_schemes():
++    if sys.platform.startswith('haiku'):
++        if os.environ.get('HAIKU_USE_VENDOR_DIRECTORIES') == '1':
++            return {
++                'prefix': 'haiku_vendor',
++                'home': 'haiku_home',
++                'user': 'haiku_user',
++            }
++        return {
++            'prefix': 'haiku',
++            'home': 'haiku_home',
++            'user': 'haiku_user',
++        }
+     if os.name == 'nt':
+         return {
+             'prefix': 'nt',
+-- 
+2.37.3
+
+
+From 022dfd22f91d24f84fba38966959b5a102cf0a1d Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Fri, 10 Mar 2023 20:15:14 -0300
+Subject: syncronize both _getuserbase() copies on site.py and sysconfig.py.
+
+
+diff --git a/Lib/sysconfig.py b/Lib/sysconfig.py
+index 6ba9d18..c3e8dbc 100644
+--- a/Lib/sysconfig.py
++++ b/Lib/sysconfig.py
+@@ -154,6 +154,14 @@ def _getuserbase():
+         return joinuser("~", "Library", sys._framework,
+                         f"{sys.version_info[0]}.{sys.version_info[1]}")
+ 
++    if sys.platform.startswith('haiku'):
++        try:
++            import subprocess
++            return subprocess.run(['finddir', 'B_USER_NONPACKAGED_DIRECTORY'],
++                stdout=subprocess.PIPE, check=True).stdout.rstrip().decode('utf-8')
++        except:
++            pass
++
+     return joinuser("~", ".local")
+ 
+ _HAS_USER_BASE = (_getuserbase() is not None)
+-- 
+2.37.3
+

--- a/dev-lang/python/patches/python3.11_x86-3.11.5.patchset
+++ b/dev-lang/python/patches/python3.11_x86-3.11.5.patchset
@@ -1,0 +1,41 @@
+From 672ea87bdc26e47c81052cecc9cfde9f4c7467a7 Mon Sep 17 00:00:00 2001
+From: Adrien Destugues <pulkomandy@pulkomandy.tk>
+Date: Sat, 3 Feb 2018 11:33:49 +0100
+Subject: Fix include paths for secondary x86
+
+This helps python find libraries and dependencies properly (openssl,
+etc), so a few more modules are enabled.
+
+It also fixes a crash because python would try to load the gcc2 libroot
+even when built with gcc5.
+
+diff --git a/Lib/ctypes/util.py b/Lib/ctypes/util.py
+index b2e4095..34e56aa 100644
+--- a/Lib/ctypes/util.py
++++ b/Lib/ctypes/util.py
+@@ -273,6 +273,7 @@ elif os.name == "posix":
+                     directory = directory.replace('%A',
+                         os.path.dirname(os.path.abspath(sys.argv[0] or os.getcwd())))
+ 
++                directory = os.path.join(directory, "x86")
+                 if not os.path.isdir(directory):
+                     continue
+ 
+diff --git a/setup.py b/setup.py
+index 704e7ec..f480cc9 100644
+--- a/setup.py
++++ b/setup.py
+@@ -696,8 +696,8 @@ class PyBuildExt(build_ext):
+         # Haiku-specific library locations
+         if HAIKU:
+             self.inc_dirs += ['/boot/develop/headers/posix',
+-                         '/boot/system/develop/headers']
+-            self.lib_dirs += ['/boot/system/develop/lib']
++                         '/boot/system/develop/headers/x86']
++            self.lib_dirs += ['/boot/system/develop/lib/x86']
+         # OSF/1 and Unixware have some stuff in /usr/ccs/lib (like -ldb)
+         if HOST_PLATFORM in ['osf1', 'unixware7', 'openunix8']:
+             self.lib_dirs += ['/usr/ccs/lib']
+-- 
+2.23.0
+

--- a/dev-lang/python/python3.11-3.11.5.recipe
+++ b/dev-lang/python/python3.11-3.11.5.recipe
@@ -1,0 +1,289 @@
+SUMMARY="An interpreted, interactive, object-oriented programming language"
+DESCRIPTION="Python is a programming language that lets you work more quickly \
+and integrate your systems more effectively. You can learn to use Python and \
+see almost immediate gains in productivity and lower maintenance costs.
+
+Python runs on Windows, Linux/Unix, Mac OS X, and has been ported to the Java \
+and .NET virtual machines.
+
+Python is free to use, even for commercial products, because of its \
+OSI-approved open source license."
+HOMEPAGE="https://www.python.org"
+LICENSE="Python"
+COPYRIGHT="1990-2023 Python Software Foundation"
+REVISION="1"
+SOURCE_URI="https://www.python.org/ftp/python/$portVersion/Python-$portVersion.tar.xz"
+CHECKSUM_SHA256="85cd12e9cf1d6d5a45f17f7afe1cebe7ee628d3282281c492e86adf636defa3f"
+SOURCE_DIR="Python-$portVersion"
+
+pyShortVer="${portVersion%.*}"
+pyVersionCompat="$portVersion compat >= $pyShortVer"
+
+PATCHES="python$pyShortVer-$portVersion.patchset"
+if [ "$secondaryArchSuffix" = _x86 ] ; then
+	PATCHES+="
+		python${pyShortVer}_x86-$portVersion.patchset
+	"
+fi
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+# On x86_gcc2 we don't want to install the commands in bin/<arch>/, but in bin/.
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+GLOBAL_WRITABLE_FILES="
+	non-packaged/lib/python$pyShortVer/site-packages directory keep-old
+	"
+
+PROVIDES="
+	python$pyShortVer$secondaryArchSuffix = $pyVersionCompat
+	cmd:2to3_$pyShortVer = $pyVersionCompat
+	cmd:idle$pyShortVer = $pyVersionCompat
+	cmd:pydoc$pyShortVer = $pyVersionCompat
+	cmd:python$pyShortVer = $pyVersionCompat
+	cmd:python${pyShortVer}_config = $pyVersionCompat
+	cmd:pyvenv_$pyShortVer = $pyVersionCompat
+	devel:libpython$pyShortVer$secondaryArchSuffix = 1.0
+	lib:libpython$pyShortVer$secondaryArchSuffix = 1.0
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	cmd:file
+	lib:libbz2$secondaryArchSuffix
+	lib:libedit$secondaryArchSuffix
+	lib:libexpat$secondaryArchSuffix
+	lib:libffi$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:liblzma$secondaryArchSuffix
+	lib:libncurses$secondaryArchSuffix
+	lib:libsqlite3$secondaryArchSuffix
+	lib:libssl$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libbz2$secondaryArchSuffix
+	devel:libedit$secondaryArchSuffix
+	devel:libexpat$secondaryArchSuffix
+	devel:libffi$secondaryArchSuffix
+	devel:liblzma$secondaryArchSuffix
+	devel:libncurses$secondaryArchSuffix
+	devel:libsqlite3$secondaryArchSuffix
+	devel:libssl$secondaryArchSuffix
+	devel:libtclstub8.6$secondaryArchSuffix
+	devel:libtk8.6$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	autoconf_archive
+	cmd:aclocal
+	cmd:autoconf
+	cmd:find
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	autoreconf -fi
+
+	# From ./configure:
+	# "compiler flags are generated in two sets, BASECFLAGS and OPT.  OPT is just
+	# for debug/optimization stuff.  BASECFLAGS is for flags that are required
+	# just to get things to compile and link."
+	export BASECFLAGS="-D_BSD_SOURCE"
+
+	# Not exporting OPT ends up with "-g -fwrapv -O3 -Wall" being used,
+	# and using OPT="" means the build ends up being "-O0".
+	export OPT="-fwrapv -O3 -Wall"
+
+	runConfigure --omit-dirs binDir,includeDir ./configure \
+		--bindir=$commandBinDir \
+		--includedir=$developDir/headers \
+		--enable-optimizations \
+		--enable-shared \
+		--with-ensurepip=no \
+		--with-readline=editline \
+		--with-system-expat \
+		--with-system-ffi \
+		--without-static-libpython
+		# configure: WARNING: --with(out)-system-ffi is ignored on this platform
+		# --with-lto # this one is too CPU/RAM intensive.
+		# ToDo: See if something like this helps with tz related tests or not.
+		# --with-tzpath=$libDir/tcl8.6/tzdata
+
+	# prevent make from rebuilding stuff that requires python
+	touch Parser/asdl* Python/Python-ast.c Include/Python-ast.h
+
+	rm -f python
+
+	# Uncomment when doing repeated builds (for testing different flags/options).
+	# make clean
+
+	# NOTE: When using "--enable-optimizations" above, using "make $jobArgs" might be unreliable.
+	# Can see several instances of, for example:
+	#
+	# libgcov profiling error:/sources/Python-3.11.4/Objects/object.gcda:Merge mismatch for function 51
+	# libgcov profiling error:/sources/Python-3.11.4/Parser/parser.gcda:Merge mismatch for function 83
+	#
+	# Build might end OK (with only some "missing profile" warnings later on), or it can fail
+	# with something like:
+	#
+	# "Parser/parser.c:38718:1: error: corrupted profile info: invalid time profile"
+	#
+	# Not using multiple jobs for make solves both the warnings and the possible error.
+	# make $jobArgs
+	make -j 1
+}
+
+INSTALL()
+{
+	# altinstall avoids clobbering $prefix/bin/{2to3,idle3,pydoc3,python3,python3-config}
+	make altinstall
+
+	rm $libDir/libpython3.so
+	# ToDo: use this instead?
+	# mv $libDir/libpython3.so $libDir/libpython$pyShortVer.so
+
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		# On x86_gcc2, move lib-dynload to lib/python3.x/
+		mv $libDir/python$pyShortVer/lib-dynload $prefix/lib/python$pyShortVer/
+	fi
+	prepareInstalledDevelLibs libpython$pyShortVer
+	fixPkgconfig
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		# fix pkgconfig to match configure flags
+		sed -i -e 's,headers/x86,headers,' $developLibDir/pkgconfig/python*.pc
+	fi
+
+	mkdir -p $prefix/lib/python$pyShortVer/vendor-packages
+	echo 'This directory contains packaged python modules.' \
+		>$prefix/lib/python$pyShortVer/vendor-packages/README
+
+	mkdir -p $prefix/non-packaged/lib/python$pyShortVer
+	mv $prefix/lib/python$pyShortVer/site-packages $prefix/non-packaged/lib/python$pyShortVer/
+
+	# drop testsuite altogether; move to a separate package if needed
+	cd $prefix/lib/python$pyShortVer
+	rm -rf ctypes/test distutils/tests idlelib/idle_test lib2to3/tests \
+		sqlite3/test test tkinter/test unittest/test
+}
+
+# Some of the test will crash, invoking the crash dialog, and will hang waiting for
+# user's interaction. To avoid that, make sure to configure your system by adding
+# the following lines in the file "~/config/settings/system/debug_server/settings":
+##---
+# executable_actions {
+#	/sources/Python-$portVersion/python kill
+# }
+##---
+# Replace $portVersion as necessary.
+
+# For some tests that purposefully crash, it would make sense to add support for
+# crash-report suppression (as done for other platforms) on "tests/support/__init__,py"'s
+# SuppressCrashReport class.
+# But that needs support from Haiku's debug_server, as we can't change settings from
+# the recipe's building environment at the moment (https://dev.haiku-os.org/ticket/10301)
+
+# To see the available test-runs options:
+# > hp -E python3.11
+# > LIBRARY_PATH=/sources/Python-3.11.4:%A/lib:/boot/home/config/non-packaged/lib:/boot/home/config/lib:/boot/system/non-packaged/lib:/boot/system/lib python -m test --help
+#
+# To only execute a particular test:
+# > cd Lib/test
+# > PYTHONPATH="../":$PYTHONPATH python -m test test_xxx
+
+TEST()
+{
+	# Remove tests data left-overs, if any:
+	rm -f -r /boot/system/cache/tmp/
+	rm -f -d -r build/test_python*
+
+	local test_options=(
+		# Use this to get same test order on different runs (actual value not important).
+		# --randseed 0
+
+		# Possibly useful?
+		# --tempdir=/another_drive/tmp
+
+		# Enable/disable certain tests by "resource" type:
+		# -uall,-audio,-cpu,-curses,-decimal,-gui,-largefile,-network,-subprocess,-tzdata,-urlfetch
+
+		# distutils is deprecated, and will be removed on 3.12.
+		-x test_distutils
+
+		# The following tests invoke the crash dialog, and unless your configure
+		# debug_server default action to "kill" or "report", they will hang waiting for
+		# user input. See comment above TEST().
+		-x test_faulthandler
+		-x test_futures # from test_asyncio. Crashes: Exception (Segment violation)
+		-x test_subprocess	# tends to hang.
+		-x test_threading	# tends to hang.
+
+		# Many of the tests hang/stall. We have two options:
+		#
+		# 1- Manually remove the problematic test-cases.
+		# 2- Set a TIMEOUT.
+		#
+		# Option 1: Works, but requires manual identification/mainteinance.
+		#
+		# Option 2: Doesn't requires maintaining a list of stalling tests, but:
+		# - Causes errors at the end of the run:
+		#	"unmounting failed: Device/File/Resource Busy"
+		# - Leaves dangling threads running when the tests timeout:
+		#	"Warning -- threading_cleanup() failed to cleanup 0 threads (count: 0, dangling: 2)"
+		#   (or otherwise leaves the system in a weird state).
+		# - The time it takes to run the full suite largely increases,
+		#
+		# For Option 2, use: "--timeout=300"
+		#
+		# Let's use Option 1, for now at least:
+
+		# These hang reliably.
+		-x test__xxsubinterpreters
+		-x test_asynchat
+		-x test_concurrent_futures
+		-x test_interpreters
+		-x test_multiprocessing_fork
+		-x test_multiprocessing_forkserver
+		-x test_multiprocessing_main_handling
+		-x test_multiprocessing_spawn
+		-x test_multiprocessing
+		-x test_threaded_import # test_importlib/test_threaded_import
+		-x test_socketserver
+
+		# "test_asyncio" doesn't seems to runs reliably, even after individually skipping
+		# all the problematic test-cases that could be identify by running them one by one.
+		-x test_asyncio
+		# -x test_asyncio/test_base_events
+		# -x test_asyncio/test_buffered_proto.py # Exception on Exception handler.
+		# -x test_asyncio/test_events
+		# -x test_asyncio/test_sendfile
+		# -x test_asyncio/test_server # Exception on Exception handler.
+		# -x test_asyncio/test_sslproto # Exception on Exception handler.
+		# -x test_asyncio/test_streams
+
+		# These not always hang/stall, but they do it enough to warrant skipping for now.
+		-x test_imaplib
+		-x test_signal
+		-x test_socket
+		-x test_ssl
+		-x test_urllib2_localnet
+
+		# 3.11
+		-x test_urllib2net
+		-x test_venv
+	)
+
+	local -x LOGNAME=buildbot # this skips tests_tools/test_freeze, copied from Gentoo's ebuild
+	make $jobArgs test EXTRATESTOPTS="${test_options[*]}"
+}


### PR DESCRIPTION
Mayor selling point of this version: it brings several speed-related improvements over 3.10.

I'm adding it here just to make it available, gather some feedback, but with the hopes it is used only for testing purpose, and not to start adding support for it to our Python packages' recipes ("_python311" versions of packages).

Python 3.12.0 will be released on October. The 3.12.0 betas, so far, run fine on Haiku, so we might want to "skip" 3.11, and add 3.12 instead (while/after dropping 3.8), specially considering that 3.12 brings up more "breaking" changes (deprecated modules, changes in packaging, etc.) than previous versions.

Run `hp --test python3.11`, results are in-line with what we normally get on Haiku:

363 tests OK. 29 tests failed. 21 tests skipped. (and a bunch of test disable to avoid hangs on the tests-run).

Related: #7252