### PR TITLE
build: update to version 1.2.1.

### DIFF
--- a/dev-python/build/build-1.2.1.recipe
+++ b/dev-python/build/build-1.2.1.recipe
@@ -2,11 +2,11 @@ SUMMARY="A simple, correct PEP 517 build frontend"
 DESCRIPTION="build will invoke the PEP 517 hooks to build a distribution package.
 It is a simple build tool and does not perform any dependency management."
 HOMEPAGE="https://pypi.org/project/build/"
-COPYRIGHT="2010-2023 Filipe Laíns"
+COPYRIGHT="2019 Filipe Laíns"
 LICENSE="MIT"
 REVISION="1"
-SOURCE_URI="https://github.com/pypa/build/archive/refs/tags/$portVersion.tar.gz"
-CHECKSUM_SHA256="4f9201228d0af78aac3c672e89a81749a001d8d7f448cf9196d93cce8d5ee45a"
+SOURCE_URI="https://files.pythonhosted.org/packages/source/b/build/build-$portVersion.tar.gz"
+CHECKSUM_SHA256="526263f4870c26f26c433545579475377b2b7588b6f1eac76a001e873ae3e19d"
 
 ARCHITECTURES="any"
 
@@ -28,7 +28,7 @@ for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
 	pythonPackage=python${pythonVersion//.}
 
-	eval "PROVIDES_${pythonPackage}=\"
+	eval "PROVIDES_$pythonPackage=\"
 		${portName}_$pythonPackage = $portVersion
 		cmd:pyproject_build_$pythonVersion
 		\""
@@ -44,19 +44,20 @@ for i in "${!PYTHON_VERSIONS[@]}"; do
 		cmd:python$pythonVersion
 		packaging_$pythonPackage
 		pyproject_hooks_$pythonPackage
-		tomli_$pythonPackage
+		tomli_$pythonPackage			# only needed for Python < 3.11
 		\""
 
 	BUILD_REQUIRES+="
-		build_$pythonPackage
 		flit_core_$pythonPackage
 		installer_$pythonPackage
 		pyproject_hooks_$pythonPackage
+		tomli_$pythonPackage			# only needed for Python < 3.11
 		"
 	BUILD_PREREQUIRES+="
 		cmd:python$pythonVersion
 		"
 done
+
 
 INSTALL()
 {
@@ -66,7 +67,8 @@ INSTALL()
 
 		python=python$pythonVersion
 
-		$python -m flit_core.wheel
+#		$python -m flit_core.wheel
+		PYTHONPATH=src $python -m build --no-isolation --skip-dependency-check
 		$python -m installer -p $prefix dist/*.whl
 
 		# Version the script, but provide suffix-less symlink for the default Python version.


### PR DESCRIPTION
Use build from the source dir instead of requiring `build` to be installed. (can also use the commented out `$python -m flit_core.wheel` alternative, if needed).

Part of the fixes for #10717.