### PR TITLE
libunistring: added v1.1 recipe

### DIFF
--- a/dev-libs/libunistring/libunistring-1.1.recipe
+++ b/dev-libs/libunistring/libunistring-1.1.recipe
@@ -1,0 +1,87 @@
+SUMMARY="A library for manipulating Unicode strings"
+DESCRIPTION="libunistring provides functions for manipulating Unicode strings \
+and for manipulating C strings according to the Unicode standard."
+HOMEPAGE="https://www.gnu.org/software/libunistring/"
+COPYRIGHT="1995-2022 Free Software Foundation, Inc."
+LICENSE="GNU GPL v2
+	GNU LGPL v3"
+REVISION="1"
+SOURCE_URI="https://ftpmirror.gnu.org/libunistring/libunistring-$portVersion.tar.gz
+	https://ftp.gnu.org/gnu/libunistring/libunistring-$portVersion.tar.gz"
+CHECKSUM_SHA256="a2252beeec830ac444b9f68d6b38ad883db19919db35b52222cf827c385bdb6a"
+
+ARCHITECTURES="!all !x86_gcc2"
+SECONDARY_ARCHITECTURES="!x86"
+
+libVersion="5.0.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+portVersionCompat="$portVersion compat >= ${portVersion%%.*}"
+
+PROVIDES="
+	libunistring$secondaryArchSuffix = $portVersionCompat
+	lib:libunistring$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	libunistring${secondaryArchSuffix}_devel = $portVersion
+	devel:libunistring$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	libunistring$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libiconv$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:autoreconf
+	cmd:gcc$secondaryArchSuffix
+	cmd:gperf
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	"
+
+defineDebugInfoPackage libunistring$secondaryArchSuffix \
+	"$libDir"/libunistring.so.$libVersion
+
+BUILD()
+{
+	autoreconf -fi
+	if [ -n "$secondaryArchSuffix" ]; then
+		runConfigure ./configure --disable-static
+	else
+		runConfigure --omit-dirs docDir ./configure \
+			--disable-static \
+			--docdir="$developDocDir"
+	fi
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+	rm -f "$libDir"/libunistring.la "$libDir"/charset.alias
+
+	if [ -n "$secondaryArchSuffix" ]; then
+		rm -rf "$documentationDir"
+		maybe_infoDir=
+	else
+		install -t "$developDocDir" README
+		maybe_infoDir="$infoDir"
+	fi
+
+	prepareInstalledDevelLib libunistring
+	packageEntries devel \
+		"$developDir" \
+		${maybe_infoDir:+"$maybe_infoDir"}
+}
+
+TEST()
+{
+	make check
+}


### PR DESCRIPTION
Warning: Core system library usage. Library API version change.

Tested on Haiku R1B4 (+94) x64 - don't enable yet, proposed/intended for Haiku R1B5/nightly builds. 

See: @waddlesplash