### PR TITLE
mame: Version bump; disable x86 as buildmaster runs out of RAM

### DIFF
--- a/games-emulation/mame/mame-0.264.patchset
+++ b/games-emulation/mame/mame-0.264.patchset
@@ -1,4 +1,4 @@
-From 7f720b8a0e204df6066b77de0554ea4e4e58c0ee Mon Sep 17 00:00:00 2001
+From e716259a265c100495961fd49636c775477ab67a Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Wed, 10 Jun 2020 22:35:16 +1000
 Subject: Haiku patches
@@ -676,7 +676,7 @@ index f0782db..5a3a636 100644
  #define PLATFORM_WINDOWS  (1)
  #define PLATFORM_STRING   "windows"
 diff --git a/makefile b/makefile
-index 3567ccd..a4dece3 100644
+index 3a886bb..e1e3bae 100644
 --- a/makefile
 +++ b/makefile
 @@ -224,6 +224,7 @@ GENIEOS := darwin
@@ -799,10 +799,10 @@ index 57ff069..e0ff74e 100644
  #include <termios.h>
  #include <libutil.h>
 -- 
-2.42.1
+2.43.2
 
 
-From c774a87041de59d3ebaac61743899e4a9cb52dc4 Mon Sep 17 00:00:00 2001
+From f5deb9c4518454165326bb62414a8cc4cb8986c2 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Thu, 11 Jun 2020 08:59:34 +1000
 Subject: Use stat Haiku
@@ -840,10 +840,10 @@ index dab8620..ceb2263 100644
  					_out.type = FileType::File;
  					_out.size = UINT64_MAX;
 -- 
-2.42.1
+2.43.2
 
 
-From 251494409f89b8de477040c79037d21b672f82c4 Mon Sep 17 00:00:00 2001
+From 4cf12b97d5c6bf2a9c07cdefa4770989e1381b41 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Thu, 11 Jun 2020 09:00:11 +1000
 Subject: Disable ptty
@@ -863,10 +863,10 @@ index e0ff74e..39a0a5a 100644
  #else // defined(__ANDROID__)
  	// TODO: handling of the slave path is insecure - should use ptsname_r/ttyname_r in a loop
 -- 
-2.42.1
+2.43.2
 
 
-From cbcc263c07bd1ae3574c6ac1e36ed70e98456a4e Mon Sep 17 00:00:00 2001
+From 9ba4dff18ff1a8febd4c479fdc7e074b0446cc13 Mon Sep 17 00:00:00 2001
 From: PulkoMandy <pulkomandy@pulkomandy.tk>
 Date: Fri, 5 Aug 2022 19:24:12 +0200
 Subject: Allow use of Qt Debugger on Haiku
@@ -902,10 +902,10 @@ index cc31fa5..2727ce7 100644
  		local str = backtick(sdlconfigcmd() .. " --libs")
  		addlibfromstring(str)
 -- 
-2.42.1
+2.43.2
 
 
-From fde4589543b60077b6f9e492c85b6dcac177c5ca Mon Sep 17 00:00:00 2001
+From 788aae9c4707ec6d6cb680b19a3f907fa17ca2da Mon Sep 17 00:00:00 2001
 From: Alex Brown <mail@alexbrown.info>
 Date: Sat, 14 Oct 2023 11:26:57 +0100
 Subject: toolchain.lua: set targetdir for Haiku
@@ -957,20 +957,20 @@ index 52d5146..0b67b44 100644
  		targetdir (_buildDir .. "osx_clang" .. "/bin/x64/Debug")
  
 -- 
-2.42.1
+2.43.2
 
 
-From 8a5384601d6aded42fc2948d0daa71f4e9f401f6 Mon Sep 17 00:00:00 2001
+From 9fd5751fad041e1633680f67e6697738db542c68 Mon Sep 17 00:00:00 2001
 From: Alex Brown <mail@alexbrown.info>
 Date: Sat, 14 Oct 2023 09:14:19 +0100
 Subject: Set LinkSupportCircularDependencies for Haiku
 
 
 diff --git a/scripts/genie.lua b/scripts/genie.lua
-index 3a6a2bf..5f1f4d0 100644
+index 3fe6096..cd98264 100644
 --- a/scripts/genie.lua
 +++ b/scripts/genie.lua
-@@ -1250,6 +1250,11 @@ configuration { "freebsd or netbsd" }
+@@ -1253,6 +1253,11 @@ configuration { "freebsd or netbsd" }
  			"LinkSupportCircularDependencies",
  		}
  
@@ -983,5 +983,5 @@ index 3a6a2bf..5f1f4d0 100644
  		links {
  			"pthread",
 -- 
-2.42.1
+2.43.2
 

--- a/games-emulation/mame/mame-0.264.recipe
+++ b/games-emulation/mame/mame-0.264.recipe
@@ -15,7 +15,7 @@ COPYRIGHT="1997-2023 MAMEDev and contributors"
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://github.com/mamedev/mame/archive/mame${portVersion/./}.tar.gz"
-CHECKSUM_SHA256="2f380a7a9344711c667aef6014d522dd876db4c04f15dbab8d14bd3b2a0d4c8c"
+CHECKSUM_SHA256="3d9f69ed3ef7c1628d5714c8ae2695ea77b1a652a93347b2703f7c862299376e"
 SOURCE_FILENAME="mame-$portVersion.tar.gz"
 SOURCE_DIR="mame-mame${portVersion/./}"
 PATCHES="mame-$portVersion.patchset"
@@ -24,20 +24,13 @@ ADDITIONAL_FILES="
 	mame.rdef.in"
 
 ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="x86"
+SECONDARY_ARCHITECTURE="!x86"
 
 bits=64
 optimize=3
 makejobs=$jobArgs
 commandBinDir=$binDir
 commandSuffix=$secondaryArchSuffix
-if [ "$targetArchitecture" = x86_gcc2 ]; then
-	bits=
-	commandBinDir=$prefix/bin
-	commandSuffix=
-	makejobs=1
-	optimize=1
-fi
 
 PROVIDES="
 	mame$secondaryArchSuffix = $portVersion


### PR DESCRIPTION
Can someone please check that I've disabled the x86 build properly? Thank you!