### PR TITLE
scipy: recipe cleanups, drop Python 3.9 support.

### DIFF
--- a/dev-python/scipy/scipy-1.6.3.recipe
+++ b/dev-python/scipy/scipy-1.6.3.recipe
@@ -11,7 +11,7 @@ HOMEPAGE="https://www.scipy.org/"
 COPYRIGHT=" 2001-2002 Enthought, Inc.
 	2003-2021 SciPy Developers"
 LICENSE="BSD (3-clause)"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://github.com/scipy/scipy/releases/download/v$portVersion/scipy-$portVersion.tar.xz"
 CHECKSUM_SHA256="3851fdcb1e6877241c3377aa971c85af0d44f90c57f4dd4e54e1b2bbd742635e"
 SOURCE_DIR="scipy-$portVersion"
@@ -25,53 +25,54 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libcblas$secondaryArchSuffix
-	lib:libarpack$secondaryArchSuffix
+	gcc${secondaryArchSuffix}_syslibs
+	numpy$secondaryArchSuffix
 	lib:libblis$secondaryArchSuffix
 	lib:liblapack$secondaryArchSuffix
 	lib:libopenblas$secondaryArchSuffix
-	lib:libumfpack$secondaryArchSuffix # not sure if actually used
-	numpy$secondaryArchSuffix
 	"
-
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libcblas$secondaryArchSuffix
-	devel:libarpack$secondaryArchSuffix
 	devel:libblis$secondaryArchSuffix
 	devel:liblapack$secondaryArchSuffix
 	devel:libopenblas$secondaryArchSuffix
-	devel:libumfpack$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\n\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku$secondaryArchSuffix\n\
-	scipy$secondaryArchSuffix\n\
-	cmd:f2py$pythonVersion\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	pybind11${secondaryArchSuffix}_$pythonPackage
-	numpy${secondaryArchSuffix}_$pythonPackage
-	setuptools_$pythonPackage
-	"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:g++$secondaryArchSuffix
-	cmd:gfortran$secondaryArchSuffix
-	cmd:make
-	cmd:pkg_config$secondaryArchSuffix
-	cmd:python$pythonVersion
-	cmd:swig # not sure if actually used
-	"
+PYTHON_VERSIONS=(3.10)
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
+
+	eval "PROVIDES_$pythonPackage=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_$pythonPackage+=\"
+			scipy_$pythonPackage = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku$secondaryArchSuffix
+		scipy$secondaryArchSuffix == $portVersion base
+		cmd:python$pythonVersion
+		\""
+
+	BUILD_REQUIRES+="
+		pybind11_$pythonPackage
+		numpy_$pythonPackage
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:g++$secondaryArchSuffix
+		cmd:gfortran$secondaryArchSuffix
+		cmd:make
+		cmd:pkg_config$secondaryArchSuffix
+		cmd:python$pythonVersion
+		"
 done
 
 
@@ -102,19 +103,21 @@ EOF
 
 	rm -rf doc/sphinxext/.git
 
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }


### PR DESCRIPTION
Rev-bump to address the following:

- Recipe cleanup.
- Dependencies cleanup (checked all the .so modules via `readelf -d <module> | grep NEEDED`).
- #8806.
- Move to Python 3.10, as the only user package on tree (noteshrink) will move there too.

This PR needs #10696 to be merged first, otherwise the build will fail.

ToDo: update to latest `scipy`, once we resolve some missing dependencies for that. This version is at least good enough to re-enable `noteshrink` (despite some benign warnings about mismatched `numpy` version).

Tested on beta4, 32 and 64 bits (heads up: build fails on machines with only 2 GB of RAM).