### PR TITLE
sphinx: move snowballstemmer to the REQUIRES section

### DIFF
--- a/dev-python/sphinx/sphinx-7.2.6.recipe
+++ b/dev-python/sphinx/sphinx-7.2.6.recipe
@@ -21,7 +21,7 @@ extensions."
 HOMEPAGE="https://www.sphinx-doc.org/"
 COPYRIGHT="2023 Georg Brandl"
 LICENSE="BSD (2-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/sphinx-doc/sphinx/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="b41c04543148937b887097f396d7b2b54ae49d0597b68625f06ffdf702d4d917"
 
@@ -74,6 +74,7 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 		packaging_$pythonPackage
 		pygments_$pythonPackage
 		requests_$pythonPackage
+		snowballstemmer_$pythonPackage
 		sphinxcontrib_applehelp_$pythonPackage
 		sphinxcontrib_devhelp_$pythonPackage
 		sphinxcontrib_htmlhelp_$pythonPackage
@@ -98,7 +99,6 @@ TEST_REQUIRES="
 	filelock_$defaultTestVersion
 	html5lib_$defaultTestVersion
 	sphinx_$defaultTestVersion
-	snowballstemmer_$defaultTestVersion
 	cmd:pytest
 	"
 


### PR DESCRIPTION
It's listed as a required package for the project and gets automatically installed when using pip