### PR TITLE
pnglite: add a symlink on the _devel package.

### DIFF
--- a/media-libs/pnglite/pnglite-0.1.17.recipe
+++ b/media-libs/pnglite/pnglite-0.1.17.recipe
@@ -4,13 +4,13 @@ It was created as a substitute for libpng in situations when libpng is more than
 HOMEPAGE="https://sourceforge.net/projects/pnglite"
 COPYRIGHT="2007 Daniel Karling"
 LICENSE="Zlib"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="http://prdownloads.sourceforge.net/pnglite/pnglite-$portVersion.zip"
 CHECKSUM_SHA256="6444b13b9ec5b6f9de8f72513a00870325779e3b05bfcf554edb1ab0c90f5962"
 SOURCE_DIR=""
 
 ARCHITECTURES="all"
-SECONDARY_ARCHITECTURES="x86_gcc2 x86"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	pnglite$secondaryArchSuffix = $portVersion
@@ -54,6 +54,7 @@ INSTALL()
 	mkdir -p $includeDir $libDir
 	cp pnglite.h $includeDir/
 	cp libpnglite.so.0 $libDir/
+	ln -sr $libDir/libpnglite.so.0 $libDir/libpnglite.so
 
 	prepareInstalledDevelLibs libpnglite
 


### PR DESCRIPTION
A user over IRC pointed out the missing "libpnglite.so".

For reference, this is what Fedora does:

https://src.fedoraproject.org/rpms/pnglite/blob/rawhide/f/pnglite.spec

---

Tested on 32 bits (gcc2 and x86), and 64 bits.