### PR TITLE
simutrans: fix x86 build

### DIFF
--- a/games-simulation/simutrans/patches/simutrans-123.0.1.patchset
+++ b/games-simulation/simutrans/patches/simutrans-123.0.1.patchset
@@ -1,4 +1,4 @@
-From c76e7b2b9fec72b2e56c9664ed05052100174d80 Mon Sep 17 00:00:00 2001
+From 585173446d1cbb25c9d79e06c5f5c8e60485c8c9 Mon Sep 17 00:00:00 2001
 From: Ken Mays <kmays2000@gmail.com>
 Date: Fri, 4 Jan 2019 19:45:50 +0100
 Subject: Fix DT_DIR handling under Haiku
@@ -29,10 +29,10 @@ index 4541b20..30a2af5 100644
  			// last return parent folder
  			closedir( dir );
 -- 
-2.30.2
+2.43.2
 
 
-From 6f8dea69fb6267f0809b5a7de44210cc35dedcb7 Mon Sep 17 00:00:00 2001
+From 174ef9d325e15205c1b8a25eccc138ded4f350f0 Mon Sep 17 00:00:00 2001
 From: Ken Mays <kmays2000@gmail.com>
 Date: Fri, 4 Jan 2019 19:45:50 +0100
 Subject: Fix UINT type handling under Haiku
@@ -77,10 +77,10 @@ index 8ca5bf5..15bff0a 100644
  #	define GCC_PACKED
  #	define GCC_ALIGN(a)
 -- 
-2.30.2
+2.43.2
 
 
-From f6d08a8374f251df352062c18b49431199e029cc Mon Sep 17 00:00:00 2001
+From 26d10e9030345e10122e26446d577209e24997b9 Mon Sep 17 00:00:00 2001
 From: Ken Mays <kmays2000@gmail.com>
 Date: Fri, 4 Jan 2019 19:45:50 +0100
 Subject: Fix save game issue on Haiku
@@ -103,5 +103,96 @@ index 5772ae2..84f0143 100644
  // buffer size for read/write - bzip2 gains up to 8M for non-threaded, 1M for threaded. binary, zipped ok with 256K or smaller.
  #define LS_BUF_SIZE (1 << 20) // 1 MiB
 -- 
-2.30.2
+2.43.2
+
+
+From 9fb62ef965e12a34b1b6f2d3a7d74941c4336318 Mon Sep 17 00:00:00 2001
+From: zeldakatze <mail@zeldakatze.de>
+Date: Wed, 21 Feb 2024 23:07:32 +0000
+Subject: fix haiku x86 build
+
+
+diff --git a/display/font.cc b/display/font.cc
+index ccb8e66..9dd0f77 100644
+--- a/display/font.cc
++++ b/display/font.cc
+@@ -193,7 +193,7 @@ bool font_t::load_from_bdf(FILE *bdf_file)
+ 			f_numglyphs = atoi(str + 5) <= 0x100 ? 0x100 : 0xFFFE;
+ 
+ 			glyphs.resize(max(f_numglyphs, 0));
+-			glyphs[(uint32)' '].advance = clamp(f_height / 2, 3u, GLYPH_BITMAP_HEIGHT);
++			glyphs[(uint32)' '].advance = clamp((long unsigned int) f_height / 2, (long unsigned int) 3u, (long unsigned int) GLYPH_BITMAP_HEIGHT);
+ 			continue;
+ 		}
+ 
+diff --git a/simcolor.h b/simcolor.h
+index 3022115..c571fe1 100644
+--- a/simcolor.h
++++ b/simcolor.h
+@@ -6,6 +6,7 @@
+ #ifndef SIMCOLOR_H
+ #define SIMCOLOR_H
+ 
++#include "simtypes.h"
+ 
+ #define LIGHT_COUNT         (15)
+ #define SPECIAL_COLOR_COUNT (224)
+@@ -19,9 +20,9 @@
+ #define OUTLINE_FLAG       (0x080000)
+ 
+ // pixels stored in system type (uint16)
+-typedef unsigned short PIXVAL;
++typedef uint16 PIXVAL;
+ // PIXVAL with above flags (eg. transparent) (uint32)
+-typedef unsigned int FLAGGED_PIXVAL;
++typedef uint32 FLAGGED_PIXVAL;
+ 
+ // Menu colours (they don't change between day and night)
+ #define MN_GREY0            229
+diff --git a/simtool.cc b/simtool.cc
+index 3b5f7ab..c99ed9e 100644
+--- a/simtool.cc
++++ b/simtool.cc
+@@ -6669,7 +6669,7 @@ void tool_merge_stop_t::mark_tiles(  player_t *player, const koord3d &start, con
+ 	}
+ 
+ 	if(  distance  < welt->get_settings().allow_merge_distant_halt  ) {
+-		distance = clamp(distance,2u,33u)-2;
++		distance = clamp(distance, (uint32) 2, (uint32) 33)-2;
+ 		workcost = welt->scale_with_month_length( (1<<distance) * welt->get_settings().cst_multiply_merge_halt );
+ 		win_set_static_tooltip( tooltip_with_price("Building costs estimates", workcost) );
+ 	}
+@@ -6706,7 +6706,7 @@ const char *tool_merge_stop_t::do_work( player_t *player, const koord3d &last_po
+ 	}
+ 
+ 	if(  distance  < welt->get_settings().allow_merge_distant_halt  ) {
+-		distance = clamp(distance,2u,33u)-2;
++		distance = clamp(distance, (uint32) 2, (uint32) 33)-2;
+ 		workcost = welt->scale_with_month_length( (1<<distance) * welt->get_settings().cst_multiply_merge_halt );
+ 		win_set_static_tooltip( tooltip_with_price("Building costs estimates", workcost) );
+ 		if(  player != welt->get_public_player()  &&  !player->can_afford(workcost)  ) {
+diff --git a/utils/sha1.h b/utils/sha1.h
+index 0c63734..1ddb73f 100644
+--- a/utils/sha1.h
++++ b/utils/sha1.h
+@@ -24,7 +24,7 @@
+ #ifndef UTILS_SHA1_H
+ #define UTILS_SHA1_H
+ 
+-
++#include "../simtypes.h"
+ #include "sha1_hash.h"
+ 
+ 
+@@ -66,7 +66,7 @@ private:
+         /*
+          *  Performs a circular left shift operation
+          */
+-        inline unsigned CircularShift(int bits, unsigned word);
++        inline uint32 CircularShift(int bits, uint32 word);
+ 
+         uint32 H[5];                      // Message digest buffers
+ 
+-- 
+2.43.2
 

--- a/games-simulation/simutrans/simutrans-123.0.1.recipe
+++ b/games-simulation/simutrans/simutrans-123.0.1.recipe
@@ -18,6 +18,7 @@ SOURCE_DIR=""
 PATCHES="simutrans-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	simutrans$secondaryArchSuffix = $portVersion


### PR DESCRIPTION
This should make simutrans compile on x86 again. I also found out that compiling on a 20+ year old laptop is slow, especially with 512 mb of RAM.