### PR TITLE
cd: fix PROVIDES and REQUIRES_devel.

### DIFF
--- a/x11-libs/cd/cd-5.12.recipe
+++ b/x11-libs/cd/cd-5.12.recipe
@@ -8,7 +8,7 @@ surface, such as Image, Clipboard, Metafile, PS, and so on."
 HOMEPAGE="http://www.tecgraf.puc-rio.br/cd/"
 COPYRIGHT="1994-2019 Tecgraf, PUC-Rio."
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://sourceforge.net/projects/canvasdraw/files/$portVersion/Docs%20and%20Sources/cd-${portVersion}_Sources.zip" # They have a tar.gz but the permissions are broken inside it (will create unreadable files)
 CHECKSUM_SHA256="288fe4decd2100b2d5fad8ba4081837b492c2ce380e86dcfcd5a4c9ee1458e60"
 SOURCE_DIR="cd"
@@ -24,15 +24,10 @@ PROVIDES="
 	lib:libcdgl$secondaryArchSuffix = $portVersion
 	lib:libcdim$secondaryArchSuffix = $portVersion
 	lib:libcdlua51$secondaryArchSuffix = $portVersion
-	lib:libcdlua52$secondaryArchSuffix = $portVersion
 	lib:libcdluacontextplus51$secondaryArchSuffix = $portVersion
-	lib:libcdluacontextplus52$secondaryArchSuffix = $portVersion
 	lib:libcdluagl51$secondaryArchSuffix = $portVersion
-	lib:libcdluagl52$secondaryArchSuffix = $portVersion
 	lib:libcdluaim51$secondaryArchSuffix = $portVersion
-	lib:libcdluaim52$secondaryArchSuffix = $portVersion
 	lib:libcdluapdf51$secondaryArchSuffix = $portVersion
-	lib:libcdluapdf52$secondaryArchSuffix = $portVersion
 	lib:libcdpdf$secondaryArchSuffix = $portVersion
 	lib:libpdflib$secondaryArchSuffix = $portVersion
 	"
@@ -56,17 +51,15 @@ PROVIDES_devel="
 	devel:libcdgl$secondaryArchSuffix = $portVersion
 	devel:libcdim$secondaryArchSuffix = $portVersion
 	devel:libcdlua51$secondaryArchSuffix = $portVersion
-	devel:libcdlua52$secondaryArchSuffix = $portVersion
 	devel:libcdluacontextplus51$secondaryArchSuffix = $portVersion
-	devel:libcdluacontextplus52$secondaryArchSuffix = $portVersion
 	devel:libcdluagl51$secondaryArchSuffix = $portVersion
-	devel:libcdluagl52$secondaryArchSuffix = $portVersion
 	devel:libcdluaim51$secondaryArchSuffix = $portVersion
-	devel:libcdluaim52$secondaryArchSuffix = $portVersion
 	devel:libcdluapdf51$secondaryArchSuffix = $portVersion
-	devel:libcdluapdf52$secondaryArchSuffix = $portVersion
 	devel:libcdpdf$secondaryArchSuffix = $portVersion
 	devel:libpdflib$secondaryArchSuffix = $portVersion
+	"
+REQUIRES_devel="
+	cd$secondaryArchSuffix == $portVersion base
 	"
 
 BUILD_REQUIRES="


### PR DESCRIPTION
- Removed provides for libs that are not present.
- Make sure you can't install `cd_devel` without the base package.

(built on beta4 64 bits)