### PR TITLE
proj: bump version

### DIFF
--- a/sci-libs/proj/proj-9.3.0.recipe
+++ b/sci-libs/proj/proj-9.3.0.recipe
@@ -6,7 +6,7 @@ COPYRIGHT="2000-2018 Frank Warmerdam"
 LICENSE="MIT"
 REVISION="1"
 SOURCE_URI="http://download.osgeo.org/proj/proj-$portVersion.tar.gz"
-CHECKSUM_SHA256="737eaacbe7906d0d6ff43f0d9ebedc5c734cccc9e6b8d7beefdec3ab22d9a6a3"
+CHECKSUM_SHA256="91a3695a004ea28db0448a34460bed4cc3b130e5c7d74339ec999efdab0e547d"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -19,7 +19,7 @@ else
 	commandBinDir=$prefix/bin
 fi
 
-libVersion="25.9.0.1"
+libVersion="25.9.3.0"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="

--- a/sci-libs/proj/proj-9.3.0.recipe
+++ b/sci-libs/proj/proj-9.3.0.recipe
@@ -2,7 +2,7 @@ SUMMARY="A generic coordinate transformation software"
 DESCRIPTION="PROJ - Cartographic Projections and
 Coordinate Transformations Library."
 HOMEPAGE="https://proj.org/"
-COPYRIGHT="2000-2018 Frank Warmerdam"
+COPYRIGHT="1983-2023 PROJ contributors"
 LICENSE="MIT"
 REVISION="1"
 SOURCE_URI="http://download.osgeo.org/proj/proj-$portVersion.tar.gz"


### PR DESCRIPTION
this updates proj to a more recent release (9.3.0)


```
> proj
Rel. 9.3.0, September 1st, 2023
usage: proj [-bdeEfiIlmorsStTvVwW [args]] [+opt[=arg] ...] [file ...]
```