### PR TITLE
haiku-format: fix 32 bit rpath errors

### DIFF
--- a/sys-devel/haiku-format/haiku_format-17.0.1.recipe
+++ b/sys-devel/haiku-format/haiku_format-17.0.1.recipe
@@ -11,7 +11,7 @@ HOMEPAGE="https://github.com/owenca/haiku-format"
 COPYRIGHT="2003-2023 University of Illinois at Urbana-Champaign
 	2018-2023 Owen Pan"
 LICENSE="Apache v2 with LLVM Exception"
-REVISION="1"
+REVISION="2"
 srcGitRev="29214632fa5f0abb8c6f40ac5c13e6cd26a6ec95"
 SOURCE_URI="https://github.com/owenca/llvm-project/archive/$srcGitRev.tar.gz"
 SOURCE_DIR="llvm-project-$srcGitRev"
@@ -42,18 +42,22 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	cmake -S llvm -B build -G Ninja -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_BUILD_TYPE=Release -Wno-dev
+	cmake -S llvm -B build -G Ninja \
+		-DLLVM_ENABLE_PROJECTS=clang \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_SKIP_RPATH=On \
+		-Wno-dev
 
-	cd build
-	ninja clang-format && strip -s bin/clang-format
+	ninja -C build clang-format
+	strip -sv build/bin/clang-format
 }
 
 INSTALL()
 {
-	mkdir -p $prefix/bin
-	cp build/bin/clang-format $prefix/bin/haiku-format
+	mkdir -pv $prefix/bin
+	cp -fv build/bin/clang-format $prefix/bin/haiku-format
 
 	gitHaikuFormat=$prefix/bin/git-haiku-format
 	sed s/clang-format/haiku-format/g clang/tools/clang-format/git-clang-format > $gitHaikuFormat
-	chmod +x $gitHaikuFormat
+	chmod -v +x $gitHaikuFormat
 }


### PR DESCRIPTION
Add -DCMAKE_SKIP_RPATH=On to the flags in order to prevent bogus rpath entries in the executable. Fixes #6817