### PR TITLE
pip: fix typo.

### DIFF
--- a/dev-python/pip/pip-23.2.1.recipe
+++ b/dev-python/pip/pip-23.2.1.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="Install Python packages, replacement for easy_install"
 HOMEPAGE="https://pypi.python.org/pypi/pip"
 COPYRIGHT="2006-2023 Python Packaging Authority"
 LICENSE="Python"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.io/packages/source/p/pip/pip-$portVersion.tar.gz"
 CHECKSUM_SHA256="fb0bd5435b3200c602b5bf61d2d43c2f13c02e29c1707567ae7fbc514eb9faf2"
 
@@ -71,7 +71,7 @@ INSTALL()
 			--root=/ --prefix=$prefix
 
 		# Remove non-version suffixed commands, except for the default python version.
-		if [ $pythonVersion != defaultVersion ]; then
+		if [ $pythonVersion != $defaultVersion ]; then
 			rm $binDir/{pip,pip3}
 		fi
 


### PR DESCRIPTION
This silly typo prevented the inclusion of `/bin/{pip,pip3}` along with `/bin/pip-3.10` (for the default Python version, it is always nice to provide non-version-suffixed commands).