### PR TITLE
OpenVPN Add Path to Where Driver gets Published

### DIFF
--- a/net-vpn/openvpn/openvpn-2.6.4.recipe
+++ b/net-vpn/openvpn/openvpn-2.6.4.recipe
@@ -7,7 +7,7 @@ HOMEPAGE="https://openvpn.net"
 COPYRIGHT="2002-2023 OpenVPN Inc"
 LICENSE="OpenVPN
 	GNU GPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/OpenVPN/openvpn/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="bfab07b900262a990fc4519596b29c380ed5a89216593f04719279715ebd04d3"
 SOURCE_FILENAME="openvpn-$portVersion.tar.gz"

--- a/net-vpn/openvpn/patches/openvpn-2.6.4.patchset
+++ b/net-vpn/openvpn/patches/openvpn-2.6.4.patchset
@@ -43,3 +43,29 @@ index 2320e8b..2fb0de9 100644
  #endif /* if defined(TARGET_LINUX) */
 --
 2.42.0.windows.1
+
+
+From 909e9a0dd31460ab7750d2473ca94c46ae364e28 Mon Sep 17 00:00:00 2001
+From: Swangeon <swangeon@gmail.com>
+Date: Mon, 4 Sep 2023 00:40:30 -0500
+Subject: [PATCH] Change where the TUN/TAP driver gets accessed
+
+
+ src/openvpn/tun.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/openvpn/tun.c b/src/openvpn/tun.c
+index 2fb0de9..cdc0131 100644
+--- a/src/openvpn/tun.c
++++ b/src/openvpn/tun.c
+@@ -1880,7 +1880,7 @@ open_tun_generic(const char *dev, const char *dev_type, const char *dev_node,
+                 for (int i = 0; i < 256; ++i)
+                 {
+                     openvpn_snprintf(tunname, sizeof(tunname),
+-                                     "/dev/%s%d", dev, i);
++                                     "/dev/tap/%d", i);
+                     openvpn_snprintf(dynamic_name, sizeof(dynamic_name),
+                                      "%s%d", dev, i);
+                     if ((tt->fd = open(tunname, O_RDWR)) > 0)
+--
+2.42.0.windows.2


### PR DESCRIPTION
Reflects change made [here](https://review.haiku-os.org/c/haiku/+/6608/31/src/add-ons/kernel/drivers/network/tun/driver.cpp#24) to the driver