### PR TITLE
lagrange: bump to 1.17.6

### DIFF
--- a/net-misc/lagrange/lagrange-1.17.6.recipe
+++ b/net-misc/lagrange/lagrange-1.17.6.recipe
@@ -4,11 +4,11 @@ It offers modern conveniences familiar from web browsers, \
 such as smooth scrolling, inline image viewing, multiple tabs, \
 visual themes, Unicode fonts, bookmarks, history, and page outlines."
 HOMEPAGE="https://gmi.skyjake.fi/lagrange/"
-COPYRIGHT="2020-2023 Jaakko Keränen"
+COPYRIGHT="2020-2024 Jaakko Keränen"
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="https://github.com/skyjake/lagrange/releases/download/v$portVersion/lagrange-$portVersion.tar.gz"
-CHECKSUM_SHA256="cd0c4797e399082ccbf4d0ede939ef286b96863c31860f62387fd94275dda3ba"
+CHECKSUM_SHA256="b9d0982617fec495565ac9c09fb788a0be207d6fdf2324edc390e5cac8b1523b"
 SOURCE_DIR="lagrange-$portVersion"
 ADDITIONAL_FILES="lagrange.rdef.in"
 


### PR DESCRIPTION
[Changelog](https://github.com/skyjake/lagrange/releases)