### PR TITLE
QuakeSpasm: bump to 0.96.1 and fix revision number

### DIFF
--- a/games-fps/quakespasm/quakespasm-0.96.1.recipe
+++ b/games-fps/quakespasm/quakespasm-0.96.1.recipe
@@ -25,9 +25,9 @@ COPYRIGHT="1996-2001 Id Software, Inc.
 	2002-2009 John Fitzgibbons and others
 	2010-2014 QuakeSpasm developers"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="3"
 SOURCE_URI="https://github.com/sezero/quakespasm/archive/refs/tags/quakespasm-$portVersion.tar.gz"
-CHECKSUM_SHA256="4087f94a822c0161fb38a0fa8941b8ddbc2a1c458d41ef88982b635be4ee8c5b"
+CHECKSUM_SHA256="d8783f1c7481ff76eb1665bcb72eb6bc6c65476d7fb8ac7ce87ae76f8c0e057f"
 SOURCE_DIR="quakespasm-quakespasm-$portVersion"
 ADDITIONAL_FILES="QuakeSpasm.rdef.in
 	haiku_readme.txt"


### PR DESCRIPTION
QuakeSpasm updated, so I'm bumping the version here. I've also bumped the revision number to 3, since I forgot to do it on the last update.

QuakeSpasm changelog:

- Fix demo recording as client-only after connection to server (was
broken by signon changes in 0.96.0. Thanks to Jozsef Szalontai for
issue report.)
- Fix potential buffer overflow in COM_Parse(), e.g. with maps with
oversized 'wad' fields. (Thanks to Andrei Drexler.)
- Minor code cleanups. 