### PR TITLE
mdnsresponder: new recipe.

### DIFF
--- a/net-dns/mdnsresponder/additional-files/mdnsresponder-finish-setup.sh
+++ b/net-dns/mdnsresponder/additional-files/mdnsresponder-finish-setup.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# for our pid file
+install -d -m 755 -o 0 -g 0 `finddir B_SYSTEM_VAR_DIRECTORY`/run

--- a/net-dns/mdnsresponder/mdnsresponder-2200.120.24.recipe
+++ b/net-dns/mdnsresponder/mdnsresponder-2200.120.24.recipe
@@ -1,0 +1,133 @@
+SUMMARY="ZeroConf a.k.a Bonjour a.k.a. mDNS + DNS-SD"
+DESCRIPTION="Apple's Open Source DNS Service Discovery Collection"
+HOMEPAGE="https://developer.apple.com/bonjour/"
+COPYRIGHT="2003-2023 Apple Inc."
+LICENSE="
+	Apache v2
+	BSD (3-clause)
+	"
+REVISION="1"
+SOURCE_URI="https://github.com/apple-oss-distributions/mDNSResponder/archive/mDNSResponder-$portVersion.tar.gz"
+CHECKSUM_SHA256="6552631de495c127dcf2fd24c466427e1f05747da58eb6464cd23db92a25f3d2"
+SOURCE_DIR="mDNSResponder-mDNSResponder-$portVersion"
+PATCHES="mdnsresponder-$portVersion.patchset"
+
+ADDITIONAL_FILES="
+	mdnsresponder-finish-setup.sh
+	"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+commandBinDir=$binDir
+commandSuffix=$secondaryArchSuffix
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandBinDir=$prefix/bin
+	commandSuffix=
+fi
+
+# Needed to make sure /var/run/ exists before running cmd:mdnsd (uses it for its PID file)
+POST_INSTALL_SCRIPTS="$relativePostInstallDir/mdnsresponder-finish-setup.sh"
+
+# Non critical: cmd:mdnsd needs user "nobody" existing, or it complains about running as root.
+PACKAGE_USERS="
+	nobody real-name nobody home /var/empty shell /bin/true groups nobody
+	"
+
+PACKAGE_GROUPS="
+	nobody
+	"
+
+PROVIDES="
+	mdnsresponder$secondaryArchSuffix = $portVersion
+	cmd:mdnsd$commandSuffix
+	cmd:dns_sd$commandSuffix
+	lib:libdns_sd$secondaryArchSuffix
+	lib:libnss_mdnsd$secondaryArchSuffix
+	devel:libdns_sd$secondaryArchSuffix
+	"
+
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	"
+
+PROVIDES_tools="
+	mdnsresponder${secondaryArchSuffix}_tools = $portVersion
+	cmd:mDNSClient$commandSuffix
+	cmd:mDNSNetMonitor$commandSuffix
+	cmd:mDNSProxyResponder$commandSuffix
+	cmd:mDNSResponder$commandSuffix
+	"
+SUMMARY_tools="Stand-alone tools for ZeroConf a.k.a Bonjour a.k.a. mDNS + DNS-SD"
+DESCRIPTION_tools="You might need to make sure /bin/mdnsd is NOT running before using these tools."
+
+REQUIRES_tools="
+	haiku$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	# After beta5, we might want to build using: -D_PLATFORM_HAS_STRONG_PRNG_
+	cd mDNSPosix
+	make $jobArgs
+}
+
+INSTALL()
+{
+	install -m 0755 -d $commandBinDir $libDir $manDir/man1 $manDir/man8 $developDir/headers
+
+	# mDNSResponder
+	install -m 0755 mDNSPosix/build/prod/mdnsd $commandBinDir
+	install -m 0644 mDNSPosix/build/prod/libdns_sd.so $libDir
+	install -m 0755 Clients/build/dns-sd $commandBinDir
+	install -m 0644 mDNSShared/dns-sd.1 $manDir/man1
+	install -m 0644 mDNSShared/mDNSResponder.8 $manDir/man8/mdnsd.8
+	install -m 0644 mDNSShared/dns_sd.h $developDir/headers
+
+	# Standalone tools
+	install -m 0755 -T mDNSPosix/build/prod/mDNSClientPosix $commandBinDir/mDNSClient
+	install -m 0755 mDNSPosix/build/prod/mDNSNetMonitor $commandBinDir
+	install -m 0755 -T mDNSPosix/build/prod/mDNSProxyResponderPosix $commandBinDir/mDNSProxyResponder
+	install -m 0755 -T mDNSPosix/build/prod/mDNSResponderPosix $commandBinDir/mDNSResponder
+
+	# ToDo: Name Service Switch (needs changes on Haiku's side).
+	# install -m 0644 mDNSPosix/build/prod/nss_mdnsd.so.0 $libDir
+	# ln -sr $libDir/nss_mdnsd.so.0 $libDir/nss_multicast_dns.so.0
+	# install -m 0644 etc/nsswitch.conf $docDir/nsswitch.conf.example
+
+	# Standalone tools package
+	packageEntries tools \
+		$commandBinDir/mDNSClient \
+		$commandBinDir/mDNSNetMonitor \
+		$commandBinDir/mDNSProxyResponder \
+		$commandBinDir/mDNSResponder
+
+	prepareInstalledDevelLib libdns_sd
+
+	install -Dm 0755 $portDir/additional-files/mdnsresponder-finish-setup.sh \
+		$postInstallDir/mdnsresponder-finish-setup.sh
+
+	# ToDo (launch_daemon integration): figure out why the following doesn't works as intended.
+
+#	mkdir -p $dataDir/launch
+#
+#	echo "target desktop {
+#	service mDNSResponder {
+#		launch $commandBinDir/mdnsd
+#		if not file_exists ~/config/settings/mdnsd_disable_autostart
+#		# "if not setting ~/config/settings/mdnsd disable_autostart" instead?
+#		no_safemode
+#		legacy
+#		on network_available
+#	}
+#}
+#" > $dataDir/launch/mDNSResponder
+}

--- a/net-dns/mdnsresponder/patches/mdnsresponder-2200.120.24.patchset
+++ b/net-dns/mdnsresponder/patches/mdnsresponder-2200.120.24.patchset
@@ -1,0 +1,227 @@
+From db5ba6e7d07ca3b651a3f1ccf3a531f54a3c869e Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Thu, 13 Jun 2024 15:14:54 -0300
+Subject: Haiku support for mDNSPosix and dns-sd.
+
+`cd mDNSPosix && make` should work out of the box now.
+
+Tried enabling the `HAVE_IPV6` code paths (except on the narrow places where it
+caused errors on Haiku: mDNSPosix.c's `SetupIPv6Socket()` and `SetupSocket()`),
+but had to disable it, as otherwise it causes `mdnsd` to immediatly exit
+without further info.
+
+Also, added a "how to browse for any services" example to `dns-sd` man page
+(weird it wasn't there already, as one it seems to be quite a common thing to
+want to do).
+
+diff --git a/Clients/Makefile b/Clients/Makefile
+index 9d62e99..92879a7 100755
+--- a/Clients/Makefile
++++ b/Clients/Makefile
+@@ -37,9 +37,14 @@ DEBUGFLAGS = -Os
+ BUILDDIR = build/prod
+ endif
+ 
++SYSTEM := $(shell uname -s)
++
+ ifneq "$(wildcard /usr/lib/libSystem.dylib)" ""
+ TARGETS = build/dns-sd build/dns-sd64
+ LIBS =
++else ifeq ($(SYSTEM), Haiku)
++TARGETS = build/dns-sd
++LIBS = -L../mDNSPosix/$(BUILDDIR)/ -ldns_sd -lnetwork
+ else
+ TARGETS = build/dns-sd
+ LIBS = -L../mDNSPosix/$(BUILDDIR)/ -ldns_sd
+diff --git a/mDNSPosix/Makefile b/mDNSPosix/Makefile
+index 0417065..83b5b75 100755
+--- a/mDNSPosix/Makefile
++++ b/mDNSPosix/Makefile
+@@ -51,6 +51,8 @@ ifeq ($(SYSTEM), Darwin)
+   os=x
+ else ifeq ($(SYSTEM), Linux)
+   os=linux
++else ifeq ($(SYSTEM), Haiku)
++  os=haiku
+ endif
+ 
+ CC = cc
+@@ -155,6 +157,27 @@ CFLAGS_OS = -DHAVE_BROKEN_RECVDSTADDR
+ LDCONFIG = ldconfig
+ else
+ 
++ifeq ($(os),haiku)
++	CFLAGS_DEBUGGING = -g -DMDNS_DEBUGMSGS=0
++	ifneq ($(DEBUG),1)
++		CFLAGS_DEBUGGING = -O2 -DMDNS_DEBUGMSGS=0
++		STRIP = $(ST)
++	endif
++
++	# From Jin Ma's GSoC:
++	# CFLAGS_OS = -DRTM_NEWADDR=0xc -DRTM_DELADDR=0xd -DRTM_IFINFO=0xe
++	CFLAGS_OS = -DHAVE_IPV6=0 -DTARGET_OS_HAIKU
++
++	LINKOPTS = -lnetwork -lbsd
++
++	# Name Service Switch
++	# OPTIONALTARG = nss_mdns
++	# The HaikuPorts .recipe won't be using "make install" (too much hardcoded paths in here)
++	# notice the "nss_mdns.conf" make target, thou.	
++	#OPTINSTALL   = InstalledNSS
++	#NSSLIBNAME  := libnss_mdnsd
++else
++
+ ifeq ($(os),x)
+ # We have to define __MAC_OS_X_VERSION_MIN_REQUIRED=__MAC_OS_X_VERSION_10_4 or on Leopard
+ # we get build failures: ‘daemon’ is deprecated (declared at /usr/include/stdlib.h:283)
+@@ -173,7 +196,8 @@ OPTIONALTARG = dnsextd
+ else
+ 
+ $(error ERROR: Must specify target OS on command-line, e.g. "make os=x [target]".\
+-Supported operating systems include: x, linux, linux-uclibc, netbsd, freebsd, openbsd, solaris)
++Supported operating systems include: x, linux, linux-uclibc, netbsd, freebsd, openbsd, solaris, haiku)
++endif
+ endif
+ endif
+ endif
+diff --git a/mDNSPosix/mDNSPosix.c b/mDNSPosix/mDNSPosix.c
+index 3b761d0..ee75d63 100644
+--- a/mDNSPosix/mDNSPosix.c
++++ b/mDNSPosix/mDNSPosix.c
+@@ -1064,7 +1064,8 @@ mDNSlocal int SetupIPv6Socket(int fd)
+ {
+     int err;
+ 
+-    #if defined(IPV6_PKTINFO)
++    #if defined(IPV6_PKTINFO) && !defined(__HAIKU__)
++    // On Haiku, this errors out with: setsockopt - IPV6_PKTINFO: Protocol option not available
+     err = setsockopt(fd, IPPROTO_IPV6, IPV6_2292_PKTINFO, &kOn, sizeof(kOn));
+     if (err < 0) { err = errno; perror("setsockopt - IPV6_PKTINFO"); }
+     #else
+@@ -1224,7 +1225,8 @@ mDNSlocal int SetupSocket(struct sockaddr *intfAddr, mDNSIPPort port, int interf
+         if (err == 0) {
+             err = SetupIPv6Socket(*sktPtr);
+         }
+-    #if defined(IPV6_HOPLIMIT)
++    #if defined(IPV6_HOPLIMIT) && !defined(__HAIKU__)
++    // On Haiku, it errors with message: "setsockopt - IPV6_HOPLIMIT: Protocol option not available"
+         if (err == 0)
+         {
+             err = setsockopt(*sktPtr, IPPROTO_IPV6, IPV6_2292_HOPLIMIT, &kOn, sizeof(kOn));
+@@ -1725,6 +1727,9 @@ mDNSlocal mDNSu32       ProcessRoutingNotification(int sd)
+ // Read through the messages on sd and if any indicate that any interface records should
+ // be torn down and rebuilt, return affected indices as a bitmask. Otherwise return 0.
+ {
++#if defined(__HAIKU__)
++    mDNSu32 result = 0;
++#else
+     ssize_t readCount;
+     char buff[4096];
+     struct ifa_msghdr       *pRSMsg = (struct ifa_msghdr*) buff;
+@@ -1747,7 +1752,7 @@ mDNSlocal mDNSu32       ProcessRoutingNotification(int sd)
+         else
+             result |= 1 << pRSMsg->ifam_index;
+     }
+-
++#endif
+     return result;
+ }
+ 
+diff --git a/mDNSShared/CommonServices.h b/mDNSShared/CommonServices.h
+index 7efb077..c9d7511 100644
+--- a/mDNSShared/CommonServices.h
++++ b/mDNSShared/CommonServices.h
+@@ -186,6 +186,10 @@ extern "C" {
+     #include    <arpa/inet.h>
+     #include    <sys/socket.h>
+ 
++#elif ( TARGET_OS_HAIKU )
++
++// Haiku (no special includes yet).
++
+ #elif ( TARGET_OS_LINUX )
+ 
+ // Linux
+@@ -447,7 +451,7 @@ typedef int socklen_t;
+ // - Mac OS X when not building with BSD headers
+ // - Windows
+ 
+-#if ( !defined(_SSIZE_T) && ( TARGET_OS_WIN32 || !defined( _BSD_SSIZE_T_DEFINED_ ) ) && !TARGET_OS_FREEBSD && !TARGET_OS_LINUX && !TARGET_OS_MAC)
++#if ( !defined(_SSIZE_T) && ( TARGET_OS_WIN32 || !defined( _BSD_SSIZE_T_DEFINED_ ) ) && !TARGET_OS_FREEBSD && !TARGET_OS_HAIKU && !TARGET_OS_LINUX && !TARGET_OS_MAC)
+ typedef int ssize_t;
+ #endif
+ 
+diff --git a/mDNSShared/PlatformCommon.c b/mDNSShared/PlatformCommon.c
+index 5635458..3917156 100644
+--- a/mDNSShared/PlatformCommon.c
++++ b/mDNSShared/PlatformCommon.c
+@@ -26,7 +26,11 @@
+ #include <sys/socket.h>         // Needed for socket() etc.
+ #include <netinet/in.h>         // Needed for sockaddr_in
+ #include <syslog.h>
++#if defined(__HAIKU__)
++#include <posix/fcntl.h>
++#else
+ #include <sys/fcntl.h>
++#endif
+ #include <netinet/tcp.h>
+ #include <arpa/inet.h>
+ #include <time.h>
+diff --git a/mDNSShared/dns-sd.1 b/mDNSShared/dns-sd.1
+index d462ae2..98d6d12 100644
+--- a/mDNSShared/dns-sd.1
++++ b/mDNSShared/dns-sd.1
+@@ -195,6 +195,10 @@ return the version of the currently running daemon/system service.
+ .El
+ .Sh EXAMPLES
+ .Pp
++To browse for any service type that might be available, use:
++.Pp
++.Dl Nm Fl B Ns \ _services._dns-sd._udp.
++.Pp
+ To advertise the existence of LPR printing service on port 515 on this
+ machine, such that it will be discovered by the Mac OS X printing software
+ and other DNS-SD compatible printing clients, use:
+diff --git a/mDNSShared/utilities/misc_utilities.c b/mDNSShared/utilities/misc_utilities.c
+index 49a6159..6d27782 100644
+--- a/mDNSShared/utilities/misc_utilities.c
++++ b/mDNSShared/utilities/misc_utilities.c
+@@ -19,6 +19,9 @@
+ 
+ #include "misc_utilities.h"
+ 
++#if defined(__HAIKU__)
++#include <arpa/inet.h>	// For inet_ntop().
++#endif
+ #include <string.h>						// For memset().
+ #include "DebugServices.h"				// For check_compile_time_code().
+ #include "mdns_strict.h"
+-- 
+2.45.1
+
+
+From 9f23df4e4a0e102f296862ef33bcac3651d11938 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Sun, 23 Jun 2024 15:41:16 -0300
+Subject: Fix location of resolv.conf file.
+
+
+diff --git a/mDNSPosix/mDNSPosix.h b/mDNSPosix/mDNSPosix.h
+index 9675591..d3fcd97 100644
+--- a/mDNSPosix/mDNSPosix.h
++++ b/mDNSPosix/mDNSPosix.h
+@@ -114,7 +114,11 @@ struct TCPListener_struct
+     TCPSocketFlags socketFlags;
+ };
+     
++#ifdef __HAIKU__
++#define uDNS_SERVERS_FILE "/boot/system/settings/network/resolv.conf"
++#else
+ #define uDNS_SERVERS_FILE "/etc/resolv.conf"
++#endif
+ extern int ParseDNSServers(mDNS *m, const char *filePath);
+ extern mStatus mDNSPlatformPosixRefreshInterfaceList(mDNS *const m);
+ // See comment in implementation.
+-- 
+2.45.1
+


### PR DESCRIPTION
Alright... here's half of the ZeroConf/Bonjour puzzle. With these we can advertize services from a Haiku system, and get to find them from other machines.

The other half, being able to resolve hostnames in the .local domain, requires building a `nss_mdnsd.so` [Name Service Switch](https://en.wikipedia.org/wiki/) module, as I have done so [here](https://github.com/OscarL/mDNSResponder/commit/d95cab2961935f21dbca9b2728a43dfec404eccb), but that requires work on Haiku's side to load without runtime_loader errors (after we patch libnetwork.so's [code](https://cgit.haiku-os.org/haiku/tree/src/system/libnetwork/netresolv/net/nsdispatch.c#n189) to actually attempt to load the nss_mdns.so module).

The module I took from NetBSD, expects some resolv functions not present on Haiku's copy of those files (and it even requires kqueue/kevent funtionality, so it wouldn't work on beta4 in any case).