### PR TITLE
noto: add recipe for version 24.2.1

### DIFF
--- a/media-fonts/noto/noto-20240201.recipe
+++ b/media-fonts/noto/noto-20240201.recipe
@@ -1,0 +1,90 @@
+SUMMARY="The Noto font"
+DESCRIPTION="The Noto fonts have superseded the Droid fonts, which were \
+originally designed for the use in Google's Android. Noto's aim is to be a \
+free for everyone, with beautiful glyphs for all languages, looking good \
+especially when multiple styles and weights and even languages are mixed on \
+a page.
+
+This package contains the 'sans-serif' and 'serif' typefaces in various \
+styles for the latin, cyrillic and thai alphabets, as well as a 'monospaced' \
+version. Also included is an unhinted 'symbols' font."
+
+SUMMARY_condensed="The Noto font (condensed variants)"
+DESCRIPTION_condensed="The Noto fonts have superseded the Droid fonts, which \
+were originally designed for the use in Google's Android. Noto's aim is to be \
+a free for everyone, with beautiful glyphs for all languages, looking good \
+especially when multiple styles and weights and even languages are mixed on \
+a page.
+
+This package contains the condensed variants of the core Noto fonts."
+
+SUMMARY_regional="The Noto font (special language/region version)"
+DESCRIPTION_regional="The Noto fonts have superseded the Droid fonts, \
+which were originally designed for the use in Google's Android. \
+Noto's aim is to be a free for everyone, \
+with beautiful glyphs for all languages, looking good \
+especially when multiple styles and weights and even languages are mixed on \
+a page.
+
+This package contains the Noto fonts ('sans-serif' and where applicable \
+'serif') for:
+
+Arabic, Armenian
+Bengali
+Cham
+Devanagari
+Ethiopic
+Georgian, Gujarati, Gurmukhi
+Hebrew, Hindi
+Kannada, Khmer
+Lao
+Malayalam, Myanmar
+Oriya
+Sinhala
+Tamil, Telugu, Thaana, Tibetan"
+HOMEPAGE="https://fonts.google.com/noto/"
+COPYRIGHT="2015-2020 Google Inc.
+2014, 2015 Adobe Systems Incorporated (http://www.adobe.com/)"
+LICENSE="SIL Open Font License v1.1"
+REVISION="1"
+notoVersion="24.2.1"
+SOURCE_URI="https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-${notoVersion}.tar.gz#noarchive"
+CHECKSUM_SHA256="1ddeec924765a925dce1adc01599d6ebbf2aff48f6b339624734b370a807e01e"
+SOURCE_URI_2="https://github.com/notofonts/NotoSansDisplay/archive/main.tar.gz"
+CHECKSUM_SHA256_2="9b306273e585b3854db8f182760a9a6e4cb5af97e17d0430fe44963a15cb5700"
+
+ARCHITECTURES="any"
+DISABLE_SOURCE_PACKAGE="yes"
+
+PROVIDES="
+	noto = $portVersion
+	"
+
+PROVIDES_condensed="
+	noto_condensed = $portVersion
+	"
+
+PROVIDES_regional="
+	noto_regional = $portVersion
+	"
+
+# Enable bash extended globbing to more easily exclude non-regional fonts from
+# the regional package.
+shopt -s extglob
+
+INSTALL()
+{
+	FONTDIR=$fontsDir/ttfonts
+	mkdir -p $FONTDIR
+
+	cp $sourceDir2/NotoSansDisplay-main/fonts/ttf/hinted/instance_ttf/*.ttf $FONTDIR
+	tar xvf noto-monthly-release-${notoVersion}.tar.gz -C $FONTDIR --wildcards --transform='s/.*\///' \
+		notofonts.github.io-noto-monthly-release-${notoVersion}/fonts/*/hinted/ttf/*.ttf
+	rm -f $FONTDIR/*UI*.ttf
+
+	packageEntries condensed \
+		${FONTDIR}/*Condensed*.ttf
+
+	packageEntries regional \
+		${FONTDIR}/Noto!(*Display*.ttf|Sans-*.ttf|SansMono-*.ttf|Serif-*.ttf|*Symbols*.ttf|SansThai-*.ttf|SerifThai-*.ttf)
+}


### PR DESCRIPTION
The default display font in Haiku, the Noto Sans Display variant, is no more.

As a consequence, when testing, the default font switched to Noto Sans Thai.