### PR TITLE
libvisio, switch to icu74

### DIFF
--- a/media-libs/libvisio/libvisio-0.1.7.recipe
+++ b/media-libs/libvisio/libvisio-0.1.7.recipe
@@ -7,7 +7,7 @@ COPYRIGHT="Fridrich Strba
 	Eilidh McAdam
 	David Tardon"
 LICENSE="MPL v2.0"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="http://dev-www.libreoffice.org/src/libvisio/libvisio-$portVersion.tar.xz"
 CHECKSUM_SHA256="8faf8df870cb27b09a787a1959d6c646faa44d0d8ab151883df408b7166bea4c"
 
@@ -43,7 +43,7 @@ PROVIDES_devel="
 	"
 REQUIRES_devel="
 	libvisio$secondaryArchSuffix == $portVersion base
-	devel:libicui18n$secondaryArchSuffix >= 66
+	devel:libicui18n$secondaryArchSuffix >= 74
 	devel:libxml2$secondaryArchSuffix
 	"
 
@@ -51,9 +51,9 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libboost_system$secondaryArchSuffix >= 1.83.0
 	devel:libcppunit$secondaryArchSuffix
-	devel:libicudata$secondaryArchSuffix >= 66
-	devel:libicui18n$secondaryArchSuffix >= 66
-	devel:libicuuc$secondaryArchSuffix >= 66
+	devel:libicudata$secondaryArchSuffix >= 74
+	devel:libicui18n$secondaryArchSuffix >= 74
+	devel:libicuuc$secondaryArchSuffix >= 74
 	devel:librevenge_0.0$secondaryArchSuffix
 	devel:librevenge_generators_0.0$secondaryArchSuffix
 	devel:librevenge_stream_0.0$secondaryArchSuffix


### PR DESCRIPTION
Looked like a rebuild for scribus still wanted to pull in the icu66 devel package, hence bumping icu version here.