### PR TITLE
qt6_positioning, remove "replaces" for qt6_locale

### DIFF
--- a/dev-qt/qt6-positioning/qt6_positioning-6.6.0.recipe
+++ b/dev-qt/qt6-positioning/qt6_positioning-6.6.0.recipe
@@ -8,7 +8,7 @@ COPYRIGHT="2015-2023 The Qt Company Ltd."
 LICENSE="GNU LGPL v2.1
 	GNU LGPL v3
 	GNU FDL v1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://download.qt.io/official_releases/qt/${portVersion%.*}/$portVersion/submodules/qtpositioning-everywhere-src-$portVersion.tar.xz"
 CHECKSUM_SHA256="8d6520fa3c759ed33eaea7cb1aa7e1e7ec999f828e496a6c592847d61f0fa539"
 SOURCE_DIR="qtpositioning-everywhere-src-$portVersion"
@@ -34,9 +34,6 @@ REQUIRES="
 	lib:libssl$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
-REPLACES="
-	qt6_location$secondaryArchSuffix
-	"
 
 PROVIDES_devel="
 	qt6_positioning${secondaryArchSuffix}_devel = $portVersion compat >= 6
@@ -46,9 +43,6 @@ PROVIDES_devel="
 REQUIRES_devel="
 	qt6_positioning$secondaryArchSuffix == $portVersion base
 	qt6_base${secondaryArchSuffix}_devel
-	"
-REPLACES_devel="
-	qt6_location${secondaryArchSuffix}_devel
 	"
 
 BUILD_REQUIRES="


### PR DESCRIPTION
This is needed to run NeoChat 24.02.0 and KF6