### PR TITLE
tvision: new recipe.

### DIFF
--- a/dev-libs/tvision/licenses/TVISION
+++ b/dev-libs/tvision/licenses/TVISION
@@ -1,0 +1,118 @@
+Borland International made the Turbo Vision source code public, accompanied
+by the following disclaimer:
+
+DISCLAIMER AND LIMITATION OF LIABILITY: Borland does not make
+or give any representation or warranty with respect to the
+usefulness or the efficiency of this software, it being
+understood that the degree of success with which equipment,
+software, modifications, and other materials can be applied to
+data processing is dependent upon many factors, many of which
+are not under Borland's control.  ACCORDINGLY, THIS SOFTWARE IS
+PROVIDED 'AS IS' WITHOUT EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING NO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE, OR NONINFRINGEMENT.  THIS SOFTWARE IS
+PROVIDED GRATUITOUSLY AND, ACCORDINGLY, BORLAND SHALL NOT BE
+LIABLE UNDER ANY THEORY FOR ANY DAMAGES SUFFERED BY YOU OR ANY
+USER OF THE SOFTWARE.  BORLAND WILL NOT SUPPORT THIS SOFTWARE
+AND IS UNDER NO OBLIGATION TO ISSUE UPDATES TO THIS SOFTWARE.
+
+WITHOUT LIMITING THE GENERALITY OF THE FOREGOING, NEITHER
+BORLAND NOR ITS SUPPLIERS SHALL BE LIABLE FOR (a) INCIDENTAL,
+CONSEQUENTIAL, SPECIAL OR INDIRECT DAMAGES OF ANY SORT, WHETHER
+ARISING IN TORT, CONTRACT OR OTHERWISE, EVEN IF BORLAND HAS BEEN
+INFORMED OF THE POSSIBILITY OF SUCH DAMAGES, OR (b) FOR ANY
+CLAIM BY ANY OTHER PARTY.  SOME STATES DO NOT ALLOW THE
+EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+SO THIS LIMITATION AND EXCLUSION MAY NOT APPLY TO YOU.  Use,
+duplication or disclosure by the Government is subject to
+restrictions set forth in subparagraphs (a) through (d) of the
+Commercial Computer-Restricted Rights clause at FAR 52.227-19
+when applicable, or in subparagraph (c) (1) (ii) of the Rights
+in Technical Data and Computer Software clause at DFARS
+252.227-7013, and in similar clauses in the NASA AR Supplement.
+Contractor / manufacturer is Borland International, Inc.,
+100 Borland Way, Scotts Valley, CA 95066.
+
+The copyright below applies only to the modifications made by magiblot to
+the original source code and the source code that was written from scratch.
+
+MIT License
+
+Copyright 2019-2021 magiblot <magiblot@hotmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Below are the copyright notices of third-party components included in this
+project.
+
+## Fast utoa()
+## https://github.com/miloyip/itoa-benchmark
+
+Copyright (C) 2014 Milo Yip
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+## wcwidth() for Unicode 5.0
+## https://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c
+
+Markus Kuhn -- 2007-05-26 (Unicode 5.0)
+
+Permission to use, copy, modify, and distribute this software
+for any purpose and without fee is hereby granted. The author
+disclaims all warranties with regard to this software.
+
+## Flexible and Economical UTF-8 Decoder
+## http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
+
+Copyright (c) 2008-2010 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+See http://bjoern.hoehrmann.de/utf-8/decoder/dfa/ for details.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/dev-libs/tvision/patches/tvision-2024.02.04~git.patchset
+++ b/dev-libs/tvision/patches/tvision-2024.02.04~git.patchset
@@ -1,0 +1,105 @@
+From eec0ebb78fa9325b1438a2779d2522eace82d317 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Wed, 27 Dec 2023 14:53:46 -0300
+Subject: Fix build under Haiku beta4.
+
+Otherwise we get:
+
+/boot/system/develop/headers/posix/string.h:72:26: error: conflicting declaration of 'char* strupr(char*)' with 'C' linkage
+   72 | extern char *strupr(char *string);
+      |                          ^~~~~~
+In file included from /sources/tvision/include/tvision/tv.h:666:
+/sources/tvision/include/tvision/util.h:106:7: note: previous declaration with 'C++' linkage
+Changes to be committed:
+  106 | char *strupr(char *s) noexcept;
+      |       ^~~~~~
+
+Kudos to @coolcoder613eb.
+
+diff --git a/include/tvision/util.h b/include/tvision/util.h
+index 9b2742a..c7afaf0 100644
+--- a/include/tvision/util.h
++++ b/include/tvision/util.h
+@@ -103,7 +103,9 @@ int vsnprintf( char _FAR *buffer, size_t size, const char _FAR *format,
+ 
+ int stricmp( const char *s1, const char *s2 ) noexcept;
+ int strnicmp( const char *s1, const char *s2, size_t maxlen ) noexcept;
++#ifndef __HAIKU__
+ char *strupr(char *s) noexcept;
++#endif
+ char *itoa( int value, char *buffer, int radix ) noexcept;
+ char *ltoa( long value, char *buffer, int radix ) noexcept;
+ char *ultoa( ulong value, char *buffer, int radix ) noexcept;
+-- 
+2.43.2
+
+
+From 1bf36a1b4ffa2022faac9da0fa3339d17c8c9c69 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Wed, 27 Dec 2023 15:52:53 -0300
+Subject: Compile as a shared library.
+
+
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index 253e3f2..a2824e0 100644
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -3,7 +3,7 @@
+ file(GLOB_RECURSE TVSOURCE "${CMAKE_CURRENT_LIST_DIR}/*/*.cpp")
+ list(REMOVE_ITEM TVSOURCE "${CMAKE_CURRENT_LIST_DIR}/tvision/geninc.cpp")
+ 
+-add_library(${PROJECT_NAME} STATIC ${TVSOURCE})
++add_library(${PROJECT_NAME} SHARED ${TVSOURCE})
+ add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+ 
+ target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
+-- 
+2.43.2
+
+
+From b6e657c29d4fc90dc0b4ebba790660b28270b5e2 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Wed, 27 Dec 2023 18:51:15 -0300
+Subject: Fix headers file location.
+
+
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index a2824e0..5a391a3 100644
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -169,7 +169,8 @@ install(EXPORT ${PROJECT_NAME}-config
+ # includes
+ # ./include/tvision and children copied to destination/include/tvision etc...
+ #
+-install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/tvision" DESTINATION include)
++install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/tvision" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++
+ 
+ # Build optimization
+ 
+-- 
+2.43.2
+
+
+From 1cd6a68cc98b7ca46f89cd655de180cb3d046f1a Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Fri, 23 Feb 2024 08:23:45 -0300
+Subject: Fix hardcoded lib/cmake path.
+
+
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index 5a391a3..bd81cb2 100644
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -160,7 +160,7 @@ install(TARGETS ${PROJECT_NAME}
+ # package configuration
+ 
+ install(EXPORT ${PROJECT_NAME}-config
+-    DESTINATION lib/cmake/${PROJECT_NAME}
++    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+     NAMESPACE ${PROJECT_NAME}::
+     FILE ${PROJECT_NAME}-config.cmake
+     COMPONENT library
+-- 
+2.43.2
+

--- a/dev-libs/tvision/tvision-2024.02.04~git.recipe
+++ b/dev-libs/tvision/tvision-2024.02.04~git.recipe
@@ -1,0 +1,107 @@
+SUMMARY="A modern port of Turbo Vision 2.0"
+DESCRIPTION="A modern port of Turbo Vision 2.0, the classical framework for text-based user interfaces. \
+Now cross-platform and with Unicode support. "
+HOMEPAGE="https://github.com/magiblot/tvision"
+COPYRIGHT="2019-2021 magiblot"
+LICENSE="TVISION
+	MIT"
+REVISION="1"
+srcGitRev="be6e64f85355c6c96b7c09174986fafb6a411c6a"
+SOURCE_URI="https://github.com/magiblot/tvision/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="cb9601551831861f06ec5e6bfefe9340b5ca0fea7eeb253630ece98790620ce7"
+SOURCE_DIR="tvision-$srcGitRev"
+
+PATCHES="tvision-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+PROVIDES="
+	tvision$secondaryArchSuffix = $portVersion
+	lib:libtvision$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libncursesw$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	tvision${secondaryArchSuffix}_devel = $portVersion
+	devel:libtvision$secondaryArchSuffix = $portVersion
+	"
+REQUIRES_devel="
+	tvision$secondaryArchSuffix == $portVersion base
+	"
+
+PROVIDES_tools="
+	tvision${secondaryArchSuffix}_tools = $portVersion
+	cmd:tvdemo$commandSuffix = $portVersion
+	cmd:tvedit$commandSuffix = $portVersion
+	cmd:tvhc$commandSuffix = $portVersion
+	"
+REQUIRES_tools="
+	$REQUIRES
+	tvision$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+#	devel:libgtest$secondaryArchSuffix # only needed if using -DTV_BUILD_TESTS=YES in BUILD below
+	devel:libncursesw$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:make
+	cmd:gcc$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	# The following is only needed when building with either:
+	#	-DTV_BUILD_TESTS=YES (`test/tvision-test-passed` bin links to libtvsion.so)
+	# or
+	#	-DTV_BUILD_EXAMPLES=YES (two binaries there are ran from the "build" dir)
+	# and libtvsion.so is located under $sourceDir/build.
+	export LIBRARY_PATH="$sourceDir/build:$LIBRARY_PATH"
+
+	cmake . -B ./build \
+		$cmakeDirArgs \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_SKIP_RPATH=YES \
+		-DTV_BUILD_EXAMPLES=YES \
+		-DTV_BUILD_TESTS=NO
+
+	cmake --build ./build $jobArgs
+}
+
+INSTALL()
+{
+	cmake --install ./build
+
+	prepareInstalledDevelLib libtvision
+
+	# Fix usage of hardcoded "/include":
+	sed -e "s|\(\${_IMPORT_PREFIX}\)/include|\1/$relativeIncludeDir|" -i \
+		$libDir/cmake/tvision/tvision-config.cmake
+
+	packageEntries devel \
+		$developDir \
+		$libDir/cmake
+
+	# Not all examples that are built get "install"ed.
+	# Not included here:
+	# 	hello, mmenu, palette, tvdir, and tvforms (w/ genparts, genphone that generate data for it)
+	# Included:
+	# - tvdemo (demo for TurboVision widgets)
+	# - tvedit (a simple text editor)
+	# - tvhc (a .hlp compiler for tvision apps)
+	packageEntries tools \
+		$commandBinDir
+}


### PR DESCRIPTION
TVision apps not looking 100% right, same issue as in `mc`: Terminal drawing leaving "vertical gaps" between "line/box drawing" chars.

Other than that, seems pretty functional.

Patched it to build/use shared libs.

The `turbo` editor (scintilla + tvision based), will follow after this one.

---

tested on beta4, both 32, and 64 bits.