### PR TITLE
guile 3.0: new version of guile

### DIFF
--- a/dev-scheme/guile/guile3.0-3.0.10.recipe
+++ b/dev-scheme/guile/guile3.0-3.0.10.recipe
@@ -1,0 +1,151 @@
+SUMMARY="Libraries for GNU Ubiquitous Intelligent Language for Extensions"
+SUMMARY_tools="Binaries for GNU Ubiquitous Intelligent Language for Extensions"
+DESCRIPTION="Guile is a library designed to help programmers create flexible \
+applications. Using Guile in an application allows programmers to write \
+plug-ins, or modules (there are many names, but the concept is essentially \
+the same) and users to use them to have an application fit their needs."
+HOMEPAGE="https://www.gnu.org/software/guile/"
+COPYRIGHT="1993-2024 Aubrey Jaffer, George Carrette, et al."
+LICENSE="GNU LGPL v3"
+REVISION="1"
+SOURCE_URI="https://ftpmirror.gnu.org/guile/guile-$portVersion.tar.gz
+	https://ftp.gnu.org/gnu/guile/guile-$portVersion.tar.gz"
+CHECKSUM_SHA256="2dbdbc97598b2faf31013564efb48e4fed44131d28e996c26abe8a5b23b56c2a"
+PATCHES="guile3.0-$portVersion.patchset"
+SOURCE_DIR="guile-$portVersion"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+relativeCommandBinDir=$relativeBinDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+	relativeCommandBinDir=bin
+fi
+
+libguileVersion="1.7.0"
+libguileVersionCompat="$libguileVersion compat >= ${libguileVersion%%.*}"
+portVersionCompat="$portVersion compat >= ${portVersion%%.*}"
+
+PROVIDES="
+	guile3.0$secondaryArchSuffix = $portVersionCompat
+	lib:libguile_3.0$secondaryArchSuffix = $libguileVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libffi$secondaryArchSuffix
+	lib:libgc$secondaryArchSuffix
+	lib:libgmp$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libltdl$secondaryArchSuffix
+	lib:libncurses$secondaryArchSuffix
+	lib:libreadline$secondaryArchSuffix
+	lib:libunistring$secondaryArchSuffix
+	"
+
+PROVIDES_tools="
+	guile3.0${secondaryArchSuffix}_tools = $portVersionCompat
+	cmd:guild_3.0$commandSuffix = $portVersion
+	cmd:guile_3.0$commandSuffix = $portVersion
+	cmd:guile_snarf_3.0$commandSuffix = $portVersion
+	cmd:guile_tools_3.0$commandSuffix = $portVersion
+	"
+REQUIRES_tools="
+	haiku$secondaryArchSuffix
+	guile3.0$secondaryArchSuffix == $portVersion base
+	lib:libffi$secondaryArchSuffix
+	lib:libgc$secondaryArchSuffix
+	lib:libgmp$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libltdl$secondaryArchSuffix
+	lib:libunistring$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	guile3.0${secondaryArchSuffix}_devel = $portVersionCompat
+	cmd:guile_config_3.0$commandSuffix = $portVersion
+	devel:libguile_3.0$secondaryArchSuffix = $libguileVersionCompat
+	"
+REQUIRES_devel="
+	guile3.0$secondaryArchSuffix == $portVersion base
+	guile3.0${secondaryArchSuffix}_tools == $portVersion
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libffi$secondaryArchSuffix
+	devel:libgc$secondaryArchSuffix
+	devel:libgmp$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
+	devel:libintl$secondaryArchSuffix
+	devel:libltdl$secondaryArchSuffix
+	devel:libncurses$secondaryArchSuffix
+	devel:libreadline$secondaryArchSuffix
+	devel:libunistring$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:gcc$secondaryArchSuffix
+	cmd:gperf
+	cmd:grep
+	cmd:make
+	cmd:ld
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:sed
+	"
+
+defineDebugInfoPackage guile3.0$secondaryArchSuffix \
+	$(getPackagePrefix tools)/"$relativeCommandBinDir"/guile-3.0 \
+	"$libDir"/libguile-3.0.so.$libguileVersion
+
+BUILD()
+{
+	CPPFLAGS="-D_BSD_SOURCE" LIBS="-lbsd -lnetwork" \
+	runConfigure --omit-dirs binDir ./configure \
+		--bindir=$commandBinDir \
+		--program-suffix=-3.0 \
+		--with-threads \
+		--with-included-regex \
+		--disable-static
+
+	# No MADV_DONTNEED, yet
+	sed --in-place '/HAVE_SYS_MMAN_H/d' config.h
+
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	rm -f "$libDir"/charset.alias
+	rm -f "$libDir"/lib*.la
+	rm -f "$libDir"/guile/3.0/extensions/*.la
+	rm -f "$libDir"/guile/3.0/extensions/*.a
+
+	prepareInstalledDevelLib libguile-3.0
+
+	fixPkgconfig
+
+	packageEntries tools \
+		"$commandBinDir"/guild-3.0 \
+		"$commandBinDir"/guile-3.0 \
+		"$commandBinDir"/guile-snarf-3.0 \
+		"$commandBinDir"/guile-tools-3.0 \
+		"$manDir"
+
+	packageEntries devel \
+		"$commandBinDir"/guile-config-3.0 \
+		"$dataDir"/aclocal \
+		"$developDir"
+}
+
+TEST()
+{
+	make check
+}

--- a/dev-scheme/guile/patches/guile3.0-3.0.10.patchset
+++ b/dev-scheme/guile/patches/guile3.0-3.0.10.patchset
@@ -1,0 +1,54 @@
+From d060dbae88a622330afe23860001e6e4ca242200 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zolt=C3=A1n=20Mizsei?= <zmizsei@extrowerk.com>
+Date: Thu, 22 Mar 2018 21:01:34 +0100
+Subject: Build fix
+
+
+diff --git a/libguile/posix.c b/libguile/posix.c
+index 9a873b5..3c106cb 100644
+--- a/libguile/posix.c
++++ b/libguile/posix.c
+@@ -475,11 +475,13 @@ SCM_DEFINE (scm_getgrgid, "getgr", 0, 1, 0,
+ 	  return SCM_BOOL_F;
+ 	}
+     }
+-  else if (scm_is_integer (name))
+-    SCM_SYSCALL (entry = getgrgid (scm_to_int (name)));
+-  else
++  else if (scm_is_integer (name)) {
++    SCM_SYSCALL (entry = getgrgid (scm_to_int (name))); 
++  }
++  else {
+     STRING_SYSCALL (name, c_name,
+-		    entry = getgrnam (c_name));
++		    entry = getgrnam (c_name)); 
++  }
+   if (!entry)
+     SCM_SYSERROR;
+ 
+-- 
+2.45.2
+
+
+From 4bc99ba7e22cf0501622a4ae05d6199e65c57c3f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
+Date: Sat, 10 Aug 2024 17:53:51 +0200
+Subject: avoid a static_assert not matching our definition of WEXITSTATUS
+
+
+diff --git a/libguile/posix.c b/libguile/posix.c
+index 3c106cb..cfcc14e 100644
+--- a/libguile/posix.c
++++ b/libguile/posix.c
+@@ -100,7 +100,7 @@
+ 
+ #ifndef W_EXITCODE
+ /* Macro for constructing a status value.  Found in glibc.  */
+-# ifdef _WIN32                            /* see Gnulib's posix-w32.h */
++# if defined(_WIN32) || defined(__HAIKU__)                            /* see Gnulib's posix-w32.h */
+ #  define W_EXITCODE(ret, sig)   (ret)
+ # else
+ #  define W_EXITCODE(ret, sig)   ((ret) << 8 | (sig))
+-- 
+2.45.2
+


### PR DESCRIPTION
This can be installed separately from guile 2.2 (and guile 1).

I added a "-3.0" suffix to the commands to avoid an otherwise unnecessary conflict on the _tools and _devel packages. The libraries are designed to allow side-by-side installation and contain that suffix anyway.

Or should we make this new version the "default" instead and add a suffix or conflicts to the tools in guile 2.2 instead?

The next version of lilypond (probably 2.26) will switch to guile 3.0 exclusively. The current version (2.24) could be built with guile 3.0, but 2.2 is still the recommended version.