### PR TITLE
aiohttp (and dependencies): recipes cleanup.

### DIFF
--- a/dev-python/aiohttp/aiohttp-3.8.1.recipe
+++ b/dev-python/aiohttp/aiohttp-3.8.1.recipe
@@ -1,13 +1,13 @@
 SUMMARY="HTTP client/server for asyncio"
 DESCRIPTION="Supports both client and server side of HTTP protocol. \
-Supports both client and server Web-Sockets out-of-the-box and avoids \
- Callback Hell. \
+Supports both client and server Web-Sockets out-of-the-box and avoids Callback Hell.
+
 Provides Web-server with middlewares and pluggable routing."
 HOMEPAGE="https://pypi.python.org/pypi/aiohttp"
 COPYRIGHT="2013-2021 Nikolay Kim and Andrew Svetlov"
 LICENSE="Apache v2"
-REVISION="5"
-SOURCE_URI="https://pypi.org/packages/source/a/aiohttp/aiohttp-$portVersion.tar.gz"
+REVISION="6"
+SOURCE_URI="https://files.pythonhosted.org/packages/source/a/aiohttp/aiohttp-$portVersion.tar.gz"
 CHECKSUM_SHA256="fc5471e1a54de15ef71c1bc6ebe80d4dc681ea600e68bfd1cbce40427f0b7578"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -23,55 +23,63 @@ REQUIRES="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
+BUILD_PREREQUIRES="
+	gcc$secondaryArchSuffix
+	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku$secondaryArchSuffix\n\
-	aiosignal_$pythonPackage\n\
-	attrs_$pythonPackage\n\
-	asynctest_$pythonPackage\n\
-	async_timeout_$pythonPackage\n\
-	charset_normalizer_$pythonPackage\n\
-	chardet_$pythonPackage\n\
-	frozenlist_$pythonPackage\n\
-	multidict_$pythonPackage\n\
-	yarl_$pythonPackage\n\
-	cmd:python$pythonVersion\
-	\""
-if [ "$targetArchitecture" = "x86_gcc2" ]; then
-	eval "PROVIDES_${pythonPackage}+=\"\n\
-		aiohttp_$pythonPackage = $portVersion\
+PYTHON_VERSIONS=(3.10)
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
+
+	eval "PROVIDES_$pythonPackage=\"
+		${portName}_$pythonPackage = $portVersion
 		\""
-fi
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:gcc$secondaryArchSuffix
-	cmd:python$pythonVersion"
+
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_$pythonPackage+=\"
+			aiohttp_$pythonPackage = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku$secondaryArchSuffix
+		aiosignal_$pythonPackage
+		attrs_$pythonPackage
+		async_timeout_$pythonPackage
+		charset_normalizer_$pythonPackage
+		frozenlist_$pythonPackage
+		multidict_$pythonPackage
+		yarl_$pythonPackage
+		cmd:python$pythonVersion
+		\""
+
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }

--- a/dev-python/aiosignal/aiosignal-1.2.0.recipe
+++ b/dev-python/aiosignal/aiosignal-1.2.0.recipe
@@ -19,8 +19,8 @@ aiohttp documentation."
 HOMEPAGE="https://pypi.org/project/aiosignal/"
 COPYRIGHT="2019-2021 Nikolay Kim and Martijn Pieters"
 LICENSE="Apache v2"
-REVISION="3"
-SOURCE_URI="https://files.pythonhosted.org/packages/27/6b/a89fbcfae70cf53f066ec22591938296889d3cc58fec1e1c393b10e8d71d/aiosignal-$portVersion.tar.gz"
+REVISION="4"
+SOURCE_URI="https://files.pythonhosted.org/packages/source/${portName:0:1}/$portName/$portName-$portVersion.tar.gz"
 CHECKSUM_SHA256="78ed67db6c7b7ced4f98e495e572106d5c432a93e1ddd1bf475e1dc05f5b7df2"
 
 ARCHITECTURES="any"
@@ -36,39 +36,46 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+PYTHON_VERSIONS=(3.10)
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cmd:python$pythonVersion
+		\""
+
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }

--- a/dev-python/frozenlist/frozenlist-1.3.1.recipe
+++ b/dev-python/frozenlist/frozenlist-1.3.1.recipe
@@ -7,8 +7,8 @@ FrozenList is also hashable, but only when frozen."
 HOMEPAGE="https://pypi.org/project/frozenlist/"
 COPYRIGHT="2019-2022 aiohttp team"
 LICENSE="Apache v2"
-REVISION="3"
-SOURCE_URI="https://files.pythonhosted.org/packages/8a/95/229aacfe85daa28e2792481a98c336bc30d3729533e6a44db537880aca21/frozenlist-$portVersion.tar.gz"
+REVISION="4"
+SOURCE_URI="https://files.pythonhosted.org/packages/source/f/frozenlist/frozenlist-$portVersion.tar.gz"
 CHECKSUM_SHA256="3a735e4211a04ccfa3f4833547acdf5d2f863bfeb01cfd3edaffbc251f15cec8"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -25,46 +25,52 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku$secondaryArchSuffix\n\
-	cmd:python$pythonVersion\
-	\""
-if [ "$targetArchitecture" = "x86_gcc2" ]; then
-	eval "PROVIDES_${pythonPackage}+=\"\n\
-		frozenlist_$pythonPackage = $portVersion\
+PYTHON_VERSIONS=(3.10)
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
+
+	eval "PROVIDES_$pythonPackage=\"
+		${portName}_$pythonPackage = $portVersion
 		\""
-fi
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:gcc$secondaryArchSuffix
-	cmd:python$pythonVersion"
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_$pythonPackage+=\"
+			frozenlist_$pythonPackage = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku$secondaryArchSuffix
+		cmd:python$pythonVersion
+		\""
+
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+	"
+	BUILD_PREREQUIRES+="
+		cmd:gcc$secondaryArchSuffix
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }
-

--- a/dev-python/multidict/multidict-4.5.2.recipe
+++ b/dev-python/multidict/multidict-4.5.2.recipe
@@ -4,8 +4,8 @@ might be occurred more than once in the container."
 HOMEPAGE="https://pypi.python.org/pypi/multidict"
 COPYRIGHT="2016-2017 Andrew Svetlov"
 LICENSE="MIT"
-REVISION="4"
-SOURCE_URI="https://pypi.io/packages/source/m/multidict/multidict-$portVersion.tar.gz"
+REVISION="5"
+SOURCE_URI="https://files.pythonhosted.org/packages/source/m/multidict/multidict-$portVersion.tar.gz"
 CHECKSUM_SHA256="024b8129695a952ebd93373e45b5d341dbb87c17ce49637b34000093f243dd4f"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -25,45 +25,53 @@ BUILD_PREREQUIRES="
 	gcc$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku$secondaryArchSuffix\n\
-	cmd:python$pythonVersion\
-	\""
-if [ "$targetArchitecture" = "x86_gcc2" ]; then
-	eval "PROVIDES_${pythonPackage}+=\"\n\
-		multidict_$pythonPackage = $portVersion\
+PYTHON_VERSIONS=(3.10)
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
+
+	eval "PROVIDES_$pythonPackage=\"
+		${portName}_$pythonPackage = $portVersion
 		\""
-fi
-BUILD_REQUIRES="$BUILD_REQUIRES
-	cython_$pythonPackage
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_${pythonPackage}+=\"
+			multidict_$pythonPackage = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku$secondaryArchSuffix
+		cmd:python$pythonVersion
+		\""
+
+	BUILD_REQUIRES+="
+		cython_$pythonPackage
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }


### PR DESCRIPTION
These packages are needed only by `slixmpp` (which is needed only by `poezio`).

As `poezio` and `slixmpp` are already Python 3.10 only, drop 3.9 from these recipes too.

---

Smoke tested each package on beta4 32 bits. Poezio still functional after installing these.