### PR TITLE
pip: add support for Python 3.12.

### DIFF
--- a/dev-python/pip/pip-23.2.1.recipe
+++ b/dev-python/pip/pip-23.2.1.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="Install Python packages, replacement for easy_install"
 HOMEPAGE="https://pypi.python.org/pypi/pip"
 COPYRIGHT="2006-2023 Python Packaging Authority"
 LICENSE="Python"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.io/packages/source/p/pip/pip-$portVersion.tar.gz"
 CHECKSUM_SHA256="fb0bd5435b3200c602b5bf61d2d43c2f13c02e29c1707567ae7fbc514eb9faf2"
 
@@ -20,8 +20,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310 python311)
-PYTHON_VERSIONS=(3.9 3.10 3.11)
+PYTHON_PACKAGES=(python39 python310 python311 python312)
+PYTHON_VERSIONS=(3.9 3.10 3.11 3.12)
 defaultVersion=3.10
 
 for i in "${!PYTHON_PACKAGES[@]}"; do


### PR DESCRIPTION
This needs #9613 to be merged first (for the `setuptools_python312` dependency).