### PR TITLE
Noto Sans CJK: Use variable width font

### DIFF
--- a/media-fonts/noto_sans_cjk/noto_sans_cjk-2.004.recipe
+++ b/media-fonts/noto_sans_cjk/noto_sans_cjk-2.004.recipe
@@ -6,38 +6,15 @@ especially when multiple styles and weights and even languages are mixed on \
 a page.
 
 This package supports Japanese, Korean and simple/traditional Chinese.
-Included are various weights and two 'monospaced' typefaces ('regular' and \
-'bold')."
+Included are the Sans and Monospace fonts as variable-width typefaces."
 HOMEPAGE="https://www.google.com/get/noto/"
-COPYRIGHT="2012 Google Inc."
+COPYRIGHT="2012-2021 Google Inc."
 LICENSE="SIL Open Font License v1.1"
-REVISION="1"
+REVISION="2"
 # Japanese
-SOURCE_URI="https://github.com/googlefonts/noto-cjk/releases/download/Sans$portVersion/06_NotoSansCJKjp.zip"
-CHECKSUM_SHA256="bf5b26feb83ee02533d4eb4a127bd90ed9d42bdd7ca7cb6e4030b2f21ef55cc5"
+SOURCE_URI="https://github.com/notofonts/noto-cjk/releases/download/Sans$portVersion/01_NotoSansCJK-OTF-VF.zip"
+CHECKSUM_SHA256="d5e33aebad9f8a0c0896a4a29199ef85ca966134db164426c74e83e6f13c43cd"
 SOURCE_DIR=""
-SOURCE_URI_2="https://github.com/googlefonts/noto-cjk/releases/download/Sans$portVersion/11_NotoSansMonoCJKjp.zip"
-CHECKSUM_SHA256_2="6c8faf475ce78fa37486dd5d8920e4bb4450b1b0f3c497edf3ba2d25cf52ab78"
-# Korean
-SOURCE_URI_3="https://github.com/googlefonts/noto-cjk/releases/download/Sans$portVersion/07_NotoSansCJKkr.zip"
-CHECKSUM_SHA256_3="e26fcf98e75176d24984875377ab921dbb46055b88ed4a39454d91d6146c5654"
-SOURCE_URI_4="https://github.com/googlefonts/noto-cjk/releases/download/Sans$portVersion/12_NotoSansMonoCJKkr.zip"
-CHECKSUM_SHA256_4="8c1368d3faac3c43991a91392fb73d985409ffe078cb731c7e303e226e4fd619"
-# Simplified Chinese
-SOURCE_URI_5="https://github.com/googlefonts/noto-cjk/releases/download/Sans$portVersion/08_NotoSansCJKsc.zip"
-CHECKSUM_SHA256_5="a927e56f53bd6c3b920bc139c0b94aa36c7d9ad0cf009b159437a1a003581140"
-SOURCE_URI_6="https://github.com/googlefonts/noto-cjk/releases/download/Sans$portVersion/13_NotoSansMonoCJKsc.zip"
-CHECKSUM_SHA256_6="e252c39994f8a278676507600a955663c23c24a7827dc63a4300b2f7b427cd5d"
-# Traditional Chinese
-SOURCE_URI_7="https://github.com/googlefonts/noto-cjk/releases/download/Sans$portVersion/09_NotoSansCJKtc.zip"
-CHECKSUM_SHA256_7="8ea0d6feb8e092c250710cdc75c138090832ddaa98d8ccb37cd89b03b72c331b"
-SOURCE_URI_8="https://github.com/googlefonts/noto-cjk/releases/download/Sans$portVersion/14_NotoSansMonoCJKtc.zip"
-CHECKSUM_SHA256_8="0126cbeef724edf21fbaeb113739adf392679fd90a2897c76159d1141df9e8c6"
-# Traditional Chinese Hongkong
-SOURCE_URI_9="https://github.com/googlefonts/noto-cjk/releases/download/Sans$portVersion/10_NotoSansCJKhk.zip"
-CHECKSUM_SHA256_9="f2a8ebfdb737a3dbfbbc501c2ad70a835b1c43c19f785d86bd5024607e069346"
-SOURCE_URI_10="https://github.com/googlefonts/noto-cjk/releases/download/Sans$portVersion/15_NotoSansMonoCJKhk.zip"
-CHECKSUM_SHA256_10="09a4df63660eee4ef0d1841566d9b4d63142f570847b965101d06ed8d67ded41"
 
 ARCHITECTURES="any"
 DISABLE_SOURCE_PACKAGE="yes"
@@ -91,7 +68,8 @@ INSTALL()
 	FONTDIR=$fontsDir/otfonts
 	mkdir -p ${FONTDIR}
 
-	cp ../sources*/*.otf ${FONTDIR}
+	cp Variable/OTF/Mono/NotoSansMonoCJK*-VF.otf ${FONTDIR}
+	cp Variable/OTF/NotoSansCJK*-VF.otf ${FONTDIR}
 
 	packageEntries jp \
 		${FONTDIR}/*CJKjp*.otf


### PR DESCRIPTION
We probably should add a new package with the fixed-width fonts for compatibility with applications that don't support variable-width fonts yet. (Haiku itself and Qt 6 should already, though.)