### PR TITLE
python3.10: fix builds on nightlies that include kqueue.

### DIFF
--- a/dev-lang/python/patches/python3.10-3.10.13.patchset
+++ b/dev-lang/python/patches/python3.10-3.10.13.patchset
@@ -1,4 +1,4 @@
-From 598e5d2dfeb8e3d250d8b00194a824e12dcccb35 Mon Sep 17 00:00:00 2001
+From 4781398b4c191430fcdaa68b234e3923125973ab Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Thu, 10 Apr 2014 16:03:33 +0000
 Subject: initial Haiku patch
@@ -582,7 +582,7 @@ index a39610a..d928e3a 100644
 2.42.1
 
 
-From 9ebccc4de6a9e09034e372b51fbc44bd48a26f64 Mon Sep 17 00:00:00 2001
+From b51d29f667d2ad9ab68ffb81358f0e136590927d Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sun, 16 Apr 2017 10:05:42 +0200
 Subject: fix for negative errnos
@@ -620,7 +620,7 @@ index b852ad7..60d4a6e 100644
 2.42.1
 
 
-From 977ed8c19438909b0385edeec5c48a12bcbe4102 Mon Sep 17 00:00:00 2001
+From e77b7776a9946759441decd6ef9b1a2acc4f4ed5 Mon Sep 17 00:00:00 2001
 From: Philippe Houdoin <philippe.houdoin@gmail.com>
 Date: Wed, 24 May 2017 11:09:43 +0000
 Subject: Implement CTypes's find_library for Haiku
@@ -704,7 +704,7 @@ index 0c2510e..2b4f04c 100644
 2.42.1
 
 
-From eef795641d2a68c943b9e5abf8e62a70ad101a3c Mon Sep 17 00:00:00 2001
+From e586cbdf3f65e55fc41d243f1f0fa10371e77f1f Mon Sep 17 00:00:00 2001
 From: Philipp Wolfer <phil@parolu.io>
 Date: Mon, 23 Sep 2019 09:14:58 +0200
 Subject: webbrowser: Support for default browsers on Haiku
@@ -730,7 +730,7 @@ index ec3cece..6a29d2a 100755
 2.42.1
 
 
-From 3e23ccf91881f202e4fc4717c5c349bdc533ef14 Mon Sep 17 00:00:00 2001
+From 7e20a6702a95b6563f89f85e498a38101bb00fcc Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 4 Oct 2019 22:02:35 +0200
 Subject: since 3.8, don't reinit locks on fork.
@@ -753,7 +753,7 @@ index d1d4333..bfe60ca 100644
 2.42.1
 
 
-From 4d3693962cbca9ec7b1119bcbc8dbd68c1f9f309 Mon Sep 17 00:00:00 2001
+From 6fdcf566f78f6f45dce16e3d096622bf1700ed52 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 15 May 2020 15:20:57 +0200
 Subject: handle errors returned by internal_connect()
@@ -786,7 +786,7 @@ index e104107..383ba52 100644
 2.42.1
 
 
-From 927a26f7c664ba17cf04eb2eb2b42612fa2444b2 Mon Sep 17 00:00:00 2001
+From a5e977b94263d2e4eaef9af5ecb369c048a1c0b3 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Mon, 19 Oct 2020 18:03:09 +0200
 Subject: ttyname_r can use MAXPATHLEN
@@ -816,7 +816,7 @@ index c0421a9..ace1449 100644
 2.42.1
 
 
-From 848dd6f0cb1d55919fbe51242b90a6f975cac74b Mon Sep 17 00:00:00 2001
+From 3cf1b4ca1040bb0bfa3133312955da2aa8b71a6e Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 21 Oct 2022 19:58:50 -0300
 Subject: Lib/test: require the "largefile" usage flag for I/O heavy tests.
@@ -869,7 +869,7 @@ index 8f34c18..999063f 100644
 2.42.1
 
 
-From 78e3c80c060fad784dba7b612cfe28cde4fe2c3e Mon Sep 17 00:00:00 2001
+From 21de43bde7cf895f01108bda42a927e9539c0f25 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Tue, 7 Mar 2023 18:29:29 +0100
 Subject: default schemes for Haiku
@@ -956,7 +956,7 @@ index 4f92119..919d883 100644
 2.42.1
 
 
-From 0c23a702cdbe778d4e439780d58c3135f4310a07 Mon Sep 17 00:00:00 2001
+From 7f34f1d66bc5045f56b1e92d17c7505dd83ba229 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 10 Mar 2023 20:15:14 -0300
 Subject: syncronize both _getuserbase() copies on site.py and sysconfig.py.
@@ -985,7 +985,7 @@ index 919d883..c306d43 100644
 2.42.1
 
 
-From f20581bcb04343ad9c3587c81cdb3fa4ab0be68b Mon Sep 17 00:00:00 2001
+From 97fdcd74f0beede67fa3c1e811ad4134ff25ef68 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sat, 27 Jan 2024 08:14:52 -0300
 Subject: Apply gh-109191 from Python upstream.
@@ -1074,6 +1074,72 @@ index 57c84e5..6d4f5fc 100644
  /* Define if you have readline 2.2 */
  #undef HAVE_RL_COMPLETION_APPEND_CHARACTER
  
+-- 
+2.42.1
+
+
+From 70238524a2232164abfc759364c37c107d3d0854 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Sat, 10 Feb 2024 06:01:25 -0300
+Subject: Fix build on nightlies, following the addition of kqueue.
+
+Together with the patch for gh-109191, fixes HaikuPorts issue #10001.
+
+diff --git a/Modules/selectmodule.c b/Modules/selectmodule.c
+index 3afcb0e..900b2a0 100644
+--- a/Modules/selectmodule.c
++++ b/Modules/selectmodule.c
+@@ -2570,13 +2570,20 @@ _select_exec(PyObject *m)
+ #ifdef EVFILT_SIGNAL
+     PyModule_AddIntConstant(m, "KQ_FILTER_SIGNAL", EVFILT_SIGNAL);
+ #endif
++#ifdef EVFILT_TIMER
+     PyModule_AddIntConstant(m, "KQ_FILTER_TIMER", EVFILT_TIMER);
+-
++#endif
+     /* event flags */
+     PyModule_AddIntConstant(m, "KQ_EV_ADD", EV_ADD);
+     PyModule_AddIntConstant(m, "KQ_EV_DELETE", EV_DELETE);
++#ifdef EV_ENABLE
+     PyModule_AddIntConstant(m, "KQ_EV_ENABLE", EV_ENABLE);
++#else
++    PyModule_AddIntConstant(m, "KQ_EV_ENABLE", 0); // "test_kqueue.py" assumes KQ_EV_ENABLE exists
++#endif
++#ifdef EV_DISABLE
+     PyModule_AddIntConstant(m, "KQ_EV_DISABLE", EV_DISABLE);
++#endif
+     PyModule_AddIntConstant(m, "KQ_EV_ONESHOT", EV_ONESHOT);
+     PyModule_AddIntConstant(m, "KQ_EV_CLEAR", EV_CLEAR);
+ 
+@@ -2609,14 +2616,28 @@ _select_exec(PyObject *m)
+     /* PROC filter flags  */
+ #ifdef EVFILT_PROC
+     PyModule_AddIntConstant(m, "KQ_NOTE_EXIT", NOTE_EXIT);
++#ifdef NOTE_FORK
+     PyModule_AddIntConstant(m, "KQ_NOTE_FORK", NOTE_FORK);
++#endif
++#ifdef NOTE_EXEC
+     PyModule_AddIntConstant(m, "KQ_NOTE_EXEC", NOTE_EXEC);
++#endif
++#ifdef NOTE_PCTRLMASK
+     PyModule_AddIntConstant(m, "KQ_NOTE_PCTRLMASK", NOTE_PCTRLMASK);
++#endif
++#ifdef NOTE_PDATAMASK
+     PyModule_AddIntConstant(m, "KQ_NOTE_PDATAMASK", NOTE_PDATAMASK);
++#endif
+ 
++#ifdef NOTE_TRACK
+     PyModule_AddIntConstant(m, "KQ_NOTE_TRACK", NOTE_TRACK);
++#endif
++#ifdef NOTE_CHILD
+     PyModule_AddIntConstant(m, "KQ_NOTE_CHILD", NOTE_CHILD);
++#endif
++#ifdef NOTE_TRACKERR
+     PyModule_AddIntConstant(m, "KQ_NOTE_TRACKERR", NOTE_TRACKERR);
++#endif
+ #endif
+ 
+     /* NETDEV filter flags */
 -- 
 2.42.1
 

--- a/dev-lang/python/python3.10-3.10.13.recipe
+++ b/dev-lang/python/python3.10-3.10.13.recipe
@@ -2,14 +2,16 @@ SUMMARY="An interpreted, interactive, object-oriented programming language"
 DESCRIPTION="Python is a programming language that lets you work more quickly \
 and integrate your systems more effectively. You can learn to use Python and \
 see almost immediate gains in productivity and lower maintenance costs.
+
 Python runs on Windows, Linux/Unix, Mac OS X, and has been ported to the Java \
 and .NET virtual machines.
+
 Python is free to use, even for commercial products, because of its \
 OSI-approved open source license."
 HOMEPAGE="https://www.python.org"
 LICENSE="Python"
 COPYRIGHT="1990-2023 Python Software Foundation"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://www.python.org/ftp/python/$portVersion/Python-$portVersion.tar.xz"
 CHECKSUM_SHA256="5c88848668640d3e152b35b4536ef1c23b2ca4bd2c957ef1ecbb053f571dd3f6"
 SOURCE_DIR="Python-$portVersion"
@@ -76,13 +78,13 @@ REPLACES="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libbz2$secondaryArchSuffix
+	devel:libedit$secondaryArchSuffix
 	devel:libexpat$secondaryArchSuffix
 	devel:libffi$secondaryArchSuffix
 	devel:liblzma$secondaryArchSuffix
 	devel:libncurses$secondaryArchSuffix
-	devel:libssl$secondaryArchSuffix
-	devel:libedit$secondaryArchSuffix
 	devel:libsqlite3$secondaryArchSuffix
+	devel:libssl$secondaryArchSuffix
 	devel:libtclstub8.6$secondaryArchSuffix
 	devel:libtk8.6$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
@@ -95,8 +97,8 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
 	cmd:libtoolize$secondaryArchSuffix
-	cmd:pkg_config$secondaryArchSuffix
 	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
 	"
 
 BUILD()
@@ -171,10 +173,9 @@ INSTALL()
 # the following lines in the file "~/config/settings/system/debug_server/settings":
 ##---
 # executable_actions {
-#	/sources/Python-$portVersion/python kill
+#	/sources/Python-3*/python kill
 # }
 ##---
-# Replace $portVersion as necessary.
 
 # For some tests that purposefully crash, it would make sense to add support for
 # crash-report suppression (as done for other platforms) on "tests/support/__init__,py"'s
@@ -182,81 +183,93 @@ INSTALL()
 # But that needs support from Haiku's debug_server, as we can't change settings from
 # the recipe's building environment at the moment (https://dev.haiku-os.org/ticket/10301)
 
+# For reference, tests results on hrev57578 (x64): 351 tests OK. 30 tests failed. 19 tests skipped.
 TEST()
 {
 	# Remove tests data left-overs, if any
 	rm -f -r /boot/system/cache/tmp/
 	rm -f -d -r build/test_python*
 
-	cd Lib/test
+	local test_options=(
+		# Use this to get same test order on different runs (actual value not important).
+		--randseed 8668208
 
-	# distutils is deprecated, and will be removed on 3.12.
-	rm -f test_distutils.py
+		# Possibly useful?
+		# --tempdir=/another_drive/tmp
 
-	# The following tests invoke the crash dialog, and unless your configure
-	# debug_server default action to "kill" or "report", they will hang waiting for
-	# user input. See comment above TEST().
-	rm -f test_asyncio/test_futures.py # Crashes: Exception (Segment violation)
-	rm -f test_faulthandler.py
-	rm -f test_subprocess.py # tends to hang.
-	rm -f test_threading.py # tends to hang.
+		# Enable/disable certain tests by "resource" type:
+		# -uall,-audio,-cpu,-curses,-decimal,-gui,-largefile,-network,-subprocess,-tzdata,-urlfetch
 
-	# Many of the tests hang/stall. We have two options:
-	#
-	# 1- Manually remove the problematic test-cases.
-	# 2- Set a TIMEOUT.
-	#
-	# Option 1: Works, but requires manual identification/mainteinance.
-	#
-	# Option 2: Doesn't requires maintaining a list of stalling tests, but:
-	# - Causes errors at the end of the run:
-	#	"unmounting failed: Device/File/Resource Busy"
-	# - Leaves dangling threads running when the tests timeout:
-	#	"Warning -- threading_cleanup() failed to cleanup 0 threads (count: 0, dangling: 2)"
-	# - The time it takes to run the full suite goes from 14 to 30+ minutes,
-	#
-	# For Option 2, use: export EXTRATESTOPTS="--timeout=300"
-	# before calling "make $jobArgs test".
-	#
-	# Let's use Option 1, for now at least:
+		# distutils is deprecated, and will be removed on 3.12.
+		-x test_distutils
 
-	# These hang reliably.
-	# You might want then to manually restore them on re-runs, use:
-	# > git checkout -- Lib/test/
-	rm -f test__xxsubinterpreters.py
-	rm -f test_asynchat.py
-	rm -f test_concurrent_futures.py
-	rm -f test_importlib/test_threaded_import.py
-	rm -f test_interpreters.py
-	rm -f test_multiprocessing_fork.py
-	rm -f test_multiprocessing_forkserver.py
-	rm -f test_multiprocessing_main_handling.py
-	rm -f test_multiprocessing_spawn.py
-	rm -f test_multiprocessing.py
-	rm -f test_socketserver.py
+		# The following tests invoke the crash dialog, and unless your configure
+		# debug_server default action to "kill" or "report", they will hang waiting for
+		# user input. See comment above TEST().
+		-x test_faulthandler
+		-x test_futures # from test_asyncio. Crashes: Exception (Segment violation)
+		-x test_subprocess # tends to hang.
+		-x test_threading # tends to hang.
 
-	# "test_asyncio" doesn't seems to runs reliably, even after individually skipping
-	# all the problematic test-cases that could be identify by running them one by one.
-	rm -f -r test_asyncio
-#	rm -f test_asyncio/test_base_events.py
-#	rm -f test_asyncio/test_buffered_proto.py # Exception on Exception handler.
-#	rm -f test_asyncio/test_events.py
-#	rm -f test_asyncio/test_sendfile.py
-#	rm -f test_asyncio/test_server.py # Exception on Exception handler.
-#	rm -f test_asyncio/test_sslproto.py # Exception on Exception handler.
-#	rm -f test_asyncio/test_streams.py
+		# Many of the tests hang/stall. We have two options:
+		#
+		# 1- Manually remove the problematic test-cases.
+		# 2- Set a TIMEOUT.
+		#
+		# Option 1: Works, but requires manual identification/mainteinance.
+		#
+		# Option 2: Doesn't requires maintaining a list of stalling tests, but:
+		# - Causes errors at the end of the run:
+		#	"unmounting failed: Device/File/Resource Busy"
+		# - Leaves dangling threads running when the tests timeout:
+		#	"Warning -- threading_cleanup() failed to cleanup 0 threads (count: 0, dangling: 2)"
+		# - The time it takes to run the full suite goes from 14 to 30+ minutes,
+		#
+		# For Option 2, use: export EXTRATESTOPTS="--timeout=300"
+		# before calling "make $jobArgs test".
+		#
+		# Let's use Option 1, for now at least:
 
-	# These not always hang/stall, but they do it enough to warrant skipping for now.
-	rm -f test_imaplib.py
-	rm -f test_signal.py
-	rm -f test_socket.py
-	rm -f test_ssl.py
-	rm -f test_urllib2_localnet.py
+		# These hang reliably.
+		-x test__xxsubinterpreters
+		-x test_asynchat
+		-x test_concurrent_futures
+		-x test_interpreters
+		-x test_multiprocessing
+		-x test_multiprocessing_fork
+		-x test_multiprocessing_forkserver
+		-x test_multiprocessing_main_handling
+		-x test_multiprocessing_spawn
+		-x test_socketserver
+		-x test_threaded_import # test_importlib/test_threaded_import
 
-	cd ../..
+		# "test_asyncio" doesn't seems to runs reliably, even after individually skipping
+		# all the problematic test-cases that could be identify by running them one by one.
+		-x test_asyncio
+		# -x test_asyncio/test_base_events
+		# -x test_asyncio/test_buffered_proto # Exception on Exception handler.
+		# -x test_asyncio/test_events
+		# -x test_asyncio/test_sendfile
+		# -x test_asyncio/test_server # Exception on Exception handler.
+		# -x test_asyncio/test_sslproto # Exception on Exception handler.
+		# -x test_asyncio/test_streams
 
-	# These allows to change what resources tests can use:
-	# export EXTRATESTOPTS="-uall,-largefile,-audio,-gui,-network,-cpu,-urlfetch,-tzdata"
+		# These not always hang/stall, but they do it enough to warrant skipping for now.
+		-x test_imaplib
+		-x test_signal
+		-x test_socket
+		-x test_ssl
+		-x test_urllib2_localnet
+
+		# Hang on nightlies
+		-x test_httplib
+		-x test_httpservers
+		-x test_logging
+		-x test_xmlrpc
+	)
+
+	local -x LOGNAME=buildbot # this skips tests_tools/test_freeze, copied from Gentoo's ebuild
+	make $jobArgs test EXTRATESTOPTS="${test_options[*]}"
 
 	# Occasionally, some test fails seemingly due to the racy nature of tempfile.mktemp().
 	# Even the help for that function says to NOT use it, but some tests still do.
@@ -264,5 +277,4 @@ TEST()
 	# If you find some strange "æ" suffix on temp dirnames, ej:
 	#    "cwd: /sources/Python-3.10.12/build/test_python_10324æ"
 	# That's due to usages of os_helper.FS_NONASCII.
-	make $jobArgs test
 }


### PR DESCRIPTION
Fixes #10001 (for 3.10 at least, rest of the versions will come later :-D)

Also:
- Use same way of excluding tests as in 3.11/3.12.
- Disable some more tests that hang reliably.


(built and `hp --test`ed on both hrev57578, and on beta4, both 64 bits)

Thanks a bunch to @korli for his guidance on how to address his one.