### PR TITLE
python3.10: fix a 'ctypes' bug I introduced on the 3.10.14 patchset.

### DIFF
--- a/dev-lang/python/patches/python3.10-3.10.14.patchset
+++ b/dev-lang/python/patches/python3.10-3.10.14.patchset
@@ -1,4 +1,4 @@
-From 8f72108a053605954500f69c86fa62714553cd73 Mon Sep 17 00:00:00 2001
+From 2588bddbcbdbc66cd4cb6b209726143ff9e3ffd7 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Thu, 25 Jul 2024 17:26:26 -0300
 Subject: Initial Haiku patch (re-worked a bit).
@@ -377,7 +377,7 @@ index a39610a..82b06a1 100644
 2.45.2
 
 
-From e59e464b2220ae95bf697b3c5c73451924546d62 Mon Sep 17 00:00:00 2001
+From 2cb60bb4e78604789e8d9c2ef2a25d4ccb380610 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sun, 16 Apr 2017 10:05:42 +0200
 Subject: fix for negative errnos
@@ -415,7 +415,7 @@ index b852ad7..60d4a6e 100644
 2.45.2
 
 
-From 7bbbb3ebe4e2b2c7607a4ca011aa4e1b390827c2 Mon Sep 17 00:00:00 2001
+From 7bbf8e82cfe9bc304eef77b75dba38783b983d91 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sat, 6 Apr 2024 23:49:30 -0300
 Subject: Implement CTypes's find_library for Haiku
@@ -425,10 +425,16 @@ This combines:
  - A slight variation of Adrien Destugues' fix for x86 32 bits.
 
 diff --git a/Lib/ctypes/util.py b/Lib/ctypes/util.py
-index 0c2510e..371eaa5 100644
+index 0c2510e..6b88fc8 100644
 --- a/Lib/ctypes/util.py
 +++ b/Lib/ctypes/util.py
-@@ -265,6 +265,60 @@ elif os.name == "posix":
+@@ -1,4 +1,5 @@
+ import os
++import platform
+ import shutil
+ import subprocess
+ import sys
+@@ -265,6 +266,60 @@ elif os.name == "posix":
          def find_library(name, is64 = False):
              return _get_soname(_findLib_crle(name, is64) or _findLib_gcc(name))
  
@@ -489,7 +495,7 @@ index 0c2510e..371eaa5 100644
      else:
  
          def _findSoname_ldconfig(name):
-@@ -367,6 +421,12 @@ def test():
+@@ -367,6 +422,12 @@ def test():
              print(f"crypt\t:: {cdll.LoadLibrary(find_library('crypt'))}")
              print(f"crypto\t:: {find_library('crypto')}")
              print(f"crypto\t:: {cdll.LoadLibrary(find_library('crypto'))}")
@@ -506,7 +512,7 @@ index 0c2510e..371eaa5 100644
 2.45.2
 
 
-From 9acb3b73870a0a3caf6432f92d1c14dcceb987ec Mon Sep 17 00:00:00 2001
+From 3a510daafa1ddc38f5d5f30e5c843e01712ef588 Mon Sep 17 00:00:00 2001
 From: Philipp Wolfer <phil@parolu.io>
 Date: Mon, 23 Sep 2019 09:14:58 +0200
 Subject: webbrowser: Support for default browsers on Haiku
@@ -532,7 +538,7 @@ index ec3cece..6a29d2a 100755
 2.45.2
 
 
-From a5f44dabeeae79d50ad890d398e3a531917bb3c6 Mon Sep 17 00:00:00 2001
+From b5394bc38179d91bd6aa0f3bd097bef4d247125c Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 4 Oct 2019 22:02:35 +0200
 Subject: since 3.8, don't reinit locks on fork.
@@ -555,7 +561,7 @@ index d1d4333..bfe60ca 100644
 2.45.2
 
 
-From c57a587e7aacb791c7588c81b7c689d5e8c24e62 Mon Sep 17 00:00:00 2001
+From ba9e8569858a36f424f7cec947710ffdc3c21923 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 15 May 2020 15:20:57 +0200
 Subject: handle errors returned by internal_connect()
@@ -588,7 +594,7 @@ index a4c555c..abdaea7 100644
 2.45.2
 
 
-From 079c6188cb26067e3f4780518563fa1f7853e065 Mon Sep 17 00:00:00 2001
+From 42663421f2b362f6686bc28cf5500e9bf69109a9 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Mon, 19 Oct 2020 18:03:09 +0200
 Subject: ttyname_r can use MAXPATHLEN
@@ -618,7 +624,7 @@ index c0421a9..ace1449 100644
 2.45.2
 
 
-From 7106f9092ebcac6706f4fb101ae238653bec5ef3 Mon Sep 17 00:00:00 2001
+From e479304cd4cd001cd56d3cac41b25cfb7ce948a0 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Thu, 25 Jul 2024 17:27:04 -0300
 Subject: Miscellaneous "Lib/test/" fixes for Haiku.
@@ -687,7 +693,7 @@ index 307e2b9..afc1772 100644
 2.45.2
 
 
-From 61d557d4a85f997cb24a15b9fedbd91c6aa99419 Mon Sep 17 00:00:00 2001
+From fcd2f73417ba32bbfd7501282d5388777cc5e359 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Thu, 25 Jul 2024 17:27:17 -0300
 Subject: _getuserbase(), getsitepackages(), and INSTALL_SCHEMES for Haiku
@@ -999,7 +1005,7 @@ index 5ee9839..35727c6 100644
 2.45.2
 
 
-From f342f4b21f9462464188884de089a35492db86f6 Mon Sep 17 00:00:00 2001
+From dfbe655d848e18c253f60841daffa79639f7dcbf Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Thu, 25 Jul 2024 17:27:28 -0300
 Subject: Fix location of REPL's history file.
@@ -1033,7 +1039,7 @@ index 69d96a3..16c4ae7 100644
 2.45.2
 
 
-From b50776355951dad9d1334882eb5e9d9cb7449ab5 Mon Sep 17 00:00:00 2001
+From e961a56eda711a52b8bf817fed8dbf4bca6be076 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sat, 27 Jan 2024 08:14:52 -0300
 Subject: Apply gh-109191 from Python upstream.
@@ -1126,7 +1132,7 @@ index 57c84e5..6d4f5fc 100644
 2.45.2
 
 
-From a0b11b560e85fb9a15fa9d4de09d03e15d2226b5 Mon Sep 17 00:00:00 2001
+From 8b3b19076cff3e8020b9fcf4c35a1155f6a214a7 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sat, 10 Feb 2024 06:01:25 -0300
 Subject: Fix build on nightlies, following the addition of kqueue.
@@ -1192,7 +1198,7 @@ index 3afcb0e..b7a2681 100644
 2.45.2
 
 
-From 14063f36ca6c9ef3d2921053b3cdeaf621f4af17 Mon Sep 17 00:00:00 2001
+From 684c9dd79c07ffc6234fb433e186fbe25115c91f Mon Sep 17 00:00:00 2001
 From: Alexander von Gluck IV <kallisti5@unixzen.com>
 Date: Thu, 14 Mar 2024 12:54:33 -0500
 Subject: config.guess: Update to universal haiku arch guessing

--- a/dev-lang/python/python3.10-3.10.14.recipe
+++ b/dev-lang/python/python3.10-3.10.14.recipe
@@ -11,7 +11,7 @@ OSI-approved open source license."
 HOMEPAGE="https://www.python.org"
 LICENSE="Python"
 COPYRIGHT="1990-2024 Python Software Foundation"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://www.python.org/ftp/python/$portVersion/Python-$portVersion.tar.xz"
 CHECKSUM_SHA256="9c50481faa8c2832329ba0fc8868d0a606a680fc4f60ec48d26ce8e076751fda"
 SOURCE_DIR="Python-$portVersion"
@@ -36,21 +36,36 @@ GLOBAL_WRITABLE_FILES="
 	non-packaged/lib/python$pyShortVer/site-packages directory keep-old
 	"
 
+# [RECIPE OPTIONS]>>>
+
+# If this is not intended to be the "default" Python version, set to "false", so "make altinstall"
+# is used, and only version-suffixed commands are used in PROVIDES.
+installAsDefaultPython=true
+
+# Set to "true" if we should build the "tkinter" module.
+# Disabled for now, as tkinter deadlocks on Haiku. Try again when tk drops undroidwish for xlibe.
+enableTkinter=false
+
+# Set to "true" to package all the tests into a separate "_tests" package (around 30 MB in size).
+# Tests are discarded if set to "false".
+packageTests=false
+
+# Set to "false" for faster local/test builds. Around 4 to 5 times faster that way.
+optimizedBuild=true
+
+# Run all tests by default. Set to "true" to make "hp --test" only run then known failing tests.
+runOnlyKnownFailingTests=false
+
+# <<<[RECIPE OPTIONS]
+
 PROVIDES="
 	python$pyShortVer$secondaryArchSuffix = $pyVersionCompat
 	cmd:2to3_$pyShortVer = $pyVersionCompat
-	cmd:idle$pyShortVer = $pyVersionCompat
 	cmd:pydoc$pyShortVer = $pyVersionCompat
 	cmd:python$pyShortVer = $pyVersionCompat
 	cmd:python${pyShortVer}_config = $pyVersionCompat
-	cmd:pyvenv_$pyShortVer = $pyVersionCompat
 	devel:libpython$pyShortVer$secondaryArchSuffix = 1.0
 	lib:libpython$pyShortVer$secondaryArchSuffix = 1.0
-	cmd:2to3 = $portVersion compat >= $pyShortVer
-	cmd:idle3 = $portVersion compat >= $pyShortVer
-	cmd:python3 = $portVersion compat >= $pyShortVer
-	cmd:pydoc3 = $portVersion compat >= $pyShortVer
-	cmd:python3_config = $portVersion compat >= $pyShortVer
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -62,7 +77,7 @@ REQUIRES="
 	lib:libffi$secondaryArchSuffix
 	lib:libintl$secondaryArchSuffix
 	lib:liblzma$secondaryArchSuffix
-	lib:libncurses$secondaryArchSuffix
+	lib:libncursesw$secondaryArchSuffix
 	lib:libsqlite3$secondaryArchSuffix
 	lib:libssl$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
@@ -77,11 +92,9 @@ BUILD_REQUIRES="
 	devel:libexpat$secondaryArchSuffix
 	devel:libffi$secondaryArchSuffix
 	devel:liblzma$secondaryArchSuffix
-	devel:libncurses$secondaryArchSuffix
+	devel:libncursesw$secondaryArchSuffix
 	devel:libsqlite3$secondaryArchSuffix
 	devel:libssl$secondaryArchSuffix
-#	devel:libtclstub8.6$secondaryArchSuffix	# "Disable" these two, as tkinter deadlocks on Haiku.
-#	devel:libtk8.6$secondaryArchSuffix		# Try again when libtk drops undroidwish for xlibe.
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
@@ -96,9 +109,31 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
-# If set to "yes", the resulting "_tests" package is around 30 MB in size.
-packageTests="no"
-if [ "$packageTests" = "yes" ]; then
+if $installAsDefaultPython; then
+	PROVIDES+="
+		cmd:2to3 = $portVersion compat >= $pyShortVer
+		cmd:python3 = $portVersion compat >= $pyShortVer
+		cmd:pydoc3 = $portVersion compat >= $pyShortVer
+		cmd:python3_config = $portVersion compat >= $pyShortVer
+		"
+fi
+
+if $enableTkinter; then
+	PROVIDES+="
+		cmd:idle$pyShortVer = $pyVersionCompat
+		"
+	if $installAsDefaultPython; then
+		PROVIDES+="
+			cmd:idle3 = $portVersion compat >= $pyShortVer
+			"
+	fi
+	BUILD_REQUIRES+="
+		devel:libtclstub8.6$secondaryArchSuffix
+		devel:libtk8.6$secondaryArchSuffix
+		"
+fi
+
+if $packageTests; then
 	PROVIDES_tests="
 		python$pyShortVer${secondaryArchSuffix}_tests = $portVersion
 		"
@@ -116,16 +151,27 @@ BUILD()
 	# "compiler flags are generated in two sets, BASECFLAGS and OPT.  OPT is just
 	# for debug/optimization stuff.  BASECFLAGS is for flags that are required
 	# just to get things to compile and link."
-	export BASECFLAGS="-pipe -D_BSD_SOURCE"
 
-	# Not exporting OPT ends up with "-g -fwrapv -O3 -Wall" being used,
-	# and using OPT="" means the build ends up being "-O0".
-	export OPT="-fwrapv -O3 -Wall"
+	# If not provided, the Makefile ends up with:
+	#	BASECFLAGS=	-Wno-unused-result -Wsign-compare
+	#	OPT=		-DNDEBUG -g -fwrapv -O3 -Wall
+	# -NDEBUG gets added by ./configure unless "--with-assertions" is used.
+
+	export BASECFLAGS="-pipe -D_BSD_SOURCE"
+	export OPT="-fwrapv -Wall"	# remove "-g" until we use "defineDebugInfoPackage".
+
+	if $optimizedBuild; then
+		export OPT+=" -O3"
+		maybeEnableOptimizations="--enable-optimizations"
+	else
+		export OPT+=" -O0"
+		maybeEnableOptimizations=
+	fi
 
 	runConfigure --omit-dirs binDir,includeDir ./configure \
 		--bindir=$commandBinDir \
 		--includedir=$developDir/headers \
-		--enable-optimizations \
+		$maybeEnableOptimizations \
 		--enable-shared \
 		--with-ensurepip=no \
 		--with-readline=editline \
@@ -142,9 +188,22 @@ BUILD()
 
 INSTALL()
 {
-	make install
+	if $installAsDefaultPython; then
+		make install
+	else
+		# altinstall avoids clobbering $prefix/bin/{idle3,pydoc3,python3,python3-config}
+		make altinstall
+	fi
 
 	rm $libDir/libpython3.so
+
+	# No point in having this if we don't have a working tkinter.
+	if ! $enableTkinter; then
+		rm $binDir/idle$pyShortVer
+		if $installAsDefaultPython; then
+			rm -f $binDir/idle3
+		fi
+	fi
 
 	if [ "$targetArchitecture" = x86_gcc2 ]; then
 		# On x86_gcc2, move lib-dynload to lib/python3.x/
@@ -164,7 +223,7 @@ INSTALL()
 	mkdir -p $prefix/non-packaged/lib/python$pyShortVer
 	mv $prefix/lib/python$pyShortVer/site-packages $prefix/non-packaged/lib/python$pyShortVer/
 
-	if [ "$packageTests" = "yes" ]; then
+	if $packageTests; then
 		packageEntries tests \
 			$prefix/lib/python$pyShortVer/idlelib/idle_test \
 			$prefix/lib/python$pyShortVer/test
@@ -201,7 +260,7 @@ INSTALL()
 #
 # > LD_PRELOAD=./libpython3.nn.so.1.0 python -m test test_datetime -W
 #
-# Beware that running test that way can cause some test to fail, while they work fine under
+# Beware that running tests that way can cause some tests to fail, while they work fine under
 # "hp --test"'s chroot. (test_sysconfig.MakefileTests.test_parse_makefile, for example).
 # Problem is "os.getcwd()" will return wrong data, causing some file operations to fail.
 
@@ -209,7 +268,7 @@ INSTALL()
 # 345 tests OK. 23 tests failed. 28 tests skipped.
 TEST()
 {
-	# Remove tests data left-overs, if any
+	# Remove tests data left-overs, if any:
 	# rm -f -r /boot/system/cache/tmp/
 	# rm -f -d -r build/test_python*
 	make $jobArgs test EXTRATESTOPTS="--cleanup"
@@ -338,10 +397,12 @@ TEST()
 
 	local -x LOGNAME=buildbot # this skips tests_tools/test_freeze, copied from Gentoo's ebuild
 
-	# This runs the full test suite (minus the tests that we explicitly exclude).
-	make $jobArgs test EXTRATESTOPTS="${test_options[*]} ${tests_to_exclude[*]}"
-	# Use this instead, to only run the tests that fail:
-	# make $jobArgs test EXTRATESTOPTS="${test_options[*]} ${tests_that_fail[*]}"
+	if $runOnlyKnownFailingTests; then
+		make $jobArgs test EXTRATESTOPTS="${test_options[*]} ${tests_that_fail[*]}"
+	else
+		# Runs the full test suite (minus the tests that we explicitly exclude).
+		make $jobArgs test EXTRATESTOPTS="${test_options[*]} ${tests_to_exclude[*]}"
+	fi
 
 	# Occasionally, some test fails seemingly due to the racy nature of tempfile.mktemp().
 	# Even the help for that function says to NOT use it, but some tests still do.


### PR DESCRIPTION
Also:
- consolidate recipe 'options' near the top.
- remove pyvenv from provides (removed on Python 3.8).