### PR TITLE
 libreoffice: enabled x86 build

### DIFF
--- a/app-office/libreoffice/libreoffice-7.3.7.2.recipe
+++ b/app-office/libreoffice/libreoffice-7.3.7.2.recipe
@@ -49,7 +49,7 @@ ADDITIONAL_FILES="
 
 POST_INSTALL_SCRIPTS="$relativePostInstallDir/create_buildid.sh"
 ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="!x86"
+SECONDARY_ARCHITECTURES="x86"
 
 boostMinimumVersion=1.70.0
 libreofficeLanguages="af ar be bg bn br brx bs ca ca-valencia cs cy da de dsb el en-GB en-ZA eo es et eu fa fi fr fy ga gd gl he hi hr hu id is it ja ka kk kmr-Latn ko lb lt lv mk mn nb ne nl nn pl pt pt-BR ro ru sa-IN sd sk sl sq sr sr-Latn sv szl tg th tr tt ug uk uz vi zh-CN zh-TW"


### PR DESCRIPTION
Tested on hrev57305 x86.
- Passed config.
- Builds without any major issues. Stopped on a missing Qt6 declaration (no issue on x64).
- Review further on buildbot x86. 