### PR TITLE
pypeg2: cleanups, support Python 3.10.

### DIFF
--- a/dev-python/pypeg2/pypeg2-2.15.2.recipe
+++ b/dev-python/pypeg2/pypeg2-2.15.2.recipe
@@ -8,7 +8,7 @@ And pyPEG supports Unicode."
 HOMEPAGE="https://pypi.python.org/pypi/pypeg2"
 COPYRIGHT="2009-2014 Volker Birk"
 LICENSE="GNU GPL v2"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://pypi.io/packages/source/p/pyPEG2/pyPEG2-$portVersion.tar.gz"
 CHECKSUM_SHA256="2b2d4f80d8e1a9370b2a91f4a25f4abf7f69b85c8da84cd23ec36451958a1f6d"
 SOURCE_DIR="pyPEG2-$portVersion"
@@ -26,22 +26,25 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39)
-PYTHON_VERSIONS=(3.9)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()
@@ -53,12 +56,14 @@ INSTALL()
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }


### PR DESCRIPTION
Nothing uses this old package (no new releases since 2015) on-tree. We might want to just drop this one next time (users will be able to use it via `pip install` if they miss it).