### PR TITLE
bash: updated recipe for bash 5.2.26

### DIFF
--- a/app-shells/bash/bash-5.2.026.recipe
+++ b/app-shells/bash/bash-5.2.026.recipe
@@ -5,7 +5,7 @@ incorporates useful features from the Korn and C shells (ksh and csh)."
 HOMEPAGE="https://www.gnu.org/software/bash/"
 COPYRIGHT="1987-2024 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://ftpmirror.gnu.org/bash/bash-5.2.tar.gz"
 for i in {001..026}; do
 	eval "SOURCE_URI_$i=\"https://ftpmirror.gnu.org/bash/bash-5.2-patches/bash52-$i#noarchive\""
@@ -84,7 +84,7 @@ GLOBAL_WRITABLE_FILES="settings/bashrc keep-old"
 PATCH()
 {
 	cd $sourceDir
-	for i in {001..015}; do
+	for i in {001..026}; do
 		echo "Applying patch $i..."
 		eval f=\$sourceDir$i/bash52-$i
 		sed -e "s|\.\./bash-5.1/||" "$f" | patch -p0


### PR DESCRIPTION
Fixed to apply additional patches for bash5.2.