### PR TITLE
paramiko: recipe cleanup.

### DIFF
--- a/dev-python/paramiko/paramiko-2.11.0.recipe
+++ b/dev-python/paramiko/paramiko-2.11.0.recipe
@@ -5,88 +5,88 @@ remote machines."
 HOMEPAGE="https://www.lag.net/paramiko/"
 COPYRIGHT="2003-2009  Robey Pointer"
 LICENSE="GNU LGPL v2.1"
-REVISION="3"
-SOURCE_URI="https://pypi.io/packages/source/p/paramiko/paramiko-$portVersion.tar.gz"
+REVISION="4"
+SOURCE_URI="https://files.pythonhosted.org/packages/source/p/paramiko/paramiko-$portVersion.tar.gz"
 CHECKSUM_SHA256="003e6bee7c034c21fbb051bf83dc0a9ee4106204dd3c53054c71452cc4ec3938"
 
-ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="any"
 
 PROVIDES="
 	$portName = $portVersion
 	"
 REQUIRES="
-	haiku$secondaryArchSuffix
+	haiku
 	"
 
 BUILD_REQUIRES="
-	haiku${secondaryArchSuffix}_devel
-	devel:libffi$secondaryArchSuffix
+	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku$secondaryArchSuffix\n\
-	bcrypt_$pythonPackage\n\
-	cryptography_$pythonPackage\n\
-	pynacl_$pythonPackage\n\
-	pyasn1_$pythonPackage\n\
-	six_$pythonPackage\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage
-	"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion
-	"
-TEST_REQUIRES="$TEST_REQUIRES
-	bcrypt_$pythonPackage
-	cryptography_$pythonPackage
-	importlib_metadata_$pythonPackage
-	mock_$pythonPackage
-	pynacl_$pythonPackage
-	pytest_$pythonPackage
-	six_$pythonPackage
-	tomli_$pythonPackage
-	typing_extensions_$pythonPackage
-	lib:libsodium$secondaryArchSuffix
-	"
+PYTHON_VERSIONS=(3.10)
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
+
+	eval "PROVIDES_$pythonPackage=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		bcrypt_$pythonPackage
+		cryptography_$pythonPackage
+		pynacl_$pythonPackage
+#		pyasn1_$pythonPackage # for the "gssapi" extra only.
+		six_$pythonPackage
+		cmd:python$pythonVersion
+		\""
+
+	BUILD_REQUIRES="$BUILD_REQUIRES
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES="$BUILD_PREREQUIRES
+		cmd:python$pythonVersion
+		"
+	TEST_REQUIRES="$TEST_REQUIRES
+		bcrypt_$pythonPackage
+		cryptography_$pythonPackage
+		importlib_metadata_$pythonPackage
+#		mock_$pythonPackage # can use unittest.mock instead (newer versions do so).
+		pynacl_$pythonPackage
+		pytest_$pythonPackage
+		six_$pythonPackage
+		tomli_$pythonPackage
+		typing_extensions_$pythonPackage
+		"
 done
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
+
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }
 
 TEST()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
 
-		python=python$pythonVersion
-		pytest$pythonVersion
+		pytest-$pythonVersion
 	done
 }


### PR DESCRIPTION
Just a quick cleanup. Moving it to "any", as this is just a pure-python module.

Tests do not run, as we're missing the "invoke" depedency for "pytest.relaxed", and that means bringing in at least 6 more new recipes.

Similar with trying to update paramiko to newer versions.

Seems like too much work for a package that is not used by anything in-tree (thus, just this clean up for now).