### PR TITLE
svgwrite: update to version 1.4.3, support Python 3.10.

### DIFF
--- a/dev-python/svgwrite/svgwrite-1.4.3.recipe
+++ b/dev-python/svgwrite/svgwrite-1.4.3.recipe
@@ -5,14 +5,13 @@ include other SVG drawings by the <image> entity."
 HOMEPAGE="https://github.com/mozman/svgwrite"
 COPYRIGHT="2012 Manfred Moitzi"
 LICENSE="MIT"
-REVISION="3"
+REVISION="1"
 SOURCE_URI="https://github.com/mozman/svgwrite/archive/refs/tags/v$portVersion.tar.gz"
-CHECKSUM_SHA256="91d633be72f3e064377068df796121a9b8797ec961f4948283a2efe1ae11299c"
+CHECKSUM_SHA256="14a0c001703a066bf9c59adb478f6db5b82dad3d3cb0a675d08cb37acab77081"
 ARCHITECTURES="any"
 
 PROVIDES="
 	$portName = $portVersion
-	cmd:svgwrite.py
 	"
 REQUIRES="
 	haiku
@@ -22,22 +21,25 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39)
-PYTHON_VERSIONS=(3.9)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES="$BUILD_REQUIRES
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES="$BUILD_PREREQUIRES
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()
@@ -49,13 +51,14 @@ INSTALL()
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }
-


### PR DESCRIPTION
Not used anywhere on-tree, and project is marked as inactive/unmaintained on GitHub. We might just want to drop this one next time.

(`pip3.xx install svgwrite` will still work for those that might need it)