### PR TITLE
Peg-E: Update to Qt 6

### DIFF
--- a/games-board/peg-e/peg_e-1.3.3.recipe
+++ b/games-board/peg-e/peg_e-1.3.3.recipe
@@ -7,8 +7,8 @@ HOMEPAGE="https://gottcode.org/peg-e/"
 COPYRIGHT="2009-2020 Graeme Gott"
 LICENSE="GNU GPL v3"
 REVISION="1"
-SOURCE_URI="https://gottcode.org/peg-e/peg-e-$portVersion-src.tar.bz2"
-CHECKSUM_SHA256="06d6a07c056b82372cdd6ac258dbfedab397ad4f13b70117f548b8218201ff17"
+SOURCE_URI="https://gottcode.org/peg-e/peg-e-$portVersion.tar.bz2"
+CHECKSUM_SHA256="5585b119f62e51c603de4fc48c1ce7c16068547b247dc343171042c3dd1c1666"
 SOURCE_DIR="peg-e-$portVersion"
 ADDITIONAL_FILES="peg_e.rdef.in"
 
@@ -17,41 +17,48 @@ SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	peg_e$secondaryArchSuffix = $portVersion
-	app:PegE$secondaryArchSuffix = $portVersion
+	app:PegE = $portVersion
 	"
+
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libGL$secondaryArchSuffix
-	lib:libQt5Core$secondaryArchSuffix
-	lib:libQt5Gui$secondaryArchSuffix
-	lib:libQt5Widgets$secondaryArchSuffix
+	lib:libQt6Core$secondaryArchSuffix
+	lib:libQt6Gui$secondaryArchSuffix
+	lib:libQt6Widgets$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libQt5Core$secondaryArchSuffix
-	devel:libQt5Gui$secondaryArchSuffix
-	devel:libQt5Widgets$secondaryArchSuffix
+	devel:libQt6Core$secondaryArchSuffix
+	devel:libQt6Gui$secondaryArchSuffix
+	devel:libQt6UiTools$secondaryArchSuffix
+	devel:libQt6Widgets$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
+	cmd:cmake
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
-	cmd:lrelease$secondaryArchSuffix >= 5
+	cmd:linguist6$secondaryArchSuffix
 	cmd:make
-	cmd:qmake$secondaryArchSuffix >= 5
 	"
 
 BUILD()
 {
-	qmake
-	make $jobArgs
+	cmake -B build -S . \
+		-DCMAKE_BUILD_TYPE='None' \
+		-DCMAKE_INSTALL_BINDIR=$appsDir \
+		-DCMAKE_INSTALL_DATADIR=$dataDir/Peg-E/ \
+		-DCMAKE_INSTALL_MANDIR=$manDir
+
+	cmake --build build $jobArgs
 }
 
 INSTALL()
 {
-	mkdir -p $appsDir/Peg-E/translations
-	cp peg-e $appsDir/Peg-E/Peg-E
-	cp -Rf translations/*.qm $appsDir/Peg-E/translations
+	cmake --install build
+	mv $appsDir/peg-e $appsDir/Peg-E
+	rm -rf $dataDir/Peg-E/{metainfo,icons,applications}
 
 	local APP_SIGNATURE="application/x-vnd.gottcode-peg-e"
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
@@ -67,9 +74,9 @@ INSTALL()
 		$portDir/additional-files/peg_e.rdef.in > $sourceDir/peg_e.rdef
 
 	addResourcesToBinaries  $sourceDir/peg_e.rdef \
-		$appsDir/Peg-E/Peg-E
+		$appsDir/Peg-E
 
-	mimeset -f $appsDir/Peg-E/Peg-E
+	mimeset -f $appsDir/Peg-E
 
-	addAppDeskbarSymlink $appsDir/Peg-E/Peg-E Peg-E
+	addAppDeskbarSymlink $appsDir/Peg-E
 }


### PR DESCRIPTION
This PR updates *Peg-E* to `1.3.3` and to switch from Qt 5 to Qt 6.

Confirmed working on `x86_64`:
![screenshot1](https://github.com/haikuports/haikuports/assets/11584387/2ff9544e-f7de-42c3-bbc5-fce893148adc)
![screenshot2](https://github.com/haikuports/haikuports/assets/11584387/634e20a0-022f-422a-9001-2feb2e0a1394)
