### PR TITLE
iup: re-enable patch, keep recipe disabled.

### DIFF
--- a/x11-libs/iup/iup-3.8.recipe
+++ b/x11-libs/iup/iup-3.8.recipe
@@ -17,10 +17,10 @@ REVISION="2"
 SOURCE_URI="http://downloads.sourceforge.net/project/iup/3.8/Docs%20and%20Sources/iup-3.8_Sources.zip" # The tar.gz has permission problems.
 CHECKSUM_SHA256="8030c4f35c3a3f096e6552cecb600d8ee95c9c379c76368d99fa6ffc6ebc8b5c"
 SOURCE_DIR="iup"
-#PATCHES="iup-3.8.patchset"
+PATCHES="iup-3.8.patchset"
 
-ARCHITECTURES="x86_gcc2"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="?all"
+SECONDARY_ARCHITECTURES="?x86"
 
 PROVIDES="
 	iup$secondaryArchSuffix = $portVersion
@@ -33,23 +33,23 @@ PROVIDES="
 	lib:libiupim$secondaryArchSuffix = $portVersion
 	lib:libiupimglib$secondaryArchSuffix = $portVersion
 	lib:libiuplua51$secondaryArchSuffix = $portVersion
-	lib:libiuplua52$secondaryArchSuffix = $portVersion
+#	lib:libiuplua52$secondaryArchSuffix = $portVersion
 	lib:libiuplua_mglplot51$secondaryArchSuffix = $portVersion
-	lib:libiuplua_mglplot52$secondaryArchSuffix = $portVersion
+#	lib:libiuplua_mglplot52$secondaryArchSuffix = $portVersion
 	lib:libiuplua_pplot51$secondaryArchSuffix = $portVersion
-	lib:libiuplua_pplot52$secondaryArchSuffix = $portVersion
+#	lib:libiuplua_pplot52$secondaryArchSuffix = $portVersion
 	lib:libiupluacd51$secondaryArchSuffix = $portVersion
-	lib:libiupluacd52$secondaryArchSuffix = $portVersion
+#	lib:libiupluacd52$secondaryArchSuffix = $portVersion
 	lib:libiupluacontrols51$secondaryArchSuffix = $portVersion
-	lib:libiupluacontrols52$secondaryArchSuffix = $portVersion
+#	lib:libiupluacontrols52$secondaryArchSuffix = $portVersion
 	lib:libiupluagl51$secondaryArchSuffix = $portVersion
-	lib:libiupluagl52$secondaryArchSuffix = $portVersion
+#	lib:libiupluagl52$secondaryArchSuffix = $portVersion
 	lib:libiupluaim51$secondaryArchSuffix = $portVersion
-	lib:libiupluaim52$secondaryArchSuffix = $portVersion
+#	lib:libiupluaim52$secondaryArchSuffix = $portVersion
 	lib:libiupluaimglib51$secondaryArchSuffix = $portVersion
-	lib:libiupluaimglib52$secondaryArchSuffix = $portVersion
+#	lib:libiupluaimglib52$secondaryArchSuffix = $portVersion
 	lib:libiupluatuio51$secondaryArchSuffix = $portVersion
-	lib:libiupluatuio52$secondaryArchSuffix = $portVersion
+#	lib:libiupluatuio52$secondaryArchSuffix = $portVersion
 	lib:libiuptuio$secondaryArchSuffix = $portVersion
 	lib:libiupweb$secondaryArchSuffix = $portVersion
 	"
@@ -74,29 +74,30 @@ PROVIDES_devel="
 	devel:libiupim$secondaryArchSuffix = $portVersion
 	devel:libiupimglib$secondaryArchSuffix = $portVersion
 	devel:libiuplua51$secondaryArchSuffix = $portVersion
-	devel:libiuplua52$secondaryArchSuffix = $portVersion
+#	devel:libiuplua52$secondaryArchSuffix = $portVersion
 	devel:libiuplua_mglplot51$secondaryArchSuffix = $portVersion
 	devel:libiuplua_mglplot52$secondaryArchSuffix = $portVersion
 	devel:libiuplua_pplot51$secondaryArchSuffix = $portVersion
 	devel:libiuplua_pplot52$secondaryArchSuffix = $portVersion
 	devel:libiupluacd51$secondaryArchSuffix = $portVersion
-	devel:libiupluacd52$secondaryArchSuffix = $portVersion
+#	devel:libiupluacd52$secondaryArchSuffix = $portVersion
 	devel:libiupluacontrols51$secondaryArchSuffix = $portVersion
-	devel:libiupluacontrols52$secondaryArchSuffix = $portVersion
+#	devel:libiupluacontrols52$secondaryArchSuffix = $portVersion
 	devel:libiupluagl51$secondaryArchSuffix = $portVersion
-	devel:libiupluagl52$secondaryArchSuffix = $portVersion
+#	devel:libiupluagl52$secondaryArchSuffix = $portVersion
 	devel:libiupluaim51$secondaryArchSuffix = $portVersion
-	devel:libiupluaim52$secondaryArchSuffix = $portVersion
+#	devel:libiupluaim52$secondaryArchSuffix = $portVersion
 	devel:libiupluaimglib51$secondaryArchSuffix = $portVersion
-	devel:libiupluaimglib52$secondaryArchSuffix = $portVersion
+#	devel:libiupluaimglib52$secondaryArchSuffix = $portVersion
 	devel:libiupluatuio51$secondaryArchSuffix = $portVersion
-	devel:libiupluatuio52$secondaryArchSuffix = $portVersion
+#	devel:libiupluatuio52$secondaryArchSuffix = $portVersion
 	devel:libiuptuio$secondaryArchSuffix = $portVersion
 	devel:libiupweb$secondaryArchSuffix = $portVersion
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	mesa${secondaryArchSuffix}_devel
 	devel:libcd$secondaryArchSuffix
 	devel:libfontconfig$secondaryArchSuffix
 	devel:libfreetype$secondaryArchSuffix
@@ -116,11 +117,11 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	export LUA52=`finddir B_SYSTEM_DIRECTORY`
+#	export LUA52=`finddir B_SYSTEM_DIRECTORY`
 	export LUA_LIB=`finddir B_SYSTEM_DEVELOP_DIRECTORY`/lib$secondaryArchSubDir
 	export LUA_BIN=/bin$secondaryArchSubDir
 	export LUA_SUFFIX=
-	export LUA_INC=`finddir B_SYSTEM_HEADERS_DIRECTORY`
+	export LUA_INC=`finddir B_SYSTEM_HEADERS_DIRECTORY`/lua5.1
 	make
 }
 

--- a/x11-libs/iup/patches/iup-3.8.patchset
+++ b/x11-libs/iup/patches/iup-3.8.patchset
@@ -1,4 +1,4 @@
-From 115eb3270ff3039a7dcbeeb3510aa11c3a0c73d3 Mon Sep 17 00:00:00 2001
+From 28a6d424e7c78d09ae7b11f4076bfd62a2e7ed36 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Sat, 16 Nov 2013 18:59:48 +0100
 Subject: Import work done on Haiku port.
@@ -8062,5 +8062,54 @@ index 8d558b2..6db8745 100644
    IUPLIB = $(IUP)/lib/$(TEC_UNAME)d
    CDLIB = $(CD)/lib/$(TEC_UNAME)d
 -- 
-1.8.3.4
+2.45.2
+
+
+From f3e2395d871ad2625ea5808ebfeecd29236e2c59 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Fri, 12 Jul 2024 01:32:12 -0300
+Subject: Fix error: call of overloaded 'RemoveItem(long int)' is ambiguous.
+
+
+diff --git a/src/haiku/iuphaiku_list.cpp b/src/haiku/iuphaiku_list.cpp
+index 30b3bd2..14148c5 100644
+--- a/src/haiku/iuphaiku_list.cpp
++++ b/src/haiku/iuphaiku_list.cpp
+@@ -166,7 +166,7 @@ void iupdrvListRemoveAllItems(Ihandle* ih)
+   BListView* listview = iuphaikuGetListView(view);
+   if(listview) {
+ 	while(!listview->IsEmpty()) {
+-	  BListItem* item = listview->RemoveItem(0L);
++	  BListItem* item = listview->RemoveItem(static_cast<int32>(0L));
+ 	  delete item;
+ 	}
+   } else {
+-- 
+2.45.2
+
+
+From 008089ab46352ddeaf73848835d0eb811d511b59 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Fri, 12 Jul 2024 02:10:56 -0300
+Subject: Use a hack to turn an error into a warning :-D.
+
+Turns build stopping error (losing precision) into:
+
+"warning: dereferencing type-punned pointer will break strict-aliasing rules".
+
+diff --git a/src/haiku/iuphaiku_timer.cpp b/src/haiku/iuphaiku_timer.cpp
+index 6839f1d..9777e54 100644
+--- a/src/haiku/iuphaiku_timer.cpp
++++ b/src/haiku/iuphaiku_timer.cpp
+@@ -58,7 +58,7 @@ void iupdrvTimerRun(Ihandle *ih)
+ 
+ 	ih->handle = (InativeHandle*)new BMessageRunner(messenger, msg, time_ms * 1000);
+ 	// Just use something "reasonably unique" as the serial...
+-	ih->serial = (int)ih->handle;
++	ih->serial = *((int*)&(ih->handle));
+ 	if (ih->serial < 0) ih->serial = -ih->serial;
+   }
+ }
+-- 
+2.45.2
 


### PR DESCRIPTION
Build still broken. Fails while trying to link led.c (code generated by yacc) due to several undefined references.

Commented out lua52 stuff, following changes for "cd" on https://github.com/haikuports/haikuports/pull/10684.

Whoever ends up fixing this build can either uncomment, or remove, them as necessary.