### PR TITLE
col: new recipe

### DIFF
--- a/sys-apps/col/col-1.20.recipe
+++ b/sys-apps/col/col-1.20.recipe
@@ -1,0 +1,53 @@
+SUMMARY="Filter out reverse line feeds"
+DESCRIPTION="OpenBSD's /usr/bin/col, for Haiku (so we can avoid installing the bigger \
+\"util_linux\" when we just need \"cmd:col\"."
+HOMEPAGE="https://github.com/OscarL/col/"
+COPYRIGHT="1990, 1993, 1994 The Regents of the University of California"
+LICENSE="BSD (3-clause)"
+REVISION="1"
+SOURCE_URI="https://github.com/OscarL/col/archive/refs/tags/v$portVersion.tar.gz"
+CHECKSUM_SHA256="cdb0c13f95d1888f2ff3efcf6b0b9f2717abe72ca66c646775d478bbe0854100"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+PROVIDES="
+	col$secondaryArchSuffix = $portVersion
+	cmd:col$commandSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	makefile_engine
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	"
+
+# Both provide cmd:col
+CONFLICTS="
+	util_linux
+	"
+
+BUILD()
+{
+	make
+}
+
+INSTALL()
+{
+	mkdir -p $commandBinDir
+	cp col $commandBinDir
+	mkdir -p $manDir/man1
+	cp col.1 $manDir/man1
+}


### PR DESCRIPTION
Ultra small package, as an alternative to having to install the bigger `util_linux` package, just because we need `cmd:col` (`zsh` and `xonch` recipes, for example).