### PR TITLE
setuptools_scm: drop importlib_metadata dependency.

### DIFF
--- a/dev-python/setuptools_scm/setuptools_scm-7.1.0.recipe
+++ b/dev-python/setuptools_scm/setuptools_scm-7.1.0.recipe
@@ -5,7 +5,7 @@ or in a SCM managed file."
 HOMEPAGE="https://github.com/pypa/setuptools_scm"
 COPYRIGHT="2015-2022 Ronny Pfannschmidt"
 LICENSE="MIT"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://pypi.io/packages/source/s/setuptools_scm/setuptools_scm-$portVersion.tar.gz"
 CHECKSUM_SHA256="6c508345a771aad7d56ebff0e70628bf2b0ec7573762be9960214730de278f27"
 
@@ -33,7 +33,6 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 		\""
 	eval "REQUIRES_$pythonPackage=\"
 		haiku
-		importlib_metadata_$pythonPackage # only for Python < 3.10
 		packaging_$pythonPackage
 		setuptools_$pythonPackage
 		tomli_$pythonPackage # only for Python < 3.11


### PR DESCRIPTION
Was only really needed for Python < 3.8.

Should fix #10809.