### PR TITLE
gertty: Recipe cleanups. Build only once.

### DIFF
--- a/dev-util/gertty/gertty-1.6.0.recipe
+++ b/dev-util/gertty/gertty-1.6.0.recipe
@@ -19,9 +19,8 @@ changes."
 HOMEPAGE="https://pypi.org/project/gertty/"
 COPYRIGHT="2022 The TTY Group"
 LICENSE="Apache v2"
-REVISION="7"
-pypiVersion="13/fa/67165ece7a08f7142bcfda2e5cee145dbda78e003c11924098bfc6efaf0e"
-SOURCE_URI="https://files.pythonhosted.org/packages/$pypiVersion/gertty-$portVersion.tar.gz"
+REVISION="8"
+SOURCE_URI="https://files.pythonhosted.org/packages/source/${portName:0:1}/$portName/$portName-$portVersion.tar.gz"
 CHECKSUM_SHA256="1c3593d2e6ce53bd84b27d6ac92df4a86d8923afd18b4f4f8e2c979f8a6277df"
 PATCHES="gertty-$portVersion.patchset"
 
@@ -38,58 +37,53 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\n\
-	cmd:gertty\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cmd:python$pythonVersion\n\
-	alembic_py_$pythonPackage\n\
-	dateutil_$pythonPackage\n\
-	gitpython_$pythonPackage\n\
-	mako_$pythonPackage\n\
-	pbr_$pythonPackage\n\
-	ply_$pythonPackage\n\
-	pyyaml_$pythonPackage\n\
-	requests_$pythonPackage\n\
-	sqlalchemy_$pythonPackage\n\
-	typing_extensions_$pythonPackage\n\
-	urwid_$pythonPackage\n\
-	voluptuous_$pythonPackage\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
+pythonVersion=3.10
+pythonPackage=python${pythonVersion//.}
+
+PROVIDES="
+	$portName = $portVersion
+	cmd:gertty = $portVersion
+	"
+REQUIRES="
+	haiku
+	cmd:python$pythonVersion
+	alembic_py_$pythonPackage
+	dateutil_$pythonPackage
+	gitpython_$pythonPackage
 	pbr_$pythonPackage
+	ply_$pythonPackage
+	pyyaml_$pythonPackage
 	requests_$pythonPackage
+	sqlalchemy_$pythonPackage
+	urwid_$pythonPackage
+	voluptuous_$pythonPackage
+	"
+BUILD_REQUIRES+="
+	pbr_$pythonPackage
 	setuptools_$pythonPackage
-	wheel_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
+	"
+BUILD_PREREQUIRES+="
 	cmd:python$pythonVersion
 	"
-done
+
+# gertty was built as a regular python package instead of a stand-alone util before.
+REPLACES="
+	gertty_python39
+	gertty_python310
+	"
+
+BUILD()
+{
+	python$pythonVersion setup.py build
+}
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
-		pythonVersion=${PYTHON_VERSIONS[$i]}
+	installLocation=$prefix/lib/$python/vendor-packages/
+	export PYTHONPATH=$installLocation:$PYTHONPATH
 
-		python=python$pythonVersion
-		installLocation=$prefix/lib/$python/vendor-packages/
-		export PYTHONPATH=$installLocation:$PYTHONPATH
-		mkdir -p $installLocation
-		rm -rf build
-		$python setup.py build install \
-			--root=/ --prefix=$prefix
+	mkdir -p $installLocation
 
-		packageEntries  $pythonPackage \
-			$prefix/lib/python* \
-			$prefix/bin \
-			$docDir
-	done
+	python$pythonVersion setup.py install \
+		--root=/ --prefix=$prefix --skip-build
 }


### PR DESCRIPTION
This is a stand-alone utility. No need to build it for multiple Python versions (switched to "default" Python 3.10).

Removed unneeded or indirect depedencies.

For example, `mako` is really a dependency of `alembic_py`. That package should be fixed instead of listing deps here (not sure what, if any, actually requires `typing-extensions`).

---

Draft for now, until `alembic_py` gets fixed, and I manage to test gertty against some real server.