### PR TITLE
agg: updated license and fixed build

### DIFF
--- a/x11-libs/agg/agg-2.7.0~r139.recipe
+++ b/x11-libs/agg/agg-2.7.0~r139.recipe
@@ -15,12 +15,11 @@ do much more than that. The ideas and the philosophy of AGG are:
   * Reliability and stability (including numerical stability)."
 HOMEPAGE="https://agg.sourceforge.net/antigrain.com"
 COPYRIGHT="2002-2006 Maxim Shemanarev
-	2009-2021 John Horigan
-	1994-2021 Free Software Foundation"
+	2023 Anti-Grain Geometry (AGG) contributors"
 LICENSE="MIT"
 REVISION="1"
 SOURCE_URI="https://sourceforge.net/code-snapshots/svn/a/ag/agg/svn/agg-svn-r139.zip"
-CHECKSUM_SHA256="f0c1be391bdd05181fb22900b3a209d29fb164e7d5ab9dc4ce71db792c0275a3"
+CHECKSUM_SHA256="aad59085d576c45fc99777a0c9f8c55cb1be653f103614d62ec8e1237d295a8a"
 PATCHES="agg-$portVersion.patchset"
 SOURCE_DIR="agg-svn-r139"
 

--- a/x11-libs/agg/agg-2.7.0~r139.recipe
+++ b/x11-libs/agg/agg-2.7.0~r139.recipe
@@ -17,7 +17,7 @@ HOMEPAGE="https://agg.sourceforge.net/antigrain.com"
 COPYRIGHT="2002-2006 Maxim Shemanarev
 	2009-2021 John Horigan
 	1994-2021 Free Software Foundation"
-LICENSE="BSD (3-clause)"
+LICENSE="MIT"
 REVISION="1"
 SOURCE_URI="https://sourceforge.net/code-snapshots/svn/a/ag/agg/svn/agg-svn-r139.zip"
 CHECKSUM_SHA256="f0c1be391bdd05181fb22900b3a209d29fb164e7d5ab9dc4ce71db792c0275a3"

--- a/x11-libs/agg/agg-2.7.0~r139.recipe
+++ b/x11-libs/agg/agg-2.7.0~r139.recipe
@@ -17,10 +17,10 @@ HOMEPAGE="https://agg.sourceforge.net/antigrain.com"
 COPYRIGHT="2002-2006 Maxim Shemanarev
 	2009-2021 John Horigan
 	1994-2021 Free Software Foundation"
-LICENSE="GNU GPL v2"
+LICENSE="BSD (3-clause)"
 REVISION="1"
 SOURCE_URI="https://sourceforge.net/code-snapshots/svn/a/ag/agg/svn/agg-svn-r139.zip"
-CHECKSUM_SHA256="dfa8ceee35c007ced689b232d84e9c71463bd9818271eb96f922ff5f0dca578c"
+CHECKSUM_SHA256="f0c1be391bdd05181fb22900b3a209d29fb164e7d5ab9dc4ce71db792c0275a3"
 PATCHES="agg-$portVersion.patchset"
 SOURCE_DIR="agg-svn-r139"
 

--- a/x11-libs/agg/agg-2.7.0~r139.recipe
+++ b/x11-libs/agg/agg-2.7.0~r139.recipe
@@ -16,12 +16,14 @@ do much more than that. The ideas and the philosophy of AGG are:
 HOMEPAGE="https://agg.sourceforge.net/antigrain.com"
 COPYRIGHT="2002-2006 Maxim Shemanarev
 	2023 Anti-Grain Geometry (AGG) contributors"
-LICENSE="MIT"
+LICENSE="MIT
+		BSD (3-clause)"
 REVISION="1"
-SOURCE_URI="https://sourceforge.net/code-snapshots/svn/a/ag/agg/svn/agg-svn-r139.zip"
-CHECKSUM_SHA256="aad59085d576c45fc99777a0c9f8c55cb1be653f103614d62ec8e1237d295a8a"
+srcGitRev="c4f36b4432142f22c0bf82c6fbdb41567a236be2"
+SOURCE_URI="https://github.com/ghaerr/agg-2.6/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="b56b0328b1467961c1cdc133310fa0588a4b6e3b594f68301756e3601ae530d0"
 PATCHES="agg-$portVersion.patchset"
-SOURCE_DIR="agg-svn-r139"
+SOURCE_DIR="agg-2.6-$srcGitRev"
 
 ARCHITECTURES="all"
 SECONDARY_ARCHITECTURES="x86"
@@ -95,7 +97,7 @@ defineDebugInfoPackage agg$secondaryArchSuffix \
 
 BUILD()
 {
-	cd agg-2.4
+	cd agg-src
 	if [ -d src/platform/BeOS ]; then
 		mv src/platform/BeOS src/platform/Haiku
 	fi
@@ -112,7 +114,7 @@ BUILD()
 
 INSTALL()
 {
-	cd agg-2.4
+	cd agg-src
 	make install
 
 	# remove libtool files
@@ -135,6 +137,6 @@ INSTALL()
 
 TEST()
 {
-	cd agg-2.4
+	cd agg-src
 	make check
 }

--- a/x11-libs/agg/patches/agg-2.7.0~r139.patchset
+++ b/x11-libs/agg/patches/agg-2.7.0~r139.patchset
@@ -1,13 +1,13 @@
-From 43ef03815c8aa6fa91c7f19a9f1754b703c173b2 Mon Sep 17 00:00:00 2001
+From 454a26f7fab24eaf3a99990353bd4a21199f2ddf Mon Sep 17 00:00:00 2001
 From: Kacper Kasper <kacperkasper@gmail.com>
 Date: Thu, 24 Apr 2014 20:00:29 +0000
 Subject: Haiku support
 
 
-diff --git a/agg-2.4/configure.ac b/agg-2.4/configure.ac
-index 4e1cb48..995c641 100644
---- a/agg-2.4/configure.ac
-+++ b/agg-2.4/configure.ac
+diff --git a/agg-src/configure.ac b/agg-src/configure.ac
+index 246e5b5..830719a 100644
+--- a/agg-src/configure.ac
++++ b/agg-src/configure.ac
 @@ -9,7 +9,7 @@ dnl Checks for programs.
  AC_PROG_CC
  AC_PROG_CXX
@@ -49,16 +49,16 @@ index 4e1cb48..995c641 100644
 2.37.3
 
 
-From 809260df4dcd81a7510c66a18e588141147915e9 Mon Sep 17 00:00:00 2001
+From ba4afca9c0986d17e92e02a6431bda748786b31a Mon Sep 17 00:00:00 2001
 From: Jonathan Schleifer <js@webkeks.org>
 Date: Thu, 19 Dec 2013 01:45:04 +0100
 Subject: Fix the agg headers to be proper C++.
 
 
-diff --git a/agg-2.4/include/agg_array.h b/agg-2.4/include/agg_array.h
+diff --git a/agg-src/include/agg_array.h b/agg-src/include/agg_array.h
 index b48010b..c5eec01 100644
---- a/agg-2.4/include/agg_array.h
-+++ b/agg-2.4/include/agg_array.h
+--- a/agg-src/include/agg_array.h
++++ b/agg-src/include/agg_array.h
 @@ -356,9 +356,10 @@ namespace agg
  
          void add_array(const T* ptr, unsigned num_elem)
@@ -97,10 +97,10 @@ index b48010b..c5eec01 100644
                  }
                  pod_allocator<block_type>::deallocate(m_blocks, m_max_blocks);
              }
-diff --git a/agg-2.4/include/agg_rasterizer_cells_aa.h b/agg-2.4/include/agg_rasterizer_cells_aa.h
+diff --git a/agg-src/include/agg_rasterizer_cells_aa.h b/agg-src/include/agg_rasterizer_cells_aa.h
 index 4dd905f..bc229e4 100644
---- a/agg-2.4/include/agg_rasterizer_cells_aa.h
-+++ b/agg-2.4/include/agg_rasterizer_cells_aa.h
+--- a/agg-src/include/agg_rasterizer_cells_aa.h
++++ b/agg-src/include/agg_rasterizer_cells_aa.h
 @@ -131,10 +131,11 @@ namespace agg
          if(m_num_blocks)
          {
@@ -142,10 +142,10 @@ index 4dd905f..bc229e4 100644
              }
          }
          
-diff --git a/agg-2.4/include/agg_renderer_outline_aa.h b/agg-2.4/include/agg_renderer_outline_aa.h
+diff --git a/agg-src/include/agg_renderer_outline_aa.h b/agg-src/include/agg_renderer_outline_aa.h
 index a1a248c..ca48577 100644
---- a/agg-2.4/include/agg_renderer_outline_aa.h
-+++ b/agg-2.4/include/agg_renderer_outline_aa.h
+--- a/agg-src/include/agg_renderer_outline_aa.h
++++ b/agg-src/include/agg_renderer_outline_aa.h
 @@ -1366,7 +1366,7 @@ namespace agg
          //---------------------------------------------------------------------
          void profile(line_profile_aa& prof) { m_profile = &prof; }
@@ -155,10 +155,10 @@ index a1a248c..ca48577 100644
  
          //---------------------------------------------------------------------
          int subpixel_width() const { return m_profile->subpixel_width(); }
-diff --git a/agg-2.4/include/agg_rendering_buffer.h b/agg-2.4/include/agg_rendering_buffer.h
+diff --git a/agg-src/include/agg_rendering_buffer.h b/agg-src/include/agg_rendering_buffer.h
 index 175bcd8..c89308b 100644
---- a/agg-2.4/include/agg_rendering_buffer.h
-+++ b/agg-2.4/include/agg_rendering_buffer.h
+--- a/agg-src/include/agg_rendering_buffer.h
++++ b/agg-src/include/agg_rendering_buffer.h
 @@ -187,10 +187,11 @@ namespace agg
  
              T** rows = &m_rows[0];
@@ -176,16 +176,16 @@ index 175bcd8..c89308b 100644
 2.37.3
 
 
-From b3422231df73113283a172fdca0c80ed68748a9e Mon Sep 17 00:00:00 2001
+From b032c7173087e803a73ff2c3df54c1df2f59f3eb Mon Sep 17 00:00:00 2001
 From: Kacper Kasper <kacperkasper@gmail.com>
 Date: Thu, 24 Apr 2014 20:00:29 +0000
 Subject: Haiku support
 
 
-diff --git a/agg-2.4/src/platform/BeOS/Makefile.am b/agg-2.4/src/platform/BeOS/Makefile.am
+diff --git a/agg-src/src/platform/BeOS/Makefile.am b/agg-src/src/platform/BeOS/Makefile.am
 index 474153c..2095717 100644
---- a/agg-2.4/src/platform/BeOS/Makefile.am
-+++ b/agg-2.4/src/platform/BeOS/Makefile.am
+--- a/agg-src/src/platform/BeOS/Makefile.am
++++ b/agg-src/src/platform/BeOS/Makefile.am
 @@ -1 +1,10 @@
 -EXTRA_DIST=agg_platform_support.cpp
 +if ENABLE_HAIKU
@@ -198,13 +198,166 @@ index 474153c..2095717 100644
 +libaggplatformHaiku_la_LIBADD = @HAIKU_LIBS@
 +endif
 +
-diff --git a/agg-2.4/src/platform/Makefile.am b/agg-2.4/src/platform/Makefile.am
+diff --git a/agg-src/src/platform/Makefile.am b/agg-src/src/platform/Makefile.am
 index ebe5e7e..c6622bc 100644
---- a/agg-2.4/src/platform/Makefile.am
-+++ b/agg-2.4/src/platform/Makefile.am
+--- a/agg-src/src/platform/Makefile.am
++++ b/agg-src/src/platform/Makefile.am
 @@ -1 +1 @@
 -SUBDIRS = X11 sdl win32 AmigaOS BeOS mac
 +SUBDIRS = X11 sdl win32 AmigaOS Haiku mac
+-- 
+2.37.3
+
+
+From 2f72bf6bd348e920a95f6a5370a617a9b0d367e4 Mon Sep 17 00:00:00 2001
+From: Ken Mays <kmays2000@gmail.com>
+Date: Mon, 4 Sep 2023 01:13:27 +0000
+Subject: Added essential AGG r139 SVN patches from SourceForge
+
+
+diff --git a/agg-src/configure.ac b/agg-src/configure.ac
+index 830719a..995c641 100644
+--- a/agg-src/configure.ac
++++ b/agg-src/configure.ac
+@@ -1,4 +1,4 @@
+-AC_INIT(agg, 2.6.0)
++AC_INIT(agg, 2.7.0)
+ AC_CONFIG_SRCDIR(src/agg_arc.cpp)
+ AC_CANONICAL_TARGET
+ AC_CONFIG_HEADERS(include/config.h)
+@@ -136,7 +136,7 @@ AC_SUBST(x_libraries)
+ dnl ###############################################
+ 
+ dnl Settung up library version
+-AGG_LIB_VERSION="2:6:0"
++AGG_LIB_VERSION="2:7:0"
+ dnl     current-´ / /
+ dnl    revision--´ /
+ dnl         age---´
+diff --git a/agg-src/examples/mol_view.cpp b/agg-src/examples/mol_view.cpp
+index 7813dc3..dcc63f1 100644
+--- a/agg-src/examples/mol_view.cpp
++++ b/agg-src/examples/mol_view.cpp
+@@ -172,7 +172,8 @@ unsigned trim_cr_lf(char* buf)
+         --len;
+         ++pos;
+     }
+-    if(pos) strcpy(buf, buf + pos);
++	// Note that strcpy has undefined behavior if the strings overlap
++    if(pos) memmove(buf, buf + pos, len);
+ 
+     // Trim "\n\r" at the end 
+     while(len && (buf[len-1] == '\n' || buf[len-1] == '\r')) --len;
+@@ -202,7 +203,7 @@ bool molecule::read(FILE* fd)
+     unsigned len;
+     if(!fgets(buf, 510, fd)) return false;
+     len = trim_cr_lf(buf);
+-    if(len > 128) len = 128;
++    if(len > 127) len = 127;
+ 
+     if(len) memcpy(m_name, buf, len);
+     m_name[len] = 0;
+@@ -800,7 +801,7 @@ public:
+         else
+         {
+             char buf[256];
+-            sprintf(buf, "File not found: '%s'. Download http://www.antigrain.com/%s\n",
++            sprintf(buf, "File not found: '%s'. Copy from ../art/%s\n",
+                     fname, fname);
+             message(buf);
+         }
+diff --git a/agg-src/include/agg_curves.h b/agg-src/include/agg_curves.h
+index 1ef02e8..63a4813 100644
+--- a/agg-src/include/agg_curves.h
++++ b/agg-src/include/agg_curves.h
+@@ -96,6 +96,7 @@ namespace agg
+     public:
+         curve3_div() : 
+             m_approximation_scale(1.0),
++            m_distance_tolerance_square(0.0),
+             m_angle_tolerance(0.0),
+             m_count(0)
+         {}
+@@ -376,6 +377,7 @@ namespace agg
+     public:
+         curve4_div() : 
+             m_approximation_scale(1.0),
++            m_distance_tolerance_square(0.0),
+             m_angle_tolerance(0.0),
+             m_cusp_limit(0.0),
+             m_count(0)
+diff --git a/agg-src/include/agg_math_stroke.h b/agg-src/include/agg_math_stroke.h
+index 6a9d604..b139711 100644
+--- a/agg-src/include/agg_math_stroke.h
++++ b/agg-src/include/agg_math_stroke.h
+@@ -172,11 +172,9 @@ namespace agg
+     {
+         double a1 = std::atan2(dy1 * m_width_sign, dx1 * m_width_sign);
+         double a2 = std::atan2(dy2 * m_width_sign, dx2 * m_width_sign);
+-        double da = a1 - a2;
++        double da = std::acos(m_width_abs / (m_width_abs + 0.125 / m_approx_scale)) * 2;
+         int i, n;
+ 
+-        da = std::acos(m_width_abs / (m_width_abs + 0.125 / m_approx_scale)) * 2;
+-
+         add_vertex(vc, x + dx1, y + dy1);
+         if(m_width_sign > 0)
+         {
+diff --git a/agg-src/include/agg_pixfmt_rgba.h b/agg-src/include/agg_pixfmt_rgba.h
+index c9172f6..2c7223c 100644
+--- a/agg-src/include/agg_pixfmt_rgba.h
++++ b/agg-src/include/agg_pixfmt_rgba.h
+@@ -2371,7 +2371,7 @@ namespace agg
+         //--------------------------------------------------------------------
+         AGG_INLINE void copy_pixel(int x, int y, const color_type& c)
+         {
+-            make_pix(pix_value_ptr(x, y, 1), c);
++            pix_value_ptr(x, y, 1)->set(c);
+         }
+ 
+         //--------------------------------------------------------------------
+diff --git a/agg-src/include/agg_trans_affine.h b/agg-src/include/agg_trans_affine.h
+index 90e464b..b3cc1b0 100644
+--- a/agg-src/include/agg_trans_affine.h
++++ b/agg-src/include/agg_trans_affine.h
+@@ -318,8 +318,8 @@ namespace agg
+     //------------------------------------------------------------------------
+     inline double trans_affine::scale() const
+     {
+-        double x = 0.707106781 * sx  + 0.707106781 * shx;
+-        double y = 0.707106781 * shy + 0.707106781 * sy;
++        double x = 0.70710678118654752440 * sx  + 0.70710678118654752440 * shx;
++        double y = 0.70710678118654752440 * shy + 0.70710678118654752440 * sy;
+         return std::sqrt(x*x + y*y);
+     }
+ 
+-- 
+2.37.3
+
+
+From bc2fdaadbf5da438d43e95eae2adf2596fdff93e Mon Sep 17 00:00:00 2001
+From: Zhardshard <zhardshard@ghaiku-os.org>
+Date: Mon, 4 Sep 2023 01:13:27 +0000
+Subject: Fix member initialization order
+
+
+diff --git a/agg-src/src/agg_trans_double_path.cpp b/agg-src/src/agg_trans_double_path.cpp
+index cd40c7f..d5692a9 100644
+--- a/agg-src/src/agg_trans_double_path.cpp
++++ b/agg-src/src/agg_trans_double_path.cpp
+@@ -21,10 +21,10 @@ namespace agg
+ 
+     //------------------------------------------------------------------------
+     trans_double_path::trans_double_path() :
+-        m_kindex1(0.0),
+-        m_kindex2(0.0),
+         m_base_length(0.0),
+         m_base_height(1.0),
++        m_kindex1(0.0),
++        m_kindex2(0.0),
+         m_status1(initial),
+         m_status2(initial),
+         m_preserve_x_scale(true)
 -- 
 2.37.3
 


### PR DESCRIPTION
- Fixed src build issue for buildbots.
- Updated for dual licensing per "copying" file in src.
Ref: https://sourceforge.net/p/agg/svn/HEAD/tree/agg-2.4/copying
Closes: https://github.com/haikuports/haikuports/issues/9322