### PR TITLE
llvm17: new recipe

### DIFF
--- a/sys-devel/llvm/llvm17-17.0.1.recipe
+++ b/sys-devel/llvm/llvm17-17.0.1.recipe
@@ -1,0 +1,807 @@
+SUMMARY="Modular and reuseable compiler and toolchain technologies"
+DESCRIPTION="LLVM is a collection of modular and reuseable compiler and and \
+toolchain technologies. The LLVM compiler system for C and C++ includes the \
+following:
+
+- Front-ends for C, C++, Objective-C, Fortran, etc. based on the GCC 4.2 \
+parsers. They support the ANSI-standard C and C++ languages to the same \
+degree that GCC supports them. Additionally, many GCC extensions are \
+supported.
+- A stable implementation of the LLVM instruction set, which serves as both \
+the online and offline code representation, together with assembly (ASCII) \
+and bytecode (binary) readers and writers, and a verifier.
+- A powerful pass-management system that automatically sequences passes \
+(including analysis, transformation, and code-generation passes) based on \
+their dependences, and pipelines them for efficiency.
+- A wide range of global scalar optimizations.
+- A link-time interprocedural optimization framework with a rich set of \
+analyses and transformations, including sophisticated whole-program pointer \
+analysis, call graph construction, and support for profile-guided optimizations.
+- An easily retargettable code generator, which currently supports X86, \
+X86-64, PowerPC, PowerPC-64, ARM, Thumb, SPARC, MIPS, MSP430, SystemZ, and XCore.
+- A Just-In-Time (JIT) code generation system, which currently supports X86, \
+X86-64, ARM, AArch64, Mips, SystemZ, PowerPC, and PowerPC-64.
+- Support for generating DWARF debugging information.
+- A C back-end useful for testing and for generating native code on targets \
+other than the ones listed above.
+- A profiling system similar to gprof.
+- A test framework with a number of benchmark codes and applications.
+- APIs and debugging tools to simplify rapid development of LLVM components."
+HOMEPAGE="https://www.llvm.org/"
+COPYRIGHT="2003-2023 University of Illinois at Urbana-Champaign"
+LICENSE="Apache v2 with LLVM Exception"
+REVISION="1"
+SOURCE_URI="https://github.com/llvm/llvm-project/releases/download/llvmorg-$portVersion/llvm-project-$portVersion.src.tar.xz"
+CHECKSUM_SHA256="b0e42aafc01ece2ca2b42e3526f54bebc4b1f1dc8de6e34f46a0446a13e882b9"
+SOURCE_DIR="llvm-project-$portVersion.src"
+PATCHES="llvm17-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+portVersionCompat="$portVersion compat >= ${portVersion%%.*}"
+
+PROVIDES="
+	llvm17$secondaryArchSuffix = $portVersionCompat
+	cmd:bugpoint
+	cmd:dsymutil
+	cmd:llc
+	cmd:lli
+	cmd:llvm_addr2line
+	cmd:llvm_ar
+	cmd:llvm_as
+	cmd:llvm_bcanalyzer
+	cmd:llvm_bitcode_strip
+	cmd:llvm_c_test
+	cmd:llvm_cat
+	cmd:llvm_cfi_verify
+	cmd:llvm_config = $portVersionCompat
+	cmd:llvm_cov
+	cmd:llvm_cvtres
+	cmd:llvm_cxxdump
+	cmd:llvm_cxxfilt
+	cmd:llvm_cxxmap
+	cmd:llvm_debuginfo_analyzer
+	cmd:llvm_debuginfod
+	cmd:llvm_debuginfod_find
+	cmd:llvm_diff
+	cmd:llvm_dis
+	cmd:llvm_dlltool
+	cmd:llvm_dwarfdump
+	cmd:llvm_dwarfutil
+	cmd:llvm_dwp
+	cmd:llvm_exegesis
+	cmd:llvm_extract
+	cmd:llvm_gsymutil
+	cmd:llvm_ifs
+	cmd:llvm_install_name_tool
+	cmd:llvm_jitlink
+	cmd:llvm_lib
+	cmd:llvm_libtool_darwin
+	cmd:llvm_link
+	cmd:llvm_lipo
+	cmd:llvm_lto
+	cmd:llvm_lto2
+	cmd:llvm_mc
+	cmd:llvm_mca
+	cmd:llvm_ml
+	cmd:llvm_modextract
+	cmd:llvm_mt
+	cmd:llvm_nm
+	cmd:llvm_objcopy
+	cmd:llvm_objdump
+	cmd:llvm_opt_report
+	cmd:llvm_otool
+	cmd:llvm_pdbutil
+	cmd:llvm_profdata
+	cmd:llvm_profgen
+	cmd:llvm_ranlib
+	cmd:llvm_rc
+	cmd:llvm_readelf
+	cmd:llvm_readobj
+	cmd:llvm_reduce
+	cmd:llvm_remark_size_diff
+	cmd:llvm_remarkutil
+	cmd:llvm_rtdyld
+	cmd:llvm_sim
+	cmd:llvm_size
+	cmd:llvm_split
+	cmd:llvm_stress
+	cmd:llvm_strings
+	cmd:llvm_strip
+	cmd:llvm_symbolizer
+	cmd:llvm_tapi_diff
+	cmd:llvm_tblgen
+	cmd:llvm_tli_checker
+	cmd:llvm_undname
+	cmd:llvm_windres
+	cmd:llvm_xray
+	cmd:opt
+	cmd:sancov
+	cmd:sanstats
+	cmd:verify_uselistorder
+	devel:libfindAllSymbols$secondaryArchSuffix
+	devel:libLLVM$secondaryArchSuffix = $portVersionCompat
+	devel:libLLVM_$portVersion$secondaryArchSuffix = $portVersionCompat
+	devel:libLLVM_17$secondaryArchSuffix = $portVersionCompat
+	devel:libLLVMAArch64AsmParser$secondaryArchSuffix
+	devel:libLLVMAArch64CodeGen$secondaryArchSuffix
+	devel:libLLVMAArch64Desc$secondaryArchSuffix
+	devel:libLLVMAArch64Disassembler$secondaryArchSuffix
+	devel:libLLVMAArch64Info$secondaryArchSuffix
+	devel:libLLVMAArch64Utils$secondaryArchSuffix
+	devel:libLLVMAMDGPUAsmParser$secondaryArchSuffix
+	devel:libLLVMAMDGPUCodeGen$secondaryArchSuffix
+	devel:libLLVMAMDGPUDesc$secondaryArchSuffix
+	devel:libLLVMAMDGPUDisassembler$secondaryArchSuffix
+	devel:libLLVMAMDGPUInfo$secondaryArchSuffix
+	devel:libLLVMAMDGPUTargetMCA$secondaryArchSuffix
+	devel:libLLVMAMDGPUUtils$secondaryArchSuffix
+	devel:libLLVMARMAsmParser$secondaryArchSuffix
+	devel:libLLVMARMCodeGen$secondaryArchSuffix
+	devel:libLLVMARMDesc$secondaryArchSuffix
+	devel:libLLVMARMDisassembler$secondaryArchSuffix
+	devel:libLLVMARMInfo$secondaryArchSuffix
+	devel:libLLVMARMUtils$secondaryArchSuffix
+	devel:libLLVMAggressiveInstCombine$secondaryArchSuffix
+	devel:libLLVMAnalysis$secondaryArchSuffix
+	devel:libLLVMAsmParser$secondaryArchSuffix
+	devel:libLLVMAsmPrinter$secondaryArchSuffix
+	devel:libLLVMBinaryFormat$secondaryArchSuffix
+	devel:libLLVMBitReader$secondaryArchSuffix
+	devel:libLLVMBitWriter$secondaryArchSuffix
+	devel:libLLVMBitstreamReader$secondaryArchSuffix
+	devel:libLLVMCFGuard$secondaryArchSuffix
+	devel:libLLVMCFIVerify$secondaryArchSuffix
+	devel:libLLVMCodeGen$secondaryArchSuffix
+	devel:libLLVMCodeGenTypes$secondaryArchSuffix
+	devel:libLLVMCore$secondaryArchSuffix
+	devel:libLLVMCoroutines$secondaryArchSuffix
+	devel:libLLVMCoverage$secondaryArchSuffix
+	devel:libLLVMDebugInfoBTF$secondaryArchSuffix
+	devel:libLLVMDebugInfoCodeView$secondaryArchSuffix
+	devel:libLLVMDebugInfoDWARF$secondaryArchSuffix
+	devel:libLLVMDebugInfoGSYM$secondaryArchSuffix
+	devel:libLLVMDebugInfoLogicalView$secondaryArchSuffix
+	devel:libLLVMDebugInfoMSF$secondaryArchSuffix
+	devel:libLLVMDebugInfoPDB$secondaryArchSuffix
+	devel:libLLVMDebuginfod$secondaryArchSuffix
+	devel:libLLVMDemangle$secondaryArchSuffix
+	devel:libLLVMDiff$secondaryArchSuffix
+	devel:libLLVMDlltoolDriver$secondaryArchSuffix
+	devel:libLLVMDWARFLinker$secondaryArchSuffix
+	devel:libLLVMDWARFLinkerParallel$secondaryArchSuffix
+	devel:libLLVMDWP$secondaryArchSuffix
+	devel:libLLVMExecutionEngine$secondaryArchSuffix
+	devel:libLLVMExegesis$secondaryArchSuffix
+	devel:libLLVMExegesisAArch64$secondaryArchSuffix
+	devel:libLLVMExegesisX86$secondaryArchSuffix
+	devel:libLLVMExtensions$secondaryArchSuffix
+	devel:libLLVMFileCheck$secondaryArchSuffix
+	devel:libLLVMFrontendHLSL$secondaryArchSuffix
+	devel:libLLVMFrontendOpenAcc$secondaryArchSuffix
+	devel:libLLVMFrontendOpenMP$secondaryArchSuffix
+	devel:libLLVMFuzzMutate$secondaryArchSuffix
+	devel:libLLVMFuzzerCLI$secondaryArchSuffix
+	devel:libLLVMGlobalISel$secondaryArchSuffix
+	devel:libLLVMIRPrinter$secondaryArchSuffix
+	devel:libLLVMIRReader$secondaryArchSuffix
+	devel:libLLVMInstCombine$secondaryArchSuffix
+	devel:libLLVMInstrumentation$secondaryArchSuffix
+	devel:libLLVMInterfaceStub$secondaryArchSuffix
+	devel:libLLVMInterpreter$secondaryArchSuffix
+	devel:libLLVMJITLink$secondaryArchSuffix
+	devel:libLLVMLTO$secondaryArchSuffix
+	devel:libLLVMLibDriver$secondaryArchSuffix
+	devel:libLLVMLineEditor$secondaryArchSuffix
+	devel:libLLVMLinker$secondaryArchSuffix
+	devel:libLLVMMC$secondaryArchSuffix
+	devel:libLLVMMCA$secondaryArchSuffix
+	devel:libLLVMMCDisassembler$secondaryArchSuffix
+	devel:libLLVMMCJIT$secondaryArchSuffix
+	devel:libLLVMMCParser$secondaryArchSuffix
+	devel:libLLVMMIRParser$secondaryArchSuffix
+	devel:libLLVMObjCARCOpts$secondaryArchSuffix
+	devel:libLLVMObjCopy$secondaryArchSuffix
+	devel:libLLVMObject$secondaryArchSuffix
+	devel:libLLVMObjectYAML$secondaryArchSuffix
+	devel:libLLVMOption$secondaryArchSuffix
+	devel:libLLVMOrcJIT$secondaryArchSuffix
+	devel:libLLVMOrcShared$secondaryArchSuffix
+	devel:libLLVMOrcTargetProcess$secondaryArchSuffix
+	devel:libLLVMPasses$secondaryArchSuffix
+	devel:libLLVMProfileData$secondaryArchSuffix
+	devel:libLLVMRISCVAsmParser$secondaryArchSuffix
+	devel:libLLVMRISCVCodeGen$secondaryArchSuffix
+	devel:libLLVMRISCVDesc$secondaryArchSuffix
+	devel:libLLVMRISCVDisassembler$secondaryArchSuffix
+	devel:libLLVMRISCVInfo$secondaryArchSuffix
+	devel:libLLVMRISCVTargetMCA$secondaryArchSuffix
+	devel:libLLVMRemarks$secondaryArchSuffix
+	devel:libLLVMRuntimeDyld$secondaryArchSuffix
+	devel:libLLVMScalarOpts$secondaryArchSuffix
+	devel:libLLVMSelectionDAG$secondaryArchSuffix
+	devel:libLLVMSupport$secondaryArchSuffix
+	devel:libLLVMSymbolize$secondaryArchSuffix
+	devel:libLLVMTableGen$secondaryArchSuffix
+	devel:libLLVMTableGenCommon$secondaryArchSuffix
+	devel:libLLVMTableGenGlobalISel$secondaryArchSuffix
+	devel:libLLVMTarget$secondaryArchSuffix
+	devel:libLLVMTargetParser$secondaryArchSuffix
+	devel:libLLVMTextAPI$secondaryArchSuffix
+	devel:libLLVMTransformUtils$secondaryArchSuffix
+	devel:libLLVMVectorize$secondaryArchSuffix
+	devel:libLLVMWebAssemblyAsmParser$secondaryArchSuffix
+	devel:libLLVMWebAssemblyCodeGen$secondaryArchSuffix
+	devel:libLLVMWebAssemblyDesc$secondaryArchSuffix
+	devel:libLLVMWebAssemblyDisassembler$secondaryArchSuffix
+	devel:libLLVMWebAssemblyInfo$secondaryArchSuffix
+	devel:libLLVMWebAssemblyUtils$secondaryArchSuffix
+	devel:libLLVMWindowsDriver$secondaryArchSuffix
+	devel:libLLVMWindowsManifest$secondaryArchSuffix
+	devel:libLLVMX86AsmParser$secondaryArchSuffix
+	devel:libLLVMX86CodeGen$secondaryArchSuffix
+	devel:libLLVMX86Desc$secondaryArchSuffix
+	devel:libLLVMX86Disassembler$secondaryArchSuffix
+	devel:libLLVMX86Info$secondaryArchSuffix
+	devel:libLLVMX86TargetMCA$secondaryArchSuffix
+	devel:libLLVMXRay$secondaryArchSuffix
+	devel:libLLVMipo$secondaryArchSuffix
+	devel:libLTO$secondaryArchSuffix = $portVersionCompat
+	devel:libRemarks$secondaryArchSuffix = $portVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libclang_cpp$secondaryArchSuffix
+	lib:libLLVM_17$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+CONFLICTS="
+	llvm$secondaryArchSuffix
+	llvm6$secondaryArchSuffix
+	llvm7$secondaryArchSuffix
+	llvm8$secondaryArchSuffix
+	llvm9$secondaryArchSuffix
+	llvm12$secondaryArchSuffix
+	llvm13$secondaryArchSuffix
+	llvm14$secondaryArchSuffix
+	llvm15$secondaryArchSuffix
+	llvm16$secondaryArchSuffix
+	"
+
+PROVIDES_clang="
+	llvm17${secondaryArchSuffix}_clang = $portVersion
+	cmd:amdgpu_arch = $portVersion
+	cmd:c_index_test = $portVersion
+	cmd:clang = $portVersion
+	cmd:clang++ = $portVersion
+	cmd:clang_17 = $portVersion
+	cmd:clang_apply_replacements = $portVersion
+	cmd:clang_change_namespace = $portVersion
+	cmd:clang_check = $portVersion
+	cmd:clang_cl = $portVersion
+	cmd:clang_cpp = $portVersion
+	cmd:clang_doc = $portVersion
+	cmd:clang_extdef_mapping = $portVersion
+	cmd:clang_format = $portVersion
+	cmd:clang_include_cleaner = $portVersion
+	cmd:clang_include_fixer = $portVersion
+	cmd:clang_linker_wrapper = $portVersion
+	cmd:clang_move = $portVersion
+	cmd:clang_offload_bundler = $portVersion
+	cmd:clang_offload_packager = $portVersion
+	cmd:clang_pseudo = $portVersion
+	cmd:clang_query = $portVersion
+	cmd:clang_refactor = $portVersion
+	cmd:clang_rename = $portVersion
+	cmd:clang_reorder_fields = $portVersion
+	cmd:clang_repl = $portVersion
+	cmd:clang_scan_deps = $portVersion
+	cmd:clang_tidy = $portVersion
+	cmd:clang_tblgen = $portVersion
+	cmd:clangd = $portVersion
+	cmd:diagtool = $portVersion
+	cmd:find_all_symbols = $portVersion
+	cmd:git_clang_format = $portVersion
+	cmd:hmaptool = $portVersion
+	cmd:modularize = $portVersion
+	cmd:nvptx_arch = $portVersion
+	cmd:pp_trace = $portVersion
+	cmd:run_clang_tidy = $portVersion
+	devel:libclang$secondaryArchSuffix = $portVersionCompat
+	devel:libclang_cpp$secondaryArchSuffix = $portVersionCompat
+	devel:libclanganalysis$secondaryArchSuffix = $portVersion
+	devel:libclanganalysisflowsensitive$secondaryArchSuffix = $portVersion
+	devel:libclanganalysisflowsensitivemodels$secondaryArchSuffix = $portVersion
+	devel:libclangapinotes$secondaryArchSuffix = $portVersion
+	devel:libclangapplyreplacements$secondaryArchSuffix = $portVersion
+	devel:libclangarcmigrate$secondaryArchSuffix = $portVersion
+	devel:libclangast$secondaryArchSuffix = $portVersion
+	devel:libclangastmatchers$secondaryArchSuffix = $portVersion
+	devel:libclangbasic$secondaryArchSuffix = $portVersion
+	devel:libclangchangenamespace$secondaryArchSuffix = $portVersion
+	devel:libclangcodegen$secondaryArchSuffix = $portVersion
+	devel:libclangcrosstu$secondaryArchSuffix = $portVersion
+	devel:libclangdaemon$secondaryArchSuffix = $portVersion
+	devel:libclangdaemontweaks$secondaryArchSuffix = $portVersion
+	devel:libclangdependencyscanning$secondaryArchSuffix = $portVersion
+	devel:libclangdoc$secondaryArchSuffix = $portVersion
+	devel:libclangdirectorywatcher$secondaryArchSuffix = $portVersion
+	devel:libclangdmain$secondaryArchSuffix = $portVersion
+	devel:libclangdremoteindex$secondaryArchSuffix = $portVersion
+	devel:libclangdriver$secondaryArchSuffix = $portVersion
+	devel:libclangdsupport$secondaryArchSuffix = $portVersion
+	devel:libclangdynamicastmatchers$secondaryArchSuffix = $portVersion
+	devel:libclangedit$secondaryArchSuffix = $portVersion
+	devel:libclangextractapi$secondaryArchSuffix = $portVersion
+	devel:libclangformat$secondaryArchSuffix = $portVersion
+	devel:libclangfrontend$secondaryArchSuffix = $portVersion
+	devel:libclangfrontendtool$secondaryArchSuffix = $portVersion
+	devel:libclanghandlecxx$secondaryArchSuffix = $portVersion
+	devel:libclanghandlellvm$secondaryArchSuffix = $portVersion
+	devel:libclangincludecleaner$secondaryArchSuffix = $portVersion
+	devel:libclangincludefixer$secondaryArchSuffix = $portVersion
+	devel:libclangincludefixerplugin$secondaryArchSuffix = $portVersion
+	devel:libclangindex$secondaryArchSuffix = $portVersion
+	devel:libclangindexserialization$secondaryArchSuffix = $portVersion
+	devel:libclanginterpreter$secondaryArchSuffix = $portVersion
+	devel:libclanglex$secondaryArchSuffix = $portVersion
+	devel:libclangmove$secondaryArchSuffix = $portVersion
+	devel:libclangparse$secondaryArchSuffix = $portVersion
+	devel:libclangpseudo$secondaryArchSuffix = $portVersion
+	devel:libclangpseudocli$secondaryArchSuffix = $portVersion
+	devel:libclangpseudocxx$secondaryArchSuffix = $portVersion
+	devel:libclangpseudogrammar$secondaryArchSuffix = $portVersion
+	devel:libclangquery$secondaryArchSuffix = $portVersion
+	devel:libclangreorderfields$secondaryArchSuffix = $portVersion
+	devel:libclangrewrite$secondaryArchSuffix = $portVersion
+	devel:libclangrewritefrontend$secondaryArchSuffix = $portVersion
+	devel:libclangsema$secondaryArchSuffix = $portVersion
+	devel:libclangserialization$secondaryArchSuffix = $portVersion
+	devel:libclangstaticanalyzercheckers$secondaryArchSuffix = $portVersion
+	devel:libclangstaticanalyzercore$secondaryArchSuffix = $portVersion
+	devel:libclangstaticanalyzerfrontend$secondaryArchSuffix = $portVersion
+	devel:libclangsupport$secondaryArchSuffix = $portVersion
+	devel:libclangtidy$secondaryArchSuffix = $portVersion
+	devel:libclangtidyabseilmodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidyalteramodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidyandroidmodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidyboostmodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidybugpronemodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidycertmodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidyconcurrencymodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidycppcoreguidelinesmodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidydarwinmodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidyfuchsiamodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidygooglemodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidyhicppmodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidylinuxkernelmodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidyllvmlibcmodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidyllvmmodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidymain$secondaryArchSuffix = $portVersion
+	devel:libclangtidymiscmodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidymodernizemodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidympimodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidyobjcmodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidyopenmpmodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidyperformancemodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidyplugin$secondaryArchSuffix = $portVersion
+	devel:libclangtidyportabilitymodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidyreadabilitymodule$secondaryArchSuffix = $portVersion
+	devel:libclangtidyutils$secondaryArchSuffix = $portVersion
+	devel:libclangtidyzirconmodule$secondaryArchSuffix = $portVersion
+	devel:libclangtooling$secondaryArchSuffix = $portVersion
+	devel:libclangtoolingastdiff$secondaryArchSuffix = $portVersion
+	devel:libclangtoolingcore$secondaryArchSuffix = $portVersion
+	devel:libclangtoolinginclusions$secondaryArchSuffix = $portVersion
+	devel:libclangtoolinginclusionsstdlib$secondaryArchSuffix = $portVersion
+	devel:libclangtoolingrefactoring$secondaryArchSuffix = $portVersion
+	devel:libclangtoolingsyntax$secondaryArchSuffix = $portVersion
+	devel:libclangtransformer$secondaryArchSuffix = $portVersion
+	lib:libclang$secondaryArchSuffix = $portVersionCompat
+	lib:libclang_cpp$secondaryArchSuffix = $portVersionCompat
+	"
+REQUIRES_clang="
+	haiku$secondaryArchSuffix
+	lib:libLLVM_17$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+CONFLICTS_clang="
+	llvm${secondaryArchSuffix}_clang
+	llvm6${secondaryArchSuffix}_clang
+	llvm7${secondaryArchSuffix}_clang
+	llvm8${secondaryArchSuffix}_clang
+	llvm9${secondaryArchSuffix}_clang
+	llvm12${secondaryArchSuffix}_clang
+	llvm13${secondaryArchSuffix}_clang
+	llvm14${secondaryArchSuffix}_clang
+	llvm15${secondaryArchSuffix}_clang
+	llvm16${secondaryArchSuffix}_clang
+	"
+
+PROVIDES_clang_analysis="
+	llvm17${secondaryArchSuffix}_clang_analysis = $portVersion
+	cmd:analyze_build = $portVersion
+	cmd:intercept_build = $portVersion
+	cmd:scan_build = $portVersion
+	cmd:scan_build_py = $portVersion
+	cmd:scan_view = $portVersion
+	"
+REQUIRES_clang_analysis="
+	llvm17${secondaryArchSuffix}_clang == $portVersion base
+	cmd:python3
+	"
+CONFLICTS_clang_analysis="
+	llvm${secondaryArchSuffix}_clang_analysis
+	llvm6${secondaryArchSuffix}_clang_analysis
+	llvm7${secondaryArchSuffix}_clang_analysis
+	llvm8${secondaryArchSuffix}_clang_analysis
+	llvm9${secondaryArchSuffix}_clang_analysis
+	llvm12${secondaryArchSuffix}_clang_analysis
+	llvm13${secondaryArchSuffix}_clang_analysis
+	llvm14${secondaryArchSuffix}_clang_analysis
+	llvm15${secondaryArchSuffix}_clang_analysis
+	llvm16${secondaryArchSuffix}_clang_analysis
+	"
+
+PROVIDES_lld="
+	llvm17${secondaryArchSuffix}_lld = $portVersion
+	cmd:ld.lld = $portVersion
+	cmd:ld64.lld = $portVersion
+	cmd:lld = $portVersion
+	cmd:lld_link = $portVersion
+	cmd:wasm_ld = $portVersion
+	devel:liblldCOFF$secondaryArchSuffix = $portVersion
+	devel:liblldCommon$secondaryArchSuffix = $portVersion
+	devel:liblldELF$secondaryArchSuffix = $portVersion
+	devel:liblldMinGW$secondaryArchSuffix = $portVersion
+	devel:liblldWasm$secondaryArchSuffix = $portVersion
+	"
+REQUIRES_lld="
+	haiku$secondaryArchSuffix
+	lib:libLLVM_17$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_libs="
+	llvm17${secondaryArchSuffix}_libs = $portVersion
+	lib:libLLVM_17$secondaryArchSuffix = $portVersionCompat
+	lib:libLTO$secondaryArchSuffix = $portVersionCompat
+	lib:libRemarks$secondaryArchSuffix = $portVersionCompat
+	"
+REQUIRES_libs="
+	haiku$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PYTHON3_VERSION="3.10"
+PROVIDES_python310="
+	llvm17${secondaryArchSuffix}_python310 = $portVersion
+	cmd:lit
+	"
+REQUIRES_python310="
+	setuptools_python310
+	cmd:python$PYTHON3_VERSION
+	"
+
+libunwindSoVersion="1"
+libunwindLibVersion="1.0"
+SUMMARY_libunwind="LLVM Unwinder - libunwind"
+DESCRIPTION_libunwind="libunwind is an implementation of the interface defined \
+by the HP libunwind project. It was contributed by Apple as a way to enable \
+clang++ to port to platforms that do not have a system unwinder. It is \
+intended to be a small and fast implementation of the ABI, leaving off some \
+features of HP's libunwind that never materialized (e.g. remote unwinding).
+
+The unwinder has two levels of API. The high level APIs are the _Unwind_* \
+functions which implement functionality required by __cxa_* exception \
+functions. The low level APIs are the unw_* functions which are an \
+interface defined by the old HP libunwind project."
+PROVIDES_libunwind="
+	llvm17${secondaryArchSuffix}_libunwind = $portVersion
+	lib:libunwind$secondaryArchSuffix = $libunwindLibVersion compat >= $libunwindSoVersion
+	"
+REQUIRES_libunwind="
+	haiku$secondaryArchSuffix
+	"
+
+SUMMARY_libunwind_devel="Headers and static libraries for LLVM Unwinder - libunwind"
+DESCRIPTION_libunwind_devel="libunwind is an implementation of the interface \
+defined by the HP libunwind project. It was contributed by Apple as a way to \
+enable clang++ to port to platforms that do not have a system unwinder. It is \
+intended to be a small and fast implementation of the ABI, leaving off some \
+features of HP's libunwind that never materialized (e.g. remote unwinding).
+
+The unwinder has two levels of API. The high level APIs are the _Unwind_* \
+functions which implement functionality required by __cxa_* exception \
+functions. The low level APIs are the unw_* functions which are an \
+interface defined by the old HP libunwind project."
+PROVIDES_libunwind_devel="
+	llvm17${secondaryArchSuffix}_libunwind_devel = $portVersion
+	devel:libunwind$secondaryArchSuffix = $libunwindLibVersion compat >= $libunwindSoVersion
+	"
+REQUIRES_libunwind_devel="
+	llvm17${secondaryArchSuffix}_libunwind == $portVersion base
+	haiku${secondaryArchSuffix}_devel
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libz$secondaryArchSuffix
+	setuptools_python310
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:diff
+	cmd:find
+	cmd:gcc$secondaryArchSuffix
+	cmd:grep
+	cmd:groff
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:ninja
+	cmd:python$PYTHON3_VERSION
+	cmd:sed
+	"
+
+BUILD()
+{
+	local cmakeFlags
+	if [ -n "$secondaryArchSuffix" ]; then
+		cmakeFlags=-DHAIKU_HYBRID_SECONDARY="\"${effectiveTargetArchitecture}\""
+		cmakeFlags="$cmakeFlags -DLLVM_LIBDIR_SUFFIX=/${effectiveTargetArchitecture}"
+	fi
+
+	# Haiku C++ requires rtti in a lot of central system components
+	# such as Mesa
+
+	# LLVM in default targets  AArch64, AMDGPU, ARM, AVR, BPF, Hexagon, Lanai, \
+	# Mips, MSP430, NVPTX, PowerPC, RISCV, Sparc, SystemZ, WebAssembly, X86, \
+	# XCore on Haiku. There is currently no good reason to build all of those.
+
+	if [ "$targetArchitecture" = x86_gcc2 ];then
+		export LIBRARY_PATH=$LIBRARY_PATH:$sourceDir/build/lib/x86
+	else
+		export LIBRARY_PATH=$LIBRARY_PATH:$sourceDir/build/lib
+	fi
+
+	cmake -S llvm -B build -G Ninja \
+		$cmakeDirArgs \
+		-DCMAKE_BUILD_TYPE=Release \
+		$cmakeFlags \
+		-DCMAKE_SKIP_RPATH=YES \
+		-DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+		-DLLVM_ENABLE_RTTI=ON -DLLVM_LINK_LLVM_DYLIB=YES \
+		-DLIBUNWIND_ENABLE_STATIC=OFF \
+		-DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;compiler-rt" \
+		-DLLVM_ENABLE_RUNTIMES="libunwind" \
+		-DLLVM_TARGETS_TO_BUILD="AArch64;AMDGPU;ARM;RISCV;WebAssembly;X86"
+
+	cmake --build build $jobArgs
+}
+
+INSTALL()
+{
+	cmake --install build
+
+	cd build
+	mkdir -p $binDir $developDir $dataDir $docDir $includeDir $manDir $libDir
+
+	# GENERIC: all python_setuptools-based installs need this
+	local pythonPackageName="${portName}_python310-$portFullVersion"
+	local packageLinksDir=$(dirname $portPackageLinksDir)
+	python=$packageLinksDir/${pythonPackageName}/cmd~python$PYTHON3_VERSION/bin/python$PYTHON3_VERSION
+	pythonVersion=$($python --version 2>&1 | sed 's/Python //' | head -c3)
+	installLocation=$prefix/lib/python$pythonVersion/vendor-packages/
+	export PYTHONPATH=$installLocation:$OLDPYTHONPATH
+
+	pushd ../llvm/utils/lit
+	$python setup.py install --root=/ --prefix="$prefix" -O1
+	popd
+
+	if [ -n "$secondaryArchSuffix" ]; then
+		mv $binDir/* $prefix/bin/
+		binDir=$prefix/bin
+	fi
+
+	# You can try and be fancy here parsing each arch in a for loop... but
+	# not all arches contain the same libraries. The inventory for each arch
+	# also changes between releases... so lets KISS.
+	prepareInstalledDevelLibs \
+		libclang \
+		libclang-cpp \
+		libclangAPINotes \
+		libclangARCMigrate \
+		libclangAST \
+		libclangASTMatchers \
+		libclangAnalysis \
+		libclangAnalysisFlowSensitive \
+		libclangAnalysisFlowSensitiveModels \
+		libclangApplyReplacements \
+		libclangBasic \
+		libclangChangeNamespace \
+		libclangCodeGen \
+		libclangCrossTU \
+		libclangDaemon \
+		libclangDaemonTweaks \
+		libclangDependencyScanning \
+		libclangDirectoryWatcher \
+		libclangDoc \
+		libclangDriver \
+		libclangDynamicASTMatchers \
+		libclangEdit \
+		libclangExtractAPI \
+		libclangFormat \
+		libclangFrontend \
+		libclangFrontendTool \
+		libclangHandleCXX \
+		libclangHandleLLVM \
+		libclangIncludeCleaner \
+		libclangIncludeFixer \
+		libclangIncludeFixerPlugin \
+		libclangIndex \
+		libclangIndexSerialization \
+		libclangInterpreter \
+		libclangLex \
+		libclangMove \
+		libclangParse \
+		libclangPseudo \
+		libclangPseudoCLI \
+		libclangPseudoCXX \
+		libclangPseudoGrammar \
+		libclangQuery \
+		libclangReorderFields \
+		libclangRewrite \
+		libclangRewriteFrontend \
+		libclangSema \
+		libclangSerialization \
+		libclangStaticAnalyzerCheckers \
+		libclangStaticAnalyzerCore \
+		libclangStaticAnalyzerFrontend \
+		libclangSupport \
+		libclangTidy \
+		libclangTidyAbseilModule \
+		libclangTidyAlteraModule \
+		libclangTidyAndroidModule \
+		libclangTidyBoostModule \
+		libclangTidyBugproneModule \
+		libclangTidyCERTModule \
+		libclangTidyConcurrencyModule \
+		libclangTidyCppCoreGuidelinesModule \
+		libclangTidyDarwinModule \
+		libclangTidyFuchsiaModule \
+		libclangTidyGoogleModule \
+		libclangTidyHICPPModule \
+		libclangTidyLLVMLibcModule \
+		libclangTidyLLVMModule \
+		libclangTidyLinuxKernelModule \
+		libclangTidyMPIModule \
+		libclangTidyMain \
+		libclangTidyMiscModule \
+		libclangTidyModernizeModule \
+		libclangTidyObjCModule \
+		libclangTidyOpenMPModule \
+		libclangTidyPerformanceModule \
+		libclangTidyPlugin \
+		libclangTidyPortabilityModule \
+		libclangTidyReadabilityModule \
+		libclangTidyUtils \
+		libclangTidyZirconModule \
+		libclangTooling \
+		libclangToolingASTDiff \
+		libclangToolingCore \
+		libclangToolingInclusions \
+		libclangToolingInclusionsStdlib \
+		libclangToolingRefactoring \
+		libclangToolingSyntax \
+		libclangTransformer \
+		libclangdMain \
+		libclangdRemoteIndex \
+		libclangdSupport \
+		libfindAllSymbols \
+		libLLVM* \
+		libLTO	\
+		liblld* \
+		libRemarks
+
+	oldLibDir=$libDir
+	libDir=$prefix/lib
+	prepareInstalledDevelLibs \
+		libunwind
+	libDir=$oldLibDir
+
+	# adjust cmake library paths because prepareInstalledDevelLibs moved them
+	sed -i 's,\${_IMPORT_PREFIX}/lib/,\${_IMPORT_PREFIX}/develop/lib/,' \
+		$libDir/cmake/clang/ClangTargets-release.cmake \
+		$libDir/cmake/lld/LLDTargets-release.cmake \
+		$libDir/cmake/llvm/LLVMExports-release.cmake
+
+	sed -i 's|/libexec/|/bin/|' $binDir/scan-build
+	sed -i 's|/share/|/data/|' $binDir/scan-build $binDir/scan-view
+
+	mv $prefix/include/* $includeDir/
+	rmdir $prefix/include
+
+	# clang package
+	packageEntries clang \
+		$binDir/amdgpu-arch \
+		$binDir/c-index-test \
+		$binDir/clang* \
+		$binDir/diagtool \
+		$binDir/find-all-symbols \
+		$binDir/git-clang-format \
+		$binDir/hmaptool \
+		$binDir/modularize \
+		$binDir/nvptx-arch \
+		$binDir/pp-trace \
+		$binDir/run-clang-tidy \
+		$dataDir/clang \
+		$includeDir/clang* \
+		$libDir/clang \
+		$libDir/libclang* \
+		$libDir/cmake/clang \
+		$developLibDir/libclang*
+
+	# analysis package
+	packageEntries clang_analysis \
+		$binDir/analyze-build \
+		$binDir/intercept-build \
+		$binDir/scan-build \
+		$binDir/scan-build-py \
+		$binDir/scan-view \
+		$libExecDir/c++-analyzer \
+		$libExecDir/ccc-analyzer \
+		$dataDir/scan-build \
+		$dataDir/scan-view \
+		$manDir/man1/scan-build.1
+
+	# lld package
+	packageEntries lld \
+		$binDir/ld.lld \
+		$binDir/ld64.lld \
+		$binDir/lld \
+		$binDir/lld-link \
+		$binDir/wasm-ld \
+		$includeDir/lld* \
+		$developLibDir/liblld*
+
+	# libs package
+	packageEntries libs \
+		$libDir/libLLVM* \
+		$libDir/libLTO* \
+		$libDir/libRemarks*
+
+	# python310 package
+	packageEntries python310 \
+		$binDir/lit \
+		$prefix/lib/python*
+
+	# libunwind package
+	packageEntries libunwind \
+		$prefix/lib/libunwind*
+
+	packageEntries libunwind_devel \
+		$developLibDir/libunwind* \
+		$includeDir/unwind*.h \
+		$includeDir/libunwind*.h \
+		$includeDir/libunwind.modulemap \
+		$includeDir/__libunwind*.h \
+		$includeDir/mach-o/compact_unwind_encoding.h \
+		$includeDir/mach-o/compact_unwind_encoding.modulemap
+
+	# Remove empty folders
+	rmdir $includeDir/mach-o
+	rmdir $manDir/man1
+	rmdir $manDir
+}
+
+TEST()
+{
+	export LIT_ARGS="-v"
+	if [ "$targetArchitecture" = x86_gcc2 ];then
+		export LIBRARY_PATH=$LIBRARY_PATH:$sourceDir/build/lib/x86
+	else
+		export LIBRARY_PATH=$LIBRARY_PATH:$sourceDir/build/lib
+	fi
+	ninja -C build check-llvm
+}

--- a/sys-devel/llvm/patches/llvm17-17.0.1.patchset
+++ b/sys-devel/llvm/patches/llvm17-17.0.1.patchset
@@ -1,0 +1,1137 @@
+From 13a702e279fc4e0536beacdbe4adcd3666c38a05 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Sun, 9 Sep 2018 16:11:42 +0100
+Subject: llvm: import header dir suffix patch from 3dEyes
+
+
+diff --git a/llvm/tools/llvm-config/llvm-config.cpp b/llvm/tools/llvm-config/llvm-config.cpp
+index e86eb2b..395a857 100644
+--- a/llvm/tools/llvm-config/llvm-config.cpp
++++ b/llvm/tools/llvm-config/llvm-config.cpp
+@@ -366,7 +366,11 @@ int main(int argc, char **argv) {
+       sys::fs::make_absolute(ActivePrefix, Path);
+       ActiveBinDir = std::string(Path.str());
+     }
++#ifdef __HAIKU__
++    ActiveLibDir = ActivePrefix + "/develop/lib" + LLVM_LIBDIR_SUFFIX;
++#else
+     ActiveLibDir = ActivePrefix + "/lib" + LLVM_LIBDIR_SUFFIX;
++#endif
+     {
+       SmallString<256> Path(LLVM_INSTALL_PACKAGE_DIR);
+       sys::fs::make_absolute(ActivePrefix, Path);
+-- 
+2.37.3
+
+
+From 3a039a9f385a63297caf3503f32b944e61d23609 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
+Date: Mon, 18 Jul 2016 14:13:19 +0200
+Subject: clang: support for secondary arch.
+
+
+diff --git a/clang/CMakeLists.txt b/clang/CMakeLists.txt
+index f7936d7..57b8ec8 100644
+--- a/clang/CMakeLists.txt
++++ b/clang/CMakeLists.txt
+@@ -336,6 +336,10 @@ if (APPLE AND NOT CMAKE_LINKER MATCHES ".*lld.*")
+   endif()
+   message(STATUS "Host linker version: ${HOST_LINK_VERSION}")
+ endif()
++if(DEFINED HAIKU_HYBRID_SECONDARY)
++  add_definitions(-DHAIKU_HYBRID_SECONDARY=${HAIKU_HYBRID_SECONDARY})
++endif()
++
+ 
+ include(CMakeParseArguments)
+ include(AddClang)
+diff --git a/clang/lib/Driver/ToolChains/Haiku.cpp b/clang/lib/Driver/ToolChains/Haiku.cpp
+index a79f0f7..e878cb1 100644
+--- a/clang/lib/Driver/ToolChains/Haiku.cpp
++++ b/clang/lib/Driver/ToolChains/Haiku.cpp
+@@ -19,6 +19,13 @@ using namespace llvm::opt;
+ Haiku::Haiku(const Driver &D, const llvm::Triple& Triple, const ArgList &Args)
+   : Generic_ELF(D, Triple, Args) {
+ 
++#ifdef HAIKU_HYBRID_SECONDARY
++  getProgramPaths().insert(getProgramPaths().begin(), getDriver().SysRoot
++                           + "/system/bin/" HAIKU_HYBRID_SECONDARY);
++  getFilePaths().clear();
++  getFilePaths().push_back(getDriver().SysRoot + "/system/lib/"
++                           HAIKU_HYBRID_SECONDARY);
++#endif
+ }
+ 
+ void Haiku::addLibCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
+@@ -29,6 +36,12 @@ void Haiku::addLibCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
+ 
+ void Haiku::addLibStdCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
+                                      llvm::opt::ArgStringList &CC1Args) const {
++#ifdef HAIKU_HYBRID_SECONDARY
++  addLibStdCXXIncludePaths(getDriver().SysRoot + "/system/develop/headers/"
++                     HAIKU_HYBRID_SECONDARY "/c++", getTriple().str(), "",
++                     DriverArgs, CC1Args);
++#else
+   addLibStdCXXIncludePaths(getDriver().SysRoot + "/system/develop/headers/c++",
+                            getTriple().str(), "", DriverArgs, CC1Args);
++#endif
+ }
+diff --git a/clang/lib/Lex/InitHeaderSearch.cpp b/clang/lib/Lex/InitHeaderSearch.cpp
+index 41382d7..de70e50 100644
+--- a/clang/lib/Lex/InitHeaderSearch.cpp
++++ b/clang/lib/Lex/InitHeaderSearch.cpp
+@@ -251,7 +251,20 @@ void InitHeaderSearch::AddDefaultCIncludePaths(const llvm::Triple &triple,
+   if (HSOpts.UseBuiltinIncludes) {
+     // Ignore the sys root, we *always* look for clang headers relative to
+     // supplied path.
++#ifdef HAIKU_HYBRID_SECONDARY
++    // Remove version from foo/lib/clang/version
++    StringRef Ver = llvm::sys::path::filename(HSOpts.ResourceDir);
++    StringRef NoVer = llvm::sys::path::parent_path(HSOpts.ResourceDir);
++    // Remove clang from foo/lib/clang
++    StringRef Clang = llvm::sys::path::filename(NoVer);
++    SmallString<128> P = llvm::sys::path::parent_path(NoVer);
++
++    // Get foo/include/c++/v1
++    llvm::sys::path::append(P, Clang, Ver);
++#else
+     SmallString<128> P = StringRef(HSOpts.ResourceDir);
++#endif
++
+     llvm::sys::path::append(P, "include");
+     AddUnmappedPath(P, ExternCSystem, false);
+   }
+@@ -281,7 +294,12 @@ void InitHeaderSearch::AddDefaultCIncludePaths(const llvm::Triple &triple,
+   }
+ 
+   case llvm::Triple::Haiku:
++#ifdef HAIKU_HYBRID_SECONDARY
++    AddPath("/boot/system/non-packaged/develop/headers/" HAIKU_HYBRID_SECONDARY,
++            System, false);
++#else
+     AddPath("/boot/system/non-packaged/develop/headers", System, false);
++#endif
+     AddPath("/boot/system/develop/headers/os", System, false);
+     AddPath("/boot/system/develop/headers/os/app", System, false);
+     AddPath("/boot/system/develop/headers/os/arch", System, false);
+@@ -313,6 +331,13 @@ void InitHeaderSearch::AddDefaultCIncludePaths(const llvm::Triple &triple,
+     AddPath("/boot/system/develop/headers/bsd", System, false);
+     AddPath("/boot/system/develop/headers/glibc", System, false);
+     AddPath("/boot/system/develop/headers/posix", System, false);
++#ifdef HAIKU_HYBRID_SECONDARY
++    AddPath("/boot/system/develop/headers/" HAIKU_HYBRID_SECONDARY, System, false);
++    AddPath("/boot/system/develop/headers/" HAIKU_HYBRID_SECONDARY "/os", System,
++            false);
++    AddPath("/boot/system/develop/headers/" HAIKU_HYBRID_SECONDARY "/os/opengl",
++            System, false);
++#endif
+     AddPath("/boot/system/develop/headers",  System, false);
+     break;
+   case llvm::Triple::RTEMS:
+-- 
+2.37.3
+
+
+From f29056bff076d192f070e599e2b2ca266732d862 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Thu, 7 Apr 2016 18:30:52 +0000
+Subject: clang: add a test for haiku driver.
+
+* upstream wants a case for libcxx in ToolChains.cpp, so add it.
+
+diff --git a/clang/test/Driver/haiku.c b/clang/test/Driver/haiku.c
+new file mode 100644
+index 0000000..9591739
+--- /dev/null
++++ b/clang/test/Driver/haiku.c
+@@ -0,0 +1,12 @@
++// RUN: %clang -no-canonical-prefixes -target x86_64-unknown-haiku %s -### 2> %t.log
++// RUN: FileCheck --check-prefix=CHECK-X86_64 -input-file %t.log %s
++
++// CHECK-X86_64: clang{{.*}}" "-cc1" "-triple" "x86_64-unknown-haiku"
++// CHECK-X86_64: gcc{{.*}}" "-o" "a.out" "{{.*}}.o"
++
++// RUN: %clang -no-canonical-prefixes -target i586-pc-haiku %s -### 2> %t.log
++// RUN: FileCheck --check-prefix=CHECK-X86 -input-file %t.log %s
++
++// CHECK-X86: clang{{.*}}" "-cc1" "-triple" "i586-pc-haiku"
++// CHECK-X86: gcc{{.*}}" "-o" "a.out" "{{.*}}.o"
++
+-- 
+2.37.3
+
+
+From c75b2afd4cd07868b3ca6df94bc5455341e5b10d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
+Date: Mon, 18 Jul 2016 14:13:19 +0200
+Subject: clang: Enable thread-local storage and disable PIE by default
+
+
+diff --git a/clang/lib/Basic/Targets/OSTargets.h b/clang/lib/Basic/Targets/OSTargets.h
+index 8f4331b..0b798a4 100644
+--- a/clang/lib/Basic/Targets/OSTargets.h
++++ b/clang/lib/Basic/Targets/OSTargets.h
+@@ -298,7 +298,6 @@ public:
+     this->IntPtrType = TargetInfo::SignedLong;
+     this->PtrDiffType = TargetInfo::SignedLong;
+     this->ProcessIDType = TargetInfo::SignedLong;
+-    this->TLSSupported = false;
+     switch (Triple.getArch()) {
+     default:
+       break;
+diff --git a/clang/lib/Driver/ToolChains/Haiku.h b/clang/lib/Driver/ToolChains/Haiku.h
+index 669379a..fd82022 100644
+--- a/clang/lib/Driver/ToolChains/Haiku.h
++++ b/clang/lib/Driver/ToolChains/Haiku.h
+@@ -22,9 +22,7 @@ public:
+   Haiku(const Driver &D, const llvm::Triple &Triple,
+           const llvm::opt::ArgList &Args);
+ 
+-  bool isPIEDefault(const llvm::opt::ArgList &Args) const override {
+-    return getTriple().getArch() == llvm::Triple::x86_64;
+-  }
++  bool isPIEDefault(const llvm::opt::ArgList &Args) const override { return false; }
+ 
+   void addLibCxxIncludePaths(
+       const llvm::opt::ArgList &DriverArgs,
+-- 
+2.37.3
+
+
+From ebb00a0fafc33e49cb606e9807bf22c26004bb8a Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Mon, 13 Feb 2023 16:28:39 +0100
+Subject: clang: Haiku: defaults to PIC
+
+
+diff --git a/clang/lib/Driver/ToolChains/Haiku.h b/clang/lib/Driver/ToolChains/Haiku.h
+index fd82022..f649d8d 100644
+--- a/clang/lib/Driver/ToolChains/Haiku.h
++++ b/clang/lib/Driver/ToolChains/Haiku.h
+@@ -23,6 +23,7 @@ public:
+           const llvm::opt::ArgList &Args);
+ 
+   bool isPIEDefault(const llvm::opt::ArgList &Args) const override { return false; }
++  bool isPICDefault() const override { return true; }
+ 
+   void addLibCxxIncludePaths(
+       const llvm::opt::ArgList &DriverArgs,
+-- 
+2.37.3
+
+
+From 64538709638b0eb14743689b10133a30b03c8807 Mon Sep 17 00:00:00 2001
+From: Jerome Duval <jerome.duval@gmail.com>
+Date: Sat, 3 Apr 2021 23:23:24 +0200
+Subject: lld: MachO needs libunwind somehow, disable
+
+
+diff --git a/lld/CMakeLists.txt b/lld/CMakeLists.txt
+index 595c286..efb08a8 100644
+--- a/lld/CMakeLists.txt
++++ b/lld/CMakeLists.txt
+@@ -199,7 +199,9 @@ endif()
+ add_subdirectory(docs)
+ add_subdirectory(COFF)
+ add_subdirectory(ELF)
++if (NOT HAIKU)
+ add_subdirectory(MachO)
++endif()
+ add_subdirectory(MinGW)
+ add_subdirectory(wasm)
+ 
+diff --git a/lld/include/lld/Common/Driver.h b/lld/include/lld/Common/Driver.h
+index 8520e6e..9562ab7 100644
+--- a/lld/include/lld/Common/Driver.h
++++ b/lld/include/lld/Common/Driver.h
+@@ -58,6 +58,15 @@ Result lldMain(llvm::ArrayRef<const char *> args, llvm::raw_ostream &stdoutOS,
+ 
+ // An array which declares that all LLD drivers are linked in your executable.
+ // Must be used along with LLD_HAS_DRIVERS. See examples in LLD unittests.
++#ifdef __HAIKU__
++#define LLD_ALL_DRIVERS                                                        \
++  {                                                                            \
++    {lld::WinLink, &lld::coff::link}, {lld::Gnu, &lld::elf::link},             \
++        {lld::MinGW, &lld::mingw::link}, {                                     \
++      lld::Wasm, &lld::wasm::link                                              \
++    }                                                                          \
++  }
++#else
+ #define LLD_ALL_DRIVERS                                                        \
+   {                                                                            \
+     {lld::WinLink, &lld::coff::link}, {lld::Gnu, &lld::elf::link},             \
+@@ -65,5 +74,6 @@ Result lldMain(llvm::ArrayRef<const char *> args, llvm::raw_ostream &stdoutOS,
+       lld::Wasm, &lld::wasm::link                                              \
+     }                                                                          \
+   }
++#endif
+ 
+ #endif
+diff --git a/lld/tools/lld/CMakeLists.txt b/lld/tools/lld/CMakeLists.txt
+index 1262839..9bf717e 100644
+--- a/lld/tools/lld/CMakeLists.txt
++++ b/lld/tools/lld/CMakeLists.txt
+@@ -18,6 +18,16 @@ function(lld_target_link_libraries target type)
+   endif()
+ endfunction()
+ 
++if (HAIKU)
++lld_target_link_libraries(lld
++  PRIVATE
++  lldCommon
++  lldCOFF
++  lldELF
++  lldMinGW
++  lldWasm
++  )
++else()
+ lld_target_link_libraries(lld
+   PRIVATE
+   lldCommon
+@@ -27,6 +37,7 @@ lld_target_link_libraries(lld
+   lldMinGW
+   lldWasm
+   )
++endif()
+ 
+ install(TARGETS lld
+   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+diff --git a/lld/tools/lld/lld.cpp b/lld/tools/lld/lld.cpp
+index 2c30bc9..5069361 100644
+--- a/lld/tools/lld/lld.cpp
++++ b/lld/tools/lld/lld.cpp
+@@ -71,7 +71,9 @@ static unsigned inTestVerbosity() {
+ LLD_HAS_DRIVER(coff)
+ LLD_HAS_DRIVER(elf)
+ LLD_HAS_DRIVER(mingw)
++#ifndef __HAIKU__
+ LLD_HAS_DRIVER(macho)
++#endif
+ LLD_HAS_DRIVER(wasm)
+ 
+ int lld_main(int argc, char **argv, const llvm::ToolContext &) {
+-- 
+2.37.3
+
+
+From 0fb97de004488ec4550ac045b2c78c8d5a705c24 Mon Sep 17 00:00:00 2001
+From: X512 <danger_mail@list.ru>
+Date: Wed, 16 Mar 2022 07:04:18 +0900
+Subject: libunwind: Haiku: Signal frame unwinding support
+
+
+diff --git a/libunwind/src/UnwindCursor.hpp b/libunwind/src/UnwindCursor.hpp
+index dde9477..e4811a7 100644
+--- a/libunwind/src/UnwindCursor.hpp
++++ b/libunwind/src/UnwindCursor.hpp
+@@ -1008,6 +1008,9 @@ private:
+   template <typename Registers> int stepThroughSigReturn(Registers &) {
+     return UNW_STEP_END;
+   }
++#elif defined(__HAIKU__)
++  bool setInfoForSigReturn();
++  int stepThroughSigReturn();
+ #endif
+ 
+ #if defined(_LIBUNWIND_SUPPORT_DWARF_UNWIND)
+@@ -1311,7 +1314,7 @@ private:
+   unw_proc_info_t  _info;
+   bool             _unwindInfoMissing;
+   bool             _isSignalFrame;
+-#if defined(_LIBUNWIND_CHECK_LINUX_SIGRETURN)
++#if defined(_LIBUNWIND_CHECK_LINUX_SIGRETURN) || defined(_LIBUNWIND_TARGET_HAIKU)
+   bool             _isSigReturn = false;
+ #endif
+ };
+@@ -2523,7 +2526,7 @@ int UnwindCursor<A, R>::stepWithTBTable(pint_t pc, tbtable *TBTable,
+ 
+ template <typename A, typename R>
+ void UnwindCursor<A, R>::setInfoBasedOnIPRegister(bool isReturnAddress) {
+-#if defined(_LIBUNWIND_CHECK_LINUX_SIGRETURN)
++#if defined(_LIBUNWIND_CHECK_LINUX_SIGRETURN) || defined(_LIBUNWIND_TARGET_HAIKU)
+   _isSigReturn = false;
+ #endif
+ 
+@@ -2638,7 +2641,7 @@ void UnwindCursor<A, R>::setInfoBasedOnIPRegister(bool isReturnAddress) {
+   }
+ #endif // #if defined(_LIBUNWIND_SUPPORT_DWARF_UNWIND)
+ 
+-#if defined(_LIBUNWIND_CHECK_LINUX_SIGRETURN)
++#if defined(_LIBUNWIND_CHECK_LINUX_SIGRETURN) || defined(_LIBUNWIND_TARGET_HAIKU)
+   if (setInfoForSigReturn())
+     return;
+ #endif
+@@ -2722,6 +2725,65 @@ int UnwindCursor<A, R>::stepThroughSigReturn(Registers_arm64 &) {
+   _isSignalFrame = true;
+   return UNW_STEP_SUCCESS;
+ }
++#elif defined(__HAIKU__)
++
++#include <commpage_defs.h>
++#include <signal.h>
++
++extern "C" {
++extern void *__gCommPageAddress;
++}
++
++template <typename A, typename R>
++bool UnwindCursor<A, R>::setInfoForSigReturn() {
++#if defined(_LIBUNWIND_TARGET_X86_64)
++  addr_t signal_handler = (((addr_t*)__gCommPageAddress)[COMMPAGE_ENTRY_X86_SIGNAL_HANDLER] + (addr_t)__gCommPageAddress);
++	addr_t signal_handler_ret = signal_handler + 45;
++#endif
++  pint_t pc = static_cast<pint_t>(this->getReg(UNW_REG_IP));
++  if (pc == signal_handler_ret) {
++    //printf("signal frame detected\n");
++    _info = {};
++    _info.start_ip = signal_handler;
++    _info.end_ip = signal_handler_ret;
++    _isSigReturn = true;
++    return true;
++  }
++  return false;
++}
++
++template <typename A, typename R>
++int UnwindCursor<A, R>::stepThroughSigReturn() {
++  //printf("stepThroughSigReturn\n");
++  _isSignalFrame = true;
++  pint_t sp = _registers.getSP();
++  // printf("sp: %p\n", (void*)sp);
++#if defined(_LIBUNWIND_TARGET_X86_64)
++  vregs *regs = (vregs*)(sp + 0x70);
++  //printf("&regs: %p\n", regs);
++ 
++  _registers.setRegister(UNW_REG_IP, regs->rip);
++  _registers.setRegister(UNW_REG_SP, regs->rsp);
++  _registers.setRegister(UNW_X86_64_RAX, regs->rax);
++  _registers.setRegister(UNW_X86_64_RDX, regs->rdx);
++  _registers.setRegister(UNW_X86_64_RCX, regs->rcx);
++  _registers.setRegister(UNW_X86_64_RBX, regs->rbx);
++  _registers.setRegister(UNW_X86_64_RSI, regs->rsi);
++  _registers.setRegister(UNW_X86_64_RDI, regs->rdi);
++  _registers.setRegister(UNW_X86_64_RBP, regs->rbp);
++  _registers.setRegister(UNW_X86_64_R8,  regs->r8);
++  _registers.setRegister(UNW_X86_64_R9,  regs->r9);
++  _registers.setRegister(UNW_X86_64_R10, regs->r10);
++  _registers.setRegister(UNW_X86_64_R11, regs->r11);
++  _registers.setRegister(UNW_X86_64_R12, regs->r12);
++  _registers.setRegister(UNW_X86_64_R13, regs->r13);
++  _registers.setRegister(UNW_X86_64_R14, regs->r14);
++  _registers.setRegister(UNW_X86_64_R15, regs->r15);
++  // TODO: XMM
++#endif
++
++  return UNW_STEP_SUCCESS;
++}
+ #endif // defined(_LIBUNWIND_CHECK_LINUX_SIGRETURN) &&
+        // defined(_LIBUNWIND_TARGET_AARCH64)
+ 
+@@ -2893,7 +2955,7 @@ template <typename A, typename R> int UnwindCursor<A, R>::step(bool stage2) {
+ 
+   // Use unwinding info to modify register set as if function returned.
+   int result;
+-#if defined(_LIBUNWIND_CHECK_LINUX_SIGRETURN)
++#if defined(_LIBUNWIND_CHECK_LINUX_SIGRETURN) || defined(_LIBUNWIND_TARGET_HAIKU)
+   if (_isSigReturn) {
+     result = this->stepThroughSigReturn();
+   } else
+-- 
+2.37.3
+
+
+From 210e16cde25aa81977ae0a816bb97a17214b446b Mon Sep 17 00:00:00 2001
+From: Trung Nguyen <trungnt282910@gmail.com>
+Date: Thu, 7 Jul 2022 22:19:34 +0700
+Subject: libunwind: Haiku: Initial support
+
+
+diff --git a/libunwind/cmake/config-ix.cmake b/libunwind/cmake/config-ix.cmake
+index d311477..82f8ce9 100644
+--- a/libunwind/cmake/config-ix.cmake
++++ b/libunwind/cmake/config-ix.cmake
+@@ -11,7 +11,11 @@ include(CheckCSourceCompiles)
+ # --unwindlib=none is supported, and use that if possible.
+ llvm_check_compiler_linker_flag(C "--unwindlib=none" CXX_SUPPORTS_UNWINDLIB_EQ_NONE_FLAG)
+ 
+-check_library_exists(c fopen "" LIBUNWIND_HAS_C_LIB)
++if (HAIKU)
++  check_library_exists(root fopen "" LIBUNWIND_HAS_ROOT_LIB)
++else()
++  check_library_exists(c fopen "" LIBUNWIND_HAS_C_LIB)
++endif()
+ 
+ if (NOT LIBUNWIND_USE_COMPILER_RT)
+   if (ANDROID)
+@@ -45,6 +49,9 @@ if (CXX_SUPPORTS_NOSTDLIBXX_FLAG OR C_SUPPORTS_NODEFAULTLIBS_FLAG)
+   if (LIBUNWIND_HAS_C_LIB)
+     list(APPEND CMAKE_REQUIRED_LIBRARIES c)
+   endif ()
++  if (LIBUNWIND_HAS_ROOT_LIB)
++    list(APPEND CMAKE_REQUIRED_LIBRARIES root)
++  endif ()
+   if (LIBUNWIND_USE_COMPILER_RT)
+     include(HandleCompilerRT)
+     find_compiler_rt_library(builtins LIBUNWIND_BUILTINS_LIBRARY
+@@ -111,3 +118,8 @@ else()
+   check_library_exists(dl dladdr "" LIBUNWIND_HAS_DL_LIB)
+   check_library_exists(pthread pthread_once "" LIBUNWIND_HAS_PTHREAD_LIB)
+ endif()
++
++if(HAIKU)
++  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -D_DEFAULT_SOURCE")
++  check_library_exists(bsd dl_iterate_phdr "" LIBUNWIND_HAS_BSD_LIB)
++endif()
+\ No newline at end of file
+diff --git a/libunwind/include/__libunwind_config.h b/libunwind/include/__libunwind_config.h
+index a317a36..2444e72 100644
+--- a/libunwind/include/__libunwind_config.h
++++ b/libunwind/include/__libunwind_config.h
+@@ -36,6 +36,9 @@
+ # if defined(__linux__)
+ #  define _LIBUNWIND_TARGET_LINUX 1
+ # endif
++# if defined(__HAIKU__)
++#  define _LIBUNWIND_TARGET_HAIKU 1
++# endif
+ # if defined(__i386__)
+ #  define _LIBUNWIND_TARGET_I386
+ #  define _LIBUNWIND_CONTEXT_SIZE 8
+diff --git a/libunwind/src/CMakeLists.txt b/libunwind/src/CMakeLists.txt
+index bb2ada9..afd50e0 100644
+--- a/libunwind/src/CMakeLists.txt
++++ b/libunwind/src/CMakeLists.txt
+@@ -102,6 +102,32 @@ if (APPLE)
+   endif ()
+ endif ()
+ 
++if (HAIKU)
++  add_library_flags_if(LIBUNWIND_HAS_ROOT_LIB root)
++
++  add_library_flags_if(LIBUNWIND_HAS_BSD_LIB bsd)
++  add_compile_flags_if(LIBUNWIND_HAS_BSD_LIB -D_DEFAULT_SOURCE=1)
++  add_compile_flags_if(LIBUNWIND_HAS_BSD_LIB -D_LIBUNWIND_USE_HAIKU_BSD_LIB=1)
++
++  add_compile_flags("-DPT_GNU_EH_FRAME=PT_EH_FRAME")
++
++  find_path(LIBUNWIND_HAIKU_PRIVATE_HEADERS
++            "commpage_defs.h"
++            PATHS ${CMAKE_SYSTEM_INCLUDE_PATH}
++            PATH_SUFFIXES "/private/system"
++            NO_DEFAULT_PATH
++            REQUIRED)
++
++  include_directories(SYSTEM "${LIBUNWIND_HAIKU_PRIVATE_HEADERS}")
++  if (LIBUNWIND_TARGET_TRIPLE)
++    if (${LIBUNWIND_TARGET_TRIPLE} MATCHES "^x86_64")
++      include_directories(SYSTEM "${LIBUNWIND_HAIKU_PRIVATE_HEADERS}/arch/x86_64")
++    endif()
++  else()
++    include_directories(SYSTEM "${LIBUNWIND_HAIKU_PRIVATE_HEADERS}/arch/${CMAKE_SYSTEM_PROCESSOR}")
++  endif()
++endif()
++
+ string(REPLACE ";" " " LIBUNWIND_COMPILE_FLAGS "${LIBUNWIND_COMPILE_FLAGS}")
+ string(REPLACE ";" " " LIBUNWIND_CXX_FLAGS "${LIBUNWIND_CXX_FLAGS}")
+ string(REPLACE ";" " " LIBUNWIND_C_FLAGS "${LIBUNWIND_C_FLAGS}")
+diff --git a/libunwind/src/UnwindCursor.hpp b/libunwind/src/UnwindCursor.hpp
+index e4811a7..b7280f4 100644
+--- a/libunwind/src/UnwindCursor.hpp
++++ b/libunwind/src/UnwindCursor.hpp
+@@ -1008,7 +1008,7 @@ private:
+   template <typename Registers> int stepThroughSigReturn(Registers &) {
+     return UNW_STEP_END;
+   }
+-#elif defined(__HAIKU__)
++#elif defined(_LIBUNWIND_TARGET_HAIKU) && defined(_LIBUNWIND_TARGET_X86_64)
+   bool setInfoForSigReturn();
+   int stepThroughSigReturn();
+ #endif
+@@ -1314,7 +1314,8 @@ private:
+   unw_proc_info_t  _info;
+   bool             _unwindInfoMissing;
+   bool             _isSignalFrame;
+-#if defined(_LIBUNWIND_CHECK_LINUX_SIGRETURN) || defined(_LIBUNWIND_TARGET_HAIKU)
++#if defined(_LIBUNWIND_CHECK_LINUX_SIGRETURN) \
++    || defined(_LIBUNWIND_TARGET_HAIKU) && defined(_LIBUNWIND_TARGET_X86_64)
+   bool             _isSigReturn = false;
+ #endif
+ };
+@@ -2526,7 +2527,8 @@ int UnwindCursor<A, R>::stepWithTBTable(pint_t pc, tbtable *TBTable,
+ 
+ template <typename A, typename R>
+ void UnwindCursor<A, R>::setInfoBasedOnIPRegister(bool isReturnAddress) {
+-#if defined(_LIBUNWIND_CHECK_LINUX_SIGRETURN) || defined(_LIBUNWIND_TARGET_HAIKU)
++#if defined(_LIBUNWIND_CHECK_LINUX_SIGRETURN) \
++    || defined(_LIBUNWIND_TARGET_HAIKU) && defined(_LIBUNWIND_TARGET_X86_64)
+   _isSigReturn = false;
+ #endif
+ 
+@@ -2641,7 +2643,8 @@ void UnwindCursor<A, R>::setInfoBasedOnIPRegister(bool isReturnAddress) {
+   }
+ #endif // #if defined(_LIBUNWIND_SUPPORT_DWARF_UNWIND)
+ 
+-#if defined(_LIBUNWIND_CHECK_LINUX_SIGRETURN) || defined(_LIBUNWIND_TARGET_HAIKU)
++#if defined(_LIBUNWIND_CHECK_LINUX_SIGRETURN) \
++    || defined(_LIBUNWIND_TARGET_HAIKU) && defined(_LIBUNWIND_TARGET_X86_64)
+   if (setInfoForSigReturn())
+     return;
+ #endif
+@@ -2725,7 +2728,7 @@ int UnwindCursor<A, R>::stepThroughSigReturn(Registers_arm64 &) {
+   _isSignalFrame = true;
+   return UNW_STEP_SUCCESS;
+ }
+-#elif defined(__HAIKU__)
++#elif defined(_LIBUNWIND_TARGET_HAIKU) && defined(_LIBUNWIND_TARGET_X86_64)
+ 
+ #include <commpage_defs.h>
+ #include <signal.h>
+@@ -2955,7 +2958,8 @@ template <typename A, typename R> int UnwindCursor<A, R>::step(bool stage2) {
+ 
+   // Use unwinding info to modify register set as if function returned.
+   int result;
+-#if defined(_LIBUNWIND_CHECK_LINUX_SIGRETURN) || defined(_LIBUNWIND_TARGET_HAIKU)
++#if defined(_LIBUNWIND_CHECK_LINUX_SIGRETURN) \
++    || defined(_LIBUNWIND_TARGET_HAIKU) && defined(_LIBUNWIND_TARGET_X86_64)
+   if (_isSigReturn) {
+     result = this->stepThroughSigReturn();
+   } else
+diff --git a/libunwind/src/config.h b/libunwind/src/config.h
+index 6707d59..db1df8c 100644
+--- a/libunwind/src/config.h
++++ b/libunwind/src/config.h
+@@ -46,6 +46,12 @@
+ #elif defined(_AIX)
+ // The traceback table at the end of each function is used for unwinding.
+ #define _LIBUNWIND_SUPPORT_TBTAB_UNWIND 1
++#elif defined(__HAIKU__)
++  #if defined(_LIBUNWIND_USE_HAIKU_BSD_LIB)
++    #define _LIBUNWIND_USE_DL_ITERATE_PHDR 1
++  #endif
++  #define _LIBUNWIND_SUPPORT_DWARF_UNWIND 1
++  #define _LIBUNWIND_SUPPORT_DWARF_INDEX 1
+ #else
+   // Assume an ELF system with a dl_iterate_phdr function.
+   #define _LIBUNWIND_USE_DL_ITERATE_PHDR 1
+-- 
+2.37.3
+
+
+From fd6579c5c47de950419ac0326b7ef9ef5b7e93d4 Mon Sep 17 00:00:00 2001
+From: X512 <danger_mail@list.ru>
+Date: Mon, 10 Oct 2022 12:18:55 +0900
+Subject: Haiku: reimplement toolchain driver, make lld functional
+
+
+diff --git a/clang/lib/Driver/ToolChains/Haiku.cpp b/clang/lib/Driver/ToolChains/Haiku.cpp
+index e878cb1..eea14dd 100644
+--- a/clang/lib/Driver/ToolChains/Haiku.cpp
++++ b/clang/lib/Driver/ToolChains/Haiku.cpp
+@@ -8,12 +8,142 @@
+ 
+ #include "Haiku.h"
+ #include "CommonArgs.h"
++#include "clang/Driver/Compilation.h"
+ 
+ using namespace clang::driver;
++using namespace clang::driver::tools;
+ using namespace clang::driver::toolchains;
+ using namespace clang;
+ using namespace llvm::opt;
+ 
++void haiku::Linker::ConstructJob(Compilation &C, const JobAction &JA,
++                                   const InputInfo &Output,
++                                   const InputInfoList &Inputs,
++                                   const ArgList &Args,
++                                   const char *LinkingOutput) const {
++  const toolchains::Haiku &ToolChain =
++      static_cast<const toolchains::Haiku &>(getToolChain());
++  const Driver &D = ToolChain.getDriver();
++  //bool IsNoPIC = Args.hasArg(options::OPT_fno_pic, options::OPT_fno_PIC);
++  ArgStringList CmdArgs;
++
++  // Silence warning for "clang -g foo.o -o foo"
++  Args.ClaimAllArgs(options::OPT_g_Group);
++  // and "clang -emit-llvm foo.o -o foo"
++  Args.ClaimAllArgs(options::OPT_emit_llvm);
++  // and for "clang -w foo.o -o foo". Other warning options are already
++  // handled somewhere else.
++  Args.ClaimAllArgs(options::OPT_w);
++
++  if (!D.SysRoot.empty())
++    CmdArgs.push_back(Args.MakeArgString("--sysroot=" + D.SysRoot));
++/*
++  if (!IsNoPIC)
++    CmdArgs.push_back("-fpic");
++*/
++  CmdArgs.push_back("--eh-frame-hdr");
++  if (Args.hasArg(options::OPT_static)) {
++    CmdArgs.push_back("-Bstatic");
++  } else {
++    if (Args.hasArg(options::OPT_rdynamic))
++      CmdArgs.push_back("-export-dynamic");
++    if (Args.hasArg(options::OPT_shared)) {
++      CmdArgs.push_back("-Bshareable");
++    }
++    CmdArgs.push_back("--enable-new-dtags");
++  }
++
++  if (Arg *A = Args.getLastArg(options::OPT_G)) {
++    if (ToolChain.getTriple().isMIPS()) {
++      StringRef v = A->getValue();
++      CmdArgs.push_back(Args.MakeArgString("-G" + v));
++      A->claim();
++    }
++  }
++
++  CmdArgs.push_back("-shared");
++  if (Args.hasArg(options::OPT_shared)) {
++    //CmdArgs.push_back("-e 0");
++  } else {
++    CmdArgs.push_back("-no-undefined");
++  }
++
++  if (Output.isFilename()) {
++    CmdArgs.push_back("-o");
++    CmdArgs.push_back(Output.getFilename());
++  } else {
++    assert(Output.isNothing() && "Invalid output.");
++  }
++
++  if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nostartfiles,
++                   options::OPT_r)) {
++    const char *crt1 = nullptr;
++    if (!Args.hasArg(options::OPT_shared)) {
++      crt1 = "start_dyn.o";
++    }
++
++    CmdArgs.push_back(Args.MakeArgString(ToolChain.GetFilePath("crtbeginS.o")));
++    if (crt1)
++      CmdArgs.push_back(Args.MakeArgString(ToolChain.GetFilePath(crt1)));
++    CmdArgs.push_back(Args.MakeArgString(ToolChain.GetFilePath("init_term_dyn.o")));
++  }
++
++  Args.AddAllArgs(CmdArgs, options::OPT_L);
++  ToolChain.AddFilePathLibArgs(Args, CmdArgs);
++  Args.AddAllArgs(CmdArgs, options::OPT_T_Group);
++  Args.AddAllArgs(CmdArgs, options::OPT_e);
++  Args.AddAllArgs(CmdArgs, options::OPT_s);
++  Args.AddAllArgs(CmdArgs, options::OPT_t);
++  Args.AddAllArgs(CmdArgs, options::OPT_Z_Flag);
++  Args.AddAllArgs(CmdArgs, options::OPT_r);
++
++  if (D.isUsingLTO()) {
++    assert(!Inputs.empty() && "Must have at least one input.");
++    addLTOOptions(ToolChain, Args, CmdArgs, Output, Inputs[0],
++                  D.getLTOMode() == LTOK_Thin);
++  }
++
++  addLinkerCompressDebugSectionsOption(ToolChain, Args, CmdArgs);
++  AddLinkerInputs(ToolChain, Inputs, Args, CmdArgs, JA);
++
++  if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs,
++                   options::OPT_r)) {
++    // Use the static OpenMP runtime with -static-openmp
++    bool StaticOpenMP = Args.hasArg(options::OPT_static_openmp) &&
++                        !Args.hasArg(options::OPT_static);
++    addOpenMPRuntime(CmdArgs, ToolChain, Args, StaticOpenMP);
++
++    if (D.CCCIsCXX()) {
++      if (ToolChain.ShouldLinkCXXStdlib(Args))
++        ToolChain.AddCXXStdlibLibArgs(Args, CmdArgs);
++    }
++    CmdArgs.push_back("-lgcc");
++    CmdArgs.push_back("--push-state");
++    CmdArgs.push_back("--as-needed");
++    CmdArgs.push_back("-lgcc_s");
++    CmdArgs.push_back("--pop-state");
++    CmdArgs.push_back("-lroot");
++    CmdArgs.push_back("-lgcc");
++    CmdArgs.push_back("--push-state");
++    CmdArgs.push_back("--as-needed");
++    CmdArgs.push_back("-lgcc_s");
++    CmdArgs.push_back("--pop-state");
++  }
++
++  if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nostartfiles,
++                   options::OPT_r)) {
++    CmdArgs.push_back(Args.MakeArgString(ToolChain.GetFilePath("crtendS.o")));
++    CmdArgs.push_back(Args.MakeArgString(ToolChain.GetFilePath("crtn.o")));
++  }
++
++  ToolChain.addProfileRTLibs(Args, CmdArgs);
++
++  const char *Exec = Args.MakeArgString(getToolChain().GetLinkerPath());
++  C.addCommand(std::make_unique<Command>(JA, *this,
++                                         ResponseFileSupport::AtFileCurCP(),
++                                         Exec, CmdArgs, Inputs, Output));
++}
++
+ /// Haiku - Haiku tool chain which can call as(1) and ld(1) directly.
+ 
+ Haiku::Haiku(const Driver &D, const llvm::Triple& Triple, const ArgList &Args)
+@@ -23,25 +153,69 @@ Haiku::Haiku(const Driver &D, const llvm::Triple& Triple, const ArgList &Args)
+   getProgramPaths().insert(getProgramPaths().begin(), getDriver().SysRoot
+                            + "/system/bin/" HAIKU_HYBRID_SECONDARY);
+   getFilePaths().clear();
+-  getFilePaths().push_back(getDriver().SysRoot + "/system/lib/"
+-                           HAIKU_HYBRID_SECONDARY);
++  getFilePaths().push_back(getDriver().SysRoot + "/boot/system/lib/" HAIKU_HYBRID_SECONDARY);
++  getFilePaths().push_back(getDriver().SysRoot + "/boot/system/develop/lib/" HAIKU_HYBRID_SECONDARY);
++#else
++  getFilePaths().push_back(getDriver().SysRoot + "/boot/system/lib");
++  getFilePaths().push_back(getDriver().SysRoot + "/boot/system/develop/lib");
+ #endif
+ }
+ 
++ToolChain::CXXStdlibType Haiku::GetDefaultCXXStdlibType() const {
++  return ToolChain::CST_Libstdcxx;
++}
++
++unsigned Haiku::GetDefaultDwarfVersion() const {
++  return 2;
++}
++
+ void Haiku::addLibCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
+                                   llvm::opt::ArgStringList &CC1Args) const {
+   addSystemInclude(DriverArgs, CC1Args,
+-                   getDriver().SysRoot + "/system/develop/headers/c++/v1");
++                   getDriver().SysRoot + "/boot/system/develop/headers/c++/v1");
+ }
+ 
+ void Haiku::addLibStdCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
+                                      llvm::opt::ArgStringList &CC1Args) const {
+ #ifdef HAIKU_HYBRID_SECONDARY
+-  addLibStdCXXIncludePaths(getDriver().SysRoot + "/system/develop/headers/"
++  addLibStdCXXIncludePaths(getDriver().SysRoot + "/boot/system/develop/headers/"
+                      HAIKU_HYBRID_SECONDARY "/c++", getTriple().str(), "",
+                      DriverArgs, CC1Args);
+ #else
+-  addLibStdCXXIncludePaths(getDriver().SysRoot + "/system/develop/headers/c++",
++  addLibStdCXXIncludePaths(getDriver().SysRoot + "/boot/system/develop/headers/c++",
+                            getTriple().str(), "", DriverArgs, CC1Args);
+ #endif
+ }
++
++void Haiku::AddCXXStdlibLibArgs(const ArgList &Args,
++                                  ArgStringList &CmdArgs) const {
++  CXXStdlibType Type = GetCXXStdlibType(Args);
++
++  switch (Type) {
++  case ToolChain::CST_Libcxx:
++    CmdArgs.push_back("-lc++");
++    break;
++
++  case ToolChain::CST_Libstdcxx:
++    CmdArgs.push_back("-lstdc++");
++    break;
++  }
++}
++
++void Haiku::AddCudaIncludeArgs(const ArgList &DriverArgs,
++                                 ArgStringList &CC1Args) const {
++  CudaInstallation->AddCudaIncludeArgs(DriverArgs, CC1Args);
++}
++
++void Haiku::AddHIPIncludeArgs(const ArgList &DriverArgs,
++                                ArgStringList &CC1Args) const {
++  RocmInstallation->AddHIPIncludeArgs(DriverArgs, CC1Args);
++}
++
++bool Haiku::HasNativeLLVMSupport() const { return true; }
++
++ToolChain::UnwindTableLevel Haiku::getDefaultUnwindTableLevel(const ArgList &Args) const { return UnwindTableLevel::Asynchronous;; }
++
++bool Haiku::GetDefaultStandaloneDebug() const { return true; }
++
++Tool *Haiku::buildLinker() const { return new tools::haiku::Linker(*this); }
+diff --git a/clang/lib/Driver/ToolChains/Haiku.h b/clang/lib/Driver/ToolChains/Haiku.h
+index f649d8d..70fc0dc 100644
+--- a/clang/lib/Driver/ToolChains/Haiku.h
++++ b/clang/lib/Driver/ToolChains/Haiku.h
+@@ -15,6 +15,25 @@
+ 
+ namespace clang {
+ namespace driver {
++namespace tools {
++
++/// haiku -- Directly call GNU Binutils linker
++namespace haiku {
++class LLVM_LIBRARY_VISIBILITY Linker : public Tool {
++public:
++  Linker(const ToolChain &TC) : Tool("haiku::Linker", "linker", TC) {}
++
++  bool hasIntegratedCPP() const override { return false; }
++  bool isLinkJob() const override { return true; }
++
++  void ConstructJob(Compilation &C, const JobAction &JA,
++                    const InputInfo &Output, const InputInfoList &Inputs,
++                    const llvm::opt::ArgList &TCArgs,
++                    const char *LinkingOutput) const override;
++};
++} // end namespace haiku
++} // end namespace tools
++
+ namespace toolchains {
+ 
+ class LLVM_LIBRARY_VISIBILITY Haiku : public Generic_ELF {
+@@ -22,6 +41,25 @@ public:
+   Haiku(const Driver &D, const llvm::Triple &Triple,
+           const llvm::opt::ArgList &Args);
+ 
++  bool HasNativeLLVMSupport() const override;
++
++  bool IsMathErrnoDefault() const override { return false; }
++  bool IsObjCNonFragileABIDefault() const override { return true; }
++
++  CXXStdlibType GetDefaultCXXStdlibType() const override;
++  const char *getDefaultLinker() const override { return "ld.lld"; }
++
++  void AddCXXStdlibLibArgs(const llvm::opt::ArgList &Args,
++                           llvm::opt::ArgStringList &CmdArgs) const override;
++  void AddCudaIncludeArgs(const llvm::opt::ArgList &DriverArgs,
++                          llvm::opt::ArgStringList &CC1Args) const override;
++  void AddHIPIncludeArgs(const llvm::opt::ArgList &DriverArgs,
++                         llvm::opt::ArgStringList &CC1Args) const override;
++
++  ToolChain::UnwindTableLevel getDefaultUnwindTableLevel(const llvm::opt::ArgList &Args) const override;
++  unsigned GetDefaultDwarfVersion() const override;
++  bool GetDefaultStandaloneDebug() const override;
++
+   bool isPIEDefault(const llvm::opt::ArgList &Args) const override { return false; }
+   bool isPICDefault() const override { return true; }
+ 
+@@ -31,6 +69,8 @@ public:
+   void addLibStdCxxIncludePaths(
+       const llvm::opt::ArgList &DriverArgs,
+       llvm::opt::ArgStringList &CC1Args) const override;
++protected:
++  Tool *buildLinker() const override;
+ };
+ 
+ } // end namespace toolchains
+-- 
+2.37.3
+
+
+From bdb20ae26aec4f7f3cbcb7addf78645d4b9a5782 Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Wed, 9 Aug 2023 23:05:15 +0200
+Subject: Haiku: implement GCC installation detection
+
+
+diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
+index 40038dc..8b49cb2 100644
+--- a/clang/lib/Driver/ToolChains/Gnu.cpp
++++ b/clang/lib/Driver/ToolChains/Gnu.cpp
+@@ -2276,6 +2276,15 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+     Prefixes.push_back("/opt/rh/devtoolset-2/root/usr");
+   }
+ 
++  if (TargetTriple.getOS() == llvm::Triple::Haiku) {
++#ifdef HAIKU_HYBRID_SECONDARY
++    Prefixes.push_back("/boot/system/develop/tools/" HAIKU_HYBRID_SECONDARY);
++#else
++    Prefixes.push_back("/boot/system/develop/tools");
++#endif
++    return;
++  }
++
+   // Fall back to /usr which is used by most non-Solaris systems.
+   Prefixes.push_back(concat(SysRoot, "/usr"));
+ }
+@@ -2422,6 +2431,23 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+   using std::begin;
+   using std::end;
+ 
++  if (TargetTriple.getOS() == llvm::Triple::Haiku) {
++    static const char *const HaikuLibDirs[] = {"/lib"};
++    static const char *const HaikuX86Triples[] = {"i586-unknown-haiku"};
++    static const char *const HaikuX86_64Triples[] = {"x86_64-unknown-haiku"};
++    LibDirs.append(begin(HaikuLibDirs), end(HaikuLibDirs));
++    switch (TargetTriple.getArch()) {
++    case llvm::Triple::x86:
++      TripleAliases.append(begin(HaikuX86Triples), end(HaikuX86Triples));
++      break;
++    case llvm::Triple::x86_64:
++      TripleAliases.append(begin(HaikuX86_64Triples), end(HaikuX86_64Triples));
++      break;
++    default:
++      break;
++    }
++  }
++
+   if (TargetTriple.getOS() == llvm::Triple::Solaris) {
+     static const char *const SolarisLibDirs[] = {"/lib"};
+     static const char *const SolarisSparcV8Triples[] = {
+diff --git a/clang/lib/Driver/ToolChains/Haiku.cpp b/clang/lib/Driver/ToolChains/Haiku.cpp
+index eea14dd..217315f 100644
+--- a/clang/lib/Driver/ToolChains/Haiku.cpp
++++ b/clang/lib/Driver/ToolChains/Haiku.cpp
+@@ -148,7 +148,7 @@ void haiku::Linker::ConstructJob(Compilation &C, const JobAction &JA,
+ 
+ Haiku::Haiku(const Driver &D, const llvm::Triple& Triple, const ArgList &Args)
+   : Generic_ELF(D, Triple, Args) {
+-
++  GCCInstallation.init(Triple, Args);
+ #ifdef HAIKU_HYBRID_SECONDARY
+   getProgramPaths().insert(getProgramPaths().begin(), getDriver().SysRoot
+                            + "/system/bin/" HAIKU_HYBRID_SECONDARY);
+@@ -159,6 +159,10 @@ Haiku::Haiku(const Driver &D, const llvm::Triple& Triple, const ArgList &Args)
+   getFilePaths().push_back(getDriver().SysRoot + "/boot/system/lib");
+   getFilePaths().push_back(getDriver().SysRoot + "/boot/system/develop/lib");
+ #endif
++
++  if (GCCInstallation.isValid()) {
++    getFilePaths().push_back(GCCInstallation.getInstallPath().str());
++  }
+ }
+ 
+ ToolChain::CXXStdlibType Haiku::GetDefaultCXXStdlibType() const {
+-- 
+2.37.3
+
+
+From 0e9da69a74b5063c88ec798844e332831077eb92 Mon Sep 17 00:00:00 2001
+From: Trung Nguyen <57174311+trungnt2910@users.noreply.github.com>
+Date: Mon, 14 Aug 2023 14:58:56 +1000
+Subject: clang: Haiku: Add missing GNU headers include path
+
+
+diff --git a/clang/lib/Lex/InitHeaderSearch.cpp b/clang/lib/Lex/InitHeaderSearch.cpp
+index de70e50..0e8df73 100644
+--- a/clang/lib/Lex/InitHeaderSearch.cpp
++++ b/clang/lib/Lex/InitHeaderSearch.cpp
+@@ -330,6 +330,7 @@ void InitHeaderSearch::AddDefaultCIncludePaths(const llvm::Triple &triple,
+     AddPath("/boot/system/develop/headers/3rdparty", System, false);
+     AddPath("/boot/system/develop/headers/bsd", System, false);
+     AddPath("/boot/system/develop/headers/glibc", System, false);
++    AddPath("/boot/system/develop/headers/gnu", System, false);
+     AddPath("/boot/system/develop/headers/posix", System, false);
+ #ifdef HAIKU_HYBRID_SECONDARY
+     AddPath("/boot/system/develop/headers/" HAIKU_HYBRID_SECONDARY, System, false);
+-- 
+2.37.3
+
+
+From a1daf6233d9d1841749b1505b75f7192dd7c41d9 Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Sat, 26 Aug 2023 09:36:42 +0200
+Subject: clang: Haiku: silence warning for -pie
+
+
+diff --git a/clang/lib/Driver/ToolChains/Haiku.cpp b/clang/lib/Driver/ToolChains/Haiku.cpp
+index 217315f..e9d1187 100644
+--- a/clang/lib/Driver/ToolChains/Haiku.cpp
++++ b/clang/lib/Driver/ToolChains/Haiku.cpp
+@@ -35,6 +35,9 @@ void haiku::Linker::ConstructJob(Compilation &C, const JobAction &JA,
+   // handled somewhere else.
+   Args.ClaimAllArgs(options::OPT_w);
+ 
++  // Silence warning for "clang -pie foo.o -o foo"
++  Args.ClaimAllArgs(options::OPT_pie);
++
+   if (!D.SysRoot.empty())
+     CmdArgs.push_back(Args.MakeArgString("--sysroot=" + D.SysRoot));
+ /*
+-- 
+2.37.3
+
+
+From 15461bd5f32674ed7b7716a5ee129c6e30ad2b44 Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Sun, 27 Aug 2023 19:32:12 +0200
+Subject: clang: Haiku: silence warning for -pthread and -pthreads when linking
+ against libroot
+
+
+diff --git a/clang/lib/Driver/ToolChains/Haiku.cpp b/clang/lib/Driver/ToolChains/Haiku.cpp
+index e9d1187..f5f7e99 100644
+--- a/clang/lib/Driver/ToolChains/Haiku.cpp
++++ b/clang/lib/Driver/ToolChains/Haiku.cpp
+@@ -131,6 +131,10 @@ void haiku::Linker::ConstructJob(Compilation &C, const JobAction &JA,
+     CmdArgs.push_back("--as-needed");
+     CmdArgs.push_back("-lgcc_s");
+     CmdArgs.push_back("--pop-state");
++
++    // No need to do anything for pthreads. Claim argument to avoid warning.
++    Args.ClaimAllArgs(options::OPT_pthread);
++    Args.ClaimAllArgs(options::OPT_pthreads);
+   }
+ 
+   if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nostartfiles,
+-- 
+2.37.3
+
+
+From bf84da36490ae8f90709ba26ae2c1a15d4d1ec0e Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Tue, 12 Sep 2023 18:30:30 +0200
+Subject: clang: Haiku: remove custom addLibStdCxxIncludePaths implementation
+
+* previous implementation referred to a non-existent directory
+* we can reuse the logic inherited from base class Generic_GCC
+
+diff --git a/clang/lib/Driver/ToolChains/Haiku.cpp b/clang/lib/Driver/ToolChains/Haiku.cpp
+index f5f7e99..60434c6 100644
+--- a/clang/lib/Driver/ToolChains/Haiku.cpp
++++ b/clang/lib/Driver/ToolChains/Haiku.cpp
+@@ -186,18 +186,6 @@ void Haiku::addLibCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
+                    getDriver().SysRoot + "/boot/system/develop/headers/c++/v1");
+ }
+ 
+-void Haiku::addLibStdCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
+-                                     llvm::opt::ArgStringList &CC1Args) const {
+-#ifdef HAIKU_HYBRID_SECONDARY
+-  addLibStdCXXIncludePaths(getDriver().SysRoot + "/boot/system/develop/headers/"
+-                     HAIKU_HYBRID_SECONDARY "/c++", getTriple().str(), "",
+-                     DriverArgs, CC1Args);
+-#else
+-  addLibStdCXXIncludePaths(getDriver().SysRoot + "/boot/system/develop/headers/c++",
+-                           getTriple().str(), "", DriverArgs, CC1Args);
+-#endif
+-}
+-
+ void Haiku::AddCXXStdlibLibArgs(const ArgList &Args,
+                                   ArgStringList &CmdArgs) const {
+   CXXStdlibType Type = GetCXXStdlibType(Args);
+diff --git a/clang/lib/Driver/ToolChains/Haiku.h b/clang/lib/Driver/ToolChains/Haiku.h
+index 70fc0dc..be3425e 100644
+--- a/clang/lib/Driver/ToolChains/Haiku.h
++++ b/clang/lib/Driver/ToolChains/Haiku.h
+@@ -66,9 +66,6 @@ public:
+   void addLibCxxIncludePaths(
+       const llvm::opt::ArgList &DriverArgs,
+       llvm::opt::ArgStringList &CC1Args) const override;
+-  void addLibStdCxxIncludePaths(
+-      const llvm::opt::ArgList &DriverArgs,
+-      llvm::opt::ArgStringList &CC1Args) const override;
+ protected:
+   Tool *buildLinker() const override;
+ };
+-- 
+2.37.3
+
+
+From b886a3d10b17674fd7449518bd7e7b1b9e5edf85 Mon Sep 17 00:00:00 2001
+From: David Karoly <karolyd577@gmail.com>
+Date: Thu, 21 Sep 2023 17:44:12 +0000
+Subject: fix build on x86 secondary arch
+
+
+diff --git a/clang/lib/Headers/CMakeLists.txt b/clang/lib/Headers/CMakeLists.txt
+index f2b0c5c..f5fbcb5 100644
+--- a/clang/lib/Headers/CMakeLists.txt
++++ b/clang/lib/Headers/CMakeLists.txt
+@@ -311,7 +311,7 @@ set(llvm_libc_wrapper_files
+ )
+ 
+ include(GetClangResourceDir)
+-get_clang_resource_dir(output_dir PREFIX ${LLVM_LIBRARY_OUTPUT_INTDIR}/.. SUBDIR include)
++get_clang_resource_dir(output_dir PREFIX ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR} SUBDIR include)
+ set(out_files)
+ set(generated_files)
+ 
+-- 
+2.37.3
+


### PR DESCRIPTION
the patchset from llvm16-16.0.6-4 can be applied with minor changes

successful build on 32-bit & 64-bit

new llvm17 toolchain seems to behave well, I can compile C and C++, include folders also looking OK