### PR TITLE
llvm16: fix build on 32-bit; fix deps for clang package

### DIFF
--- a/sys-devel/llvm/llvm16-16.0.6.recipe
+++ b/sys-devel/llvm/llvm16-16.0.6.recipe
@@ -30,7 +30,7 @@ other than the ones listed above.
 HOMEPAGE="https://www.llvm.org/"
 COPYRIGHT="2003-2023 University of Illinois at Urbana-Champaign"
 LICENSE="Apache v2 with LLVM Exception"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/llvm/llvm-project/releases/download/llvmorg-$portVersion/llvm-project-$portVersion.src.tar.xz"
 CHECKSUM_SHA256="ce5e71081d17ce9e86d7cbcfa28c4b04b9300f8fb7e78422b1feb6bc52c3028e"
 SOURCE_DIR="llvm-project-$portVersion.src"
@@ -396,11 +396,11 @@ PROVIDES_clang="
 	devel:libclangtoolingrefactoring$secondaryArchSuffix = $portVersion
 	devel:libclangtoolingsyntax$secondaryArchSuffix = $portVersion
 	devel:libclangtransformer$secondaryArchSuffix = $portVersion
+	lib:libclang$secondaryArchSuffix = $portVersionCompat
+	lib:libclang_cpp$secondaryArchSuffix = $portVersionCompat
 	"
 REQUIRES_clang="
 	haiku$secondaryArchSuffix
-	lib:libclang$secondaryArchSuffix
-	lib:libclang_cpp$secondaryArchSuffix
 	lib:libLLVM_16$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
@@ -458,7 +458,6 @@ REQUIRES_lld="
 
 PROVIDES_libs="
 	llvm16${secondaryArchSuffix}_libs = $portVersion
-	lib:libclang_cpp$secondaryArchSuffix = $portVersionCompat
 	lib:libLLVM_16$secondaryArchSuffix = $portVersionCompat
 	lib:libLTO$secondaryArchSuffix = $portVersionCompat
 	lib:libRemarks$secondaryArchSuffix = $portVersionCompat
@@ -602,13 +601,106 @@ INSTALL()
 	# not all arches contain the same libraries. The inventory for each arch
 	# also changes between releases... so lets KISS.
 	prepareInstalledDevelLibs \
+		libclang \
+		libclang-cpp \
+		libclangAPINotes \
+		libclangARCMigrate \
+		libclangAST \
+		libclangASTMatchers \
+		libclangAnalysis \
+		libclangAnalysisFlowSensitive \
+		libclangAnalysisFlowSensitiveModels \
+		libclangApplyReplacements \
+		libclangBasic \
+		libclangChangeNamespace \
+		libclangCodeGen \
+		libclangCrossTU \
+		libclangDaemon \
+		libclangDaemonTweaks \
+		libclangDependencyScanning \
+		libclangDirectoryWatcher \
+		libclangDoc \
+		libclangDriver \
+		libclangDynamicASTMatchers \
+		libclangEdit \
+		libclangExtractAPI \
+		libclangFormat \
+		libclangFrontend \
+		libclangFrontendTool \
+		libclangHandleCXX \
+		libclangHandleLLVM \
+		libclangIncludeCleaner \
+		libclangIncludeFixer \
+		libclangIncludeFixerPlugin \
+		libclangIndex \
+		libclangIndexSerialization \
+		libclangInterpreter \
+		libclangLex \
+		libclangMove \
+		libclangParse \
+		libclangPseudo \
+		libclangPseudoCLI \
+		libclangPseudoCXX \
+		libclangPseudoGrammar \
+		libclangQuery \
+		libclangReorderFields \
+		libclangRewrite \
+		libclangRewriteFrontend \
+		libclangSema \
+		libclangSerialization \
+		libclangStaticAnalyzerCheckers \
+		libclangStaticAnalyzerCore \
+		libclangStaticAnalyzerFrontend \
+		libclangSupport \
+		libclangTidy \
+		libclangTidyAbseilModule \
+		libclangTidyAlteraModule \
+		libclangTidyAndroidModule \
+		libclangTidyBoostModule \
+		libclangTidyBugproneModule \
+		libclangTidyCERTModule \
+		libclangTidyConcurrencyModule \
+		libclangTidyCppCoreGuidelinesModule \
+		libclangTidyDarwinModule \
+		libclangTidyFuchsiaModule \
+		libclangTidyGoogleModule \
+		libclangTidyHICPPModule \
+		libclangTidyLLVMLibcModule \
+		libclangTidyLLVMModule \
+		libclangTidyLinuxKernelModule \
+		libclangTidyMPIModule \
+		libclangTidyMain \
+		libclangTidyMiscModule \
+		libclangTidyModernizeModule \
+		libclangTidyObjCModule \
+		libclangTidyOpenMPModule \
+		libclangTidyPerformanceModule \
+		libclangTidyPlugin \
+		libclangTidyPortabilityModule \
+		libclangTidyReadabilityModule \
+		libclangTidyUtils \
+		libclangTidyZirconModule \
+		libclangTooling \
+		libclangToolingASTDiff \
+		libclangToolingCore \
+		libclangToolingInclusions \
+		libclangToolingInclusionsStdlib \
+		libclangToolingRefactoring \
+		libclangToolingSyntax \
+		libclangTransformer \
+		libclangdRemoteIndex \
+		libclangdSupport \
 		libfindAllSymbols \
 		libLLVM* \
 		libLTO	\
-		libclang* \
 		liblld* \
-		libRemarks \
+		libRemarks
+
+	oldLibDir=$libDir
+	libDir=$prefix/lib
+	prepareInstalledDevelLibs \
 		$effectiveTargetMachineTriple/libunwind
+	libDir=$oldLibDir
 
 	# adjust cmake library paths because prepareInstalledDevelLibs moved them
 	sed -i 's,\${_IMPORT_PREFIX}/lib/,\${_IMPORT_PREFIX}/develop/lib/,' \
@@ -631,6 +723,7 @@ INSTALL()
 		$dataDir/clang \
 		$includeDir/clang* \
 		$libDir/clang \
+		$libDir/libclang* \
 		$libDir/cmake/clang \
 		$developLibDir/libclang*
 
@@ -656,7 +749,6 @@ INSTALL()
 
 	# libs package
 	packageEntries libs \
-		$libDir/libclang* \
 		$libDir/libLLVM* \
 		$libDir/libLTO* \
 		$libDir/libRemarks*
@@ -668,7 +760,7 @@ INSTALL()
 
 	# libunwind package
 	packageEntries libunwind \
-		$libDir/$effectiveTargetMachineTriple/libunwind*
+		$prefix/lib/$effectiveTargetMachineTriple/libunwind*
 
 	packageEntries libunwind_devel \
 		$developLibDir/libunwind* \


### PR DESCRIPTION
Trying tackle issues #9324 and #9333
* adjust path for `libunwind` so that we always look for it in `$prefix/lib` (also in case of x86 secondary architecture)
* expand the list of `libclang...` when invoking `prepareInstalledDevelLibs` so that the libs land in the correct folders
* move `libclang` and `libclang-cpp` to the `llvm16-clang` package
* adjust provides and requires accordingly
