### PR TITLE
command_not_found: switch to Python3.

### DIFF
--- a/app-shells/command_not_found/command_not_found-0.0.1~git.recipe
+++ b/app-shells/command_not_found/command_not_found-0.0.1~git.recipe
@@ -5,7 +5,7 @@ It can also check for typos (a feature of zsh)."
 HOMEPAGE="https://github.com/jrabbit/haiku-cnf"
 COPYRIGHT="2011 Jrabbit"
 LICENSE="GNU GPL v2"
-REVISION="4"
+REVISION="5"
 srcGitRev="db1be8b57dedff781dc68caa46f403d88c5eedb9"
 SOURCE_URI="$HOMEPAGE/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="a1ce4e6c8a7307c0d5c1e65a90b3d2a7ba9d16d9506a70aab1005129333d6121"
@@ -21,7 +21,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku
-	cmd:python3.9
+	cmd:python3
 	"
 
 BUILD_REQUIRES="
@@ -32,8 +32,7 @@ BUILD_PREREQUIRES="
 	"
 
 TEST_REQUIRES="
-	cmd:python3.9
-	mock_python3.9
+	cmd:python3
 	"
 
 BUILD()

--- a/app-shells/command_not_found/patches/command_not_found-0.0.1~git.patchset
+++ b/app-shells/command_not_found/patches/command_not_found-0.0.1~git.patchset
@@ -1,4 +1,4 @@
-From 9dd9d0084cfb2f3526d0f5e6c33ad944e1b197ec Mon Sep 17 00:00:00 2001
+From af99265c4bd9c2014525942c14424af2182cccf4 Mon Sep 17 00:00:00 2001
 From: tts2k <tranthaison2000@gmail.com>
 Date: Sun, 7 Jan 2018 02:49:19 +0000
 Subject: Add read permission
@@ -33,7 +33,7 @@ index 1e1dd35..fc0051b 100644
 2.37.3
 
 
-From 8fd2339e220b14e4402d3098ed9bc797244bc605 Mon Sep 17 00:00:00 2001
+From 8ac41f59adfcd610544e0583745d5103f141abaa Mon Sep 17 00:00:00 2001
 From: tts2k <tranthaison2000@gmail.com>
 Date: Tue, 9 Jan 2018 12:27:13 +0000
 Subject: write default option if not available
@@ -90,7 +90,7 @@ index c7f51d9..d9e0644 100644
 2.37.3
 
 
-From 3d0031ec35ff3491d13205b79250e75476fe09b3 Mon Sep 17 00:00:00 2001
+From 72cb67f6d656f95a77135bbaec335254cf5100ef Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 23 Apr 2023 15:15:02 -0300
 Subject: Switch to Python3
@@ -180,7 +180,7 @@ index d9e0644..23e2179 100644
 2.37.3
 
 
-From 36c7f10ba246de1913f2aaf63ce6c1091ed5a1d8 Mon Sep 17 00:00:00 2001
+From 96ec2cc13f6b46a7f22b526cc476811a759ac0a2 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 23 Apr 2023 16:19:31 -0300
 Subject: Shut up already!
@@ -203,7 +203,7 @@ index 23e2179..304b2fa 100644
 2.37.3
 
 
-From 6cd502dedca16845ac2e908022a5f3dcfb2c88dc Mon Sep 17 00:00:00 2001
+From ae2640725537f3b500188db7b85dcf6b49d8ca98 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 23 Apr 2023 16:22:32 -0300
 Subject: Use quotes around the suggested command
@@ -226,7 +226,7 @@ index 304b2fa..f8bd459 100644
 2.37.3
 
 
-From e4c10ec446113ee64c853ff0065b9ee38e9694fd Mon Sep 17 00:00:00 2001
+From 15575933aa916b203ad307c15ca2a4251ecd3aa7 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 23 Apr 2023 16:37:16 -0300
 Subject: Fix tests for Python3
@@ -275,17 +275,17 @@ index 0183a5e..7ab8416 100644
 2.37.3
 
 
-From c1608ba6cc01dddae53d2520a3bd77571cd1060c Mon Sep 17 00:00:00 2001
+From d8877dd8a78678637d54b07ac45a3a3dfc9bf9bc Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 23 Apr 2023 17:10:20 -0300
 Subject: More quotation fixes, some spellchecking too.
 
 
 diff --git a/haiku_cnf.py b/haiku_cnf.py
-index f8bd459..2c519d3 100644
+index f8bd459..9e765ec 100644
 --- a/haiku_cnf.py
 +++ b/haiku_cnf.py
-@@ -135,12 +135,12 @@ def cnf(command):
+@@ -135,15 +135,15 @@ def cnf(command):
      if options['haikuports'] == True:
          logger.debug("CNF: Haikuports check")
          if command in json.loads(db['haikuports']):
@@ -293,14 +293,40 @@ index f8bd459..2c519d3 100644
 +            print('This application is available via "haikuporter -i %s"' % command)
      elif command in json.loads(db['haikudepot']):
 -        print("This application is aviaiblible via pkgman install {}".format(command))
-+        print('This application is available via pkgman install {}"'.format(command))
++        print('This application is available via "pkgman install {}"'.format(command))
      elif provides_info:
          if len(provides_info) == 1:
 -            print("This application is aviaiblible via pkgman install {}".format(command))
 +            print('This application is available via "pkgman install {}"'.format(command))
          else:
-             print("I found multiple potential packages for {}".format(command))
-             print("Try one of these: {}".format(provides_info))
+-            print("I found multiple potential packages for {}".format(command))
+-            print("Try one of these: {}".format(provides_info))
++            print('I found multiple potential packages for "{}"'.format(command))
++            print('Try one of these: "{}"'.format(provides_info))
+     else:
+         print("{} : Command not found. Sorry.".format(command))
+ 
+-- 
+2.37.3
+
+
+From b081c20bba94df134a4336542effe45011f7e64e Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Mon, 25 Sep 2023 03:58:18 -0300
+Subject: Use unitest.mock from Python's stdlib.
+
+
+diff --git a/test_cnf.py b/test_cnf.py
+index 7ab8416..2ce98e3 100644
+--- a/test_cnf.py
++++ b/test_cnf.py
+@@ -1,5 +1,5 @@
+ import unittest
+-import mock
++from unittest import mock
+ 
+ from haiku_cnf import search_provides, read_haikuports, firstrun
+ 
 -- 
 2.37.3
 


### PR DESCRIPTION
Dropped usage of the `mock` backported module, and fixed some quotation issues.