### PR TITLE
importlib_metadata: hopefully fix the build for good this time.

### DIFF
--- a/dev-python/importlib_metadata/importlib_metadata-6.8.0.recipe
+++ b/dev-python/importlib_metadata/importlib_metadata-6.8.0.recipe
@@ -51,10 +51,20 @@ done
 
 INSTALL()
 {
+	# Needed due to the presence of HaikuPorter's work .git dir:
+	# setuptools_scm assumes that .git is from the project, and fails to get the info it needs
+	# generating wrong default value in that case.
+	export SETUPTOOLS_SCM_PRETEND_VERSION=$portVersion
+
 	for i in "${!PYTHON_PACKAGES[@]}"; do
 		pythonPackage=${PYTHON_PACKAGES[i]}
 
 		python=python${PYTHON_VERSIONS[$i]}
+
+		# Needed to build without -G in the haikuporter build call.
+		# the presence of HaikuPorter's working .git dir seems to confuse
+		# some python's builds/packages.
+		rm -rf dist
 
 		$python -m build --wheel --skip-dependency-check --no-isolation
 		$python -m installer -p $prefix dist/*.whl


### PR DESCRIPTION
The presence of HaikuPorter's work git repo interferes with the operation of some python packages used at build time, causing builds with "hp -G" to succeed, but fail without that flag, unless these work-arounds are applied:

- exporting a `SETUPTOOLS_SCM_PRETEND_VERSION` variable
- `rm -rf dist`