### PR TITLE
perl: bump version, enable threads, don't install sitecustomize.pl

### DIFF
--- a/dev-lang/perl/patches/perl-5.40.0.patchset
+++ b/dev-lang/perl/patches/perl-5.40.0.patchset
@@ -19,7 +19,7 @@ index 570f25a..81baf48 100644
    # fall-through if we can't unlink now
    _deferred_unlink($fh, $path, 0);
 -- 
-2.45.1
+2.45.2
 
 
 From 9ecf37f2989d220763e11553ce938d0c9095b4f8 Mon Sep 17 00:00:00 2001
@@ -43,7 +43,7 @@ index 7bcd491..85260b8 100644
    } else {
      plan tests => 4;
 -- 
-2.45.1
+2.45.2
 
 
 From 7f9232cdcd444ae11980276a1df2c4be8644ad18 Mon Sep 17 00:00:00 2001
@@ -105,7 +105,7 @@ index 0ec7479..0f09f53 100644
 -
 +# haiku sets all its specifics via Configure
 -- 
-2.45.1
+2.45.2
 
 
 From 58103414df3ca4fa4ba920538f7879ae34a9aeaa Mon Sep 17 00:00:00 2001
@@ -131,7 +131,7 @@ index 3c8af53..1bbbf5b 100755
  
  
 -- 
-2.45.1
+2.45.2
 
 
 From 5b1ca829779068d5c29c456909c3598dc8676206 Mon Sep 17 00:00:00 2001
@@ -182,7 +182,7 @@ index ce3270e..cab9a79 100644
    }
  
 -- 
-2.45.1
+2.45.2
 
 
 From 89ddca4242c23b959888f837199c223f32304a21 Mon Sep 17 00:00:00 2001
@@ -286,7 +286,7 @@ index 0000000..81e5f99
 +__END__
 +
 -- 
-2.45.1
+2.45.2
 
 
 From 8b1508e136aa3dfe3dd032c5d8e17178ada2c4d5 Mon Sep 17 00:00:00 2001
@@ -334,62 +334,10 @@ index 81e5f99..25ace13 100644
  __END__
  
 -- 
-2.45.1
+2.45.2
 
 
-From 888bb0055430fe31da4a8bbf35f8fe2f482273a5 Mon Sep 17 00:00:00 2001
-From: Oliver Tappe <zooey@hirschkaefer.de>
-Date: Tue, 8 Oct 2013 22:17:26 +0200
-Subject: Add script sitecustomize.pl for setting up @INC as we need it.
-
-
-diff --git a/sitecustomize.pl b/sitecustomize.pl
-new file mode 100644
-index 0000000..a321e51
---- /dev/null
-+++ b/sitecustomize.pl
-@@ -0,0 +1,36 @@
-+#! perl
-+
-+use Config;
-+
-+# Remove all compiled-in paths referring to Perl's installation dir
-+# and replace them with a static set of paths that implement the intended
-+# searching order:
-+my @ourINC = (
-+	"/boot/home/config/lib/perl5/$Config{version}/$Config{archname}",
-+	"/boot/home/config/lib/perl5/$Config{version}",
-+	"/boot/home/config/non-packaged/lib/perl5/site_perl/$Config{version}/$Config{archname}",
-+	"/boot/home/config/non-packaged/lib/perl5/site_perl/$Config{version}",
-+	"/boot/home/config/lib/perl5/vendor_perl/$Config{version}/$Config{archname}",
-+	"/boot/home/config/lib/perl5/vendor_perl/$Config{version}",
-+	"/boot/home/config/lib/perl5/vendor_perl",
-+	"/boot/system/lib/perl5/$Config{version}/$Config{archname}",
-+	"/boot/system/lib/perl5/$Config{version}",
-+	"/boot/system/non-packaged/lib/perl5/site_perl/$Config{version}/$Config{archname}",
-+	"/boot/system/non-packaged/lib/perl5/site_perl/$Config{version}",
-+	"/boot/system/lib/perl5/vendor_perl/$Config{version}/$Config{archname}",
-+	"/boot/system/lib/perl5/vendor_perl/$Config{version}",
-+	"/boot/system/lib/perl5/vendor_perl",
-+);
-+my @newINC;
-+my $removedPerlPaths;
-+foreach my $inc (@INC) {
-+	if ($inc =~ m[^/packages/perl-$Config{version}-\d+/.self/]o) {
-+		if (! $removedPerlPaths) {
-+			push @newINC, @ourINC;
-+			$removedPerlPaths = 1;
-+		}
-+		next;
-+	}
-+	push @newINC, $inc;
-+}
-+@INC = @newINC;
--- 
-2.45.1
-
-
-From b800124bbbe5e7751dc0ac3d4cd4b7a760d5e8c0 Mon Sep 17 00:00:00 2001
+From 4dc0c351b91f831df7b13c51087ca02d955f9bc8 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Wed, 9 Oct 2013 20:29:38 +0200
 Subject: Fix initialization check for CPAN.
@@ -416,10 +364,10 @@ index 8934f4a..1716a55 100644
          && -w $Config{installarchlib}
          && -w $Config{installsitelib}
 -- 
-2.45.1
+2.45.2
 
 
-From afb39a432ecc454f9e28d75975e33d7ebd2cbb4e Mon Sep 17 00:00:00 2001
+From ea008000245d5cf2618298fe18c99a3cf296ecb7 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sun, 13 Oct 2013 17:32:50 +0200
 Subject: Add support for HAIKU_USE_VENDOR_DIRECTORIES.
@@ -492,10 +440,10 @@ index 25ace13..8a04ead 100644
  __END__
  
 -- 
-2.45.1
+2.45.2
 
 
-From 587853920e03a11121c9d26c51b63080256d1bb5 Mon Sep 17 00:00:00 2001
+From 0c34348a5674f4a8b42aff7161474bd2b86a5b45 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 9 Jun 2017 21:30:33 +0200
 Subject: disable fstack-protector for Haiku
@@ -511,76 +459,10 @@ index 0f09f53..b76c7c1 100644
 +
 +ccflags="$ccflags -fno-stack-protector"
 -- 
-2.45.1
+2.45.2
 
 
-From 1f79db86954bb75e4212034e8dde0b6eda989245 Mon Sep 17 00:00:00 2001
-From: Jerome Duval <jerome.duval@gmail.com>
-Date: Wed, 14 Mar 2018 21:33:54 +0100
-Subject: sitecustomize.pl: use the shortVersion for site and vendor.
-
-
-diff --git a/sitecustomize.pl b/sitecustomize.pl
-index a321e51..76c0e46 100644
---- a/sitecustomize.pl
-+++ b/sitecustomize.pl
-@@ -8,17 +8,17 @@ use Config;
- my @ourINC = (
- 	"/boot/home/config/lib/perl5/$Config{version}/$Config{archname}",
- 	"/boot/home/config/lib/perl5/$Config{version}",
--	"/boot/home/config/non-packaged/lib/perl5/site_perl/$Config{version}/$Config{archname}",
--	"/boot/home/config/non-packaged/lib/perl5/site_perl/$Config{version}",
--	"/boot/home/config/lib/perl5/vendor_perl/$Config{version}/$Config{archname}",
--	"/boot/home/config/lib/perl5/vendor_perl/$Config{version}",
-+	"/boot/home/config/non-packaged/lib/perl5/site_perl/$Config{revision}.$Config{patchlevel}/$Config{archname}",
-+	"/boot/home/config/non-packaged/lib/perl5/site_perl/$Config{revision}.$Config{patchlevel}",
-+	"/boot/home/config/lib/perl5/vendor_perl/$Config{revision}.$Config{patchlevel}/$Config{archname}",
-+	"/boot/home/config/lib/perl5/vendor_perl/$Config{revision}.$Config{patchlevel}",
- 	"/boot/home/config/lib/perl5/vendor_perl",
- 	"/boot/system/lib/perl5/$Config{version}/$Config{archname}",
- 	"/boot/system/lib/perl5/$Config{version}",
--	"/boot/system/non-packaged/lib/perl5/site_perl/$Config{version}/$Config{archname}",
--	"/boot/system/non-packaged/lib/perl5/site_perl/$Config{version}",
--	"/boot/system/lib/perl5/vendor_perl/$Config{version}/$Config{archname}",
--	"/boot/system/lib/perl5/vendor_perl/$Config{version}",
-+	"/boot/system/non-packaged/lib/perl5/site_perl/$Config{revision}.$Config{patchlevel}/$Config{archname}",
-+	"/boot/system/non-packaged/lib/perl5/site_perl/$Config{revision}.$Config{patchlevel}",
-+	"/boot/system/lib/perl5/vendor_perl/$Config{revision}.$Config{patchlevel}/$Config{archname}",
-+	"/boot/system/lib/perl5/vendor_perl/$Config{revision}.$Config{patchlevel}",
- 	"/boot/system/lib/perl5/vendor_perl",
- );
- my @newINC;
--- 
-2.45.1
-
-
-From a3940547651bbdd2a863be98ba3794bf132c2edf Mon Sep 17 00:00:00 2001
-From: Jerome Duval <jerome.duval@gmail.com>
-Date: Sun, 7 Jul 2019 20:32:13 +0200
-Subject: numeric.c: move down optional declaration
-
-numeric.c:38:5: error: ISO C90 forbids mixed declarations and code
-NV result;
-
-diff --git a/numeric.c b/numeric.c
-index c22e4ef..1b6d520 100644
---- a/numeric.c
-+++ b/numeric.c
-@@ -31,8 +31,8 @@ values, including such things as replacements for the OS's atof() function
- PERL_STATIC_INLINE NV
- S_strtod(pTHX_ const char * const s, char ** e)
- {
--    DECLARATION_FOR_LC_NUMERIC_MANIPULATION;
-     NV result;
-+    DECLARATION_FOR_LC_NUMERIC_MANIPULATION;
- 
-     STORE_LC_NUMERIC_SET_TO_NEEDED();
- 
--- 
-2.45.1
-
-
-From 4d45637b47fd1358d37bbe284ed5f7deb8fb0cb1 Mon Sep 17 00:00:00 2001
+From b4a2db350ea26481f6a743467f6754f920d7d66e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
 Date: Sat, 22 Jun 2024 22:24:38 +0200
 Subject: disable some reentrant variants of functions which we don't have
@@ -617,10 +499,10 @@ index 4b13cc2..931eca2 100644
  #    undef HAS_READDIR_R
  #    undef HAS_READDIR64_R
 -- 
-2.45.1
+2.45.2
 
 
-From efd834171358f845db9324c5431a03f7e75eac71 Mon Sep 17 00:00:00 2001
+From c0b43dfe8d5ef5abb149b43878e787e1ae8b9659 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
 Date: Sat, 22 Jun 2024 22:25:46 +0200
 Subject: disable check involving sizeof(dirent.d_name)
@@ -648,10 +530,10 @@ index 0b3d142..880a108 100644
          else Newx(name, len, char);
          Move(dirent->d_name, name, len, char);
 -- 
-2.45.1
+2.45.2
 
 
-From de82e8f99fbd8361debbf3d1f20a52f212f64298 Mon Sep 17 00:00:00 2001
+From 235f9aef9790b298c90c467da688384d0debbcda Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
 Date: Sun, 23 Jun 2024 17:35:15 +0200
 Subject: disable locking mutexes at fork
@@ -685,5 +567,5 @@ index 4053ca4..66db5e2 100644
  #  ifdef USE_PERLIO
      MUTEX_UNLOCK(&PL_perlio_mutex);
 -- 
-2.45.1
+2.45.2
 

--- a/dev-lang/perl/patches/perl-5.40.0.patchset
+++ b/dev-lang/perl/patches/perl-5.40.0.patchset
@@ -1,14 +1,14 @@
-From 3410e7e2e37488e45d2914ca6cf02b6d1dbe4584 Mon Sep 17 00:00:00 2001
+From ccf836120a4029aea12e932e074d062173253bca Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sun, 22 Sep 2013 14:52:03 +0200
 Subject: Tell perl that BFS has a link count of 1
 
 
 diff --git a/cpan/File-Temp/lib/File/Temp.pm b/cpan/File-Temp/lib/File/Temp.pm
-index 39e15d5..2b6f4d9 100644
+index 570f25a..81baf48 100644
 --- a/cpan/File-Temp/lib/File/Temp.pm
 +++ b/cpan/File-Temp/lib/File/Temp.pm
-@@ -2142,7 +2142,8 @@ sub unlink0 {
+@@ -2157,7 +2157,8 @@ sub unlink0 {
      # On NFS the link count may still be 1 but we can't know that
      # we are on NFS.  Since we can't be sure, we'll defer it
  
@@ -19,17 +19,17 @@ index 39e15d5..2b6f4d9 100644
    # fall-through if we can't unlink now
    _deferred_unlink($fh, $path, 0);
 -- 
-2.21.0
+2.45.1
 
 
-From 99c4fbfa1db4160b320b69a57f9b81b3ee583004 Mon Sep 17 00:00:00 2001
+From 9ecf37f2989d220763e11553ce938d0c9095b4f8 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sun, 22 Sep 2013 14:52:53 +0200
 Subject: Haiku defines, but does not implement O_EXLOCK
 
 
 diff --git a/cpan/File-Temp/t/lock.t b/cpan/File-Temp/t/lock.t
-index 0d7dfc0..e928eee 100644
+index 7bcd491..85260b8 100644
 --- a/cpan/File-Temp/t/lock.t
 +++ b/cpan/File-Temp/t/lock.t
 @@ -8,7 +8,8 @@ use Fcntl;
@@ -43,33 +43,33 @@ index 0d7dfc0..e928eee 100644
    } else {
      plan tests => 4;
 -- 
-2.21.0
+2.45.1
 
 
-From c6e44c1257df7f181753c19c3ad07e526d0103e1 Mon Sep 17 00:00:00 2001
+From 7f9232cdcd444ae11980276a1df2c4be8644ad18 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sun, 22 Sep 2013 14:53:40 +0200
 Subject: haiku sets all its specifics via Configure
 
 
 diff --git a/hints/haiku.sh b/hints/haiku.sh
-index fa8ebe5..0f09f53 100644
+index 0ec7479..0f09f53 100644
 --- a/hints/haiku.sh
 +++ b/hints/haiku.sh
-@@ -1,44 +1 @@
+@@ -1,46 +1 @@
 -# Haiku hints file
 -# $Id$
 -
 -case "$prefix" in
--'') prefix="/boot/common" ;;
+-'') prefix="$(finddir B_COMMON_DIRECTORY)" ;;
 -*) ;; # pass the user supplied value through
 -esac
 -
--libpth='/boot/home/config/lib /boot/common/lib /system/lib'
--usrinc='/boot/develop/headers/posix'
--locinc='/boot/home/config/include /boot/common/include /boot/develop/headers'
+-libpth="$(finddir B_USER_DEVELOP_DIRECTORY)/lib $(finddir B_SYSTEM_DEVELOP_DIRECTORY)/lib $(finddir B_COMMON_DIRECTORY)/lib /system/lib"
+-usrinc="$(finddir B_SYSTEM_DEVELOP_DIRECTORY)/headers/posix"
+-locinc="$(finddir B_USER_CONFIG_DIRECTORY)/develop/headers $(finddir B_COMMON_DIRECTORY)/headers $(finddir B_SYSTEM_DEVELOP_DIRECTORY)/headers"
 -
--libc='/system/lib/libroot.so'
+-libc="$(finddir B_SYSTEM_LIB_DIRECTORY)/libroot.so"
 -libs='-lnetwork'
 -
 -# Use Haiku's malloc() by default.
@@ -90,6 +90,8 @@ index fa8ebe5..0f09f53 100644
 -cc="gcc"
 -ld='gcc'
 -
+-ccflags="$ccflags -fno-stack-protector"
+-
 -# The runtime loader library path variable is LIBRARY_PATH.
 -case "$ldlibpthname" in
 -'') ldlibpthname=LIBRARY_PATH ;;
@@ -103,20 +105,20 @@ index fa8ebe5..0f09f53 100644
 -
 +# haiku sets all its specifics via Configure
 -- 
-2.21.0
+2.45.1
 
 
-From fd6c456c03b5adc20d27c0a96e5941dc91171580 Mon Sep 17 00:00:00 2001
+From 58103414df3ca4fa4ba920538f7879ae34a9aeaa Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sun, 22 Sep 2013 14:54:15 +0200
 Subject: Tell perl that Haiku needs haikuish.h installed as well
 
 
 diff --git a/installperl b/installperl
-index 6cd65a0..6114fce 100755
+index 3c8af53..1bbbf5b 100755
 --- a/installperl
 +++ b/installperl
-@@ -382,6 +382,11 @@ elsif ($Is_Cygwin) { # On Cygwin symlink it to CORE to make Makefile happy
+@@ -343,6 +343,11 @@ elsif ($Is_Cygwin) { # On Cygwin symlink it to CORE to make Makefile happy
  
      # AIX needs perl.exp installed as well.
      push(@corefiles,'perl.exp') if $^O eq 'aix';
@@ -129,10 +131,10 @@ index 6cd65a0..6114fce 100755
  
  
 -- 
-2.21.0
+2.45.1
 
 
-From f637daec44d0ef383f0240cf09676417aa7b8c08 Mon Sep 17 00:00:00 2001
+From 5b1ca829779068d5c29c456909c3598dc8676206 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sun, 22 Sep 2013 14:55:13 +0200
 Subject: Fix handling of exit codes on Haiku
@@ -180,33 +182,10 @@ index ce3270e..cab9a79 100644
    }
  
 -- 
-2.21.0
+2.45.1
 
 
-From db5dc758bb4e949eeaef4cc9704325112087b698 Mon Sep 17 00:00:00 2001
-From: Oliver Tappe <zooey@hirschkaefer.de>
-Date: Sun, 22 Sep 2013 15:00:44 +0200
-Subject: Fix include path of errno.h
-
-
-diff --git a/ext/Errno/Errno_pm.PL b/ext/Errno/Errno_pm.PL
-index 84fd151..41cb5e5 100644
---- a/ext/Errno/Errno_pm.PL
-+++ b/ext/Errno/Errno_pm.PL
-@@ -143,7 +143,7 @@ sub get_files {
- 	$file{$linux_errno_h} = 1;
-     } elsif ($^O eq 'haiku') {
- 	# hidden in a special place
--	$file{'/boot/develop/headers/posix/errno.h'} = 1;
-+	$file{'/boot/system/develop/headers/posix/errno.h'} = 1;
- 
-     } elsif ($^O eq 'vos') {
- 	# avoid problem where cpp returns non-POSIX pathnames
--- 
-2.21.0
-
-
-From 7b40bf018aa385fe4610197e44ee172b52ea1149 Mon Sep 17 00:00:00 2001
+From 89ddca4242c23b959888f837199c223f32304a21 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sat, 28 Sep 2013 13:46:42 +0200
 Subject: Adjust ExtUtils::MakeMaker for PM-Haiku.
@@ -217,10 +196,10 @@ Subject: Adjust ExtUtils::MakeMaker for PM-Haiku.
   for MakeMaker.
 
 diff --git a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM.pm b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM.pm
-index b2c360b..c91c3c8 100644
+index 554e6fb..7cccf41 100644
 --- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM.pm
 +++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM.pm
-@@ -60,7 +60,8 @@ if( $^O eq 'MSWin32' ) {
+@@ -61,7 +61,8 @@ if( $^O eq 'MSWin32' ) {
  $Is{UWIN}   = $^O =~ /^uwin(-nt)?$/;
  $Is{Cygwin} = $^O eq 'cygwin';
  $Is{NW5}    = $Config{osname} eq 'NetWare';  # intentional
@@ -307,10 +286,10 @@ index 0000000..81e5f99
 +__END__
 +
 -- 
-2.21.0
+2.45.1
 
 
-From ecd64a3fa3feae09cb89f1ba2f05585286051b6f Mon Sep 17 00:00:00 2001
+From 8b1508e136aa3dfe3dd032c5d8e17178ada2c4d5 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Tue, 8 Oct 2013 22:16:37 +0200
 Subject: Avoid using -rpath for dynamic modules.
@@ -355,10 +334,10 @@ index 81e5f99..25ace13 100644
  __END__
  
 -- 
-2.21.0
+2.45.1
 
 
-From 57fa1985f6edd826cdb17e40da3c6cce93b40ada Mon Sep 17 00:00:00 2001
+From 888bb0055430fe31da4a8bbf35f8fe2f482273a5 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Tue, 8 Oct 2013 22:17:26 +0200
 Subject: Add script sitecustomize.pl for setting up @INC as we need it.
@@ -407,10 +386,10 @@ index 0000000..a321e51
 +}
 +@INC = @newINC;
 -- 
-2.21.0
+2.45.1
 
 
-From c8a62fd04f29f2934b51059b67fe092d2d4333a8 Mon Sep 17 00:00:00 2001
+From b800124bbbe5e7751dc0ac3d4cd4b7a760d5e8c0 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Wed, 9 Oct 2013 20:29:38 +0200
 Subject: Fix initialization check for CPAN.
@@ -420,10 +399,10 @@ Subject: Fix initialization check for CPAN.
   circumvent unwritable lib dirs.
 
 diff --git a/cpan/CPAN/lib/CPAN/FirstTime.pm b/cpan/CPAN/lib/CPAN/FirstTime.pm
-index 49fa8ab..bc701d8 100644
+index 8934f4a..1716a55 100644
 --- a/cpan/CPAN/lib/CPAN/FirstTime.pm
 +++ b/cpan/CPAN/lib/CPAN/FirstTime.pm
-@@ -2068,6 +2068,12 @@ sub _print_urllist {
+@@ -2167,6 +2167,12 @@ sub _print_urllist {
  }
  
  sub _can_write_to_libdirs {
@@ -437,10 +416,10 @@ index 49fa8ab..bc701d8 100644
          && -w $Config{installarchlib}
          && -w $Config{installsitelib}
 -- 
-2.21.0
+2.45.1
 
 
-From 28543e5ee77e6d98aa9e08465230a2d5c6b96695 Mon Sep 17 00:00:00 2001
+From afb39a432ecc454f9e28d75975e33d7ebd2cbb4e Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sun, 13 Oct 2013 17:32:50 +0200
 Subject: Add support for HAIKU_USE_VENDOR_DIRECTORIES.
@@ -513,32 +492,29 @@ index 25ace13..8a04ead 100644
  __END__
  
 -- 
-2.21.0
+2.45.1
 
 
-From 2f7ece189875184caa314e5362a27044f54b80d7 Mon Sep 17 00:00:00 2001
+From 587853920e03a11121c9d26c51b63080256d1bb5 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 9 Jun 2017 21:30:33 +0200
 Subject: disable fstack-protector for Haiku
 
 
-diff --git a/Configure b/Configure
-index 684a9c0..f0b1d8a 100755
---- a/Configure
-+++ b/Configure
-@@ -5500,6 +5500,7 @@ default|recommended)
- 	# thing. (NWC)
- 	case "$osname" in
- 	amigaos) ;; # -fstack-protector builds but doesn't work
-+	haiku) ;; # -fstack-protector builds but doesn't work
- 	*)	case "$gccversion" in
- 		?*)	set stack-protector-strong -fstack-protector-strong
- 			eval $checkccflag
+diff --git a/hints/haiku.sh b/hints/haiku.sh
+index 0f09f53..b76c7c1 100644
+--- a/hints/haiku.sh
++++ b/hints/haiku.sh
+@@ -1 +1,3 @@
+-# haiku sets all its specifics via Configure
++# haiku sets nearly all its specifics via Configure
++
++ccflags="$ccflags -fno-stack-protector"
 -- 
-2.21.0
+2.45.1
 
 
-From 7393131191509a0d0c57c7776027b7d61d8d1e63 Mon Sep 17 00:00:00 2001
+From 1f79db86954bb75e4212034e8dde0b6eda989245 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Wed, 14 Mar 2018 21:33:54 +0100
 Subject: sitecustomize.pl: use the shortVersion for site and vendor.
@@ -575,10 +551,10 @@ index a321e51..76c0e46 100644
  );
  my @newINC;
 -- 
-2.21.0
+2.45.1
 
 
-From b500365b5a960c8ad1ba719f3e4d64ce635c3c35 Mon Sep 17 00:00:00 2001
+From a3940547651bbdd2a863be98ba3794bf132c2edf Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sun, 7 Jul 2019 20:32:13 +0200
 Subject: numeric.c: move down optional declaration
@@ -587,10 +563,10 @@ numeric.c:38:5: error: ISO C90 forbids mixed declarations and code
 NV result;
 
 diff --git a/numeric.c b/numeric.c
-index d4e3493..7657a56 100644
+index c22e4ef..1b6d520 100644
 --- a/numeric.c
 +++ b/numeric.c
-@@ -34,8 +34,8 @@ values, including such things as replacements for the OS's atof() function
+@@ -31,8 +31,8 @@ values, including such things as replacements for the OS's atof() function
  PERL_STATIC_INLINE NV
  S_strtod(pTHX_ const char * const s, char ** e)
  {
@@ -601,5 +577,113 @@ index d4e3493..7657a56 100644
      STORE_LC_NUMERIC_SET_TO_NEEDED();
  
 -- 
-2.21.0
+2.45.1
+
+
+From 4d45637b47fd1358d37bbe284ed5f7deb8fb0cb1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
+Date: Sat, 22 Jun 2024 22:24:38 +0200
+Subject: disable some reentrant variants of functions which we don't have
+
+
+diff --git a/reentr.h b/reentr.h
+index 90f6b6d..5fa312a 100644
+--- a/reentr.h
++++ b/reentr.h
+@@ -73,6 +73,10 @@
+ #    define NETDB_R_OBSOLETE
+ #  endif
+ 
++#  ifdef __HAIKU__
++#    define NETDB_R_OBSOLETE
++#  endif
++
+ #  if defined(__GLIBC__) && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 24))
+ #    undef HAS_READDIR_R
+ #    undef HAS_READDIR64_R
+diff --git a/regen/reentr.pl b/regen/reentr.pl
+index 4b13cc2..931eca2 100644
+--- a/regen/reentr.pl
++++ b/regen/reentr.pl
+@@ -121,6 +121,10 @@ print $h <<EOF;
+ #    define NETDB_R_OBSOLETE
+ #  endif
+ 
++#  ifdef __HAIKU__
++#    define NETDB_R_OBSOLETE
++#  endif
++
+ #  if defined(__GLIBC__) && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 24))
+ #    undef HAS_READDIR_R
+ #    undef HAS_READDIR64_R
+-- 
+2.45.1
+
+
+From efd834171358f845db9324c5431a03f7e75eac71 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
+Date: Sat, 22 Jun 2024 22:25:46 +0200
+Subject: disable check involving sizeof(dirent.d_name)
+
+This is a flexible array member and sizeof isn't allowed for these.
+
+diff --git a/sv.c b/sv.c
+index 0b3d142..880a108 100644
+--- a/sv.c
++++ b/sv.c
+@@ -14066,6 +14066,7 @@ Perl_dirp_dup(pTHX_ DIR *const dp, CLONE_PARAMS *const param)
+     pos = PerlDir_tell(dp);
+     if ((dirent = PerlDir_read(dp))) {
+         len = d_namlen(dirent);
++#ifndef __HAIKU__
+         if (len > sizeof(dirent->d_name) && sizeof(dirent->d_name) > PTRSIZE) {
+             /* If the len is somehow magically longer than the
+              * maximum length of the directory entry, even though
+@@ -14074,6 +14075,7 @@ Perl_dirp_dup(pTHX_ DIR *const dp, CLONE_PARAMS *const param)
+             PerlDir_close(ret);
+             return (DIR*)NULL;
+         }
++#endif
+         if (len <= sizeof smallbuf) name = smallbuf;
+         else Newx(name, len, char);
+         Move(dirent->d_name, name, len, char);
+-- 
+2.45.1
+
+
+From de82e8f99fbd8361debbf3d1f20a52f212f64298 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
+Date: Sun, 23 Jun 2024 17:35:15 +0200
+Subject: disable locking mutexes at fork
+
+This is broken on Haiku.
+ * mutex_unlock fails with EPERM (according to a panic message from miniperl)
+ * the child process hangs in _kern_mutex_lock, pegging a core
+
+TODO: is this safe?
+
+diff --git a/util.c b/util.c
+index 4053ca4..66db5e2 100644
+--- a/util.c
++++ b/util.c
+@@ -2846,7 +2846,7 @@ Perl_atfork_lock(void)
+   PERL_TSA_ACQUIRE(PL_op_mutex)
+ #endif
+ {
+-#if defined(USE_ITHREADS)
++#if defined(USE_ITHREADS) && !defined(__HAIKU__)
+     /* locks must be held in locking order (if any) */
+ #  ifdef USE_PERLIO
+     MUTEX_LOCK(&PL_perlio_mutex);
+@@ -2871,7 +2871,7 @@ Perl_atfork_unlock(void)
+   PERL_TSA_RELEASE(PL_op_mutex)
+ #endif
+ {
+-#if defined(USE_ITHREADS)
++#if defined(USE_ITHREADS) && !defined(__HAIKU__)
+     /* locks must be released in same order as in atfork_lock() */
+ #  ifdef USE_PERLIO
+     MUTEX_UNLOCK(&PL_perlio_mutex);
+-- 
+2.45.1
 

--- a/dev-lang/perl/perl-5.40.0.recipe
+++ b/dev-lang/perl/perl-5.40.0.recipe
@@ -132,26 +132,58 @@ INSTALL()
 TEST()
 {
 #x86_64
-#Failed 19 tests out of 2439, 99.22% okay.
+#Failed 51 tests out of 2677, 98.09% okay.
 #        ../cpan/ExtUtils-MakeMaker/t/INST.t
 #        ../cpan/ExtUtils-MakeMaker/t/INST_PREFIX.t
 #        ../cpan/ExtUtils-MakeMaker/t/MM_BeOS.t
 #        ../cpan/IO-Socket-IP/t/11sockopts.t
 #        ../cpan/IO-Socket-IP/t/18fdopen.t
-#        ../cpan/IPC-SysV/t/msg.t
-#        ../cpan/Socket/t/socketpair.t
 #        ../cpan/Time-Piece/t/02core.t
-#        ../cpan/version/t/07locale.t
 #        ../dist/IO/t/cachepropagate-unix.t
-#        ../dist/Net-Ping/t/010_pingecho.t
-#        ../dist/Net-Ping/t/450_service.t
-#        ../dist/PathTools/t/cwd_enoent.t
-#        ../dist/Time-HiRes/t/stat.t
 #        ../dist/Time-HiRes/t/utime.t
+#        ../ext/I18N-Langinfo/t/Langinfo.t
+#        ../ext/POSIX/t/mb.t
+#        ../ext/POSIX/t/time.t
 #        ../ext/POSIX/t/wrappers.t
+#        ../ext/Pod-Html/t/htmldir3.t
+#        ../ext/XS-APItest/t/handy00.t
+#        ../ext/XS-APItest/t/handy01.t
+#        ../ext/XS-APItest/t/handy02.t
+#        ../ext/XS-APItest/t/handy03.t
+#        ../ext/XS-APItest/t/handy04.t
+#        ../ext/XS-APItest/t/handy05.t
+#        ../ext/XS-APItest/t/handy06.t
+#        ../ext/XS-APItest/t/handy07.t
+#        ../ext/XS-APItest/t/handy08.t
+#        ../ext/XS-APItest/t/handy09.t
+#        ../ext/XS-APItest/t/locale.t
+#        ../lib/locale.t
+#        ../lib/locale_threads.t
+#        ../lib/warnings.t
 #        io/socket.t
+#        op/lc.t
+#        op/sigsystem.t
 #        op/time.t
 #        porting/regen.t
+#        re/charset.t
+#        re/fold_grind_8.t
+#        re/fold_grind_T.t
+#        re/pat.t
+#        re/pat_thr.t
+#        re/regex_sets.t
+#        re/uniprops01.t
+#        re/uniprops02.t
+#        re/uniprops03.t
+#        re/uniprops04.t
+#        re/uniprops05.t
+#        re/uniprops06.t
+#        re/uniprops07.t
+#        re/uniprops08.t
+#        re/uniprops09.t
+#        re/uniprops10.t
+#        run/locale.t
+#        run/runenv_randseed.t
+#        uni/fold.t
 
 	make test
 }

--- a/dev-lang/perl/perl-5.40.0.recipe
+++ b/dev-lang/perl/perl-5.40.0.recipe
@@ -13,13 +13,13 @@ applications. Perl is nicknamed 'the Swiss Army chainsaw of scripting \
 languages' because of its flexibility and power, and possibly also because of \
 its perceived 'ugliness'."
 HOMEPAGE="https://www.perl.org/"
-COPYRIGHT="1993-2019 Larry Wall and others"
+COPYRIGHT="1993-2024 Larry Wall and others"
 LICENSE="GNU GPL v1
 	Artistic"
-REVISION="3"
+REVISION="1"
 perlShortVersion="${portVersion%.*}"
 SOURCE_URI="http://www.cpan.org/src/perl-$portVersion.tar.gz"
-CHECKSUM_SHA256="03b693901cd8ae807231b1787798cf1f2e0b8a56218d07b7da44f784a7caeb2c"
+CHECKSUM_SHA256="c740348f357396327a9795d3e8323bafd0fe8a5c7835fc1cbaba0cc8dfe7161f"
 PATCHES="perl-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -81,16 +81,15 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	cmd:awk
 	cmd:gcc$secondaryArchSuffix
+	cmd:grep
 	cmd:ld$secondaryArchSuffix
 	cmd:make
 	cmd:sed
-	cmd:grep
 	"
 
-perlArchName="$(uname -m)-haiku"
+perlArchName="$(uname -m)-haiku-thread-multi"
 
 GLOBAL_WRITABLE_FILES="
-	non-packaged/lib/perl5/site_perl/$perlShortVersion/sitecustomize.pl keep-old
 	non-packaged/lib/perl5/site_perl/$perlShortVersion/$perlArchName directory keep-old
 	"
 
@@ -106,7 +105,7 @@ BUILD()
 		-Dvendorprefix=$prefix \
 		-Dvendorlib=$prefix/lib/perl5/vendor_perl/$perlShortVersion \
 		-Dcf_email=zooey@hirschkaefer.de \
-		-Uusenm -Duseshrplib -Uusemymalloc \
+		-Uusenm -Duseshrplib -Dusethreads -Uusemymalloc \
 		-Dlibpth="$(finddir B_USER_DEVELOP_DIRECTORY)/lib$secondaryArchSubDir $(finddir B_SYSTEM_DEVELOP_DIRECTORY)/lib$secondaryArchSubDir $(finddir B_USER_LIB_DIRECTORY)$secondaryArchSubDir $(finddir B_SYSTEM_LIB_DIRECTORY)$secondaryArchSubDir" \
 		-Dusrinc="$(finddir B_SYSTEM_DEVELOP_DIRECTORY)/headers$secondaryArchSubDir/posix" \
 		-Dlocinc="$(finddir B_USER_CONFIG_DIRECTORY)/develop/headers$secondaryArchSubDir $(finddir B_SYSTEM_DEVELOP_DIRECTORY)/headers$secondaryArchSubDir" \
@@ -128,10 +127,6 @@ INSTALL()
 {
 	make install
 	chmod a+x $prefix/bin/{perl,perlthanks}
-
-	# copy script into site_perl that takes care of massaging @INC into what we need.
-	cp sitecustomize.pl $prefix/non-packaged/lib/perl5/site_perl/$perlShortVersion/sitecustomize.pl
-	# TODO: maybe generate the script dynamically in the recipe (using recipe variables) instead of statically in the patchset
 }
 
 TEST()


### PR DESCRIPTION
See https://perldoc.perl.org/perl#History for details of changes. Fixes CVE-2023-47038. (the other security fix affects only Windows)

Because this is a major update of perl, this requires rebuilding all perl packages.
 - including git, among others! -- which is why this is still a draft.

Enable threads, which are enabled by most Linux distros as well, apparently. This required some additional patches.
 - maybe this helps with sdl_perl on x86 (we will see)

Don't install the `sitecustomize.pl` script any more. I don't think it is actually needed. If it is retained though, it would need some changes to support secondaryArch. The patches which create the script are still included for now, but they could be removed if this change is accepted.
Fixes #10624.