### PR TITLE
lxml: added TEST(), fixed build requirements.

### DIFF
--- a/dev-python/lxml/lxml-4.9.1.recipe
+++ b/dev-python/lxml/lxml-4.9.1.recipe
@@ -13,7 +13,7 @@ LICENSE="BSD (3-clause)
 	ElementTree
 	GNU GPL v2
 	PSF-2"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/lxml/lxml/releases/download/lxml-$portVersion/lxml-$portVersion.tar.gz"
 CHECKSUM_SHA256="fe749b052bb7233fe5d072fcb549221a8cb1a16725c47c37e42b0b9cb3ff2c3f"
 SOURCE_DIR="lxml-$portVersion"
@@ -30,6 +30,7 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	devel:libiconv$secondaryArchSuffix
 	devel:libxml2$secondaryArchSuffix
 	devel:libxslt$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
@@ -39,11 +40,11 @@ BUILD_PREREQUIRES="
 	cmd:ld$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python39 python310)
 PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_${pythonPackage}=\"
 		${portName}_$pythonPackage = $portVersion
@@ -72,17 +73,24 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 		"
 done
 
+TEST_REQUIRES="
+	cmd:make
+	cmd:python3
+	"
+
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=${pythonVersion//.}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation
+
 		mkdir -p "$installLocation"
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix="$prefix" --without-cython
 
@@ -94,4 +102,13 @@ INSTALL()
 		install -m 755 -d "$docDir"
 		install -m 644 -t "$docDir" CHANGES.txt CREDITS.txt README.rst
 	fi
+}
+
+
+# For reference, on beta4, 32 bits, with Python 3.10:
+#Ran 1965 tests in 74.267s
+#FAILED (failures=2, errors=2)
+TEST()
+{
+	make test3
 }


### PR DESCRIPTION
Tested on 32 bits.

After `sigil` (and `beautifulsoup4`'s `TEST()`) gets switched to 3.10, we could just drop the `_python39` version of this package.