### PR TITLE
perl: drop gcc2, making perl_x86 the default

### DIFF
--- a/dev-lang/perl/perl-5.32.1.recipe
+++ b/dev-lang/perl/perl-5.32.1.recipe
@@ -16,58 +16,64 @@ HOMEPAGE="https://www.perl.org/"
 COPYRIGHT="1993-2019 Larry Wall and others"
 LICENSE="GNU GPL v1
 	Artistic"
-REVISION="1"
+REVISION="2"
 perlShortVersion="${portVersion%.*}"
 SOURCE_URI="http://www.cpan.org/src/perl-$portVersion.tar.gz"
 CHECKSUM_SHA256="03b693901cd8ae807231b1787798cf1f2e0b8a56218d07b7da44f784a7caeb2c"
 PATCHES="perl-$portVersion.patchset"
 
-ARCHITECTURES="all"
+ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	# assume that any perl commands are backwards compatible to version 5.
 	perl$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:corelist$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:cpan$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:enc2xs$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:encguess$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:h2ph$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:h2xs$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:instmodsh$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:json_pp$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:libnetcfg$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:perl$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:perl$portVersion$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:perlbug$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:perldoc$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:perlivp$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:perlthanks$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:piconv$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:pl2pm$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:pod2html$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:pod2man$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:pod2text$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:pod2usage$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:podchecker$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:podselect$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:prove$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:ptar$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:ptardiff$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:ptargrep$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:shasum$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:splain$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:streamzip$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:xsubpp$secondaryArchSuffix = $portVersion compat >= 5
-	cmd:zipdetails$secondaryArchSuffix = $portVersion compat >= 5
+	cmd:corelist = $portVersion compat >= 5
+	cmd:cpan = $portVersion compat >= 5
+	cmd:enc2xs = $portVersion compat >= 5
+	cmd:encguess = $portVersion compat >= 5
+	cmd:h2ph = $portVersion compat >= 5
+	cmd:h2xs = $portVersion compat >= 5
+	cmd:instmodsh = $portVersion compat >= 5
+	cmd:json_pp = $portVersion compat >= 5
+	cmd:libnetcfg = $portVersion compat >= 5
+	cmd:perl = $portVersion compat >= 5
+	cmd:perl$portVersion = $portVersion compat >= 5
+	cmd:perlbug = $portVersion compat >= 5
+	cmd:perldoc = $portVersion compat >= 5
+	cmd:perlivp = $portVersion compat >= 5
+	cmd:perlthanks = $portVersion compat >= 5
+	cmd:piconv = $portVersion compat >= 5
+	cmd:pl2pm = $portVersion compat >= 5
+	cmd:pod2html = $portVersion compat >= 5
+	cmd:pod2man = $portVersion compat >= 5
+	cmd:pod2text = $portVersion compat >= 5
+	cmd:pod2usage = $portVersion compat >= 5
+	cmd:podchecker = $portVersion compat >= 5
+	cmd:podselect = $portVersion compat >= 5
+	cmd:prove = $portVersion compat >= 5
+	cmd:ptar = $portVersion compat >= 5
+	cmd:ptardiff = $portVersion compat >= 5
+	cmd:ptargrep = $portVersion compat >= 5
+	cmd:shasum = $portVersion compat >= 5
+	cmd:splain = $portVersion compat >= 5
+	cmd:streamzip = $portVersion compat >= 5
+	cmd:xsubpp = $portVersion compat >= 5
+	cmd:zipdetails = $portVersion compat >= 5
 	# vendor_perl refers to the path to packaged perl modules, which includes
 	# the short perl version, so it is backwards compatible up this one.
-	vendor_perl$secondaryArchSuffix = $perlShortVersion compat >= $perlShortVersion
-	lib:libperl$secondaryArchSuffix = $portVersion compat >= $perlShortVersion
+	vendor_perl = $perlShortVersion compat >= $perlShortVersion
+	lib:libperl = $portVersion compat >= $perlShortVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
 	"
+
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	REPLACES="
+		perl
+		"
+fi
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
@@ -84,8 +90,8 @@ BUILD_PREREQUIRES="
 perlArchName="$(uname -m)-haiku"
 
 GLOBAL_WRITABLE_FILES="
-	non-packaged/$relativeLibDir/perl5/site_perl/$perlShortVersion/sitecustomize.pl keep-old
-	non-packaged/$relativeLibDir/perl5/site_perl/$perlShortVersion/$perlArchName directory keep-old
+	non-packaged/lib/perl5/site_perl/$perlShortVersion/sitecustomize.pl keep-old
+	non-packaged/lib/perl5/site_perl/$perlShortVersion/$perlArchName directory keep-old
 	"
 
 BUILD_PACKAGE_ACTIVATION_PHASE=INSTALL
@@ -94,13 +100,11 @@ BUILD()
 {
 	./Configure \
 		-Dprefix=$prefix \
-		-Dbin=$binDir \
-		-Dscriptdir=$binDir \
-		-Dprivlib=$libDir/perl5/$portVersion \
+		-Dprivlib=$prefix/lib/perl5/$portVersion \
 		-Dsiteprefix=$prefix/non-packaged \
-		-Dsitelib=$prefix/non-packaged/$relativeLibDir/perl5/site_perl/$perlShortVersion \
+		-Dsitelib=$prefix/non-packaged/lib/perl5/site_perl/$perlShortVersion \
 		-Dvendorprefix=$prefix \
-		-Dvendorlib=$libDir/perl5/vendor_perl/$perlShortVersion \
+		-Dvendorlib=$prefix/lib/perl5/vendor_perl/$perlShortVersion \
 		-Dcf_email=zooey@hirschkaefer.de \
 		-Uusenm -Duseshrplib -Uusemymalloc \
 		-Dlibpth="$(finddir B_USER_DEVELOP_DIRECTORY)/lib$secondaryArchSubDir $(finddir B_SYSTEM_DEVELOP_DIRECTORY)/lib$secondaryArchSubDir" \
@@ -110,7 +114,7 @@ BUILD()
 		-Dlibs=-lnetwork -Dcc=gcc -Dld=gcc \
 		-Ud_link -Ddont_use_nlink -Ud_syserrlst \
 		-Dldlibpthname=LIBRARY_PATH -Dstartperl="#! perl" \
-		-Dccdlflags="-Wl,-fno-stack-protector,-rpath=$libDir/perl5/$portVersion/$perlArchName/CORE" \
+		-Dccdlflags="-Wl,-fno-stack-protector,-rpath=$prefix/lib/perl5/$portVersion/$perlArchName/CORE" \
 		-Dusesitecustomize \
 		-de
 
@@ -123,10 +127,10 @@ BUILD()
 INSTALL()
 {
 	make install
-	chmod a+x $binDir/{perl,perlthanks}
+	chmod a+x $prefix/bin/{perl,perlthanks}
 
 	# copy script into site_perl that takes care of massaging @INC into what we need.
-	sed "s|/lib/|/lib$secondaryArchSubDir/|g" sitecustomize.pl > $prefix/non-packaged/$relativeLibDir/perl5/site_perl/$perlShortVersion/sitecustomize.pl
+	cp sitecustomize.pl $prefix/non-packaged/lib/perl5/site_perl/$perlShortVersion/sitecustomize.pl
 	# TODO: maybe generate the script dynamically in the recipe (using recipe variables) instead of statically in the patchset
 }
 

--- a/dev-lang/perl/perl-5.32.1.recipe
+++ b/dev-lang/perl/perl-5.32.1.recipe
@@ -107,7 +107,7 @@ BUILD()
 		-Dvendorlib=$prefix/lib/perl5/vendor_perl/$perlShortVersion \
 		-Dcf_email=zooey@hirschkaefer.de \
 		-Uusenm -Duseshrplib -Uusemymalloc \
-		-Dlibpth="$(finddir B_USER_DEVELOP_DIRECTORY)/lib$secondaryArchSubDir $(finddir B_SYSTEM_DEVELOP_DIRECTORY)/lib$secondaryArchSubDir" \
+		-Dlibpth="$(finddir B_USER_DEVELOP_DIRECTORY)/lib$secondaryArchSubDir $(finddir B_SYSTEM_DEVELOP_DIRECTORY)/lib$secondaryArchSubDir $(finddir B_USER_LIB_DIRECTORY)$secondaryArchSubDir $(finddir B_SYSTEM_LIB_DIRECTORY)$secondaryArchSubDir" \
 		-Dusrinc="$(finddir B_SYSTEM_DEVELOP_DIRECTORY)/headers$secondaryArchSubDir/posix" \
 		-Dlocinc="$(finddir B_USER_CONFIG_DIRECTORY)/develop/headers$secondaryArchSubDir $(finddir B_SYSTEM_DEVELOP_DIRECTORY)/headers$secondaryArchSubDir" \
 		-Dlibc="'$(finddir B_SYSTEM_LIB_DIRECTORY)$secondaryArchSubDir/libroot.so'" \


### PR DESCRIPTION
This is an alternative solution to #9394