### PR TITLE
yab 1.8.2 update build2, because crash under 64bit

### DIFF
--- a/dev-lang/yab/yab-1.8.2.recipe
+++ b/dev-lang/yab/yab-1.8.2.recipe
@@ -7,9 +7,9 @@ COPYRIGHT="1995-2006 Marc-Oliver Ihm (yabasic)
 	2013-2020 Jim Saxton (yab improvements)
 	2018-2022 Lorenz Glaser (yab improvements)"
 LICENSE="Artistic"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/lorglas/yab/archive/$portVersion.tar.gz"
-CHECKSUM_SHA256="0ab367e7dc3bc9e5eb47ef534a336a57f6a0b48f6032276f15f8a4b4047e5546"
+CHECKSUM_SHA256="fcdcd4eef73b7368a56deb1b5b60dd9a5fd46feedc9c85b67441ae51c0a2d3d5"
 SOURCE_FILENAME="yab-$portVersion.tar.gz"
 SOURCE_DIR="yab-$portVersion"
 


### PR DESCRIPTION
yab 1.8.2 update build2, because crash under 64bit