### PR TITLE
xcb_proto: fix location of installed Python code.

### DIFF
--- a/x11-proto/xcb_proto/xcb_proto-1.13.recipe
+++ b/x11-proto/xcb_proto/xcb_proto-1.13.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="The X C Bindings protocol headers."
 HOMEPAGE="https://xcb.freedesktop.org/"
 COPYRIGHT="2001-2018 Bart Massey, Jamey Sharp, and Josh Triplett."
 LICENSE="MIT (no promotion)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://xcb.freedesktop.org/dist/xcb-proto-$portVersion.tar.bz2"
 CHECKSUM_SHA256="7b98721e669be80284e9bbfeab02d2d0d54cd11172b72271e47a2fe875e2bde1"
 SOURCE_DIR="xcb-proto-$portVersion"
@@ -33,13 +33,15 @@ BUILD_PREREQUIRES="
 	cmd:python3
 	"
 
+# Build/install bindings for the default Python version. Assumes n.nn version format.
+pythonVersion=$(python3 --version 2>&1 | sed 's/Python //' | head -c4)
+
 BUILD()
 {
 	autoreconf -vfi
 	runConfigure --omit-dirs libDir ./configure --libdir=$dataDir
 	# force python dirs as the autodected one is the non-packaged one.
 	export PATH="$portPackageLinksDir/cmd~python/bin:$PATH"
-	pythonVersion=$(python --version 2>&1 | sed 's/Python //' | head -c3)
 	export pyexecdir=$prefix/lib/python$pythonVersion/vendor-packages
 	export pythondir=$prefix/lib/python$pythonVersion/vendor-packages
 	make pyexecdir=$pyexecdir pythondir=$pythondir
@@ -49,7 +51,6 @@ INSTALL()
 {
 	# force python dirs as the autodected one is the non-packaged one.
 	export PATH="$portPackageLinksDir/cmd~python/bin:$PATH"
-	pythonVersion=$(python --version 2>&1 | sed 's/Python //' | head -c3)
 	export pyexecdir=$prefix/lib/python$pythonVersion/vendor-packages
 	export pythondir=$prefix/lib/python$pythonVersion/vendor-packages
 	# the .pc file doesn't get it anyway, force it


### PR DESCRIPTION
Due to bogus python version detection (expecting "Python 2.x"), current package is installing files under:

/system/lib/python/po/vendor-packages

instead of

/system/lib/python3.xx/vendor-packages

This is just a quick fix for that.