### PR TITLE
at: add recipe for 3.2.5

### DIFF
--- a/sys-process/at/additional-files/at-finish-setup.sh.in
+++ b/sys-process/at/additional-files/at-finish-setup.sh.in
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# for our pid file
+install -d -m 755 -o 0 -g 0 `finddir B_SYSTEM_VAR_DIRECTORY`/run
+
+# create our spool dirs/files with the right mode
+spoolDir=`finddir B_SYSTEM_SPOOL_DIRECTORY`
+install -d -m 1770 -o atd -g atd $spoolDir/atjobs $spoolDir/atspool
+install -D -m 600 -o atd -g atd /dev/null $spoolDir/atjobs/.SEQ
+
+# copy the bin to non-packaged so that we can change the user/group
+install -D -m 6755 -o atd -g atd @AT_BIN@ `finddir B_SYSTEM_NONPACKAGED_LIB_DIRECTORY`/at

--- a/sys-process/at/additional-files/atd.launch.in
+++ b/sys-process/at/additional-files/atd.launch.in
@@ -1,0 +1,8 @@
+
+
+job x-vnd.at-atd {
+	launch @ATD_BIN@ -f
+	on initial_volumes_mounted
+	no_safemode
+	legacy
+}

--- a/sys-process/at/at-3.2.5.recipe
+++ b/sys-process/at/at-3.2.5.recipe
@@ -1,0 +1,117 @@
+SUMMARY="Queues jobs for later execution"
+DESCRIPTION="This is the standard UNIX 'at' daemon which allows batch processing and queueing of \
+jobs for later execution."
+HOMEPAGE="https://packages.qa.debian.org/a/at.html"
+COPYRIGHT="
+	1993-1997 Thomas Koenig
+	1993 David Parsons
+	2002-2005 Ryan Murray
+	1989-2007 Free Software Foundation Inc
+	"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="http://ftp.debian.org/debian/pool/main/a/at/at_$portVersion.orig.tar.gz"
+CHECKSUM_SHA256="bb066b389d7c9bb9d84a35738032b85c30cba7d949f758192adc72c9477fd3b8"
+PATCHES="at-$portVersion.patchset"
+ADDITIONAL_FILES="
+	at-finish-setup.sh.in
+	atd.launch.in
+	"
+GLOBAL_WRITABLE_FILES="settings/at.deny keep-old"
+POST_INSTALL_SCRIPTS="$relativePostInstallDir/at-finish-setup.sh"
+
+PACKAGE_USERS="
+    atd real-name \"atd daemon\" home \"/var/empty\" shell \"/bin/true\" groups \"atd\"
+	"
+PACKAGE_GROUPS="atd"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	at$secondaryArchSuffix = $portVersion
+	cmd:at = $portVersion
+	cmd:atd = $portVersion
+	cmd:atq = $portVersion
+	cmd:atrm = $portVersion
+	cmd:atrun = $portVersion
+	cmd:batch = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	cmd:sendmail
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:autoheader
+	cmd:autoreconf
+	cmd:bison
+	cmd:flex
+	cmd:gcc$secondaryArchSuffix
+	cmd:grep
+	cmd:m4
+	cmd:make
+	"
+
+PATCH()
+{
+	# we don't have a 'root' user or an existing 'atd' user/group so use UID/GID 0
+	sed -i \
+		-e 's,o root,o 0,' \
+		-e 's,g $(DAEMON_GROUPNAME),g 0,' \
+		-e 's,o $(DAEMON_USERNAME),o 0,' \
+		-e 's,$(DAEMON_USERNAME):$(DAEMON_GROUPNAME),0:0,' \
+		Makefile.in
+
+	# adjust documentation to match out layout
+	sed -i "s,/etc/at,$settingsDir/at," atd.8.in at.allow.5.in
+}
+
+BUILD()
+{
+	autoreconf -vfi
+
+	# needed so the configure script detects where to put the pid file
+	mkdir -pv `finddir B_SYSTEM_VAR_DIRECTORY`/run
+
+	local spoolDir=`finddir B_SYSTEM_SPOOL_DIRECTORY`
+
+	SENDMAIL=/bin/sendmail \
+	runConfigure --omit-dirs "binDir sbinDir docDir" ./configure \
+		--bindir=$prefix/bin \
+		--sbindir=$prefix/bin \
+		--docdir=$documentationDir/packages \
+		--with-etcdir=$settingsDir \
+		--with-jobdir=$spoolDir/atjobs \
+		--with-atspool=$spoolDir/atspool \
+		--with-daemon_username=atd \
+		--with-daemon_groupname=atd
+
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make -k $jobArgs install
+
+	mkdir -pv $dataDir/launch
+	sed "s,@ATD_BIN@,$prefix/bin/atd," $portDir/additional-files/atd.launch.in \
+		> $dataDir/launch/atd.launch
+
+	# workarounds because you can't have files owned by a user that's created by the package
+	rm -rf $localStateDir
+
+	mkdir -pv $prefix/lib
+	mv -fv $prefix/bin/at $prefix/lib/at
+	ln -sfv `finddir B_SYSTEM_NONPACKAGED_LIB_DIRECTORY`/at $prefix/bin/at
+
+	mkdir -pv $postInstallDir
+	sed "s,@AT_BIN@,$prefix/lib/at," $portDir/additional-files/at-finish-setup.sh.in \
+		> $postInstallDir/at-finish-setup.sh
+	chmod +x $postInstallDir/at-finish-setup.sh
+}

--- a/sys-process/at/patches/at-3.2.5.patchset
+++ b/sys-process/at/patches/at-3.2.5.patchset
@@ -1,0 +1,84 @@
+From 1ee9f9d74dbd48544f3875e63152171bf23a8562 Mon Sep 17 00:00:00 2001
+From: Chris Roberts <cpr420@gmail.com>
+Date: Sun, 28 Apr 2024 22:13:12 -0600
+Subject: disable pam since it causes problems
+
+
+diff --git a/configure.ac b/configure.ac
+index 073bc9f..a143109 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -95,10 +95,10 @@ dnl Checks for library functions.
+ AC_FUNC_VPRINTF
+ AC_FUNC_GETLOADAVG
+ AC_CHECK_FUNCS(getcwd mktime strftime setreuid setresuid sigaction waitpid)
+-AC_CHECK_HEADERS(security/pam_appl.h, [
+-  PAMLIB="-lpam"
+-  AC_DEFINE(HAVE_PAM, 1, [Define to 1 for PAM support])
+-])
++dnl AC_CHECK_HEADERS(security/pam_appl.h, [
++dnl   PAMLIB="-lpam"
++dnl   AC_DEFINE(HAVE_PAM, 1, [Define to 1 for PAM support])
++dnl ])
+ 
+ dnl Checking for programs
+ 
+-- 
+2.43.2
+
+
+From ee9edcf456e61418faa7686a030bc7f040a6bd1b Mon Sep 17 00:00:00 2001
+From: Chris Roberts <cpr420@gmail.com>
+Date: Sun, 28 Apr 2024 22:14:01 -0600
+Subject: use symlinks on Haiku
+
+
+diff --git a/atd.c b/atd.c
+index f3d85b0..6f5062b 100644
+--- a/atd.c
++++ b/atd.c
+@@ -322,7 +322,7 @@ run_file(const char *filename, uid_t uid, gid_t gid)
+      * fact and return.
+      */
+     PRIV_START
+-    rc = link(filename, newname);
++    rc = symlink(filename, newname);
+     PRIV_END
+     if (rc == -1) {
+ 	syslog(LOG_WARNING, "could not lock job %lu: %m", jobno);
+@@ -418,7 +418,8 @@ run_file(const char *filename, uid_t uid, gid_t gid)
+      * original.
+      */
+ 
+-    unlink(filename);
++    unlink(newname);
++    rename(filename, newname);
+ 
+     fclose(stream);
+     if (chdir(ATSPOOL_DIR) < 0)
+-- 
+2.43.2
+
+
+From 80de4567597c442f5c923fef66babd5635d51cb0 Mon Sep 17 00:00:00 2001
+From: Chris Roberts <cpr420@gmail.com>
+Date: Sun, 28 Apr 2024 22:43:26 -0600
+Subject: respect docdir flag
+
+
+diff --git a/Makefile.in b/Makefile.in
+index 4ae194f..a814c1b 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -14,7 +14,7 @@ atdatadir	= $(datadir)/at
+ man1dir		= $(mandir)/man1
+ man5dir		= $(mandir)/man5
+ man8dir		= $(mandir)/man8
+-docdir		= $(prefix)/doc
++docdir		= @docdir@
+ atdocdir	= $(docdir)/at
+ etcdir		= @ETCDIR@
+ atjobdir	= @ATJBD@
+-- 
+2.43.2
+


### PR DESCRIPTION
The recipe needs the ugly post-install script to fix directory and executable permissions, similar to the 'dma' recipe, in order to run with reduced permissions.