### PR TITLE
lagrange: bump to 1.17.0

### DIFF
--- a/net-misc/lagrange/lagrange-1.17.0.recipe
+++ b/net-misc/lagrange/lagrange-1.17.0.recipe
@@ -8,7 +8,7 @@ COPYRIGHT="2020-2023 Jaakko Keränen"
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="https://github.com/skyjake/lagrange/releases/download/v$portVersion/lagrange-$portVersion.tar.gz"
-CHECKSUM_SHA256="c8d37a32d99ff444e4e61d73269f6244e08a5232c91bb97e2b74823dc6e29d53"
+CHECKSUM_SHA256="c0f68e7d8d7b4a94eeaaf2c041f08b13abc2a2922b2485d69844b823e710cc8a"
 SOURCE_DIR="lagrange-$portVersion"
 ADDITIONAL_FILES="lagrange.rdef.in"
 


### PR DESCRIPTION
[Changelog](https://github.com/skyjake/lagrange/releases)