### PR TITLE
llvm17, move binaries back to /bin (reverts previous move)

### DIFF
--- a/sys-devel/llvm/llvm17-17.0.6.recipe
+++ b/sys-devel/llvm/llvm17-17.0.6.recipe
@@ -30,7 +30,7 @@ other than the ones listed above.
 HOMEPAGE="https://www.llvm.org/"
 COPYRIGHT="2003-2023 University of Illinois at Urbana-Champaign"
 LICENSE="Apache v2 with LLVM Exception"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/llvm/llvm-project/releases/download/llvmorg-$portVersion/llvm-project-$portVersion.src.tar.xz"
 CHECKSUM_SHA256="58a8818c60e6627064f312dbf46c02d9949956558340938b71cf731ad8bc0813"
 SOURCE_DIR="llvm-project-$portVersion.src"
@@ -43,83 +43,83 @@ portVersionCompat="$portVersion compat >= ${portVersion%%.*}"
 
 PROVIDES="
 	llvm17$secondaryArchSuffix = $portVersionCompat
-	cmd:bugpoint$secondaryArchSuffix
-	cmd:dsymutil$secondaryArchSuffix
-	cmd:llc$secondaryArchSuffix
-	cmd:lli$secondaryArchSuffix
-	cmd:llvm_addr2line$secondaryArchSuffix
-	cmd:llvm_ar$secondaryArchSuffix
-	cmd:llvm_as$secondaryArchSuffix
-	cmd:llvm_bcanalyzer$secondaryArchSuffix
-	cmd:llvm_bitcode_strip$secondaryArchSuffix
-	cmd:llvm_c_test$secondaryArchSuffix
-	cmd:llvm_cat$secondaryArchSuffix
-	cmd:llvm_cfi_verify$secondaryArchSuffix
-	cmd:llvm_config$secondaryArchSuffix = $portVersionCompat
-	cmd:llvm_cov$secondaryArchSuffix
-	cmd:llvm_cvtres$secondaryArchSuffix
-	cmd:llvm_cxxdump$secondaryArchSuffix
-	cmd:llvm_cxxfilt$secondaryArchSuffix
-	cmd:llvm_cxxmap$secondaryArchSuffix
-	cmd:llvm_debuginfo_analyzer$secondaryArchSuffix
-	cmd:llvm_debuginfod$secondaryArchSuffix
-	cmd:llvm_debuginfod_find$secondaryArchSuffix
-	cmd:llvm_diff$secondaryArchSuffix
-	cmd:llvm_dis$secondaryArchSuffix
-	cmd:llvm_dlltool$secondaryArchSuffix
-	cmd:llvm_dwarfdump$secondaryArchSuffix
-	cmd:llvm_dwarfutil$secondaryArchSuffix
-	cmd:llvm_dwp$secondaryArchSuffix
-	cmd:llvm_exegesis$secondaryArchSuffix
-	cmd:llvm_extract$secondaryArchSuffix
-	cmd:llvm_gsymutil$secondaryArchSuffix
-	cmd:llvm_ifs$secondaryArchSuffix
-	cmd:llvm_install_name_tool$secondaryArchSuffix
-	cmd:llvm_jitlink$secondaryArchSuffix
-	cmd:llvm_lib$secondaryArchSuffix
-	cmd:llvm_libtool_darwin$secondaryArchSuffix
-	cmd:llvm_link$secondaryArchSuffix
-	cmd:llvm_lipo$secondaryArchSuffix
-	cmd:llvm_lto$secondaryArchSuffix
-	cmd:llvm_lto2$secondaryArchSuffix
-	cmd:llvm_mc$secondaryArchSuffix
-	cmd:llvm_mca$secondaryArchSuffix
-	cmd:llvm_ml$secondaryArchSuffix
-	cmd:llvm_modextract$secondaryArchSuffix
-	cmd:llvm_mt$secondaryArchSuffix
-	cmd:llvm_nm$secondaryArchSuffix
-	cmd:llvm_objcopy$secondaryArchSuffix
-	cmd:llvm_objdump$secondaryArchSuffix
-	cmd:llvm_opt_report$secondaryArchSuffix
-	cmd:llvm_otool$secondaryArchSuffix
-	cmd:llvm_pdbutil$secondaryArchSuffix
-	cmd:llvm_profdata$secondaryArchSuffix
-	cmd:llvm_profgen$secondaryArchSuffix
-	cmd:llvm_ranlib$secondaryArchSuffix
-	cmd:llvm_rc$secondaryArchSuffix
-	cmd:llvm_readelf$secondaryArchSuffix
-	cmd:llvm_readobj$secondaryArchSuffix
-	cmd:llvm_reduce$secondaryArchSuffix
-	cmd:llvm_remark_size_diff$secondaryArchSuffix
-	cmd:llvm_remarkutil$secondaryArchSuffix
-	cmd:llvm_rtdyld$secondaryArchSuffix
-	cmd:llvm_sim$secondaryArchSuffix
-	cmd:llvm_size$secondaryArchSuffix
-	cmd:llvm_split$secondaryArchSuffix
-	cmd:llvm_stress$secondaryArchSuffix
-	cmd:llvm_strings$secondaryArchSuffix
-	cmd:llvm_strip$secondaryArchSuffix
-	cmd:llvm_symbolizer$secondaryArchSuffix
-	cmd:llvm_tapi_diff$secondaryArchSuffix
-	cmd:llvm_tblgen$secondaryArchSuffix
-	cmd:llvm_tli_checker$secondaryArchSuffix
-	cmd:llvm_undname$secondaryArchSuffix
-	cmd:llvm_windres$secondaryArchSuffix
-	cmd:llvm_xray$secondaryArchSuffix
-	cmd:opt$secondaryArchSuffix
-	cmd:sancov$secondaryArchSuffix
-	cmd:sanstats$secondaryArchSuffix
-	cmd:verify_uselistorder$secondaryArchSuffix
+	cmd:bugpoint
+	cmd:dsymutil
+	cmd:llc
+	cmd:lli
+	cmd:llvm_addr2line
+	cmd:llvm_ar
+	cmd:llvm_as
+	cmd:llvm_bcanalyzer
+	cmd:llvm_bitcode_strip
+	cmd:llvm_c_test
+	cmd:llvm_cat
+	cmd:llvm_cfi_verify
+	cmd:llvm_config = $portVersionCompat
+	cmd:llvm_cov
+	cmd:llvm_cvtres
+	cmd:llvm_cxxdump
+	cmd:llvm_cxxfilt
+	cmd:llvm_cxxmap
+	cmd:llvm_debuginfo_analyzer
+	cmd:llvm_debuginfod
+	cmd:llvm_debuginfod_find
+	cmd:llvm_diff
+	cmd:llvm_dis
+	cmd:llvm_dlltool
+	cmd:llvm_dwarfdump
+	cmd:llvm_dwarfutil
+	cmd:llvm_dwp
+	cmd:llvm_exegesis
+	cmd:llvm_extract
+	cmd:llvm_gsymutil
+	cmd:llvm_ifs
+	cmd:llvm_install_name_tool
+	cmd:llvm_jitlink
+	cmd:llvm_lib
+	cmd:llvm_libtool_darwin
+	cmd:llvm_link
+	cmd:llvm_lipo
+	cmd:llvm_lto
+	cmd:llvm_lto2
+	cmd:llvm_mc
+	cmd:llvm_mca
+	cmd:llvm_ml
+	cmd:llvm_modextract
+	cmd:llvm_mt
+	cmd:llvm_nm
+	cmd:llvm_objcopy
+	cmd:llvm_objdump
+	cmd:llvm_opt_report
+	cmd:llvm_otool
+	cmd:llvm_pdbutil
+	cmd:llvm_profdata
+	cmd:llvm_profgen
+	cmd:llvm_ranlib
+	cmd:llvm_rc
+	cmd:llvm_readelf
+	cmd:llvm_readobj
+	cmd:llvm_reduce
+	cmd:llvm_remark_size_diff
+	cmd:llvm_remarkutil
+	cmd:llvm_rtdyld
+	cmd:llvm_sim
+	cmd:llvm_size
+	cmd:llvm_split
+	cmd:llvm_stress
+	cmd:llvm_strings
+	cmd:llvm_strip
+	cmd:llvm_symbolizer
+	cmd:llvm_tapi_diff
+	cmd:llvm_tblgen
+	cmd:llvm_tli_checker
+	cmd:llvm_undname
+	cmd:llvm_windres
+	cmd:llvm_xray
+	cmd:opt
+	cmd:sancov
+	cmd:sanstats
+	cmd:verify_uselistorder
 	devel:libfindAllSymbols$secondaryArchSuffix
 	devel:libLLVM$secondaryArchSuffix = $portVersionCompat
 	devel:libLLVM_$portVersion$secondaryArchSuffix = $portVersionCompat
@@ -264,43 +264,43 @@ CONFLICTS="
 
 PROVIDES_clang="
 	llvm17${secondaryArchSuffix}_clang = $portVersion
-	cmd:amdgpu_arch$secondaryArchSuffix = $portVersion
-	cmd:c_index_test$secondaryArchSuffix = $portVersion
-	cmd:clang$secondaryArchSuffix = $portVersion
-	cmd:clang++$secondaryArchSuffix = $portVersion
-	cmd:clang_17$secondaryArchSuffix = $portVersion
-	cmd:clang_apply_replacements$secondaryArchSuffix = $portVersion
-	cmd:clang_change_namespace$secondaryArchSuffix = $portVersion
-	cmd:clang_check$secondaryArchSuffix = $portVersion
-	cmd:clang_cl$secondaryArchSuffix = $portVersion
-	cmd:clang_cpp$secondaryArchSuffix = $portVersion
-	cmd:clang_doc$secondaryArchSuffix = $portVersion
-	cmd:clang_extdef_mapping$secondaryArchSuffix = $portVersion
-	cmd:clang_format$secondaryArchSuffix = $portVersion
-	cmd:clang_include_cleaner$secondaryArchSuffix = $portVersion
-	cmd:clang_include_fixer$secondaryArchSuffix = $portVersion
-	cmd:clang_linker_wrapper$secondaryArchSuffix = $portVersion
-	cmd:clang_move$secondaryArchSuffix = $portVersion
-	cmd:clang_offload_bundler$secondaryArchSuffix = $portVersion
-	cmd:clang_offload_packager$secondaryArchSuffix = $portVersion
-	cmd:clang_pseudo$secondaryArchSuffix = $portVersion
-	cmd:clang_query$secondaryArchSuffix = $portVersion
-	cmd:clang_refactor$secondaryArchSuffix = $portVersion
-	cmd:clang_rename$secondaryArchSuffix = $portVersion
-	cmd:clang_reorder_fields$secondaryArchSuffix = $portVersion
-	cmd:clang_repl$secondaryArchSuffix = $portVersion
-	cmd:clang_scan_deps$secondaryArchSuffix = $portVersion
-	cmd:clang_tidy$secondaryArchSuffix = $portVersion
-	cmd:clang_tblgen$secondaryArchSuffix = $portVersion
-	cmd:clangd$secondaryArchSuffix = $portVersion
-	cmd:diagtool$secondaryArchSuffix = $portVersion
-	cmd:find_all_symbols$secondaryArchSuffix = $portVersion
-	cmd:git_clang_format$secondaryArchSuffix = $portVersion
-	cmd:hmaptool$secondaryArchSuffix = $portVersion
-	cmd:modularize$secondaryArchSuffix = $portVersion
-	cmd:nvptx_arch$secondaryArchSuffix = $portVersion
-	cmd:pp_trace$secondaryArchSuffix = $portVersion
-	cmd:run_clang_tidy$secondaryArchSuffix = $portVersion
+	cmd:amdgpu_arch = $portVersion
+	cmd:c_index_test = $portVersion
+	cmd:clang = $portVersion
+	cmd:clang++ = $portVersion
+	cmd:clang_17 = $portVersion
+	cmd:clang_apply_replacements = $portVersion
+	cmd:clang_change_namespace = $portVersion
+	cmd:clang_check = $portVersion
+	cmd:clang_cl = $portVersion
+	cmd:clang_cpp = $portVersion
+	cmd:clang_doc = $portVersion
+	cmd:clang_extdef_mapping = $portVersion
+	cmd:clang_format = $portVersion
+	cmd:clang_include_cleaner = $portVersion
+	cmd:clang_include_fixer = $portVersion
+	cmd:clang_linker_wrapper = $portVersion
+	cmd:clang_move = $portVersion
+	cmd:clang_offload_bundler = $portVersion
+	cmd:clang_offload_packager = $portVersion
+	cmd:clang_pseudo = $portVersion
+	cmd:clang_query = $portVersion
+	cmd:clang_refactor = $portVersion
+	cmd:clang_rename = $portVersion
+	cmd:clang_reorder_fields = $portVersion
+	cmd:clang_repl = $portVersion
+	cmd:clang_scan_deps = $portVersion
+	cmd:clang_tidy = $portVersion
+	cmd:clang_tblgen = $portVersion
+	cmd:clangd = $portVersion
+	cmd:diagtool = $portVersion
+	cmd:find_all_symbols = $portVersion
+	cmd:git_clang_format = $portVersion
+	cmd:hmaptool = $portVersion
+	cmd:modularize = $portVersion
+	cmd:nvptx_arch = $portVersion
+	cmd:pp_trace = $portVersion
+	cmd:run_clang_tidy = $portVersion
 	devel:libclang$secondaryArchSuffix = $portVersionCompat
 	devel:libclang_cpp$secondaryArchSuffix = $portVersionCompat
 	devel:libclanganalysis$secondaryArchSuffix = $portVersion
@@ -407,11 +407,11 @@ CONFLICTS_clang="
 
 PROVIDES_clang_analysis="
 	llvm17${secondaryArchSuffix}_clang_analysis = $portVersion
-	cmd:analyze_build$secondaryArchSuffix = $portVersion
-	cmd:intercept_build$secondaryArchSuffix = $portVersion
-	cmd:scan_build$secondaryArchSuffix = $portVersion
-	cmd:scan_build_py$secondaryArchSuffix = $portVersion
-	cmd:scan_view$secondaryArchSuffix = $portVersion
+	cmd:analyze_build = $portVersion
+	cmd:intercept_build = $portVersion
+	cmd:scan_build = $portVersion
+	cmd:scan_build_py = $portVersion
+	cmd:scan_view = $portVersion
 	"
 REQUIRES_clang_analysis="
 	llvm17${secondaryArchSuffix}_clang == $portVersion base
@@ -425,11 +425,11 @@ CONFLICTS_clang_analysis="
 
 PROVIDES_lld="
 	llvm17${secondaryArchSuffix}_lld = $portVersion
-	cmd:ld.lld$secondaryArchSuffix = $portVersion
-	cmd:ld64.lld$secondaryArchSuffix = $portVersion
-	cmd:lld$secondaryArchSuffix = $portVersion
-	cmd:lld_link$secondaryArchSuffix = $portVersion
-	cmd:wasm_ld$secondaryArchSuffix = $portVersion
+	cmd:ld.lld = $portVersion
+	cmd:ld64.lld = $portVersion
+	cmd:lld = $portVersion
+	cmd:lld_link = $portVersion
+	cmd:wasm_ld = $portVersion
 	devel:liblldCOFF$secondaryArchSuffix = $portVersion
 	devel:liblldCommon$secondaryArchSuffix = $portVersion
 	devel:liblldELF$secondaryArchSuffix = $portVersion
@@ -548,6 +548,7 @@ BUILD()
 		$cmakeDirArgs \
 		-DCMAKE_BUILD_TYPE=Release \
 		$cmakeFlags \
+		-DCMAKE_INSTALL_BINDIR=bin \
 		-DCMAKE_SKIP_RPATH=YES \
 		-DCOMPILER_RT_BUILD_SANITIZERS=OFF \
 		-DLLVM_ENABLE_RTTI=ON -DLLVM_LINK_LLVM_DYLIB=YES \
@@ -690,24 +691,24 @@ INSTALL()
 		$libDir/cmake/lld/LLDTargets-release.cmake \
 		$libDir/cmake/llvm/LLVMExports-release.cmake
 
-	sed -i 's|/share/|/data/|' $binDir/scan-build $binDir/scan-view
+	sed -i 's|/share/|/data/|' $prefix/bin/scan-build $prefix/bin/scan-view
 
 	mv $prefix/include/* $includeDir/
 	rmdir $prefix/include
 
 	# clang package
 	packageEntries clang \
-		$binDir/amdgpu-arch \
-		$binDir/c-index-test \
-		$binDir/clang* \
-		$binDir/diagtool \
-		$binDir/find-all-symbols \
-		$binDir/git-clang-format \
-		$binDir/hmaptool \
-		$binDir/modularize \
-		$binDir/nvptx-arch \
-		$binDir/pp-trace \
-		$binDir/run-clang-tidy \
+		$prefix/bin/amdgpu-arch \
+		$prefix/bin/c-index-test \
+		$prefix/bin/clang* \
+		$prefix/bin/diagtool \
+		$prefix/bin/find-all-symbols \
+		$prefix/bin/git-clang-format \
+		$prefix/bin/hmaptool \
+		$prefix/bin/modularize \
+		$prefix/bin/nvptx-arch \
+		$prefix/bin/pp-trace \
+		$prefix/bin/run-clang-tidy \
 		$dataDir/clang \
 		$includeDir/clang* \
 		$libDir/clang \
@@ -717,11 +718,11 @@ INSTALL()
 
 	# analysis package
 	packageEntries clang_analysis \
-		$binDir/analyze-build \
-		$binDir/intercept-build \
-		$binDir/scan-build \
-		$binDir/scan-build-py \
-		$binDir/scan-view \
+		$prefix/bin/analyze-build \
+		$prefix/bin/intercept-build \
+		$prefix/bin/scan-build \
+		$prefix/bin/scan-build-py \
+		$prefix/bin/scan-view \
 		$libExecDir/c++-analyzer \
 		$libExecDir/ccc-analyzer \
 		$dataDir/scan-build \
@@ -730,11 +731,11 @@ INSTALL()
 
 	# lld package
 	packageEntries lld \
-		$binDir/ld.lld \
-		$binDir/ld64.lld \
-		$binDir/lld \
-		$binDir/lld-link \
-		$binDir/wasm-ld \
+		$prefix/bin/ld.lld \
+		$prefix/bin/ld64.lld \
+		$prefix/bin/lld \
+		$prefix/bin/lld-link \
+		$prefix/bin/wasm-ld \
 		$includeDir/lld* \
 		$developLibDir/liblld*
 


### PR DESCRIPTION
Also fixes building Qt5 on 32bit: https://github.com/haikuports/haikuports/pull/10453