### PR TITLE
scons: remove extra vendor-packages directory

### DIFF
--- a/dev-build/scons/scons-4.6.0.recipe
+++ b/dev-build/scons/scons-4.6.0.recipe
@@ -7,7 +7,7 @@ an easier, more reliable and faster way to build software."
 HOMEPAGE="https://www.scons.org/"
 COPYRIGHT="2001-2023 The SCons Foundation"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/scons/scons/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="085fc9df961224b91ed715c5c44a11796a3e614d146139989ab14e8a347425ff"
 SOURCE_FILENAME="scons-$portVersion.tar.gz"
@@ -66,14 +66,7 @@ BUILD()
 
 INSTALL()
 {
-	# GENERIC: all python_setuptools-based installs need this
-	python=$portPackageLinksDir/cmd~python$PYTHON_VERSION/bin/python$PYTHON_VERSION
-	pythonVersion=$($python --version 2>&1 | sed 's/Python //' | head -c3)
-	installLocation=$prefix/lib/python$pythonVersion/vendor-packages/
-	export PYTHONPATH=$installLocation:$PYTHONPATH
-	mkdir -p $installLocation
-
-	$python setup.py install \
+	$portPackageLinksDir/cmd~python$PYTHON_VERSION/bin/python$PYTHON_VERSION setup.py install \
 		--root=/ \
 		--prefix=$prefix
 


### PR DESCRIPTION
The commands from the install section don't work properly if the python minor version is double digits.  The commands could easily be rewritten but they don't seem to be doing anything anyhow so we can just remove them.