### PR TITLE
xion, 0.17.0, move binaries to tools package

### DIFF
--- a/dev-libs/ixion/ixion0.18-0.18.1.recipe
+++ b/dev-libs/ixion/ixion0.18-0.18.1.recipe
@@ -10,20 +10,20 @@ and a partial calculation of only the affected cells need to be calculated."
 HOMEPAGE="https://gitlab.com/ixion/ixion"
 COPYRIGHT="Kohei Yoshida et al."
 LICENSE="MPL v2.0"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://gitlab.com/ixion/ixion/-/archive/$portVersion/ixion-$portVersion.tar.bz2"
-CHECKSUM_SHA256="63f3942defc684be82046b9d7454602dadafced9be7b3b60e9e8a5fa63ee91a8"
+CHECKSUM_SHA256="c2975b0aa9f6e1a76c690928cdaa6f48d414cf6f8cca83c9e8c713dec4da18f0"
 SOURCE_DIR="ixion-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
-boostMinimumVersion=1.69.0
+boostMinimumVersion=1.83.0
 
 soVersion="${portVersion%.*}"
 
 PROVIDES="
-	ixion$secondaryArchSuffix = $portVersion
+	ixion0.18$secondaryArchSuffix = $portVersion
 	lib:libixion_$soVersion$secondaryArchSuffix = 0.0.0 compat >= 0
 	"
 REQUIRES="
@@ -35,22 +35,25 @@ REQUIRES="
 	"
 
 PROVIDES_devel="
-	ixion${secondaryArchSuffix}_devel = $portVersion
+	ixion0.18${secondaryArchSuffix}_devel = $portVersion
 	devel:libixion_$soVersion$secondaryArchSuffix = 0.0.0 compat >= 0
 	"
 REQUIRES_devel="
-	ixion$secondaryArchSuffix == $portVersion base
+	ixion0.18$secondaryArchSuffix == $portVersion base
 	"
 
 PROVIDES_tools="
-	ixion${secondaryArchSuffix}_tools = $portVersion
+	ixion0.18${secondaryArchSuffix}_tools = $portVersion
 	cmd:ixion_formula_tokenizer$secondaryArchSuffix = $portVersion
 	cmd:ixion_parser$secondaryArchSuffix = $portVersion
 	cmd:ixion_sorter$secondaryArchSuffix = $portVersion
 	"
 REQUIRES_tools="
 	$REQUIRES
-	ixion$secondaryArchSuffix == $portVersion base
+	ixion0.18$secondaryArchSuffix == $portVersion base
+	"
+CONFLICTS_tools="
+	ixion${secondaryArchSuffix}_tools
 	"
 
 BUILD_REQUIRES="
@@ -60,7 +63,7 @@ BUILD_REQUIRES="
 	devel:libboost_system$secondaryArchSuffix >= $boostMinimumVersion
 	devel:libz$secondaryArchSuffix
 	devel:libspdlog$secondaryArchSuffix
-	devel:mdds >= 2
+	devel:mdds$secondaryArchSuffix >= 2.1
 	"
 BUILD_PREREQUIRES="
 	cmd:aclocal
@@ -73,7 +76,7 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
-defineDebugInfoPackage ixion$secondaryArchSuffix \
+defineDebugInfoPackage ixion0.18$secondaryArchSuffix \
 	"$(getPackagePrefix tools)"/bin/ixion-formula-tokenizer \
 	"$(getPackagePrefix tools)"/bin/ixion-parser \
 	"$(getPackagePrefix tools)"/bin/ixion-sorter \


### PR DESCRIPTION
0.18.1 new version, add conflicts for tools package Both versions can be co-installed aside from the binaries