### PR TITLE
python3.12: update to version 3.12.4.

### DIFF
--- a/dev-lang/python/patches/python3.12-3.12.4.patchset
+++ b/dev-lang/python/patches/python3.12-3.12.4.patchset
@@ -1,4 +1,4 @@
-From 666d6b836b05ef4ba74e7c75d097a77283da31b8 Mon Sep 17 00:00:00 2001
+From 91fcc766ffa94f609e0bcbdf440c6032e56f904e Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 8 Oct 2023 01:02:25 -0300
 Subject: initial Haiku patch
@@ -9,7 +9,7 @@ over 3.12's sources.
 Parts of that original patch were split into specific commit/patches.
 
 diff --git a/Include/pyport.h b/Include/pyport.h
-index 35eca72..7dd2f84 100644
+index e2bac3b..0d8b825 100644
 --- a/Include/pyport.h
 +++ b/Include/pyport.h
 @@ -691,7 +691,7 @@ extern char * _getpty(int *, int, mode_t, int);
@@ -32,7 +32,7 @@ index 0000000..4372ee2
 +set -v
 +eval $PYTHON_FOR_BUILD ../../Tools/scripts/h2py.py -i "'(u_long)'" $HEADERS/posix/netinet/in.h
 diff --git a/Makefile.pre.in b/Makefile.pre.in
-index dd5e69f..7846bd0 100644
+index 4a957fb..2d5cbcc 100644
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
 @@ -147,7 +147,7 @@ BINDIR=		@bindir@
@@ -184,7 +184,7 @@ index 13f1115..45f477c 100644
          else
              PyErr_SetString(PyExc_KeyError, "getspnam(): name not found");
 diff --git a/configure.ac b/configure.ac
-index 384718d..8b2ad86 100644
+index 8a32cb5..3e89457 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -1524,6 +1524,16 @@ if test $enable_shared = "yes"; then
@@ -212,7 +212,7 @@ index 384718d..8b2ad86 100644
  		CYGWIN*) LN="ln -s";;
  		*) LN=ln;;
  	esac
-@@ -3415,7 +3426,7 @@ then
+@@ -3441,7 +3452,7 @@ then
  		 else CCSHARED="+z";
  		 fi;;
  	Linux-android*) ;;
@@ -221,7 +221,7 @@ index 384718d..8b2ad86 100644
  	Emscripten*|WASI*)
  		AS_VAR_IF([enable_wasm_dynamic_linking], [yes], [
  			CCSHARED="-fPIC"
-@@ -3448,7 +3459,7 @@ then
+@@ -3474,7 +3485,7 @@ then
  	    LINKFORSHARED="-Wl,-E -Wl,+s";;
  #	    LINKFORSHARED="-Wl,-E -Wl,+s -Wl,+b\$(BINLIBDEST)/lib-dynload";;
  	Linux-android*) LINKFORSHARED="-pie -Xlinker -export-dynamic";;
@@ -230,7 +230,7 @@ index 384718d..8b2ad86 100644
  	# -u libsys_s pulls in all symbols in libsys
  	Darwin/*)
  		LINKFORSHARED="$extra_undefs -framework CoreFoundation"
-@@ -5596,6 +5607,7 @@ AC_CHECK_FUNC([__fpu_control],
+@@ -5622,6 +5633,7 @@ AC_CHECK_FUNC([__fpu_control],
  AC_SUBST([LIBM])
  case $ac_sys_system in
  Darwin) ;;
@@ -239,20 +239,20 @@ index 384718d..8b2ad86 100644
  esac
  AC_MSG_CHECKING([for --with-libm=STRING])
 -- 
-2.42.1
+2.45.2
 
 
-From f356f5fb0ebffb2c49bf3453cea4a747fc4f9351 Mon Sep 17 00:00:00 2001
+From b2cb235d39502638956efdbbf7fedbc81499f72d Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sun, 16 Apr 2017 10:05:42 +0200
 Subject: fix for negative errnos
 
 
 diff --git a/Lib/subprocess.py b/Lib/subprocess.py
-index 3264d9a..829477d 100644
+index 1d17ae3..4461393 100644
 --- a/Lib/subprocess.py
 +++ b/Lib/subprocess.py
-@@ -1938,6 +1938,8 @@ class Popen:
+@@ -1940,6 +1940,8 @@ class Popen:
                          SubprocessError)
                  if issubclass(child_exception_type, OSError) and hex_errno:
                      errno_num = int(hex_errno, 16)
@@ -262,7 +262,7 @@ index 3264d9a..829477d 100644
                          err_msg = ""
                          # The error must be from chdir(cwd).
 diff --git a/Modules/_posixsubprocess.c b/Modules/_posixsubprocess.c
-index d75bb92..cce5acc 100644
+index 35ea2ac..ccc25ed 100644
 --- a/Modules/_posixsubprocess.c
 +++ b/Modules/_posixsubprocess.c
 @@ -756,6 +756,10 @@ error:
@@ -277,10 +277,10 @@ index d75bb92..cce5acc 100644
              *--cur = Py_hexdigits[saved_errno % 16];
              saved_errno /= 16;
 -- 
-2.42.1
+2.45.2
 
 
-From 369c0684ddc4e0ae9fddcaa61a54b4abd75c7ecc Mon Sep 17 00:00:00 2001
+From 5ddac642fb5e6f9c47b3fa055d6623b40d62520d Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 8 Oct 2023 20:06:31 -0300
 Subject: Implement CTypes's find_library for Haiku
@@ -374,10 +374,10 @@ index c550883..6b23423 100644
              print(cdll.LoadLibrary("libm.so"))
              print(cdll.LoadLibrary("libcrypt.so"))
 -- 
-2.42.1
+2.45.2
 
 
-From b20fcfb936ab8a295bfdbf39034a47b04bebb688 Mon Sep 17 00:00:00 2001
+From 07884d11a7e06ce5c648357e61e22f049ebc826c Mon Sep 17 00:00:00 2001
 From: Philipp Wolfer <phil@parolu.io>
 Date: Mon, 23 Sep 2019 09:14:58 +0200
 Subject: webbrowser: Support for default browsers on Haiku
@@ -401,17 +401,17 @@ index ba6711e..ba543ab 100755
          # First try to use the default Windows browser
          register("windows-default", WindowsDefault)
 -- 
-2.42.1
+2.45.2
 
 
-From 4606de02e0b3084650e40920cfc0ce24cdcc0749 Mon Sep 17 00:00:00 2001
+From db43569939664fbd43fc89da29481a6ca100b705 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 4 Oct 2019 22:02:35 +0200
 Subject: since 3.8, don't reinit locks on fork.
 
 
 diff --git a/Lib/logging/__init__.py b/Lib/logging/__init__.py
-index 056380f..4836719 100644
+index 22d3198..f369a88 100644
 --- a/Lib/logging/__init__.py
 +++ b/Lib/logging/__init__.py
 @@ -250,7 +250,7 @@ def _releaseLock():
@@ -424,10 +424,10 @@ index 056380f..4836719 100644
          pass  # no-op when os.register_at_fork does not exist.
  else:
 -- 
-2.42.1
+2.45.2
 
 
-From e307fa5fe7c3e649784139b9de373e22df415b06 Mon Sep 17 00:00:00 2001
+From 5e457b2ab1ec159f441fdb714e95ae4d1dce970f Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 15 May 2020 15:20:57 +0200
 Subject: handle errors returned by internal_connect()
@@ -457,20 +457,20 @@ index 9724879..f714ed8 100644
  
      return PyLong_FromLong((long) res);
 -- 
-2.42.1
+2.45.2
 
 
-From 7057c788962153b1fb4f4796d08fe5c8c434757c Mon Sep 17 00:00:00 2001
+From 662f057c3b9cf8f81d55ba4518c71a640b587a97 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Mon, 19 Oct 2020 18:03:09 +0200
 Subject: ttyname_r can use MAXPATHLEN
 
 
 diff --git a/Modules/posixmodule.c b/Modules/posixmodule.c
-index 1c23061..60d70cb 100644
+index 9cc53c8..efe83f4 100644
 --- a/Modules/posixmodule.c
 +++ b/Modules/posixmodule.c
-@@ -3178,11 +3178,14 @@ static PyObject *
+@@ -3249,11 +3249,14 @@ static PyObject *
  os_ttyname_impl(PyObject *module, int fd)
  /*[clinic end generated code: output=c424d2e9d1cd636a input=9ff5a58b08115c55]*/
  {
@@ -487,10 +487,10 @@ index 1c23061..60d70cb 100644
      if (buffer == NULL) {
          return PyErr_NoMemory();
 -- 
-2.42.1
+2.45.2
 
 
-From 3fd68c9485a6a48650b0b1dcf59c8d6e58514475 Mon Sep 17 00:00:00 2001
+From bde99c8775e120a51ede13921aaa473699b6aa59 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Mon, 24 Oct 2022 20:04:10 -0300
 Subject: Lib/test: require the "largefile" usage flag for I/O heavy tests.
@@ -501,10 +501,10 @@ This avoids needing several GBs of storage to run the tests
 (unless the "largefile" resource usage flag is enabled).
 
 diff --git a/Lib/test/test_io.py b/Lib/test/test_io.py
-index cceaed8..38ba876 100644
+index daa40a6..1a49ab2 100644
 --- a/Lib/test/test_io.py
 +++ b/Lib/test/test_io.py
-@@ -613,7 +613,7 @@ class IOTest(unittest.TestCase):
+@@ -634,7 +634,7 @@ class IOTest(unittest.TestCase):
          # On Windows and Mac OSX this test consumes large resources; It takes
          # a long time to build the >2 GiB file and takes >2 GiB of disk space
          # therefore the resource must be enabled to run this test.
@@ -540,62 +540,176 @@ index 1867e8c..e4fab02 100644
                  'test requires %s bytes and a long time to run' % str(0x180000000))
          f = open(TESTFN, 'w+b')
 -- 
-2.42.1
+2.45.2
 
 
-From 52cae49f99338cea29be70b9ee8df39c183914ca Mon Sep 17 00:00:00 2001
+From 27d9c9a14b97c392ba739b57176640f0520072b6 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
-Date: Sun, 8 Oct 2023 01:04:42 -0300
-Subject: default schemes for Haiku
+Date: Fri, 26 Jul 2024 19:18:56 -0300
+Subject: _getuserbase(), getsitepackages(), and INSTALL_SCHEMES for Haiku.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
-Based on previous patches by Jerome Duval.
+This combines (at least parts of) previous "commits" on older ".patchset"s:
 
+* Initial Haiku patch.
+* default schemes for Haiku
+
+from Jérôme Duval
+
+* syncronize both _getuserbase() copies on site.py and sysconfig.py.
+* Add missing 'platinclude' to sysconfig's _INSTALL_SCHEMES.
+* Adjust test_sysconfig.test_get_scheme_names for Haiku.
+
+by me, plus:
+
+* new changes to allow Python to find modules installed via 'pkgman -H'.
+* Attempt to support the "venv" install scheme (untested).
+
+The idea was to have all _getuserbase()/INSTALL_SCHEMES related changes in "one place".
+
+diff --git a/Lib/site.py b/Lib/site.py
+index 924cfbe..5f3f5da 100644
+--- a/Lib/site.py
++++ b/Lib/site.py
+@@ -302,6 +302,14 @@ def _getuserbase():
+         return joinuser("~", "Library", sys._framework,
+                         "%d.%d" % sys.version_info[:2])
+ 
++    if sys.platform.startswith('haiku'):
++        try:
++            import subprocess
++            return subprocess.check_output(
++                ['finddir', 'B_USER_NONPACKAGED_DIRECTORY']).rstrip().decode('utf-8')
++        except:
++            pass
++
+     return joinuser("~", ".local")
+ 
+ 
+@@ -382,7 +390,31 @@ def getsitepackages(prefixes=None):
+             continue
+         seen.add(prefix)
+ 
+-        if os.sep == '/':
++        if sys.platform.startswith('haiku'):
++            # Locations under /system/
++            sitepackages.append(os.path.join(prefix, "non-packaged", "lib",
++                                        "python%d.%d" % sys.version_info[:2],
++                                        "site-packages"))
++            sitepackages.append(os.path.join(prefix, "lib",
++                                        "python%d.%d" % sys.version_info[:2],
++                                        "vendor-packages"))
++
++            # For .hpkg installed under ~/config/ (pkgman install -H)
++            # ("pip install --user" uses ~/config/non-packaged/, and gets
++            # handled by the "haiku_user" install scheme.
++            try:
++                import subprocess
++                _home_prefix = subprocess.check_output(
++                    ['finddir', 'B_USER_CONFIG_DIRECTORY']).rstrip().decode('utf-8')
++            except:
++                print("'finddir B_USER_CONFIG_DIRECTORY' failed.")
++                _home_prefix = None
++
++            if _home_prefix is not None:
++                sitepackages.append(os.path.join(_home_prefix, "lib",
++                                        "python%d.%d" % sys.version_info[:2],
++                                        "vendor-packages"))
++        elif os.sep == '/':
+             libdirs = [sys.platlibdir]
+             if sys.platlibdir != "lib":
+                 libdirs.append("lib")
 diff --git a/Lib/sysconfig.py b/Lib/sysconfig.py
-index 122d441..a27fa57 100644
+index 122d441..f491415 100644
 --- a/Lib/sysconfig.py
 +++ b/Lib/sysconfig.py
-@@ -47,6 +47,34 @@ _INSTALL_SCHEMES = {
+@@ -47,6 +47,36 @@ _INSTALL_SCHEMES = {
          'scripts': '{base}/bin',
          'data': '{base}',
          },
 +     'haiku': {
-+        'stdlib': '{installed_base}/{platlibdir}/python{py_version_short}',
-+        'platstdlib': '{platbase}/{platlibdir}/python{py_version_short}',
++        'stdlib': '{installed_base}/lib/python{py_version_short}',
++        'platstdlib': '{platbase}/lib/python{py_version_short}',
 +        'purelib': '{base}/non-packaged/lib/python{py_version_short}/site-packages',
-+        'platlib': '{platbase}/non-packaged/{platlibdir}/python{py_version_short}/site-packages',
-+        'include': '{base}/non-packaged/develop/headers/python{py_version_short}',
++        'platlib': '{platbase}/non-packaged/lib/python{py_version_short}/site-packages',
++        'include': '{installed_base}/non-packaged/develop/headers/python{py_version_short}',
++        'platinclude': '{installed_platbase}/develop/headers/python{py_version_short}',
 +        'scripts': '{base}/non-packaged/bin',
 +        'data'   : '{base}/non-packaged',
 +        },
 +     'haiku_vendor': {
-+        'stdlib': '{installed_base}/{platlibdir}/python{py_version_short}',
-+        'platstdlib': '{platbase}/{platlibdir}/python{py_version_short}',
++        'stdlib': '{installed_base}/lib/python{py_version_short}',
++        'platstdlib': '{platbase}/lib/python{py_version_short}',
 +        'purelib': '{base}/lib/python{py_version_short}/vendor-packages',
 +        'platlib': '{platbase}/lib/python{py_version_short}/vendor-packages',
-+        'include': '{base}/develop/headers/python{py_version_short}',
++        'include': '{installed_base}/develop/headers/python{py_version_short}',
++        'platinclude': '{installed_platbase}/develop/headers/python{py_version_short}',
 +        'scripts': '{base}/bin',
 +        'data'   : '{base}',
 +        },
 +     'haiku_home': {
-+        'stdlib': '{installed_base}/lib/python',
-+        'platstdlib': '{base}/lib/python',
-+        'purelib': '{base}/lib/python',
-+        'platlib': '{base}/lib/python',
-+        'include': '{installed_base}/develop/headers/python',
-+        'platinclude': '{installed_base}/develop/headers/python',
++        'stdlib': '{installed_base}/lib/python{py_version_short}',
++        'platstdlib': '{base}/lib/python{py_version_short}',
++        'purelib': '{base}/lib/python{py_version_short}',
++        'platlib': '{base}/lib/python{py_version_short}',
++        'include': '{installed_base}/develop/headers/python{py_version_short}',
++        'platinclude': '{installed_base}/develop/headers/python{py_version_short}',
 +        'scripts': '{base}/bin',
 +        'data': '{base}',
 +        },
      'nt': {
          'stdlib': '{installed_base}/Lib',
          'platstdlib': '{base}/Lib',
-@@ -152,6 +180,15 @@ if _HAS_USER_BASE:
+@@ -86,6 +116,16 @@ _INSTALL_SCHEMES = {
+         'scripts': '{base}/bin',
+         'data': '{base}',
+         },
++     'haiku_venv': {
++        'stdlib': '{installed_base}/lib/python{py_version_short}',
++        'platstdlib': '{platbase}/lib/python{py_version_short}',
++        'purelib': '{base}/non-packaged/lib/python{py_version_short}/site-packages',
++        'platlib': '{platbase}/non-packaged/lib/python{py_version_short}/site-packages',
++        'include': '{installed_base}/non-packaged/develop/headers/python{py_version_short}',
++        'platinclude': '{installed_platbase}/develop/headers/python{py_version_short}',
++        'scripts': '{base}/non-packaged/bin',
++        'data'   : '{base}/non-packaged',
++        },
+     'nt_venv': {
+         'stdlib': '{installed_base}/Lib',
+         'platstdlib': '{base}/Lib',
+@@ -101,6 +141,8 @@ _INSTALL_SCHEMES = {
+ # For the OS-native venv scheme, we essentially provide an alias:
+ if os.name == 'nt':
+     _INSTALL_SCHEMES['venv'] = _INSTALL_SCHEMES['nt_venv']
++elif sys.platform.startswith('haiku'):
++    _INSTALL_SCHEMES['venv'] = _INSTALL_SCHEMES['haiku_venv']
+ else:
+     _INSTALL_SCHEMES['venv'] = _INSTALL_SCHEMES['posix_venv']
+ 
+@@ -127,6 +169,14 @@ def _getuserbase():
+         return joinuser("~", "Library", sys._framework,
+                         f"{sys.version_info[0]}.{sys.version_info[1]}")
+ 
++    if sys.platform.startswith('haiku'):
++        try:
++            import subprocess
++            return subprocess.check_output(
++                ['finddir', 'B_USER_NONPACKAGED_DIRECTORY']).rstrip().decode('utf-8')
++        except:
++            pass
++
+     return joinuser("~", ".local")
+ 
+ _HAS_USER_BASE = (_getuserbase() is not None)
+@@ -152,6 +202,15 @@ if _HAS_USER_BASE:
              'scripts': '{userbase}/bin',
              'data': '{userbase}',
              },
 +        'haiku_user': {
-+            'stdlib': '{userbase}/{platlibdir}/python{py_version_short}',
-+            'platstdlib': '{userbase}/{platlibdir}/python{py_version_short}',
++            'stdlib': '{userbase}/lib/python{py_version_short}',
++            'platstdlib': '{userbase}/lib/python{py_version_short}',
 +            'purelib': '{userbase}/lib/python{py_version_short}/site-packages',
 +            'platlib': '{userbase}/lib/python{py_version_short}/site-packages',
 +            'include': '{userbase}/develop/headers/python{py_version_short}',
@@ -605,7 +719,7 @@ index 122d441..a27fa57 100644
          'osx_framework_user': {
              'stdlib': '{userbase}/lib/python',
              'platstdlib': '{userbase}/lib/python',
-@@ -282,6 +319,18 @@ def _expand_vars(scheme, vars):
+@@ -282,6 +341,18 @@ def _expand_vars(scheme, vars):
  
  
  def _get_preferred_schemes():
@@ -624,87 +738,42 @@ index 122d441..a27fa57 100644
      if os.name == 'nt':
          return {
              'prefix': 'nt',
+diff --git a/Lib/test/test_sysconfig.py b/Lib/test/test_sysconfig.py
+index 1137c20..575e4e5 100644
+--- a/Lib/test/test_sysconfig.py
++++ b/Lib/test/test_sysconfig.py
+@@ -344,9 +344,10 @@ class TestSysConfig(unittest.TestCase):
+         self.assertTrue(os.path.isfile(config_h), config_h)
+ 
+     def test_get_scheme_names(self):
+-        wanted = ['nt', 'posix_home', 'posix_prefix', 'posix_venv', 'nt_venv', 'venv']
++        wanted = ['nt', 'posix_home', 'posix_prefix', 'posix_venv', 'nt_venv', 'venv', 'haiku',
++            'haiku_home', 'haiku_vendor']
+         if HAS_USER_BASE:
+-            wanted.extend(['nt_user', 'osx_framework_user', 'posix_user'])
++            wanted.extend(['nt_user', 'osx_framework_user', 'posix_user', 'haiku_user'])
+         self.assertEqual(get_scheme_names(), tuple(sorted(wanted)))
+ 
+     @skip_unless_symlink
 -- 
-2.42.1
+2.45.2
 
 
-From 7302823ccc167141842859053fddb08ab2cbd3b2 Mon Sep 17 00:00:00 2001
+From c3aa3d84811cc4d9a6e6803ec1cb767ad4b237cf Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
-Date: Sun, 8 Oct 2023 01:05:12 -0300
-Subject: Fix _getuserbase() and getsizepackages() for Haiku.
-
-Based on previous patches by Jerome Duval and me.
-
-diff --git a/Lib/site.py b/Lib/site.py
-index 924b246..aaa646c 100644
---- a/Lib/site.py
-+++ b/Lib/site.py
-@@ -291,6 +291,14 @@ def _getuserbase():
-         return joinuser("~", "Library", sys._framework,
-                         "%d.%d" % sys.version_info[:2])
- 
-+    if sys.platform.startswith('haiku'):
-+        try:
-+            import subprocess
-+            return subprocess.run(['finddir', 'B_USER_NONPACKAGED_DIRECTORY'],
-+                stdout=subprocess.PIPE, check=True).stdout.rstrip().decode('utf-8')
-+        except:
-+            pass
-+
-     return joinuser("~", ".local")
- 
- 
-@@ -371,7 +379,14 @@ def getsitepackages(prefixes=None):
-             continue
-         seen.add(prefix)
- 
--        if os.sep == '/':
-+        if sys.platform.startswith('haiku'):
-+           sitepackages.append(os.path.join(prefix, "non-packaged", "lib",
-+                                       "python%d.%d" % sys.version_info[:2],
-+                                       "site-packages"))
-+           sitepackages.append(os.path.join(prefix, "lib",
-+                                       "python%d.%d" % sys.version_info[:2],
-+                                       "vendor-packages"))
-+        elif os.sep == '/':
-             libdirs = [sys.platlibdir]
-             if sys.platlibdir != "lib":
-                 libdirs.append("lib")
-diff --git a/Lib/sysconfig.py b/Lib/sysconfig.py
-index a27fa57..80e1c3f 100644
---- a/Lib/sysconfig.py
-+++ b/Lib/sysconfig.py
-@@ -155,6 +155,14 @@ def _getuserbase():
-         return joinuser("~", "Library", sys._framework,
-                         f"{sys.version_info[0]}.{sys.version_info[1]}")
- 
-+    if sys.platform.startswith('haiku'):
-+        try:
-+            import subprocess
-+            return subprocess.run(['finddir', 'B_USER_NONPACKAGED_DIRECTORY'],
-+                stdout=subprocess.PIPE, check=True).stdout.rstrip().decode('utf-8')
-+        except:
-+            pass
-+
-     return joinuser("~", ".local")
- 
- _HAS_USER_BASE = (_getuserbase() is not None)
--- 
-2.42.1
-
-
-From 4a0d231167cb942ca9d67271b700ec36cedbdece Mon Sep 17 00:00:00 2001
-From: Oscar Lesta <oscar.lesta@gmail.com>
-Date: Sun, 8 Oct 2023 01:05:31 -0300
+Date: Fri, 26 Jul 2024 19:01:05 -0300
 Subject: Fix location of REPL's history file.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
-From "initial Haiku patch" by Jerome Duval.
+From "initial Haiku patch" by Jérôme Duval.
 
 diff --git a/Lib/site.py b/Lib/site.py
-index aaa646c..e9b0ca3 100644
+index 5f3f5da..6dea062 100644
 --- a/Lib/site.py
 +++ b/Lib/site.py
-@@ -490,8 +490,16 @@ def enablerlcompleter():
+@@ -518,8 +518,16 @@ def enablerlcompleter():
              # each interpreter exit when readline was already configured
              # through a PYTHONSTARTUP hook, see:
              # http://bugs.python.org/issue5845#msg198636
@@ -712,8 +781,8 @@ index aaa646c..e9b0ca3 100644
 -                                   '.python_history')
 +            import subprocess
 +            try:
-+                history = os.path.join(subprocess.run(['finddir', 'B_USER_VAR_DIRECTORY'],
-+                            check=True, stdout=subprocess.PIPE).stdout.rstrip().decode('utf-8'),
++                history = os.path.join(subprocess.check_output(
++                            ['finddir', 'B_USER_VAR_DIRECTORY']).rstrip().decode('utf-8'),
 +                            'python', 'history')
 +                if not os.path.exists(os.path.dirname(history)):
 +                    os.makedirs(os.path.dirname(history))
@@ -724,10 +793,10 @@ index aaa646c..e9b0ca3 100644
                  readline.read_history_file(history)
              except OSError:
 -- 
-2.42.1
+2.45.2
 
 
-From 798c0cfe518fd6ee067decc43617007bac937624 Mon Sep 17 00:00:00 2001
+From c3abf4b23c9810536c3c02bade51284173049133 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 8 Oct 2023 17:02:19 -0300
 Subject: Use spawn instead of fork for multiprocessing.
@@ -777,10 +846,10 @@ index de8a264..02a301e 100644
          # on macOS since macOS 10.14 (Mojave). Use spawn by default instead.
          _default_context = DefaultContext(_concrete_contexts['spawn'])
 -- 
-2.42.1
+2.45.2
 
 
-From 5403dd2261900f25730afe2bf8485925103cd9eb Mon Sep 17 00:00:00 2001
+From 700d8924d4ec7b7d9a5d4b0c6a18903e7c12b6c2 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 10 Dec 2023 19:50:22 -0300
 Subject: Miscellaneous "Lib/test/" fixes for Haiku.
@@ -791,10 +860,10 @@ Content-Transfer-Encoding: 8bit
 test_fileio.py fix from "initial Haiku patch" by Jérôme Duval.
 
 diff --git a/Lib/test/datetimetester.py b/Lib/test/datetimetester.py
-index 55e0619..24a811e 100644
+index 404894a..9fee3f7 100644
 --- a/Lib/test/datetimetester.py
 +++ b/Lib/test/datetimetester.py
-@@ -5917,6 +5917,9 @@ def pairs(iterable):
+@@ -5921,6 +5921,9 @@ def pairs(iterable):
  
  class ZoneInfo(tzinfo):
      zoneroot = '/usr/share/zoneinfo'
@@ -816,28 +885,11 @@ index ebfcffd..0517b87 100644
                         not sys.platform.startswith(('sunos', 'aix')):
                          # Somehow /dev/tty appears seekable on some BSDs
                          self.assertEqual(f.seekable(), False)
-diff --git a/Lib/test/test_sysconfig.py b/Lib/test/test_sysconfig.py
-index b6dbf3d..5d5e43f 100644
---- a/Lib/test/test_sysconfig.py
-+++ b/Lib/test/test_sysconfig.py
-@@ -335,9 +335,10 @@ class TestSysConfig(unittest.TestCase):
-         self.assertTrue(os.path.isfile(config_h), config_h)
- 
-     def test_get_scheme_names(self):
--        wanted = ['nt', 'posix_home', 'posix_prefix', 'posix_venv', 'nt_venv', 'venv']
-+        wanted = ['nt', 'posix_home', 'posix_prefix', 'posix_venv', 'nt_venv', 'venv', 'haiku',
-+            'haiku_home', 'haiku_vendor']
-         if HAS_USER_BASE:
--            wanted.extend(['nt_user', 'osx_framework_user', 'posix_user'])
-+            wanted.extend(['nt_user', 'osx_framework_user', 'posix_user', 'haiku_user'])
-         self.assertEqual(get_scheme_names(), tuple(sorted(wanted)))
- 
-     @skip_unless_symlink
 -- 
-2.42.1
+2.45.2
 
 
-From 54ad51aa2db24c579f90dc1170c74d98f40cc980 Mon Sep 17 00:00:00 2001
+From 4cafbc8ddd4c7c4f982bdba23991328a96964d5d Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sat, 10 Feb 2024 06:01:25 -0300
 Subject: Fix build on nightlies, following the addition of kqueue.
@@ -845,7 +897,7 @@ Subject: Fix build on nightlies, following the addition of kqueue.
 See HaikuPorts issue #10001.
 
 diff --git a/Modules/selectmodule.c b/Modules/selectmodule.c
-index b7c6b1b..84bb449 100644
+index 97f1db2..17bc54c 100644
 --- a/Modules/selectmodule.c
 +++ b/Modules/selectmodule.c
 @@ -2722,13 +2722,20 @@ _select_exec(PyObject *m)
@@ -900,18 +952,16 @@ index b7c6b1b..84bb449 100644
  
      /* NETDEV filter flags */
 -- 
-2.42.1
+2.45.2
 
-From 7cc64ef6b93717111109443ef8f51b932f1a33f3 Mon Sep 17 00:00:00 2001
+
+From 8d881ebce1d3948d0d9b1b64cf92c01ced88aea8 Mon Sep 17 00:00:00 2001
 From: Alexander von Gluck IV <kallisti5@unixzen.com>
 Date: Thu, 14 Mar 2024 12:54:33 -0500
-Subject: [PATCH] config.guess: Update to universal haiku arch guessing
+Subject: config.guess: Update to universal haiku arch guessing
 
 * Matches upstream config.guess as of 2022, python just
   ships a really old one
----
- config.guess | 7 +++++--
- 1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/config.guess b/config.guess
 index e81d3ae..366429c 100755
@@ -932,5 +982,5 @@ index e81d3ae..366429c 100755
      SX-4:SUPER-UX:*:*)
  	GUESS=sx4-nec-superux$UNAME_RELEASE
 -- 
-2.44.0
+2.45.2
 

--- a/dev-lang/python/python3.12-3.12.4.recipe
+++ b/dev-lang/python/python3.12-3.12.4.recipe
@@ -10,10 +10,10 @@ Python is free to use, even for commercial products, because of its \
 OSI-approved open source license."
 HOMEPAGE="https://www.python.org"
 LICENSE="Python"
-COPYRIGHT="1990-2023 Python Software Foundation"
-REVISION="2"
+COPYRIGHT="1990-2024 Python Software Foundation"
+REVISION="1"
 SOURCE_URI="https://www.python.org/ftp/python/$portVersion/Python-${portVersion}.tar.xz"
-CHECKSUM_SHA256="be28112dac813d2053545c14bf13a16401a21877f1a69eb6ea5d84c4a0f3d870"
+CHECKSUM_SHA256="f6d419a6d8743ab26700801b4908d26d97e8b986e14f95de31b32de2b0e79554"
 SOURCE_DIR="Python-$portVersion"
 
 pyShortVer="${portVersion%.*}"
@@ -72,8 +72,8 @@ BUILD_REQUIRES="
 	devel:libncurses$secondaryArchSuffix
 	devel:libsqlite3$secondaryArchSuffix
 	devel:libssl$secondaryArchSuffix
-	devel:libtclstub8.6$secondaryArchSuffix
-	devel:libtk8.6$secondaryArchSuffix
+#	devel:libtclstub8.6$secondaryArchSuffix	# "Disable" these two, as tkinter deadlocks on Haiku.
+#	devel:libtk8.6$secondaryArchSuffix		# Try again when libtk drops undroidwish for xlibe.
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
@@ -114,7 +114,7 @@ BUILD()
 	# "compiler flags are generated in two sets, BASECFLAGS and OPT.  OPT is just
 	# for debug/optimization stuff.  BASECFLAGS is for flags that are required
 	# just to get things to compile and link."
-	export BASECFLAGS="-D_BSD_SOURCE"
+	export BASECFLAGS="-pipe -D_BSD_SOURCE"
 
 	# Not exporting OPT ends up with "-g -fwrapv -O3 -Wall" being used,
 	# and using OPT="" means the build ends up being "-O0".
@@ -185,11 +185,6 @@ INSTALL()
 		sed -i -e 's,headers/x86,headers,' $developLibDir/pkgconfig/python*.pc
 	fi
 
-	## Provide symlink to libpython3.nn.so
-	# Having `libpython3.nn.so` can help software like CudaText (via python4delphi), for example,
-	# to detect the different Python versions available for runtime loading.
-	ln -sr $libDir/libpython${pyShortVer}.so.1.0 $libDir/libpython${pyShortVer}.so
-
 	mkdir -p $prefix/lib/python$pyShortVer/vendor-packages
 	echo 'This directory contains packaged python modules.' \
 		>$prefix/lib/python$pyShortVer/vendor-packages/README
@@ -225,17 +220,18 @@ INSTALL()
 
 # To see the available test-runs options:
 # > hp -E python3.nn
-# > LIBRARY_PATH=/sources/Python-3.nn.n:%A/lib:/boot/home/config/non-packaged/lib:/boot/home/config/lib:/boot/system/non-packaged/lib:/boot/system/lib python -m test --help
-# or just:
+# > LIBRARY_PATH=%A:/boot/system/lib python -m test --help
+# or:
 # > LD_PRELOAD=./libpython3.nn.so.1.0 python -m test --help
 #
 # To only execute a particular test (from the $sourceDir):
 #
 # > LD_PRELOAD=./libpython3.nn.so.1.0 python -m test test_datetime -W
 
-# For reference, results on hrev57581 (64 bits):
-# Total duration: 4 min 10 sec
-# Total test files: run=437/424 failed=22 skipped=24 resource_denied=9 rerun=22
+# For reference, results on hrev56578+96 (64 bits VBox):
+#Total duration: 12 min 39 sec
+#Total tests: run=36,147 failures=254 skipped=1,798
+#Total test files: run=442/424 failed=23 skipped=33 resource_denied=6 rerun=24
 TEST()
 {
 	# Remove tests data left-overs, if any:
@@ -247,7 +243,7 @@ TEST()
 		# Use this to get same test order on different runs (actual value not important).
 		--randseed 7858065
 
- 		# Print the names of the 10 slowest tests.
+		# Print the names of the 10 slowest tests.
 		--slowest
 
 		# Possibly useful?
@@ -260,14 +256,19 @@ TEST()
 		#
 		# Let's be explicit to avoid surprises:
 		-unone,curses,tzdata
+	)
+
+	local tests_to_exclude=(
+		# distutils is deprecated, and will be removed on 3.12.
+		-x test_distutils
 
 		# The following tests invoke the crash dialog, and unless your configure
 		# debug_server default action to "kill" or "report", they will hang waiting for
 		# user input. See comment above TEST().
 		-x test_faulthandler
 		-x test_futures # from test_asyncio. Crashes: Exception (Segment violation)
-		-x test_subprocess	# tends to hang.
-		-x test_threading	# tends to hang.
+		-x test_subprocess # tends to hang.
+		-x test_threading # tends to hang.
 
 		# Many of the tests hang/stall. We have two options:
 		#
@@ -275,6 +276,7 @@ TEST()
 		# 2- Set a TIMEOUT (eg: --timeout=300).
 		#
 		# Option 1: Works, but requires manual identification/mainteinance.
+		#
 		# Option 2: Doesn't requires maintaining a list of stalling tests, but:
 		# at the end of the test run it causes:
 		# - "unmounting failed: Device/File/Resource Busy" errors, as there are
@@ -314,7 +316,7 @@ TEST()
 		-x test_sslproto # Exception on Exception handler.
 		-x test_streams
 		-x test_unix_events
-	#	-i TestThreadedServer # in test_asyncio.functioonal
+	#	-i TestThreadedServer # in test_asyncio.functional
 
 		# These not always hang/stall, but they do it enough to warrant skipping for now.
 		-x test_imaplib
@@ -347,8 +349,48 @@ TEST()
 		# between 1 to 3+ minutes to end (and gets re-run!). Run it manually if needed, or
 		# re-enable once those SSLSocket warninings, that also pop up on other tests, get resolved.
 		-x test_ftplib
+
+		# 3.12.4 hang at least once on beta4.
+		-x test_importlib
+	)
+
+	local tests_that_fail=(
+		test_c_locale_coercion
+		test_compileall
+		test_datetime
+		test_fcntl
+		test_fork1
+		test_genericpath
+		test_import
+		test_json
+		test_pathlib
+		test_popen
+		test_pty
+		test_re
+		test_readline
+		test_shutil
+		test_site
+		test_support
+		test_sysconfig
+		test_tarfile
+		test_termios
+		test_time
+		test_tools
+		test_utf8_mode
+		test_zipfile
 	)
 
 	local -x LOGNAME=buildbot # this skips tests_tools/test_freeze, copied from Gentoo's ebuild
-	make $jobArgs test EXTRATESTOPTS="${test_options[*]}"
+
+	# This runs the full test suite (minus the tests that we explicitly exclude).
+	make $jobArgs test EXTRATESTOPTS="${test_options[*]} ${tests_to_exclude[*]}"
+	# Use this instead, to only run the tests that fail:
+	# make $jobArgs test EXTRATESTOPTS="${test_options[*]} ${tests_that_fail[*]}"
+
+	# Occasionally, some test fails seemingly due to the racy nature of tempfile.mktemp().
+	# Even the help for that function says to NOT use it, but some tests still do.
+	#
+	# If you find some strange "æ" suffix on temp dirnames, ej:
+	#    "cwd: /sources/Python-3.10.12/build/test_python_10324æ"
+	# That's due to usages of os_helper.FS_NONASCII.
 }


### PR DESCRIPTION
Built and tested on 64 bits ~only~ and 32 bits too (beta4).

`venv` install scheme additions are untested, but doesn't seems to make things worse than before at least. (I haven't worked with venvs so far, and not really planning to start anytime soon... I prefer PEP-582 :-D).