### PR TITLE
Hexalate: Update to Qt 6

### DIFF
--- a/games-puzzle/hexalate/hexalate-1.2.3.recipe
+++ b/games-puzzle/hexalate/hexalate-1.2.3.recipe
@@ -21,7 +21,6 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	qt6_tools$secondaryArchSuffix
 	lib:libGL$secondaryArchSuffix
 	lib:libQt6Core$secondaryArchSuffix
 	lib:libQt6Gui$secondaryArchSuffix

--- a/games-puzzle/hexalate/hexalate-1.2.3.recipe
+++ b/games-puzzle/hexalate/hexalate-1.2.3.recipe
@@ -7,8 +7,8 @@ HOMEPAGE="https://gottcode.org/hexalate/"
 COPYRIGHT="2009-2020 Graeme Gott"
 LICENSE="GNU GPL v3"
 REVISION="1"
-SOURCE_URI="https://gottcode.org/hexalate/hexalate-$portVersion-src.tar.bz2"
-CHECKSUM_SHA256="5d3198523960d4df394d2092cd7e7b9003878a70a2934dbada60947651b1c88d"
+SOURCE_URI="https://gottcode.org/hexalate/hexalate-$portVersion.tar.bz2"
+CHECKSUM_SHA256="4e1a8391c072d030964cc4b4953031217bc8633c0d9a326a43110e9e4e4e0a62"
 SOURCE_DIR="hexalate-$portVersion"
 ADDITIONAL_FILES="hexalate.rdef.in"
 
@@ -21,37 +21,49 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	qt6_tools$secondaryArchSuffix
 	lib:libGL$secondaryArchSuffix
-	lib:libQt5Core$secondaryArchSuffix
-	lib:libQt5Gui$secondaryArchSuffix
-	lib:libQt5Widgets$secondaryArchSuffix
+	lib:libQt6Core$secondaryArchSuffix
+	lib:libQt6Gui$secondaryArchSuffix
+	lib:libQt6Widgets$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libQt5Core$secondaryArchSuffix
-	devel:libQt5Gui$secondaryArchSuffix
-	devel:libQt5Widgets$secondaryArchSuffix
+	qt6_tools${secondaryArchSuffix}_devel
+	devel:libQt6Core$secondaryArchSuffix
+	devel:libQt6Gui$secondaryArchSuffix
+	devel:libQt6Widgets$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
+	cmd:cmake
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
-	cmd:lrelease$secondaryArchSuffix >= 5
+	cmd:linguist6$secondaryArchSuffix
+	cmd:lrelease$secondaryArchSuffix
 	cmd:make
-	cmd:qmake$secondaryArchSuffix >= 5
+	cmd:pkg_config$xecondaryArchSuffix
 	"
 
 BUILD()
 {
-	qmake
-	make $jobArgs
+	cmake -B build -S . \
+		-DCMAKE_BUILD_TYPE='None' \
+		-Wno-dev \
+		-DCMAKE_INSTALL_BINDIR=$appsDir \
+		-DCMAKE_INSTALL_DATADIR=$dataDir/Hexalate \
+		-DCMAKE_INSTALL_MANDIR=$manDir
+	cmake --build build $jobArgs
 }
 
 INSTALL()
 {
-	mkdir -p $appsDir/Hexalate/translations
-	cp hexalate $appsDir/Hexalate/Hexalate
-	cp -Rf translations/*.qm $appsDir/Hexalate/translations
+	cmake --install build
+
+	# Remove unnecessary data files
+	rm -r $dataDir/Hexalate/applications
+	rm -r $dataDir/Hexalate/icons
+	rm -r $dataDir/Hexalate/metainfo
 
 	local APP_SIGNATURE="application/x-vnd.gottcode-hexalate"
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
@@ -66,10 +78,11 @@ INSTALL()
 		-e "s|@LONG_INFO@|$LONG_INFO|" \
 		$portDir/additional-files/hexalate.rdef.in > $sourceDir/hexalate.rdef
 
+	mv $appsDir/hexalate $appsDir/Hexalate
 	addResourcesToBinaries  $sourceDir/hexalate.rdef \
-		$appsDir/Hexalate/Hexalate
+		$appsDir/Hexalate
 
-	mimeset -f $appsDir/Hexalate/Hexalate
+	mimeset -f $appsDir/Hexalate
 
-	addAppDeskbarSymlink $appsDir/Hexalate/Hexalate Hexalate
+	addAppDeskbarSymlink $appsDir/Hexalate
 }

--- a/games-puzzle/hexalate/hexalate-1.2.3.recipe
+++ b/games-puzzle/hexalate/hexalate-1.2.3.recipe
@@ -29,9 +29,9 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	qt6_tools${secondaryArchSuffix}_devel
 	devel:libQt6Core$secondaryArchSuffix
 	devel:libQt6Gui$secondaryArchSuffix
+	devel:libQt6UiTools$secondaryArchSuffix
 	devel:libQt6Widgets$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
@@ -39,9 +39,7 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
 	cmd:linguist6$secondaryArchSuffix
-	cmd:lrelease$secondaryArchSuffix
 	cmd:make
-	cmd:pkg_config$xecondaryArchSuffix
 	"
 
 BUILD()


### PR DESCRIPTION
This recipe updates *Hexalate* to `1.2.3` and use Qt 6.

Confirmed working on `x86_64`:
![screenshot1](https://github.com/haikuports/haikuports/assets/11584387/2b447548-76bb-4db8-ae90-96573dfef40d)
