### PR TITLE
caffe, remove reference to python2.7

### DIFF
--- a/dev-libs/caffe/caffe-1.0.recipe
+++ b/dev-libs/caffe/caffe-1.0.recipe
@@ -103,7 +103,6 @@ BUILD_PREREQUIRES="
 #	cmd:f2py3
 	cmd:ld$secondaryArchSuffix
 	cmd:make
-#	cmd:python2
 #	cmd:python3
 	"
 


### PR DESCRIPTION
No need for rebuilding.