### PR TITLE
capstone: remove sed editing of .pc file

### DIFF
--- a/dev-libs/capstone/capstone5-5.0.1.recipe
+++ b/dev-libs/capstone/capstone5-5.0.1.recipe
@@ -16,7 +16,7 @@ various X86 malware tricks)."
 HOMEPAGE="http://www.capstone-engine.org"
 COPYRIGHT="2013-2020 COSEINC"
 LICENSE="BSD (3-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/capstone-engine/capstone/archive/refs/tags/$portVersion.tar.gz"
 CHECKSUM_SHA256="2b9c66915923fdc42e0e32e2a9d7d83d3534a45bb235e163a70047951890c01a"
 SOURCE_FILENAME="capstone-$portVersion.tar.gz"
@@ -91,15 +91,6 @@ INSTALL()
 
 	prepareInstalledDevelLib libcapstone
 	fixPkgconfig
-
-	# Fix broken include path
-	if [ -n "$secondaryArchSuffix" ]; then
-		sed -i 's,\/headers/x86,\/headers/x86/capstone,g' \
-			$prefix/$relativeDevelopLibDir/pkgconfig/capstone.pc
-	else
-		sed -i 's,\/headers,\/headers/capstone,g' \
-			$prefix/$relativeDevelopLibDir/pkgconfig/capstone.pc
-	fi
 
 	packageEntries tools \
 		$commandBinDir


### PR DESCRIPTION
Include paths are already correct on x86_64 and x86 without it. Fixes #9591