### PR TITLE
python pathtools, rename recipe (conflicts)

### DIFF
--- a/dev-python/py_pathtools/py_pathtools-0.1.2.recipe
+++ b/dev-python/py_pathtools/py_pathtools-0.1.2.recipe
@@ -3,9 +3,10 @@ DESCRIPTION="Pattern matching and various utilities for file systems paths."
 HOMEPAGE="https://github.com/gorakhargosh/pathtools"
 COPYRIGHT="2010 Yesudeep Mangalapilly"
 LICENSE="MIT"
-REVISION="8"
+REVISION="9"
 SOURCE_URI="https://pypi.python.org/packages/source/p/pathtools/pathtools-$portVersion.tar.gz"
 CHECKSUM_SHA256="7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0"
+SOURCE_DIR="pathtools-$portVersion"
 
 ARCHITECTURES="any"
 

--- a/dev-python/watchdog/watchdog-0.9.0.recipe
+++ b/dev-python/watchdog/watchdog-0.9.0.recipe
@@ -4,7 +4,7 @@ HOMEPAGE="https://pypi.python.org/pypi/watchdog"
 COPYRIGHT="2011 Yesudeep Mangalapilly
 	2012 Google, Inc."
 LICENSE="Apache v2"
-REVISION="7"
+REVISION="8"
 SOURCE_URI="https://pypi.python.org/packages/source/w/watchdog/watchdog-$portVersion.tar.gz"
 CHECKSUM_SHA256="965f658d0732de3188211932aeb0bb457587f04f63ab4c1e33eab878e9de961d"
 
@@ -47,7 +47,7 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 		haiku
 		cmd:python$pythonVersion
 		argh_$pythonPackage
-		pathtools_$pythonPackage
+		py_pathtools_$pythonPackage
 		pyyaml_$pythonPackage
 		\""
 


### PR DESCRIPTION
This seems somehow deprecated (latest commit 2016), whatchdog depends on this, but has seen newer versions upstream, could be newer ones don't depend on this anymore, if not on a version bump there this could be removed from the repository.