### PR TITLE
ffmpeg: refreshed for GCC2 build

### DIFF
--- a/media-video/ffmpeg/ffmpeg-4.2.9.recipe
+++ b/media-video/ffmpeg/ffmpeg-4.2.9.recipe
@@ -6,7 +6,7 @@ HOMEPAGE="https://ffmpeg.org/"
 COPYRIGHT="2000-2003 Fabrice Bellard
 	2003-2023 the FFmpeg developers"
 LICENSE="GNU LGPL v3"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://ffmpeg.org/releases/ffmpeg-$portVersion.tar.xz"
 CHECKSUM_SHA256="4974d62e7507ba3b26fa5f30af8ee36825917ddb4a1ad4118277698c1c8818cf"
 PATCHES="ffmpeg-$portVersion.patchset"
@@ -64,29 +64,16 @@ REQUIRES="
 if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
 	REQUIRES+="
 		lib:libass$secondaryArchSuffix
-#		lib:libbluray$secondaryArchSuffix
-#		lib:libbs2b$secondaryArchSuffix
-#		lib:libcaca$secondaryArchSuffix
-#		lib:libcairo$secondaryArchSuffix
-#		lib:libdav1d$secondaryArchSuffix
 		lib:libfdk_aac$secondaryArchSuffix
 		lib:libfontconfig$secondaryArchSuffix
 		lib:libfreetype$secondaryArchSuffix
 		lib:libfribidi$secondaryArchSuffix
-#		lib:libgdk_pixbuf_2.0$secondaryArchSuffix
 		lib:libgme$secondaryArchSuffix
 		lib:libgmp$secondaryArchSuffix
-#		lib:libglib_2.0$secondaryArchSuffix
-#		lib:libgobject_2.0$secondaryArchSuffix
 		lib:libopenjp2$secondaryArchSuffix
 		lib:libopenmpt$secondaryArchSuffix
-#		lib:librsvg_2$secondaryArchSuffix
-#		lib:librubberband$secondaryArchSuffix
 		lib:libsnappy$secondaryArchSuffix
 		lib:libsoxr$secondaryArchSuffix
-#		lib:libSvtAv1Dec$secondaryArchSuffix
-#		lib:libtesseract$secondaryArchSuffix
-#		lib:libvmaf$secondaryArchSuffix
 		lib:libvpx$secondaryArchSuffix
 		lib:libwavpack$secondaryArchSuffix
 		lib:libwebp$secondaryArchSuffix
@@ -187,27 +174,16 @@ BUILD_REQUIRES="
 if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
 	BUILD_REQUIRES+="
 		devel:libass$secondaryArchSuffix
-#		devel:libbluray$secondaryArchSuffix
-#		devel:libbs2b$secondaryArchSuffix
-#		devel:libcaca$secondaryArchSuffix
-#		devel:libcairo$secondaryArchSuffix
-#		devel:libdav1d$secondaryArchSuffix
 		devel:libfdk_aac$secondaryArchSuffix
 		devel:libfontconfig$secondaryArchSuffix
 		devel:libfreetype$secondaryArchSuffix
 		devel:libfribidi$secondaryArchSuffix
-#		devel:libgdk_pixbuf_2.0$secondaryArchSuffix
 		devel:libgme$secondaryArchSuffix
 		devel:libgmp$secondaryArchSuffix
 		devel:libopenjp2$secondaryArchSuffix
 		devel:libopenmpt$secondaryArchSuffix
-#		devel:librsvg_2$secondaryArchSuffix
-#		devel:librubberband$secondaryArchSuffix
 		devel:libsnappy$secondaryArchSuffix
 		devel:libsoxr$secondaryArchSuffix
-#		devel:libSvtAv1Dec$secondaryArchSuffix
-#		devel:libtesseract$secondaryArchSuffix
-#		devel:libvmaf$secondaryArchSuffix
 		devel:libvpx$secondaryArchSuffix
 		devel:libwavpack$secondaryArchSuffix
 		devel:libwebp$secondaryArchSuffix

--- a/media-video/ffmpeg/patches/ffmpeg-4.2.9.patchset
+++ b/media-video/ffmpeg/patches/ffmpeg-4.2.9.patchset
@@ -1,4 +1,4 @@
-From 396a7f950a2cac0fb7752bd2b0d7be702f1996ac Mon Sep 17 00:00:00 2001
+From 0a4352f3865e4a6f0d1d6d8f5433dab93345cdeb Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Wed, 7 Aug 2019 16:21:12 +0300
 Subject: disable ebx on x86.
@@ -17,10 +17,10 @@ index 5ee289f..1a6dedb 100755
  *-dos|freedos|opendos)
      if test_cpp_condition sys/version.h "defined(__DJGPP__) && __DJGPP__ == 2 && __DJGPP_MINOR__ == 5"; then
 -- 
-2.42.0
+2.42.1
 
 
-From 0b3c0c11bbffe70c2479b1101780e92eced62c63 Mon Sep 17 00:00:00 2001
+From e8f7eff2e3bf440bda829adeb033c316b15a5ce7 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Wed, 7 Aug 2019 16:21:32 +0300
 Subject: Re-enable memalign for Haiku
@@ -45,20 +45,20 @@ index 1a6dedb..c9d5f43 100755
      ;;
  *-dos|freedos|opendos)
 -- 
-2.42.0
+2.42.1
 
 
-From 4f88c3d7ae7e326af1544ff54b219588a26edd5a Mon Sep 17 00:00:00 2001
+From 2c347569d84689cea4460e19d388ca1c1ac5b6a3 Mon Sep 17 00:00:00 2001
 From: Remi Denis-Courmont <remi@remlab.net>
 Date: Sun, 16 Jul 2023 07:18:02 +0000
 Subject: Fixes assembling with binutils as >= 2.41
 
 
 diff --git a/libavcodec/x86/mathops.h b/libavcodec/x86/mathops.h
-index 6298f5e..fb822e9 100644
+index 6298f5e..ca7e2df 100644
 --- a/libavcodec/x86/mathops.h
 +++ b/libavcodec/x86/mathops.h
-@@ -35,12 +35,19 @@
+@@ -35,12 +35,20 @@
  static av_always_inline av_const int MULL(int a, int b, unsigned shift)
  {
      int rt, dummy;
@@ -70,52 +70,50 @@ index 6298f5e..fb822e9 100644
 -        :"a"(a), "rm"(b), "ci"((uint8_t)shift)
 +        :"a"(a), "rm"(b), "i"(shift & 0x1F)
      );
-+	else
-+	   __asm__ (
-+        "imull %3               \n\t"
-+        "shrdl %4, %%edx, %%eax \n\t"
-+        :"=a"(rt), "=d"(dummy)
-+        :"a"(a), "rm"(b), "ic"((uint8_t)shift)
++    else
++        __asm__ (
++            "imull %3               \n\t"
++            "shrdl %4, %%edx, %%eax \n\t"
++            :"=a"(rt), "=d"(dummy)
++            :"a"(a), "rm"(b), "c"((uint8_t)shift)
++        );
      return rt;
  }
  
-@@ -113,20 +120,33 @@ __asm__ volatile(\
+@@ -113,19 +121,31 @@ __asm__ volatile(\
  // avoid +32 for shift optimization (gcc should do that ...)
  #define NEG_SSR32 NEG_SSR32
  static inline  int32_t NEG_SSR32( int32_t a, int8_t s){
-+	if (__builtin_constant_p(s))
++    if (__builtin_constant_p(s))
      __asm__ ("sarl %1, %0\n\t"
           : "+r" (a)
 -         : "ic" ((uint8_t)(-s))
 +         : "i" (-s & 0x1F)
-+    );
-+	else
-+	__asm__ ("sarl %1, %0\n\t"
-+         : "+r" (a)
-+         : "c" ((uint8_t)(-s))
      );
-+
++    else
++        __asm__ ("sarl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
      return a;
  }
  
  #define NEG_USR32 NEG_USR32
  static inline uint32_t NEG_USR32(uint32_t a, int8_t s){
-+	if (__builtin_constant_p(s))
++    if (__builtin_constant_p(s))
      __asm__ ("shrl %1, %0\n\t"
           : "+r" (a)
 -         : "ic" ((uint8_t)(-s))
 +         : "i" (-s & 0x1F)
      );
--    return a;
-+	else
-+	__asm__ ("shrl %1, %0\n\t"
-+         : "+r" (a)
-+         : "c" ((uint8_t)(-s))
-+    );
-+	return a;
++    else
++        __asm__ ("shrl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
  }
  
- #endif /* HAVE_INLINE_ASM */
 -- 
-2.42.0
+2.42.1
 


### PR DESCRIPTION
Review for: https://build.haiku-os.org/buildmaster/master/x86_gcc2/?buildrunDir=5386&viewMode=expanded
- Fixed patchset formatting.
