### PR TITLE
dma: add recipe for 0.14~git

### DIFF
--- a/mail-mta/dma/additional-files/dma-finish-setup.sh.in
+++ b/mail-mta/dma/additional-files/dma-finish-setup.sh.in
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# create our spool dirs with the right group and setgid bit on
+install -d -m 2775 -o 0 -g mail \
+	`finddir B_SYSTEM_VAR_DIRECTORY`/mail \
+	`finddir B_SYSTEM_SPOOL_DIRECTORY`/dma
+
+# copy the bin to non-packaged so that we can change the group
+install -D -m 2755 -g mail @DMA_BIN@ `finddir B_SYSTEM_NONPACKAGED_LIB_DIRECTORY`/dma

--- a/mail-mta/dma/dma-0.14~git.recipe
+++ b/mail-mta/dma/dma-0.14~git.recipe
@@ -1,0 +1,100 @@
+SUMMARY="A small Mail Transport Agent (MTA), designed for home and office use"
+DESCRIPTION="DragonFly Mail Agent is a small Mail Transport Agent (MTA), designed for home and \
+office use.  It accepts mails from locally installed Mail User Agents (MUA) and delivers the mails \
+either locally or to a remote destination.  Remote delivery includes several features like TLS/SSL \
+support and SMTP authentication.
+
+dma is not intended as a replacement for real, big MTAs like sendmail or postfix.  Consequently, \
+dma does not listen on port 25 for incoming connections."
+HOMEPAGE="https://github.com/corecode/dma"
+COPYRIGHT="
+	2008-2014 Simon Schubert
+	2008 The DragonFly Project
+	"
+LICENSE="BSD (3-clause)"
+REVISION="1"
+srcGitRev="a4ed8467f11854045bea48e25df78528db225b72"
+SOURCE_URI="https://github.com/corecode/dma/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="7ccb3d0428fc34ff1625eae2f0b1f116f4374f03b3f1a54f4c1410e63067256e"
+SOURCE_DIR="dma-$srcGitRev"
+PATCHES="dma-$portVersion.patchset"
+ADDITIONAL_FILES="dma-finish-setup.sh.in"
+
+GLOBAL_WRITABLE_FILES="
+	settings/dma/auth.conf keep-old
+	settings/dma/dma.conf keep-old
+	"
+
+PACKAGE_USERS="
+    mail real-name \"mail daemon\" home \"/var/empty\" shell \"/bin/true\" groups \"mail\"
+    "
+PACKAGE_GROUPS="mail"
+
+POST_INSTALL_SCRIPTS="$relativePostInstallDir/dma-finish-setup.sh"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	dma$secondaryArchSuffix = $portVersion
+	cmd:dma = $portVersion
+	cmd:mailq = $portVersion
+	cmd:sendmail = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcrypto
+	lib:libssl
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libcrypto
+	devel:libssl
+	"
+BUILD_PREREQUIRES="
+	cmd:flex
+	cmd:make
+	cmd:gcc$secondaryArchSuffix
+	cmd:yacc
+	"
+
+PATCH()
+{
+	# we don't have a 'root' user or an existing 'mail' group so use UID/GID for now
+	sed -i -e 's,o root,o 0,' -e 's,g mail,g 0,' Makefile
+
+	# adjust paths in documentation
+	sed -i "s, /etc/dma, $settingsDir/dma," dma.8 dma.conf
+}
+
+BUILD()
+{
+	CFLAGS="-D_DEFAULT_SOURCE -DHAVE_GETPROGNAME -DDMA_GROUP='\"mail\"' -DDMA_ROOT_USER='\"mail\"'" \
+	make LDADD="-lssl -lcrypto -lnetwork -lbsd" \
+		PREFIX=$prefix \
+		SBIN=$prefix/bin \
+		MAN=$manDir \
+		VAR=$localStateDir \
+		CONFDIR=$settingsDir/dma
+}
+
+INSTALL()
+{
+	make \
+		PREFIX=$prefix \
+		SBIN=$prefix/bin \
+		MAN=$manDir \
+		VAR=$localStateDir \
+		CONFDIR=$settingsDir/dma \
+		install install-etc sendmail-link mailq-link
+
+	# workarounds because we can't have files owned by a user that's created by the package
+	mv -fv $prefix/bin/dma $prefix/lib
+	ln -sfv `finddir B_SYSTEM_NONPACKAGED_LIB_DIRECTORY`/dma $prefix/bin/dma
+
+	mkdir -pv $postInstallDir
+	sed "s,@DMA_BIN@,$prefix/lib/dma," $portDir/additional-files/dma-finish-setup.sh.in \
+		> $postInstallDir/dma-finish-setup.sh
+	chmod +x $postInstallDir/dma-finish-setup.sh
+}

--- a/mail-mta/dma/patches/dma-0.14~git.patchset
+++ b/mail-mta/dma/patches/dma-0.14~git.patchset
@@ -1,0 +1,47 @@
+From ec4e5444464ceb06eb5beff9b3e74ca564ec45f5 Mon Sep 17 00:00:00 2001
+From: Chris Roberts <cpr420@gmail.com>
+Date: Sun, 28 Apr 2024 11:56:56 -0600
+Subject: add roundup macro on Haiku
+
+
+diff --git a/dns.c b/dns.c
+index 8867c83..01ac6b1 100644
+--- a/dns.c
++++ b/dns.c
+@@ -46,6 +46,10 @@
+ 
+ #include "dma.h"
+ 
++#ifdef __HAIKU__
++#define roundup(x, y)    ((((x)+((y)-1))/(y))*(y))
++#endif
++
+ static int
+ sort_pref(const void *a, const void *b)
+ {
+-- 
+2.43.2
+
+
+From 6a6cad894ac72d11b1b0eeb278e96d8032ce5c85 Mon Sep 17 00:00:00 2001
+From: Chris Roberts <cpr420@gmail.com>
+Date: Sun, 28 Apr 2024 11:57:44 -0600
+Subject: use rename instead of hard links
+
+
+diff --git a/spool.c b/spool.c
+index 1cdce75..c37bbf6 100644
+--- a/spool.c
++++ b/spool.c
+@@ -258,7 +258,7 @@ linkspool(struct queue *queue)
+ 		if (writequeuef(it) != 0)
+ 			goto delfiles;
+ 
+-		if (link(queue->tmpf, it->mailfn) != 0)
++		if (rename(queue->tmpf, it->mailfn) != 0)
+ 			goto delfiles;
+ 	}
+ 
+-- 
+2.43.2
+


### PR DESCRIPTION
Untested with internet delivery but delivering to local users works.

The recipe is a bit ugly since the `dma` executable wants to have setgid of the group that is created by the package itself.  The package could be made to run as uid/gid 0, but, using a post-install script to make the spool dirs and a copy of the dma executable with correct ownership seems to work ok for now.