### PR TITLE
nextcloud_client: remove cmocka dependency, remove extra files

### DIFF
--- a/net-misc/nextcloud-client/nextcloud_client-3.11.1.recipe
+++ b/net-misc/nextcloud-client/nextcloud_client-3.11.1.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="This Nextcloud client is a tool to synchronize files with a Nextclo
 HOMEPAGE="https://nextcloud.com"
 COPYRIGHT="Nextcloud GmbH"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/nextcloud/desktop/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="9f60a6707d31e82357780dff11168ede88d1f859481a22f2d04c827e656f3fba"
 SOURCE_DIR="desktop-$portVersion"
@@ -38,7 +38,6 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libcmocka$secondaryArchSuffix
 	lib:libcrypto$secondaryArchSuffix
 	lib:libkf5archive$secondaryArchSuffix
 	lib:libQt5Concurrent$secondaryArchSuffix
@@ -82,7 +81,7 @@ REQUIRES_devel="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	extra_cmake_modules$secondaryArchSuffix
-	devel:libcmocka$secondaryArchSuffix
+	devel:libcmocka$secondaryArchSuffix # only needed during configure and testing
 	devel:libcrypto$secondaryArchSuffix
 	devel:libkf5archive$secondaryArchSuffix
 	devel:libQt5Concurrent$secondaryArchSuffix
@@ -125,23 +124,23 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	cmake -Bbuild -S. $cmakeDirArgs \
+	cmake -B build -S . $cmakeDirArgs \
 		-DCMAKE_INSTALL_BINDIR=$commandBinDir \
 		-DINCLUDE_INSTALL_DIR=$includeDir \
 		-DSYSCONF_INSTALL_DIR=$settingsDir \
 		-DCMAKE_BUILD_TYPE=Release -Wno-dev
-	make -Cbuild $jobArgs
+	make -C build $jobArgs
 }
 
 INSTALL()
 {
-	make -Cbuild install
+	make -C build install
 
 	# don't mess with shared_mime_info files
 	rm -rf $dataDir/mime/{aliases,generic-icons,globs,globs2,icons,magic}
 	rm -rf $dataDir/mime/{mime.cache,subclasses,treemagic,types,version,XMLnamespaces}
 	# cleanup (not needed)
-	rm -rf $dataDir/{applications/icons}
+	rm -rf $dataDir/{applications,icons,caja-python,nautilus-python,nemo-python}
 
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
 	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
@@ -168,4 +167,9 @@ INSTALL()
 
 	packageEntries devel \
 		$developDir
+}
+
+TEST()
+{
+	make -C build test
 }


### PR DESCRIPTION
cmocka is only used for testing and can be removed from REQUIRES.

Fix typo in the rm command to remove the applications and icons directories. Also, add several more directories to be pruned.