### PR TITLE
borgbackup: recipe/dependencies cleanup.

### DIFF
--- a/app-backup/borgbackup/borgbackup-1.4.0.recipe
+++ b/app-backup/borgbackup/borgbackup-1.4.0.recipe
@@ -8,20 +8,18 @@ changes are stored.
 The authenticated encryption technique makes it suitable for backups to not fully \
 trusted targets."
 HOMEPAGE="https://www.borgbackup.org/"
-COPYRIGHT="2015-2023 The Borg Collective
+COPYRIGHT="2015-2024 The Borg Collective
 	2010-2014 Jonas Borgström"
 LICENSE="BSD (3-clause)"
-REVISION="1"
-SOURCE_URI="https://github.com/borgbackup/borg/archive/refs/tags/$portVersion.tar.gz"
-CHECKSUM_SHA256="88d0e37bee67398ee12414c18d67502a5dbf06b1a72fbffe2e20fcd5736e7320"
-SOURCE_FILENAME="borgbackup-$portVersion.tar.gz"
-SOURCE_DIR="borg-$portVersion"
+REVISION="2"
+SOURCE_URI="https://files.pythonhosted.org/packages/source/b/borgbackup/borgbackup-$portVersion.tar.gz"
+CHECKSUM_SHA256="c54c45155643fa66fed7f9ff2d134ea0a58d0ac197c18781ddc2fb236bf6ed29"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 pythonVersion="3.10"
-pythonPackage="python310"
+pythonPackage="python${pythonVersion//.}"
 
 PROVIDES="
 	$portName = $portVersion
@@ -30,14 +28,9 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	argon2_cffi_bindings_$pythonPackage
-	cffi_$pythonPackage
 	msgpack_$pythonPackage
 	packaging_$pythonPackage
-	lib:libargon2$secondaryArchSuffix
 	lib:libcrypto$secondaryArchSuffix
-	lib:libdeflate$secondaryArchSuffix
-	lib:libffi$secondaryArchSuffix
 	lib:liblz4$secondaryArchSuffix
 	lib:libxxhash$secondaryArchSuffix
 	lib:libzstd$secondaryArchSuffix
@@ -45,32 +38,32 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	python_pkgconfig_$pythonPackage
+	setuptools_$pythonPackage
+	setuptools_scm_$pythonPackage
+	wheel_$pythonPackage
 	devel:libcrypto$secondaryArchSuffix
-	devel:libdeflate$secondaryArchSuffix
 	devel:liblz4$secondaryArchSuffix
 	devel:libxxhash$secondaryArchSuffix
 	devel:libzstd$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	python_pkgconfig_$pythonPackage
-	setuptools_scm_$pythonPackage
-	wheel_$pythonPackage
 	cmd:cython$pythonVersion
 	cmd:gcc$secondaryArchSuffix
-	cmd:git
-	cmd:pip$pythonVersion
-	cmd:pkg_config$secondaryArchSuffix
 	cmd:python$pythonVersion
 	"
 
-SETUPTOOLS_SCM_PRETEND_VERSION=$portVersion
-export SETUPTOOLS_SCM_PRETEND_VERSION
-
 INSTALL()
 {
+	# This is only needed if NOT using "haikuporter -G", as  the presence of a ".git" folder
+	# confuses the dumb build system (it assumes that the .git is the one from upstream).
+	export SETUPTOOLS_SCM_PRETEND_VERSION=$portVersion
+
 	installLocation=$prefix/lib/python$pythonVersion/vendor-packages/
 	export PYTHONPATH=$installLocation:$PYTHONPATH
+
 	mkdir -p $installLocation
+
 	python$pythonVersion setup.py build install \
 		--root=/ --prefix=$prefix
 }


### PR DESCRIPTION
Used `readelf -d | grep NEEDED` on the compiled modules to make sure we only require what is actually needed at runtime.

Double checked documented runtime dependencies on Python modules, grepped the sources for the "dependencies" I removed, and smoke tested the provided `cmd:`s after install.

Cleaned up build requirementes while at it. In particular, `cmd:pip` wasn't actually required, (and we should avoid using it on recipes, in any case, IMO, at least in a way we don't control, and using `--no-deps` while at it).