### PR TITLE
autoconf: update to version 2.72

### DIFF
--- a/dev-build/autoconf/autoconf-2.72.recipe
+++ b/dev-build/autoconf/autoconf-2.72.recipe
@@ -1,0 +1,78 @@
+SUMMARY="A tool to automatically configure source code"
+DESCRIPTION="GNU Autoconf is a tool for configuring source code and \
+makefiles. Using autoconf, programmers can create portable and configurable \
+packages, because the person building the package is allowed to specify \
+various configuration options."
+HOMEPAGE="http://www.gnu.org/software/autoconf/"
+COPYRIGHT="1996, 2000-2001, 2005, 2007-2017, 2020-2023 Free Software"
+LICENSE="GNU GPL v2
+	GNU GPL v3"
+REVISION="1"
+SOURCE_URI="http://ftp.gnu.org/gnu/autoconf/autoconf-$portVersion.tar.gz"
+CHECKSUM_SHA256="afb181a76e1ee72832f6581c0eddf8df032b83e2e0239ef79ebedc4467d92d6e"
+BUILD_PACKAGE_ACTIVATION_PHASE="INSTALL"
+
+ARCHITECTURES="all"
+
+PROVIDES="
+	autoconf = $portVersion compat >= 2.60
+	cmd:autoconf = $portVersion compat >= 2.60
+	cmd:autoheader = $portVersion compat >= 2.60
+	cmd:autom4te = $portVersion compat >= 2.60
+	cmd:autoreconf = $portVersion compat >= 2.60
+	cmd:autoscan = $portVersion compat >= 2.60
+	cmd:autoupdate = $portVersion compat >= 2.60
+	cmd:ifnames = $portVersion compat >= 2.60
+	"
+REQUIRES="
+	haiku
+	cmd:awk
+	cmd:cmp
+	cmd:expr
+	cmd:grep
+	cmd:m4 >= 1.4
+	cmd:mkdir
+	cmd:perl >= 5.8
+	cmd:sh
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:m4
+	cmd:make
+	cmd:makeinfo
+	cmd:perl >= 5
+	cmd:sed
+	cmd:cmp
+	"
+
+TEST_REQUIRES="
+	cmd:find
+	"
+
+BUILD()
+{
+	# make sure that the build system doesn't try to update the manpages,
+	# as that requires help2man, which isn't available
+	touch man/*.1
+	# same for the configure, which needs autoconf
+	touch configure
+
+	PERL="/bin/env perl" M4="m4" SED="sed" \
+		runConfigure ./configure
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+	make install-html
+}
+
+TEST()
+{
+	make check
+}

--- a/dev-build/autoconf/autoconf2.71-2.71.recipe
+++ b/dev-build/autoconf/autoconf2.71-2.71.recipe
@@ -7,22 +7,23 @@ HOMEPAGE="http://www.gnu.org/software/autoconf/"
 COPYRIGHT="1996, 2000-2001, 2005, 2007-2017, 2020-2021 Free Software"
 LICENSE="GNU GPL v2
 	GNU GPL v3"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="http://ftp.gnu.org/gnu/autoconf/autoconf-2.71.tar.gz"
 CHECKSUM_SHA256="431075ad0bf529ef13cb41e9042c542381103e80015686222b8a9d4abef42a1c"
+SOURCE_DIR="autoconf-$portVersion"
 BUILD_PACKAGE_ACTIVATION_PHASE="INSTALL"
 
 ARCHITECTURES="all"
 
 PROVIDES="
-	autoconf = $portVersion compat >= 2.60
-	cmd:autoconf = $portVersion compat >= 2.60
-	cmd:autoheader = $portVersion compat >= 2.60
-	cmd:autom4te = $portVersion compat >= 2.60
-	cmd:autoreconf = $portVersion compat >= 2.60
-	cmd:autoscan = $portVersion compat >= 2.60
-	cmd:autoupdate = $portVersion compat >= 2.60
-	cmd:ifnames = $portVersion compat >= 2.60
+	autoconf2.71 = $portVersion compat >= 2.71
+	cmd:autoconf_2.71 = $portVersion compat >= 2.71
+	cmd:autoheader_2.71 = $portVersion compat >= 2.71
+	cmd:autom4te_2.71 = $portVersion compat >= 2.71
+	cmd:autoreconf_2.71 = $portVersion compat >= 2.71
+	cmd:autoscan_2.71 = $portVersion compat >= 2.71
+	cmd:autoupdate_2.71 = $portVersion compat >= 2.71
+	cmd:ifnames_2.71 = $portVersion compat >= 2.71
 	"
 REQUIRES="
 	haiku
@@ -62,14 +63,13 @@ BUILD()
 	touch configure
 
 	PERL="/bin/env perl" M4="m4" SED="sed" \
-		runConfigure ./configure
-	make $jobArgs
+		./configure $configureDirArgs --program-suffix=-$portVersion
+	make $jobArgs pkgdatadir=$dataDir/autoconf-$portVersion
 }
 
 INSTALL()
 {
-	make install
-	make install-html
+	make $jobArgs pkgdatadir=$dataDir/autoconf-$portVersion install install-html
 }
 
 TEST()


### PR DESCRIPTION
retain version 2.71 for compatibility, similar to the existing older versions.

Questions for the experts:
 - do we need to keep version 2.71?
 - the current, version-less version (2.71 before, 2.72 now) uses `compat >= 2.60`. Should that be changed?