### PR TITLE
psutil: switch to Python 3.10.

### DIFF
--- a/dev-python/psutil/psutil-5.6.7.recipe
+++ b/dev-python/psutil/psutil-5.6.7.recipe
@@ -33,8 +33,8 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python39)
-PYTHON_VERSIONS=(3.9)
+PYTHON_PACKAGES=(python310)
+PYTHON_VERSIONS=(3.10)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -79,7 +79,7 @@ INSTALL()
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }


### PR DESCRIPTION
Still disabled, as it fails on import (same as before).

---

This one is required by the (also disabled) `sys-process/glances` recipe. Will move that to Python 3.10 next.