### PR TITLE
speedtest-cli: switch to Python 3.10, recipe clean ups.

### DIFF
--- a/net-analyzer/speedtest-cli/patches/0001-Python-3.10-support.patch
+++ b/net-analyzer/speedtest-cli/patches/0001-Python-3.10-support.patch
@@ -1,0 +1,156 @@
+From 22210ca35228f0bbcef75a7c14587c4ecb875ab4 Mon Sep 17 00:00:00 2001
+From: Matt Martz <matt@sivel.net>
+Date: Wed, 7 Jul 2021 14:50:15 -0500
+Subject: Python 3.10 support
+
+
+diff --git a/setup.py b/setup.py
+index a617be4..f3d21ad 100644
+--- a/setup.py
++++ b/setup.py
+@@ -92,5 +92,8 @@ setup(
+         'Programming Language :: Python :: 3.5',
+         'Programming Language :: Python :: 3.6',
+         'Programming Language :: Python :: 3.7',
++        'Programming Language :: Python :: 3.8',
++        'Programming Language :: Python :: 3.9',
++        'Programming Language :: Python :: 3.10',
+     ]
+ )
+diff --git a/speedtest.py b/speedtest.py
+index a33296d..186b529 100755
+--- a/speedtest.py
++++ b/speedtest.py
+@@ -15,18 +15,18 @@
+ #    License for the specific language governing permissions and limitations
+ #    under the License.
+ 
+-import os
+-import re
+ import csv
+-import sys
+-import math
++import datetime
+ import errno
++import math
++import os
++import platform
++import re
+ import signal
+ import socket
+-import timeit
+-import datetime
+-import platform
++import sys
+ import threading
++import timeit
+ import xml.parsers.expat
+ 
+ try:
+@@ -36,7 +36,7 @@ except ImportError:
+     gzip = None
+     GZIP_BASE = object
+ 
+-__version__ = '2.1.3'
++__version__ = '2.1.4b1'
+ 
+ 
+ class FakeShutdownEvent(object):
+@@ -49,6 +49,8 @@ class FakeShutdownEvent(object):
+         "Dummy method to always return false"""
+         return False
+ 
++    is_set = isSet
++
+ 
+ # Some global variables we use
+ DEBUG = False
+@@ -56,6 +58,7 @@ _GLOBAL_DEFAULT_TIMEOUT = object()
+ PY25PLUS = sys.version_info[:2] >= (2, 5)
+ PY26PLUS = sys.version_info[:2] >= (2, 6)
+ PY32PLUS = sys.version_info[:2] >= (3, 2)
++PY310PLUS = sys.version_info[:2] >= (3, 10)
+ 
+ # Begin import game to handle Python 2 and Python 3
+ try:
+@@ -266,17 +269,6 @@ else:
+             write(arg)
+         write(end)
+ 
+-if PY32PLUS:
+-    etree_iter = ET.Element.iter
+-elif PY25PLUS:
+-    etree_iter = ET_Element.getiterator
+-
+-if PY26PLUS:
+-    thread_is_alive = threading.Thread.is_alive
+-else:
+-    thread_is_alive = threading.Thread.isAlive
+-
+-
+ # Exception "constants" to support Python 2 through Python 3
+ try:
+     import ssl
+@@ -293,6 +285,23 @@ except ImportError:
+     ssl = None
+     HTTP_ERRORS = (HTTPError, URLError, socket.error, BadStatusLine)
+ 
++if PY32PLUS:
++    etree_iter = ET.Element.iter
++elif PY25PLUS:
++    etree_iter = ET_Element.getiterator
++
++if PY26PLUS:
++    thread_is_alive = threading.Thread.is_alive
++else:
++    thread_is_alive = threading.Thread.isAlive
++
++
++def event_is_set(event):
++    try:
++        return event.is_set()
++    except AttributeError:
++        return event.isSet()
++
+ 
+ class SpeedtestException(Exception):
+     """Base exception for this module"""
+@@ -769,7 +778,7 @@ def print_dots(shutdown_event):
+     status
+     """
+     def inner(current, total, start=False, end=False):
+-        if shutdown_event.isSet():
++        if event_is_set(shutdown_event):
+             return
+ 
+         sys.stdout.write('.')
+@@ -808,7 +817,7 @@ class HTTPDownloader(threading.Thread):
+         try:
+             if (timeit.default_timer() - self.starttime) <= self.timeout:
+                 f = self._opener(self.request)
+-                while (not self._shutdown_event.isSet() and
++                while (not event_is_set(self._shutdown_event) and
+                         (timeit.default_timer() - self.starttime) <=
+                         self.timeout):
+                     self.result.append(len(f.read(10240)))
+@@ -864,7 +873,7 @@ class HTTPUploaderData(object):
+ 
+     def read(self, n=10240):
+         if ((timeit.default_timer() - self.start) <= self.timeout and
+-                not self._shutdown_event.isSet()):
++                not event_is_set(self._shutdown_event)):
+             chunk = self.data.read(n)
+             self.total.append(len(chunk))
+             return chunk
+@@ -902,7 +911,7 @@ class HTTPUploader(threading.Thread):
+         request = self.request
+         try:
+             if ((timeit.default_timer() - self.starttime) <= self.timeout and
+-                    not self._shutdown_event.isSet()):
++                    not event_is_set(self._shutdown_event)):
+                 try:
+                     f = self._opener(request)
+                 except TypeError:
+-- 
+2.37.3
+

--- a/net-analyzer/speedtest-cli/speedtest_cli-2.1.3.recipe
+++ b/net-analyzer/speedtest-cli/speedtest_cli-2.1.3.recipe
@@ -12,61 +12,50 @@ and CPU and Memory capacity and speed."
 HOMEPAGE="https://github.com/sivel/speedtest-cli"
 COPYRIGHT="2012-2021 Matt Martz"
 LICENSE="Apache v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="$HOMEPAGE/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="45e3ca21c3ce3c339646100de18db8a26a27d240c29f1c9e07b6c13995a969be"
 SOURCE_FILENAME="speedtest-cli-$portVersion.tar.gz"
 SOURCE_DIR="speedtest-cli-$portVersion"
+PATCHES="0001-Python-3.10-support.patch"
 
 ARCHITECTURES="any"
 
+# Ideally should match Haiku's default Python version.
+pythonVersion=3.10
+pythonPackage=python${pythonVersion//.}
+
 PROVIDES="
 	$portName = $portVersion
+	cmd:speedtest_cli
 	"
 REQUIRES="
 	haiku
-	"
-BUILD_REQUIRES="
-	haiku_devel
+	cmd:python$pythonVersion
 	"
 
-PYTHON_PACKAGES=(python39)
-PYTHON_VERSIONS=(3.9)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\n\
-	cmd:speedtest_cli_$pythonPackage
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
-done
+REPLACES="
+	speedtest_cli_python39
+	"
+
+BUILD_REQUIRES="
+	build_$pythonPackage
+	installer_$pythonPackage
+	setuptools_$pythonPackage
+	wheel_$pythonPackage
+	"
+BUILD_PREREQUIRES="
+	cmd:python$pythonVersion
+	"
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
-		pythonVersion=${PYTHON_VERSIONS[$i]}
+	python=python$pythonVersion
 
-		python=python$pythonVersion
-		installLocation=$prefix/lib/$python/vendor-packages
-		export PYTHONPATH=$installLocation:$PYTHONPATH
-		mkdir -p $installLocation
-		rm -rf build
-		$python setup.py build install \
-			--root=/ --prefix=$prefix
+	$python -m build --wheel --skip-dependency-check --no-isolation
+	$python -m installer -p $prefix dist/*.whl
 
-		rm -rf $binDir/speedtest
-		mv $binDir/speedtest-cli $binDir/speedtest-cli-$pythonPackage
-		packageEntries  $pythonPackage \
-			$prefix/lib/python* \
-			$binDir
-	done
+	# Package installs both bin/speedtest and speedtest-cli.
+	# Keep only the latter to match the package name.
+	rm $binDir/speedtest
 }


### PR DESCRIPTION
No need to have this for multiple versions of Python, as this is just a cli program/tool.

This is still technically version 2.1.3 (no new release yet), but with a patch that adds a commit from upstream, which adds Python 3.10 support.