### PR TITLE
Gottet: Update to 1.2.3 and Qt 6

### DIFF
--- a/games-puzzle/gottet/gottet-1.2.3.recipe
+++ b/games-puzzle/gottet/gottet-1.2.3.recipe
@@ -1,4 +1,4 @@
-SUMMARY="A tetris clone based on Qt5"
+SUMMARY="A tetris clone based on Qt6"
 DESCRIPTION="Gottet is a clean, simple falling blocks game. \
 Use the arrow keys to rotate and position each piece as it \
 falls. Fill a whole row to clear it. Unlimited levels, with \
@@ -7,8 +7,8 @@ HOMEPAGE="https://gottcode.org/gottet/"
 COPYRIGHT="2009-2020 Graeme Gott"
 LICENSE="GNU GPL v3"
 REVISION="1"
-SOURCE_URI="https://gottcode.org/gottet/gottet-$portVersion-src.tar.bz2"
-CHECKSUM_SHA256="6c979caa5b3fa6854ca8367ca0595814fcc101f0bdfad02d64219dd9049abb2b"
+SOURCE_URI="https://gottcode.org/gottet/gottet-$portVersion.tar.bz2"
+CHECKSUM_SHA256="0fafb1f4e43a91bfc86c6948af986605d458ec618476b803b40d5d0841d43f1a"
 SOURCE_DIR="gottet-$portVersion"
 ADDITIONAL_FILES="gottet.rdef.in"
 
@@ -21,37 +21,49 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	qt6_tools$secondaryArchSuffix
 	lib:libGL$secondaryArchSuffix
-	lib:libQt5Core$secondaryArchSuffix
-	lib:libQt5Gui$secondaryArchSuffix
-	lib:libQt5Widgets$secondaryArchSuffix
+	lib:libQt6Core$secondaryArchSuffix
+	lib:libQt6Gui$secondaryArchSuffix
+	lib:libQt6Widgets$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libQt5Core$secondaryArchSuffix
-	devel:libQt5Gui$secondaryArchSuffix
-	devel:libQt5Widgets$secondaryArchSuffix
+	qt6_tools${secondaryArchSuffix}_devel
+	devel:libQt6Core$secondaryArchSuffix
+	devel:libQt6Gui$secondaryArchSuffix
+	devel:libQt6Widgets$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
+	cmd:cmake
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
-	cmd:lrelease$secondaryArchSuffix >= 5
+	cmd:linguist6$secondaryArchSuffix
+	cmd:lrelease$secondaryArchSuffix
 	cmd:make
-	cmd:qmake$secondaryArchSuffix >= 5
+	cmd:pkg_config$xecondaryArchSuffix
 	"
 
 BUILD()
 {
-	qmake
-	make $jobArgs
+	cmake -B build -S . \
+		-DCMAKE_BUILD_TYPE='None' \
+		-Wno-dev \
+		-DCMAKE_INSTALL_BINDIR=$appsDir \
+		-DCMAKE_INSTALL_DATADIR=$dataDir/Gottet \
+		-DCMAKE_INSTALL_MANDIR=$manDir
+	cmake --build build $jobArgs
 }
 
 INSTALL()
 {
-	mkdir -p $appsDir/Gottet/translations
-	cp gottet $appsDir/Gottet/Gottet
-	cp -Rf translations/*.qm $appsDir/Gottet/translations
+	cmake --install build
+
+	# Remove unnecessary data files
+	rm -r $dataDir/Gottet/applications
+	rm -r $dataDir/Gottet/icons
+	rm -r $dataDir/Gottet/metainfo
 
 	local APP_SIGNATURE="application/x-vnd.gottcode-gottet"
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
@@ -66,10 +78,11 @@ INSTALL()
 		-e "s|@LONG_INFO@|$LONG_INFO|" \
 		$portDir/additional-files/gottet.rdef.in > $sourceDir/gottet.rdef
 
+	mv $appsDir/gottet $appsDir/Gottet
 	addResourcesToBinaries  $sourceDir/gottet.rdef \
-		$appsDir/Gottet/Gottet
+		$appsDir/Gottet
 
-	mimeset -f $appsDir/Gottet/Gottet
+	mimeset -f $appsDir/Gottet
 
-	addAppDeskbarSymlink $appsDir/Gottet/Gottet
+	addAppDeskbarSymlink $appsDir/Gottet
 }


### PR DESCRIPTION
This PR updates Gottet to version `1.2.3` and to use Qt 6.

Confirmed working on `x86_64`:
![screenshot1](https://github.com/haikuports/haikuports/assets/11584387/00fba1bd-c184-4a77-9efb-650549463421)
![screenshot2](https://github.com/haikuports/haikuports/assets/11584387/8e73123d-0ac5-4650-ad05-2a3c5966d1bd)
