### PR TITLE
dbuspython: update to version 1.3.2, support Python 3.10.

### DIFF
--- a/dev-python/dbuspython/dbuspython-1.3.2.recipe
+++ b/dev-python/dbuspython/dbuspython-1.3.2.recipe
@@ -17,9 +17,9 @@ COPYRIGHT="2002-2010 Red Hat Inc.
 LICENSE="MIT
 	AFL v2.1
 	GNU GPL v2"
-REVISION="5"
+REVISION="1"
 SOURCE_URI="https://dbus.freedesktop.org/releases/dbus-python/dbus-python-$portVersion.tar.gz"
-CHECKSUM_SHA256="b10206ba3dd641e4e46411ab91471c88e0eec1749860e4285193ee68df84ac31"
+CHECKSUM_SHA256="ad67819308618b5069537be237f8e68ca1c7fcc95ee4a121fe6845b1418248f8"
 SOURCE_DIR="dbus-python-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -47,8 +47,8 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python39)
-PYTHON_VERSIONS=(3.9)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -109,7 +109,7 @@ INSTALL()
 
 		packageEntries $pythonPackage \
 			$prefix/lib/python*
-
 	done
+
 	fixPkgconfig
 }


### PR DESCRIPTION
Only user of this package, Calibre, dropped this dependency in favor of the "pure-Python" `jeepney` package on newer versions.

For now, this will do.