### PR TITLE
texinfo: move commands to $prefix/bin and update for secondaryArch perl

### DIFF
--- a/sys-apps/texinfo/texinfo-6.1.recipe
+++ b/sys-apps/texinfo/texinfo-6.1.recipe
@@ -4,12 +4,12 @@ Texinfo is the official documentation format of the GNU project."
 HOMEPAGE="http://www.gnu.org/software/texinfo/"
 COPYRIGHT="1992-2008 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3"
-REVISION="7"
+REVISION="8"
 SOURCE_URI="http://ftp.gnu.org/gnu/texinfo/texinfo-$portVersion.tar.gz"
 CHECKSUM_SHA256="02582b6d9b0552f1cb1312be6bd7023e9799603c3b2320fa68a36029e4cbafbb"
 PATCHES="texinfo-$portVersion.patchset"
 
-ARCHITECTURES="all"
+ARCHITECTURES="x86_gcc2"
 
 PROVIDES="
 	texinfo = $portVersion compat >= 4
@@ -30,7 +30,6 @@ REQUIRES="
 	lib:libiconv
 	lib:libintl
 	lib:libncurses
-	lib:libperl
 	"
 
 BUILD_REQUIRES="

--- a/sys-apps/texinfo/texinfo-7.0.3.recipe
+++ b/sys-apps/texinfo/texinfo-7.0.3.recipe
@@ -38,12 +38,8 @@ REQUIRES="
 	lib:libiconv$secondaryArchSuffix
 	lib:libintl$secondaryArchSuffix
 	lib:libncurses$secondaryArchSuffix
+	lib:libperl
 	"
-if [ -z "$secondaryArchSuffix" ]; then
-	REQUIRES+="
-		lib:libperl
-		"
-fi
 if [ "$targetArchitecture" = x86_gcc2 ]; then
 	CONFLICTS="texinfo"
 fi
@@ -69,11 +65,7 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	local configureArgs;
-	if [ -n "$secondaryArchSuffix" ]; then
-		configureArgs="--disable-perl-xs"
-	fi
-	AUTOPOINT=: runConfigure  --omit-dirs binDir ./configure --bindir=$commandBinDir $configureArgs
+	AUTOPOINT=: runConfigure  --omit-dirs binDir ./configure --bindir=$commandBinDir
 	make $jobArgs
 }
 
@@ -81,9 +73,6 @@ INSTALL()
 {
 	make install
 
-	if [ -z "$secondaryArchSuffix" ]; then
-		# remove libtool files
-		rm $libDir/texinfo/*.la
-	fi
-
+	# remove libtool files
+	rm $libDir/texinfo/*.la
 }

--- a/sys-apps/texinfo/texinfo-7.0.3.recipe
+++ b/sys-apps/texinfo/texinfo-7.0.3.recipe
@@ -38,7 +38,7 @@ REQUIRES="
 	lib:libiconv$secondaryArchSuffix
 	lib:libintl$secondaryArchSuffix
 	lib:libncurses$secondaryArchSuffix
-	lib:libperl
+	lib:libperl$secondaryArchSuffix
 	"
 if [ "$targetArchitecture" = x86_gcc2 ]; then
 	CONFLICTS="texinfo"

--- a/sys-apps/texinfo/texinfo-7.0.3.recipe
+++ b/sys-apps/texinfo/texinfo-7.0.3.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="Texinfo is the official documentation format of the GNU project."
 HOMEPAGE="http://www.gnu.org/software/texinfo/"
 COPYRIGHT="1992-2008 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="http://ftp.gnu.org/gnu/texinfo/texinfo-$portVersion.tar.gz"
 CHECKSUM_SHA256="3cc5706fb086b895e1dc2b407aade9f95a3a233ff856273e2b659b089f117683"
 PATCHES="texinfo-$portVersion.patchset"
@@ -11,18 +11,26 @@ PATCHES="texinfo-$portVersion.patchset"
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
+# On x86_gcc2 we don't want to install the commands in bin/<arch>/, but in bin/.
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
 PROVIDES="
 	texinfo$secondaryArchSuffix = $portVersion compat >= 4
-	cmd:info$secondaryArchSuffix = $portVersion compat >= 4
-	cmd:infokey$secondaryArchSuffix = $portVersion compat >= 4
-	cmd:install_info$secondaryArchSuffix = $portVersion compat >= 4
-	cmd:makeinfo$secondaryArchSuffix = $portVersion compat >= 4
-	cmd:pdftexi2dvi$secondaryArchSuffix = $portVersion compat >= 4
-	cmd:pod2texi$secondaryArchSuffix = $portVersion compat >= 6
-	cmd:texi2any$secondaryArchSuffix = $portVersion compat >= 6
-	cmd:texi2dvi$secondaryArchSuffix = $portVersion compat >= 4
-	cmd:texi2pdf$secondaryArchSuffix = $portVersion compat >= 4
-	cmd:texindex$secondaryArchSuffix = $portVersion compat >= 4
+	cmd:info$commandSuffix = $portVersion compat >= 4
+	cmd:infokey$commandSuffix = $portVersion compat >= 4
+	cmd:install_info$commandSuffix = $portVersion compat >= 4
+	cmd:makeinfo$commandSuffix = $portVersion compat >= 4
+	cmd:pdftexi2dvi$commandSuffix = $portVersion compat >= 4
+	cmd:pod2texi$commandSuffix = $portVersion compat >= 6
+	cmd:texi2any$commandSuffix = $portVersion compat >= 6
+	cmd:texi2dvi$commandSuffix = $portVersion compat >= 4
+	cmd:texi2pdf$commandSuffix = $portVersion compat >= 4
+	cmd:texindex$commandSuffix = $portVersion compat >= 4
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -30,12 +38,14 @@ REQUIRES="
 	lib:libiconv$secondaryArchSuffix
 	lib:libintl$secondaryArchSuffix
 	lib:libncurses$secondaryArchSuffix
-	lib:libperl$secondaryArchSuffix
 	"
-if [ -n "$secondaryArchSuffix" ]; then
-CONFLICTS="
-	texinfo
-	"
+if [ -z "$secondaryArchSuffix" ]; then
+	REQUIRES+="
+		lib:libperl
+		"
+fi
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	CONFLICTS="texinfo"
 fi
 
 BUILD_REQUIRES="
@@ -49,17 +59,21 @@ BUILD_PREREQUIRES="
 	cmd:autoconf
 	cmd:gawk
 	cmd:gcc$secondaryArchSuffix
-	cmd:gettext
+	cmd:gettext$secondaryArchSuffix
 	cmd:grep
 	cmd:ld$secondaryArchSuffix
 	cmd:make
-	cmd:perl$secondaryArchSuffix
+	cmd:perl
 	cmd:sed
 	"
 
 BUILD()
 {
-	AUTOPOINT=true runConfigure ./configure
+	local configureArgs;
+	if [ -n "$secondaryArchSuffix" ]; then
+		configureArgs="--disable-perl-xs"
+	fi
+	AUTOPOINT=: runConfigure  --omit-dirs binDir ./configure --bindir=$commandBinDir $configureArgs
 	make $jobArgs
 }
 
@@ -67,6 +81,9 @@ INSTALL()
 {
 	make install
 
-	# remove libtool files
-	rm $libDir/texinfo/*.la
+	if [ -z "$secondaryArchSuffix" ]; then
+		# remove libtool files
+		rm $libDir/texinfo/*.la
+	fi
+
 }


### PR DESCRIPTION
to drop the dependency on libperl_x86.
installs binaries in $prefix/bin on x86.