### PR TITLE
jasper: updated to version 2.0.33 for x86/x64

### DIFF
--- a/media-libs/jasper/jasper-2.0.33.recipe
+++ b/media-libs/jasper/jasper-2.0.33.recipe
@@ -1,0 +1,115 @@
+SUMMARY="Implementation of the codec specified in the JPEG-2000 Part-1 standard"
+DESCRIPTION="The JasPer Project is an open-source initiative to provide a \
+free software-based reference implementation of the codec specified in the \
+JPEG-2000 Part-1 standard. More details about this software can be found in \
+the JasPer Software Reference Manual."
+HOMEPAGE="http://www.ece.uvic.ca/~frodo/jasper/"
+COPYRIGHT="1999-2021 Michael D. Adams"
+LICENSE="JasPer v2"
+REVISION="1"
+SOURCE_URI="https://github.com/mdadams/jasper/archive/version-$portVersion.tar.gz"
+CHECKSUM_SHA256="38b8f74565ee9e7fec44657e69adb5c9b2a966ca5947ced5717cde18a7d2eca6"
+SOURCE_DIR="jasper-version-$portVersion"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="4.0.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	jasper$secondaryArchSuffix = $portVersion
+	lib:libjasper$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libjpeg$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	jasper${secondaryArchSuffix}_devel = $portVersion
+	devel:libjasper$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	jasper$secondaryArchSuffix == $portVersion base
+	"
+
+if [ -z "$secondaryArchSuffix" ]; then
+	SUMMARY_tools="The jasper tools"
+	PROVIDES_tools="
+		jasper${secondaryArchSuffix}_tools = $portVersion
+		cmd:imgcmp$secondaryArchSuffix = $portVersion
+		cmd:imginfo$secondaryArchSuffix = $portVersion
+		cmd:jasper$secondaryArchSuffix = $portVersion
+		cmd:jiv$secondaryArchSuffix = $portVersion
+		"
+	REQUIRES_tools="
+		jasper$secondaryArchSuffix == $portVersion base
+		haiku$secondaryArchSuffix
+		lib:libGL$secondaryArchSuffix
+		lib:libglu$secondaryArchSuffix
+		lib:libjpeg$secondaryArchSuffix
+		"
+fi
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libGL$secondaryArchSuffix
+	devel:libglu$secondaryArchSuffix
+	devel:libjpeg$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+TEST_REQUIRES="
+	cmd:awk
+	"
+
+BUILD()
+{
+	cmake -Bbuild -S. -DCMAKE_BUILD_TYPE=Release \
+		$cmakeDirArgs \
+		-DJAS_ENABLE_AUTOMATIC_DEPENDENCIES=OFF \
+		-DCMAKE_SKIP_RPATH=ON \
+		-DJAS_ENABLE_OPENGL=ON
+	make -C build
+}
+
+INSTALL()
+{
+	make -C build install
+
+	sed  -i "1i prefix=$prefix" \
+		$libDir/pkgconfig/jasper.pc
+
+	prepareInstalledDevelLib libjasper
+	fixPkgconfig
+
+	# devel package
+	packageEntries devel \
+		$developDir
+
+	# tools package
+	if [ -z "$secondaryArchSuffix" ]; then
+		packageEntries tools \
+			$binDir \
+			$documentationDir
+	fi
+
+	# Remove stuff we don't need in the secondary architecture base package.
+	if [ -n "$secondaryArchSuffix" ]; then
+		rm -rf $prefix/bin
+		rm -rf $documentationDir
+	fi
+}
+
+TEST()
+{
+	export LIBRARY_PATH="$sourceDir/build/src/libjasper${LIBRARY_PATH:+:$LIBRARY_PATH}"
+	make -C build test
+}


### PR DESCRIPTION
See: https://jasper-software.github.io/jasper-manual/releases/version-2.0.33/html/index.html
- Tested on Haiku R1B4 x64.
- Don't bump the x86_gcc2 (GCC2) at the moment.
- Passed all unit tests on Haiku x64.
- Passed all unit tests on Haiku x86.