### PR TITLE
setuptools: update to version 68.2.2, add support for Python 3.12.

### DIFF
--- a/dev-python/setuptools/patches/setuptools-68.2.2.patchset
+++ b/dev-python/setuptools/patches/setuptools-68.2.2.patchset
@@ -1,57 +1,66 @@
-From cfe9a1ed59a7ae85a0befbb1e40e88df855c310f Mon Sep 17 00:00:00 2001
-From: Jerome Duval <jerome.duval@gmail.com>
-Date: Tue, 14 Dec 2021 17:34:48 +0100
+From f9d8bc1cfd0ad2d8aab4804af6bf7ccdc3363059 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Wed, 11 Oct 2023 13:07:51 -0300
 Subject: Distutils patch for Haiku
 
+This is just the previous patch from Jerome Duval, but made to match
+the rest of the code's string substitution style on `command/install.py`.
 
 diff --git a/setuptools/_distutils/command/install.py b/setuptools/_distutils/command/install.py
-index a7ac4e6..8e49005 100644
+index a7ac4e6..daf6d72 100644
 --- a/setuptools/_distutils/command/install.py
 +++ b/setuptools/_distutils/command/install.py
-@@ -50,6 +50,27 @@ INSTALL_SCHEMES = {
+@@ -50,6 +50,33 @@ INSTALL_SCHEMES = {
          'data': '{base}',
      },
      'nt': WINDOWS_SCHEME,
 +    'haiku': {
-+        'purelib': '$base/non-packaged/lib/python$py_version_short/site-packages',
-+        'platlib': '$platbase/non-packaged/lib/python$py_version_short/site-packages',
-+        'headers': '$base/non-packaged/develop/headers/python$py_version_short/$dist_name',
-+        'scripts': '$base/non-packaged/bin',
-+        'data'   : '$base/non-packaged',
++        'purelib': '{base}/non-packaged/lib/{implementation_lower}'
++        '{py_version_short}/site-packages',
++        'platlib': '{platbase}/non-packaged/lib/{implementation_lower}'
++        '{py_version_short}/site-packages',
++        'headers': '{base}/non-packaged/develop/headers/{implementation_lower}'
++        '{py_version_short}/{dist_name}',
++        'scripts': '{base}/non-packaged/bin',
++        'data'   : '{base}/non-packaged',
 +        },
 +    'haiku_vendor': {
-+        'purelib': '$base/lib/python$py_version_short/vendor-packages',
-+        'platlib': '$platbase/lib/python$py_version_short/vendor-packages',
-+        'headers': '$base/develop/headers/python$py_version_short/$dist_name',
-+        'scripts': '$base/bin',
-+        'data'   : '$base',
++        'purelib': '{base}/lib/{implementation_lower}'
++        '{py_version_short}/vendor-packages',
++        'platlib': '{platbase}/lib/{implementation_lower}'
++        '{py_version_short}/vendor-packages',
++        'headers': '{base}/develop/headers/{implementation_lower}'
++        '{py_version_short}/{dist_name}',
++        'scripts': '{base}/bin',
++        'data'   : '{base}',
 +        },
 +    'haiku_home': {
-+        'purelib': '$base/lib/python',
-+        'platlib': '$base/lib/python',
-+        'headers': '$base/develop/headers/python/$dist_name',
-+        'scripts': '$base/bin',
-+        'data'   : '$base',
++        'purelib': '{base}/lib/python',
++        'platlib': '{base}/lib/python',
++        'headers': '{base}/develop/headers/python/{dist_name}',
++        'scripts': '{base}/bin',
++        'data'   : '{base}',
 +        },
      'pypy': {
          'purelib': '{base}/site-packages',
          'platlib': '{base}/site-packages',
-@@ -86,7 +107,13 @@ if HAS_USER_SITE:
+@@ -86,7 +113,14 @@ if HAS_USER_SITE:
          'data': '{userbase}',
      }
  
 -
 +    INSTALL_SCHEMES['haiku_user'] = {
-+        'purelib': '$usersite',
-+        'platlib': '$usersite',
-+        'headers': '$userbase/develop/headers/python$py_version_short/$dist_name',
-+        'scripts': '$userbase/bin',
-+        'data'   : '$userbase',
++        'purelib': '{usersite}',
++        'platlib': '{usersite}',
++        'headers': '{usersite}/develop/headers/{implementation}'
++        '{py_version_short}/{dist_name}',
++        'scripts': '{usersite}/bin',
++        'data'   : '{usersite}',
 +        }
  INSTALL_SCHEMES.update(fw.schemes)
  
  
-@@ -554,10 +581,16 @@ class install(Command):
+@@ -554,10 +588,16 @@ class install(Command):
              if self.install_userbase is None:
                  raise DistutilsPlatformError("User base directory is not specified")
              self.install_base = self.install_platbase = self.install_userbase
@@ -70,7 +79,7 @@ index a7ac4e6..8e49005 100644
          else:
              if self.prefix is None:
                  if self.exec_prefix is not None:
-@@ -577,7 +610,13 @@ class install(Command):
+@@ -577,7 +617,13 @@ class install(Command):
  
              self.install_base = self.prefix
              self.install_platbase = self.exec_prefix
@@ -116,5 +125,5 @@ index a40a723..9bfa334 100644
              # Platform-specific modules (any module from a non-pure-Python
              # module distribution) or standard Python library modules.
 -- 
-2.37.3
+2.42.0
 

--- a/dev-python/setuptools/setuptools-68.2.2.recipe
+++ b/dev-python/setuptools/setuptools-68.2.2.recipe
@@ -9,7 +9,7 @@ LICENSE="MIT"
 REVISION="1"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/s/setuptools/setuptools-$portVersion.tar.gz"
 SOURCE_FILENAME="setuptools-$portVersion.tar.gz"
-CHECKSUM_SHA256="3d4dfa6d95f1b101d695a6160a7626e15583af71a5f52176efa5d39a054d475d"
+CHECKSUM_SHA256="4ac1475276d2f1c48684874089fefcd83bd7162ddaafb81fac866ba0db282a87"
 PATCHES="setuptools-$portVersion.patchset"
 
 ARCHITECTURES="any"
@@ -27,8 +27,8 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	"
 
-PYTHON_PACKAGES=(python39 python310 python311)
-PYTHON_VERSIONS=(3.9 3.10 3.11)
+PYTHON_PACKAGES=(python39 python310 python311 python312)
+PYTHON_VERSIONS=(3.9 3.10 3.11 3.12)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -56,8 +56,6 @@ INSTALL()
 
 		mkdir -p $installLocation
 		rm -rf build
-
-		export SETUPTOOLS_USE_DISTUTILS=local
 
 		$python setup.py build install \
 			--root=/ --prefix=$prefix


### PR DESCRIPTION
removed the `export SETUPTOOLS_USE_DISTUTILS=local`, as that's the default behavior (again) since 60.0.0.