### PR TITLE
openssh: update to version 9.8p1.

### DIFF
--- a/net-misc/openssh/openssh-9.8p1.recipe
+++ b/net-misc/openssh/openssh-9.8p1.recipe
@@ -18,7 +18,7 @@ COPYRIGHT="2005-2020 Tatu Ylonen et al."
 LICENSE="OpenSSH"
 REVISION="1"
 SOURCE_URI="https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$portVersion.tar.gz"
-CHECKSUM_SHA256="490426f766d82a2763fcacd8d83ea3d70798750c7bd2aff2e57dc5660f773ffd"
+CHECKSUM_SHA256="dd8bd002a379b5d499dfb050dd1fa9af8029e80461f4bb6c523c49973f5a39f3"
 PATCHES="openssh-$portVersion.patchset"
 ADDITIONAL_FILES="
 	sshd_keymaker.sh

--- a/net-misc/openssh/patches/openssh-9.8p1.patchset
+++ b/net-misc/openssh/patches/openssh-9.8p1.patchset
@@ -1,4 +1,4 @@
-From 757c8db8e07aeaec1826a5644d3930c4def405e9 Mon Sep 17 00:00:00 2001
+From c927d5db34599663bf24c2e7033411ccde159f8e Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Thu, 16 Jul 2020 17:57:38 +0200
 Subject: applying patch sshd_config.patch
@@ -18,20 +18,20 @@ index 36894ac..c783c84 100644
  #AuthorizedPrincipalsFile none
  
 -- 
-2.42.1
+2.45.2
 
 
-From 67cdb7ddfaebf71b6ee6e460c7aba3d63317b23e Mon Sep 17 00:00:00 2001
+From 1695c92f7ba1c8d7ba99b07a4e22713a0ffc50cc Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Thu, 16 Jul 2020 17:57:38 +0200
 Subject: applying patch pathnames.patch
 
 
 diff --git a/pathnames.h b/pathnames.h
-index f7ca5a7..828e43e 100644
+index 61c5f84..e322c12 100644
 --- a/pathnames.h
 +++ b/pathnames.h
-@@ -57,7 +57,7 @@
+@@ -62,7 +62,7 @@
   * The directory in user's home directory in which the files reside. The
   * directory should be world-readable (though not all files are).
   */
@@ -41,10 +41,10 @@ index f7ca5a7..828e43e 100644
  /*
   * Per-user file containing host keys of known hosts.  This file need not be
 -- 
-2.42.1
+2.45.2
 
 
-From 3105ff59ea826b1fb34b4bf297dc301556914d59 Mon Sep 17 00:00:00 2001
+From c386c16a8d1e94531db3213acef0892c61dee35a Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Thu, 16 Jul 2020 17:57:38 +0200
 Subject: applying patch ssh-copy-id.patch
@@ -73,10 +73,10 @@ index da6bd18..866f467 100644
  then
    chmod 0700 "$SCRATCH_DIR"
 -- 
-2.42.1
+2.45.2
 
 
-From 8866fd05b3498493e69936540c0ce5e876bf4f8b Mon Sep 17 00:00:00 2001
+From ab2399c753597302a99cb98fdd8041bda4751aa4 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Thu, 16 Jul 2020 17:57:38 +0200
 Subject: applying patch sha2-gcc2-build-fix.patch
@@ -129,17 +129,17 @@ index 4f2ad8f..8946d87 100644
  	memcpy(digest, context->state.st64, SHA384_DIGEST_LENGTH);
  #endif
 -- 
-2.42.1
+2.45.2
 
 
-From 1544b1f2ae8a746f475b82c5b16377fed23f386c Mon Sep 17 00:00:00 2001
+From a5becac58159b52f71d2f54032497f70fbc8a87b Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Thu, 16 Jul 2020 18:08:27 +0200
 Subject: Fix configuration path in manpages
 
 
 diff --git a/contrib/ssh-copy-id.1 b/contrib/ssh-copy-id.1
-index 74eec2f..35a6cc4 100644
+index 74eec2f..5d7b5de 100644
 --- a/contrib/ssh-copy-id.1
 +++ b/contrib/ssh-copy-id.1
 @@ -58,7 +58,7 @@ It then assembles a list of those that failed to log in and, using
@@ -147,7 +147,7 @@ index 74eec2f..35a6cc4 100644
  enables logins with those keys on the remote server.
  By default it adds the keys by appending them to the remote user's
 -.Pa ~/.ssh/authorized_keys
-+.Pa ~/config/settings/settings/ssh/authorized_keys
++.Pa ~/config/settings/ssh/authorized_keys
  (creating the file, and directory, if necessary).
  It is also capable of detecting if the remote system is a NetScreen,
  and using its
@@ -156,277 +156,273 @@ index 74eec2f..35a6cc4 100644
  .Ic default_ID_file
  is the most recent file that matches:
 -.Pa ~/.ssh/id*.pub ,
-+.Pa ~/config/settings/settings/ssh/id*.pub ,
++.Pa ~/config/settings/ssh/id*.pub ,
  (excluding those that match
 -.Pa ~/.ssh/*-cert.pub )
-+.Pa ~/config/settings/settings/ssh/*-cert.pub )
++.Pa ~/config/settings/ssh/*-cert.pub )
  so if you create a key that is not the one you want
  .Nm
  to use, just use
 diff --git a/ssh-add.0 b/ssh-add.0
-index fed9969..8b1e554 100644
+index 30eed66..0e0b400 100644
 --- a/ssh-add.0
 +++ b/ssh-add.0
-@@ -13,8 +13,8 @@ SYNOPSIS
+@@ -13,11 +13,12 @@ SYNOPSIS
  DESCRIPTION
       ssh-add adds private key identities to the authentication agent,
       ssh-agent(1).  When run without arguments, it adds the files
--     ~/.ssh/id_rsa, ~/.ssh/id_ecdsa, ~/.ssh/id_ecdsa_sk, ~/.ssh/id_ed25519,
--     ~/.ssh/id_ed25519_sk, and ~/.ssh/id_dsa.  After loading a private key,
-+     ~/config/settings/settings/ssh/id_rsa, ~/config/settings/settings/ssh/id_ecdsa, ~/config/settings/settings/ssh/id_ecdsa_sk, ~/config/settings/settings/ssh/id_ed25519,
-+     ~/config/settings/settings/ssh/id_ed25519_sk, and ~/config/settings/settings/ssh/id_dsa.  After loading a private key,
-      ssh-add will try to load corresponding certificate information from the
-      filename obtained by appending -cert.pub to the name of the private key
-      file.  Alternative file names can be given on the command line.
-@@ -63,8 +63,8 @@ DESCRIPTION
+-     ~/.ssh/id_rsa, ~/.ssh/id_ecdsa, ~/.ssh/id_ecdsa_sk, ~/.ssh/id_ed25519 and
+-     ~/.ssh/id_ed25519_sk.  After loading a private key, ssh-add will try to
+-     load corresponding certificate information from the filename obtained by
+-     appending -cert.pub to the name of the private key file.  Alternative
+-     file names can be given on the command line.
++     ~/config/settings/ssh/id_rsa, ~/config/settings/ssh/id_ecdsa,
++     ~/config/settings/ssh/id_ecdsa_sk, ~/config/settings/ssh/id_ed25519 and
++     ~/config/settings/ssh/id_ed25519_sk.  After loading a private key, ssh-add
++     will try to load corresponding certificate information from the filename
++     obtained by appending -cert.pub to the name of the private key file.
++     Alternative file names can be given on the command line.
+ 
+      If any file requires a passphrase, ssh-add asks for the passphrase from
+      the user.  The passphrase is read from the user's tty.  ssh-add retries
+@@ -63,8 +64,8 @@ DESCRIPTION
               destination-constrained keys via the -h flag.  This option may be
               specified multiple times to allow multiple files to be searched.
               If no files are specified, ssh-add will use the default
 -             ssh_config(5) known hosts files: ~/.ssh/known_hosts,
 -             ~/.ssh/known_hosts2, /etc/ssh/ssh_known_hosts, and
-+             ssh_config(5) known hosts files: ~/config/settings/settings/ssh/known_hosts,
-+             ~/config/settings/settings/ssh/known_hosts2, /etc/ssh/ssh_known_hosts, and
++             ssh_config(5) known hosts files: ~/config/settings/ssh/known_hosts,
++             ~/config/settings/ssh/known_hosts2, /etc/ssh/ssh_known_hosts, and
               /etc/ssh/ssh_known_hosts2.
  
       -h destination_constraint
-@@ -180,12 +180,12 @@ ENVIRONMENT
+@@ -180,11 +181,11 @@ ENVIRONMENT
               the built-in USB HID support.
  
  FILES
--     ~/.ssh/id_dsa
 -     ~/.ssh/id_ecdsa
 -     ~/.ssh/id_ecdsa_sk
 -     ~/.ssh/id_ed25519
 -     ~/.ssh/id_ed25519_sk
 -     ~/.ssh/id_rsa
-+     ~/config/settings/settings/ssh/id_dsa
-+     ~/config/settings/settings/ssh/id_ecdsa
-+     ~/config/settings/settings/ssh/id_ecdsa_sk
-+     ~/config/settings/settings/ssh/id_ed25519
-+     ~/config/settings/settings/ssh/id_ed25519_sk
-+     ~/config/settings/settings/ssh/id_rsa
-              Contains the DSA, ECDSA, authenticator-hosted ECDSA, Ed25519,
++     ~/config/settings/ssh/id_ecdsa
++     ~/config/settings/ssh/id_ecdsa_sk
++     ~/config/settings/ssh/id_ed25519
++     ~/config/settings/ssh/id_ed25519_sk
++     ~/config/settings/ssh/id_rsa
+              Contains the ECDSA, authenticator-hosted ECDSA, Ed25519,
               authenticator-hosted Ed25519 or RSA authentication identity of
               the user.
 diff --git a/ssh-add.1 b/ssh-add.1
-index f0186cd..b7f704f 100644
+index c31de4d..67772eb 100644
 --- a/ssh-add.1
 +++ b/ssh-add.1
-@@ -64,13 +64,13 @@
+@@ -64,10 +64,10 @@
  adds private key identities to the authentication agent,
  .Xr ssh-agent 1 .
  When run without arguments, it adds the files
 -.Pa ~/.ssh/id_rsa ,
 -.Pa ~/.ssh/id_ecdsa ,
 -.Pa ~/.ssh/id_ecdsa_sk ,
--.Pa ~/.ssh/id_ed25519 ,
--.Pa ~/.ssh/id_ed25519_sk ,
-+.Pa ~/config/settings/settings/ssh/id_rsa ,
-+.Pa ~/config/settings/settings/ssh/id_ecdsa ,
-+.Pa ~/config/settings/settings/ssh/id_ecdsa_sk ,
-+.Pa ~/config/settings/settings/ssh/id_ed25519 ,
-+.Pa ~/config/settings/settings/ssh/id_ed25519_sk ,
+-.Pa ~/.ssh/id_ed25519
++.Pa ~/config/settings/ssh/id_rsa ,
++.Pa ~/config/settings/ssh/id_ecdsa ,
++.Pa ~/config/settings/ssh/id_ecdsa_sk ,
++.Pa ~/config/settings/ssh/id_ed25519
  and
--.Pa ~/.ssh/id_dsa .
-+.Pa ~/config/settings/settings/ssh/id_dsa .
+ .Pa ~/.ssh/id_ed25519_sk .
  After loading a private key,
- .Nm
- will try to load corresponding certificate information from the
-@@ -148,8 +148,8 @@ If no files are specified,
+@@ -147,8 +147,8 @@ If no files are specified,
  will use the default
  .Xr ssh_config 5
  known hosts files:
 -.Pa ~/.ssh/known_hosts ,
 -.Pa ~/.ssh/known_hosts2 ,
-+.Pa ~/config/settings/settings/ssh/known_hosts ,
-+.Pa ~/config/settings/settings/ssh/known_hosts2 ,
++.Pa ~/config/settings/ssh/known_hosts ,
++.Pa ~/config/settings/ssh/known_hosts2 ,
  .Pa /etc/ssh/ssh_known_hosts ,
  and
  .Pa /etc/ssh/ssh_known_hosts2 .
-@@ -314,12 +314,12 @@ the built-in USB HID support.
+@@ -313,11 +313,11 @@ the built-in USB HID support.
  .El
  .Sh FILES
  .Bl -tag -width Ds -compact
--.It Pa ~/.ssh/id_dsa
 -.It Pa ~/.ssh/id_ecdsa
 -.It Pa ~/.ssh/id_ecdsa_sk
 -.It Pa ~/.ssh/id_ed25519
 -.It Pa ~/.ssh/id_ed25519_sk
 -.It Pa ~/.ssh/id_rsa
-+.It Pa ~/config/settings/settings/ssh/id_dsa
-+.It Pa ~/config/settings/settings/ssh/id_ecdsa
-+.It Pa ~/config/settings/settings/ssh/id_ecdsa_sk
-+.It Pa ~/config/settings/settings/ssh/id_ed25519
-+.It Pa ~/config/settings/settings/ssh/id_ed25519_sk
-+.It Pa ~/config/settings/settings/ssh/id_rsa
- Contains the DSA, ECDSA, authenticator-hosted ECDSA, Ed25519,
++.It Pa ~/config/settings/ssh/id_ecdsa
++.It Pa ~/config/settings/ssh/id_ecdsa_sk
++.It Pa ~/config/settings/ssh/id_ed25519
++.It Pa ~/config/settings/ssh/id_ed25519_sk
++.It Pa ~/config/settings/ssh/id_rsa
+ Contains the ECDSA, authenticator-hosted ECDSA, Ed25519,
  authenticator-hosted Ed25519 or RSA authentication identity of the user.
  .El
 diff --git a/ssh-keygen.0 b/ssh-keygen.0
-index 95e4aa3..b8ece71 100644
+index a731a7f..bc9139d 100644
 --- a/ssh-keygen.0
 +++ b/ssh-keygen.0
-@@ -56,9 +56,9 @@ DESCRIPTION
+@@ -56,10 +56,11 @@ DESCRIPTION
       KEY REVOCATION LISTS section for details.
  
       Normally each user wishing to use SSH with public key authentication runs
--     this once to create the authentication key in ~/.ssh/id_dsa,
--     ~/.ssh/id_ecdsa, ~/.ssh/id_ecdsa_sk, ~/.ssh/id_ed25519,
--     ~/.ssh/id_ed25519_sk or ~/.ssh/id_rsa.  Additionally, the system
-+     this once to create the authentication key in ~/config/settings/settings/ssh/id_dsa,
-+     ~/config/settings/settings/ssh/id_ecdsa, ~/config/settings/settings/ssh/id_ecdsa_sk, ~/config/settings/settings/ssh/id_ed25519,
-+     ~/config/settings/settings/ssh/id_ed25519_sk or ~/config/settings/settings/ssh/id_rsa.  Additionally, the system
-      administrator may use this to generate host keys, as seen in /etc/rc.
+-     this once to create the authentication key in ~/.ssh/id_ecdsa,
+-     ~/.ssh/id_ecdsa_sk, ~/.ssh/id_ed25519, ~/.ssh/id_ed25519_sk or
+-     ~/.ssh/id_rsa.  Additionally, the system administrator may use this to
+-     generate host keys, as seen in /etc/rc.
++     this once to create the authentication key in ~/config/settings/ssh/id_ecdsa,
++     ~/config/settings/ssh/id_ecdsa_sk, ~/config/settings/ssh/id_ed25519,
++     ~/config/settings/ssh/id_ed25519_sk or ~/config/settings/ssh/id_rsa.
++     Additionally, the system administrator may use this to generate host
++     keys, as seen in /etc/rc.
  
       Normally this program generates the key and asks for a file in which to
-@@ -622,7 +622,7 @@ CERTIFICATES
+      store the private key.  The public key is stored in a file with the same
+@@ -621,7 +622,8 @@ CERTIFICATES
       no-pty  Disable PTY allocation (permitted by default).
  
       no-user-rc
 -             Disable execution of ~/.ssh/rc by sshd(8) (permitted by default).
-+             Disable execution of ~/config/settings/settings/ssh/rc by sshd(8) (permitted by default).
++             Disable execution of ~/config/settings/ssh/rc by sshd(8)
++             (permitted by default).
  
       no-x11-forwarding
               Disable X11 forwarding (permitted by default).
-@@ -637,7 +637,7 @@ CERTIFICATES
+@@ -636,7 +638,7 @@ CERTIFICATES
               Allows PTY allocation.
  
       permit-user-rc
 -             Allows execution of ~/.ssh/rc by sshd(8).
-+             Allows execution of ~/config/settings/settings/ssh/rc by sshd(8).
++             Allows execution of ~/config/settings/ssh/rc by sshd(8).
  
       permit-X11-forwarding
               Allows X11 forwarding.
-@@ -862,12 +862,12 @@ ENVIRONMENT
+@@ -861,11 +863,11 @@ ENVIRONMENT
               the built-in USB HID support.
  
  FILES
--     ~/.ssh/id_dsa
 -     ~/.ssh/id_ecdsa
 -     ~/.ssh/id_ecdsa_sk
 -     ~/.ssh/id_ed25519
 -     ~/.ssh/id_ed25519_sk
 -     ~/.ssh/id_rsa
-+     ~/config/settings/settings/ssh/id_dsa
-+     ~/config/settings/settings/ssh/id_ecdsa
-+     ~/config/settings/settings/ssh/id_ecdsa_sk
-+     ~/config/settings/settings/ssh/id_ed25519
-+     ~/config/settings/settings/ssh/id_ed25519_sk
-+     ~/config/settings/settings/ssh/id_rsa
-              Contains the DSA, ECDSA, authenticator-hosted ECDSA, Ed25519,
++     ~/config/settings/ssh/id_ecdsa
++     ~/config/settings/ssh/id_ecdsa_sk
++     ~/config/settings/ssh/id_ed25519
++     ~/config/settings/ssh/id_ed25519_sk
++     ~/config/settings/ssh/id_rsa
+              Contains the ECDSA, authenticator-hosted ECDSA, Ed25519,
               authenticator-hosted Ed25519 or RSA authentication identity of
               the user.  This file should not be readable by anyone but the
-@@ -878,16 +878,16 @@ FILES
+@@ -876,17 +878,17 @@ FILES
               the private key.  ssh(1) will read this file when a login attempt
               is made.
  
--     ~/.ssh/id_dsa.pub
 -     ~/.ssh/id_ecdsa.pub
 -     ~/.ssh/id_ecdsa_sk.pub
 -     ~/.ssh/id_ed25519.pub
 -     ~/.ssh/id_ed25519_sk.pub
 -     ~/.ssh/id_rsa.pub
-+     ~/config/settings/settings/ssh/id_dsa.pub
-+     ~/config/settings/settings/ssh/id_ecdsa.pub
-+     ~/config/settings/settings/ssh/id_ecdsa_sk.pub
-+     ~/config/settings/settings/ssh/id_ed25519.pub
-+     ~/config/settings/settings/ssh/id_ed25519_sk.pub
-+     ~/config/settings/settings/ssh/id_rsa.pub
-              Contains the DSA, ECDSA, authenticator-hosted ECDSA, Ed25519,
++     ~/config/settings/ssh/id_ecdsa.pub
++     ~/config/settings/ssh/id_ecdsa_sk.pub
++     ~/config/settings/ssh/id_ed25519.pub
++     ~/config/settings/ssh/id_ed25519_sk.pub
++     ~/config/settings/ssh/id_rsa.pub
+              Contains the ECDSA, authenticator-hosted ECDSA, Ed25519,
               authenticator-hosted Ed25519 or RSA public key for
               authentication.  The contents of this file should be added to
 -             ~/.ssh/authorized_keys on all machines where the user wishes to
-+             ~/config/settings/settings/ssh/authorized_keys on all machines where the user wishes to
-              log in using public key authentication.  There is no need to keep
-              the contents of this file secret.
+-             log in using public key authentication.  There is no need to keep
+-             the contents of this file secret.
++             ~/config/settings/ssh/authorized_keys on all machines where the
++             user wishes to log in using public key authentication.  There is
++             no need to keep the contents of this file secret.
  
+      /etc/moduli
+              Contains Diffie-Hellman groups used for DH-GEX.  The file format
 diff --git a/ssh-keygen.1 b/ssh-keygen.1
-index c392141..8038472 100644
+index df6803f..9581edd 100644
 --- a/ssh-keygen.1
 +++ b/ssh-keygen.1
-@@ -205,13 +205,13 @@ section for details.
+@@ -205,12 +205,12 @@ section for details.
  Normally each user wishing to use SSH
  with public key authentication runs this once to create the authentication
  key in
--.Pa ~/.ssh/id_dsa ,
 -.Pa ~/.ssh/id_ecdsa ,
 -.Pa ~/.ssh/id_ecdsa_sk ,
 -.Pa ~/.ssh/id_ed25519 ,
 -.Pa ~/.ssh/id_ed25519_sk
-+.Pa ~/config/settings/settings/ssh/id_dsa ,
-+.Pa ~/config/settings/settings/ssh/id_ecdsa ,
-+.Pa ~/config/settings/settings/ssh/id_ecdsa_sk ,
-+.Pa ~/config/settings/settings/ssh/id_ed25519 ,
-+.Pa ~/config/settings/settings/ssh/id_ed25519_sk
++.Pa ~/config/settings/ssh/id_ecdsa ,
++.Pa ~/config/settings/ssh/id_ecdsa_sk ,
++.Pa ~/config/settings/ssh/id_ed25519 ,
++.Pa ~/config/settings/ssh/id_ed25519_sk
  or
 -.Pa ~/.ssh/id_rsa .
-+.Pa ~/config/settings/settings/ssh/id_rsa .
++.Pa ~/config/settings/ssh/id_rsa .
  Additionally, the system administrator may use this to generate host keys,
  as seen in
  .Pa /etc/rc .
-@@ -1000,7 +1000,7 @@ Disable PTY allocation (permitted by default).
+@@ -996,7 +996,7 @@ Disable PTY allocation (permitted by default).
  .Pp
  .It Ic no-user-rc
  Disable execution of
 -.Pa ~/.ssh/rc
-+.Pa ~/config/settings/settings/ssh/rc
++.Pa ~/config/settings/ssh/rc
  by
  .Xr sshd 8
  (permitted by default).
-@@ -1021,7 +1021,7 @@ Allows PTY allocation.
+@@ -1017,7 +1017,7 @@ Allows PTY allocation.
  .Pp
  .It Ic permit-user-rc
  Allows execution of
 -.Pa ~/.ssh/rc
-+.Pa ~/config/settings/settings/ssh/rc
++.Pa ~/config/settings/ssh/rc
  by
  .Xr sshd 8 .
  .Pp
-@@ -1290,12 +1290,12 @@ the built-in USB HID support.
+@@ -1286,11 +1286,11 @@ the built-in USB HID support.
  .El
  .Sh FILES
  .Bl -tag -width Ds -compact
--.It Pa ~/.ssh/id_dsa
 -.It Pa ~/.ssh/id_ecdsa
 -.It Pa ~/.ssh/id_ecdsa_sk
 -.It Pa ~/.ssh/id_ed25519
 -.It Pa ~/.ssh/id_ed25519_sk
 -.It Pa ~/.ssh/id_rsa
-+.It Pa ~/config/settings/settings/ssh/id_dsa
-+.It Pa ~/config/settings/settings/ssh/id_ecdsa
-+.It Pa ~/config/settings/settings/ssh/id_ecdsa_sk
-+.It Pa ~/config/settings/settings/ssh/id_ed25519
-+.It Pa ~/config/settings/settings/ssh/id_ed25519_sk
-+.It Pa ~/config/settings/settings/ssh/id_rsa
- Contains the DSA, ECDSA, authenticator-hosted ECDSA, Ed25519,
++.It Pa ~/config/settings/ssh/id_ecdsa
++.It Pa ~/config/settings/ssh/id_ecdsa_sk
++.It Pa ~/config/settings/ssh/id_ed25519
++.It Pa ~/config/settings/ssh/id_ed25519_sk
++.It Pa ~/config/settings/ssh/id_rsa
+ Contains the ECDSA, authenticator-hosted ECDSA, Ed25519,
  authenticator-hosted Ed25519 or RSA authentication identity of the user.
  This file should not be readable by anyone but the user.
-@@ -1308,16 +1308,16 @@ but it is offered as the default file for the private key.
+@@ -1303,15 +1303,15 @@ but it is offered as the default file for the private key.
  .Xr ssh 1
  will read this file when a login attempt is made.
  .Pp
--.It Pa ~/.ssh/id_dsa.pub
 -.It Pa ~/.ssh/id_ecdsa.pub
 -.It Pa ~/.ssh/id_ecdsa_sk.pub
 -.It Pa ~/.ssh/id_ed25519.pub
 -.It Pa ~/.ssh/id_ed25519_sk.pub
 -.It Pa ~/.ssh/id_rsa.pub
-+.It Pa ~/config/settings/settings/ssh/id_dsa.pub
-+.It Pa ~/config/settings/settings/ssh/id_ecdsa.pub
-+.It Pa ~/config/settings/settings/ssh/id_ecdsa_sk.pub
-+.It Pa ~/config/settings/settings/ssh/id_ed25519.pub
-+.It Pa ~/config/settings/settings/ssh/id_ed25519_sk.pub
-+.It Pa ~/config/settings/settings/ssh/id_rsa.pub
- Contains the DSA, ECDSA, authenticator-hosted ECDSA, Ed25519,
++.It Pa ~/config/settings/ssh/id_ecdsa.pub
++.It Pa ~/config/settings/ssh/id_ecdsa_sk.pub
++.It Pa ~/config/settings/ssh/id_ed25519.pub
++.It Pa ~/config/settings/ssh/id_ed25519_sk.pub
++.It Pa ~/config/settings/ssh/id_rsa.pub
+ Contains the ECDSA, authenticator-hosted ECDSA, Ed25519,
  authenticator-hosted Ed25519 or RSA public key for authentication.
  The contents of this file should be added to
 -.Pa ~/.ssh/authorized_keys
-+.Pa ~/config/settings/settings/ssh/authorized_keys
++.Pa ~/config/settings/ssh/authorized_keys
  on all machines
  where the user wishes to log in using public key authentication.
  There is no need to keep the contents of this file secret.
 diff --git a/ssh.0 b/ssh.0
-index 5b5e2ad..fd78948 100644
+index 78863b1..ecfa44e 100644
 --- a/ssh.0
 +++ b/ssh.0
 @@ -113,7 +113,7 @@ DESCRIPTION
@@ -438,103 +434,106 @@ index 5b5e2ad..fd78948 100644
               set to M-bM-^@M-^\noneM-bM-^@M-^], no configuration files will be read.
  
       -f      Requests ssh to go to background just before command execution.
-@@ -144,9 +144,9 @@ DESCRIPTION
+@@ -144,8 +144,11 @@ DESCRIPTION
               key authentication is read.  You can also specify a public key
               file to use the corresponding private key that is loaded in
               ssh-agent(1) when the private key file is not present locally.
 -             The default is ~/.ssh/id_rsa, ~/.ssh/id_ecdsa,
--             ~/.ssh/id_ecdsa_sk, ~/.ssh/id_ed25519, ~/.ssh/id_ed25519_sk and
--             ~/.ssh/id_dsa.  Identity files may also be specified on a per-
-+             The default is ~/config/settings/settings/ssh/id_rsa, ~/config/settings/settings/ssh/id_ecdsa,
-+             ~/config/settings/settings/ssh/id_ecdsa_sk, ~/config/settings/settings/ssh/id_ed25519, ~/config/settings/settings/ssh/id_ed25519_sk and
-+             ~/config/settings/settings/ssh/id_dsa.  Identity files may also be specified on a per-
-              host basis in the configuration file.  It is possible to have
-              multiple -i options (and multiple identities specified in
-              configuration files).  If no certificates have been explicitly
-@@ -162,7 +162,7 @@ DESCRIPTION
-              is a shortcut to specify a ProxyJump configuration directive.
-              Note that configuration directives supplied on the command-line
-              generally apply to the destination host and not any specified
--             jump hosts.  Use ~/.ssh/config to specify configuration for jump
-+             jump hosts.  Use ~/config/settings/settings/ssh/config to specify configuration for jump
-              hosts.
+-             ~/.ssh/id_ecdsa_sk, ~/.ssh/id_ed25519 and ~/.ssh/id_ed25519_sk.
++             The default is ~/config/settings/ssh/id_rsa,
++             ~/config/settings/ssh/id_ecdsa,
++             ~/config/settings/ssh/id_ecdsa_sk,
++             ~/config/settings/ssh/id_ed25519 and
++             ~/config/settings/ssh/id_ed25519_sk.
+              Identity files may also be specified on a per-host basis in the
+              configuration file.  It is possible to have multiple -i options
+              (and multiple identities specified in configuration files).  If
+@@ -163,8 +166,9 @@ DESCRIPTION
+              brackets.  This is a shortcut to specify a ProxyJump
+              configuration directive.  Note that configuration directives
+              supplied on the command-line generally apply to the destination
+-             host and not any specified jump hosts.  Use ~/.ssh/config to
+-             specify configuration for jump hosts.
++             host and not any specified jump hosts.
++             Use ~/config/settings/ssh/config to specify configuration for
++             jump hosts.
  
       -K      Enables GSSAPI-based authentication and forwarding (delegation)
-@@ -488,7 +488,7 @@ AUTHENTICATION
+              of GSSAPI credentials to the server.
+@@ -489,7 +493,7 @@ AUTHENTICATION
       the client machine and the name of the user on that machine, the user is
       considered for login.  Additionally, the server must be able to verify
       the client's host key (see the description of /etc/ssh/ssh_known_hosts
 -     and ~/.ssh/known_hosts, below) for login to be permitted.  This
-+     and ~/config/settings/settings/ssh/known_hosts, below) for login to be permitted.  This
++     and ~/config/settings/ssh/known_hosts, below) for login to be permitted.  This
       authentication method closes security holes due to IP spoofing, DNS
       spoofing, and routing spoofing.  [Note to the administrator:
       /etc/hosts.equiv, ~/.rhosts, and the rlogin/rsh protocol in general, are
-@@ -504,7 +504,7 @@ AUTHENTICATION
-      one of the DSA, ECDSA, Ed25519 or RSA algorithms.  The HISTORY section of
-      ssl(8) contains a brief discussion of the DSA and RSA algorithms.
+@@ -504,7 +508,7 @@ AUTHENTICATION
+      ssh implements public key authentication protocol automatically, using
+      one of the ECDSA, Ed25519 or RSA algorithms.
  
 -     The file ~/.ssh/authorized_keys lists the public keys that are permitted
-+     The file ~/config/settings/settings/ssh/authorized_keys lists the public keys that are permitted
++     The file ~/config/settings/ssh/authorized_keys lists the public keys that are permitted
       for logging in.  When the user logs in, the ssh program tells the server
       which key pair it would like to use for authentication.  The client
       proves that it has access to the private key and the server checks that
-@@ -516,15 +516,15 @@ AUTHENTICATION
+@@ -516,14 +520,14 @@ AUTHENTICATION
       DEBUG or higher (e.g. by using the -v flag).
  
       The user creates their key pair by running ssh-keygen(1).  This stores
--     the private key in ~/.ssh/id_dsa (DSA), ~/.ssh/id_ecdsa (ECDSA),
--     ~/.ssh/id_ecdsa_sk (authenticator-hosted ECDSA), ~/.ssh/id_ed25519
--     (Ed25519), ~/.ssh/id_ed25519_sk (authenticator-hosted Ed25519), or
--     ~/.ssh/id_rsa (RSA) and stores the public key in ~/.ssh/id_dsa.pub (DSA),
--     ~/.ssh/id_ecdsa.pub (ECDSA), ~/.ssh/id_ecdsa_sk.pub (authenticator-hosted
--     ECDSA), ~/.ssh/id_ed25519.pub (Ed25519), ~/.ssh/id_ed25519_sk.pub
--     (authenticator-hosted Ed25519), or ~/.ssh/id_rsa.pub (RSA) in the user's
-+     the private key in ~/config/settings/ssh/id_dsa (DSA), ~/config/settings/ssh/id_ecdsa (ECDSA),
-+     ~/config/settings/ssh/id_ecdsa_sk (authenticator-hosted ECDSA), ~/config/settings/ssh/id_ed25519
-+     (Ed25519), ~/config/settings/ssh/id_ed25519_sk (authenticator-hosted Ed25519), or
-+     ~/config/settings/ssh/id_rsa (RSA) and stores the public key in ~/config/settings/ssh/id_dsa.pub (DSA),
-+     ~/config/settings/ssh/id_ecdsa.pub (ECDSA), ~/config/settings/ssh/id_ecdsa_sk.pub (authenticator-hosted
-+     ECDSA), ~/config/settings/ssh/id_ed25519.pub (Ed25519), ~/config/settings/ssh/id_ed25519_sk.pub
-+     (authenticator-hosted Ed25519), or ~/config/settings/ssh/id_rsa.pub (RSA) in the user's
-      home directory.  The user should then copy the public key to
--     ~/.ssh/authorized_keys in their home directory on the remote machine.
-+     ~/config/settings/ssh/authorized_keys in their home directory on the remote machine.
-      The authorized_keys file corresponds to the conventional ~/.rhosts file,
-      and has one key per line, though the lines can be very long.  After this,
-      the user can log in without giving the password.
-@@ -552,7 +552,7 @@ AUTHENTICATION
+-     the private key in ~/.ssh/id_ecdsa (ECDSA), ~/.ssh/id_ecdsa_sk
+-     (authenticator-hosted ECDSA), ~/.ssh/id_ed25519 (Ed25519),
+-     ~/.ssh/id_ed25519_sk (authenticator-hosted Ed25519), or ~/.ssh/id_rsa
+-     (RSA) and stores the public key in ~/.ssh/id_ecdsa.pub (ECDSA),
+-     ~/.ssh/id_ecdsa_sk.pub (authenticator-hosted ECDSA),
+-     ~/.ssh/id_ed25519.pub (Ed25519), ~/.ssh/id_ed25519_sk.pub (authenticator-
+-     hosted Ed25519), or ~/.ssh/id_rsa.pub (RSA) in the user's home directory.
+-     The user should then copy the public key to ~/.ssh/authorized_keys in
++     the private key in ~/config/settings/ssh/id_ecdsa (ECDSA), ~/config/settings/ssh/id_ecdsa_sk
++     (authenticator-hosted ECDSA), ~/config/settings/ssh/id_ed25519 (Ed25519),
++     ~/config/settings/ssh/id_ed25519_sk (authenticator-hosted Ed25519), or ~/config/settings/ssh/id_rsa
++     (RSA) and stores the public key in ~/config/settings/ssh/id_ecdsa.pub (ECDSA),
++     ~/config/settings/ssh/id_ecdsa_sk.pub (authenticator-hosted ECDSA),
++     ~/config/settings/ssh/id_ed25519.pub (Ed25519), ~/config/settings/ssh/id_ed25519_sk.pub (authenticator-
++     hosted Ed25519), or ~/config/settings/ssh/id_rsa.pub (RSA) in the user's home directory.
++     The user should then copy the public key to ~/config/settings/ssh/authorized_keys in
+      their home directory on the remote machine.  The authorized_keys file
+      corresponds to the conventional ~/.rhosts file, and has one key per line,
+      though the lines can be very long.  After this, the user can log in
+@@ -552,7 +556,7 @@ AUTHENTICATION
  
       ssh automatically maintains and checks a database containing
       identification for all hosts it has ever been used with.  Host keys are
 -     stored in ~/.ssh/known_hosts in the user's home directory.  Additionally,
-+     stored in ~/config/settings/settings/ssh/known_hosts in the user's home directory.  Additionally,
++     stored in ~/config/settings/ssh/known_hosts in the user's home directory.  Additionally,
       the file /etc/ssh/ssh_known_hosts is automatically checked for known
       hosts.  Any new hosts are automatically added to the user's file.  If a
       host's identification ever changes, ssh warns about this and disables
-@@ -707,7 +707,7 @@ VERIFYING HOST KEYS
+@@ -707,7 +711,7 @@ VERIFYING HOST KEYS
       To get a listing of the fingerprints along with their random art for all
       known hosts, the following command line can be used:
  
 -           $ ssh-keygen -lv -f ~/.ssh/known_hosts
-+           $ ssh-keygen -lv -f ~/config/settings/settings/ssh/known_hosts
++           $ ssh-keygen -lv -f ~/config/settings/ssh/known_hosts
  
       If the fingerprint is unknown, an alternative method of verification is
       available: SSH fingerprints verified by DNS.  An additional resource
-@@ -851,7 +851,7 @@ ENVIRONMENT
+@@ -851,7 +855,7 @@ ENVIRONMENT
  
       USER                  Set to the name of the user logging in.
  
 -     Additionally, ssh reads ~/.ssh/environment, and adds lines of the format
-+     Additionally, ssh reads ~/config/settings/settings/ssh/environment, and adds lines of the format
++     Additionally, ssh reads ~/config/settings/ssh/environment, and adds lines of the format
       M-bM-^@M-^\VARNAME=valueM-bM-^@M-^] to the environment if the file exists and users are
       allowed to change their environment.  For more information, see the
       PermitUserEnvironment option in sshd_config(5).
-@@ -871,36 +871,36 @@ FILES
+@@ -871,35 +875,35 @@ FILES
               host-based authentication without permitting login with
               rlogin/rsh.
  
 -     ~/.ssh/
-+     ~/config/settings/settings/ssh/
++     ~/config/settings/ssh/
               This directory is the default location for all user-specific
               configuration and authentication information.  There is no
               general requirement to keep the entire contents of this directory
@@ -542,73 +541,69 @@ index 5b5e2ad..fd78948 100644
               for the user, and not accessible by others.
  
 -     ~/.ssh/authorized_keys
-+     ~/config/settings/settings/ssh/authorized_keys
-              Lists the public keys (DSA, ECDSA, Ed25519, RSA) that can be used
-              for logging in as this user.  The format of this file is
-              described in the sshd(8) manual page.  This file is not highly
-              sensitive, but the recommended permissions are read/write for the
-              user, and not accessible by others.
++     ~/config/settings/ssh/authorized_keys
+              Lists the public keys (ECDSA, Ed25519, RSA) that can be used for
+              logging in as this user.  The format of this file is described in
+              the sshd(8) manual page.  This file is not highly sensitive, but
+              the recommended permissions are read/write for the user, and not
+              accessible by others.
  
 -     ~/.ssh/config
-+     ~/config/settings/settings/ssh/config
++     ~/config/settings/ssh/config
               This is the per-user configuration file.  The file format and
               configuration options are described in ssh_config(5).  Because of
               the potential for abuse, this file must have strict permissions:
               read/write for the user, and not writable by others.
  
 -     ~/.ssh/environment
-+     ~/config/settings/settings/ssh/environment
++     ~/config/settings/ssh/environment
               Contains additional definitions for environment variables; see
               ENVIRONMENT, above.
  
--     ~/.ssh/id_dsa
 -     ~/.ssh/id_ecdsa
 -     ~/.ssh/id_ecdsa_sk
 -     ~/.ssh/id_ed25519
 -     ~/.ssh/id_ed25519_sk
 -     ~/.ssh/id_rsa
-+     ~/config/settings/settings/ssh/id_dsa
-+     ~/config/settings/settings/ssh/id_ecdsa
-+     ~/config/settings/settings/ssh/id_ecdsa_sk
-+     ~/config/settings/settings/ssh/id_ed25519
-+     ~/config/settings/settings/ssh/id_ed25519_sk
-+     ~/config/settings/settings/ssh/id_rsa
++     ~/config/settings/ssh/id_ecdsa
++     ~/config/settings/ssh/id_ecdsa_sk
++     ~/config/settings/ssh/id_ed25519
++     ~/config/settings/ssh/id_ed25519_sk
++     ~/config/settings/ssh/id_rsa
               Contains the private key for authentication.  These files contain
               sensitive data and should be readable by the user but not
               accessible by others (read/write/execute).  ssh will simply
-@@ -909,22 +909,22 @@ FILES
+@@ -908,21 +912,21 @@ FILES
               will be used to encrypt the sensitive part of this file using
               AES-128.
  
--     ~/.ssh/id_dsa.pub
 -     ~/.ssh/id_ecdsa.pub
 -     ~/.ssh/id_ecdsa_sk.pub
 -     ~/.ssh/id_ed25519.pub
 -     ~/.ssh/id_ed25519_sk.pub
 -     ~/.ssh/id_rsa.pub
-+     ~/config/settings/settings/ssh/id_dsa.pub
-+     ~/config/settings/settings/ssh/id_ecdsa.pub
-+     ~/config/settings/settings/ssh/id_ecdsa_sk.pub
-+     ~/config/settings/settings/ssh/id_ed25519.pub
-+     ~/config/settings/settings/ssh/id_ed25519_sk.pub
-+     ~/config/settings/settings/ssh/id_rsa.pub
++     ~/config/settings/ssh/id_ecdsa.pub
++     ~/config/settings/ssh/id_ecdsa_sk.pub
++     ~/config/settings/ssh/id_ed25519.pub
++     ~/config/settings/ssh/id_ed25519_sk.pub
++     ~/config/settings/ssh/id_rsa.pub
               Contains the public key for authentication.  These files are not
               sensitive and can (but need not) be readable by anyone.
  
 -     ~/.ssh/known_hosts
-+     ~/config/settings/settings/ssh/known_hosts
++     ~/config/settings/ssh/known_hosts
               Contains a list of host keys for all hosts the user has logged
               into that are not already in the systemwide list of known host
               keys.  See sshd(8) for further details of the format of this
               file.
  
 -     ~/.ssh/rc
-+     ~/config/settings/settings/ssh/rc
++     ~/config/settings/ssh/rc
               Commands in this file are executed by ssh when the user logs in,
               just before the user's shell (or command) is started.  See the
               sshd(8) manual page for more information.
 diff --git a/sshd.0 b/sshd.0
-index 98855e8..80ff7b9 100644
+index c7de2d3..6d1f898 100644
 --- a/sshd.0
 +++ b/sshd.0
 @@ -194,13 +194,13 @@ LOGIN PROCESS
@@ -616,14 +611,14 @@ index 98855e8..80ff7b9 100644
             5.   Sets up basic environment.
  
 -           6.   Reads the file ~/.ssh/environment, if it exists, and users are
-+           6.   Reads the file ~/config/settings/settings/ssh/environment, if it exists, and users are
++           6.   Reads the file ~/config/settings/ssh/environment, if it exists, and users are
                  allowed to change their environment.  See the
                  PermitUserEnvironment option in sshd_config(5).
  
             7.   Changes to user's home directory.
  
 -           8.   If ~/.ssh/rc exists and the sshd_config(5) PermitUserRC option
-+           8.   If ~/config/settings/settings/ssh/rc exists and the sshd_config(5) PermitUserRC option
++           8.   If ~/config/settings/ssh/rc exists and the sshd_config(5) PermitUserRC option
                  is set, runs it; else if /etc/ssh/sshrc exists, runs it;
                  otherwise runs xauth(1).  The M-bM-^@M-^\rcM-bM-^@M-^] files are given the X11
                  authentication protocol and cookie in standard input.  See
@@ -632,7 +627,7 @@ index 98855e8..80ff7b9 100644
  
  SSHRC
 -     If the file ~/.ssh/rc exists, sh(1) runs it after reading the environment
-+     If the file ~/config/settings/settings/ssh/rc exists, sh(1) runs it after reading the environment
++     If the file ~/config/settings/ssh/rc exists, sh(1) runs it after reading the environment
       files but before starting the user's shell or command.  It must not
       produce any output on stdout; stderr must be used instead.  If X11
       forwarding is in use, it will receive the "proto cookie" pair in its
@@ -641,52 +636,61 @@ index 98855e8..80ff7b9 100644
       AuthorizedKeysFile specifies the files containing public keys for public
       key authentication; if this option is not specified, the default is
 -     ~/.ssh/authorized_keys and ~/.ssh/authorized_keys2.  Each line of the
-+     ~/config/settings/settings/ssh/authorized_keys and ~/config/settings/settings/ssh/authorized_keys2.  Each line of the
++     ~/config/settings/ssh/authorized_keys and ~/config/settings/ssh/authorized_keys2.  Each line of the
       file contains one key (empty lines and lines starting with a M-bM-^@M-^X#M-bM-^@M-^Y are
       ignored as comments).  Public keys consist of the following space-
       separated fields: options, keytype, base64-encoded key, comment.  The
-@@ -356,7 +356,7 @@ AUTHORIZED_KEYS FILE FORMAT
+@@ -355,7 +355,7 @@ AUTHORIZED_KEYS FILE FORMAT
       no-pty  Prevents tty allocation (a request to allocate a pty will fail).
  
       no-user-rc
 -             Disables execution of ~/.ssh/rc.
-+             Disables execution of ~/config/settings/settings/ssh/rc.
++             Disables execution of ~/config/settings/ssh/rc.
  
       no-X11-forwarding
               Forbids X11 forwarding when this key is used for authentication.
-@@ -422,7 +422,7 @@ AUTHORIZED_KEYS FILE FORMAT
+@@ -412,7 +412,7 @@ AUTHORIZED_KEYS FILE FORMAT
+      restrict
+              Enable all restrictions, i.e. disable port, agent and X11
+              forwarding, as well as disabling PTY allocation and execution of
+-             ~/.ssh/rc.  If any future restriction capabilities are added to
++             ~/config/settings/ssh/rc.  If any future restriction capabilities are added to
+              authorized_keys files, they will be included in this set.
+ 
+      tunnel="n"
+@@ -421,7 +421,7 @@ AUTHORIZED_KEYS FILE FORMAT
               tunnel.
  
       user-rc
 -             Enables execution of ~/.ssh/rc previously disabled by the
-+             Enables execution of ~/config/settings/settings/ssh/rc previously disabled by the
++             Enables execution of ~/config/settings/ssh/rc previously disabled by the
               restrict option.
  
       X11-forwarding
-@@ -452,7 +452,7 @@ AUTHORIZED_KEYS FILE FORMAT
+@@ -451,7 +451,7 @@ AUTHORIZED_KEYS FILE FORMAT
          cert-authority,no-touch-required,principals="user_a" ssh-rsa ...
  
  SSH_KNOWN_HOSTS FILE FORMAT
 -     The /etc/ssh/ssh_known_hosts and ~/.ssh/known_hosts files contain host
-+     The /etc/ssh/ssh_known_hosts and ~/config/settings/settings/ssh/known_hosts files contain host
++     The /etc/ssh/ssh_known_hosts and ~/config/settings/ssh/known_hosts files contain host
       public keys for all known hosts.  The global file should be prepared by
       the administrator (optional), and the per-user file is maintained
       automatically: whenever the user connects to an unknown host, its key is
-@@ -522,7 +522,7 @@ SSH_KNOWN_HOSTS FILE FORMAT
+@@ -521,7 +521,7 @@ SSH_KNOWN_HOSTS FILE FORMAT
       Rather, generate them by a script, ssh-keyscan(1) or by taking, for
       example, /etc/ssh/ssh_host_rsa_key.pub and adding the host names at the
       front.  ssh-keygen(1) also offers some basic automated editing for
 -     ~/.ssh/known_hosts including removing hosts matching a host name and
-+     ~/config/settings/settings/ssh/known_hosts including removing hosts matching a host name and
++     ~/config/settings/ssh/known_hosts including removing hosts matching a host name and
       converting all host names to their hashed representations.
  
       An example ssh_known_hosts file:
-@@ -559,27 +559,27 @@ FILES
+@@ -558,14 +558,14 @@ FILES
               host-based authentication without permitting login with
               rlogin/rsh.
  
 -     ~/.ssh/
-+     ~/config/settings/settings/ssh/
++     ~/config/settings/ssh/
               This directory is the default location for all user-specific
               configuration and authentication information.  There is no
               general requirement to keep the entire contents of this directory
@@ -694,31 +698,25 @@ index 98855e8..80ff7b9 100644
               for the user, and not accessible by others.
  
 -     ~/.ssh/authorized_keys
-+     ~/config/settings/settings/ssh/authorized_keys
-              Lists the public keys (DSA, ECDSA, Ed25519, RSA) that can be used
-              for logging in as this user.  The format of this file is
-              described above.  The content of the file is not highly
-              sensitive, but the recommended permissions are read/write for the
-              user, and not accessible by others.
- 
--             If this file, the ~/.ssh directory, or the user's home directory
-+             If this file, the ~/config/settings/settings/ssh directory, or the user's home directory
-              are writable by other users, then the file could be modified or
-              replaced by unauthorized users.  In this case, sshd will not
++     ~/config/settings/ssh/authorized_keys
+              Lists the public keys (ECDSA, Ed25519, RSA) that can be used for
+              logging in as this user.  The format of this file is described
+              above.  The content of the file is not highly sensitive, but the
+@@ -578,7 +578,7 @@ FILES
               allow it to be used unless the StrictModes option has been set to
               M-bM-^@M-^\noM-bM-^@M-^].
  
 -     ~/.ssh/environment
-+     ~/config/settings/settings/ssh/environment
++     ~/config/settings/ssh/environment
               This file is read into the environment at login (if it exists).
               It can only contain empty lines, comment lines (that start with
               M-bM-^@M-^X#M-bM-^@M-^Y), and assignment lines of the form name=value.  The file
-@@ -587,14 +587,14 @@ FILES
+@@ -586,14 +586,14 @@ FILES
               anyone else.  Environment processing is disabled by default and
               is controlled via the PermitUserEnvironment option.
  
 -     ~/.ssh/known_hosts
-+     ~/config/settings/settings/ssh/known_hosts
++     ~/config/settings/ssh/known_hosts
               Contains a list of host keys for all hosts the user has logged
               into that are not already in the systemwide list of known host
               keys.  The format of this file is described above.  This file
@@ -726,21 +724,21 @@ index 98855e8..80ff7b9 100644
               be, world-readable.
  
 -     ~/.ssh/rc
-+     ~/config/settings/settings/ssh/rc
++     ~/config/settings/ssh/rc
               Contains initialization routines to be run before the user's home
               directory becomes accessible.  This file should be writable only
               by the user, and need not be readable by anyone else.
-@@ -653,7 +653,7 @@ FILES
+@@ -652,7 +652,7 @@ FILES
               configuration options are described in sshd_config(5).
  
       /etc/ssh/sshrc
 -             Similar to ~/.ssh/rc, it can be used to specify machine-specific
-+             Similar to ~/config/settings/settings/ssh/rc, it can be used to specify machine-specific
++             Similar to ~/config/settings/ssh/rc, it can be used to specify machine-specific
               login-time initializations globally.  This file should be
               writable only by root, and should be world-readable.
  
 diff --git a/sshd.8 b/sshd.8
-index 73d5e92..747ac84 100644
+index c0f095c..fb8b4fb 100644
 --- a/sshd.8
 +++ b/sshd.8
 @@ -360,7 +360,7 @@ Changes to run with normal user privileges.
@@ -748,7 +746,7 @@ index 73d5e92..747ac84 100644
  .It
  Reads the file
 -.Pa ~/.ssh/environment ,
-+.Pa ~/config/settings/settings/ssh/environment ,
++.Pa ~/config/settings/ssh/environment ,
  if it exists, and users are allowed to change their environment.
  See the
  .Cm PermitUserEnvironment
@@ -757,7 +755,7 @@ index 73d5e92..747ac84 100644
  .It
  If
 -.Pa ~/.ssh/rc
-+.Pa ~/config/settings/settings/ssh/rc
++.Pa ~/config/settings/ssh/rc
  exists and the
  .Xr sshd_config 5
  .Cm PermitUserRC
@@ -766,7 +764,7 @@ index 73d5e92..747ac84 100644
  .Sh SSHRC
  If the file
 -.Pa ~/.ssh/rc
-+.Pa ~/config/settings/settings/ssh/rc
++.Pa ~/config/settings/ssh/rc
  exists,
  .Xr sh 1
  runs it after reading the
@@ -775,64 +773,64 @@ index 73d5e92..747ac84 100644
  public key authentication;
  if this option is not specified, the default is
 -.Pa ~/.ssh/authorized_keys
-+.Pa ~/config/settings/settings/ssh/authorized_keys
++.Pa ~/config/settings/ssh/authorized_keys
  and
 -.Pa ~/.ssh/authorized_keys2 .
-+.Pa ~/config/settings/settings/ssh/authorized_keys2 .
++.Pa ~/config/settings/ssh/authorized_keys2 .
  Each line of the file contains one
  key (empty lines and lines starting with a
  .Ql #
-@@ -585,7 +585,7 @@ option.
+@@ -582,7 +582,7 @@ option.
  Prevents tty allocation (a request to allocate a pty will fail).
  .It Cm no-user-rc
  Disables execution of
 -.Pa ~/.ssh/rc .
-+.Pa ~/config/settings/settings/ssh/rc .
++.Pa ~/config/settings/ssh/rc .
  .It Cm no-X11-forwarding
  Forbids X11 forwarding when this key is used for authentication.
  Any X11 forward requests by the client will return an error.
-@@ -666,7 +666,7 @@ and
+@@ -663,7 +663,7 @@ and
  Enable all restrictions, i.e. disable port, agent and X11 forwarding,
  as well as disabling PTY allocation
  and execution of
 -.Pa ~/.ssh/rc .
-+.Pa ~/config/settings/settings/ssh/rc .
++.Pa ~/config/settings/ssh/rc .
  If any future restriction capabilities are added to authorized_keys files,
  they will be included in this set.
  .It Cm tunnel="n"
-@@ -677,7 +677,7 @@ Without this option, the next available device will be used if
+@@ -674,7 +674,7 @@ Without this option, the next available device will be used if
  the client requests a tunnel.
  .It Cm user-rc
  Enables execution of
 -.Pa ~/.ssh/rc
-+.Pa ~/config/settings/settings/ssh/rc
++.Pa ~/config/settings/ssh/rc
  previously disabled by the
  .Cm restrict
  option.
-@@ -713,7 +713,7 @@ cert-authority,no-touch-required,principals="user_a" ssh-rsa ...
+@@ -710,7 +710,7 @@ cert-authority,no-touch-required,principals="user_a" ssh-rsa ...
  The
  .Pa /etc/ssh/ssh_known_hosts
  and
 -.Pa ~/.ssh/known_hosts
-+.Pa ~/config/settings/settings/ssh/known_hosts
++.Pa ~/config/settings/ssh/known_hosts
  files contain host public keys for all known hosts.
  The global file should
  be prepared by the administrator (optional), and the per-user file is
-@@ -822,7 +822,7 @@ or by taking, for example,
+@@ -819,7 +819,7 @@ or by taking, for example,
  and adding the host names at the front.
  .Xr ssh-keygen 1
  also offers some basic automated editing for
 -.Pa ~/.ssh/known_hosts
-+.Pa ~/config/settings/settings/ssh/known_hosts
++.Pa ~/config/settings/ssh/known_hosts
  including removing hosts matching a host name and converting all host
  names to their hashed representations.
  .Pp
-@@ -873,14 +873,14 @@ This file is used in exactly the same way as
+@@ -870,14 +870,14 @@ This file is used in exactly the same way as
  but allows host-based authentication without permitting login with
  rlogin/rsh.
  .Pp
 -.It Pa ~/.ssh/
-+.It Pa ~/config/settings/settings/ssh/
++.It Pa ~/config/settings/ssh/
  This directory is the default location for all user-specific configuration
  and authentication information.
  There is no general requirement to keep the entire contents of this directory
@@ -840,34 +838,34 @@ index 73d5e92..747ac84 100644
  and not accessible by others.
  .Pp
 -.It Pa ~/.ssh/authorized_keys
-+.It Pa ~/config/settings/settings/ssh/authorized_keys
- Lists the public keys (DSA, ECDSA, Ed25519, RSA)
++.It Pa ~/config/settings/ssh/authorized_keys
+ Lists the public keys (ECDSA, Ed25519, RSA)
  that can be used for logging in as this user.
  The format of this file is described above.
-@@ -888,7 +888,7 @@ The content of the file is not highly sensitive, but the recommended
+@@ -885,7 +885,7 @@ The content of the file is not highly sensitive, but the recommended
  permissions are read/write for the user, and not accessible by others.
  .Pp
  If this file, the
 -.Pa ~/.ssh
-+.Pa ~/config/settings/settings/ssh
++.Pa ~/config/settings/ssh
  directory, or the user's home directory are writable
  by other users, then the file could be modified or replaced by unauthorized
  users.
-@@ -899,7 +899,7 @@ will not allow it to be used unless the
+@@ -896,7 +896,7 @@ will not allow it to be used unless the
  option has been set to
  .Dq no .
  .Pp
 -.It Pa ~/.ssh/environment
-+.It Pa ~/config/settings/settings/ssh/environment
++.It Pa ~/config/settings/ssh/environment
  This file is read into the environment at login (if it exists).
  It can only contain empty lines, comment lines (that start with
  .Ql # ) ,
-@@ -911,14 +911,14 @@ controlled via the
+@@ -908,14 +908,14 @@ controlled via the
  .Cm PermitUserEnvironment
  option.
  .Pp
 -.It Pa ~/.ssh/known_hosts
-+.It Pa ~/config/settings/settings/ssh/known_hosts
++.It Pa ~/config/settings/ssh/known_hosts
  Contains a list of host keys for all hosts the user has logged into
  that are not already in the systemwide list of known host keys.
  The format of this file is described above.
@@ -875,21 +873,21 @@ index 73d5e92..747ac84 100644
  can, but need not be, world-readable.
  .Pp
 -.It Pa ~/.ssh/rc
-+.It Pa ~/config/settings/settings/ssh/rc
++.It Pa ~/config/settings/ssh/rc
  Contains initialization routines to be run before
  the user's home directory becomes accessible.
  This file should be writable only by the user, and need not be
-@@ -996,7 +996,7 @@ The file format and configuration options are described in
+@@ -993,7 +993,7 @@ The file format and configuration options are described in
  .Pp
  .It Pa /etc/ssh/sshrc
  Similar to
 -.Pa ~/.ssh/rc ,
-+.Pa ~/config/settings/settings/ssh/rc ,
++.Pa ~/config/settings/ssh/rc ,
  it can be used to specify
  machine-specific login-time initializations globally.
  This file should be writable only by root, and should be world-readable.
 diff --git a/sshd_config.5 b/sshd_config.5
-index 7e1a56c..c00127a 100644
+index 1ab0f41..cdcd5fb 100644
 --- a/sshd_config.5
 +++ b/sshd_config.5
 @@ -365,7 +365,7 @@ Note that
@@ -897,65 +895,65 @@ index 7e1a56c..c00127a 100644
  .Cm TrustedUserCAKeys
  and is not consulted for certification authorities trusted via
 -.Pa ~/.ssh/authorized_keys ,
-+.Pa ~/config/settings/settings/ssh/authorized_keys ,
++.Pa ~/config/settings/ssh/authorized_keys ,
  though the
  .Cm principals=
  key option offers a similar facility (see
-@@ -685,7 +685,7 @@ The default is
+@@ -693,7 +693,7 @@ The default is
  Forces the execution of the command specified by
  .Cm ForceCommand ,
  ignoring any command supplied by the client and
 -.Pa ~/.ssh/rc
-+.Pa ~/config/settings/settings/ssh/rc
++.Pa ~/config/settings/ssh/rc
  if present.
  The command is invoked by using the user's login shell with the -c option.
  This applies to shell, command, or subsystem execution.
-@@ -894,7 +894,7 @@ and
+@@ -902,7 +902,7 @@ and
  Specifies whether
  .Xr sshd 8
  should ignore the user's
 -.Pa ~/.ssh/known_hosts
-+.Pa ~/config/settings/settings/ssh/known_hosts
++.Pa ~/config/settings/ssh/known_hosts
  during
  .Cm HostbasedAuthentication
  and use only the system-wide known hosts file
-@@ -1507,11 +1507,11 @@ Independent of this setting, the permissions of the selected
+@@ -1529,11 +1529,11 @@ Independent of this setting, the permissions of the selected
  device must allow access to the user.
  .It Cm PermitUserEnvironment
  Specifies whether
 -.Pa ~/.ssh/environment
-+.Pa ~/config/settings/settings/ssh/environment
++.Pa ~/config/settings/ssh/environment
  and
  .Cm environment=
  options in
 -.Pa ~/.ssh/authorized_keys
-+.Pa ~/config/settings/settings/ssh/authorized_keys
++.Pa ~/config/settings/ssh/authorized_keys
  are processed by
  .Xr sshd 8 .
  Valid options are
-@@ -1527,7 +1527,7 @@ restrictions in some configurations using mechanisms such as
+@@ -1549,7 +1549,7 @@ restrictions in some configurations using mechanisms such as
  .Ev LD_PRELOAD .
  .It Cm PermitUserRC
  Specifies whether any
 -.Pa ~/.ssh/rc
-+.Pa ~/config/settings/settings/ssh/rc
++.Pa ~/config/settings/ssh/rc
  file is executed.
  The default is
  .Cm yes .
-@@ -1865,7 +1865,7 @@ very same IP address.
+@@ -1982,7 +1982,7 @@ very same IP address.
  If this option is set to
  .Cm no
  (the default) then only addresses and not host names may be used in
 -.Pa ~/.ssh/authorized_keys
-+.Pa ~/config/settings/settings/ssh/authorized_keys
++.Pa ~/config/settings/ssh/authorized_keys
  .Cm from
  and
  .Nm
 -- 
-2.42.1
+2.45.2
 
 
-From c8ee4d0b0cb156f606599899460244d1a9cf1172 Mon Sep 17 00:00:00 2001
+From f3b2aa8efe2b24a59b6fc57e1cb6d6859e596e6d Mon Sep 17 00:00:00 2001
 From: Zach Dykstra <dykstra.zachary@gmail.com>
 Date: Sun, 27 Dec 2020 21:38:07 -0600
 Subject: mux.c: use rename instead of unsupported hard link
@@ -986,10 +984,10 @@ index d598a17..651e920 100644
  	options.control_path = orig_control_path;
  
 -- 
-2.42.1
+2.45.2
 
 
-From a9429ac035afe9f14a7db9e56e333b742e326ea4 Mon Sep 17 00:00:00 2001
+From ba2547d439b95a56968ab8511192a931fbdf2e42 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Tue, 8 Jun 2021 14:25:15 +0200
 Subject: gcc2 patch sntrup761.c
@@ -1016,10 +1014,10 @@ index 57368bd..1fe66d0 100644
        while (i + p <= n - q) {
          for (j = i;j < i + p;++j) {
 -- 
-2.42.1
+2.45.2
 
 
-From d9d29a3defce982d6878938b808c0ab4e92c75c8 Mon Sep 17 00:00:00 2001
+From e8037654776f51f929b359b163edd08ab83f92a7 Mon Sep 17 00:00:00 2001
 From: Sergei Reznikov <diver@gelios.net>
 Date: Wed, 20 Oct 2021 16:57:50 +0300
 Subject: Use a link to take a backup while replacing the known_hosts file
@@ -1043,10 +1041,10 @@ index c5669c7..7fa07ba 100644
  			error_f("link %.100s to %.100s: %s", filename,
  			    back, strerror(errno));
 diff --git a/ssh-keygen.c b/ssh-keygen.c
-index 5b945a8..e41fd04 100644
+index 97c6d13..65e70f9 100644
 --- a/ssh-keygen.c
 +++ b/ssh-keygen.c
-@@ -1369,7 +1369,11 @@ do_known_hosts(struct passwd *pw, const char *name, int find_host,
+@@ -1385,7 +1385,11 @@ do_known_hosts(struct passwd *pw, const char *name, int find_host,
  		/* Backup existing file */
  		if (unlink(old) == -1 && errno != ENOENT)
  			fatal("unlink %.100s: %s", old, strerror(errno));
@@ -1059,5 +1057,5 @@ index 5b945a8..e41fd04 100644
  			    strerror(errno));
  		/* Move new one into place */
 -- 
-2.42.1
+2.45.2
 


### PR DESCRIPTION
Smoke tested on beta4, 64 bits.

`hp --test openssh` seems broken (since before this update). Tests log ends in:

```
make[1]: Entering directory '/sources/openssh-9.8p1/regress'
run test connect.sh ...
Missing privilege separation directory: /packages/openssh-9.8p1-1/.self/data/openssh/empty
/sources/openssh-9.8p1/regress/test-exec.sh: line 528: /sources/openssh-9.8p1/regress/ssh.log: No such file or directory
cat: /sources/openssh-9.8p1/regress/ssh.log: No such file or directory
tar: Removing leading `/' from member names
tar: Removing leading `/' from hard link targets
FATAL: /sources/openssh-9.8p1/regress/test-exec.sh: line 528: /sources/openssh-9.8p1/regress/ssh.log: No such file or directory
cat: /sources/openssh-9.8p1/regress/ssh.log: No such file or directory
tar: Removing leading `/' from member names
tar: Removing leading `/' from hard link targets
sshd_proxy broken
Makefile:254: recipe for target 't-exec' failed
make[1]: *** [t-exec] Error 1
make[1]: Leaving directory '/sources/openssh-9.8p1/regress'
Makefile:742: recipe for target 't-exec' failed
make: *** [t-exec] Error 2
Warning: Command '['bash', '-c', '. /wrapper-script']' returned non-zero exit status 2.
cleaning 'chroot/boot' folder
keeping chroot folder /boot/home/SourceCode/haikuports/haikuports/net-misc/openssh/work-9.8p1 intact for inspection
```

Was able to connect via ssh, from Windows to Haiku's sshd, without issues, at least.