### PR TITLE
python3.8: bulk removal of now obsolete "_python38" packages.

### DIFF
--- a/dev-python/aiodns/aiodns-2.0.0.recipe
+++ b/dev-python/aiodns/aiodns-2.0.0.recipe
@@ -4,7 +4,7 @@ resolutions with a synchronous looking interface by using pycares"
 HOMEPAGE="https://pypi.python.org/pypi/aiodns"
 COPYRIGHT="2016 Saúl Ibarra Corretgé"
 LICENSE="MIT"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://pypi.org/packages/source/a/aiodns/aiodns-$portVersion.tar.gz"
 CHECKSUM_SHA256="815fdef4607474295d68da46978a54481dd1e7be153c7d60f9e72773cd38d77d"
 
@@ -21,22 +21,25 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()

--- a/dev-python/aiohttp-socks/aiohttp_socks-0.6.0.recipe
+++ b/dev-python/aiohttp-socks/aiohttp_socks-0.6.0.recipe
@@ -4,7 +4,7 @@ DESCRIPTION="Proxy connector for aiohttp. SOCKS4(a), SOCKS5, HTTP \
 HOMEPAGE="https://github.com/romis2012/aiohttp-socks"
 COPYRIGHT="2018-2020 Santiago Torres"
 LICENSE="Apache v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/romis2012/aiohttp-socks/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="7d3fc71f6c992d134cc1ebdfecb2cb2531a06fba529b38d8120a1085372563d6"
 SOURCE_DIR="aiohttp-socks-$portVersion"
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/aiohttp/aiohttp-3.8.1.recipe
+++ b/dev-python/aiohttp/aiohttp-3.8.1.recipe
@@ -6,7 +6,7 @@ Provides Web-server with middlewares and pluggable routing."
 HOMEPAGE="https://pypi.python.org/pypi/aiohttp"
 COPYRIGHT="2013-2021 Nikolay Kim and Andrew Svetlov"
 LICENSE="Apache v2"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://pypi.org/packages/source/a/aiohttp/aiohttp-$portVersion.tar.gz"
 CHECKSUM_SHA256="fc5471e1a54de15ef71c1bc6ebe80d4dc681ea600e68bfd1cbce40427f0b7578"
 
@@ -24,8 +24,8 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/aiorpcx/aiorpcx-0.21.0.recipe
+++ b/dev-python/aiorpcx/aiorpcx-0.21.0.recipe
@@ -4,7 +4,7 @@ application that is a client, server or both."
 HOMEPAGE="https://github.com/kyuupichan/aiorpcX/"
 COPYRIGHT="2018 Neil Booth"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/kyuupichan/aiorpcX/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="99d88850a3663bcccc0fe8adf44ea6b6b6831f7fa728fb0485654efe0bc325e5"
 SOURCE_DIR="aiorpcX-$portVersion"
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/aiosignal/aiosignal-1.2.0.recipe
+++ b/dev-python/aiosignal/aiosignal-1.2.0.recipe
@@ -19,7 +19,7 @@ aiohttp documentation."
 HOMEPAGE="https://pypi.org/project/aiosignal/"
 COPYRIGHT="2019-2021 Nikolay Kim and Martijn Pieters"
 LICENSE="Apache v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://files.pythonhosted.org/packages/27/6b/a89fbcfae70cf53f066ec22591938296889d3cc58fec1e1c393b10e8d71d/aiosignal-$portVersion.tar.gz"
 CHECKSUM_SHA256="78ed67db6c7b7ced4f98e495e572106d5c432a93e1ddd1bf475e1dc05f5b7df2"
 
@@ -36,8 +36,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/alembic/alembic_py-1.8.0.recipe
+++ b/dev-python/alembic/alembic_py-1.8.0.recipe
@@ -11,7 +11,7 @@ database to a new version, and optionally a series of steps that can \
 HOMEPAGE="https://pypi.org/project/alembic/"
 COPYRIGHT="2011-2019 Mike Bayer"
 LICENSE="MIT"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://pypi.python.org/packages/source/a/alembic/alembic-$portVersion.tar.gz"
 SOURCE_DIR="alembic-$portVersion"
 CHECKSUM_SHA256="a2d4d90da70b30e70352cd9455e35873a255a31402a438fe24815758d7a0e5e1"
@@ -29,8 +29,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/apsw/apsw-3.36.0~r1.recipe
+++ b/dev-python/apsw/apsw-3.36.0~r1.recipe
@@ -7,7 +7,7 @@ HOMEPAGE="https://github.com/rogerbinns/apsw/
 	https://pypi.org/project/apsw/"
 COPYRIGHT="2004-2021 Roger Binns"
 LICENSE="OSI"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/rogerbinns/apsw/archive/3.36.0-r1.tar.gz"
 CHECKSUM_SHA256="133ee2291851e0144661eba25517c7feb026c6d5896df90ef7ea0feddf03a842"
 SOURCE_DIR="apsw-3.36.0-r1"
@@ -28,8 +28,8 @@ BUILD_REQUIRES="
 	sqlite${secondaryArchSuffix}_devel >= 3.36
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/argh/argh-0.28.1.recipe
+++ b/dev-python/argh/argh-0.28.1.recipe
@@ -7,7 +7,7 @@ Argh just makes it easy to use."
 HOMEPAGE="https://pypi.python.org/pypi/argh"
 COPYRIGHT="2010-2023 Andrey Mikhaylenko and contributors"
 LICENSE="GNU LGPL v3"
-REVISION="1"
+REVISION="2"
 pypiVersion="b2/03/7cad222e3aed5ed668c3c93c35f7ee866bc1da5cdcac945275f45e8caf80"
 SOURCE_URI="https://files.pythonhosted.org/packages/$pypiVersion/$portName-$portVersion-py3-none-any.whl#noarchive"
 CHECKSUM_SHA256="10e7311f3ea54a78a366e5456900d8b81049f44d8d653b524eb90cf7d29a71ee"
@@ -25,8 +25,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/asn1crypto/asn1crypto-1.5.1.recipe
+++ b/dev-python/asn1crypto/asn1crypto-1.5.1.recipe
@@ -4,7 +4,7 @@ serializing ASN.1 structures."
 HOMEPAGE="https://github.com/wbond/asn1crypto"
 COPYRIGHT="2015-2019 Will Bond"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/wbond/asn1crypto/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="c06e6827971891a7c42299eff3f0881d6fbf1ada53f11c5797240a9c0cec6a1c"
 SOURCE_FILENAME="asn1crypto-$portVersion.tar.gz"
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/async-timeout/async_timeout-4.0.2.recipe
+++ b/dev-python/async-timeout/async_timeout-4.0.2.recipe
@@ -6,7 +6,7 @@ because timeout doesn't create a new task."
 HOMEPAGE="https://pypi.python.org/pypi/async_timeout"
 COPYRIGHT="2019 Andrew Svetlov"
 LICENSE="Apache v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.io/packages/source/a/async-timeout/async-timeout-$portVersion.tar.gz"
 SOURCE_DIR="async-timeout-$portVersion"
 CHECKSUM_SHA256="2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15"
@@ -24,8 +24,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/asynctest/asynctest-0.13.0.recipe
+++ b/dev-python/asynctest/asynctest-0.13.0.recipe
@@ -7,7 +7,7 @@ Windows’ proactor."
 HOMEPAGE="https://pypi.org/project/asynctest/"
 COPYRIGHT="2015-2019 Martin Richard"
 LICENSE="Apache v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://files.pythonhosted.org/packages/0c/0f/6056f4435923d2f8c89ac9ef2d18506a569348d8f9cc827b0dd7a4c8acc4/asynctest-$portVersion.tar.gz"
 CHECKSUM_SHA256="c27862842d15d83e6a34eb0b2866c323880eb3a75e4485b079ea11748fd77fac"
 
@@ -24,8 +24,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/atomicwrites/atomicwrites-1.4.1.recipe
+++ b/dev-python/atomicwrites/atomicwrites-1.4.1.recipe
@@ -7,7 +7,7 @@ combination of 'link' and 'unlink'."
 HOMEPAGE="https://pypi.python.org/pypi/atomicwrites"
 COPYRIGHT="2015-2020 Markus Unterwaditzer"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.io/packages/source/a/atomicwrites/atomicwrites-$portVersion.tar.gz"
 CHECKSUM_SHA256="81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"
 
@@ -24,8 +24,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/attrs/attrs-22.1.0.recipe
+++ b/dev-python/attrs/attrs-22.1.0.recipe
@@ -8,7 +8,7 @@ slowing down your code."
 HOMEPAGE="https://pypi.python.org/pypi/attrs"
 COPYRIGHT="2015-2019 Hynek Schlawack"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.io/packages/source/${portName:0:1}/$portName/$portName-$portVersion.tar.gz"
 CHECKSUM_SHA256="29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"
 
@@ -25,8 +25,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/bitstring/bitstring-3.1.7.recipe
+++ b/dev-python/bitstring/bitstring-3.1.7.recipe
@@ -4,7 +4,7 @@ and analysis of binary data as simple and natural as possible."
 HOMEPAGE="https://scott-griffiths.github.io/bitstring/"
 COPYRIGHT="2006 - 2019 Scott Griffiths"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/scott-griffiths/bitstring/archive/bitstring-$portVersion.tar.gz"
 CHECKSUM_SHA256="fa4a9f6fc8a15e69c6266968741b2cd7827001d646bd66b46fb6e93a28571f79"
 SOURCE_DIR="bitstring-bitstring-$portVersion"
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/bottle/bottle-0.12.23.recipe
+++ b/dev-python/bottle/bottle-0.12.23.recipe
@@ -14,7 +14,7 @@ bjoern, gae, cherrypy or any other WSGI capable HTTP server."
 HOMEPAGE="https://bottlepy.org"
 COPYRIGHT="2012 Marcel Hellkamp"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.io/packages/source/b/bottle/bottle-$portVersion.tar.gz"
 CHECKSUM_SHA256="683de3aa399fb26e87b274dbcf70b1a651385d459131716387abdc3792e04167"
 ARCHITECTURES="any"
@@ -30,8 +30,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/build/build-0.10.0.recipe
+++ b/dev-python/build/build-0.10.0.recipe
@@ -4,7 +4,7 @@ It is a simple build tool and does not perform any dependency management."
 HOMEPAGE="https://pypi.org/project/build/"
 COPYRIGHT="2010-2022 Filipe Laíns"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/pypa/build/archive/refs/tags/$portVersion.tar.gz"
 CHECKSUM_SHA256="0cbeebaa6047cf8bfc82451038479e41d6cf1e196126a8a110991b1173b39390"
 
@@ -21,8 +21,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/certifi/certifi-2021.10.8.recipe
+++ b/dev-python/certifi/certifi-2021.10.8.recipe
@@ -5,7 +5,7 @@ identity of TLS hosts. It has been extracted from the Requests project."
 HOMEPAGE="https://pypi.org/project/certifi/"
 COPYRIGHT="2011-2020 Kenneth Reitz"
 LICENSE="MPL v2.0"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.python.org/packages/source/c/certifi/certifi-$portVersion.tar.gz"
 CHECKSUM_SHA256="78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"
 
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/cffi/cffi-1.15.1.recipe
+++ b/dev-python/cffi/cffi-1.15.1.recipe
@@ -4,7 +4,7 @@ HOMEPAGE="https://cffi.readthedocs.io/
 	https://pypi.org/project/cffi/"
 COPYRIGHT="2012-2021 Armin Rigo, Maciej Fijalkowski"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/c/cffi/cffi-$portVersion.tar.gz"
 CHECKSUM_SHA256="d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"
 
@@ -27,8 +27,8 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 PYTHON_LIBSUFFIXES+=()
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}

--- a/dev-python/chardet/chardet-4.0.0.recipe
+++ b/dev-python/chardet/chardet-4.0.0.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="Python module for character encoding auto-detection."
 HOMEPAGE="https://github.com/chardet/chardet"
 COPYRIGHT="2011-2022 Mark Pilgrim, Dan Blanchard"
 LICENSE="GNU LGPL v2.1"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://pypi.io/packages/source/${portName:0:1}/$portName/${portName}-$portVersion.tar.gz"
 CHECKSUM_SHA256="0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"
 
@@ -20,8 +20,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 commandSuffixes=(3.8 "" 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}

--- a/dev-python/charset-normalizer/charset_normalizer-2.1.1.recipe
+++ b/dev-python/charset-normalizer/charset_normalizer-2.1.1.recipe
@@ -6,7 +6,7 @@ All IANA character set names for which the Python core library provides codecs a
 HOMEPAGE="https://pypi.org/project/charset-normalizer/"
 COPYRIGHT="2019-2022 Ahmed TAHRI"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://files.pythonhosted.org/packages/a1/34/44964211e5410b051e4b8d2869c470ae8a68ae274953b1c7de6d98bbcf94/charset-normalizer-$portVersion.tar.gz"
 SOURCE_DIR="charset-normalizer-$portVersion"
 CHECKSUM_SHA256="5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845"
@@ -25,8 +25,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/click/click-8.1.3.recipe
+++ b/dev-python/click/click-8.1.3.recipe
@@ -8,7 +8,7 @@ COPYRIGHT="2014-2018 Pallets Team
 	2001-2006 Gregory P. Ward
 	2002-2006 Python Software Foundation"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/pallets/click/archive/refs/tags/$portVersion.tar.gz"
 CHECKSUM_SHA256="abb9959ec2d6cf198f70ca78ec2a5cd74110a6de728ecd19d8892ff65576f184"
 SOURCE_FILENAME="click-$portVersion.tar.gz"
@@ -26,8 +26,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/constantly/constantly-15.1.0~git.recipe
+++ b/dev-python/constantly/constantly-15.1.0~git.recipe
@@ -5,7 +5,7 @@ Originally twisted.python.constants from the Twisted project."
 HOMEPAGE="https://github.com/twisted/constantly"
 COPYRIGHT="2011-2015 Twisted Matrix Laboratories et all"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 srcGitRev="39887b6e131a72b04a338919519e972de668c586"
 SOURCE_URI="$HOMEPAGE/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="0cfe2235cd6fcd677ffb0710891ffb839a1d748b98acb32e5df683e6f4a1ea71"
@@ -25,8 +25,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/cppy/cppy-1.2.1.recipe
+++ b/dev-python/cppy/cppy-1.2.1.recipe
@@ -5,7 +5,7 @@ DESCRIPTION="A small C++ header library which makes it easier to write Python ex
 HOMEPAGE="https://github.com/nucleic/cppy/"
 COPYRIGHT="2014-2022, Nucleic Development Team"
 LICENSE="BSD (3-clause)"
-REVISION="1"
+REVISION="2"
 pypiVersion="31/5e/b8faf2b2aeb679c0f4359fd1a4716fe90d65f72f72639413ffb95f3c3b46"
 SOURCE_URI="https://files.pythonhosted.org/packages/$pypiVersion/$portName-$portVersion-py3-none-any.whl#noarchive"
 CHECKSUM_SHA256='c5b5eac3d3f42593a07d35275b0bc27f447b76b9ad8f27c62e3cfa286dc1988a'
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/cryptography/cryptography-3.3.2.recipe
+++ b/dev-python/cryptography/cryptography-3.3.2.recipe
@@ -8,7 +8,7 @@ HOMEPAGE="https://cryptography.io/"
 COPYRIGHT="2013-2020 The cryptography developers"
 LICENSE="Apache v2
 	BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://pypi.io/packages/source/c/cryptography/cryptography-$portVersion.tar.gz"
 CHECKSUM_SHA256="5a60d3780149e13b7a6ff7ad6526b38846354d11a15e21068e57073e29e19bed"
 
@@ -33,8 +33,8 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/css-parser/css_parser-1.0.6.recipe
+++ b/dev-python/css-parser/css_parser-1.0.6.recipe
@@ -5,7 +5,7 @@ working with ebooks."
 HOMEPAGE="https://github.com/ebook-utils/css-parser"
 COPYRIGHT="2004-2013 Christof Hoeke"
 LICENSE="GNU LGPL v3"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/ebook-utils/css-parser/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="64916bc4030a339daf22f98c54e20d1e1bb4a8b7a15ccd2fd20771c49c3f7f4e"
 SOURCE_DIR="css-parser-$portVersion"
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/cython/cython-0.29.32.recipe
+++ b/dev-python/cython/cython-0.29.32.recipe
@@ -5,7 +5,7 @@ Pyrex). It makes writing C extensions for Python as easy as Python itself."
 HOMEPAGE="https://cython.org/"
 COPYRIGHT="2007-2020 Stefan Behnel, Robert Bradshaw, et al."
 LICENSE="Apache v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/cython/cython/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="3f53fbe1398666e77fd4ce388f939309a11efd273d16f20f58f0df7b03d6b4cc"
 SOURCE_FILENAME="cython-$portVersion.tar.gz"
@@ -24,8 +24,8 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/dateutil/dateutil-2.8.2.recipe
+++ b/dev-python/dateutil/dateutil-2.8.2.recipe
@@ -4,7 +4,7 @@ datetime module, available in Python 2.3+."
 HOMEPAGE="https://github.com/dateutil/dateutil/"
 COPYRIGHT="2003-2010 Gustavo Niemeyer"
 LICENSE="BSD (3-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/dateutil/dateutil/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="46e7c1fd13287cd72b428c9cfe7ced53cf854a8a6c05277ba3047e8f86d57b16"
 
@@ -21,8 +21,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/dbuspython/dbuspython-1.2.14.recipe
+++ b/dev-python/dbuspython/dbuspython-1.2.14.recipe
@@ -17,7 +17,7 @@ COPYRIGHT="2002-2010 Red Hat Inc.
 LICENSE="MIT
 	AFL v2.1
 	GNU GPL v2"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://dbus.freedesktop.org/releases/dbus-python/dbus-python-$portVersion.tar.gz"
 CHECKSUM_SHA256="b10206ba3dd641e4e46411ab91471c88e0eec1749860e4285193ee68df84ac31"
 SOURCE_DIR="dbus-python-$portVersion"
@@ -47,8 +47,8 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/decorator/decorator-5.1.1.recipe
+++ b/dev-python/decorator/decorator-5.1.1.recipe
@@ -8,7 +8,7 @@ whatever you want with it but I am not responsible."
 HOMEPAGE="https://github.com/micheles/decorator"
 COPYRIGHT="2003-2019 Michele Simionato"
 LICENSE="BSD (2-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.io/packages/source/${portName:0:1}/$portName/$portName-$portVersion.tar.gz"
 CHECKSUM_SHA256="637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"
 
@@ -25,8 +25,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/discid/discid-1.2.0.recipe
+++ b/dev-python/discid/discid-1.2.0.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="Python-discid implements Python bindings for MusicBrainz Libdiscid.
 HOMEPAGE="https://python-discid.readthedocs.io/"
 COPYRIGHT="Johannes Dewender"
 LICENSE="GNU LGPL v2.1"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/d/$portName/$portName-$portVersion.tar.gz"
 CHECKSUM_SHA256="cd9630bc53f5566df92819641040226e290b2047573f2c74a6e92b8eed9e86b9"
 SOURCE_DIR="discid-$portVersion"
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/dnspython/dnspython-1.16.0.recipe
+++ b/dev-python/dnspython/dnspython-1.16.0.recipe
@@ -7,7 +7,7 @@ COPYRIGHT="Dnspython Contributors
 	2001-2017 Nominum, Inc.
 	Google Inc."
 LICENSE="ISC"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/rthalley/dnspython/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="b339ac2eb070d0133f020a6e0cc137a10fc380f3eba3e0655d62a19e64626cbd"
 
@@ -24,8 +24,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/docutils/docutils-0.20.1.recipe
+++ b/dev-python/docutils/docutils-0.20.1.recipe
@@ -11,7 +11,7 @@ LICENSE="Public Domain
 	BSD (2-clause)
 	GNU GPL v3
 	Python"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.io/packages/source/${portName:0:1}/$portName/$portName-$portVersion.tar.gz"
 CHECKSUM_SHA256="f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b"
 
@@ -28,8 +28,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 defaultVersion=3.9
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}

--- a/dev-python/dukpy/dukpy-0.3.recipe
+++ b/dev-python/dukpy/dukpy-0.3.recipe
@@ -5,7 +5,7 @@ With dukpy, you can run JavaScript in Python."
 HOMEPAGE="https://github.com/kovidgoyal/dukpy"
 COPYRIGHT="2007-2019 Ian Bicking and contributors"
 LICENSE="GNU LGPL v3"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://github.com/kovidgoyal/dukpy/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="cc78c39ebba51f381c623b164cfb7dcf3caddf515fe7094bc53b7eca5d4e435e"
 SOURCE_FILENAME="$portName-v$portVersion.tar.gz"
@@ -27,8 +27,8 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/dulwich/dulwich-0.20.32.recipe
+++ b/dev-python/dulwich/dulwich-0.20.32.recipe
@@ -8,7 +8,7 @@ LICENSE="
 	Apache v2
 	GNU GPL v2
 	"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.python.org/packages/source/${portName:0:1}/dulwich/dulwich-$portVersion.tar.gz"
 CHECKSUM_SHA256="dc5498b072bdc12c1effef4b6202cd2a4542bb1c6dbb4ddcfc8c6d53e08b488c"
 
@@ -26,8 +26,8 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/ecdsa/ecdsa-0.16.1.recipe
+++ b/dev-python/ecdsa/ecdsa-0.16.1.recipe
@@ -4,7 +4,7 @@ the ECDSA cryptographic signature library."
 HOMEPAGE="https://github.com/warner/python-ecdsa"
 COPYRIGHT="2010 Brian Warner"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.python.org/packages/source/e/ecdsa/ecdsa-$portVersion.tar.gz"
 CHECKSUM_SHA256="cfc046a2ddd425adbd1a78b3c46f0d1325c657811c0f45ecc3a0a6236c1e50ff"
 
@@ -21,8 +21,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/editor/editor-1.0.4.recipe
+++ b/dev-python/editor/editor-1.0.4.recipe
@@ -4,7 +4,7 @@ for programmatically interfacing with your system's editor."
 HOMEPAGE="https://github.com/fmoo/python-editor"
 COPYRIGHT="2015-2019 Peter Ruibal"
 LICENSE="Apache v2"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://files.pythonhosted.org/packages/0a/85/78f4a216d28343a67b7397c99825cff336330893f00601443f7c7b2f2234/python-editor-1.0.4.tar.gz"
 CHECKSUM_SHA256="51fda6bcc5ddbbb7063b2af7509e43bd84bfc32a4ff71349ec7847713882327b"
 SOURCE_DIR="python-editor-$portVersion"
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/editorconfig-core-py/editorconfig_core_py-0.12.3.recipe
+++ b/dev-python/editorconfig-core-py/editorconfig_core_py-0.12.3.recipe
@@ -9,7 +9,7 @@ website."
 HOMEPAGE="https://editorconfig.org/"
 COPYRIGHT="2011-2018 EditorConfig Team"
 LICENSE="BSD (2-clause)"
-REVISION="2"
+REVISION="3"
 pyName="EditorConfig"
 SOURCE_URI="https://pypi.io/packages/source/${pyName:0:1}/$pyName/$pyName-$portVersion.tar.gz"
 CHECKSUM_SHA256="57f8ce78afcba15c8b18d46b5170848c88d56fd38f05c2ec60dbbfcb8996e89e"
@@ -29,8 +29,8 @@ BUILD_REQUIRES="
 	cmd:cmake
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/fasteners/fasteners-0.16.recipe
+++ b/dev-python/fasteners/fasteners-0.16.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="Python cross platform locks for threads and processes."
 HOMEPAGE="https://github.com/harlowja/fasteners"
 LICENSE="Apache v2"
 COPYRIGHT="2014-2021 fasteners authors"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://pypi.python.org/packages/source/f/fasteners/fasteners-$portVersion.tar.gz"
 CHECKSUM_SHA256="c995d8c26b017c5d6a6de9ad29a0f9cdd57de61ae1113d28fac26622b06a0933"
 
@@ -20,8 +20,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/feedparser/feedparser-5.2.1.recipe
+++ b/dev-python/feedparser/feedparser-5.2.1.recipe
@@ -7,7 +7,7 @@ COPYRIGHT="2010-2015 Kurt McKee
 	2002-2008 Mark Pilgrim"
 LICENSE="BSD (2-clause)
 	Python"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://github.com/kurtmckee/feedparser/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="09367f95e58b9c5f70da70061d3e7f397ed8ec5d3c970e231ef011ff62de462f"
 
@@ -24,8 +24,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/flake8/flake8-5.0.4.recipe
+++ b/dev-python/flake8/flake8-5.0.4.recipe
@@ -5,7 +5,7 @@ HOMEPAGE="https://github.com/PyCQA/flake8"
 COPYRIGHT="2011-2013 Tarek Ziade
 	2012-2016 Ian Cordasco"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="$HOMEPAGE/archive/refs/tags/$portVersion.tar.gz"
 CHECKSUM_SHA256="31bcbe068edcb150503957bfa58a912f865ef4c75ea5d81e903cdde9be03b089"
 
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/flit-core/flit_core-3.8.0.recipe
+++ b/dev-python/flit-core/flit_core-3.8.0.recipe
@@ -4,7 +4,7 @@ The only public interface is the API specified by PEP 517, at ``flit_core.builda
 HOMEPAGE="https://pypi.org/project/flit_core/"
 COPYRIGHT="2015 Thomas Kluyver and contributors"
 LICENSE="BSD (3-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/f/flit-core/flit_core-$portVersion.tar.gz"
 CHECKSUM_SHA256="b305b30c99526df5e63d6022dd2310a0a941a187bd3884f4c8ef0418df6c39f3"
 
@@ -21,8 +21,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/flit/flit-3.7.1.recipe
+++ b/dev-python/flit/flit-3.7.1.recipe
@@ -5,7 +5,7 @@ mistakes."
 HOMEPAGE="https://pypi.org/project/flit/"
 COPYRIGHT="2015 Thomas Kluyver and contributors"
 LICENSE="BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 pypiVersion="f8/81/5281e3f50a238d1169cc5c4c3acec91c631da79962d387ea843083bd151e"
 SOURCE_URI="https://files.pythonhosted.org/packages/$pypiVersion/flit-$portVersion-py3-none-any.whl#noarchive"
 CHECKSUM_SHA256="06a93a6737fa9380ba85fe8d7f28efb6c93c4f4ee9c7d00cc3375a81f33b91a4"
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/fluidity-sm/fluidity_sm-0.2.1~git.recipe
+++ b/dev-python/fluidity-sm/fluidity_sm-0.2.1~git.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="fluidity, state machine implementation for Python objects."
 HOMEPAGE="https://github.com/nsi-iff/fluidity"
 COPYRIGHT="2011 Rodrigo S. Manhães"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 srcGitRev="468627ea13ed4c3043dc67ccc1ff16089fdb7b25"
 SOURCE_URI="$HOMEPAGE/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="2471d195b5ddd3457f51ddaf7eeca920cfd39ae01a368faa4434a11eac86b2e4"
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/frozendict/frozendict-1.2.recipe
+++ b/dev-python/frozendict/frozendict-1.2.recipe
@@ -17,7 +17,7 @@ immutable copy."
 HOMEPAGE="https://pypi.org/project/frozendict/"
 COPYRIGHT="2012-2016 Santiago Lezica"
 LICENSE="MIT"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://files.pythonhosted.org/packages/4e/55/a12ded2c426a4d2bee73f88304c9c08ebbdbadb82569ebdd6a0c007cfd08/frozendict-$portVersion.tar.gz"
 CHECKSUM_SHA256="774179f22db2ef8a106e9c38d4d1f8503864603db08de2e33be5b778230f6e45"
 
@@ -34,8 +34,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/frozenlist/frozenlist-1.3.1.recipe
+++ b/dev-python/frozenlist/frozenlist-1.3.1.recipe
@@ -7,7 +7,7 @@ FrozenList is also hashable, but only when frozen."
 HOMEPAGE="https://pypi.org/project/frozenlist/"
 COPYRIGHT="2019-2022 aiohttp team"
 LICENSE="Apache v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://files.pythonhosted.org/packages/8a/95/229aacfe85daa28e2792481a98c336bc30d3729533e6a44db537880aca21/frozenlist-$portVersion.tar.gz"
 CHECKSUM_SHA256="3a735e4211a04ccfa3f4833547acdf5d2f863bfeb01cfd3edaffbc251f15cec8"
 
@@ -25,8 +25,8 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/future/future-0.18.2.recipe
+++ b/dev-python/future/future-0.18.2.recipe
@@ -5,7 +5,7 @@ to support both Python 2 and Python 3 with minimal overhead."
 HOMEPAGE="https://pypi.org/project/future/"
 COPYRIGHT="2013-2016 Ed Schofield"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.io/packages/source/${portName:0:1}/$portName/$portName-$portVersion.tar.gz"
 CHECKSUM_SHA256="b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
 
@@ -24,8 +24,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/gitdb/gitdb-4.0.9.recipe
+++ b/dev-python/gitdb/gitdb-4.0.9.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="Pure-Python git object database."
 HOMEPAGE="https://pypi.org/project/gitdb/"
 COPYRIGHT="2010-2021 Sebastian Thiel"
 LICENSE="BSD (3-clause)"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://pypi.io/packages/source/g/gitdb/gitdb-$portVersion.tar.gz"
 CHECKSUM_SHA256="bac2fd45c0a1c9cf619e63a90d62bdc63892ef92387424b855792a6cabe789aa"
 
@@ -20,8 +20,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/html2text/html2text-2020.1.16.recipe
+++ b/dev-python/html2text/html2text-2020.1.16.recipe
@@ -8,7 +8,7 @@ HOMEPAGE="https://github.com/html2text/html2text.py
 	https://pypi.python.org/pypi/html2text"
 COPYRIGHT="2004-2008 Aaron Swartz"
 LICENSE="GNU GPL v3"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/Alir3z4/html2text/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="209a2c4d7897e83a6999160ef51ae71bdb8c3eede99e103f12edb25199d4d11e"
 
@@ -25,8 +25,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 commandSuffixes=(3.8 "" 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}

--- a/dev-python/html5-parser/html5_parser-0.4.10.recipe
+++ b/dev-python/html5-parser/html5_parser-0.4.10.recipe
@@ -13,7 +13,7 @@ COPYRIGHT="2017 Kovid Goyal
 	2015-2016 Kevin B. Hendricks, Stratford Ontario
 	2008-2009 Bjoern Hoehrmann"
 LICENSE="Apache v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/h/html5-parser/html5-parser-$portVersion.tar.gz"
 CHECKSUM_SHA256="f9294418c0da95c2d5facc19d3dc32941093a6b8e3b3e4b36cc7b5a1697fbca4"
 SOURCE_DIR="html5-parser-$portVersion"
@@ -37,8 +37,8 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/html5lib/html5lib-1.0.1.recipe
+++ b/dev-python/html5lib/html5lib-1.0.1.recipe
@@ -5,7 +5,7 @@ all major web browsers."
 HOMEPAGE="https://github.com/html5lib"
 COPYRIGHT="2006-2017 James Graham and other contributors"
 LICENSE="MIT"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://github.com/html5lib/html5lib-python/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="fabbebd6a55d07842087f13849076eeed350aa8bb6c9ec840f6a6aba9388db06"
 SOURCE_DIR="html5lib-python-$portVersion"
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/httplib2/httplib2-0.20.4.recipe
+++ b/dev-python/httplib2/httplib2-0.20.4.recipe
@@ -4,7 +4,7 @@ libraries."
 HOMEPAGE="https://github.com/httplib2/httplib2/"
 COPYRIGHT="2006-2022 Joe Gregorio"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="$HOMEPAGE/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="a6d079ae974ae408ac57d61aa2eee1d3be2cb250ae31d60507f1ecd2c6ca3002"
 SOURCE_FILENAME="httplib2-v$portVersion.tar.gz"
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/hyperlink/hyperlink-21.0.0.recipe
+++ b/dev-python/hyperlink/hyperlink-21.0.0.recipe
@@ -14,7 +14,7 @@ COPYRIGHT="2017 Glyph Lefkowitz
 	Wilfredo Sanchez Vega et all"
 LICENSE="MIT
 	Public Domain"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="$HOMEPAGE/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="6fdef854115f413e5d8a0241e1e67e93f0bd29c1d1317a742f3fdb189e1d57b5"
 
@@ -31,8 +31,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/idna/idna-3.3.recipe
+++ b/dev-python/idna/idna-3.3.recipe
@@ -4,7 +4,7 @@ DESCRIPTION="Support for the Internationalised Domain Names in Applications \
 HOMEPAGE="https://pypi.python.org/pypi/idna"
 COPYRIGHT="2013-2021 Kim Davies"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.io/packages/source/i/idna/idna-$portVersion.tar.gz"
 CHECKSUM_SHA256="9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
 
@@ -21,8 +21,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/ifaddr/ifaddr-0.1.7.recipe
+++ b/dev-python/ifaddr/ifaddr-0.1.7.recipe
@@ -4,7 +4,7 @@ the IP addresses of the computer."
 HOMEPAGE="https://github.com/pydron/ifaddr/"
 COPYRIGHT="2014 Stefan C. Mueller"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/pydron/ifaddr/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="e72a677a66411bfd2ca2157f8adbf27ad59ed36f6185365b263d7bb475a6240c"
 SOURCE_FILENAME="ifaddr-$portVersion.tar.gz"
@@ -21,8 +21,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[i]}

--- a/dev-python/importlib_metadata/importlib_metadata-4.6.1.recipe
+++ b/dev-python/importlib_metadata/importlib_metadata-4.6.1.recipe
@@ -6,7 +6,7 @@ by PyPA tools (or other conforming packages). It does not support:
 HOMEPAGE="https://pypi.python.org/pypi/importlib-metadata"
 COPYRIGHT="2017-2021 Jason R. Coombs, Barry Warsaw"
 LICENSE="Apache v2"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://files.pythonhosted.org/packages/a7/08/c5f2e6193c12ceb5b5048d579e8f1f82c9957b57427da808c15b44479dec/importlib_metadata-4.6.1.tar.gz"
 CHECKSUM_SHA256="079ada16b7fc30dfbb5d13399a5113110dab1aa7c2bc62f66af75f0b717c8cac"
 
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/importlib_resources/importlib_resources-5.4.0.recipe
+++ b/dev-python/importlib_resources/importlib_resources-5.4.0.recipe
@@ -6,7 +6,7 @@ consistent semantics."
 HOMEPAGE="https://pypi.python.org/pypi/importlib-resources"
 COPYRIGHT="2017-2019 Brett Cannon, Barry Warsaw"
 LICENSE="Apache v2"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://pypi.python.org/packages/source/i/importlib_resources/importlib_resources-$portVersion.tar.gz"
 CHECKSUM_SHA256="d756e2f85dd4de2ba89be0b21dba2a3bbec2e871a42a3a16719258a11f87506b"
 
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/incremental/incremental-21.3.0.recipe
+++ b/dev-python/incremental/incremental-21.3.0.recipe
@@ -54,7 +54,7 @@ COPYRIGHT="2001-2015
 	Tom Prince
 	Travis B. Hartwell"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="$HOMEPAGE/archive/refs/tags/incremental-$portVersion.tar.gz"
 CHECKSUM_SHA256="57b6a0785f265ffe59a454276efac1062943bb5b7bff7b5505bf054a563c22c4"
 SOURCE_DIR="incremental-incremental-$portVersion"
@@ -72,8 +72,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/iniconfig/iniconfig-1.1.1.recipe
+++ b/dev-python/iniconfig/iniconfig-1.1.1.recipe
@@ -13,7 +13,7 @@ HOMEPAGE="https://pypi.org/project/iniconfig/
 	http://github.com/RonnyPfannschmidt/iniconfig/"
 COPYRIGHT="2010-2020 Holger Krekel and Ronny Pfannschmidt"
 LICENSE="MIT"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://github.com/RonnyPfannschmidt/iniconfig/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="a4489e91242e035cb58700d9a3c4bf49e0b106a85fefefe48025e333ea5ee49c"
 
@@ -30,8 +30,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/installer/installer-0.7.0.recipe
+++ b/dev-python/installer/installer-0.7.0.recipe
@@ -10,7 +10,7 @@ wheels.
 HOMEPAGE="https://pypi.org/project/installer/"
 COPYRIGHT="2020 Pradyun Gedam"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.io/packages/source/i/installer/installer-$portVersion.tar.gz"
 CHECKSUM_SHA256="a26d3e3116289bb08216e0d0f7d925fcef0b0194eedfa0c944bcaaa106c4b631"
 
@@ -27,8 +27,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/jdtranslationhelper/jdtranslationhelper-2.1.recipe
+++ b/dev-python/jdtranslationhelper/jdtranslationhelper-2.1.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="With this lib you can translate your programs using .lang files"
 HOMEPAGE="https://gitlab.com/Jakobdev/jdTranslationHelper"
 COPYRIGHT="2019 JakobDev"
 LICENSE="BSD (2-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://gitlab.com/JakobDev/jdTranslationHelper/-/archive/$portVersion/jdTranslationHelper-$portVersion.tar.gz"
 CHECKSUM_SHA256="86be8fb6ca81505cc1e9fd393cab853867923b2ed01e1a06fa630ab877557d87"
 SOURCE_DIR="jdTranslationHelper-$portVersion"
@@ -21,8 +21,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/jinja/jinja-3.1.2.recipe
+++ b/dev-python/jinja/jinja-3.1.2.recipe
@@ -5,7 +5,7 @@ an optional \`sandboxed\`_ environment."
 HOMEPAGE="https://pypi.python.org/pypi/jinja2"
 COPYRIGHT="2022 the Jinja Team"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.io/packages/source/J/Jinja2/Jinja2-$portVersion.tar.gz"
 CHECKSUM_SHA256="31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"
 SOURCE_DIR="Jinja2-$portVersion"
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/kiwisolver/kiwisolver-1.3.1.recipe
+++ b/dev-python/kiwisolver/kiwisolver-1.3.1.recipe
@@ -8,7 +8,7 @@ with typical use cases gaining a 40x improvement. Memory savings are consistentl
 HOMEPAGE="https://github.com/nucleic/kiwi"
 COPYRIGHT="2018-2020, Nucleic team"
 LICENSE="BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/nucleic/kiwi/archive/refs/tags/$portVersion.tar.gz"
 CHECKSUM_SHA256="91d56ec628be2513a02c3721d4d8173416daf37c49423fe7a41a0e30c1101269"
 SOURCE_DIR="kiwi-$portVersion"
@@ -31,8 +31,8 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/lexicon/lexicon-2.0.1.recipe
+++ b/dev-python/lexicon/lexicon-2.0.1.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="Lexicon is a simple collection of dict sub-classes providing extra 
 HOMEPAGE="https://github.com/bitprophet/lexicon"
 COPYRIGHT="2020 Jeff Forcier"
 LICENSE="BSD (2-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="$HOMEPAGE/archive/refs/tags/$portVersion.tar.gz"
 CHECKSUM_SHA256="6b01123e824ee571ecfe45651d5cf6fece4709b439444c5915a83bbc8c4cbbb9"
 SOURCE_FILENAME="lexicon-$portVersion.tar.gz"
@@ -21,8 +21,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/lxml/lxml-4.9.1.recipe
+++ b/dev-python/lxml/lxml-4.9.1.recipe
@@ -13,7 +13,7 @@ LICENSE="BSD (3-clause)
 	ElementTree
 	GNU GPL v2
 	PSF-2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/lxml/lxml/releases/download/lxml-$portVersion/lxml-$portVersion.tar.gz"
 CHECKSUM_SHA256="fe749b052bb7233fe5d072fcb549221a8cb1a16725c47c37e42b0b9cb3ff2c3f"
 SOURCE_DIR="lxml-$portVersion"
@@ -39,31 +39,37 @@ BUILD_PREREQUIRES="
 	cmd:ld$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES+=(python38 python39 python310)
-PYTHON_VERSIONS+=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku$secondaryArchSuffix\n\
-	cmd:python$pythonVersion\n\
-	lib:libpython$pythonVersion$secondaryArchSuffix\n\
-	lib:libxml2$secondaryArchSuffix\n\
-	lib:libxslt$secondaryArchSuffix\n\
-	lib:libz$secondaryArchSuffix\
-	\""
-if [ "$targetArchitecture" = "x86_gcc2" ]; then
-	eval "PROVIDES_${pythonPackage}+=\"\n\
-		lxml_$pythonPackage = $portVersion\
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
 		\""
-fi
-BUILD_REQUIRES+="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES+="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_${pythonPackage}+=\"
+			lxml_$pythonPackage = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku$secondaryArchSuffix
+		cmd:python$pythonVersion
+		lib:libpython$pythonVersion$secondaryArchSuffix
+		lib:libxml2$secondaryArchSuffix
+		lib:libxslt$secondaryArchSuffix
+		lib:libz$secondaryArchSuffix
+		\""
+
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()

--- a/dev-python/mako/mako-1.2.2.recipe
+++ b/dev-python/mako/mako-1.2.2.recipe
@@ -11,7 +11,7 @@ also maintaining close ties to Python calling and scoping semantics."
 HOMEPAGE="http://www.makotemplates.org"
 COPYRIGHT="2006-2015 the Mako authors and contributors"
 LICENSE="MIT"
-REVISION="6"
+REVISION="7"
 SOURCE_URI="https://pypi.python.org/packages/source/M/Mako/Mako-$portVersion.tar.gz"
 CHECKSUM_SHA256="3724869b363ba630a272a5f89f68c070352137b8fd1757650017b7e06fda163f"
 SOURCE_DIR="Mako-$portVersion"
@@ -29,8 +29,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/markdown-math/markdown_math-0.8.recipe
+++ b/dev-python/markdown-math/markdown_math-0.8.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="This extension adds math formulas support to Python-Markdown."
 HOMEPAGE="https://github.com/mitya57/python-markdown-math/"
 COPYRIGHT="2015-2017 Dmitry Shachnev"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/p/python-markdown-math/python-markdown-math-$portVersion.tar.gz"
 CHECKSUM_SHA256="8564212af679fc18d53f38681f16080fcd3d186073f23825c7ce86fadd3e3635"
 SOURCE_DIR="python-markdown-math-$portVersion"
@@ -21,8 +21,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/markdown/markdown-3.1.1.recipe
+++ b/dev-python/markdown/markdown-3.1.1.recipe
@@ -8,7 +8,7 @@ COPYRIGHT="2007, 2008 The Python Markdown Project
 	2004, 2005, 2006 Yuri Takhteyev
 	2004 Manfred Stienstra"
 LICENSE="BSD (3-clause)"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/M/Markdown/Markdown-$portVersion.tar.gz"
 CHECKSUM_SHA256="2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a"
 SOURCE_DIR="Markdown-$portVersion"
@@ -26,8 +26,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 commandSuffixes=(3.8 "" 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}

--- a/dev-python/markups/markups-3.1.3.recipe
+++ b/dev-python/markups/markups-3.1.3.recipe
@@ -7,7 +7,7 @@ HOMEPAGE="http://python-requests.org/
 	http://pypi.python.org/pypi/markups"
 COPYRIGHT="2012-2015 Dmitry Shachnev"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/M/Markups/Markups-$portVersion.tar.gz"
 CHECKSUM_SHA256="ab9747a72c1c6457418eb4276c79871977c13a654618e4f12e2a1f0990fbf2fc"
 SOURCE_DIR="Markups-$portVersion"
@@ -25,8 +25,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/markupsafe/markupsafe-1.1.1.recipe
+++ b/dev-python/markupsafe/markupsafe-1.1.1.recipe
@@ -4,7 +4,7 @@ for Python."
 HOMEPAGE="https://pypi.org/project/MarkupSafe/"
 COPYRIGHT="2019 Armin Ronacher and contributors"
 LICENSE="BSD (3-clause)"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://github.com/pallets/markupsafe/archive/1.1.1.tar.gz"
 CHECKSUM_SHA256="222a10e3237d92a9cd45ed5ea882626bc72bc5e0264d3ed0f2c9129fa69fc167"
 SOURCE_FILENAME="markupsafe-$portVersion.tag.gz"
@@ -25,8 +25,8 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	cmd:gcc
 	"
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/mccabe/mccabe-0.7.0.recipe
+++ b/dev-python/mccabe/mccabe-0.7.0.recipe
@@ -7,7 +7,7 @@ COPYRIGHT="<year> Ned Batchelder
 	2011-2013 Tarek Ziade
 	2013 Florent Xicluna"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="$HOMEPAGE/archive/refs/tags/$portVersion.tar.gz"
 CHECKSUM_SHA256="f4f7fa5ed8b7f77601fea3e748d6238928323a291fcde0fddbbe6cb2d0cb2da2"
 
@@ -24,8 +24,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/mechanize/mechanize-0.4.5.recipe
+++ b/dev-python/mechanize/mechanize-0.4.5.recipe
@@ -22,7 +22,7 @@ COPYRIGHT="2002-2010 John J. Lee
 	1997-1999 Johnny Lee
 	2003 Andy Lester"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/python-mechanize/mechanize/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="08515f36d315566b256888bbe50e3587293397028c45b5289f3e38fede3c574f"
 
@@ -39,8 +39,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/meson-python/meson_python-0.13.1.recipe
+++ b/dev-python/meson-python/meson_python-0.13.1.recipe
@@ -11,7 +11,7 @@ HOMEPAGE="https://github.com/mesonbuild/meson-python"
 COPYRIGHT="2022 The meson-python developers
 	2021 Quansight Labs and Filipe Laíns"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="$HOMEPAGE/archive/refs/tags/$portVersion.tar.gz"
 CHECKSUM_SHA256="1637fc6b69b0b3152f5998fa0a6acfb4733c6ec246ea1e811e75e9ba8a53a64c"
 SOURCE_DIR="meson-python-$portVersion"
@@ -29,8 +29,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/mock/mock-4.0.3.recipe
+++ b/dev-python/mock/mock-4.0.3.recipe
@@ -14,7 +14,7 @@ testing, particularly monkey patching."
 HOMEPAGE="http://pypi.python.org/pypi/mock"
 COPYRIGHT="2003-2012, Michael Foord"
 LICENSE="BSD (2-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://pypi.python.org/packages/source/m/mock/mock-$portVersion.tar.gz"
 CHECKSUM_SHA256="7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc"
 
@@ -31,8 +31,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/more-itertools/more_itertools-8.14.0.recipe
+++ b/dev-python/more-itertools/more_itertools-8.14.0.recipe
@@ -6,7 +6,7 @@ for working with Python iterables."
 HOMEPAGE="https://pypi.python.org/pypi/more-itertools"
 COPYRIGHT="2012 Erik Rose"
 LICENSE="MIT"
-REVISION="4"
+REVISION="5"
 pypiVersion="0b/ff/1ad78678bee731ae5414ea5e97396b3f91de32186028daa614d322ac5a8b"
 SOURCE_URI="https://files.pythonhosted.org/packages/$pypiVersion/more_itertools-$portVersion-py3-none-any.whl#noarchive"
 CHECKSUM_SHA256="1bc4f91ee5b1b31ac7ceacc17c09befe6a40a503907baf9c839c229b5095cfd2"
@@ -24,8 +24,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/msgpack/msgpack-1.0.3.recipe
+++ b/dev-python/msgpack/msgpack-1.0.3.recipe
@@ -7,7 +7,7 @@ HOMEPAGE="https://github.com/msgpack/msgpack-python/
 	https://pypi.org/project/msgpack/"
 COPYRIGHT="2007-2021 Ian Bicking and contributors"
 LICENSE="Apache v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/msgpack/msgpack-python/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="576a1835a8b48d5861c883a6e10fd374065c6ae56287b221d1a4791e9529c71c"
 SOURCE_DIR="msgpack-python-$portVersion"
@@ -25,8 +25,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/multidict/multidict-4.5.2.recipe
+++ b/dev-python/multidict/multidict-4.5.2.recipe
@@ -4,7 +4,7 @@ might be occurred more than once in the container."
 HOMEPAGE="https://pypi.python.org/pypi/multidict"
 COPYRIGHT="2016-2017 Andrew Svetlov"
 LICENSE="MIT"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://pypi.io/packages/source/m/multidict/multidict-$portVersion.tar.gz"
 CHECKSUM_SHA256="024b8129695a952ebd93373e45b5d341dbb87c17ce49637b34000093f243dd4f"
 
@@ -25,8 +25,8 @@ BUILD_PREREQUIRES="
 	gcc$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/mutagen/mutagen-1.45.1.recipe
+++ b/dev-python/mutagen/mutagen-1.45.1.recipe
@@ -9,7 +9,7 @@ Ogg streams on an individual packet/page level."
 HOMEPAGE="https://github.com/quodlibet/mutagen"
 COPYRIGHT="Joe Wreschnig, Michael Urman, Lukáš Lalinský, Christoph Reiter, Ben Ockmore & others"
 LICENSE="GNU GPL v2"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/m/$portName/$portName-$portVersion.tar.gz"
 CHECKSUM_SHA256="6397602efb3c2d7baebd2166ed85731ae1c1d475abca22090b7141ff5034b3e1"
 SOURCE_DIR="mutagen-$portVersion"
@@ -27,8 +27,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 commandSuffixes=(3.8 "" 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}

--- a/dev-python/networkx/networkx-2.5.recipe
+++ b/dev-python/networkx/networkx-2.5.recipe
@@ -4,7 +4,7 @@ study of the structure, dynamics, and functions of complex networks."
 HOMEPAGE="https://networkx.github.io/"
 COPYRIGHT="2004-2018 NetworkX Developers"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/networkx/networkx/archive/networkx-$portVersion.tar.gz"
 CHECKSUM_SHA256="db3adff2eaf91d4eba16268504ef12bed920d4dc2bd5e1e3812d8fd11d166a73"
 SOURCE_DIR="networkx-networkx-$portVersion"
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/node-semver/node_semver-0.8.1.recipe
+++ b/dev-python/node-semver/node_semver-0.8.1.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="node-semver, python version of *node-semver* https://github.com/isa
 HOMEPAGE="https://github.com/podhmo/python-node-semver"
 COPYRIGHT="2016 podhmo"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://files.pythonhosted.org/packages/e7/4a/559f42d01f1ed75a94ee8afc77dc4bec9b062b808b2cf266352278811444/node-semver-$portVersion.tar.gz"
 CHECKSUM_SHA256="281600d009606f4f63ddcbe148992e235b39a69937b9c20359e2f4a2adbb1e00"
 SOURCE_DIR="node-semver-$portVersion"
@@ -21,8 +21,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/nose/nose-1.3.7.recipe
+++ b/dev-python/nose/nose-1.3.7.recipe
@@ -16,7 +16,7 @@ HOMEPAGE="https://readthedocs.io/docs/nose/
 	https://github.com/nose-devs/nose"
 COPYRIGHT="2008-2010 anatoly techtonik"
 LICENSE="GNU LGPL v2.1"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://pypi.io/packages/source/n/nose/nose-$portVersion.tar.gz"
 CHECKSUM_SHA256="f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98"
 PATCHES="
@@ -48,8 +48,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 defaultVersion=3.9
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}

--- a/dev-python/numpy/numpy-1.23.3.recipe
+++ b/dev-python/numpy/numpy-1.23.3.recipe
@@ -9,7 +9,7 @@ general-purpose data-base applications."
 HOMEPAGE="https://www.numpy.org/"
 COPYRIGHT="2005-2021 Travis E. Oliphant et al."
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/numpy/numpy/releases/download/v$portVersion/numpy-$portVersion.tar.gz"
 CHECKSUM_SHA256="51bf49c0cd1d52be0a240aa66f3458afc4b95d8993d2d04f0d91fa60c10af6cd"
 SOURCE_DIR="numpy-$portVersion"
@@ -44,8 +44,8 @@ BUILD_REQUIRES="
 #	devel:libumfpack$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/packaging/packaging-23.0.recipe
+++ b/dev-python/packaging/packaging-23.0.recipe
@@ -4,7 +4,7 @@ version handling, specifiers, markers, requirements, tags, utilities."
 HOMEPAGE="https://pypi.python.org/pypi/packaging"
 COPYRIGHT="2014-2021 Donald Stufft and individual contributors"
 LICENSE="Apache v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.io/packages/source/${portName:0:1}/$portName/$portName-$portVersion.tar.gz"
 CHECKSUM_SHA256="b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"
 
@@ -21,8 +21,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pandas/pandas-1.3.2.recipe
+++ b/dev-python/pandas/pandas-1.3.2.recipe
@@ -9,7 +9,7 @@ COPYRIGHT="2008-2012 AQR Capital Management, LLC
 	Lambda Foundry, Inc.
 	PyData Development Team"
 LICENSE="BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/p/pandas/pandas-$portVersion.tar.gz"
 CHECKSUM_SHA256="cbcb84d63867af3411fa063af3de64902665bb5b3d40b25b2059e40603594e87"
 
@@ -33,8 +33,8 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/parameterized/parameterized-0.8.1.recipe
+++ b/dev-python/parameterized/parameterized-0.8.1.recipe
@@ -4,7 +4,7 @@ parameterized testing for py.test, parameterized testing for unittest."
 HOMEPAGE="https://github.com/wolever/parameterized"
 COPYRIGHT="2010 David Wolever"
 LICENSE="BSD (2-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.io/packages/source/p/parameterized/parameterized-$portVersion.tar.gz"
 CHECKSUM_SHA256="41bbff37d6186430f77f900d777e5bb6a24928a1c46fb1de692f8b52b8833b5c"
 
@@ -20,8 +20,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[i]}

--- a/dev-python/patch-ng/patch_ng-1.17.4.recipe
+++ b/dev-python/patch-ng/patch_ng-1.17.4.recipe
@@ -37,7 +37,7 @@ HOMEPAGE="https://github.com/conan-io/python-patch-ng"
 COPYRIGHT="2019-2020 Uilian Ries
 	2008-2019 Anatoly Techtonik"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="$HOMEPAGE/archive/refs/tags/$portVersion.tar.gz"
 CHECKSUM_SHA256="e332ea2c2e64e95b988c6e904a51be65b80560518a9b101c604a1a4378673795"
 SOURCE_DIR="python-patch-ng-$portVersion"
@@ -55,8 +55,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pathtools/pathtools-0.1.2.recipe
+++ b/dev-python/pathtools/pathtools-0.1.2.recipe
@@ -6,7 +6,7 @@ HOMEPAGE="http://python-requests.org/
 	http://pypi.python.org/pypi/requests"
 COPYRIGHT="2010 Yesudeep Mangalapilly"
 LICENSE="MIT"
-REVISION="6"
+REVISION="7"
 SOURCE_URI="https://pypi.python.org/packages/source/p/pathtools/pathtools-$portVersion.tar.gz"
 CHECKSUM_SHA256="7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0"
 
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pep517/pep517-0.12.0.recipe
+++ b/dev-python/pep517/pep517-0.12.0.recipe
@@ -12,7 +12,7 @@ are defined."
 HOMEPAGE="https://pypi.org/project/pep517/"
 COPYRIGHT="2017 Thomas Kluyver"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 pypiVersion="0a/65/6e656d49c679136edfba25f25791f45ffe1ea4ae2ec1c59fe9c35e061cd1"
 SOURCE_URI="https://files.pythonhosted.org/packages/$pypiVersion/pep517-0.12.0.tar.gz"
 CHECKSUM_SHA256="931378d93d11b298cf511dd634cf5ea4cb249a28ef84160b3247ee9afb4e8ab0"
@@ -30,8 +30,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pep8/pep8-1.7.1.recipe
+++ b/dev-python/pep8/pep8-1.7.1.recipe
@@ -4,7 +4,7 @@ PEP 8_."
 HOMEPAGE="https://pypi.org/project/pep8/"
 COPYRIGHT="2017 Ian Lee"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 pypiVersion="64ba19519db49e4094d82599412a9660dee8c26a7addbbb1bf17927ceefe"
 SOURCE_URI="https://files.pythonhosted.org/packages/01/a0/$pypiVersion/pep8-$portVersion.tar.gz"
 CHECKSUM_SHA256="fe249b52e20498e59e0b5c5256aa52ee99fc295b26ec9eaa85776ffdb9fe6374"
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pillow/pillow-9.2.0.recipe
+++ b/dev-python/pillow/pillow-9.2.0.recipe
@@ -7,7 +7,7 @@ COPYRIGHT="1997-2011 by Secret Labs AB
 	1995-2011 by Fredrik Lundh
 	2010-2022 by Alex Clark and contributors"
 LICENSE="HPND"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/python-pillow/Pillow/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="95836f00972dbf724bf1270178683a0ac4ea23c6c3a980858fc9f2f9456e32ef"
 SOURCE_FILENAME="pillow-$portVersion.tar.gz"
@@ -40,8 +40,8 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pkgconfig/python_pkgconfig-1.5.5.recipe
+++ b/dev-python/pkgconfig/python_pkgconfig-1.5.5.recipe
@@ -4,7 +4,7 @@ Python 3.3+."
 HOMEPAGE="https://pypi.org/project/pkgconfig/"
 COPYRIGHT="201-2021 Mathias Vogelgesang"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.python.org/packages/source/p/pkgconfig/pkgconfig-$portVersion.tar.gz"
 CHECKSUM_SHA256="deb4163ef11f75b520d822d9505c1f462761b4309b1bb713d08689759ea8b899"
 SOURCE_DIR="pkgconfig-$portVersion"
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/ply/ply-3.11.recipe
+++ b/dev-python/ply/ply-3.11.recipe
@@ -13,7 +13,7 @@ HOMEPAGE="https://www.dabeaz.com/ply/
 	https://pypi.org/project/ply/"
 COPYRIGHT="2006-2018 David Beazley"
 LICENSE="BSD (3-clause)"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://pypi.io/packages/source/p/ply/ply-$portVersion.tar.gz"
 CHECKSUM_SHA256="00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"
 
@@ -30,8 +30,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/polib/polib-1.1.0.recipe
+++ b/dev-python/polib/polib-1.1.0.recipe
@@ -6,7 +6,7 @@ files from scratch."
 HOMEPAGE="https://pypi.org/project/polib/"
 COPYRIGHT="2006-2015 David Jean Louis."
 LICENSE="MIT"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://pypi.python.org/packages/source/p/polib/polib-$portVersion.tar.gz"
 CHECKSUM_SHA256="fad87d13696127ffb27ea0882d6182f1a9cf8a5e2b37a587751166c51e5a332a"
 
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pretend/pretend-1.0.9.recipe
+++ b/dev-python/pretend/pretend-1.0.9.recipe
@@ -5,7 +5,7 @@ HOMEPAGE="https://github.com/alex/pretend
 	https://pypi.org/project/pretend/"
 COPYRIGHT="2012-2018 Alex Gaynor and individual contributors"
 LICENSE="BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/p/pretend/pretend-$portVersion.tar.gz"
 CHECKSUM_SHA256="c90eb810cde8ebb06dafcb8796f9a95228ce796531bc806e794c2f4649aa1b10"
 
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pyasn1-modules/pyasn1_modules-0.2.8.recipe
+++ b/dev-python/pyasn1-modules/pyasn1_modules-0.2.8.recipe
@@ -5,7 +5,7 @@ data structures (X.509, PKCS etc.)."
 HOMEPAGE="https://pypi.org/project/pyasn1-modules/"
 COPYRIGHT="2011-2019 Ilya Etingof "
 LICENSE="BSD (2-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://pypi.io/packages/source/p/pyasn1-modules/pyasn1-modules-$portVersion.tar.gz"
 SOURCE_DIR="pyasn1-modules-$portVersion"
 CHECKSUM_SHA256="905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e"
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pyasn1/pyasn1-0.4.8.recipe
+++ b/dev-python/pyasn1/pyasn1-0.4.8.recipe
@@ -6,7 +6,7 @@ HOMEPAGE="http://snmplabs.com/pyasn1/
 	https://pypi.org/project/pyasn1"
 COPYRIGHT="2007-2018 Ilya Etingof"
 LICENSE="BSD (2-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/p/pyasn1/pyasn1-$portVersion.tar.gz"
 CHECKSUM_SHA256="aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"
 
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pybind11/pybind11-2.11.1.recipe
+++ b/dev-python/pybind11/pybind11-2.11.1.recipe
@@ -8,7 +8,7 @@ by inferring type information using compile-time introspection."
 HOMEPAGE="https://pypi.org/project/pybind11/"
 COPYRIGHT="2015-2023 Wenzel Jakob"
 LICENSE="BSD (2-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/pybind/pybind11/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="d475978da0cdc2d43b73f30910786759d593a9d8ee05b1b6846d1eb16c6d2e0c"
 SOURCE_FILENAME="pybind11-v$portVersion.tar.gz"
@@ -23,8 +23,8 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 defaultVersion=3.10
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}

--- a/dev-python/pycairo/pycairo-1.24.0.recipe
+++ b/dev-python/pycairo/pycairo-1.24.0.recipe
@@ -4,7 +4,7 @@ and to deviate only in cases which are clearly better implemented in a more ‘P
 HOMEPAGE="https://pypi.org/project/pycairo/"
 COPYRIGHT="2023 pycairo developers"
 LICENSE="GNU LGPL v2.1"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/pygobject/pycairo/releases/download/v$portVersion/pycairo-$portVersion.tar.gz"
 CHECKSUM_SHA256="1444d52f1bb4cc79a4a0c0fe2ccec4bd78ff885ab01ebe1c0f637d8392bcafb6"
 
@@ -31,8 +31,8 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pycodestyle/pycodestyle-2.9.1.recipe
+++ b/dev-python/pycodestyle/pycodestyle-2.9.1.recipe
@@ -14,7 +14,7 @@ COPYRIGHT="2006-2009 Johann C. Rocholl
 	2009-2014 Florent Xicluna
 	2014-2020 Ian Lee"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 pypiVersion="b6/83/5bcaedba1f47200f0665ceb07bcb00e2be123192742ee0edfb66b600e5fd"
 SOURCE_URI="https://files.pythonhosted.org/packages/$pypiVersion/pycodestyle-$portVersion.tar.gz"
 CHECKSUM_SHA256="2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785"
@@ -32,8 +32,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pycparser/pycparser-2.21.recipe
+++ b/dev-python/pycparser/pycparser-2.21.recipe
@@ -5,7 +5,7 @@ source code."
 HOMEPAGE="https://github.com/eliben/pycparser"
 COPYRIGHT="2008-2018 Eli Bendersky"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/eliben/pycparser/archive/release_v$portVersion.tar.gz"
 CHECKSUM_SHA256="3c797eb2eb1ba57772bb99ffa7caed23c3a2c2ae58daef114c9b09d3a6da97e2"
 SOURCE_FILENAME="pycparser-$portVersion.tar.gz"
@@ -24,8 +24,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pycrypto/pycrypto-2.6.1.recipe
+++ b/dev-python/pycrypto/pycrypto-2.6.1.recipe
@@ -7,7 +7,7 @@ etc.).
 HOMEPAGE="http://pypi.python.org/pypi/pycrypto/2.6"
 LICENSE="pycrypto"
 COPYRIGHT="2010 Dwayne C. Litzenberger"
-REVISION="6"
+REVISION="7"
 SOURCE_URI="https://pypi.python.org/packages/source/p/pycrypto/pycrypto-$portVersion.tar.gz"
 CHECKSUM_SHA256="f2ce1e989b272cfcb677616763e0a2e7ec659effa67a88aa92b3a65528f60a3c"
 
@@ -29,8 +29,8 @@ BUILD_PREREQUIRES="
 	cmd:awk
 	cmd:cc$secondaryArchSuffix
 	"
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pyenchant/pyenchant-3.2.2.recipe
+++ b/dev-python/pyenchant/pyenchant-3.2.2.recipe
@@ -5,7 +5,7 @@ information, visit the project website."
 HOMEPAGE="http://pyenchant.github.io/pyenchant/"
 COPYRIGHT="2020 Dimitri Merejkowsky"
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/pyenchant/pyenchant/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="dd107d7a51b77277d7605dd6df113e818efe9c7ac10ea03aadf65055edef1c04"
 
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pyflakes/pyflakes-2.5.0.recipe
+++ b/dev-python/pyflakes/pyflakes-2.5.0.recipe
@@ -4,7 +4,7 @@ HOMEPAGE="https://github.com/PyCQA/pyflakes"
 COPYRIGHT="2005-2011 Divmod, Inc.
 	2013-2014 Florent Xicluna"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="$HOMEPAGE/archive/refs/tags/$portVersion.tar.gz"
 CHECKSUM_SHA256="0b71a63ab57f5cc9c4a3032460b850da86af8afc63b1888f77527d98b5323a37"
 
@@ -21,8 +21,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pygments/pygments-2.14.0.recipe
+++ b/dev-python/pygments/pygments-2.14.0.recipe
@@ -14,7 +14,7 @@ ANSI sequences
 HOMEPAGE="https://pygments.org/"
 COPYRIGHT="2006-2023 by the Pygments team"
 LICENSE="BSD (2-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.org/packages/source/P/Pygments/Pygments-$portVersion.tar.gz"
 CHECKSUM_SHA256="b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297"
 SOURCE_DIR="Pygments-$portVersion"
@@ -32,8 +32,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 commandSuffixes=(3.8 "" 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}

--- a/dev-python/pyjwt/pyjwt-2.4.0.recipe
+++ b/dev-python/pyjwt/pyjwt-2.4.0.recipe
@@ -7,7 +7,7 @@ securely between two parties.
 HOMEPAGE="https://github.com/harlowja/fasteners"
 LICENSE="MIT"
 COPYRIGHT="2014-2022 Jose Padilla, 2011-2014 Jeff Lindsay"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.python.org/packages/source/P/PyJWT/PyJWT-$portVersion.tar.gz"
 CHECKSUM_SHA256="d42908208c699b3b973cbeb01a969ba6a96c821eefb1c5bfe4c390c01d67abba"
 SOURCE_DIR="PyJWT-$portVersion"
@@ -25,8 +25,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pymupdf/pymupdf-1.20.2.recipe
+++ b/dev-python/pymupdf/pymupdf-1.20.2.recipe
@@ -10,7 +10,7 @@ HOMEPAGE="https://pypi.org/project/PyMuPDF/
 	https://github.com/pymupdf/PyMuPDF/"
 COPYRIGHT="2022 Jorj X. McKie and Ruikai Liu"
 LICENSE="AGPL-3.0"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/pymupdf/PyMuPDF/archive/refs/tags/$portVersion.tar.gz"
 CHECKSUM_SHA256="e639e5190067bc3ff599ffb09bfad7da0165c0098fe42ddc1a849715904b0ee0"
 SOURCE_FILENAME="PyMuPDF-$portVersion.tar.gz"
@@ -38,8 +38,8 @@ BUILD_PREREQUIRES="
 	cmd:git
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pyopenssl/pyopenssl-22.0.0.recipe
+++ b/dev-python/pyopenssl/pyopenssl-22.0.0.recipe
@@ -10,7 +10,7 @@ HOMEPAGE="https://github.com/pyca/pyopenssl
 COPYRIGHT="2008-2022 The pyOpenSSL developers"
 LICENSE="Apache v2
 	BSD (3-clause)"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://github.com/pyca/pyopenssl/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="4e92f6c2f08a8d1f0d9695335037a3d50ef8f58cd326514b89104acb9abb2838"
 SOURCE_FILENAME="pyopenssl-$portVersion.tar.gz"
@@ -28,8 +28,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pypandoc/pypandoc-1.11.recipe
+++ b/dev-python/pypandoc/pypandoc-1.11.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="thin wrapper for pandoc, a universal document converter"
 HOMEPAGE="https://pypi.org/project/pypandoc/"
 COPYRIGHT="2011-2017 Juho Vepsäläinen"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.io/packages/source/p/pypandoc/pypandoc-$portVersion.tar.gz"
 CHECKSUM_SHA256="7f6d68db0e57e0f6961bec2190897118c4d305fc2d31c22cd16037f22ee084a5"
 
@@ -20,8 +20,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pyparsing/pyparsing-3.0.7.recipe
+++ b/dev-python/pyparsing/pyparsing-3.0.7.recipe
@@ -7,7 +7,7 @@ Python code."
 HOMEPAGE="https://pypi.python.org/pypi/pyparsing"
 COPYRIGHT="2003-2022 Paul T. McGuire"
 LICENSE="MIT"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/pyparsing/pyparsing/archive/pyparsing_$portVersion.tar.gz"
 CHECKSUM_SHA256="9303df2c7998485cc71a246c6cc0489c48ad571adc9d250c2d1314c47768ba59"
 SOURCE_DIR="pyparsing-pyparsing_$portVersion"
@@ -25,8 +25,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pypeg2/pypeg2-2.15.2.recipe
+++ b/dev-python/pypeg2/pypeg2-2.15.2.recipe
@@ -8,7 +8,7 @@ And pyPEG supports Unicode."
 HOMEPAGE="https://pypi.python.org/pypi/pypeg2"
 COPYRIGHT="2009-2014 Volker Birk"
 LICENSE="GNU GPL v2"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://pypi.io/packages/source/p/pyPEG2/pyPEG2-$portVersion.tar.gz"
 CHECKSUM_SHA256="2b2d4f80d8e1a9370b2a91f4a25f4abf7f69b85c8da84cd23ec36451958a1f6d"
 SOURCE_DIR="pyPEG2-$portVersion"
@@ -26,8 +26,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pyproject-metadata/pyproject_metadata-0.7.1.recipe
+++ b/dev-python/pyproject-metadata/pyproject_metadata-0.7.1.recipe
@@ -8,7 +8,7 @@ validate this input and generate a PEP 643-compliant metadata file (e.g. *PKG-IN
 HOMEPAGE="https://github.com/FFY00/python-pyproject-metadata"
 COPYRIGHT="2019 Filipe Laíns"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.python.org/packages/source/p/pyproject-metadata/pyproject-metadata-$portVersion.tar.gz"
 CHECKSUM_SHA256="0a94f18b108b9b21f3a26a3d541f056c34edcb17dc872a144a15618fed7aef67"
 SOURCE_DIR="pyproject-metadata-$portVersion"
@@ -26,8 +26,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pyproject_hooks/pyproject_hooks-1.0.0.recipe
+++ b/dev-python/pyproject_hooks/pyproject_hooks-1.0.0.recipe
@@ -12,7 +12,7 @@ Note: The 'pep517' project has been replaced by this project (low level) and the
 HOMEPAGE="https://pypi.org/project/pyproject_hooks/"
 COPYRIGHT="2017 Thomas Kluyver"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/pypa/pyproject-hooks/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="d45c52f9af6bce94755eecf9dbfe6b3c89ef9a50088a8809f5bbec4ed0f9be0b"
 SOURCE_DIR="pyproject-hooks-$portVersion"
@@ -30,8 +30,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pyrfc3339/pyrfc3339-1.1.recipe
+++ b/dev-python/pyrfc3339/pyrfc3339-1.1.recipe
@@ -5,7 +5,7 @@ HOMEPAGE="https://github.com/kurtraschke/pyRFC3339
 	https://pypi.org/project/pyRFC3339/"
 COPYRIGHT="2011-2018 Kurt Raschke"
 LICENSE="MIT"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://pypi.io/packages/source/p/pyRFC3339/pyRFC3339-$portVersion.tar.gz"
 CHECKSUM_SHA256="81b8cbe1519cdb79bed04910dd6fa4e181faf8c88dff1e1b987b5f7ab23a5b1a"
 SOURCE_DIR="pyRFC3339-$portVersion"
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pyrsistent/pyrsistent-0.17.3.recipe
+++ b/dev-python/pyrsistent/pyrsistent-0.17.3.recipe
@@ -9,7 +9,7 @@ HOMEPAGE="https://pypi.org/project/pyrsistent/
 	https://github.com/tobgu/pyrsistent/"
 COPYRIGHT="2019 Tobias Gustafsson"
 LICENSE="MIT"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://pypi.org/packages/source/p/pyrsistent/pyrsistent-$portVersion.tar.gz"
 CHECKSUM_SHA256="2e636185d9eb976a18a8a8e96efce62f2905fea90041958d8cc2a189756ebf3e"
 
@@ -26,8 +26,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pyserial/pyserial-3.5~20211205.recipe
+++ b/dev-python/pyserial/pyserial-3.5~20211205.recipe
@@ -6,7 +6,7 @@ The module named "serial" automatically selects the appropriate backend."
 HOMEPAGE="https://github.com/pyserial/pyserial"
 COPYRIGHT="2001-2020 Chris Liechti"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 srcGitRev="31fa4807d73ed4eb9891a88a15817b439c4eea2d"
 SOURCE_URI="https://github.com/pyserial/pyserial/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="d77a5431db2d1d8e1c7d99bc2d736981c7ae9f73d0ffff9861be94589b1c14b3"
@@ -27,8 +27,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/python-distutils-extra/python_distutils_extra-2.47.recipe
+++ b/dev-python/python-distutils-extra/python_distutils_extra-2.47.recipe
@@ -4,7 +4,7 @@ based documentation into Python's distutils."
 HOMEPAGE="https://salsa.debian.org/python-team/packages/python-distutils-extra"
 COPYRIGHT="2022 Debian Python Team"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="$HOMEPAGE/-/archive/$portVersion/python-distutils-extra-$portVersion.tar.bz2"
 CHECKSUM_SHA256="bc8979d320d5b79016e65b5e598aa100f96ef04aeba0e389d4dfec7c4d9f6c15"
 SOURCE_DIR="python-distutils-extra-$portVersion"
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/python-graphviz/python_graphviz-0.20.1.recipe
+++ b/dev-python/python-graphviz/python_graphviz-0.20.1.recipe
@@ -15,7 +15,7 @@ Jupyter QtConsole_."
 HOMEPAGE="https://github.com/xflr6/graphviz"
 COPYRIGHT="2013-2022 Sebastian Bank"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="$HOMEPAGE/archive/refs/tags/$portVersion.tar.gz"
 CHECKSUM_SHA256="815346b8c2fcd8ccede29623a67bfc30abdbb75749e96128b9d414573d6d8f04"
 SOURCE_FILENAME="graphviz-$portVersion.tar.gz"
@@ -35,8 +35,8 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/python-ly/python_ly-0.9.7.recipe
+++ b/dev-python/python-ly/python_ly-0.9.7.recipe
@@ -10,7 +10,7 @@ Wilbert Berendsen."
 HOMEPAGE="https://github.com/frescobaldi/python-ly/"
 COPYRIGHT="2008-2015 Wilbert Berendsen"
 LICENSE="GNU GPL v2"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://pypi.io/packages/source/p/python-ly/python-ly-$portVersion.tar.gz"
 CHECKSUM_SHA256="d4d2b68eb0ef8073200154247cc9bd91ed7fb2671ac966ef3d2853281c15d7a8"
 SOURCE_FILENAME="python-ly-$portVersion.tar.gz"
@@ -28,8 +28,8 @@ REQUIRES="
 BUILD_REQUIRES="
 	haiku_devel
 	"
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 commandSuffixes=(38 "" 310)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}

--- a/dev-python/python-markdown-math/python_markdown_math-0.8.recipe
+++ b/dev-python/python-markdown-math/python_markdown_math-0.8.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="This extension adds math formulas support to [Python-Markdown]."
 HOMEPAGE="https://pypi.org/project/python-markdown-math/"
 COPYRIGHT="2015-2017 Dmitry Shachnev"
 LICENSE="BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 pyName="python-markdown-math"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/${pyName:0:1}/$pyName/$pyName-$portVersion.tar.gz"
 CHECKSUM_SHA256="8564212af679fc18d53f38681f16080fcd3d186073f23825c7ce86fadd3e3635"
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pythonzeroconf/pythonzeroconf-0.29.0.recipe
+++ b/dev-python/pythonzeroconf/pythonzeroconf-0.29.0.recipe
@@ -4,7 +4,7 @@ HOMEPAGE="https://github.com/jstasiak/python-zeroconf/"
 COPYRIGHT="2003 Paul Scott-Murphy
 	2014 William McBrine"
 LICENSE="GNU LGPL v2.1"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/jstasiak/python-zeroconf/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="b8e7c55f36973362314b7d8cf716a76afea3c91abe9d2f435329dc67b973fe06"
 SOURCE_FILENAME="zeroconf-$portVersion.tar.gz"
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[i]}

--- a/dev-python/pytz/pytz-2023.3.recipe
+++ b/dev-python/pytz/pytz-2023.3.recipe
@@ -6,7 +6,7 @@ HOMEPAGE="https://pythonhosted.org/pytz/
 	https://pypi.org/project/pytz/"
 COPYRIGHT="2003-2019 Stuart Bishop"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.io/packages/source/${portName:0:1}/$portName/$portName-$portVersion.tar.gz"
 CHECKSUM_SHA256="1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588"
 
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 defaultTestVersion="python39"
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}

--- a/dev-python/pyyaml/pyyaml-6.0.recipe
+++ b/dev-python/pyyaml/pyyaml-6.0.recipe
@@ -14,7 +14,7 @@ HOMEPAGE="https://pyyaml.org/"
 COPYRIGHT="2017-2021 Ingy döt Net
 	2006-2016 Kirill Simonov"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/yaml/pyyaml/archive/refs/tags/$portVersion.tar.gz"
 CHECKSUM_SHA256="f33eaba25d8e0c1a959bbf00655198c287dfc5868f5b7b01e401eaa1796cc778"
 SOURCE_FILENAME="pyyaml-$portVersion.tar.gz"
@@ -35,8 +35,8 @@ BUILD_PREREQUIRES="
 	cmd:gcc
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/pyzmq/pyzmq-18.1.0.recipe
+++ b/dev-python/pyzmq/pyzmq-18.1.0.recipe
@@ -5,7 +5,7 @@ This package contains Python bindings for ØMQ. \
 HOMEPAGE="https://zeromq.org/"
 COPYRIGHT="2009-2019, Brian Granger, Min Ragan-Kelley"
 LICENSE="GNU LGPL v3"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://github.com/zeromq/pyzmq/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="32f7618b8104021bc96cbd60be4330bdf37b929e8061dbce362c9f3478a08e21"
 
@@ -27,8 +27,8 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:pkg_config$secondaryArchSuffix
 	"
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/qrcode/qrcode-7.2.recipe
+++ b/dev-python/qrcode/qrcode-7.2.recipe
@@ -4,7 +4,7 @@ the generation of QR Codes."
 HOMEPAGE="https://github.com/lincolnloop/python-qrcode/"
 COPYRIGHT="2011 Lincoln Loop"
 LICENSE="BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/lincolnloop/python-qrcode/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="051935ae06d8180a5a2413192dd236fdc6a2f3da3ef04af682afbe9d5c3286f4"
 SOURCE_FILENAME="qrcode-v$portVersion.tar.gz"
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 defaultVersion=3.9
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}

--- a/dev-python/rdflib/rdflib-5.0.0.recipe
+++ b/dev-python/rdflib/rdflib-5.0.0.recipe
@@ -4,7 +4,7 @@ yet powerful language for representing information as graphs."
 HOMEPAGE="https://github.com/RDFLib/rdflib"
 COPYRIGHT="2002-2017 RDFLib Team"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.io/packages/source/r/rdflib/rdflib-$portVersion.tar.gz"
 CHECKSUM_SHA256="78149dd49d385efec3b3adfbd61c87afaf1281c30d3fcaf1b323b34f603fb155"
 
@@ -21,8 +21,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/regex/regex-2020.1.8.recipe
+++ b/dev-python/regex/regex-2020.1.8.recipe
@@ -4,7 +4,7 @@ standard ‘re’ module, but offers additional functionality."
 HOMEPAGE="https://pypi.org/project/regex/"
 COPYRIGHT="2013-2020 Matthew Barnett"
 LICENSE="MIT"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://pypi.org/packages/source/r/regex/regex-$portVersion.tar.gz"
 CHECKSUM_SHA256="d0f424328f9822b0323b3b6f2e4b9c90960b24743d220763c7f07071e0778351"
 
@@ -26,8 +26,8 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/reportlab/reportlab-3.6.9.recipe
+++ b/dev-python/reportlab/reportlab-3.6.9.recipe
@@ -9,7 +9,7 @@ HOMEPAGE="https://pypi.org/project/reportlab/
 	https://www.reportlab.com/"
 COPYRIGHT="2000-2021 ReportLab Europe Ltd."
 LICENSE="BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 pypi="81ff7e3f9fd345cd4685f964fbc3d89a06f39a4f552ab1c2a5769a0f9013"
 SOURCE_URI="https://files.pythonhosted.org/packages/16/31/$pypi/reportlab-$portVersion.tar.gz"
 CHECKSUM_SHA256="5d0cc3682456ad213150f6dbffe7d47eab737d809e517c316103376be548fb84"
@@ -35,8 +35,8 @@ BUILD_PREREQUIRES="
 	cmd:git
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/requests/requests-2.27.1.recipe
+++ b/dev-python/requests/requests-2.27.1.recipe
@@ -4,7 +4,7 @@ HOMEPAGE="http://python-requests.org/
 	http://pypi.python.org/pypi/requests"
 COPYRIGHT="2022 Kenneth Reitz"
 LICENSE="Apache v2"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://pypi.io/packages/source/${portName:0:1}/$portName/$portName-$portVersion.tar.gz"
 CHECKSUM_SHA256="68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"
 SOURCE_FILENAME="requests-$portVersion.tar.gz"
@@ -21,8 +21,8 @@ REQUIRES="
 BUILD_REQUIRES="
 	haiku_devel
 	"
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/scipy/scipy-1.6.3.recipe
+++ b/dev-python/scipy/scipy-1.6.3.recipe
@@ -11,7 +11,7 @@ HOMEPAGE="https://www.scipy.org/"
 COPYRIGHT=" 2001-2002 Enthought, Inc.
 	2003-2021 SciPy Developers"
 LICENSE="BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/scipy/scipy/releases/download/v$portVersion/scipy-$portVersion.tar.xz"
 CHECKSUM_SHA256="3851fdcb1e6877241c3377aa971c85af0d44f90c57f4dd4e54e1b2bbd742635e"
 SOURCE_DIR="scipy-$portVersion"
@@ -45,8 +45,8 @@ BUILD_REQUIRES="
 	devel:libumfpack$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/setuptools_scm/setuptools_scm-7.1.0.recipe
+++ b/dev-python/setuptools_scm/setuptools_scm-7.1.0.recipe
@@ -5,7 +5,7 @@ or in a SCM managed file."
 HOMEPAGE="https://github.com/pypa/setuptools_scm"
 COPYRIGHT="2015-2022 Ronny Pfannschmidt"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.io/packages/source/s/setuptools_scm/setuptools_scm-$portVersion.tar.gz"
 CHECKSUM_SHA256="6c508345a771aad7d56ebff0e70628bf2b0ec7573762be9960214730de278f27"
 
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/six/six-1.15.0.recipe
+++ b/dev-python/six/six-1.15.0.recipe
@@ -6,7 +6,7 @@ Python versions."
 HOMEPAGE="https://pypi.python.org/pypi/six"
 COPYRIGHT="2010-2018 Benjamin Peterson"
 LICENSE="MIT"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://pypi.io/packages/source/s/six/six-$portVersion.tar.gz"
 CHECKSUM_SHA256="30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"
 
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/smartypants/smartypants-2.0.1.recipe
+++ b/dev-python/smartypants/smartypants-2.0.1.recipe
@@ -7,7 +7,7 @@ COPYRIGHT="2003 John Gruber
 	2013-2016 Yu-Jie Lin
 	2004-2013 Chad Miller"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="$HOMEPAGE/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="b98191911ff3b4144ef8ad53e776a2d0ad24bd508a905c6ce523597c40022773"
 SOURCE_DIR="smartypants.py-$portVersion"
@@ -24,8 +24,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/smmap/smmap-3.0.5.recipe
+++ b/dev-python/smmap/smmap-3.0.5.recipe
@@ -11,7 +11,7 @@ not be enough for some applications."
 HOMEPAGE="https://pypi.org/project/smmap/"
 COPYRIGHT="2011-2015 Sebastian Thiel"
 LICENSE="BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://pypi.io/packages/source/s/smmap/smmap-$portVersion.tar.gz"
 CHECKSUM_SHA256="84c2751ef3072d4f6b2785ec7ee40244c6f45eb934d9e543e2c51f1bd3d54c50"
 
@@ -28,8 +28,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/soupsieve/soupsieve-1.9.5.recipe
+++ b/dev-python/soupsieve/soupsieve-1.9.5.recipe
@@ -7,7 +7,7 @@ and beyond (though some are not yet implemented)."
 HOMEPAGE="https://github.com/facelessuser/soupsieve"
 COPYRIGHT="2018 Isaac Muse"
 LICENSE="MIT"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://github.com/facelessuser/soupsieve/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="ba6a129e3e0e8ea5928684fd720f548eec65bc53947d9ac2b264dd2412d5cf55"
 SOURCE_FILENAME="$portName-v$portVersion.tar.gz"
@@ -25,8 +25,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/sqlalchemy/sqlalchemy-1.3.22.recipe
+++ b/dev-python/sqlalchemy/sqlalchemy-1.3.22.recipe
@@ -8,7 +8,7 @@ simple and Pythonic domain language."
 HOMEPAGE="https://www.sqlalchemy.org/"
 COPYRIGHT="2006-2019 SQLAlchemy authors and contributors"
 LICENSE="MIT"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://pypi.org/packages/source/S/SQLAlchemy/SQLAlchemy-$portVersion.tar.gz"
 CHECKSUM_SHA256="758fc8c4d6c0336e617f9f6919f9daea3ab6bb9b07005eda9a1a682e24a6cacc"
 SOURCE_DIR="SQLAlchemy-$portVersion"
@@ -30,8 +30,8 @@ BUILD_PREREQUIRES="
 	gcc$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/sqlalchemy/sqlalchemy-1.3.22.recipe
+++ b/dev-python/sqlalchemy/sqlalchemy-1.3.22.recipe
@@ -8,7 +8,7 @@ simple and Pythonic domain language."
 HOMEPAGE="https://www.sqlalchemy.org/"
 COPYRIGHT="2006-2019 SQLAlchemy authors and contributors"
 LICENSE="MIT"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://pypi.org/packages/source/S/SQLAlchemy/SQLAlchemy-$portVersion.tar.gz"
 CHECKSUM_SHA256="758fc8c4d6c0336e617f9f6919f9daea3ab6bb9b07005eda9a1a682e24a6cacc"
 SOURCE_DIR="SQLAlchemy-$portVersion"
@@ -33,33 +33,31 @@ BUILD_PREREQUIRES="
 PYTHON_PACKAGES=(python39 python310)
 PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\n\
-	cmd:alembic$pythonVersion\n\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku$secondaryArchSuffix\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
-done
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
 
-if [ "$targetArchitecture" = "x86_gcc2" ]; then
-	PROVIDES_python38+="
-		sqlalchemy_python38 = $portVersion
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		cmd:alembic$pythonVersion
+		\""
+
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_${pythonPackage}+=\"
+			sqlalchemy_$pythonPackage = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku$secondaryArchSuffix
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
 		"
-	PROVIDES_python39+="
-		sqlalchemy_python39 = $portVersion
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
 		"
-	PROVIDES_python310+="
-		sqlalchemy_python310 = $portVersion
-		"
-fi
+done
 
 BUILD()
 {

--- a/dev-python/svgwrite/svgwrite-1.4.1.recipe
+++ b/dev-python/svgwrite/svgwrite-1.4.1.recipe
@@ -5,7 +5,7 @@ include other SVG drawings by the <image> entity."
 HOMEPAGE="https://github.com/mozman/svgwrite"
 COPYRIGHT="2012 Manfred Moitzi"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/mozman/svgwrite/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="91d633be72f3e064377068df796121a9b8797ec961f4948283a2efe1ae11299c"
 ARCHITECTURES="any"
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/toml/toml-0.10.2.recipe
+++ b/dev-python/toml/toml-0.10.2.recipe
@@ -9,7 +9,7 @@ COPYRIGHT="2013-2019 William Pearson
 	2017 Jack Evans
 	2019 Filippo Broggini."
 LICENSE="MIT"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/uiri/toml/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="71d4039bbdec91e3e7591ec5d6c943c58f9a2d17e5f6783acdc378f743fcdd2a"
 
@@ -26,8 +26,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/tomli/tomli-2.0.1.recipe
+++ b/dev-python/tomli/tomli-2.0.1.recipe
@@ -6,7 +6,7 @@ module is not available and that have not yet reached their end-of-life."
 HOMEPAGE="https://pypi.org/project/gitdb/"
 COPYRIGHT="2021 Taneli Hukkinen"
 LICENSE="BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 pypiVersion="97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9"
 SOURCE_URI="https://files.pythonhosted.org/packages/$pypiVersion/tomli-2.0.1-py3-none-any.whl#noarchive"
 CHECKSUM_SHA256='939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc'
@@ -24,8 +24,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/tqdm/tqdm-4.65.0.recipe
+++ b/dev-python/tqdm/tqdm-4.65.0.recipe
@@ -7,7 +7,7 @@ HOMEPAGE="https://github.com/tqdm/tqdm"
 COPYRIGHT="2015-2023 tqdm contributors"
 LICENSE="MIT
 	MPL v2.0"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="$HOMEPAGE/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="d06536be27d945bea1b3e3b0fc9bdabcf44e7262fae4027955a2b30c2ad8ff8e"
 
@@ -24,8 +24,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 defaultVersion=3.9
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}

--- a/dev-python/typing-extensions/typing_extensions-4.3.0.recipe
+++ b/dev-python/typing-extensions/typing_extensions-4.3.0.recipe
@@ -22,7 +22,7 @@ Python versions will be dropped some time after that version reaches end of life
 HOMEPAGE="https://github.com/python/typing_extensions"
 COPYRIGHT="2022 Guido van Rossum, Jukka Lehtosalo, Łukasz Langa, Michael Lee"
 LICENSE="Python"
-REVISION="3"
+REVISION="4"
 pypiVersion="ed/d6/2afc375a8d55b8be879d6b4986d4f69f01115e795e36827fd3a40166028b"
 SOURCE_URI="https://files.pythonhosted.org/packages/$pypiVersion/typing_extensions-$portVersion-py3-none-any.whl#noarchive"
 CHECKSUM_SHA256="25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"
@@ -40,8 +40,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/typogrify/typogrify-2.0.7.recipe
+++ b/dev-python/typogrify/typogrify-2.0.7.recipe
@@ -7,7 +7,7 @@ HOMEPAGE="https://github.com/mintchaos/typogrify"
 COPYRIGHT="2007 Christian Metts
 	2014 Justin Mayer"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="$HOMEPAGE/archive/refs/tags/$portVersion.tar.gz"
 CHECKSUM_SHA256="d5081966c1c1423157e240d5cfe7435b56ca30be57ff8c7fe6f90f6cc42295ee"
 
@@ -24,8 +24,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/tzlocal/tzlocal-2.1.recipe
+++ b/dev-python/tzlocal/tzlocal-2.1.recipe
@@ -5,7 +5,7 @@ HOMEPAGE="https://github.com/regebro/tzlocal
 	https://pypi.org/project/tzlocal/"
 COPYRIGHT="2011-2017 Lennart Regebro"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/regebro/tzlocal/archive/$portVersion.tar.gz"
 SOURCE_FILENAME="tzlocal-$portVersion.tar.gz"
 CHECKSUM_SHA256="72ed8518bfa3506f7fed7f7205f468f70eaa4622b52c82d27fd9b8fb2d817631"
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/unrardll/unrardll-0.1.4.recipe
+++ b/dev-python/unrardll/unrardll-0.1.4.recipe
@@ -4,7 +4,7 @@ HOMEPAGE="https://github.com/kovidgoyal/unrardll
 	https://pypi.org/project/unrardll/"
 COPYRIGHT="2017 Kovid Goyal"
 LICENSE="BSD (3-clause)"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://github.com/kovidgoyal/unrardll/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="88c23a76492cf0d4aef5861947064698984c930294776dc66e9c46c2004ff0a2"
 
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	devel:libunrar$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/unrardll/unrardll-0.1.4.recipe
+++ b/dev-python/unrardll/unrardll-0.1.4.recipe
@@ -4,7 +4,7 @@ HOMEPAGE="https://github.com/kovidgoyal/unrardll
 	https://pypi.org/project/unrardll/"
 COPYRIGHT="2017 Kovid Goyal"
 LICENSE="BSD (3-clause)"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://github.com/kovidgoyal/unrardll/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="88c23a76492cf0d4aef5861947064698984c930294776dc66e9c46c2004ff0a2"
 
@@ -26,31 +26,32 @@ BUILD_REQUIRES="
 PYTHON_PACKAGES=(python39)
 PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	lib:libunrar$secondaryArchSuffix\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion\n\
-	cmd:gcc$secondaryArchSuffix"
-done
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
 
-if [ "$targetArchitecture" = "x86_gcc2" ]; then
-	PROVIDES_python38+="
-		unrardll_python38 = $portVersion
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_$pythonPackage=\"
+			unrardll_$pythonPackage = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		lib:libunrar$secondaryArchSuffix
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
 		"
-	PROVIDES_python39+="
-		unrardll_python39 = $portVersion
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		cmd:gcc$secondaryArchSuffix
 		"
-fi
+done
 
 INSTALL()
 {

--- a/dev-python/urllib3/urllib3-1.26.12.recipe
+++ b/dev-python/urllib3/urllib3-1.26.12.recipe
@@ -18,7 +18,7 @@ HOMEPAGE="https://urllib3.readthedocs.io/
 	https://github.com/urllib3/urllib3"
 COPYRIGHT="2008-2018 Andrey Petrov and contributors"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/shazow/urllib3/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="c7356205ca6c14df2f35d1d9cf18cd8a1981185b7dca13e1c3af91a214037c9d"
 SOURCE_FILENAME="urllib3-$portVersion.tar.gz"
@@ -36,8 +36,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/urwid/urwid-2.1.2.recipe
+++ b/dev-python/urwid/urwid-2.1.2.recipe
@@ -4,7 +4,7 @@ directly and handles many of the difficult and tedious tasks for you."
 HOMEPAGE="http://urwid.org/"
 COPYRIGHT="2004-2018  Ian Ward"
 LICENSE="GNU LGPL v2.1"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://pypi.org/packages/source/u/urwid/urwid-$portVersion.tar.gz"
 CHECKSUM_SHA256="588bee9c1cb208d0906a9f73c613d2bd32c3ed3702012f51efe318a3f2127eae"
 
@@ -21,8 +21,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/voluptuous/voluptuous-0.12.1.recipe
+++ b/dev-python/voluptuous/voluptuous-0.12.1.recipe
@@ -10,7 +10,7 @@ It has three goals:
 HOMEPAGE="https://pypi.org/project/voluptuous/"
 COPYRIGHT="2010-2018 Alec Thomas"
 LICENSE="BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://pypi.python.org/packages/source/v/voluptuous/voluptuous-$portVersion.tar.gz"
 CHECKSUM_SHA256="663572419281ddfaf4b4197fd4942d181630120fb39b333e3adad70aeb56444b"
 
@@ -27,8 +27,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/waitress/waitress-2.1.2.recipe
+++ b/dev-python/waitress/waitress-2.1.2.recipe
@@ -7,7 +7,7 @@ It supports HTTP/1.0 and HTTP/1.1."
 HOMEPAGE="https://pypi.org/project/waitress/"
 COPYRIGHT="2011-2017 Pylons Project"
 LICENSE="ZPL v2.1"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.python.org/packages/source/w/waitress/waitress-$portVersion.tar.gz"
 CHECKSUM_SHA256="780a4082c5fbc0fde6a2fcfe5e26e6efc1e8f425730863c04085769781f51eba"
 ARCHITECTURES="any"
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/watchdog/watchdog-0.9.0.recipe
+++ b/dev-python/watchdog/watchdog-0.9.0.recipe
@@ -4,7 +4,7 @@ HOMEPAGE="https://pypi.python.org/pypi/watchdog"
 COPYRIGHT="2011 Yesudeep Mangalapilly
 	2012 Google, Inc."
 LICENSE="Apache v2"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://pypi.python.org/packages/source/w/watchdog/watchdog-$portVersion.tar.gz"
 CHECKSUM_SHA256="965f658d0732de3188211932aeb0bb457587f04f63ab4c1e33eab878e9de961d"
 
@@ -24,52 +24,69 @@ BUILD_PREREQUIRES="
 	cmd:gcc
 	"
 
-PYTHON_PACKAGES=(python39)
-PYTHON_VERSIONS=(3.9)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
+defaultVersion=3.10
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\n\
-	argh_$pythonPackage\n\
-	pathtools_$pythonPackage\n\
-	pyyaml_$pythonPackage\n\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		cmd:watchmedo_$pythonVersion = $portVersion
+		\""
+
+	# Provide non-suffixed cmd only for the default Python version
+	if [ $pythonVersion = $defaultVersion ]; then
+		eval "PROVIDES_$pythonPackage+=\"
+			cmd:watchmedo = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cmd:python$pythonVersion
+		argh_$pythonPackage
+		pathtools_$pythonPackage
+		pyyaml_$pythonPackage
+		\""
+
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
-PROVIDES_python38="$PROVIDES_python38
-	cmd:watchmedo3.8 = $portVersion
-	"
-PROVIDES_python39="$PROVIDES_python39
-	cmd:watchmedo = $portVersion
-	"
 INSTALL()
 {
 	for i in "${!PYTHON_PACKAGES[@]}"; do
 		pythonPackage=${PYTHON_PACKAGES[i]}
 		pythonVersion=${PYTHON_VERSIONS[$i]}
 
-		# GENERIC: all python_setuptools-based installs need this
 		python=python$pythonVersion
-		pythonVersion=$($python --version 2>&1 | sed 's/Python //' | head -c3)
 		installLocation=$prefix/lib/python$pythonVersion/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		if [ $pythonPackage != python39 ]; then
-			mv $binDir/watchmedo $binDir/watchmedo$pythonVersion
+		# Version suffix all the scripts
+		for f in $binDir/*; do
+			mv $f $f-$pythonVersion
+		done
+
+		# And provide suffix-less symlinks for the default version
+		if [ $pythonVersion = $defaultVersion ]; then
+			for f in $binDir/*; do
+				ln -sr $f ${f%-$pythonVersion}
+			done
 		fi
+
 		packageEntries  $pythonPackage \
 			$prefix/lib/python* \
 			$binDir

--- a/dev-python/watchdog/watchdog-0.9.0.recipe
+++ b/dev-python/watchdog/watchdog-0.9.0.recipe
@@ -4,7 +4,7 @@ HOMEPAGE="https://pypi.python.org/pypi/watchdog"
 COPYRIGHT="2011 Yesudeep Mangalapilly
 	2012 Google, Inc."
 LICENSE="Apache v2"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://pypi.python.org/packages/source/w/watchdog/watchdog-$portVersion.tar.gz"
 CHECKSUM_SHA256="965f658d0732de3188211932aeb0bb457587f04f63ab4c1e33eab878e9de961d"
 
@@ -24,8 +24,8 @@ BUILD_PREREQUIRES="
 	cmd:gcc
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/wcwidth/wcwidth-0.2.6.recipe
+++ b/dev-python/wcwidth/wcwidth-0.2.6.recipe
@@ -6,7 +6,7 @@ HOMEPAGE="https://github.com/jquast/wcwidth/"
 COPYRIGHT="2007 Markus Kuhn
 	2014 Jeff Quast"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/jquast/wcwidth/archive/refs/tags/$portVersion.tar.gz"
 CHECKSUM_SHA256="ebcd44c0ba3049d9b813cd8ad1bc7d151674b322a82f99ff09f0e604de1ecf09"
 SOURCE_FILENAME="wcwidth-$portVersion.tar.gz"
@@ -24,8 +24,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/webencodings/webencodings-0.5.1.recipe
+++ b/dev-python/webencodings/webencodings-0.5.1.recipe
@@ -9,7 +9,7 @@ so that implementations do not have to reverse-engineer each other."
 HOMEPAGE="https://github.com/gsnedders/python-webencodings"
 COPYRIGHT="2012 Simon Sapin"
 LICENSE="BSD (3-clause)"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://github.com/gsnedders/python-webencodings/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="082367f568a7812aa5f6922ffe3d9d027cd83829dc32bcaac4c874eeed618000"
 SOURCE_DIR="python-webencodings-$portVersion"
@@ -27,8 +27,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/wheel/wheel-0.36.2.recipe
+++ b/dev-python/wheel/wheel-0.36.2.recipe
@@ -4,7 +4,7 @@ for working with wheel files."
 HOMEPAGE="https://pypi.org/project/wheel"
 COPYRIGHT="2012-2020 Daniel Holth, Alex Grönholm"
 LICENSE="MIT"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/pypa/wheel/archive/$portVersion.tar.gz"
 SOURCE_FILENAME="wheel-$portVersion.tar.gz"
 CHECKSUM_SHA256="c31e70355935f1d47bf0d898661a1e9dd47966d935c0a785dbe5b41eedf6802a"
@@ -25,8 +25,8 @@ BUILD_PREREQUIRES="
 	cmd:sed
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/whichcraft/whichcraft-0.6.1.recipe
+++ b/dev-python/whichcraft/whichcraft-0.6.1.recipe
@@ -4,7 +4,7 @@ portable way."
 HOMEPAGE="https://pypi.org/project/whichcraft"
 COPYRIGHT="2015-2019 Daniel Roy Greenfeld"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/cookiecutter/whichcraft/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="bfa077578261e8bce72ebd44025a2ac196f943123e551589bd5f1c25af9f0085"
 SOURCE_FILENAME="whichcraft-$portVersion.tar.gz"
@@ -23,8 +23,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39)
-PYTHON_VERSIONS=(3.8 3.9)
+PYTHON_PACKAGES=(python39)
+PYTHON_VERSIONS=(3.9)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/yarl/yarl-1.6.3.recipe
+++ b/dev-python/yarl/yarl-1.6.3.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="The module provides handy URL class for URL parsing and changing."
 HOMEPAGE="https://pypi.python.org/pypi/yarl"
 COPYRIGHT="2016-2018 Andrew Svetlov and aio-libs team"
 LICENSE="Apache v2"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://pypi.io/packages/source/y/yarl/yarl-$portVersion.tar.gz"
 CHECKSUM_SHA256="8a9066529240171b68893d60dca86a763eae2139dd42f42106b03cf4b426bf10"
 
@@ -24,8 +24,8 @@ BUILD_PREREQUIRES="
 	gcc$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/zipp/zipp-3.7.0.recipe
+++ b/dev-python/zipp/zipp-3.7.0.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="Zipp is a pathlib-compatible Zipfile object wrapper."
 HOMEPAGE="https://pypi.python.org/pypi/zipp"
 COPYRIGHT="2018-2021 Jason R. Coombs"
 LICENSE="MIT"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://pypi.io/packages/source/${portName:0:1}/$portName/$portName-$portVersion.tar.gz"
 CHECKSUM_SHA256="9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d"
 
@@ -20,8 +20,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}

--- a/dev-python/zope-interface/zope_interface-5.4.0.recipe
+++ b/dev-python/zope-interface/zope_interface-5.4.0.recipe
@@ -9,7 +9,7 @@ For detailed documentation, please see http://docs.zope.org/zope.interface"
 HOMEPAGE="http://pypi.python.org/pypi/zope.interface"
 COPYRIGHT="2004-2014 Zope Foundation and Contributors"
 LICENSE="ZPL 2.1"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.io/packages/source/z/zope.interface/zope.interface-$portVersion.tar.gz"
 CHECKSUM_SHA256="5dba5f530fec3f0988d83b78cc591b58c0b6eb8431a85edd1569a0539a8a5a0e"
 SOURCE_DIR="zope.interface-$portVersion"
@@ -29,8 +29,8 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	cmd:gcc
 	"
-PYTHON_PACKAGES=(python38 python39 python310)
-PYTHON_VERSIONS=(3.8 3.9 3.10)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 pythonPackage=${PYTHON_PACKAGES[i]}
 pythonVersion=${PYTHON_VERSIONS[$i]}


### PR DESCRIPTION
Changes on the first commit where automated, but untested. Will fix up if something fails at buildmasters.

Changes on second commit where manual, and tested under beta4 64 bits.

In both cases, no functional change intended nor expected. Just dropping of `_python38`, and some recipe fixups / style updates.