### PR TITLE
scipy: disable recipe for now.

### DIFF
--- a/dev-python/scipy/scipy-1.6.3.recipe
+++ b/dev-python/scipy/scipy-1.6.3.recipe
@@ -11,14 +11,14 @@ HOMEPAGE="https://www.scipy.org/"
 COPYRIGHT=" 2001-2002 Enthought, Inc.
 	2003-2021 SciPy Developers"
 LICENSE="BSD (3-clause)"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://github.com/scipy/scipy/releases/download/v$portVersion/scipy-$portVersion.tar.xz"
 CHECKSUM_SHA256="3851fdcb1e6877241c3377aa971c85af0d44f90c57f4dd4e54e1b2bbd742635e"
 SOURCE_DIR="scipy-$portVersion"
 PATCHES="scipy-$portVersion.patchset"
 
-ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="?all !x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
 
 PROVIDES="
 	$portName = $portVersion

--- a/media-gfx/noteshrink/noteshrink-0.1.1.recipe
+++ b/media-gfx/noteshrink/noteshrink-0.1.1.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="Noteshrink is an utility that is used to convert scans of notes to 
 HOMEPAGE="https://mzucker.github.io/2016/09/20/noteshrink.html"
 COPYRIGHT="2016 Matt Zucker"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/mzucker/noteshrink/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="2a29c09768973e688b693b61337c6c49384e8123cf88824dba335cc8c4ed2ca8"
 
@@ -39,6 +39,7 @@ INSTALL()
 {
 	mkdir -p $binDir
 	sed 's|#!/usr/bin/env python|#!/bin/python3|' noteshrink.py > $binDir/noteshrink
+	chmod +x $binDir/noteshrink
 }
 
 


### PR DESCRIPTION
Keeps getting the buildmasters stuck (despite working for me on both 64 and 32 bits, on my Phenom II X4 with 8 GB of RAM).

Fix noteshrink while we're at it, even if will not work still (at least on 32 bits) due to missing "scipy" package.