### PR TITLE
fuse-nfs: add disabled recipe for 1.0.0~git

### DIFF
--- a/sys-fs/fuse-nfs/fuse_nfs-1.0.0~git.recipe
+++ b/sys-fs/fuse-nfs/fuse_nfs-1.0.0~git.recipe
@@ -1,0 +1,73 @@
+SUMMARY="A FUSE module for mounting NFSv3/4 network shares"
+DESCRIPTION="A FUSE module for mounting NFSv3/4 network shares
+Mounting an NFSv3 share can be done with:
+
+> mkdir /MyShare
+> mount -t userlandfs -o \"fuse-nfs -n nfs://server/MyShare -m /MyShare\" /MyShare
+
+Or to mount an NFSv4 share:
+
+> mkdir /MyShare
+> mount -t userlandfs -o \"fuse-nfs -n nfs://server/MyShare?version=4 -m /MyShare\" /MyShare
+
+Other options for the NFS URL can be found in the *libnfs* documentation."
+HOMEPAGE="https://github.com/sahlberg/fuse-nfs"
+COPYRIGHT="2013 Ronnie Sahlberg"
+LICENSE="GNU GPL v3"
+REVISION="1"
+srcGitRev="331e6fe5ea39d2353bbbe85e87b5850e4b144d9f"
+SOURCE_URI="https://github.com/sahlberg/fuse-nfs/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="5efff3db3ea5d9508f309bf5b27a3562b29c9a6f910b8f822ba43d26869a3dc8"
+PATCHES="fuse_nfs-$portVersion.patchset"
+SOURCE_DIR="fuse-nfs-$srcGitRev"
+
+ARCHITECTURES="?all ?x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
+
+PROVIDES="
+	fuse_nfs$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	userland_fs
+	lib:libnfs$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	docbook_xsl_stylesheets
+	userland_fs
+	devel:libnfs$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoheader
+	cmd:autoconf
+	cmd:automake
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:xsltproc
+	"
+
+BUILD()
+{
+	autoreconf -vfi
+
+	CFLAGS="-I/boot/system/develop/headers/userlandfs/fuse -DFUSE_USE_VERSION=26" \
+	LIBS="-lnetwork" \
+	runConfigure --omit-dirs binDir ./configure --bindir=$prefix/add-ons/userlandfs
+
+	XSLTPROC=/bin/xsltproc \
+	make $jobArgs
+}
+
+INSTALL()
+{
+	XSLTPROC=/bin/xsltproc \
+	make $jobArgs install
+
+	fixPkgconfig
+}

--- a/sys-fs/fuse-nfs/patches/fuse_nfs-1.0.0~git.patchset
+++ b/sys-fs/fuse-nfs/patches/fuse_nfs-1.0.0~git.patchset
@@ -1,0 +1,42 @@
+From c7ff1c9174ba6285e94c0266b7228fc8c484c136 Mon Sep 17 00:00:00 2001
+From: Chris Roberts <cpr420@gmail.com>
+Date: Tue, 16 Jan 2024 00:34:38 -0700
+Subject: Allow overriding XSLTPROC makefile variable
+
+
+diff --git a/doc/Makefile.am b/doc/Makefile.am
+index 8d7d340..d38859e 100644
+--- a/doc/Makefile.am
++++ b/doc/Makefile.am
+@@ -1,4 +1,4 @@
+-XSLTPROC = /usr/bin/xsltproc
++XSLTPROC ?= /usr/bin/xsltproc
+ 
+ EXTRA_DIST = fuse-nfs.1 fuse-nfs.xml
+ 
+-- 
+2.42.1
+
+
+From 3f6e081d27a353c2c7ef9fd8d44d05dc8d3b0af1 Mon Sep 17 00:00:00 2001
+From: Chris Roberts <cpr420@gmail.com>
+Date: Tue, 16 Jan 2024 00:35:32 -0700
+Subject: Add userlandfs_fuse to the library search list
+
+
+diff --git a/configure.ac b/configure.ac
+index 1301fed..dcf5139 100755
+--- a/configure.ac
++++ b/configure.ac
+@@ -47,7 +47,7 @@ if test x"$libiscsi_cv_HAVE_ST_ATIM" = x"yes"; then
+     AC_DEFINE(HAVE_ST_ATIM,1,[Whether we have st_atim support])
+ fi
+ 
+-AC_SEARCH_LIBS([fuse_get_context], [fuse dokanfuse1.dll dokanfuse2.dll], [], [
++AC_SEARCH_LIBS([fuse_get_context], [fuse userlandfs_fuse dokanfuse1.dll dokanfuse2.dll], [], [
+   AC_MSG_ERROR([fuse library unavailable])
+ ])
+ 
+-- 
+2.42.1
+


### PR DESCRIPTION
Mounting and listing files/directires works for NFSv3/NFSv4.

Copying files from an NFSv3 share causes an SMAP violation and stalls with NFSv4.

It doesn't seem possible to unmount a share.  Tracker doesn't give the option in the context menu and running `unmount` in a Terminal fails with a device busy message.