### PR TITLE
irssi: enable build on 32 bits (x86).

### DIFF
--- a/net-irc/irssi/irssi-1.2.3.recipe
+++ b/net-irc/irssi/irssi-1.2.3.recipe
@@ -97,54 +97,68 @@ REVISION="1"
 SOURCE_URI="https://github.com/irssi/irssi/releases/download/$portVersion/irssi-$portVersion.tar.gz"
 CHECKSUM_SHA256="29cbb746d7e57591d8fcf799406fb28cb7c2d734bc4288cbb8b4c4e05cf99c25"
 
-ARCHITECTURES="all ?x86_gcc2 ?x86"
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
 
 GLOBAL_WRITABLE_FILES="
 	settings/irssi.conf keep-old
 	"
 
 PROVIDES="
-	irssi = $portVersion
-	cmd:irssi = $portVersion
+	irssi$secondaryArchSuffix = $portVersion
+	cmd:irssi$commandSuffix = $portVersion
 	"
 REQUIRES="
-	haiku
-	lib:libglib_2.0
-	lib:libiconv
-	lib:libintl
-	lib:libncursesw
-	lib:libperl
-	lib:libssl
+	haiku$secondaryArchSuffix
+	lib:libglib_2.0$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libncursesw$secondaryArchSuffix
+	lib:libperl$secondaryArchSuffix
+	lib:libssl$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
-	devel:libglib_2.0
-	devel:libncursesw
-	devel:libssl
+	haiku${secondaryArchSuffix}_devel
+	devel:libglib_2.0$secondaryArchSuffix
+	devel:libncursesw$secondaryArchSuffix
+	devel:libssl$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:autoreconf
-	cmd:gcc
-	cmd:ld
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
 	cmd:libtoolize
 	cmd:make
 	cmd:perl
-	cmd:pkg_config
+	cmd:pkg_config$secondaryArchSuffix
 	"
 
-defineDebugInfoPackage irssi\
-	"$binDir"/irssi
+defineDebugInfoPackage irssi$secondaryArchSuffix \
+	"$commandBinDir"/irssi
 
 BUILD()
 {
 	autoreconf -fi
+
 	# remove unichar typedef in SupportDefs.h
 	cp /system/develop/headers/os/support/SupportDefs.h .
 	sed -i 's/unichar/unichar2/' SupportDefs.h
 	export CPPFLAGS="-include `pwd`/SupportDefs.h"
-	runConfigure ./configure --with-perl=module --with-socks \
-		--with-proxy --enable-true-color
+
+	runConfigure --omit-dirs binDir ./configure \
+		--bindir=$commandBinDir \
+		--with-perl=module \
+		--with-socks \
+		--with-proxy \
+		--enable-true-color
 	make $jobArgs
 }
 

--- a/net-irc/irssi/irssi-1.4.5.recipe
+++ b/net-irc/irssi/irssi-1.4.5.recipe
@@ -95,7 +95,7 @@ LICENSE="GNU GPL v2
 	OpenSSL GPL2 exception"
 REVISION="1"
 SOURCE_URI="https://github.com/irssi/irssi/releases/download/$portVersion/irssi-$portVersion.tar.gz"
-CHECKSUM_SHA256="29cbb746d7e57591d8fcf799406fb28cb7c2d734bc4288cbb8b4c4e05cf99c25"
+CHECKSUM_SHA256="31653e8e0c5b1ef9b89905c330a0d77fe3f0592f88d163e504c1923dcd28ac47"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -132,12 +132,9 @@ BUILD_REQUIRES="
 	devel:libssl$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:autoreconf
+	cmd:awk
 	cmd:gcc$secondaryArchSuffix
-	cmd:ld$secondaryArchSuffix
-	cmd:libtoolize
 	cmd:make
-	cmd:perl
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
@@ -146,8 +143,6 @@ defineDebugInfoPackage irssi$secondaryArchSuffix \
 
 BUILD()
 {
-	autoreconf -fi
-
 	# remove unichar typedef in SupportDefs.h
 	cp /system/develop/headers/os/support/SupportDefs.h .
 	sed -i 's/unichar/unichar2/' SupportDefs.h


### PR DESCRIPTION
Not sure if we require a revbump on this case.

Tested on 32 bits. I was able to connect to the Haiku channel on OFTC.

Might as well try to update to newest version thou, so opening as draft for now.