### PR TITLE
python3.10: fix build on 32 bits.

### DIFF
--- a/dev-lang/python/python3.10-3.10.14.recipe
+++ b/dev-lang/python/python3.10-3.10.14.recipe
@@ -199,9 +199,9 @@ INSTALL()
 
 	# No point in having this if we don't have a working tkinter.
 	if ! $enableTkinter; then
-		rm $binDir/idle$pyShortVer
+		rm $prefix/bin/idle$pyShortVer
 		if $installAsDefaultPython; then
-			rm -f $binDir/idle3
+			rm -f $prefix/bin/idle3
 		fi
 	fi
 


### PR DESCRIPTION
No revbump, to avoid a rebuild on 64 bits.