### PR TITLE
rdflib: switch recipe to Python 3.10.

### DIFF
--- a/dev-python/rdflib/rdflib-5.0.0.recipe
+++ b/dev-python/rdflib/rdflib-5.0.0.recipe
@@ -4,7 +4,7 @@ yet powerful language for representing information as graphs."
 HOMEPAGE="https://github.com/RDFLib/rdflib"
 COPYRIGHT="2002-2017 RDFLib Team"
 LICENSE="BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://pypi.io/packages/source/r/rdflib/rdflib-$portVersion.tar.gz"
 CHECKSUM_SHA256="78149dd49d385efec3b3adfbd61c87afaf1281c30d3fcaf1b323b34f603fb155"
 
@@ -21,8 +21,9 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39)
-PYTHON_VERSIONS=(3.9)
+PYTHON_PACKAGES=(python310)
+PYTHON_VERSIONS=(3.10)
+defaultVersion=3.10 # just in case we support it for more than one Python version
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -35,41 +36,34 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 		cmd:rdfpipe_$pythonVersion
 		cmd:rdfs2dot_$pythonVersion
 		\""
-	eval "REQUIRES_$pythonPackage=\"
-		haiku
-		cmd:python$pythonVersion
-		\""
-	if [ $pythonPackage = python39 ]; then
-		PROVIDES_python39+="
+
+	if [ $pythonVersion = $defaultVersion ]; then
+		eval "PROVIDES_${pythonPackage}+=\"
 			cmd:csv2rdf
 			cmd:rdf2dot
 			cmd:rdfgraphisomorphism
 			cmd:rdfpipe
 			cmd:rdfs2dot
-			"
+			\""
 	fi
-	BUILD_REQUIRES="$BUILD_REQUIRES
-		setuptools_$pythonPackage"
-	BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-		cmd:python$pythonVersion"
-	TEST_REQUIRES="$TEST_REQUIRES
-		nose_$pythonPackage"
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cmd:python$pythonVersion
+		\""
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
+	TEST_REQUIRES+="
+		nose_$pythonPackage
+		setuptools_$pythonPackage
+		pip_$pythonPackage # to install "doctest-ignore-unicode"
+		wheel_$pythonPackage
+		"
 done
-
-BUILD()
-{
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
-		pythonVersion=${PYTHON_VERSIONS[$i]}
-
-		rm -rf "$sourceDir"-$pythonPackage
-		cp -a "$sourceDir" "$sourceDir"-$pythonPackage
-		cd "$sourceDir"-$pythonPackage
-
-		python=python$pythonVersion
-		$python setup.py build
-	done
-}
 
 INSTALL()
 {
@@ -77,36 +71,38 @@ INSTALL()
 		pythonPackage=${PYTHON_PACKAGES[i]}
 		pythonVersion=${PYTHON_VERSIONS[$i]}
 
-		cd "$sourceDir"-$pythonPackage
-
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
-		export PYTHONPATH=$installLocation
-		mkdir -p "$installLocation"
-		$python setup.py install \
-			--root=/ --prefix="$prefix"
+		export PYTHONPATH=$installLocation:$PYTHONPATH
 
-		maybeBinDir="$binDir"
-		if [ "$pythonPackage" != python39 ]; then
-			rm -rf "$binDir"
-			maybeBinDir=
+		mkdir -p $installLocation
+		rm -rf build
+
+		$python setup.py build install \
+			--root=/ --prefix=$prefix
+
+		# Version suffix all the scripts
+		for f in $binDir/*; do
+			mv $f $f-$pythonVersion
+		done
+
+		# And provide suffix-less symlinks for the default version
+		if [ $pythonVersion = $defaultVersion ]; then
+			for f in $binDir/*; do
+				ln -sr $f ${f%-$pythonVersion}
+			done
 		fi
 
 		packageEntries $pythonPackage \
-			"$prefix"/lib/$python \
-			$maybeBinDir
+			$prefix/lib/python* \
+			$binDir
 	done
 }
 
 TEST()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
-		pythonVersion=${PYTHON_VERSIONS[$i]}
-
-		cd "$sourceDir"-$pythonPackage
-
-		python=python$pythonVersion
+	for i in "${!PYTHON_VERSIONS[@]}"; do
+		python=python${PYTHON_VERSIONS[$i]}
 		$python setup.py test
 	done
 }


### PR DESCRIPTION
Instead of dropping it, just move it to Python 3.10.

Original PR description follows:

---
Nothing uses it on-tree. Still available via `pip install`.