### PR TITLE
Genio: Depend on cmd::clang instead of a specific library version

### DIFF
--- a/haiku-apps/genio/genio-2.1.0.recipe
+++ b/haiku-apps/genio/genio-2.1.0.recipe
@@ -13,7 +13,7 @@ HOMEPAGE="https://github.com/Genio-The-Haiku-IDE/Genio/releases"
 COPYRIGHT="2022-2024 The Genio Team"
 LICENSE="BSD (3-clause)
 	MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/Genio-The-Haiku-IDE/Genio/archive/v2.1.tar.gz"
 CHECKSUM_SHA256="0ffdff036c7dd7abf9221d2b93c3419d9451ca9b45f2eb36137c0ff58a5ab079"
 SOURCE_FILENAME="Genio-v2.1.tar.gz"
@@ -29,7 +29,7 @@ PROVIDES="
 REQUIRES="
 	haiku${secondaryArchSuffix}
 	gcc${secondaryArchSuffix}_syslibs_devel
-	llvm17${secondaryArchSuffix}_clang
+	cmd:clang$secondaryArchSuffix
 	lib:liblexilla$secondaryArchSuffix >= 5.2.4
 	lib:libgit2$secondaryArchSuffix
 	lib:libyaml_cpp$secondaryArchSuffix


### PR DESCRIPTION
Removed dependency to specific llvm version