### PR TITLE
tig: fix build.

### DIFF
--- a/dev-vcs/tig/tig-2.5.8.recipe
+++ b/dev-vcs/tig/tig-2.5.8.recipe
@@ -63,7 +63,12 @@ BUILD()
 INSTALL()
 {
 	make install
-	make install-doc-man
+
+	# temporary solution because `make install-doc-man` fails/works randomly.
+	mkdir -p $manDir/man{1,5,7}
+	cp -af doc/tig.1 $manDir/man1
+	cp -af doc/tigrc.5 $manDir/man5
+	cp -af doc/tigmanual.7 $manDir/man7
 }
 
 # Results for 2.5.8 (took around 15 minutes):


### PR DESCRIPTION
`make install-doc-man` is just too unreliable, for some reason.