### PR TITLE
deark: new recipe

### DIFF
--- a/app-misc/deark/deark-1.6.5.recipe
+++ b/app-misc/deark/deark-1.6.5.recipe
@@ -1,0 +1,49 @@
+SUMMARY="Utility to extract data from various file formats"
+DESCRIPTION="Deark is a command-line utility that can decode certain types of files, and either:
+
+1. convert them to a more-modern or more-readable format; or
+2. extract embedded files from them"
+HOMEPAGE="https://entropymine.com/deark/
+	https://github.com/jsummers/deark"
+COPYRIGHT="2023 Jason Summers"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://github.com/jsummers/deark/archive/v$portVersion.tar.gz"
+CHECKSUM_SHA256="2aa29675c0b326c5242da2c5e4b1d7746f2aad7bcc9bfefa73448e580e9fae2c"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	deark$secondaryArchSuffix = $portVersion
+	cmd:deark = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	help2man$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:help2man
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	make
+	make man
+}
+
+INSTALL()
+{
+	mkdir -p $prefix/bin
+	mkdir -p $manDir/man1
+
+	make DEARK_INSTALLDIR=$prefix/bin install
+	cp deark.1 $manDir/man1
+}


### PR DESCRIPTION
Compiled with no patches. Did some tests with some old Psion files and it works fine.

I have only one concern. The developer describes the license as "MIT-style," and then mentions that some files might be under other licenses.

> Starting with version 1.4.x, Deark is distributed under an MIT-style license. See the [COPYING](https://github.com/jsummers/deark/blob/master/COPYING) file for the license text.
>
> The main Deark license does not necessarily apply to the code in the "foreign" subdirectory. Each file there may have its own licensing terms.

I've set `"MIT"` as the `LICENSE` in the recipe as that was the closest option. I've also seen a Gentoo overlay that has also used `"MIT"`. Please let me know if there is a more appropriate option.