### PR TITLE
libxml2: make _devel package require iconv_devel.

### DIFF
--- a/dev-libs/libxml2/libxml2-2.12.5.recipe
+++ b/dev-libs/libxml2/libxml2-2.12.5.recipe
@@ -10,7 +10,7 @@ available in other environments."
 HOMEPAGE="http://www.xmlsoft.org/"
 COPYRIGHT="1998-2013 Daniel Veillard.  All Rights Reserved."
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://download.gnome.org/sources/libxml2/2.12/libxml2-$portVersion.tar.xz"
 CHECKSUM_SHA256="a972796696afd38073e0f59c283c3a2f5a560b5268b4babc391b286166526b21"
 SOURCE_URI_2="https://www.w3.org/XML/Test/xmlts20130923.tar.gz"
@@ -54,6 +54,7 @@ PROVIDES_devel="
 	"
 REQUIRES_devel="
 	libxml2$secondaryArchSuffix == $portVersion base
+	devel:libiconv$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"
 
@@ -77,8 +78,8 @@ fi
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libz$secondaryArchSuffix
 	devel:libiconv$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
 	"
 if $pythonModuleEnabled; then
 	BUILD_REQUIRES="$BUILD_REQUIRES


### PR DESCRIPTION
Now that libxml2 use iconv, this avoids having to add "devel:libiconv" as build requirements for (at least some) packages that require "devel:libxml2" (as imagemagick and lxml, for example).