### PR TITLE
libpostproc, depend on ffmpeg5_devel for now

### DIFF
--- a/media-libs/libpostproc/libpostproc-10~20172510.recipe
+++ b/media-libs/libpostproc/libpostproc-10~20172510.recipe
@@ -4,7 +4,7 @@ HOMEPAGE="https://github.com/lu-zero/postproc"
 COPYRIGHT="2012 Derek Buitenhuis
 	2017 Luca Barbato"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 srcGitRev="bea950e5011e71310dcc5683977ea217d32e5d7c"
 SOURCE_URI="https://github.com/lu-zero/postproc/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="19c6cf1844f81b5ebc0b354094df144120a2911736b3ff2d78af800d415f8052"
@@ -32,12 +32,12 @@ PROVIDES_devel="
 	"
 REQUIRES_devel="
 	libpostproc$secondaryArchSuffix == $portVersion base
-	devel:libavutil$secondaryArchSuffix
+	ffmpeg5${secondaryArchSuffix}_devel
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libavutil$secondaryArchSuffix
+	ffmpeg5${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
 	cmd:awk


### PR DESCRIPTION
Although old, seems to be still in use, so use ffmpeg5_devel for now.