### PR TITLE
zsh: completion fixes and cleanup

### DIFF
--- a/app-shells/zsh/patches/zsh-5.8.1.patchset
+++ b/app-shells/zsh/patches/zsh-5.8.1.patchset
@@ -1,4 +1,4 @@
-From 7069941ad1f2f038b3773cc332fdf09a0128e71b Mon Sep 17 00:00:00 2001
+From 370db124e6c542236cde597cfda50d782656af7f Mon Sep 17 00:00:00 2001
 From: Chris Roberts <cpr420@gmail.com>
 Date: Wed, 18 Sep 2013 03:11:28 -0600
 Subject: Fix for gcc2
@@ -102,10 +102,10 @@ index af8c5bb..fa01cc2 100644
  
  case $LIBS in
 -- 
-2.30.2
+2.42.1
 
 
-From 31279d64cc9229182b6b8c0e89ca1b7e3933eee1 Mon Sep 17 00:00:00 2001
+From 581791250b1ca0c0f6bf779feffe8f7f74033156 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
 Date: Wed, 11 Jan 2017 18:17:20 +0100
 Subject: Haiku rusage fix
@@ -125,10 +125,10 @@ index e743825..96837e9 100644
  	j->procs->ti.ru_maxrss / 1024 > reportmemory)
  	return 1;
 -- 
-2.30.2
+2.42.1
 
 
-From da6bb93f40b1ec7a014e89bf7924c2c884db6626 Mon Sep 17 00:00:00 2001
+From 16706ebf1de5aa55485ffed98baf070fb92efa3e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
 Date: Thu, 17 Aug 2017 16:16:21 +0200
 Subject: Enable dynamic modules on Haiku
@@ -157,10 +157,10 @@ index fa01cc2..8119cc0 100644
        if test x$zsh_cv_sys_elf = xyes; then
  	DLLDFLAGS="${DLLDFLAGS=-shared -fPIC}"
 -- 
-2.30.2
+2.42.1
 
 
-From 13d11d66e5c8817af6c693bdbd077e98148c1fcf Mon Sep 17 00:00:00 2001
+From 66308274f4327f0f5c2ba781d569e06d4fe41a47 Mon Sep 17 00:00:00 2001
 From: fbrosson <fbrosson@localhost>
 Date: Sat, 14 Apr 2018 18:11:49 +0000
 Subject: C89 fixes for gcc2 compatibility
@@ -247,10 +247,10 @@ index f5667f3..465048f 100644
  	int ignoredots = !isset(GLOBDOTS);
  	char *fname;
 -- 
-2.30.2
+2.42.1
 
 
-From eb706f0fe03c8c4b2ad36fc4ef852fc9c3f2b261 Mon Sep 17 00:00:00 2001
+From 73396c1c6f6b6348caf5feb1e175c81cf93c7cef Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
 Date: Sat, 27 Oct 2018 10:36:50 +0200
 Subject: Some other function resides in libroot
@@ -274,10 +274,10 @@ index 8119cc0..c31387b 100644
  dnl Various features of ncurses depend on having the right header
  dnl (the system's own curses.h may well not be good enough).
 -- 
-2.30.2
+2.42.1
 
 
-From a7c2aadccb985847800cf550de5e59c6a4d7d48f Mon Sep 17 00:00:00 2001
+From fa80aa8bbb19977151fad2b745714873eec01bc6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
 Date: Mon, 18 Feb 2019 13:41:08 +0100
 Subject: Build fix for gcc2 from hanya
@@ -307,10 +307,10 @@ index b49ee9a..44313ba 100644
      /* Observer. = 2 degrees, Illuminant = D65 */
      double X = (R * 0.4124 + G * 0.3576 + B * 0.1805) / 95.047;
 -- 
-2.30.2
+2.42.1
 
 
-From 58eb212be9f1497968c052a7b68212de8a15f52e Mon Sep 17 00:00:00 2001
+From f28915820baec904120b843a3138f35cc0e6fe92 Mon Sep 17 00:00:00 2001
 From: begasus <begasus@gmail.com>
 Date: Sun, 13 Mar 2022 15:56:24 +0000
 Subject: zsh, fix for gcc2
@@ -337,5 +337,75 @@ index 96837e9..d830d39 100644
  	    if (setpgrp(0, 0) == 0) {
  		mypgrp = mypid;
 -- 
-2.30.2
+2.42.1
+
+
+From a4d0acb9cc97d23f7931ace95ac20ee1737b236d Mon Sep 17 00:00:00 2001
+From: Chris Roberts <cpr420@gmail.com>
+Date: Mon, 11 Dec 2023 18:27:05 -0700
+Subject: remove hd from hexdump completions
+
+
+diff --git a/Completion/Unix/Command/_hexdump b/Completion/Unix/Command/_hexdump
+index f700ca6..6c0e0ba 100644
+--- a/Completion/Unix/Command/_hexdump
++++ b/Completion/Unix/Command/_hexdump
+@@ -1,4 +1,4 @@
+-#compdef hexdump hd
++#compdef hexdump
+ 
+ local -a args fmts optpar
+ fmts=(
+-- 
+2.42.1
+
+
+From 5064c0bcabe0bb8f1188b7190a6ab08ffc073bf8 Mon Sep 17 00:00:00 2001
+From: Chris Roberts <cpr420@gmail.com>
+Date: Mon, 11 Dec 2023 18:27:51 -0700
+Subject: quick fixes for Haiku filesystem layout
+
+
+diff --git a/Completion/Unix/Type/_domains b/Completion/Unix/Type/_domains
+index 851ac79..614e625 100644
+--- a/Completion/Unix/Type/_domains
++++ b/Completion/Unix/Type/_domains
+@@ -5,11 +5,11 @@ local expl domains tmp
+ if ! zstyle -a ":completion:${curcontext}:domains" domains domains; then
+   if (( ! $+_cache_domains )); then
+     _cache_domains=()
+-    if [[ -f /etc/resolv.conf ]]; then
++    if [[ -f /boot/system/settings/network/resolv.conf ]]; then
+       while read tmp; do
+         [[ "$tmp" = (domain|search)* ]] &&
+             _cache_domains=( "$_cache_domains[@]" "${=${tmp%%[ 	]#}#*[ 	]}" )
+-      done < /etc/resolv.conf
++      done < /boot/system/settings/network/resolv.conf
+       _cache_domains=( "${(@)_cache_domains:#[ 	]#}" )
+     fi
+   fi
+diff --git a/Completion/Unix/Type/_hosts b/Completion/Unix/Type/_hosts
+index 4057fee..4df5155 100644
+--- a/Completion/Unix/Type/_hosts
++++ b/Completion/Unix/Type/_hosts
+@@ -21,7 +21,7 @@ if ! zstyle -a ":completion:${curcontext}:hosts" hosts _hosts; then
+       # tested _cache_hosts doesn't exist.
+       _cache_hosts=(${(s: :)${(ps:\t:)${(f)~~"$(_call_program hosts getent hosts 2>/dev/null)"}##${~ipstrip}}})
+     else
+-      _cache_hosts=(${(s: :)${(ps:\t:)${${(f)~~"$(</etc/hosts)"}%%\#*}##${~ipstrip}}})
++      _cache_hosts=(${(s: :)${(ps:\t:)${${(f)~~"$(</boot/system/settings/network/hosts)"}%%\#*}##${~ipstrip}}})
+       if (( ${+commands[ypcat]} )) &&
+     	tmp=$(_call_program hosts ypcat hosts.byname 2>/dev/null); then
+         _cache_hosts+=( ${=${(f)tmp}##${~ipstrip}} ) # If you use YP
+@@ -37,7 +37,7 @@ if ! zstyle -a ":completion:${curcontext}:hosts" hosts _hosts; then
+     # discarded. ssh's known_hosts files are thus supported. This style defaults
+     # to the list /etc/ssh/ssh_known_hosts, ~/.ssh/known_hosts
+     zstyle -a ":completion:${curcontext}:hosts" known-hosts-files khostfiles ||
+-    khostfiles=(/etc/ssh/ssh_known_hosts ~/.ssh/known_hosts)
++    khostfiles=(/boot/system/settings/ssh/ssh_known_hosts ~/config/settings/ssh/known_hosts)
+ 
+     for khostfile in $khostfiles; do
+       if [[ -r $khostfile ]]; then
+-- 
+2.42.1
 

--- a/app-shells/zsh/zsh-5.8.1.recipe
+++ b/app-shells/zsh/zsh-5.8.1.recipe
@@ -7,7 +7,7 @@ HOMEPAGE="https://www.zsh.org/"
 COPYRIGHT="1992-2020 The Zsh Development Group"
 LICENSE="ZSH
 	GNU GPL v2"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://downloads.sf.net/zsh/zsh-$portVersion.tar.xz"
 CHECKSUM_SHA256="b6973520bace600b4779200269b1e5d79e5f505ac4952058c11ad5bbf0dd9919"
 SOURCE_URI_2="https://downloads.sf.net/zsh/zsh-$portVersion-doc.tar.xz"
@@ -86,6 +86,19 @@ BUILD_PREREQUIRES="
 	cmd:texi2html
 	cmd:texi2pdf
 	"
+
+PATCH()
+{
+	# Remove unneeded and conflicting completion scripts
+	for _fpath in AIX BSD Cygwin Darwin Debian Linux Mandriva openSUSE Redhat Solaris; do
+		rm -rf Completion/$_fpath
+		sed "s#\s*Completion/$_fpath/\*/\*##g" -i Src/Zle/complete.mdd
+	done
+	# Disable these completions until Haiku support is added
+	for _fpath in _arp _beep _df _ifconfig _mount _ps _shutdown; do
+		rm -rf Completion/Unix/Command/$_fpath
+	done
+}
 
 BUILD()
 {


### PR DESCRIPTION
* remove completions for other operating systems.  commands borrowed from the Arch Linux recipe

* disable completions that need Haiku support to function properly

* quick path fixes for hosts, known_hosts, and resolv.conf files

existing users can 'rm -r /system/settings/zsh/functions' before updating or they will have stale files left around from the previous package