### PR TITLE
muon: resolve 'hp --lint' error.

### DIFF
--- a/dev-build/muon/muon-0.2.0.recipe
+++ b/dev-build/muon/muon-0.2.0.recipe
@@ -1,7 +1,7 @@
 SUMMARY="A meson implementation in C"
 DESCRIPTION="Muon is a meson implementation in c99 with minimal dependencies"
 HOMEPAGE="https://sr.ht/~lattis/muon"
-COPYRIGHT="2022-2024 Stone Tickle <lattis@mochiro.moe>"
+COPYRIGHT="2022-2024 Stone Tickle"
 LICENSE="GNU GPL v3"
 REVISION="1"
 SOURCE_URI="https://git.sr.ht/~lattis/muon/archive/$portVersion.tar.gz"


### PR DESCRIPTION
Fixes "Error: COPYRIGHT must not contain e-mail addresses". (not bumping rev, as this is only a lint clean up).