### PR TITLE
weechat: update to version 4.0.4, move to Python 3.10.

### DIFF
--- a/net-irc/weechat/weechat-4.0.4.recipe
+++ b/net-irc/weechat/weechat-4.0.4.recipe
@@ -7,7 +7,7 @@ COPYRIGHT="2003-2023 Sébastien Helleu"
 LICENSE="GNU GPL v3"
 REVISION="1"
 SOURCE_URI="https://weechat.org/files/src/weechat-$portVersion.tar.xz"
-CHECKSUM_SHA256="f7cb65c200f8c090c56f2cf98c0b184051e516e5f7099a4308cacf86f174bf28"
+CHECKSUM_SHA256="ae5f4979b5ada0339b84e741d5f7e481ee91e3fecd40a09907b64751829eb6f6"
 ADDITIONAL_FILES="weechat.rdef.in"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -31,6 +31,7 @@ REQUIRES="
 	lib:libintl$secondaryArchSuffix
 	lib:liblua$secondaryArchSuffix >= 5.3
 	lib:libncurses$secondaryArchSuffix
+	lib:libpython3.10$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	lib:libzstd$secondaryArchSuffix
 	"
@@ -54,7 +55,7 @@ BUILD_REQUIRES="
 	devel:libintl$secondaryArchSuffix
 	devel:liblua$secondaryArchSuffix >= 5.3
 	devel:libncurses$secondaryArchSuffix
-	devel:libpython3.9$secondaryArchSuffix
+	devel:libpython3.10$secondaryArchSuffix
 #	devel:libtclstub8.6$secondaryArchSuffix
 #	devel:libtk8.6$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix


### PR DESCRIPTION
Lightly tested on beta4 64 bits (was able to connect and chat over the OFTC's `#haiku` channel).