### PR TITLE
python_pkgconfig: recipe cleanup/fixes.

### DIFF
--- a/dev-python/pkgconfig/python_pkgconfig-1.5.5.recipe
+++ b/dev-python/pkgconfig/python_pkgconfig-1.5.5.recipe
@@ -4,58 +4,74 @@ Python 3.3+."
 HOMEPAGE="https://pypi.org/project/pkgconfig/"
 COPYRIGHT="201-2021 Mathias Vogelgesang"
 LICENSE="MIT"
-REVISION="3"
-SOURCE_URI="https://pypi.python.org/packages/source/p/pkgconfig/pkgconfig-$portVersion.tar.gz"
+REVISION="4"
+SOURCE_URI="https://files.pythonhosted.org/packages/source/p/pkgconfig/pkgconfig-$portVersion.tar.gz"
 CHECKSUM_SHA256="deb4163ef11f75b520d822d9505c1f462761b4309b1bb713d08689759ea8b899"
 SOURCE_DIR="pkgconfig-$portVersion"
 
-ARCHITECTURES="any"
+# Ideally, this should be "any", but we really want "pkg-config-x86" here, not the gcc2 version.
+# Python modules using this one have no concept of Haiku's x86_gcc2 vs x86, and we can pretty
+# much assume they only care for the non-gcc2 version of libs.
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	$portName = $portVersion
 	"
 REQUIRES="
-	haiku
+	haiku$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
+	haiku${secondaryArchSuffix}_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:pkg_config\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+PYTHON_VERSIONS=(3.10)
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_$pythonPackage+=\"
+			python_pkgconfig_$pythonPackage = $portVersion
+			\""
+	fi
+	eval "REQUIRES_$pythonPackage=\"
+		$REQUIRES
+		cmd:pkg_config$secondaryArchSuffix
+		cmd:python$pythonVersion
+		\""
+
+	BUILD_REQUIRES+="
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
+
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
 		mkdir -p $installLocation
+
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }


### PR DESCRIPTION
While this module could be "any" in theory, doing so means the "x86_gcc2" version of "pkg-config" gets called (that causes problems when packages that use this module to build stuff, get the wrong info on 32 bits, no sane python3 package would be asking for, or expecting, GCC2 stuff).

Cleaned up a bit the recipe while at it, and droped 3.9, as the only user on-tree of this module is Python 3.10 only already (borgbackup).

---

Tested builds of this and `borgbackup` (after reverting #10741) on both 32 and 64 bits. If this gets merged, will open a PR removing from `borgbackup` the transitive/indirect requirement for `cmd:pkg_config$secondaryArchSuffix`.