### PR TITLE
whichcraft: cleanup, support only Python 3.10 for now.

### DIFF
--- a/dev-python/whichcraft/whichcraft-0.6.1.recipe
+++ b/dev-python/whichcraft/whichcraft-0.6.1.recipe
@@ -4,7 +4,7 @@ portable way."
 HOMEPAGE="https://pypi.org/project/whichcraft"
 COPYRIGHT="2015-2019 Daniel Roy Greenfeld"
 LICENSE="BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/cookiecutter/whichcraft/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="bfa077578261e8bce72ebd44025a2ac196f943123e551589bd5f1c25af9f0085"
 SOURCE_FILENAME="whichcraft-$portVersion.tar.gz"
@@ -23,22 +23,25 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39)
-PYTHON_VERSIONS=(3.9)
+PYTHON_PACKAGES=(python310)
+PYTHON_VERSIONS=(3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()
@@ -50,13 +53,14 @@ INSTALL()
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }
-


### PR DESCRIPTION
Nothing uses this on-tree. Seems this is (or was) needed by webkit's unit tests, but `haikuwebkit` already has moved to Python 3.10.