### PR TITLE
GCC: disable the use of dl_iterate_phdr in libbacktrace

### DIFF
--- a/sys-devel/gcc/gcc-13.2.0_2023_08_10.recipe
+++ b/sys-devel/gcc/gcc-13.2.0_2023_08_10.recipe
@@ -5,7 +5,7 @@ HOMEPAGE="https://gcc.gnu.org/"
 COPYRIGHT="1988-2023 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3
 	GNU LGPL v3"
-REVISION="2"
+REVISION="3"
 gccVersion="${portVersion%%_*}"
 SOURCE_URI="https://ftpmirror.gnu.org/gcc/gcc-$gccVersion/gcc-$gccVersion.tar.xz
 	https://ftp.gnu.org/gnu/gcc/gcc-$gccVersion/gcc-$gccVersion.tar.xz"

--- a/sys-devel/gcc/patches/gcc-13.2.0_2023_08_10.patchset
+++ b/sys-devel/gcc/patches/gcc-13.2.0_2023_08_10.patchset
@@ -1,4 +1,4 @@
-From 7c8661ad7e72f2ac5e4d7e75f70b833eb1a93254 Mon Sep 17 00:00:00 2001
+From bef5a4cff865d9f7b50636943217721c08ea3943 Mon Sep 17 00:00:00 2001
 From: Niels Sascha Reedijk <niels.reedijk@gmail.com>
 Date: Tue, 15 Aug 2023 06:19:59 +0100
 Subject: [PATCH] Modifications for GCC 13.2.0 for Haiku (from buildtools
@@ -42,6 +42,8 @@ Subject: [PATCH] Modifications for GCC 13.2.0 for Haiku (from buildtools
  libatomic/configure                           |   33 +-
  libatomic/configure.ac                        |   24 +-
  libatomic/configure.tgt                       |    2 +-
+ libbacktrace/configure                        |    5 +
+ libbacktrace/configure.ac                     |    5 +
  libcody/configure                             |    2 +-
  libgcc/config.host                            |   37 +-
  libgcc/config/aarch64/haiku-unwind.h          |   51 +
@@ -59,7 +61,7 @@ Subject: [PATCH] Modifications for GCC 13.2.0 for Haiku (from buildtools
  libstdc++-v3/crossconfig.m4                   |   44 +-
  libstdc++-v3/libsupc++/tinfo.cc               |    9 +
  libtool.m4                                    |   11 +-
- 54 files changed, 3756 insertions(+), 1464 deletions(-)
+ 56 files changed, 3766 insertions(+), 1464 deletions(-)
  create mode 100644 gcc/config/aarch64/aarch64-haiku.h
  create mode 100644 gcc/config/aarch64/t-aarch64-haiku
  create mode 100644 gcc/config/arm/haiku.h
@@ -7042,6 +7044,38 @@ index a92ae9e83..fc746b4aa 100644
  	# POSIX system.  The OS is supported.
  	config_path="${config_path} posix"
  	;;
+diff --git a/libbacktrace/configure b/libbacktrace/configure
+index 6af2c04c8..dc1bf68d1 100755
+--- a/libbacktrace/configure
++++ b/libbacktrace/configure
+@@ -13331,6 +13331,11 @@ else
+   have_dl_iterate_phdr=no
+ fi
+ rm -f conftest*
++    # On Haiku, this function only exists when linking against libbsd. This
++    # may be enabled in the future, but for now, disable support.
++    case "${host}" in
++      *-*-haiku*) have_dl_iterate_phdr=no ;;
++    esac
+ 
+   else
+     ac_fn_c_check_func "$LINENO" "dl_iterate_phdr" "ac_cv_func_dl_iterate_phdr"
+diff --git a/libbacktrace/configure.ac b/libbacktrace/configure.ac
+index 39e6bf41e..032341812 100644
+--- a/libbacktrace/configure.ac
++++ b/libbacktrace/configure.ac
+@@ -347,6 +347,11 @@ else
+     # When built as a GCC target library, we can't do a link test.
+     AC_EGREP_HEADER([dl_iterate_phdr], [$link_h], [have_dl_iterate_phdr=yes],
+ 		    [have_dl_iterate_phdr=no])
++    # On Haiku, this function only exists when linking against libbsd. This
++    # may be enabled in the future, but for now, disable support.
++    case "${host}" in
++      *-*-haiku*) have_dl_iterate_phdr=no ;;
++    esac
+   else
+     AC_CHECK_FUNC([dl_iterate_phdr], [have_dl_iterate_phdr=yes],
+ 		  [have_dl_iterate_phdr=no])
 diff --git a/libcody/configure b/libcody/configure
 index da52a5cfc..d92e55a09 100755
 --- a/libcody/configure


### PR DESCRIPTION
This fixes libfortan.so.

Closes #9241