### PR TITLE
llvm16: clean up recipe

### DIFF
--- a/sys-devel/llvm/llvm16-16.0.6.recipe
+++ b/sys-devel/llvm/llvm16-16.0.6.recipe
@@ -30,7 +30,7 @@ other than the ones listed above.
 HOMEPAGE="https://www.llvm.org/"
 COPYRIGHT="2003-2023 University of Illinois at Urbana-Champaign"
 LICENSE="Apache v2 with LLVM Exception"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/llvm/llvm-project/releases/download/llvmorg-$portVersion/llvm-project-$portVersion.src.tar.xz"
 CHECKSUM_SHA256="ce5e71081d17ce9e86d7cbcfa28c4b04b9300f8fb7e78422b1feb6bc52c3028e"
 SOURCE_DIR="llvm-project-$portVersion.src"
@@ -43,14 +43,8 @@ portVersionCompat="$portVersion compat >= ${portVersion%%.*}"
 
 PROVIDES="
 	llvm16$secondaryArchSuffix = $portVersionCompat
-	cmd:amdgpu_arch
-	cmd:analyze_build
 	cmd:bugpoint
-	cmd:diagtool
 	cmd:dsymutil
-	cmd:find_all_symbols
-	cmd:hmaptool
-	cmd:intercept_build
 	cmd:llc
 	cmd:lli
 	cmd:llvm_addr2line
@@ -122,13 +116,9 @@ PROVIDES="
 	cmd:llvm_undname
 	cmd:llvm_windres
 	cmd:llvm_xray
-	cmd:nvptx_arch
 	cmd:opt
-	cmd:pp_trace
-	cmd:run_clang_tidy
 	cmd:sancov
 	cmd:sanstats
-	cmd:scan_build_py
 	cmd:verify_uselistorder
 	devel:libfindAllSymbols$secondaryArchSuffix
 	devel:libLLVM$secondaryArchSuffix = $portVersionCompat
@@ -277,6 +267,7 @@ CONFLICTS="
 
 PROVIDES_clang="
 	llvm16${secondaryArchSuffix}_clang = $portVersion
+	cmd:amdgpu_arch = $portVersion
 	cmd:c_index_test = $portVersion
 	cmd:clang = $portVersion
 	cmd:clang++ = $portVersion
@@ -305,8 +296,14 @@ PROVIDES_clang="
 	cmd:clang_tidy = $portVersion
 	cmd:clang_tblgen = $portVersion
 	cmd:clangd = $portVersion
+	cmd:diagtool = $portVersion
+	cmd:find_all_symbols = $portVersion
 	cmd:git_clang_format = $portVersion
+	cmd:hmaptool = $portVersion
 	cmd:modularize = $portVersion
+	cmd:nvptx_arch = $portVersion
+	cmd:pp_trace = $portVersion
+	cmd:run_clang_tidy = $portVersion
 	devel:libclang$secondaryArchSuffix = $portVersionCompat
 	devel:libclang_cpp$secondaryArchSuffix = $portVersionCompat
 	devel:libclanganalysis$secondaryArchSuffix = $portVersion
@@ -418,7 +415,10 @@ CONFLICTS_clang="
 
 PROVIDES_clang_analysis="
 	llvm16${secondaryArchSuffix}_clang_analysis = $portVersion
+	cmd:analyze_build = $portVersion
+	cmd:intercept_build = $portVersion
 	cmd:scan_build = $portVersion
+	cmd:scan_build_py = $portVersion
 	cmd:scan_view = $portVersion
 	"
 REQUIRES_clang_analysis="
@@ -716,10 +716,17 @@ INSTALL()
 
 	# clang package
 	packageEntries clang \
+		$binDir/amdgpu-arch \
 		$binDir/c-index-test \
 		$binDir/clang* \
+		$binDir/diagtool \
+		$binDir/find-all-symbols \
 		$binDir/git-clang-format \
+		$binDir/hmaptool \
 		$binDir/modularize \
+		$binDir/nvptx-arch \
+		$binDir/pp-trace \
+		$binDir/run-clang-tidy \
 		$dataDir/clang \
 		$includeDir/clang* \
 		$libDir/clang \
@@ -729,7 +736,10 @@ INSTALL()
 
 	# analysis package
 	packageEntries clang_analysis \
+		$binDir/analyze-build \
+		$binDir/intercept-build \
 		$binDir/scan-build \
+		$binDir/scan-build-py \
 		$binDir/scan-view \
 		$libExecDir/c++-analyzer \
 		$libExecDir/ccc-analyzer \
@@ -770,6 +780,12 @@ INSTALL()
 		$includeDir/__libunwind*.h \
 		$includeDir/mach-o/compact_unwind_encoding.h \
 		$includeDir/mach-o/compact_unwind_encoding.modulemap
+
+	# Remove empty folders
+	rmdir $includeDir/mach-o
+	rmdir $manDir/man1
+	rmdir $manDir
+	rmdir $prefix/lib/$effectiveTargetMachineTriple
 }
 
 TEST()


### PR DESCRIPTION
Following up on the suggestions from @augiedoggie 
* move scan-build-py scripts to clang_analysis package
* move other clang scripts to clang package
* remove empty folders from llvm16 base package

successful build on 32-bit&64-bit