### PR TITLE
git: update to version 2.43.2.

### DIFF
--- a/dev-vcs/git/git-2.43.2.recipe
+++ b/dev-vcs/git/git-2.43.2.recipe
@@ -12,11 +12,11 @@ COPYRIGHT="2005-2023 Git Authors (see git web site for list)"
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://www.kernel.org/pub/software/scm/git/git-$portVersion.tar.xz"
-CHECKSUM_SHA256="8e46fa96bf35a65625d85fde50391e39bc0620d1bb39afb70b96c4a237a1a4f7"
+CHECKSUM_SHA256="f612c1abc63557d50ad3849863fc9109670139fc9901e574460ec76e0511adb9"
 SOURCE_URI_2="https://www.kernel.org/pub/software/scm/git/git-manpages-$portVersion.tar.xz"
-CHECKSUM_SHA256_2="3d0495a10351b3541056a7923c63f3fd8a54992914cf56301809af8c69636b5d"
+CHECKSUM_SHA256_2="3739b021aa186a59de42153b70306684e7da85715d37a1b3bfe614c3dda0cab1"
 SOURCE_URI_3="https://www.kernel.org/pub/software/scm/git/git-htmldocs-$portVersion.tar.xz"
-CHECKSUM_SHA256_3="8d593e8184cea31a3527e810a15d6e0851b2bd258c74b5293fbf32b167847421"
+CHECKSUM_SHA256_3="9b3265e3a825f6eaac3ef29b2ae82aeffd71f30e039f2e173f9df95e15d6ebf7"
 PATCHES="git-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -133,10 +133,13 @@ REQUIRES_scalar="
 	lib:libz$secondaryArchSuffix
 	git$secondaryArchSuffix == $portVersion base
 	"
+
+# The `subversion` package includes perl bindings that this tool needs.
+# Note: `subversion` still built with gcc2 on 32 bits (matching perl there, at least).
 REQUIRES_svn="
 	haiku$secondaryArchSuffix
-	alien_svn
 	git$secondaryArchSuffix == $portVersion base
+	subversion
 	"
 
 BUILD_REQUIRES="

--- a/dev-vcs/git/patches/git-2.43.2.patchset
+++ b/dev-vcs/git/patches/git-2.43.2.patchset
@@ -1,4 +1,4 @@
-From d76d0f338cd939904b75b3ff05eb149d52be4ecb Mon Sep 17 00:00:00 2001
+From 2b068650b98a70d5043fd8e5d78307b36d75d933 Mon Sep 17 00:00:00 2001
 From: Ingo Weinhold <ingo_weinhold@gmx.de>
 Date: Tue, 13 Aug 2013 08:07:25 +0200
 Subject: git-web--browse.sh: use "open" on Haiku
@@ -24,7 +24,7 @@ index ae15253..b074d1a 100755
 2.42.1
 
 
-From 7cf641be5e878f38dd6374291c4388ba44c3b01c Mon Sep 17 00:00:00 2001
+From 2044c3faec789218c6a5ea84d86d83dbf33303b6 Mon Sep 17 00:00:00 2001
 From: Ingo Weinhold <ingo_weinhold@gmx.de>
 Date: Mon, 19 Jan 2015 15:37:16 -0500
 Subject: On Haiku use the user settings directory instead of HOME
@@ -70,17 +70,17 @@ index 67e2690..95d98f3 100644
 2.42.1
 
 
-From 05dff4504f99fa31e9562ea7e5786d444bde3ab2 Mon Sep 17 00:00:00 2001
+From 38ed749a67a68fd99ffe70867d63c4af6458176c Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Mon, 19 Jan 2015 15:50:09 -0500
 Subject: Ensure config-directory exists before using it.
 
 
 diff --git a/config.c b/config.c
-index 3846a37..301ad6c 100644
+index 9ff6ae1..dc1b3c1 100644
 --- a/config.c
 +++ b/config.c
-@@ -3342,6 +3342,14 @@ int git_config_set_multivar_in_file_gently(const char *config_filename,
+@@ -3196,6 +3196,14 @@ int git_config_set_multivar_in_file_gently(const char *config_filename,
  	if (!config_filename)
  		config_filename = filename_buf = git_pathdup("config");
  
@@ -99,7 +99,7 @@ index 3846a37..301ad6c 100644
 2.42.1
 
 
-From 090f78ca7956d26e71ec9129d9cce40000ae7bc6 Mon Sep 17 00:00:00 2001
+From a2e72070f1d0ac280e316a8e3f6392742047cecb Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Sun, 14 Feb 2016 10:32:12 +0100
 Subject: Move credential cache to the config directory.
@@ -107,10 +107,10 @@ Subject: Move credential cache to the config directory.
 Do not clutter the home dir.
 
 diff --git a/builtin/credential-cache.c b/builtin/credential-cache.c
-index 43b9d0e..9e8be52 100644
+index bba96d4..52af077 100644
 --- a/builtin/credential-cache.c
 +++ b/builtin/credential-cache.c
-@@ -120,7 +120,7 @@ static char *get_socket_path(void)
+@@ -118,7 +118,7 @@ static char *get_socket_path(void)
  {
  	struct stat sb;
  	char *old_dir, *socket;
@@ -123,7 +123,7 @@ index 43b9d0e..9e8be52 100644
 2.42.1
 
 
-From 9de908fc0e75a4c15cd06efc1b55ad1d09c38cf5 Mon Sep 17 00:00:00 2001
+From de7c3f6327496e87d11db4fca561bdaaee46c263 Mon Sep 17 00:00:00 2001
 From: sfanxiang <sfanxiang@gmail.com>
 Date: Mon, 1 Jan 2018 13:26:28 +0000
 Subject: builtin: config: use xdg_config even if it does not exist
@@ -166,7 +166,7 @@ index 11a4d4e..67dc39d 100644
 2.42.1
 
 
-From 150f7fa461a292adfc13378eacf659d510888297 Mon Sep 17 00:00:00 2001
+From e760a2733796a1a329b73fd586e7fc1a0a66583d Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Sun, 18 Nov 2018 11:56:26 +0100
 Subject: Fix detection of Haiku for git web browse
@@ -193,14 +193,14 @@ index b074d1a..0f95000 100755
 2.42.1
 
 
-From d1a56cd070ef9039f67ae55a5ab41c7bbbfe7ce7 Mon Sep 17 00:00:00 2001
+From 95bb6016f79aec4d15f3c42b4281af2a9f050a1d Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 29 Nov 2019 21:46:54 +0100
 Subject: ignore test failures.
 
 
 diff --git a/t/Makefile b/t/Makefile
-index 3e00cdd..8b27e50 100644
+index fae3012..22798c1 100644
 --- a/t/Makefile
 +++ b/t/Makefile
 @@ -63,7 +63,7 @@ prove: pre-clean check-chainlint $(TEST_LINT)
@@ -216,14 +216,14 @@ index 3e00cdd..8b27e50 100644
 2.42.1
 
 
-From 56649a0389cff232cff2674f806dce571f19e5fa Mon Sep 17 00:00:00 2001
+From bdcdb42ad1d8936edb4d0d06a455e493c08947fd Mon Sep 17 00:00:00 2001
 From: Augustin Cavalier <waddlesplash@gmail.com>
 Date: Wed, 17 Nov 2021 18:11:17 -0500
 Subject: git-gui: Use symbolic links.
 
 
 diff --git a/git-gui/Makefile b/git-gui/Makefile
-index a0d5a4b..b00a622 100644
+index 3f80435..69c1ef6 100644
 --- a/git-gui/Makefile
 +++ b/git-gui/Makefile
 @@ -59,7 +59,7 @@ INSTALL_X1 =


### PR DESCRIPTION
Switch dependencies for git-svn from alien_svn (obsolete), to subversion.

Built and smoke-tested (bot `git` and `git svn`) on beta4, 64 bits.

Edit: same on 32 bits now.