### PR TITLE
lagrange: bump to 1.17.3

### DIFF
--- a/net-misc/lagrange/lagrange-1.17.3.recipe
+++ b/net-misc/lagrange/lagrange-1.17.3.recipe
@@ -8,7 +8,7 @@ COPYRIGHT="2020-2023 Jaakko Keränen"
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="https://github.com/skyjake/lagrange/releases/download/v$portVersion/lagrange-$portVersion.tar.gz"
-CHECKSUM_SHA256="c0f68e7d8d7b4a94eeaaf2c041f08b13abc2a2922b2485d69844b823e710cc8a"
+CHECKSUM_SHA256="cd0c4797e399082ccbf4d0ede939ef286b96863c31860f62387fd94275dda3ba"
 SOURCE_DIR="lagrange-$portVersion"
 ADDITIONAL_FILES="lagrange.rdef.in"
 


### PR DESCRIPTION
[Changelog](https://github.com/skyjake/lagrange/releases)