### PR TITLE
picard: bump version to 2.11

### DIFF
--- a/media-sound/picard/picard-2.11.recipe
+++ b/media-sound/picard/picard-2.11.recipe
@@ -9,12 +9,12 @@ identified by the actual music, even if they have no metadata.
 * Plugin support - If you need a particular feature, you can choose from a \
 selection of available plugins or write your own."
 HOMEPAGE="https://picard.musicbrainz.org/"
-COPYRIGHT="2004-2023 Robert Kaye, Lukas Lalinsky, Laurent Monin, \
+COPYRIGHT="2004-2024 Robert Kaye, Lukas Lalinsky, Laurent Monin, \
 Sambhav Kothari, Philipp Wolfer and others"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="ftp://ftp.eu.metabrainz.org/pub/musicbrainz/picard/picard-$portVersion.tar.gz"
-CHECKSUM_SHA256="5a97133e3549a81367c5128678237b0cb013f49ca8279ba88272a09a5cdc3939"
+CHECKSUM_SHA256="449a318a8834b2a81b83a5ad0f1e4c595fd16ef4ecce962eca8821279315f85e"
 SOURCE_DIR="picard-$portVersion"
 SOURCE_FILENAME="picard-$portVersion"
 ADDITIONAL_FILES="


### PR DESCRIPTION
New release, see https://blog.metabrainz.org/2024/01/25/picard-2-11-released/

Build and tested locally (64bit)