### PR TITLE
add libiconv support to libxml2

### DIFF
--- a/dev-libs/libxml2/libxml2-2.12.5.recipe
+++ b/dev-libs/libxml2/libxml2-2.12.5.recipe
@@ -10,7 +10,7 @@ available in other environments."
 HOMEPAGE="http://www.xmlsoft.org/"
 COPYRIGHT="1998-2013 Daniel Veillard.  All Rights Reserved."
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://download.gnome.org/sources/libxml2/2.12/libxml2-$portVersion.tar.xz"
 CHECKSUM_SHA256="a972796696afd38073e0f59c283c3a2f5a560b5268b4babc391b286166526b21"
 SOURCE_URI_2="https://www.w3.org/XML/Test/xmlts20130923.tar.gz"
@@ -44,7 +44,7 @@ fi
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
-        lib:libiconv
+	lib:libiconv$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
@@ -78,7 +78,7 @@ fi
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libz$secondaryArchSuffix
-        devel:libiconv
+	devel:libiconv$secondaryArchSuffix
 	"
 if $pythonModuleEnabled; then
 	BUILD_REQUIRES="$BUILD_REQUIRES

--- a/dev-libs/libxml2/libxml2-2.12.5.recipe
+++ b/dev-libs/libxml2/libxml2-2.12.5.recipe
@@ -44,6 +44,7 @@ fi
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
+        lib:libiconv
 	"
 
 PROVIDES_devel="
@@ -77,6 +78,7 @@ fi
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libz$secondaryArchSuffix
+        devel:libiconv
 	"
 if $pythonModuleEnabled; then
 	BUILD_REQUIRES="$BUILD_REQUIRES


### PR DESCRIPTION
Hello,

I ran into  a string encoding problem with a Python package that uses lxml.

```
Traceback (most recent call last):
[...irrelevant bits snipped...]
  File "/boot/home/.venv/nikola/non-packaged/lib/python3.10/site-packages/lxml/html/__init__.py", line 806, in fragment_fromstring
    elements = fragments_fromstring(
  File "/boot/home/.venv/nikola/non-packaged/lib/python3.10/site-packages/lxml/html/__init__.py", line 769, in fragments_fromstring
    doc = document_fromstring(html, parser=parser, base_url=base_url, **kw)
  File "/boot/home/.venv/nikola/non-packaged/lib/python3.10/site-packages/lxml/html/__init__.py", line 736, in document_fromstring
    value = etree.fromstring(html, parser, **kw)
  File "src/lxml/etree.pyx", line 3307, in lxml.etree.fromstring
  File "src/lxml/parser.pxi", line 1989, in lxml.etree._parseMemoryDocument
  File "src/lxml/parser.pxi", line 1869, in lxml.etree._parseDoc
  File "src/lxml/parser.pxi", line 1105, in lxml.etree._BaseParser._parseUnicodeDoc
  File "src/lxml/parser.pxi", line 633, in lxml.etree._ParserContext._handleParseResultDoc
  File "src/lxml/parser.pxi", line 743, in lxml.etree._handleParseResult
  File "src/lxml/parser.pxi", line 672, in lxml.etree._raiseParseError
  File "<string>", line 1
lxml.etree.XMLSyntaxError: encoding not supported: ISO-10646-UCS-4, line 1, column 1
```

After some digging, I figured out that the issue was that Python was representing some data internally as a UCS-4 string. That string was being passed by lxml to the underlying libxml2 library, which was built without iconv support and therefore has no support for UCS-4. This patch adds the required dependencies on libiconv, which will allow libxml2 to handle UCS-4  (and a variety of other encodings).