### PR TITLE
dnspython: cleanup, support Python 3.10.

### DIFF
--- a/dev-python/dnspython/dnspython-1.16.0.recipe
+++ b/dev-python/dnspython/dnspython-1.16.0.recipe
@@ -7,7 +7,7 @@ COPYRIGHT="Dnspython Contributors
 	2001-2017 Nominum, Inc.
 	Google Inc."
 LICENSE="ISC"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://github.com/rthalley/dnspython/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="b339ac2eb070d0133f020a6e0cc137a10fc380f3eba3e0655d62a19e64626cbd"
 
@@ -24,23 +24,26 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39)
-PYTHON_VERSIONS=(3.9)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\n\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\n\
-	setuptools_$pythonPackage\n\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cmd:python$pythonVersion
+		setuptools_$pythonPackage
+		\""
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()
@@ -52,12 +55,14 @@ INSTALL()
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }


### PR DESCRIPTION
Not updating this one for now, as the one needed by the only package on-tree that uses it (`calibre`) requires not the latest version but version 2.1.0, and to build that version and up, we need to have the `poetry` build system available first.