### PR TITLE
ed: update to version 1.19

### DIFF
--- a/sys-apps/ed/ed-1.19.recipe
+++ b/sys-apps/ed/ed-1.19.recipe
@@ -6,15 +6,11 @@ the current directory and cannot execute shell commands.
 Ed is the \"standard\" text editor in the sense that it is the original editor \
 for Unix, and thus widely available."
 HOMEPAGE="https://www.gnu.org/software/ed/"
-COPYRIGHT="1992-2020 Free Software Foundation, Inc."
+COPYRIGHT="1992-2023 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3"
 REVISION="1"
-# Upstream only ships lziped tarballs, not usable on pure x86_gcc2.
-#SOURCE_URI="https://ftp.gnu.org/gnu/ed/ed-$portVersion.tar.lz"
-#CHECKSUM_SHA256="ffb97eb8f2a2b5a71a9b97e3872adce953aa1b8958e04c5b7bf11d556f32552a"
-# So use gziped tarball from fossies until we have lzip for x86_gcc2.
-SOURCE_URI="https://fossies.org/linux/privat/ed-$portVersion.tar.gz"
-CHECKSUM_SHA256="57b75b7da213b1844fd9d4b3897ec019d1f2961fecf3fc47fad0a4fb95ca9c34"
+SOURCE_URI="https://ftp.gnu.org/gnu/ed/ed-$portVersion.tar.lz"
+CHECKSUM_SHA256="ce2f2e5c424790aa96d09dacb93d9bbfdc0b7eb6249c9cb7538452e8ec77cd48"
 
 ARCHITECTURES="all !x86_gcc2"
 if [ "$targetArchitecture" = x86_gcc2 ]; then


### PR DESCRIPTION
Switch SOURCE_URI to upstream. HaikuPorter can handle .tar.lz files transparently thanks to Python's tarfile module.

Fix #9548.