### PR TITLE
grcompiler, drop recipe, no updates after icu66

### DIFF
--- a/app-text/grcompiler/grcompiler-5.2.1.recipe
+++ b/app-text/grcompiler/grcompiler-5.2.1.recipe
@@ -14,8 +14,8 @@ SOURCE_URI="https://github.com/silnrsi/grcompiler/archive/refs/tags/v$portVersio
 SOURCE_FILENAME="grcompiler-$portVersion.tar.gz"
 CHECKSUM_SHA256="a125e9d2746638a538e59af8ece2268fda078572f50e82f82d6f95ccb08ed890"
 
-ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="?all !x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
 
 commandBinDir=$binDir
 commandSuffix=$secondaryArchSuffix


### PR DESCRIPTION
Can't be build with newer ICU version, no activity upstream for 3 years, repology doesn't give lot's of hits for it anymore.
If no one is using it I guess it's safe to drop it.