### PR TITLE
llvm16: link binaries against crti.o

### DIFF
--- a/sys-devel/llvm/llvm16-16.0.6.recipe
+++ b/sys-devel/llvm/llvm16-16.0.6.recipe
@@ -30,7 +30,7 @@ other than the ones listed above.
 HOMEPAGE="https://www.llvm.org/"
 COPYRIGHT="2003-2023 University of Illinois at Urbana-Champaign"
 LICENSE="Apache v2 with LLVM Exception"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://github.com/llvm/llvm-project/releases/download/llvmorg-$portVersion/llvm-project-$portVersion.src.tar.xz"
 CHECKSUM_SHA256="ce5e71081d17ce9e86d7cbcfa28c4b04b9300f8fb7e78422b1feb6bc52c3028e"
 SOURCE_DIR="llvm-project-$portVersion.src"

--- a/sys-devel/llvm/patches/llvm16-16.0.6.patchset
+++ b/sys-devel/llvm/patches/llvm16-16.0.6.patchset
@@ -1,4 +1,4 @@
-From 23f712a9bf56c19dd30c50d87f6cd4e75334da98 Mon Sep 17 00:00:00 2001
+From 7595befce0ea7a5ae5757930ce7daf962594ee6e Mon Sep 17 00:00:00 2001
 From: Calvin Hill <calvin@hakobaito.co.uk>
 Date: Sun, 9 Sep 2018 16:11:42 +0100
 Subject: llvm: import header dir suffix patch from 3dEyes
@@ -21,10 +21,10 @@ index b1d795a..0e76401 100644
        SmallString<256> Path(LLVM_INSTALL_PACKAGE_DIR);
        sys::fs::make_absolute(ActivePrefix, Path);
 -- 
-2.37.3
+2.42.0
 
 
-From 4f2899af07a0087f3e33203bcccce0f2cfc9ad82 Mon Sep 17 00:00:00 2001
+From 9c54536e4cb0d403aec7008fa089e12514de3a43 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Mon, 18 Jul 2016 14:13:19 +0200
 Subject: clang: support for secondary arch.
@@ -129,10 +129,10 @@ index d446556..5b91907 100644
      break;
    case llvm::Triple::RTEMS:
 -- 
-2.37.3
+2.42.0
 
 
-From c09f6b8f5424358496350377f4aa494c3ab2966a Mon Sep 17 00:00:00 2001
+From a9f4b411055de488ac13aa2250956f82c0d3b135 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Thu, 7 Apr 2016 18:30:52 +0000
 Subject: clang: add a test for haiku driver.
@@ -158,10 +158,10 @@ index 0000000..9591739
 +// CHECK-X86: gcc{{.*}}" "-o" "a.out" "{{.*}}.o"
 +
 -- 
-2.37.3
+2.42.0
 
 
-From 7e8af352745c1c42d8b43a294b04c77e0bc3c9a6 Mon Sep 17 00:00:00 2001
+From 835ee45cfabf2928b4af39b34e833a31d400f43f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Mon, 18 Jul 2016 14:13:19 +0200
 Subject: clang: Enable thread-local storage and disable PIE by default
@@ -195,10 +195,10 @@ index 669379a..fd82022 100644
    void addLibCxxIncludePaths(
        const llvm::opt::ArgList &DriverArgs,
 -- 
-2.37.3
+2.42.0
 
 
-From fb858814531b5f01da6012092e9e41d17e0f4033 Mon Sep 17 00:00:00 2001
+From 9d1d2623ae2eedf6aa30b279b4c02b3a670ef2d1 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Mon, 13 Feb 2023 16:28:39 +0100
 Subject: clang: Haiku: defaults to PIC
@@ -217,10 +217,10 @@ index fd82022..f649d8d 100644
    void addLibCxxIncludePaths(
        const llvm::opt::ArgList &DriverArgs,
 -- 
-2.37.3
+2.42.0
 
 
-From 686dd1b9024f0f9035edbeb0fbf4123b86cb7355 Mon Sep 17 00:00:00 2001
+From a9ab39e821d5fbed29c48815ffa40fc99f6ea52f Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sat, 3 Apr 2021 23:23:24 +0200
 Subject: lld: MachO needs libunwind somehow, disable
@@ -285,10 +285,10 @@ index eb746ae..b88d902 100644
        return lld::wasm::link;
      else
 -- 
-2.37.3
+2.42.0
 
 
-From f7bcd19592f41182058b3d1c063ad8f81781d6b7 Mon Sep 17 00:00:00 2001
+From 94f32de017ac8e49b1f0a9af50ab59ac0cc3515c Mon Sep 17 00:00:00 2001
 From: X512 <danger_mail@list.ru>
 Date: Wed, 16 Mar 2022 07:04:18 +0900
 Subject: libunwind: Haiku: Signal frame unwinding support
@@ -411,10 +411,10 @@ index 0c6cda3..26bbfa0 100644
      result = this->stepThroughSigReturn();
    } else
 -- 
-2.37.3
+2.42.0
 
 
-From 3bd9695d255c5bf79e6a190a37dbe4c7eb2312c5 Mon Sep 17 00:00:00 2001
+From a1af376c0a6e531a163877f97b9cdbccea245fbe Mon Sep 17 00:00:00 2001
 From: Trung Nguyen <trungnt282910@gmail.com>
 Date: Thu, 7 Jul 2022 22:19:34 +0700
 Subject: libunwind: Haiku: Initial support
@@ -588,10 +588,10 @@ index 4bbac95..0dd10e0 100644
    // Assume an ELF system with a dl_iterate_phdr function.
    #define _LIBUNWIND_USE_DL_ITERATE_PHDR 1
 -- 
-2.37.3
+2.42.0
 
 
-From bd21e1d8dd2d9c57854108d75b2d802b8d508a30 Mon Sep 17 00:00:00 2001
+From dde08f90f1e64bbcfea8cb7827b81ad1dac656a7 Mon Sep 17 00:00:00 2001
 From: X512 <danger_mail@list.ru>
 Date: Mon, 10 Oct 2022 12:18:55 +0900
 Subject: Haiku: reimplement toolchain driver, make lld functional
@@ -885,10 +885,10 @@ index f649d8d..70fc0dc 100644
  
  } // end namespace toolchains
 -- 
-2.37.3
+2.42.0
 
 
-From dba4f86ac22bdf3e7d25641a296e2925a071979b Mon Sep 17 00:00:00 2001
+From b9f756f2bfb966a4979ab4ae90d671d4eaba56f6 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Wed, 9 Aug 2023 23:05:15 +0200
 Subject: Haiku: implement GCC installation detection
@@ -963,10 +963,10 @@ index 5be6a7f..ff29972 100644
  
  ToolChain::CXXStdlibType Haiku::GetDefaultCXXStdlibType() const {
 -- 
-2.37.3
+2.42.0
 
 
-From 000a381c4d0c2ef0cc4669f2de4bebc903620c39 Mon Sep 17 00:00:00 2001
+From e1b6776661931d3717b8318658a853a9c7cbf096 Mon Sep 17 00:00:00 2001
 From: Trung Nguyen <57174311+trungnt2910@users.noreply.github.com>
 Date: Mon, 14 Aug 2023 14:58:56 +1000
 Subject: clang: Haiku: Add missing GNU headers include path
@@ -985,10 +985,10 @@ index 5b91907..5208b05 100644
  #ifdef HAIKU_HYBRID_SECONDARY
      AddPath("/boot/system/develop/headers/" HAIKU_HYBRID_SECONDARY, System, false);
 -- 
-2.37.3
+2.42.0
 
 
-From 22198a3f8c7792d6a49931be9653d44ad6c2a922 Mon Sep 17 00:00:00 2001
+From a266756c012140879a2c78e155379745b3f53b14 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Sat, 26 Aug 2023 09:36:42 +0200
 Subject: clang: Haiku: silence warning for -pie
@@ -1009,10 +1009,10 @@ index ff29972..18888e0 100644
      CmdArgs.push_back(Args.MakeArgString("--sysroot=" + D.SysRoot));
  /*
 -- 
-2.37.3
+2.42.0
 
 
-From aaf578a669b46977cf97b20825cd88a6d0546e8e Mon Sep 17 00:00:00 2001
+From 5a250e7ee6ade4f980229b58906148cfdf408d5a Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Sun, 27 Aug 2023 19:32:12 +0200
 Subject: clang: Haiku: silence warning for -pthread and -pthreads when linking
@@ -1035,10 +1035,10 @@ index 18888e0..fcd2a1e 100644
  
    if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nostartfiles,
 -- 
-2.37.3
+2.42.0
 
 
-From c01ea9092bcd168d21a3d9b36de5b1695446b603 Mon Sep 17 00:00:00 2001
+From 4f97a0fd02bb8a746ffd35876729d27d088063c9 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Tue, 12 Sep 2023 18:30:30 +0200
 Subject: clang: Haiku: remove custom addLibStdCxxIncludePaths implementation
@@ -1084,5 +1084,27 @@ index 70fc0dc..be3425e 100644
    Tool *buildLinker() const override;
  };
 -- 
-2.37.3
+2.42.0
+
+
+From 6134d1ee34af1f1dba6cd20e697608c19d96214b Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Fri, 13 Oct 2023 21:35:29 +0200
+Subject: clang: link against crti.o
+
+
+diff --git a/clang/lib/Driver/ToolChains/Haiku.cpp b/clang/lib/Driver/ToolChains/Haiku.cpp
+index 231f514..d883c03 100644
+--- a/clang/lib/Driver/ToolChains/Haiku.cpp
++++ b/clang/lib/Driver/ToolChains/Haiku.cpp
+@@ -85,6 +85,7 @@ void haiku::Linker::ConstructJob(Compilation &C, const JobAction &JA,
+       crt1 = "start_dyn.o";
+     }
+ 
++    CmdArgs.push_back(Args.MakeArgString(ToolChain.GetFilePath("crti.o")));
+     CmdArgs.push_back(Args.MakeArgString(ToolChain.GetFilePath("crtbeginS.o")));
+     if (crt1)
+       CmdArgs.push_back(Args.MakeArgString(ToolChain.GetFilePath(crt1)));
+-- 
+2.42.0
 


### PR DESCRIPTION
I guess this is still good to have, in case we'd like to do llvm16 vs llvm17 comparison for any reason.