### PR TITLE
android_file_transfer: fix build

### DIFF
--- a/sys-fs/android_file_transfer/patches/android_file_transfer-4.3.patchset
+++ b/sys-fs/android_file_transfer/patches/android_file_transfer-4.3.patchset
@@ -1,4 +1,4 @@
-From ea6462037c6bfa69496b3a35173a6d09e8347e7a Mon Sep 17 00:00:00 2001
+From 03806b0528362257724271b547367215009bd6bf Mon Sep 17 00:00:00 2001
 From: Javier Steinaker <jsteinaker@gmail.com>
 Date: Sat, 3 Sep 2022 09:12:54 +1000
 Subject: Fix build: readline env variables should only be used when readline
@@ -24,5 +24,27 @@ index b82248c..dd75599 100644
  install(TARGETS aft-mtp-cli RUNTIME DESTINATION bin)
  
 -- 
-2.36.1
+2.43.2
+
+
+From 94f2d8686fe689308c426d318f5207555ac13c97 Mon Sep 17 00:00:00 2001
+From: zeldakatze <mail@zeldakatze.de>
+Date: Sat, 24 Feb 2024 16:57:08 +0100
+Subject: fix build
+
+
+diff --git a/mtp/types.h b/mtp/types.h
+index 32024e4..17d9f44 100644
+--- a/mtp/types.h
++++ b/mtp/types.h
+@@ -28,6 +28,7 @@
+ #include <mutex>
+ #include <exception>
+ #include <string>
++#include <stdexcept>
+ 
+ namespace mtp
+ {
+-- 
+2.43.2
 


### PR DESCRIPTION
Should now compile again. I cannot test it because
I currently don't have a working cable with me but I guess it should work as it worked before