### PR TITLE
timezone_data: fix 32 bits build.

### DIFF
--- a/sys-libs/timezone_data/timezone_data-2023c.recipe
+++ b/sys-libs/timezone_data/timezone_data-2023c.recipe
@@ -11,7 +11,7 @@ LICENSE="
 	Public Domain
 	BSD (3-clause)
 	"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://data.iana.org/time-zones/releases/tzdb-$portVersion.tar.lz"
 CHECKSUM_SHA256="08fd090f1a16d522ae4e9247445056f4155002239e5be760b31ba0376d2e632c"
 SOURCE_DIR="tzdb-$portVersion"
@@ -43,6 +43,7 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	make \
+		CFLAGS="-DPORT_TO_C89" \
 		USRDIR=$prefix \
 		USRSHAREDIR=${dataDir:1} \
 		ZICDIR=$binDir \


### PR DESCRIPTION
This workaround works for now. In the future we should probably move this recipe to "_x86".

See details on #9519.