### PR TITLE
pythonzeroconf: cleanup, support Python 3.10.

### DIFF
--- a/dev-python/pythonzeroconf/pythonzeroconf-0.29.0.recipe
+++ b/dev-python/pythonzeroconf/pythonzeroconf-0.29.0.recipe
@@ -4,7 +4,7 @@ HOMEPAGE="https://github.com/jstasiak/python-zeroconf/"
 COPYRIGHT="2003 Paul Scott-Murphy
 	2014 William McBrine"
 LICENSE="GNU LGPL v2.1"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/jstasiak/python-zeroconf/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="b8e7c55f36973362314b7d8cf716a76afea3c91abe9d2f435329dc67b973fe06"
 SOURCE_FILENAME="zeroconf-$portVersion.tar.gz"
@@ -22,11 +22,12 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39)
-PYTHON_VERSIONS=(3.9)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[i]}
+
 	eval "PROVIDES_$pythonPackage=\"
 		pythonzeroconf_$pythonPackage = $portVersion
 		\""
@@ -35,44 +36,31 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 		ifaddr_$pythonPackage
 		cmd:python$pythonVersion
 		\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage
-	"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
-
-BUILD()
-{
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
-		pythonVersion=${PYTHON_VERSIONS[i]}
-
-		rm -rf "$sourceDir"-$pythonPackage
-		cp -a "$sourceDir" "$sourceDir"-$pythonPackage
-		cd "$sourceDir"-$pythonPackage
-
-		python=python$pythonVersion
-		$python setup.py build
-	done
-}
 
 INSTALL()
 {
 	for i in "${!PYTHON_PACKAGES[@]}"; do
 		pythonPackage=${PYTHON_PACKAGES[i]}
-		pythonVersion=${PYTHON_VERSIONS[i]}
-
-		cd "$sourceDir"-$pythonPackage
+		pythonVersion=${PYTHON_VERSIONS[$i]}
 
 		python=python$pythonVersion
-		installLocation=$prefix/lib/$python/vendor-packages
-		export PYTHONPATH=$installLocation
-		mkdir -p "$installLocation"
-		$python setup.py install \
-			--root=/ --prefix="$prefix" --skip-build
+		installLocation=$prefix/lib/$python/vendor-packages/
+		export PYTHONPATH=$installLocation:$PYTHONPATH
+
+		mkdir -p $installLocation
+		rm -rf build
+
+		$python setup.py build install \
+			--root=/ --prefix=$prefix
 
 		packageEntries $pythonPackage \
-			"$prefix"/lib/$python
+			$prefix/lib/python*
 	done
 }


### PR DESCRIPTION
Just the necessary bits to get it to work with Python 3.10.

Not updating to the latest version, for now at least, as that requires building it with `poetry` (which we currently do not have).