### PR TITLE
Follow up to PR 9328.

### DIFF
--- a/dev-python/importlib_resources/importlib_resources-5.4.0.recipe
+++ b/dev-python/importlib_resources/importlib_resources-5.4.0.recipe
@@ -6,7 +6,7 @@ consistent semantics."
 HOMEPAGE="https://pypi.python.org/pypi/importlib-resources"
 COPYRIGHT="2017-2019 Brett Cannon, Barry Warsaw"
 LICENSE="Apache v2"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://pypi.python.org/packages/source/i/importlib_resources/importlib_resources-$portVersion.tar.gz"
 CHECKSUM_SHA256="d756e2f85dd4de2ba89be0b21dba2a3bbec2e871a42a3a16719258a11f87506b"
 
@@ -26,20 +26,23 @@ BUILD_REQUIRES="
 PYTHON_PACKAGES=(python39 python310)
 PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	zipp_$pythonPackage\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_scm_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		zipp_$pythonPackage
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		setuptools_scm_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()
@@ -53,12 +56,14 @@ INSTALL()
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }

--- a/dev-python/iniconfig/iniconfig-1.1.1.recipe
+++ b/dev-python/iniconfig/iniconfig-1.1.1.recipe
@@ -13,7 +13,7 @@ HOMEPAGE="https://pypi.org/project/iniconfig/
 	http://github.com/RonnyPfannschmidt/iniconfig/"
 COPYRIGHT="2010-2020 Holger Krekel and Ronny Pfannschmidt"
 LICENSE="MIT"
-REVISION="6"
+REVISION="7"
 SOURCE_URI="https://github.com/RonnyPfannschmidt/iniconfig/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="a4489e91242e035cb58700d9a3c4bf49e0b106a85fefefe48025e333ea5ee49c"
 
@@ -33,29 +33,28 @@ BUILD_REQUIRES="
 PYTHON_PACKAGES=(python39 python310)
 PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_scm_$pythonPackage
-	"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:git
-	cmd:python$pythonVersion
-	"
-done
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
 
-SETUPTOOLS_SCM_PRETEND_VERSION=$portVersion
-export SETUPTOOLS_SCM_PRETEND_VERSION
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		setuptools_scm_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
+done
 
 INSTALL()
 {
+	export SETUPTOOLS_SCM_PRETEND_VERSION=$portVersion
+
 	for i in "${!PYTHON_PACKAGES[@]}"; do
 		pythonPackage=${PYTHON_PACKAGES[i]}
 		pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -63,12 +62,14 @@ INSTALL()
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }

--- a/dev-python/pyparsing/pyparsing-3.0.7.recipe
+++ b/dev-python/pyparsing/pyparsing-3.0.7.recipe
@@ -7,7 +7,7 @@ Python code."
 HOMEPAGE="https://pypi.python.org/pypi/pyparsing"
 COPYRIGHT="2003-2022 Paul T. McGuire"
 LICENSE="MIT"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://github.com/pyparsing/pyparsing/archive/pyparsing_$portVersion.tar.gz"
 CHECKSUM_SHA256="9303df2c7998485cc71a246c6cc0489c48ad571adc9d250c2d1314c47768ba59"
 SOURCE_DIR="pyparsing-pyparsing_$portVersion"
@@ -28,20 +28,21 @@ BUILD_REQUIRES="
 PYTHON_PACKAGES=(python39 python310)
 PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_scm_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-#	cmd:git
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		setuptools_scm_$pythonPackage"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()
@@ -53,12 +54,14 @@ INSTALL()
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }

--- a/dev-python/watchdog/watchdog-0.9.0.recipe
+++ b/dev-python/watchdog/watchdog-0.9.0.recipe
@@ -4,7 +4,7 @@ HOMEPAGE="https://pypi.python.org/pypi/watchdog"
 COPYRIGHT="2011 Yesudeep Mangalapilly
 	2012 Google, Inc."
 LICENSE="Apache v2"
-REVISION="6"
+REVISION="7"
 SOURCE_URI="https://pypi.python.org/packages/source/w/watchdog/watchdog-$portVersion.tar.gz"
 CHECKSUM_SHA256="965f658d0732de3188211932aeb0bb457587f04f63ab4c1e33eab878e9de961d"
 
@@ -87,7 +87,7 @@ INSTALL()
 			done
 		fi
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python* \
 			$binDir
 	done

--- a/dev-python/zipp/zipp-3.7.0.recipe
+++ b/dev-python/zipp/zipp-3.7.0.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="Zipp is a pathlib-compatible Zipfile object wrapper."
 HOMEPAGE="https://pypi.python.org/pypi/zipp"
 COPYRIGHT="2018-2021 Jason R. Coombs"
 LICENSE="MIT"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://pypi.io/packages/source/${portName:0:1}/$portName/$portName-$portVersion.tar.gz"
 CHECKSUM_SHA256="9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d"
 
@@ -23,19 +23,22 @@ BUILD_REQUIRES="
 PYTHON_PACKAGES=(python39 python310)
 PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_scm_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		setuptools_scm_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()
@@ -49,12 +52,14 @@ INSTALL()
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }


### PR DESCRIPTION
Just revision bumps to trigger builds at buildmasters, and some minor recipe cleanups.

No functional changes intended or expected.

This should leave only 4 recipes that need fixes after #9328 (and fixes in #9338).