### PR TITLE
qemu: update to 8.0.5

### DIFF
--- a/app-emulation/qemu/patches/qemu-8.0.5-haiku.patchset
+++ b/app-emulation/qemu/patches/qemu-8.0.5-haiku.patchset
@@ -1495,3 +1495,34 @@ index 4e54c00..65ca248 100644
 -- 
 2.37.3
 
+
+From f22065f8389c6dbb33be178d6b67f660adfe6033 Mon Sep 17 00:00:00 2001
+From: David Karoly <david.karoly@outlook.com>
+Date: Fri, 3 Nov 2023 10:43:46 +0100
+Subject: bitmap.h: fix build on Haiku
+
+
+diff --git a/include/qemu/bitmap.h b/include/qemu/bitmap.h
+index 9780681..99be159 100644
+--- a/include/qemu/bitmap.h
++++ b/include/qemu/bitmap.h
+@@ -93,7 +93,7 @@ long slow_bitmap_count_one(const unsigned long *bitmap, long nbits);
+ static inline unsigned long *bitmap_try_new(long nbits)
+ {
+     long len = BITS_TO_LONGS(nbits) * sizeof(unsigned long);
+-    return g_try_malloc0(len);
++    return (unsigned long *) g_try_malloc0(len);
+ }
+ 
+ static inline unsigned long *bitmap_new(long nbits)
+@@ -266,7 +266,7 @@ static inline unsigned long *bitmap_zero_extend(unsigned long *old,
+                                                 long old_nbits, long new_nbits)
+ {
+     long new_len = BITS_TO_LONGS(new_nbits) * sizeof(unsigned long);
+-    unsigned long *new = g_realloc(old, new_len);
++    unsigned long *new = (unsigned long *) g_realloc(old, new_len);
+     bitmap_clear(new, old_nbits, new_nbits - old_nbits);
+     return new;
+ }
+-- 
+2.42.0

--- a/app-emulation/qemu/patches/qemu-8.0.5.patchset
+++ b/app-emulation/qemu/patches/qemu-8.0.5.patchset
@@ -1,4 +1,4 @@
-From 9c0e39e2efb85dd15eaa7e79126adae4bdbb6343 Mon Sep 17 00:00:00 2001
+From 89b7d1620826fe203511b680d7ee66382605b8a8 Mon Sep 17 00:00:00 2001
 From: Alexander von Gluck IV <kallisti5@unixzen.com>
 Date: Tue, 18 May 2021 16:49:20 -0500
 Subject: haiku: fixes and patches, rebased from qemu 3.x
@@ -39,5 +39,5 @@ index 76bab21..7c1ea84 100644
          if (ret != 0) {
              break;
 -- 
-2.37.3
+2.42.0
 

--- a/app-emulation/qemu/qemu-8.0.5.recipe
+++ b/app-emulation/qemu/qemu-8.0.5.recipe
@@ -9,7 +9,7 @@ COPYRIGHT="2003-2023 Fabrice Bellard"
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://download.qemu.org/qemu-$portVersion.tar.xz"
-CHECKSUM_SHA256="81c817dda38af958be5bef1a6cf55b658bb2d3fb87c1e6a571de6b7b2c44516c"
+CHECKSUM_SHA256="91d3024d51e441c235dcb1b0c87cb3aab302283166e8d3d5f8282aa06c346be1"
 SOURCE_DIR="qemu-$portVersion"
 PATCHES="
 	qemu-$portVersion.patchset


### PR DESCRIPTION
Almost straightforward update, no regressions.
The already known issues are still there.