### PR TITLE
llvm17: link binaries against crti.o

### DIFF
--- a/sys-devel/llvm/llvm17-17.0.1.recipe
+++ b/sys-devel/llvm/llvm17-17.0.1.recipe
@@ -30,7 +30,7 @@ other than the ones listed above.
 HOMEPAGE="https://www.llvm.org/"
 COPYRIGHT="2003-2023 University of Illinois at Urbana-Champaign"
 LICENSE="Apache v2 with LLVM Exception"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/llvm/llvm-project/releases/download/llvmorg-$portVersion/llvm-project-$portVersion.src.tar.xz"
 CHECKSUM_SHA256="b0e42aafc01ece2ca2b42e3526f54bebc4b1f1dc8de6e34f46a0446a13e882b9"
 SOURCE_DIR="llvm-project-$portVersion.src"

--- a/sys-devel/llvm/patches/llvm17-17.0.1.patchset
+++ b/sys-devel/llvm/patches/llvm17-17.0.1.patchset
@@ -1,4 +1,4 @@
-From 13a702e279fc4e0536beacdbe4adcd3666c38a05 Mon Sep 17 00:00:00 2001
+From 78fd4cd66742fbc2b5969b705f50ed11163da268 Mon Sep 17 00:00:00 2001
 From: Calvin Hill <calvin@hakobaito.co.uk>
 Date: Sun, 9 Sep 2018 16:11:42 +0100
 Subject: llvm: import header dir suffix patch from 3dEyes
@@ -24,7 +24,7 @@ index e86eb2b..395a857 100644
 2.37.3
 
 
-From 3a039a9f385a63297caf3503f32b944e61d23609 Mon Sep 17 00:00:00 2001
+From 14d787427d77e8d7d39092d4b78b85337226e9dd Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Mon, 18 Jul 2016 14:13:19 +0200
 Subject: clang: support for secondary arch.
@@ -132,7 +132,7 @@ index 41382d7..de70e50 100644
 2.37.3
 
 
-From f29056bff076d192f070e599e2b2ca266732d862 Mon Sep 17 00:00:00 2001
+From 16dfc3e011efd8abc3deda3a2571971a0e82ae0f Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Thu, 7 Apr 2016 18:30:52 +0000
 Subject: clang: add a test for haiku driver.
@@ -161,7 +161,7 @@ index 0000000..9591739
 2.37.3
 
 
-From c75b2afd4cd07868b3ca6df94bc5455341e5b10d Mon Sep 17 00:00:00 2001
+From 16c1a667a4949f6cc84b055eee15da92507850eb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Mon, 18 Jul 2016 14:13:19 +0200
 Subject: clang: Enable thread-local storage and disable PIE by default
@@ -198,7 +198,7 @@ index 669379a..fd82022 100644
 2.37.3
 
 
-From ebb00a0fafc33e49cb606e9807bf22c26004bb8a Mon Sep 17 00:00:00 2001
+From b680e8eb2c3e8041fcad6b8d79bba1d519c52413 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Mon, 13 Feb 2023 16:28:39 +0100
 Subject: clang: Haiku: defaults to PIC
@@ -220,7 +220,7 @@ index fd82022..f649d8d 100644
 2.37.3
 
 
-From 64538709638b0eb14743689b10133a30b03c8807 Mon Sep 17 00:00:00 2001
+From 75e5baa4350bcaa40bc6a73b9645860e3760255d Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sat, 3 Apr 2021 23:23:24 +0200
 Subject: lld: MachO needs libunwind somehow, disable
@@ -314,7 +314,7 @@ index 2c30bc9..5069361 100644
 2.37.3
 
 
-From 0fb97de004488ec4550ac045b2c78c8d5a705c24 Mon Sep 17 00:00:00 2001
+From d69cb1bd702c957b7051a5e16bbae4a09ad7a45b Mon Sep 17 00:00:00 2001
 From: X512 <danger_mail@list.ru>
 Date: Wed, 16 Mar 2022 07:04:18 +0900
 Subject: libunwind: Haiku: Signal frame unwinding support
@@ -440,7 +440,7 @@ index dde9477..e4811a7 100644
 2.37.3
 
 
-From 210e16cde25aa81977ae0a816bb97a17214b446b Mon Sep 17 00:00:00 2001
+From 7fb7059580868d1d4eae4ea2d7f8b21fbbe6b829 Mon Sep 17 00:00:00 2001
 From: Trung Nguyen <trungnt282910@gmail.com>
 Date: Thu, 7 Jul 2022 22:19:34 +0700
 Subject: libunwind: Haiku: Initial support
@@ -617,7 +617,7 @@ index 6707d59..db1df8c 100644
 2.37.3
 
 
-From fd6579c5c47de950419ac0326b7ef9ef5b7e93d4 Mon Sep 17 00:00:00 2001
+From b18fb57a69741225ecb8d907834fc0c673d1de75 Mon Sep 17 00:00:00 2001
 From: X512 <danger_mail@list.ru>
 Date: Mon, 10 Oct 2022 12:18:55 +0900
 Subject: Haiku: reimplement toolchain driver, make lld functional
@@ -914,7 +914,7 @@ index f649d8d..70fc0dc 100644
 2.37.3
 
 
-From bdb20ae26aec4f7f3cbcb7addf78645d4b9a5782 Mon Sep 17 00:00:00 2001
+From f53b17cf8ba376933ad7ec830c269c8f68ad2ed7 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Wed, 9 Aug 2023 23:05:15 +0200
 Subject: Haiku: implement GCC installation detection
@@ -992,7 +992,7 @@ index eea14dd..217315f 100644
 2.37.3
 
 
-From 0e9da69a74b5063c88ec798844e332831077eb92 Mon Sep 17 00:00:00 2001
+From 6d4b15a93a47ad67c848495f2e648e78257dba08 Mon Sep 17 00:00:00 2001
 From: Trung Nguyen <57174311+trungnt2910@users.noreply.github.com>
 Date: Mon, 14 Aug 2023 14:58:56 +1000
 Subject: clang: Haiku: Add missing GNU headers include path
@@ -1014,7 +1014,7 @@ index de70e50..0e8df73 100644
 2.37.3
 
 
-From a1daf6233d9d1841749b1505b75f7192dd7c41d9 Mon Sep 17 00:00:00 2001
+From 7f82b82527163a56bf4436f0561bff6f93b703fd Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Sat, 26 Aug 2023 09:36:42 +0200
 Subject: clang: Haiku: silence warning for -pie
@@ -1038,7 +1038,7 @@ index 217315f..e9d1187 100644
 2.37.3
 
 
-From 15461bd5f32674ed7b7716a5ee129c6e30ad2b44 Mon Sep 17 00:00:00 2001
+From e632668f1189eb54013c12574b9e464c1391811d Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Sun, 27 Aug 2023 19:32:12 +0200
 Subject: clang: Haiku: silence warning for -pthread and -pthreads when linking
@@ -1064,7 +1064,7 @@ index e9d1187..f5f7e99 100644
 2.37.3
 
 
-From bf84da36490ae8f90709ba26ae2c1a15d4d1ec0e Mon Sep 17 00:00:00 2001
+From 0c7d493a437fb03520eb12b0d026e5c3e7fa23b9 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Tue, 12 Sep 2023 18:30:30 +0200
 Subject: clang: Haiku: remove custom addLibStdCxxIncludePaths implementation
@@ -1113,7 +1113,7 @@ index 70fc0dc..be3425e 100644
 2.37.3
 
 
-From b886a3d10b17674fd7449518bd7e7b1b9e5edf85 Mon Sep 17 00:00:00 2001
+From 1e0dd83fb4394c03d3d39946a6c191a11645dd62 Mon Sep 17 00:00:00 2001
 From: David Karoly <karolyd577@gmail.com>
 Date: Thu, 21 Sep 2023 17:44:12 +0000
 Subject: fix build on x86 secondary arch
@@ -1132,6 +1132,28 @@ index f2b0c5c..f5fbcb5 100644
  set(out_files)
  set(generated_files)
  
+-- 
+2.37.3
+
+
+From d2a06a00ab12ffeb1a5b165e5f92d2cc312d3197 Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Fri, 13 Oct 2023 21:35:29 +0200
+Subject: clang: link against crti.o
+
+
+diff --git a/clang/lib/Driver/ToolChains/Haiku.cpp b/clang/lib/Driver/ToolChains/Haiku.cpp
+index 60434c6..2b507b1 100644
+--- a/clang/lib/Driver/ToolChains/Haiku.cpp
++++ b/clang/lib/Driver/ToolChains/Haiku.cpp
+@@ -85,6 +85,7 @@ void haiku::Linker::ConstructJob(Compilation &C, const JobAction &JA,
+       crt1 = "start_dyn.o";
+     }
+ 
++    CmdArgs.push_back(Args.MakeArgString(ToolChain.GetFilePath("crti.o")));
+     CmdArgs.push_back(Args.MakeArgString(ToolChain.GetFilePath("crtbeginS.o")));
+     if (crt1)
+       CmdArgs.push_back(Args.MakeArgString(ToolChain.GetFilePath(crt1)));
 -- 
 2.37.3
 


### PR DESCRIPTION
This is already part of the upstream patch but somehow went missing in the downstream patch for llvm17. This results in quirky .init/.fini sections (i.e. stack frame setup is not entirely correct)

This change adds crti.o so that we can have proper stack frame setup in the .init/.fini sections.