### PR TITLE
texinfo: fix compat versions

### DIFF
--- a/sys-apps/texinfo/texinfo-6.1.recipe
+++ b/sys-apps/texinfo/texinfo-6.1.recipe
@@ -4,25 +4,27 @@ Texinfo is the official documentation format of the GNU project."
 HOMEPAGE="http://www.gnu.org/software/texinfo/"
 COPYRIGHT="1992-2008 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3"
-REVISION="8"
+REVISION="9"
 SOURCE_URI="http://ftp.gnu.org/gnu/texinfo/texinfo-$portVersion.tar.gz"
 CHECKSUM_SHA256="02582b6d9b0552f1cb1312be6bd7023e9799603c3b2320fa68a36029e4cbafbb"
 PATCHES="texinfo-$portVersion.patchset"
 
 ARCHITECTURES="x86_gcc2"
 
+portVersionCompat="$portVersion compat >= ${portVersion%%.*}"
+
 PROVIDES="
-	texinfo = $portVersion compat >= 4
-	cmd:info = $portVersion compat >= 4
-	cmd:infokey = $portVersion compat >= 4
-	cmd:install_info = $portVersion compat >= 4
-	cmd:makeinfo = $portVersion compat >= 4
-	cmd:pdftexi2dvi = $portVersion compat >= 4
-	cmd:pod2texi = $portVersion compat >= 6
-	cmd:texi2any = $portVersion compat >= 6
-	cmd:texi2dvi = $portVersion compat >= 4
-	cmd:texi2pdf = $portVersion compat >= 4
-	cmd:texindex = $portVersion compat >= 4
+	texinfo = $portVersionCompat
+	cmd:info = $portVersionCompat
+	cmd:infokey = $portVersionCompat
+	cmd:install_info = $portVersionCompat
+	cmd:makeinfo = $portVersionCompat
+	cmd:pdftexi2dvi = $portVersionCompat
+	cmd:pod2texi = $portVersionCompat
+	cmd:texi2any = $portVersionCompat
+	cmd:texi2dvi = $portVersionCompat
+	cmd:texi2pdf = $portVersionCompat
+	cmd:texindex = $portVersionCompat
 	"
 REQUIRES="
 	haiku

--- a/sys-apps/texinfo/texinfo-7.1.recipe
+++ b/sys-apps/texinfo/texinfo-7.1.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="Texinfo is the official documentation format of the GNU project."
 HOMEPAGE="http://www.gnu.org/software/texinfo/"
 COPYRIGHT="1992-2023 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://ftp.gnu.org/gnu/texinfo/texinfo-$portVersion.tar.gz"
 CHECKSUM_SHA256="dd5710b3a53ac002644677a06145748e260592a35be182dc830ebebb79c5d5a0"
 PATCHES="texinfo-$portVersion.patchset"
@@ -19,18 +19,20 @@ if [ "$targetArchitecture" = x86_gcc2 ]; then
 	commandBinDir=$prefix/bin
 fi
 
+portVersionCompat="$portVersion compat >= ${portVersion%%.*}"
+
 PROVIDES="
-	texinfo$secondaryArchSuffix = $portVersion compat >= 4
-	cmd:info$commandSuffix = $portVersion compat >= 4
-	cmd:infokey$commandSuffix = $portVersion compat >= 4
-	cmd:install_info$commandSuffix = $portVersion compat >= 4
-	cmd:makeinfo$commandSuffix = $portVersion compat >= 4
-	cmd:pdftexi2dvi$commandSuffix = $portVersion compat >= 4
-	cmd:pod2texi$commandSuffix = $portVersion compat >= 6
-	cmd:texi2any$commandSuffix = $portVersion compat >= 6
-	cmd:texi2dvi$commandSuffix = $portVersion compat >= 4
-	cmd:texi2pdf$commandSuffix = $portVersion compat >= 4
-	cmd:texindex$commandSuffix = $portVersion compat >= 4
+	texinfo$secondaryArchSuffix = $portVersionCompat
+	cmd:info$commandSuffix = $portVersionCompat
+	cmd:infokey$commandSuffix = $portVersionCompat
+	cmd:install_info$commandSuffix = $portVersionCompat
+	cmd:makeinfo$commandSuffix = $portVersionCompat
+	cmd:pdftexi2dvi$commandSuffix = $portVersionCompat
+	cmd:pod2texi$commandSuffix = $portVersionCompat
+	cmd:texi2any$commandSuffix = $portVersionCompat
+	cmd:texi2dvi$commandSuffix = $portVersionCompat
+	cmd:texi2pdf$commandSuffix = $portVersionCompat
+	cmd:texindex$commandSuffix = $portVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix


### PR DESCRIPTION
This is needed to distinguish the two versions on x86.