### PR TITLE
watchdog: update to version 3.0.0

### DIFF
--- a/dev-python/watchdog/watchdog-3.0.0.recipe
+++ b/dev-python/watchdog/watchdog-3.0.0.recipe
@@ -4,9 +4,9 @@ HOMEPAGE="https://pypi.python.org/pypi/watchdog"
 COPYRIGHT="2011 Yesudeep Mangalapilly
 	2012 Google, Inc."
 LICENSE="Apache v2"
-REVISION="8"
+REVISION="1"
 SOURCE_URI="https://pypi.python.org/packages/source/w/watchdog/watchdog-$portVersion.tar.gz"
-CHECKSUM_SHA256="965f658d0732de3188211932aeb0bb457587f04f63ab4c1e33eab878e9de961d"
+CHECKSUM_SHA256="4d98a320595da7a7c5a18fc48cb633c2e73cda78f93cac2ef42d42bf609a33f9"
 
 ARCHITECTURES="any"
 
@@ -46,8 +46,6 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 	eval "REQUIRES_$pythonPackage=\"
 		haiku
 		cmd:python$pythonVersion
-		argh_$pythonPackage
-		py_pathtools_$pythonPackage
 		pyyaml_$pythonPackage
 		\""
 


### PR DESCRIPTION
Drops requirements for `argh` and `py_pathtools` (we might just want to get rid of the latter).