### PR TITLE
tqdm: update to version 4.66.1

### DIFF
--- a/dev-python/tqdm/tqdm-4.66.1.recipe
+++ b/dev-python/tqdm/tqdm-4.66.1.recipe
@@ -7,9 +7,9 @@ HOMEPAGE="https://github.com/tqdm/tqdm"
 COPYRIGHT="2015-2023 tqdm contributors"
 LICENSE="MIT
 	MPL v2.0"
-REVISION="2"
-SOURCE_URI="$HOMEPAGE/archive/refs/tags/v$portVersion.tar.gz"
-CHECKSUM_SHA256="d06536be27d945bea1b3e3b0fc9bdabcf44e7262fae4027955a2b30c2ad8ff8e"
+REVISION="1"
+SOURCE_URI="https://pypi.io/packages/source/${portName:0:1}/$portName/$portName-$portVersion.tar.gz"
+CHECKSUM_SHA256="d88e651f9db8d8551a62556d3cff9e3034274ca5d66e93197cf2490e2dcb69c7"
 
 ARCHITECTURES="any"
 
@@ -26,7 +26,7 @@ BUILD_REQUIRES="
 
 PYTHON_PACKAGES=(python39 python310)
 PYTHON_VERSIONS=(3.9 3.10)
-defaultVersion=3.9
+defaultVersion=3.10
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -47,7 +47,11 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 		cmd:python$pythonVersion
 		\""
 	BUILD_REQUIRES+="
+		build_$pythonPackage
+		installer_$pythonPackage
 		setuptools_scm_$pythonPackage
+		setuptools_$pythonPackage
+		wheel_$pythonPackage
 		"
 	BUILD_PREREQUIRES+="
 		cmd:python$pythonVersion
@@ -57,43 +61,39 @@ done
 
 INSTALL()
 {
-	export SETUPTOOLS_SCM_PRETEND_VERSION=$portVersion
-
 	for i in "${!PYTHON_PACKAGES[@]}"; do
 		pythonPackage=${PYTHON_PACKAGES[i]}
 		pythonVersion=${PYTHON_VERSIONS[$i]}
 
 		python=python$pythonVersion
-		installLocation=$prefix/lib/$python/vendor-packages/
-		export PYTHONPATH=$installLocation:$PYTHONPATH
 
-		mkdir -p $installLocation
+		# Avoid leftovers from the previous package build
 		rm -rf build
 
-		$python setup.py build install \
-			--root=/ --prefix=$prefix
+		$python -m build --wheel --skip-dependency-check --no-isolation
+		$python -m installer -p $prefix dist/*.whl
 
 		# For non default versions, only provide suffixed commands
-		mv "$binDir"/tqdm "$binDir"/tqdm-$pythonVersion
+		mv $binDir/tqdm $binDir/tqdm-$pythonVersion
 		if [ $pythonVersion = $defaultVersion ]; then
-			ln -s "$binDir"/tqdm-$pythonVersion "$binDir"/tqdm
+			ln -sr $binDir/tqdm-$pythonVersion $binDir/tqdm
 		fi
-
-		install -m 755 -d $manDir/man1
-		install -m 644 -t $manDir/man1 tqdm/tqdm.1
 
 		packageEntries $pythonPackage \
 			$binDir \
-			$prefix/lib/python* \
-			$manDir
+			$prefix/lib/python*
 
-		# Bash completion file only works for the default "tqdm" name
+		# Install man page and bash completions only for "tqdm".
 		if [ $pythonVersion = $defaultVersion ]; then
-			install -m 755 -d "$dataDir"/bash-completion/completions
-			install -m 644 tqdm/completion.sh "$dataDir"/bash-completion/completions/tqdm
+			install -m 755 -d $manDir/man1
+			install -m 644 -t $manDir/man1 tqdm/tqdm.1
+
+			install -m 755 -d $dataDir/bash-completion/completions
+			install -m 644 tqdm/completion.sh $dataDir/bash-completion/completions/tqdm
 
 			packageEntries $pythonPackage \
-				$dataDir
+				$dataDir \
+				$manDir
 		fi
 	done
 }


### PR DESCRIPTION
- Switched build to use build/installer.
- Switched default version to Python 3.10.
- Only install man page / bash completions for the default Python version.
- Changed SOURCE_URI to avoid:
  > LookupError: setuptools-scm was unable to detect version
  for /sources/tqdm-4.66.1.

  (that error message suggested using PyPI's tarballs instead of Github ones)