### PR TITLE
mdds2.1, add new version

### DIFF
--- a/dev-util/mdds/mdds2.1-2.1.1.recipe
+++ b/dev-util/mdds/mdds2.1-2.1.1.recipe
@@ -1,0 +1,56 @@
+SUMMARY="Multi-Dimensional Data Structure"
+DESCRIPTION="mdds is a collection of multi-dimensional data structure \
+and indexing algorithms."
+HOMEPAGE="https://gitlab.com/mdds/mdds"
+COPYRIGHT="2010-2021 Kohei Yoshida et al."
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://kohei.us/files/mdds/src/mdds-$portVersion.tar.bz2"
+CHECKSUM_SHA256="8a3767f0a60c53261b5ebbaa717381446813aef8cf28fe9d0ea1371123bbe3f1"
+SOURCE_DIR="mdds-$portVersion"
+
+ARCHITECTURES="any"
+
+PROVIDES="
+	mdds2.1 = $portVersion compat >= 2.1
+	devel:mdds = $portVersion compat >= 2.1
+	"
+REQUIRES="
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:automake
+	cmd:autoreconf
+	cmd:g++
+	cmd:ld
+	cmd:make
+	cmd:sed
+	"
+
+PATCH()
+{
+	sed -e '/AX_CXX_COMPILE_STDCXX_17/ s/^#*/#/' -i configure.ac
+}
+
+BUILD()
+{
+	autoreconf
+	runConfigure ./configure
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+}
+
+TEST()
+{
+	make check
+}


### PR DESCRIPTION
Required for newer ixion and orcus. Doesn't conflict with mdds2-2.0.1.