### PR TITLE
classicube, disable 32bit, failure on buildmaster

### DIFF
--- a/games-action/classicube/classicube-1.3.6~20240714.recipe
+++ b/games-action/classicube/classicube-1.3.6~20240714.recipe
@@ -29,7 +29,7 @@ ADDITIONAL_FILES="
 	"
 
 ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="x86"
+SECONDARY_ARCHITECTURES="?x86"
 
 PROVIDES="
 	classicube$secondaryArchSuffix = $portVersion


### PR DESCRIPTION
Failure: https://build.haiku-os.org/buildmaster/master/x86_gcc2/logviewer.html?buildruns/6528/builds/83773.log
Previous PR: https://github.com/haikuports/haikuports/pull/10229