### PR TITLE
Add QBE Compiler Backend port

### DIFF
--- a/dev-lang/qbe/qbe-1.1.recipe
+++ b/dev-lang/qbe/qbe-1.1.recipe
@@ -1,0 +1,43 @@
+SUMMARY="A small compiler backend"
+DESCRIPTION="QBE is a compiler backend that aims to provide 70% of the \
+performance of industrial optimizing compilers in 10% of the code. QBE \
+fosters language innovation by offering a compact user-friendly and \
+performant backend. The size limit constrains QBE to focus on the essential \
+and prevents embarking on a never-ending path of diminishing returns."
+HOMEPAGE="http://c9x.me/compile/"
+COPYRIGHT="2015-2023 Quentin Carbonneaux"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="http://c9x.me/compile/release/qbe-1.1.tar.xz"
+CHECKSUM_SHA256="7d0a53dd40df48072aae317e11ddde15d1a980673160e514e235b9ecaa1db12c"
+
+ARCHITECTURES="all !x86_gcc2"
+
+PROVIDES="
+	qbe = $portVersion
+	cmd:qbe
+	"
+REQUIRES="
+	haiku
+	"
+
+BUILD_PREREQUIRES="
+	haiku_devel
+	cmd:gcc
+	cmd:make
+	"
+
+BUILD()
+{
+	make $jobArgs CC=cc
+}
+
+INSTALL()
+{
+	mkdir -p $docDir
+	cp -r $sourceDir/doc/* $docDir/
+
+	mkdir -p $binDir
+	cp $sourceDir/qbe $binDir/
+}
+


### PR DESCRIPTION
A neat tool to aid in programming language development. Package consists of one executable and several documentation files. Tested and works under Haiku x86_64 on hrev56578+95.

Since this tool only supports 64-bit architechtures (amd64, arm64, rv64) I have disabled secondary architechtures alltogether.