### PR TITLE
minipro: new recipe

### DIFF
--- a/sci-electronics/minipro/minipro-0.6.recipe
+++ b/sci-electronics/minipro/minipro-0.6.recipe
@@ -1,0 +1,61 @@
+SUMMARY="An open source program for controlling the MiniPRO TL866xx programmers"
+DESCRIPTION="Minipro is an Open Source tool intended to become a complete cross-platform
+replacement for the proprietary utility from Autoelectric. Currently it
+supports more than 13000 of target devices - including AVRs, PICs as
+well as a huge number of other microcontrollers and various memory
+chips.
+"
+HOMEPAGE="https://gitlab.com/DavidGriffith/minipro"
+COPYRIGHT="2014-2024 David Griffith"
+LICENSE="GNU GPL v3"
+REVISION="1"
+SOURCE_URI="https://gitlab.com/DavidGriffith/minipro/-/archive/$portVersion/minipro-$portVersion.tar.gz"
+CHECKSUM_SHA256="16b4220b5fc07dddc4d1d49cc181a2c6a735c833cc27f24ab73eac2572c9304a"
+PATCHES="minipro-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+
+PROVIDES="
+	minipro = $portVersion
+	cmd:minipro = $portVersion
+	"
+REQUIRES="
+	haiku
+	lib:libusb_1.0
+	"
+
+PROVIDES_devel="
+	minipro_devel = $portVersion
+	devel:libminipro = $portVersion
+"
+REQUIRES_devel="$REQUIRES"
+
+BUILD_REQUIRES="
+	haiku_devel
+	devel:libusb_1.0
+	"
+
+BUILD_PREREQUIRES="
+	cmd:ar
+	cmd:cp
+	cmd:gcc
+	cmd:make
+	cmd:mkdir
+	cmd:pkg_config
+	cmd:ranlib
+	cmd:sed
+	"
+
+BUILD()
+{
+	DEST_DIR=$installDestDir PREFIX=$prefix SHARE_DIR=$relativeDataDir make $jobArgs
+	DEST_DIR=$installDestDir PREFIX=$prefix SHARE_DIR=$relativeDataDir make library $jobArgs
+}
+
+INSTALL()
+{
+	DEST_DIR=$installDestDir PREFIX=$prefix BIN_DIR=$relativeBinDir SHARE_DIR=$relativeDataDir MAN_DIR=$relativeManDir make install
+	DEST_DIR=$installDestDir PREFIX=$prefix LIB_DIR=$relativeDevelopLibDir INCLUDE_DIR=$relativeIncludeDir/libminipro make install_library
+
+	packageEntries devel $developDir
+}

--- a/sci-electronics/minipro/patches/minipro-0.6.patchset
+++ b/sci-electronics/minipro/patches/minipro-0.6.patchset
@@ -1,0 +1,62 @@
+From cf0c466939d5e6af78ecd766ca8f6459ebd64845 Mon Sep 17 00:00:00 2001
+From: Maxime Chretien <mchretien@linuxmail.org>
+Date: Wed, 24 Jan 2024 21:00:19 +0100
+Subject: Adapt Makefile for Haiku
+
+Signed-off-by: Maxime Chretien <mchretien@linuxmail.org>
+
+diff --git a/Makefile b/Makefile
+index f2eeeb4..2f7711b 100644
+--- a/Makefile
++++ b/Makefile
+@@ -24,7 +24,7 @@ MANDIR ?= $(PREFIX)/share/man
+ ##########################################################################
+ 
+ NAME = minipro
+-VERSION = 0.5
++VERSION = 0.6
+ 
+ # If we're working from git, we have access to proper variables. If
+ # not, make it clear that we're working from a release.
+@@ -67,12 +67,18 @@ LOGICIC=logicic.xml
+ TESTS=$(wildcard tests/test_*.c);
+ OBJCOPY=objcopy
+ 
++BIN_DIR ?= bin
++LIB_DIR ?= lib
++SHARE_DIR ?= share/minipro
++INCLUDE_DIR ?= include/libminipro
++MAN_DIR ?= share/man/man1
++
+ DIST_DIR = $(MINIPRO)-$(VERSION)
+-BIN_INSTDIR=$(DESTDIR)$(PREFIX)/bin
+-LIB_INSTDIR=$(DESTDIR)$(PREFIX)/lib
+-SHARE_INSTDIR=$(DESTDIR)$(PREFIX)/share/minipro
+-INCLUDE_INSTDIR=$(DESTDIR)$(PREFIX)/include/libminipro
+-MAN_INSTDIR=$(DESTDIR)$(PREFIX)/share/man/man1
++BIN_INSTDIR=$(DESTDIR)$(PREFIX)/$(BIN_DIR)
++LIB_INSTDIR=$(DESTDIR)$(PREFIX)/$(LIB_DIR)
++SHARE_INSTDIR=$(DESTDIR)$(PREFIX)/$(SHARE_DIR)
++INCLUDE_INSTDIR=$(DESTDIR)$(PREFIX)/$(INCLUDE_DIR)
++MAN_INSTDIR=$(DESTDIR)$(PREFIX)/$(MAN_DIR)
+ 
+ UDEV_DIR=$(shell $(PKG_CONFIG) --define-variable=prefix=$(PREFIX) --silence-errors --variable=udevdir udev)
+ UDEV_RULES_INSTDIR=$(DESTDIR)$(UDEV_DIR)/rules.d
+@@ -170,12 +176,10 @@ install_library:
+ 	cp $(STATIC_LIB) $(LIB_INSTDIR)/
+ 	cp *.h $(INCLUDE_INSTDIR)/
+ 	cp libminipro.pc $(LIB_INSTDIR)/pkgconfig/
+-	sed -e "s#MINIPROPREFIX#$(DESTDIR)$(PREFIX)#" -i "" "$(LIB_INSTDIR)/pkgconfig/libminipro.pc"
+-	sed -e "s#MINIPROVERSION#$(VERSION)#" -i "" "$(LIB_INSTDIR)/pkgconfig/libminipro.pc"
+-	ln -s "$(LIB_INSTDIR)/pkgconfig/libminipro.pc" /usr/local/lib/pkgconfig/libminipro.pc
++	sed -e "s#MINIPROPREFIX#$(DESTDIR)$(PREFIX)#" -i"" "$(LIB_INSTDIR)/pkgconfig/libminipro.pc"
++	sed -e "s#MINIPROVERSION#$(VERSION)#" -i"" "$(LIB_INSTDIR)/pkgconfig/libminipro.pc"
+ 
+ uninstall_library:
+-	rm /usr/local/lib/pkgconfig/libminipro.pc
+ 	rm -f $(LIB_INSTDIR)/pkgconfig/libminipro.pc
+ 	rm -f $(LIB_INSTDIR)/$(STATIC_LIB)
+ 	rm -f $(INCLUDE_INSTDIR)/*.h
+-- 
+2.42.1
+


### PR DESCRIPTION
Minipro is an open source software used to control Minipro TL866xxx MCU programmers/logic testers/... (Over 13000 supported chips).

Considering that it is a rather small program, I looked like a nice exercise to make my first recipe. I did my best to follow the documentation and it seems like files are at the right places after install, at least for my understanding.

I tested the basic functionalities of the program, especially the ones using the local data files and it seems to work fine so far.

There's a few things I'm not sure about:
 - Is there any way to support the bash completion files ? I didn't see anything that allows me to put them somewhere relevant.
 - I put `all !x86_gcc2` for the architectures. I believe this program should work everywhere since it only depends on `libusb` although I can only test it on x86_64 so far. As for `x86_gcc2`, I understood that it's only relevant for old BeOS apps, right ?

As I mentionned before, this is my first recipe and I'm also fairly new to Haiku so any feedback is welcome !