### PR TITLE
barrier_haiku: new recipe.

### DIFF
--- a/haiku-misc/barrier_haiku/barrier_haiku-1.0~git.recipe
+++ b/haiku-misc/barrier_haiku/barrier_haiku-1.0~git.recipe
@@ -1,0 +1,70 @@
+SUMMARY="Mouse and Keyboard sharing software"
+DESCRIPTION="Barrier allows a central machine running the Barrier server to share its Keyboard \
+and Mouse across multiple systems running the clien as if they were one desktop.
+
+Limitations:
+
+* Barrier for Haiku is only a barrier client at this time.
+* Some minor bugs still exist in the keymap translation
+* For now, client name is always "haiku".
+* SSL/TLS is not currently supported and must be disabled on the server.
+
+Usage:
+
+Create a configuration file at ~/config/settings/barrier with:
+
+    enable = true
+    server = 192.168.1.X  # (IP of your Barrier server)
+    server_keymap = "X11" # (or "AT" if the server is not running on Linux)
+"
+HOMEPAGE="https://gitlab.com/kallisti5/barrier-haiku"
+COPYRIGHT="2004-2006 Jérôme Duval
+	2004-2012 Haiku, Inc
+	2005-2010 Axel Dörfler
+	2012 Alex Evans
+	2012 Synergy Si Ltd.
+	2014 Ed Robbins
+	2014 Jessica Hamilton
+	2015-2016 Alexander von Gluck IV
+	"
+LICENSE="MIT"
+REVISION="1"
+srcGitRev="6c551ed8f374b2941a335930a6d84e5d47242020"
+SOURCE_URI="https://gitlab.com/kallisti5/barrier-haiku/-/archive/$srcGitRev/barrier-haiku-$srcGitRev.tar.bz2"
+CHECKSUM_SHA256="f73be62c4a5b900ceb693a2348811114e2d1880c123af739b70f06d989abf66e"
+SOURCE_FILENAME="barrier_haiku-$portVersion.tar.bz2"
+SOURCE_DIR="barrier-haiku-$srcGitRev"
+
+PATCHES="barrier_haiku-1.0~git.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	barrier_haiku$secondaryArchSuffix = $portVersion
+	add_on:barrier_client = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	makefile_engine
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	"
+
+BUILD()
+{
+	make OBJ_DIR=objects $jobArgs
+}
+
+INSTALL()
+{
+	input_devices=$addOnsDir/input_server/devices
+	mkdir -p $input_devices
+	cp -a objects/barrier_client $input_devices
+}

--- a/haiku-misc/barrier_haiku/patches/barrier_haiku-1.0~git.patchset
+++ b/haiku-misc/barrier_haiku/patches/barrier_haiku-1.0~git.patchset
@@ -1,0 +1,58 @@
+From 9251686a6c5edd6db977e75c00c156aceef5321c Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Sat, 13 Jan 2024 05:03:10 -0300
+Subject: Fix missing header for snprintf
+
+
+diff --git a/haiku-ubarrier.cpp b/haiku-ubarrier.cpp
+index c94b6a3..41a8b46 100644
+--- a/haiku-ubarrier.cpp
++++ b/haiku-ubarrier.cpp
+@@ -33,6 +33,7 @@
+ #include <Screen.h>
+ #include <TranslationUtils.h>
+ 
++#include <cstdio>
+ #include <cstdlib>
+ #include <strings.h>
+ #include <errno.h>
+-- 
+2.42.1
+
+
+From abfa78bcbfc290d05afa429147d1a203aba0ea7e Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Sat, 13 Jan 2024 09:17:13 -0300
+Subject: Disable clipboard sharing.
+
+Server logs shows
+
+'ERROR: invalid message from client "haiku": DCLP'
+
+and seems to cause a disconnect/reconnect.
+
+(tested with Barrier 2.4.0-release-330d758b server on Windows)
+
+diff --git a/haiku-ubarrier.cpp b/haiku-ubarrier.cpp
+index 41a8b46..85ca3dd 100644
+--- a/haiku-ubarrier.cpp
++++ b/haiku-ubarrier.cpp
+@@ -281,6 +281,7 @@ uBarrierInputServerDevice::MessageReceived(BMessage* message)
+ 			Start(NULL, NULL);
+ 			break;
+ 		}
++#if 0
+ 		case B_CLIPBOARD_CHANGED:
+ 		{
+ 			const char *text = NULL;
+@@ -300,6 +301,7 @@ uBarrierInputServerDevice::MessageReceived(BMessage* message)
+ 			} else
+ 				TRACE("barrier: couldn't add data to clipboard\n");
+ 		}
++#endif
+ 		default:
+ 			BHandler::MessageReceived(message);
+ 	}
+-- 
+2.42.1
+


### PR DESCRIPTION
Opening as draft for now. I was trying to update `synergy_haiku`, but couldn't make it work with a barrier server running on Windows... then... found @kallisti5's [barrier-haiku](https://gitlab.com/kallisti5/barrier-haiku), and it worked (almost) right away.

Leaving it as draft for now (in case @kallisti5 has some feedback on the recipe), and because I want to see if I can address an issue I found with the settings file monitoring code.

Still..., pretty handy!

Tested (for now) only on nightly (hrev57509) 64 bits (connecting to a Barrier server version 2.4.0-release-330d758b running on Windows 10).