### PR TITLE
openssl: added openssl 3.2.1 recipe

### DIFF
--- a/dev-libs/openssl/openssl-3.2.1.recipe
+++ b/dev-libs/openssl/openssl-3.2.1.recipe
@@ -1,0 +1,159 @@
+SUMMARY="Full-strength general purpose cryptography library (with SSL/TLS)"
+DESCRIPTION="The OpenSSL Project is a collaborative effort to develop a \
+robust, commercial-grade, full-featured, and Open Source toolkit implementing \
+the Secure Sockets Layer (SSL v2/v3) and Transport Layer Security (TLS v1) \
+protocols as well as a full-strength general purpose cryptography library. The \
+project is managed by a worldwide community of volunteers that use the \
+Internet to communicate, plan, and develop the OpenSSL toolkit and its related \
+documentation.
+OpenSSL is based on the excellent SSLeay library developed by Eric A. Young \
+and Tim J. Hudson. The OpenSSL toolkit is licensed under an Apache-style \
+licence, which basically means that you are free to get and use it for \
+commercial and non-commercial purposes subject to some simple license \
+conditions."
+HOMEPAGE="https://www.openssl.org/"
+COPYRIGHT="1995-1998 Eric Young
+	1998-2024 The OpenSSL Project"
+LICENSE="OpenSSL"
+REVISION="1"
+SOURCE_URI="https://www.openssl.org/source/openssl-$portVersion.tar.gz"
+CHECKSUM_SHA256="83c7329fe52c850677d75e5d0b0ca245309b97e8ecbcfdc1dfdc4ab9fac35b39"
+SOURCE_DIR="openssl-$portVersion"
+
+ARCHITECTURES="?all"
+SECONDARY_ARCHITECTURES="?x86"
+
+libVersion=3
+cmdSuffix=""
+mySuffix=
+altSuffix=3.2.1
+
+PROVIDES="
+	openssl$mySuffix$secondaryArchSuffix = $portVersion compat >= 3
+	lib:libcrypto$secondaryArchSuffix = $libVersion compat >= $libVersion
+	lib:libssl$secondaryArchSuffix = $libVersion compat >= $libVersion
+	"
+if [ -z "$secondaryArchSuffix" ]; then
+	PROVIDES="$PROVIDES
+		cmd:c_rehash${cmdSuffix/-/_} = $portVersion compat >= 3
+		cmd:openssl${cmdSuffix/-/_} = $portVersion compat >= 3
+		"
+fi
+
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix >= 1.2.3
+	ca_root_certificates
+	"
+
+if [ -z "$secondaryArchSuffix" ]; then
+	SUMMARY_man="Manual pages for openssl $portVersion"
+	ARCHITECTURES_man="any"
+	PROVIDES_man="
+		openssl${mySuffix}_man = $portVersion
+		"
+	REQUIRES_man="
+		openssl$mySuffix == $portVersion
+		"
+	SUPPLEMENTS_man="
+		openssl$mySuffix == $portVersion
+		"
+	CONFLICTS_man="
+		openssl${altSuffix}_man
+		"
+fi
+
+PROVIDES_devel="
+	openssl$mySuffix${secondaryArchSuffix}_devel = $portVersion
+	devel:libcrypto$secondaryArchSuffix = $libVersion compat >= $libVersion
+	devel:libssl$secondaryArchSuffix = $libVersion compat >= $libVersion
+	"
+REQUIRES_devel="
+	openssl$mySuffix$secondaryArchSuffix == $portVersion base
+	"
+CONFLICTS_devel="
+	openssl$altSuffix${secondaryArchSuffix}_devel
+	"
+
+BUILD_REQUIRES="
+	devel:libz$secondaryArchSuffix >= 1.2.3
+	"
+BUILD_PREREQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	cmd:awk
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:perl >= 5
+	cmd:sed
+	"
+
+if [ -n "$secondaryArchSuffix" ]; then
+	maybe_binDir_runtimes=
+else
+	maybe_binDir_runtimes="
+		$binDir/openssl$cmdSuffix \
+		"
+fi
+defineDebugInfoPackage openssl$mySuffix$secondaryArchSuffix \
+	$libDir/libcrypto.so.$libVersion \
+	$libDir/libssl.so.$libVersion \
+	$maybe_binDir_runtimes
+
+BUILD()
+{
+	./config --prefix=$prefix --libdir=$relativeLibDir \
+		--openssldir=$dataRootDir/ssl \
+		shared no-zlib no-ssl3 no-asm -g
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make MANDIR=$manDir DOCDIR=$docDir install
+
+	# move include dir to correct location
+	mkdir -p $(dirname $includeDir)
+	mv $prefix/include $includeDir
+
+	# remove static libraries
+	rm $libDir/*.a
+
+	# prepare develop/lib
+	prepareInstalledDevelLibs libcrypto libssl
+	fixPkgconfig
+
+	if [ -n "$secondaryArchSuffix" ]; then
+		maybe_docDir_html_man3=
+		maybe_manDir_man3=
+	else
+		maybe_docDir_html_man3=$docDir/html/man3
+		maybe_manDir_man3=$manDir/man3
+	fi
+
+	# devel package
+	packageEntries devel \
+		$developDir \
+		$maybe_docDir_html_man3 \
+		$maybe_manDir_man3
+
+	# Remove stuff we don't need in the secondary architecture base package
+	if [ -n "$secondaryArchSuffix" ]; then
+		rm -rf $prefix/bin
+		rm -rf $dataRootDir/ssl
+		rm -rf $documentationDir
+	else
+		if [ -n "$cmdSuffix" ]; then
+			mv $binDir/openssl $binDir/openssl$cmdSuffix
+			mv $binDir/c_rehash $binDir/c_rehash$cmdSuffix
+		fi
+		# man package
+		packageEntries man \
+			$manDir
+	fi
+}
+
+TEST()
+{
+	make test
+}


### PR DESCRIPTION
Tested and built on Haiku R1B4 x64.

NOTE: Disabled. Await for Haiku R1B5 review. Await full Haikuports integration review (await for Haiku R1B5/OpenSSL 1.1.1 compatibility checks/review). Feel free to help on any further Haiku R1B5 integration patching. 

OpenSSL 3.2.1 is backward compatible with OpenSSL 3.2.0 and OpenSSL 3.1.0, but not with OpenSSL 1.1.1. OpenSSL versions before 1.1.1 are out of support and no longer receiving updates.

OpenSSL 3.2.1 support ends on Nov 2025. OpenSSL 1.1.1 support ended as of Sept 2023.

See: https://dev.haiku-os.org/ticket/18581
See: https://www.openssl.org/docs/man3.1/man7/migration_guide.html
