### PR TITLE
xash3d: switch to Python 3 for building.

### DIFF
--- a/games-action/xash3d/xash3d-0.20~git.recipe
+++ b/games-action/xash3d/xash3d-0.20~git.recipe
@@ -6,7 +6,7 @@ which aims on crossplatform and compatibility with original Xash3D and Gold Sour
 HOMEPAGE="https://xash.su"
 COPYRIGHT="2007-2019 Uncle Mike, 2015-2021 Flying With Gauss Team"
 LICENSE="GNU GPL v3"
-REVISION="1"
+REVISION="2"
 
 srcGitRev="a1c948e591603012437976fe531a47d5f91fe707"
 SOURCE_URI="https://github.com/FWGS/xash3d-fwgs/archive/$srcGitRev.tar.gz"
@@ -25,21 +25,21 @@ SOURCE_DIR_3="MiniUTL-$srcGitRev3"
 
 # Half-Life
 srcGitRev4="7fdc58743d1c3a4de6489232a233cf6f3a1b7a28"
-SOURCE_URI_4="https://github.com/FWGS/hlsdk-xash3d/archive/$srcGitRev4.tar.gz"
-CHECKSUM_SHA256_4="8dfc173899fcc4fa3449efefaf7bd91a886c7832ea05edf6c0e44d53e0afd754"
-SOURCE_DIR_4="hlsdk-xash3d-$srcGitRev4"
+SOURCE_URI_4="https://github.com/FWGS/hlsdk-portable/archive/$srcGitRev4.tar.gz"
+CHECKSUM_SHA256_4="0cf80747710e76add5054875e955135d0b91b82207207a2e0359c7e9d70b236a"
+SOURCE_DIR_4="hlsdk-portable-$srcGitRev4"
 
 # Blue Shift
 srcGitRev5="06b530d9af95e9a1e110acb2f2429c0e80c663a8"
-SOURCE_URI_5="https://github.com/FWGS/hlsdk-xash3d/archive/$srcGitRev5.tar.gz"
-CHECKSUM_SHA256_5="bfcc90e00c47dcf1373879499a1e611f4f48814cabc8f895144b8e8115e82a0b"
-SOURCE_DIR_5="hlsdk-xash3d-$srcGitRev5"
+SOURCE_URI_5="https://github.com/FWGS/hlsdk-portable/archive/$srcGitRev5.tar.gz"
+CHECKSUM_SHA256_5="bc36520cec54503277c38c0f1f2b4ddacc3c2e3622f54ac7b811cff0b8b16502"
+SOURCE_DIR_5="hlsdk-portable-$srcGitRev5"
 
 # Opposing Force
 srcGitRev6="efa2dae5897a64d309396f9398ace9bba19547a8"
-SOURCE_URI_6="https://github.com/FWGS/hlsdk-xash3d/archive/$srcGitRev6.tar.gz"
-CHECKSUM_SHA256_6="6abeb50efa8d3b586f999f81e85c56426338ea348558c7e4621e5701e785b9a1"
-SOURCE_DIR_6="hlsdk-xash3d-$srcGitRev6"
+SOURCE_URI_6="https://github.com/FWGS/hlsdk-portable/archive/$srcGitRev6.tar.gz"
+CHECKSUM_SHA256_6="640d442e1d2797f2b52c21a642155433848224ceb24f257b79b797a03f7f0bbf"
+SOURCE_DIR_6="hlsdk-portable-$srcGitRev6"
 
 srcGitRev7="9a15200d91cacd3f93e55f94b36c882ea326e1ac"
 SOURCE_URI_7="https://github.com/EXL/BeGameLauncher/archive/$srcGitRev7.tar.gz"
@@ -77,7 +77,7 @@ BUILD_REQUIRES="
 	devel:libSDL2_2.0$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:python2
+	cmd:python3
 	cmd:cmake
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
@@ -86,6 +86,10 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
+	# Quick and dirty workaround to the build system expecting Python to be called "python":
+	mkdir -p ~/config/non-packaged/bin
+	ln -s /bin/python3 ~/config/non-packaged/bin/python
+
 	cd $sourceDir
 	cp -aR $sourceDir2/* mainui/
 	cp -aR $sourceDir3/* mainui/miniutl/
@@ -115,6 +119,9 @@ BUILD()
 		-DCMAKE_BUILD_TYPE=Release \
 		-DLAUNCHER=xash3d
 	make $jobArgs
+
+	# Just in case, undo our hack.
+	rm -f ~/config/non-packaged/bin/python
 }
 
 INSTALL()


### PR DESCRIPTION
Just a quick hack, to make sure we still can use this version.

Will try to update to a newer Xash3D later on.

----

Build went just fine on beta4, 64 bits. Installs, and "Xash3D Launcher" starts OK.

~(I haven't, yet, tried to run games with it, thou, nor with the version from the repos).~

Half-Life seems to run fine on beta4 64 bits (my PC is slow, so I had to use the Software Renderer, and keep resolution at no more than 1024x768 or 1360x768).