### PR TITLE
editorconfig_core_py: clean ups, support Python 3.10.

### DIFF
--- a/dev-python/editorconfig-core-py/editorconfig_core_py-0.12.3.recipe
+++ b/dev-python/editorconfig-core-py/editorconfig_core_py-0.12.3.recipe
@@ -9,7 +9,7 @@ website."
 HOMEPAGE="https://editorconfig.org/"
 COPYRIGHT="2011-2018 EditorConfig Team"
 LICENSE="BSD (2-clause)"
-REVISION="3"
+REVISION="1"
 pyName="EditorConfig"
 SOURCE_URI="https://pypi.io/packages/source/${pyName:0:1}/$pyName/$pyName-$portVersion.tar.gz"
 CHECKSUM_SHA256="57f8ce78afcba15c8b18d46b5170848c88d56fd38f05c2ec60dbbfcb8996e89e"
@@ -26,26 +26,38 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku_devel
-	cmd:cmake
 	"
 
-PYTHON_PACKAGES=(python39)
-PYTHON_VERSIONS=(3.9)
+PYTHON_PACKAGES=(python39 python310)
+PYTHON_VERSIONS=(3.9 3.10)
+defaultVersion=3.10
 for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\n\
-	cmd:editorconfig${pythonVersion}\n\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	pythonPackage=${PYTHON_PACKAGES[i]}
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		cmd:editorconfig_$pythonVersion
+		\""
+
+	if [ $pythonVersion = $defaultVersion ]; then
+		eval "PROVIDES_${pythonPackage}+=\"
+			cmd:editorconfig
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cmd:python$pythonVersion
+		\""
+
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:cmake
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()
@@ -57,31 +69,27 @@ INSTALL()
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
-		mv $prefix/bin/editorconfig $prefix/bin/editorconfig${pythonVersion}
 
-		packageEntries  $pythonPackage \
+		# Version suffix all the scripts
+		for f in $binDir/*; do
+			mv $f $f-$pythonVersion
+		done
+
+		# And provide suffix-less symlinks for the default version
+		if [ $pythonVersion = $defaultVersion ]; then
+			for f in $binDir/*; do
+				ln -sr $f ${f%-$pythonVersion}
+			done
+		fi
+
+		packageEntries $pythonPackage \
 			$prefix/lib/python* \
-			$prefix/bin
-
-	done
-}
-
-TEST()
-{
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
-		pythonVersion=${PYTHON_VERSIONS[$i]}
-
-		cd "$sourceDir"-$pythonPackage
-
-		python=python$pythonVersion
-
-		cmake -DPYTHON_EXECUTABLE=/usr/bin/$python
-		ctest .
-
+			$binDir
 	done
 }


### PR DESCRIPTION
Removed TESTS(), as the packages contains no tests at all, less so making use of cmake/ctest.