### PR TITLE
llvm16: fix C++ include paths

### DIFF
--- a/sys-devel/llvm/llvm16-16.0.6.recipe
+++ b/sys-devel/llvm/llvm16-16.0.6.recipe
@@ -30,7 +30,7 @@ other than the ones listed above.
 HOMEPAGE="https://www.llvm.org/"
 COPYRIGHT="2003-2023 University of Illinois at Urbana-Champaign"
 LICENSE="Apache v2 with LLVM Exception"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/llvm/llvm-project/releases/download/llvmorg-$portVersion/llvm-project-$portVersion.src.tar.xz"
 CHECKSUM_SHA256="ce5e71081d17ce9e86d7cbcfa28c4b04b9300f8fb7e78422b1feb6bc52c3028e"
 SOURCE_DIR="llvm-project-$portVersion.src"

--- a/sys-devel/llvm/patches/llvm16-16.0.6.patchset
+++ b/sys-devel/llvm/patches/llvm16-16.0.6.patchset
@@ -1,4 +1,4 @@
-From a9ec0abbb67ad31e3c4f4ece8029c8ebbff611af Mon Sep 17 00:00:00 2001
+From 23f712a9bf56c19dd30c50d87f6cd4e75334da98 Mon Sep 17 00:00:00 2001
 From: Calvin Hill <calvin@hakobaito.co.uk>
 Date: Sun, 9 Sep 2018 16:11:42 +0100
 Subject: llvm: import header dir suffix patch from 3dEyes
@@ -24,7 +24,7 @@ index b1d795a..0e76401 100644
 2.37.3
 
 
-From 103c93cf4313c7ab75616b28310ce3a48f1614aa Mon Sep 17 00:00:00 2001
+From 4f2899af07a0087f3e33203bcccce0f2cfc9ad82 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Mon, 18 Jul 2016 14:13:19 +0200
 Subject: clang: support for secondary arch.
@@ -132,7 +132,7 @@ index d446556..5b91907 100644
 2.37.3
 
 
-From ac9d530e3ef032e034fef038ddef881ea4cdfdcd Mon Sep 17 00:00:00 2001
+From c09f6b8f5424358496350377f4aa494c3ab2966a Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Thu, 7 Apr 2016 18:30:52 +0000
 Subject: clang: add a test for haiku driver.
@@ -161,7 +161,7 @@ index 0000000..9591739
 2.37.3
 
 
-From e20b77ce214fbddf305cc00d6da4c146e1561ec4 Mon Sep 17 00:00:00 2001
+From 7e8af352745c1c42d8b43a294b04c77e0bc3c9a6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Mon, 18 Jul 2016 14:13:19 +0200
 Subject: clang: Enable thread-local storage and disable PIE by default
@@ -198,7 +198,7 @@ index 669379a..fd82022 100644
 2.37.3
 
 
-From c5b0a3f49049bc0526fb65f1b15262f29f128475 Mon Sep 17 00:00:00 2001
+From fb858814531b5f01da6012092e9e41d17e0f4033 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Mon, 13 Feb 2023 16:28:39 +0100
 Subject: clang: Haiku: defaults to PIC
@@ -220,7 +220,7 @@ index fd82022..f649d8d 100644
 2.37.3
 
 
-From f12c5a2515d5ed451f0789117e42d33ce2510acf Mon Sep 17 00:00:00 2001
+From 686dd1b9024f0f9035edbeb0fbf4123b86cb7355 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sat, 3 Apr 2021 23:23:24 +0200
 Subject: lld: MachO needs libunwind somehow, disable
@@ -288,7 +288,7 @@ index eb746ae..b88d902 100644
 2.37.3
 
 
-From 7c9dd7de9bd1eca14f5c04faef9d37c92855e928 Mon Sep 17 00:00:00 2001
+From f7bcd19592f41182058b3d1c063ad8f81781d6b7 Mon Sep 17 00:00:00 2001
 From: X512 <danger_mail@list.ru>
 Date: Wed, 16 Mar 2022 07:04:18 +0900
 Subject: libunwind: Haiku: Signal frame unwinding support
@@ -414,7 +414,7 @@ index 0c6cda3..26bbfa0 100644
 2.37.3
 
 
-From 1ed17450fa38ef9a07f75f92039968e7a0ea37d5 Mon Sep 17 00:00:00 2001
+From 3bd9695d255c5bf79e6a190a37dbe4c7eb2312c5 Mon Sep 17 00:00:00 2001
 From: Trung Nguyen <trungnt282910@gmail.com>
 Date: Thu, 7 Jul 2022 22:19:34 +0700
 Subject: libunwind: Haiku: Initial support
@@ -591,7 +591,7 @@ index 4bbac95..0dd10e0 100644
 2.37.3
 
 
-From 6463a9177747abdfddbbd765064114559b573b4e Mon Sep 17 00:00:00 2001
+From bd21e1d8dd2d9c57854108d75b2d802b8d508a30 Mon Sep 17 00:00:00 2001
 From: X512 <danger_mail@list.ru>
 Date: Mon, 10 Oct 2022 12:18:55 +0900
 Subject: Haiku: reimplement toolchain driver, make lld functional
@@ -888,7 +888,7 @@ index f649d8d..70fc0dc 100644
 2.37.3
 
 
-From 0cd8d7503903aed24646c4b0fe07c8ec55e0a58f Mon Sep 17 00:00:00 2001
+From dba4f86ac22bdf3e7d25641a296e2925a071979b Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Wed, 9 Aug 2023 23:05:15 +0200
 Subject: Haiku: implement GCC installation detection
@@ -966,7 +966,7 @@ index 5be6a7f..ff29972 100644
 2.37.3
 
 
-From aef871bfd3b0c88bebbab105158e35291a6850d6 Mon Sep 17 00:00:00 2001
+From 000a381c4d0c2ef0cc4669f2de4bebc903620c39 Mon Sep 17 00:00:00 2001
 From: Trung Nguyen <57174311+trungnt2910@users.noreply.github.com>
 Date: Mon, 14 Aug 2023 14:58:56 +1000
 Subject: clang: Haiku: Add missing GNU headers include path
@@ -988,7 +988,7 @@ index 5b91907..5208b05 100644
 2.37.3
 
 
-From d5467f1730e80f5b6c16d7d3e83c7da1a0722826 Mon Sep 17 00:00:00 2001
+From 22198a3f8c7792d6a49931be9653d44ad6c2a922 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Sat, 26 Aug 2023 09:36:42 +0200
 Subject: clang: Haiku: silence warning for -pie
@@ -1012,7 +1012,7 @@ index ff29972..18888e0 100644
 2.37.3
 
 
-From 61eaa737063a16c93ec722f93ec55b16cf6a3fcb Mon Sep 17 00:00:00 2001
+From aaf578a669b46977cf97b20825cd88a6d0546e8e Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Sun, 27 Aug 2023 19:32:12 +0200
 Subject: clang: Haiku: silence warning for -pthread and -pthreads when linking
@@ -1034,6 +1034,55 @@ index 18888e0..fcd2a1e 100644
    }
  
    if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nostartfiles,
+-- 
+2.37.3
+
+
+From c01ea9092bcd168d21a3d9b36de5b1695446b603 Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Tue, 12 Sep 2023 18:30:30 +0200
+Subject: clang: Haiku: remove custom addLibStdCxxIncludePaths implementation
+
+* previous implementation referred to a non-existent directory
+* we can reuse the logic inherited from base class Generic_GCC
+
+diff --git a/clang/lib/Driver/ToolChains/Haiku.cpp b/clang/lib/Driver/ToolChains/Haiku.cpp
+index fcd2a1e..231f514 100644
+--- a/clang/lib/Driver/ToolChains/Haiku.cpp
++++ b/clang/lib/Driver/ToolChains/Haiku.cpp
+@@ -186,18 +186,6 @@ void Haiku::addLibCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
+                    getDriver().SysRoot + "/boot/system/develop/headers/c++/v1");
+ }
+ 
+-void Haiku::addLibStdCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
+-                                     llvm::opt::ArgStringList &CC1Args) const {
+-#ifdef HAIKU_HYBRID_SECONDARY
+-  addLibStdCXXIncludePaths(getDriver().SysRoot + "/boot/system/develop/headers/"
+-                     HAIKU_HYBRID_SECONDARY "/c++", getTriple().str(), "",
+-                     DriverArgs, CC1Args);
+-#else
+-  addLibStdCXXIncludePaths(getDriver().SysRoot + "/boot/system/develop/headers/c++",
+-                           getTriple().str(), "", DriverArgs, CC1Args);
+-#endif
+-}
+-
+ void Haiku::AddCXXStdlibLibArgs(const ArgList &Args,
+                                   ArgStringList &CmdArgs) const {
+   CXXStdlibType Type = GetCXXStdlibType(Args);
+diff --git a/clang/lib/Driver/ToolChains/Haiku.h b/clang/lib/Driver/ToolChains/Haiku.h
+index 70fc0dc..be3425e 100644
+--- a/clang/lib/Driver/ToolChains/Haiku.h
++++ b/clang/lib/Driver/ToolChains/Haiku.h
+@@ -66,9 +66,6 @@ public:
+   void addLibCxxIncludePaths(
+       const llvm::opt::ArgList &DriverArgs,
+       llvm::opt::ArgStringList &CC1Args) const override;
+-  void addLibStdCxxIncludePaths(
+-      const llvm::opt::ArgList &DriverArgs,
+-      llvm::opt::ArgStringList &CC1Args) const override;
+ protected:
+   Tool *buildLinker() const override;
+ };
 -- 
 2.37.3
 


### PR DESCRIPTION
this should help with #9407

successful build on 32-bit & 64-bit
