### PR TITLE
llvm17: turn --no-undefined-version into a warning for lld and clang

### DIFF
--- a/sys-devel/llvm/llvm17-17.0.1.recipe
+++ b/sys-devel/llvm/llvm17-17.0.1.recipe
@@ -30,7 +30,7 @@ other than the ones listed above.
 HOMEPAGE="https://www.llvm.org/"
 COPYRIGHT="2003-2023 University of Illinois at Urbana-Champaign"
 LICENSE="Apache v2 with LLVM Exception"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/llvm/llvm-project/releases/download/llvmorg-$portVersion/llvm-project-$portVersion.src.tar.xz"
 CHECKSUM_SHA256="b0e42aafc01ece2ca2b42e3526f54bebc4b1f1dc8de6e34f46a0446a13e882b9"
 SOURCE_DIR="llvm-project-$portVersion.src"

--- a/sys-devel/llvm/patches/llvm17-17.0.1.patchset
+++ b/sys-devel/llvm/patches/llvm17-17.0.1.patchset
@@ -1,4 +1,4 @@
-From 78fd4cd66742fbc2b5969b705f50ed11163da268 Mon Sep 17 00:00:00 2001
+From d1cfb6800bf2dcb08fc023e0fa569f02f13e7b7c Mon Sep 17 00:00:00 2001
 From: Calvin Hill <calvin@hakobaito.co.uk>
 Date: Sun, 9 Sep 2018 16:11:42 +0100
 Subject: llvm: import header dir suffix patch from 3dEyes
@@ -24,7 +24,7 @@ index e86eb2b..395a857 100644
 2.37.3
 
 
-From 14d787427d77e8d7d39092d4b78b85337226e9dd Mon Sep 17 00:00:00 2001
+From a1acf9482f39b430e48f767b829de24287a1b3f2 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Mon, 18 Jul 2016 14:13:19 +0200
 Subject: clang: support for secondary arch.
@@ -132,7 +132,7 @@ index 41382d7..de70e50 100644
 2.37.3
 
 
-From 16dfc3e011efd8abc3deda3a2571971a0e82ae0f Mon Sep 17 00:00:00 2001
+From 090d11535e856778bdd61ec10d1b742be0e21ae0 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Thu, 7 Apr 2016 18:30:52 +0000
 Subject: clang: add a test for haiku driver.
@@ -161,7 +161,7 @@ index 0000000..9591739
 2.37.3
 
 
-From 16c1a667a4949f6cc84b055eee15da92507850eb Mon Sep 17 00:00:00 2001
+From d0e47545dfbb35a7cc6c2d3fb88f7e9025f8f174 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?J=C3=A9r=C3=B4me=20Duval?= <jerome.duval@gmail.com>
 Date: Mon, 18 Jul 2016 14:13:19 +0200
 Subject: clang: Enable thread-local storage and disable PIE by default
@@ -198,7 +198,7 @@ index 669379a..fd82022 100644
 2.37.3
 
 
-From b680e8eb2c3e8041fcad6b8d79bba1d519c52413 Mon Sep 17 00:00:00 2001
+From 32c0bb82925d2a0be4faf3498f05970a5b11ba43 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Mon, 13 Feb 2023 16:28:39 +0100
 Subject: clang: Haiku: defaults to PIC
@@ -220,7 +220,7 @@ index fd82022..f649d8d 100644
 2.37.3
 
 
-From 75e5baa4350bcaa40bc6a73b9645860e3760255d Mon Sep 17 00:00:00 2001
+From fb9728fa8c3b75fd71fc7d274f8dd7359c12048a Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sat, 3 Apr 2021 23:23:24 +0200
 Subject: lld: MachO needs libunwind somehow, disable
@@ -314,7 +314,7 @@ index 2c30bc9..5069361 100644
 2.37.3
 
 
-From d69cb1bd702c957b7051a5e16bbae4a09ad7a45b Mon Sep 17 00:00:00 2001
+From 2cef519b57b202ee37bf332d0ded106929ef33d5 Mon Sep 17 00:00:00 2001
 From: X512 <danger_mail@list.ru>
 Date: Wed, 16 Mar 2022 07:04:18 +0900
 Subject: libunwind: Haiku: Signal frame unwinding support
@@ -440,7 +440,7 @@ index dde9477..e4811a7 100644
 2.37.3
 
 
-From 7fb7059580868d1d4eae4ea2d7f8b21fbbe6b829 Mon Sep 17 00:00:00 2001
+From 6cf513f733f879de4b23e99ea8d07a23c1759cb4 Mon Sep 17 00:00:00 2001
 From: Trung Nguyen <trungnt282910@gmail.com>
 Date: Thu, 7 Jul 2022 22:19:34 +0700
 Subject: libunwind: Haiku: Initial support
@@ -617,7 +617,7 @@ index 6707d59..db1df8c 100644
 2.37.3
 
 
-From b18fb57a69741225ecb8d907834fc0c673d1de75 Mon Sep 17 00:00:00 2001
+From 948ee9ce1334115c99b4753cd9047812c923c02c Mon Sep 17 00:00:00 2001
 From: X512 <danger_mail@list.ru>
 Date: Mon, 10 Oct 2022 12:18:55 +0900
 Subject: Haiku: reimplement toolchain driver, make lld functional
@@ -914,7 +914,7 @@ index f649d8d..70fc0dc 100644
 2.37.3
 
 
-From f53b17cf8ba376933ad7ec830c269c8f68ad2ed7 Mon Sep 17 00:00:00 2001
+From 9017451e454169413103bb46db54b5d07eebcbf0 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Wed, 9 Aug 2023 23:05:15 +0200
 Subject: Haiku: implement GCC installation detection
@@ -992,7 +992,7 @@ index eea14dd..217315f 100644
 2.37.3
 
 
-From 6d4b15a93a47ad67c848495f2e648e78257dba08 Mon Sep 17 00:00:00 2001
+From e08a1468aed84255bea789fc6ce618011b0e22eb Mon Sep 17 00:00:00 2001
 From: Trung Nguyen <57174311+trungnt2910@users.noreply.github.com>
 Date: Mon, 14 Aug 2023 14:58:56 +1000
 Subject: clang: Haiku: Add missing GNU headers include path
@@ -1014,7 +1014,7 @@ index de70e50..0e8df73 100644
 2.37.3
 
 
-From 7f82b82527163a56bf4436f0561bff6f93b703fd Mon Sep 17 00:00:00 2001
+From 05bcacbb80ffe9065b26725b54ca058ddab3ee6b Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Sat, 26 Aug 2023 09:36:42 +0200
 Subject: clang: Haiku: silence warning for -pie
@@ -1038,7 +1038,7 @@ index 217315f..e9d1187 100644
 2.37.3
 
 
-From e632668f1189eb54013c12574b9e464c1391811d Mon Sep 17 00:00:00 2001
+From bbdc6d4b32fed7999880e024a3f1198b6a590aa4 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Sun, 27 Aug 2023 19:32:12 +0200
 Subject: clang: Haiku: silence warning for -pthread and -pthreads when linking
@@ -1064,7 +1064,7 @@ index e9d1187..f5f7e99 100644
 2.37.3
 
 
-From 0c7d493a437fb03520eb12b0d026e5c3e7fa23b9 Mon Sep 17 00:00:00 2001
+From 04be9a0fd76dbe4566d32cc3a649c76ef9bbcfbf Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Tue, 12 Sep 2023 18:30:30 +0200
 Subject: clang: Haiku: remove custom addLibStdCxxIncludePaths implementation
@@ -1113,7 +1113,7 @@ index 70fc0dc..be3425e 100644
 2.37.3
 
 
-From 1e0dd83fb4394c03d3d39946a6c191a11645dd62 Mon Sep 17 00:00:00 2001
+From 1302099a935edd11510b8233d1b7035892d09a86 Mon Sep 17 00:00:00 2001
 From: David Karoly <karolyd577@gmail.com>
 Date: Thu, 21 Sep 2023 17:44:12 +0000
 Subject: fix build on x86 secondary arch
@@ -1136,7 +1136,7 @@ index f2b0c5c..f5fbcb5 100644
 2.37.3
 
 
-From d2a06a00ab12ffeb1a5b165e5f92d2cc312d3197 Mon Sep 17 00:00:00 2001
+From f8dfc7073c0316607557b2eb7331d86bf18d0f31 Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Fri, 13 Oct 2023 21:35:29 +0200
 Subject: clang: link against crti.o
@@ -1154,6 +1154,54 @@ index 60434c6..2b507b1 100644
      CmdArgs.push_back(Args.MakeArgString(ToolChain.GetFilePath("crtbeginS.o")));
      if (crt1)
        CmdArgs.push_back(Args.MakeArgString(ToolChain.GetFilePath(crt1)));
+-- 
+2.37.3
+
+
+From 636386a5e94aa96f0c39c7544bbb1e0a20de8d52 Mon Sep 17 00:00:00 2001
+From: Calvin Hill <calvin@hakobaito.co.uk>
+Date: Thu, 2 Nov 2023 07:44:17 +0000
+Subject: lld: Make --no-undefined-version into a warning
+
+
+diff --git a/lld/ELF/SymbolTable.cpp b/lld/ELF/SymbolTable.cpp
+index 0437095..85a0041 100644
+--- a/lld/ELF/SymbolTable.cpp
++++ b/lld/ELF/SymbolTable.cpp
+@@ -280,7 +280,7 @@ void SymbolTable::scanVersionScript() {
+                                    pat.isExternCpp, /*hasWildCard=*/false},
+                                   id, ver, /*includeNonDefault=*/true);
+       if (!found && !config->undefinedVersion)
+-        errorOrWarn("version script assignment of '" + ver + "' to symbol '" +
++        warn("version script assignment of '" + ver + "' to symbol '" +
+                     pat.name + "' failed: symbol not defined");
+     };
+     for (SymbolVersion &pat : v.nonLocalPatterns)
+diff --git a/lld/test/ELF/version-script-noundef.s b/lld/test/ELF/version-script-noundef.s
+index b99fb17..9cdfa1e 100644
+--- a/lld/test/ELF/version-script-noundef.s
++++ b/lld/test/ELF/version-script-noundef.s
+@@ -5,17 +5,17 @@
+ # RUN: not ld.lld --version-script %t.script -shared %t.o -o /dev/null \
+ # RUN:    --fatal-warnings 2>&1 | FileCheck -check-prefix=ERR1 %s
+ # RUN: ld.lld --version-script %t.script -shared --undefined-version %t.o -o %t.so
+-# RUN: not ld.lld --version-script %t.script -shared --no-undefined-version \
++# RUN: ld.lld --version-script %t.script -shared --no-undefined-version \
+ # RUN:   %t.o -o %t.so 2>&1 | FileCheck -check-prefix=ERR1 %s
+ # ERR1: version script assignment of 'VERSION_1.0' to symbol 'bar' failed: symbol not defined
+ 
+ # RUN: echo "VERSION_1.0 { global: und; };" > %t2.script
+-# RUN: not ld.lld --version-script %t2.script -shared --no-undefined-version \
++# RUN: ld.lld --version-script %t2.script -shared --no-undefined-version \
+ # RUN:   %t.o -o %t.so 2>&1 | FileCheck -check-prefix=ERR2 %s
+ # ERR2: version script assignment of 'VERSION_1.0' to symbol 'und' failed: symbol not defined
+ 
+ # RUN: echo "VERSION_1.0 { local: und; };" > %t3.script
+-# RUN: not ld.lld --version-script %t3.script -shared --no-undefined-version \
++# RUN: ld.lld --version-script %t3.script -shared --no-undefined-version \
+ # RUN:   %t.o -o %t.so 2>&1 | FileCheck -check-prefix=ERR3 %s
+ # ERR3: version script assignment of 'local' to symbol 'und' failed: symbol not defined
+ 
 -- 
 2.37.3
 


### PR DESCRIPTION
This PR changes the --no-undefined-version flag in the LLD linker to be set to report a warning instead of an error and to not require the version script assignment when lld is used for linking. It is also a patch to revert this change introduced in LLVM 16: https://reviews.llvm.org/D135402 and was set to a warning in a patch release of LLVM 16 in this PR: https://github.com/llvm/llvm-project-release-prs/pull/347/files 

This change is also useful for the purpose of LLD being able to compile itself under the host OS and in situations where Clang (not gcc/g++) is required. Otherwise you will get this error:

```
[3153/4369][ 72%][11549.390s] Linking CXX shared library lib/libIndexStore.so.13git
FAILED: lib/libIndexStore.so.13git 
: && /bin/clang++ -fPIC -Wno-unknown-warning-option -Werror=unguarded-availability-new -fno-stack-protector -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-class-memaccess -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wno-comment -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -fno-common -Woverloaded-virtual -Wno-nested-anon-types -O3 -DNDEBUG  -Wl,-z,defs -Wl,--color-diagnostics   -Wl,--gc-sections  -Wl,--version-script,".../llvm-haiku-x86_64/tools/clang/tools/IndexStore/IndexStore.exports" -shared -Wl,-soname,libIndexStore.so.13git -o lib/libIndexStore.so.13git tools/clang/tools/IndexStore/CMakeFiles/IndexStore.dir/IndexStore.cpp.o  -Wl,-rpath,"\$ORIGIN/../lib:"  lib/libclangIndex.a  lib/libclangIndexDataStore.a  lib/libLLVMSupport.a  lib/libclangIndex.a  lib/libclangFormat.a  lib/libclangToolingInclusions.a  lib/libclangFrontend.a  lib/libclangDriver.a  lib/libLLVMWindowsDriver.a  lib/libclangParse.a  lib/libclangCAS.a  lib/libLLVMCAS.a  lib/libLLVMOption.a  lib/libclangSerialization.a  lib/libclangSema.a  lib/libclangAPINotes.a  lib/libclangEdit.a  lib/libclangAnalysis.a  lib/libclangASTMatchers.a  lib/libclangAST.a  lib/libLLVMFrontendOpenMP.a  lib/libLLVMScalarOpts.a  lib/libLLVMAggressiveInstCombine.a  lib/libLLVMInstCombine.a  lib/libLLVMTransformUtils.a  lib/libLLVMAnalysis.a  lib/libLLVMProfileData.a  lib/libLLVMSymbolize.a  lib/libLLVMDebugInfoPDB.a  lib/libLLVMDebugInfoMSF.a  lib/libLLVMDebugInfoDWARF.a  lib/libLLVMObject.a  lib/libLLVMMCParser.a  lib/libLLVMMC.a  lib/libLLVMDebugInfoCodeView.a  lib/libLLVMIRReader.a  lib/libLLVMAsmParser.a  lib/libLLVMTextAPI.a  lib/libclangSupport.a  lib/libclangToolingCore.a  lib/libclangRewrite.a  lib/libclangLex.a  lib/libclangBasic.a  lib/libLLVMBitReader.a  lib/libLLVMCore.a  lib/libLLVMBinaryFormat.a  lib/libLLVMRemarks.a  lib/libLLVMBitstreamReader.a  lib/libclangDirectoryWatcher.a  lib/libLLVMSupport.a  -lexecinfo  -lbsd  /boot/system/develop/lib/libz.so  lib/libLLVMDemangle.a && :
ld.lld: error: version script assignment of 'LLVM_13' to symbol 'indexstore_store_units_apply' failed: symbol not defined
ld.lld: error: version script assignment of 'LLVM_13' to symbol 'indexstore_store_set_unit_event_handler' failed: symbol not defined
ld.lld: error: version script assignment of 'LLVM_13' to symbol 'indexstore_occurrence_relations_apply' failed: symbol not defined
ld.lld: error: version script assignment of 'LLVM_13' to symbol 'indexstore_record_reader_search_symbols' failed: symbol not defined
ld.lld: error: version script assignment of 'LLVM_13' to symbol 'indexstore_record_reader_symbols_apply' failed: symbol not defined
ld.lld: error: version script assignment of 'LLVM_13' to symbol 'indexstore_record_reader_occurrences_apply' failed: symbol not defined
ld.lld: error: version script assignment of 'LLVM_13' to symbol 'indexstore_record_reader_occurrences_in_line_range_apply' failed: symbol not defined
ld.lld: error: version script assignment of 'LLVM_13' to symbol 'indexstore_record_reader_occurrences_of_symbols_apply' failed: symbol not defined
ld.lld: error: version script assignment of 'LLVM_13' to symbol 'indexstore_unit_reader_dependencies_apply' failed: symbol not defined
ld.lld: error: version script assignment of 'LLVM_13' to symbol 'indexstore_unit_reader_includes_apply' failed: symbol not defined
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
[3156/4369][ 72%][11564.295s] Building CXX object tools/clang/tools/c-index-test/CMakeFiles/c-index-test.dir/core_main.cpp.o
ninja: build stopped: subcommand failed.
ERROR: command terminated with a non-zero exit status 1, aborting 
```