### PR TITLE
timezone_data: update to version 2023c

### DIFF
--- a/sys-libs/timezone_data/patches/timezone_data-2023c.patchset
+++ b/sys-libs/timezone_data/patches/timezone_data-2023c.patchset
@@ -1,14 +1,14 @@
-From 8cf4e37523a8ec3fc4267c54f5b7c1a83d3227a0 Mon Sep 17 00:00:00 2001
+From 45d6570d90bb9b04a55f59e92db9cf53c9ee4f93 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Thu, 24 Feb 2022 18:49:00 +0100
 Subject: applying patch timezone_data-2021e.patch
 
 
 diff --git a/zic.c b/zic.c
-index b70a606..f506bc8 100644
+index 5518051..7f8bb11 100644
 --- a/zic.c
 +++ b/zic.c
-@@ -1138,7 +1138,7 @@ dolink(char const *target, char const *linkname, bool staysymlink)
+@@ -1456,7 +1456,7 @@ dolink(char const *target, char const *linkname, bool staysymlink)
  	    break;
  	  }
  	  link_errno = errno;
@@ -17,7 +17,7 @@ index b70a606..f506bc8 100644
  	    break;
  
  	  if (link_errno == EEXIST) {
-@@ -1150,9 +1150,9 @@ dolink(char const *target, char const *linkname, bool staysymlink)
+@@ -1468,9 +1468,9 @@ dolink(char const *target, char const *linkname, bool staysymlink)
  	    mkdirs(linkname, true);
  	    linkdirs_made = true;
  	  } else {
@@ -29,7 +29,7 @@ index b70a606..f506bc8 100644
  	    exit(EXIT_FAILURE);
  	  }
  	}
-@@ -1178,7 +1178,7 @@ dolink(char const *target, char const *linkname, bool staysymlink)
+@@ -1496,7 +1496,7 @@ dolink(char const *target, char const *linkname, bool staysymlink)
  	  }
  	  free(linkalloc);
  	  if (symlink_errno == 0) {
@@ -38,7 +38,7 @@ index b70a606..f506bc8 100644
  	      warning(_("symbolic link used because hard link failed: %s"),
  		      strerror(link_errno));
  	  } else {
-@@ -1196,7 +1196,7 @@ dolink(char const *target, char const *linkname, bool staysymlink)
+@@ -1514,7 +1514,7 @@ dolink(char const *target, char const *linkname, bool staysymlink)
  	      putc(c, tp);
  	    close_file(tp, directory, linkname, tempname);
  	    close_file(fp, directory, target, NULL);
@@ -48,5 +48,5 @@ index b70a606..f506bc8 100644
  		      strerror(link_errno));
  	    else if (symlink_errno != ENOTSUP)
 -- 
-2.30.2
+2.37.3
 

--- a/sys-libs/timezone_data/timezone_data-2023c.recipe
+++ b/sys-libs/timezone_data/timezone_data-2023c.recipe
@@ -13,7 +13,7 @@ LICENSE="
 	"
 REVISION="1"
 SOURCE_URI="https://data.iana.org/time-zones/releases/tzdb-$portVersion.tar.lz"
-CHECKSUM_SHA256="180343dda8b24e000d8f718ab5871efa2ec0ed7725ba9a4267b8bd36af155bc2"
+CHECKSUM_SHA256="08fd090f1a16d522ae4e9247445056f4155002239e5be760b31ba0376d2e632c"
 SOURCE_DIR="tzdb-$portVersion"
 PATCHES="timezone_data-$portVersion.patchset"
 
@@ -24,7 +24,6 @@ PROVIDES="
 	cmd:tzselect
 	cmd:zdump
 	cmd:zic
-	lib:libtz
 	devel:libtz
 	"
 REQUIRES="
@@ -43,7 +42,11 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	make
+	make \
+		USRDIR=$prefix \
+		USRSHAREDIR=${dataDir:1} \
+		ZICDIR=$binDir \
+		MANDIR=$manDir
 }
 
 INSTALL()


### PR DESCRIPTION
Set make flags also on BUILD(), otherwise tzselect ended up with the wrong location for TZDIR.

Previous version failed with:
`/bin/tzselect: time zone files are not set up correctly`

Now it finds the files ok, but trying to use it further causes /bin/date to crash around 7 times in a row (?!).

`> zdump -v America/Buenos_Aires` also works now, while previously failed with:

`America/Buenos_Aires: No such file or directory`,

or with:

```
> ln -s /boot/system/data/zoneinfo/America/Buenos_Aires /etc/localtime
> zdump -v /etc/localtime
/etc/localtime: No error
```

Now the latter also works OK.