### PR TITLE
Qt5: look for SSL library with version 3 suffix

### DIFF
--- a/dev-qt/qt5/patches/qtbase-5.15.14.patchset
+++ b/dev-qt/qt5/patches/qtbase-5.15.14.patchset
@@ -1,5 +1,4 @@
-
-From 5d39eaa4c2578632be296d2cebbc4b830c77ccff Mon Sep 17 00:00:00 2001
+From 162eebac0d16049549b138401c9ba2a76bf3dd79 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Fran=C3=A7ois=20Revol?= <revol@free.fr>
 Date: Mon, 11 Feb 2019 15:53:49 +1000
 Subject: Make sure libs are searched in the develop/ dir by CMake
@@ -7,7 +6,7 @@ Subject: Make sure libs are searched in the develop/ dir by CMake
 Static libs at least are not in the lib[/x86] dirs...
 
 diff --git a/mkspecs/features/create_cmake.prf b/mkspecs/features/create_cmake.prf
-index 24ed125..52f637e 100644
+index 64639f1..42ad698 100644
 --- a/mkspecs/features/create_cmake.prf
 +++ b/mkspecs/features/create_cmake.prf
 @@ -112,6 +112,9 @@ win32:!static:!staticlib {
@@ -21,10 +20,10 @@ index 24ed125..52f637e 100644
      CMAKE_DLL_DIR = $$CMAKE_LIB_DIR
      CMAKE_DLL_DIR_IS_ABSOLUTE = $$CMAKE_LIB_DIR_IS_ABSOLUTE
 -- 
-2.28.0
+2.45.2
 
 
-From 3f3429604a1a48e23444cda1861526351da2bc10 Mon Sep 17 00:00:00 2001
+From 83f98bb3eeb34cca31d33a971dd3c5d8660c8481 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Mon, 11 Feb 2019 15:55:08 +1000
 Subject: Disable built-in haiku QPA plugin
@@ -46,9 +45,10 @@ index 23f838a..8ef1812 100644
  
  qtConfig(integrityfb): SUBDIRS += integrity
 -- 
-2.28.0
+2.45.2
 
-From 437c03637773374d1b084752c81860b7e3bbc766 Mon Sep 17 00:00:00 2001
+
+From fae20ebc004c913a5a99411715b89acffbab748a Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Mon, 11 Feb 2019 15:56:12 +1000
 Subject: Fix QStandartPaths for Haiku
@@ -108,20 +108,20 @@ index 044d69f..1f255a9 100644
      case GenericConfigLocation:
          paths += haikuStandardPath(B_SYSTEM_SETTINGS_DIRECTORY);
 -- 
-2.28.0
+2.45.2
 
 
-From 682592ede1decdfc17128e7d4e3837d3334fd89a Mon Sep 17 00:00:00 2001
+From eef708ff70cf863c17938ab0c034fa4ea4b4410f Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Mon, 11 Feb 2019 15:56:39 +1000
 Subject: QSslSocketPrivate::unixRootCertDirectories(): add ssl path for Haiku.
 
 
 diff --git a/src/network/ssl/qsslsocket.cpp b/src/network/ssl/qsslsocket.cpp
-index fbeb9de..02cc653 100644
+index 2a0b3a4..e0a1d6f 100644
 --- a/src/network/ssl/qsslsocket.cpp
 +++ b/src/network/ssl/qsslsocket.cpp
-@@ -2958,6 +2958,7 @@ QList<QByteArray> QSslSocketPrivate::unixRootCertDirectories()
+@@ -2963,6 +2963,7 @@ QList<QByteArray> QSslSocketPrivate::unixRootCertDirectories()
                                 << "/usr/local/ssl/certs/" // Solaris
                                 << "/etc/openssl/certs/" // BlackBerry
                                 << "/opt/openssl/certs/" // HP-UX
@@ -130,20 +130,20 @@ index fbeb9de..02cc653 100644
  }
  
 -- 
-2.28.0
+2.45.2
 
 
-From e19569f03ff18d11e985db17df76ae542b4f82d2 Mon Sep 17 00:00:00 2001
+From 56a4693f5855f2967256c8246e492c63dc7329c2 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Mon, 11 Feb 2019 15:56:59 +1000
 Subject: Fix build for Haiku platform
 
 
 diff --git a/mkspecs/features/toolchain.prf b/mkspecs/features/toolchain.prf
-index 9d790f6..55d156c 100644
+index 0c505fc..38fbe4f 100644
 --- a/mkspecs/features/toolchain.prf
 +++ b/mkspecs/features/toolchain.prf
-@@ -254,7 +254,7 @@ isEmpty($${target_prefix}.INCDIRS) {
+@@ -263,7 +263,7 @@ isEmpty($${target_prefix}.INCDIRS) {
                  }
              }
          }
@@ -153,10 +153,10 @@ index 9d790f6..55d156c 100644
              # or gold under Linux) will not print any library search path. Need to use another
              # invocation with different options (which in turn doesn't print include search
 -- 
-2.28.0
+2.45.2
 
 
-From f54915880945d5dcd7e79a85adb4d483c3f2c5e9 Mon Sep 17 00:00:00 2001
+From caa7088f601f85ccf9657c6a4e76d18552cabff2 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Mon, 11 Feb 2019 15:57:54 +1000
 Subject: Fix endian detection
@@ -180,10 +180,10 @@ index 9bb306e..9f0ea58 100644
  #    endif
  #  endif
 -- 
-2.28.0
+2.45.2
 
 
-From 4c650b583fea535c61bf2f71f44f6ef7582032b8 Mon Sep 17 00:00:00 2001
+From 42d5ca1bb1bf9a8ac6af68855f4b3e73b8306dac Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Sat, 27 Apr 2019 17:47:23 +1000
 Subject: Add dnslookup query function for Haiku
@@ -268,17 +268,17 @@ index 0000000..0b387df
 +
 +QT_END_NAMESPACE
 -- 
-2.28.0
+2.45.2
 
 
-From b378401733f24ec8666c2d88c6985d47341f88f5 Mon Sep 17 00:00:00 2001
+From b12bf7f7635d6d19e5ab3c8702d5de8ad6e29a42 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Wed, 27 May 2020 19:54:30 +1000
 Subject: Disable LibResolv for Haiku
 
 
 diff --git a/src/network/kernel/qhostinfo_unix.cpp b/src/network/kernel/qhostinfo_unix.cpp
-index 9b0a2ee..480671b 100644
+index 73679c9..73ce64c 100644
 --- a/src/network/kernel/qhostinfo_unix.cpp
 +++ b/src/network/kernel/qhostinfo_unix.cpp
 @@ -87,7 +87,7 @@ typedef void (*res_nclose_proto)(res_state_ptr);
@@ -291,17 +291,17 @@ index 9b0a2ee..480671b 100644
  struct LibResolv
  {
 -- 
-2.28.0
+2.45.2
 
 
-From 3c308f71240c494fe3f3131614d1ec71b8ba1d13 Mon Sep 17 00:00:00 2001
+From a5369dfc5f06af29695bfceaec19d38688a40259 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Sun, 8 Sep 2019 00:17:19 +1000
 Subject: Don't use ifaddrs for Haiku
 
 
 diff --git a/src/network/kernel/qnetworkinterface_unix.cpp b/src/network/kernel/qnetworkinterface_unix.cpp
-index 4c57bff..0c8e38f 100644
+index e7889b6..1036ead 100644
 --- a/src/network/kernel/qnetworkinterface_unix.cpp
 +++ b/src/network/kernel/qnetworkinterface_unix.cpp
 @@ -51,7 +51,7 @@
@@ -314,10 +314,10 @@ index 4c57bff..0c8e38f 100644
  #endif
  
 -- 
-2.28.0
+2.45.2
 
 
-From 09d34cea1ca67bb36367710d0d2dcabeb30a4f10 Mon Sep 17 00:00:00 2001
+From 263eb1866affb5d20dff84da8127678cc08887f7 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Sun, 8 Sep 2019 18:32:05 +1000
 Subject: Add platform plugins installer
@@ -336,7 +336,7 @@ index 20372d9..803e9b7 100644
  CONFIG += simd optimize_full
  
 diff --git a/src/gui/kernel/qguiapplication.cpp b/src/gui/kernel/qguiapplication.cpp
-index 239a783..8bdb7f6 100644
+index c7ff2a6..4d83bdc 100644
 --- a/src/gui/kernel/qguiapplication.cpp
 +++ b/src/gui/kernel/qguiapplication.cpp
 @@ -116,6 +116,11 @@
@@ -380,18 +380,17 @@ index 239a783..8bdb7f6 100644
          // Windows: Display message box unless it is a console application
          // or debug build showing an assert box.
 -- 
-2.28.0
+2.45.2
 
 
-
-From 61e1c632163e47eb6fe825084ba459b55010c687 Mon Sep 17 00:00:00 2001
+From d29dcbdeff35fb4bbf7b4098dd974b5298799738 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Wed, 27 May 2020 19:54:58 +1000
 Subject: Disable sharedmemory feature for bootstrap
 
 
 diff --git a/src/tools/bootstrap/bootstrap.pro b/src/tools/bootstrap/bootstrap.pro
-index c212ccb..1a31b62 100644
+index 24862a0..0d6df52 100644
 --- a/src/tools/bootstrap/bootstrap.pro
 +++ b/src/tools/bootstrap/bootstrap.pro
 @@ -11,7 +11,8 @@ MODULE_DEFINES = \
@@ -405,10 +404,10 @@ index c212ccb..1a31b62 100644
  
  DEFINES += \
 -- 
-2.28.0
+2.45.2
 
 
-From 05f9feef7a57b1dd03b62c0e9190fecd63603a49 Mon Sep 17 00:00:00 2001
+From 6f413c134e7cd49c37bedafaba19b275ff6c10b2 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Sun, 29 Dec 2019 18:13:19 +1000
 Subject: Fix build for x86_gcc2
@@ -428,10 +427,10 @@ index b663b8a..5ad2b12 100644
          /* release the child */
  #ifdef HAVE_EVENTFD
 -- 
-2.28.0
+2.45.2
 
 
-From d9fb34037c2500d55ee24212110360127d9e8994 Mon Sep 17 00:00:00 2001
+From bf11f042898f8e98d74ace015d8f18859dbf0f2b Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Thu, 4 Jun 2020 23:11:17 +1000
 Subject: Implement QFilesystemWatcher for Haiku
@@ -824,20 +823,20 @@ index 0000000..8a8d75a
 +#endif // QFILESYSTEMWATCHER_HAIKU_P_H
 +
 -- 
-2.28.0
+2.45.2
 
 
-From 99c3380949601083a8b194b9d6bb70d2d68a8fdd Mon Sep 17 00:00:00 2001
+From 3609bcacf7af5d7f0f15f9a29999b2188deb2865 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Tue, 16 Jun 2020 18:06:57 +1000
 Subject: Don't use AF_INET6 for new sockets
 
 
 diff --git a/src/network/socket/qnativesocketengine_unix.cpp b/src/network/socket/qnativesocketengine_unix.cpp
-index e5b9fbb..a1b1fc4 100644
+index feb102b..07b65cc 100644
 --- a/src/network/socket/qnativesocketengine_unix.cpp
 +++ b/src/network/socket/qnativesocketengine_unix.cpp
-@@ -265,8 +265,12 @@ bool QNativeSocketEnginePrivate::createNewSocket(QAbstractSocket::SocketType soc
+@@ -266,8 +266,12 @@ bool QNativeSocketEnginePrivate::createNewSocket(QAbstractSocket::SocketType soc
      }
      int protocol = 0;
  #endif // QT_NO_SCTP
@@ -851,17 +850,17 @@ index e5b9fbb..a1b1fc4 100644
  
      int socket = qt_safe_socket(domain, type, protocol, O_NONBLOCK);
 -- 
-2.28.0
+2.45.2
 
 
-From cd28dcebb36aedacc5f826acd30c6ba6c5f24286 Mon Sep 17 00:00:00 2001
+From 52ddd48661bf19773ebb1a43d9696cc32ca21c60 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Mon, 5 Oct 2020 19:40:40 +1000
 Subject: Disable Haswell CPU feature for plugins
 
 
 diff --git a/src/corelib/plugin/qlibrary_unix.cpp b/src/corelib/plugin/qlibrary_unix.cpp
-index a5c72f8..cc2afac 100644
+index 5cd21b6..2de224d 100644
 --- a/src/corelib/plugin/qlibrary_unix.cpp
 +++ b/src/corelib/plugin/qlibrary_unix.cpp
 @@ -191,7 +191,7 @@ bool QLibraryPrivate::load_sys()
@@ -874,10 +873,10 @@ index a5c72f8..cc2afac 100644
          auto transform = [](QStringList &list, void (*f)(QString *)) {
              QStringList tmp;
 -- 
-2.28.0
+2.45.2
 
 
-From d7e8622c4b1b6246c80a54c0c84dc164ea8afeac Mon Sep 17 00:00:00 2001
+From dfb96d82878f846fed5d90448122fe5a55fde6fc Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Sat, 9 Oct 2021 18:33:27 +1000
 Subject: QSharedMemory implementation for Haiku
@@ -938,7 +937,7 @@ index 2d65e0b..8fd63d1 100644
  #else
 diff --git a/src/corelib/kernel/qsharedmemory_haiku.cpp b/src/corelib/kernel/qsharedmemory_haiku.cpp
 new file mode 100644
-index 0000000..afc24ed
+index 0000000..b404b8b
 --- /dev/null
 +++ b/src/corelib/kernel/qsharedmemory_haiku.cpp
 @@ -0,0 +1,183 @@
@@ -1126,10 +1125,10 @@ index 0000000..afc24ed
 +
 +#endif // QT_NO_SHAREDMEMORY
 diff --git a/src/corelib/kernel/qsharedmemory_p.h b/src/corelib/kernel/qsharedmemory_p.h
-index e6e989a..dbf32b6 100644
+index 0c13375..172ca95 100644
 --- a/src/corelib/kernel/qsharedmemory_p.h
 +++ b/src/corelib/kernel/qsharedmemory_p.h
-@@ -72,10 +72,14 @@ namespace QSharedMemoryPrivate
+@@ -78,10 +78,14 @@ QT_END_NAMESPACE
  # include "private/qobject_p.h"
  #endif
  
@@ -1145,7 +1144,7 @@ index e6e989a..dbf32b6 100644
  QT_BEGIN_NAMESPACE
  
  #ifndef QT_NO_SYSTEMSEMAPHORE
-@@ -138,6 +142,8 @@ public:
+@@ -144,6 +148,8 @@ public:
              const QString &prefix = QLatin1String("qipc_sharedmemory_"));
  #ifdef Q_OS_WIN
      Qt::HANDLE handle();
@@ -1154,7 +1153,7 @@ index e6e989a..dbf32b6 100644
  #elif defined(QT_POSIX_IPC)
      int handle();
  #else
-@@ -165,6 +171,8 @@ public:
+@@ -171,6 +177,8 @@ public:
  private:
  #ifdef Q_OS_WIN
      Qt::HANDLE hand;
@@ -1164,17 +1163,14 @@ index e6e989a..dbf32b6 100644
      int hand;
  #else
 -- 
-2.30.2
+2.45.2
 
-From eae7d61615b76c6459747505a13d0b0fa85f4270 Mon Sep 17 00:00:00 2001
+
+From 17e4477201bf92163c76078a0f999eaf155872cd Mon Sep 17 00:00:00 2001
 From: PulkoMandy <pulkomandy@pulkomandy.tk>
 Date: Sat, 10 Aug 2024 17:05:17 +0200
-Subject: [PATCH] Fix build on Haiku R1/beta5
+Subject: Fix build on Haiku R1/beta5
 
----
- src/corelib/io/forkfd_qt.cpp     | 4 ++++
- src/network/kernel/qhostinfo.cpp | 2 ++
- 2 files changed, 6 insertions(+)
 
 diff --git a/src/corelib/io/forkfd_qt.cpp b/src/corelib/io/forkfd_qt.cpp
 index cf44874..8a0938d 100644
@@ -1203,6 +1199,40 @@ index 0159636..7ca58a4 100644
  #include "qhostinfo.h"
  #include "qhostinfo_p.h"
  #include <qplatformdefs.h>
+-- 
+2.45.2
+
+
+From 15e10a741f4254fa99ab6861edd3d3f627fce2a8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
+Date: Fri, 23 Aug 2024 20:30:08 +0200
+Subject: SSL: try opening with OPENSSL_SHLIB_VERSION version number
+
+Version 3 removed SHLIB_VERSION_NUMBER and now has OPENSSL_SHLIB_VERSION.
+
+diff --git a/src/network/ssl/qsslsocket_openssl_symbols.cpp b/src/network/ssl/qsslsocket_openssl_symbols.cpp
+index 6a9a3ef..6a24bfc 100644
+--- a/src/network/ssl/qsslsocket_openssl_symbols.cpp
++++ b/src/network/ssl/qsslsocket_openssl_symbols.cpp
+@@ -767,6 +767,18 @@ static LoadedOpenSsl loadOpenSsl()
+         libcrypto->unload();
+     }
+ #endif
++#if defined(OPENSSL_SHLIB_VERSION) && !defined(Q_OS_QNX) // on QNX, the libs are always libssl.so and libcrypto.so
++    // still first attempt: version 3 removed SHLIB_VERSION_NUMBER and has OPENSSL_SHLIB_VERSION
++    libssl->setFileNameAndVersion(QLatin1String("ssl"), OPENSSL_SHLIB_VERSION);
++    libcrypto->setFileNameAndVersion(QLatin1String("crypto"), OPENSSL_SHLIB_VERSION);
++    if (libcrypto->load() && libssl->load()) {
++        // libssl.so.<OPENSSL_SHLIB_VERSION> and libcrypto.so.<OPENSSL_SHLIB_VERSION> found
++        return result;
++    } else {
++        libssl->unload();
++        libcrypto->unload();
++    }
++#endif
+ 
+ #ifndef Q_OS_DARWIN
+     // second attempt: find the development files libssl.so and libcrypto.so
 -- 
 2.45.2
 

--- a/dev-qt/qt5/qt5-5.15.14.recipe
+++ b/dev-qt/qt5/qt5-5.15.14.recipe
@@ -8,7 +8,7 @@ COPYRIGHT="2015-2020 The Qt Company Ltd."
 LICENSE="GNU LGPL v2.1
 	GNU LGPL v3
 	FDL"
-REVISION="2"
+REVISION="3"
 #baseURL="https://download.qt.io/official_releases/qt/${portVersion%.*}/$portVersion/submodules"
 baseURL="http://qt-mirror.dannhauer.de/official_releases/qt/${portVersion%.*}/$portVersion/submodules/"
 SOURCE_URI="https://github.com/qt/qt5/archive/v$portVersion-lts-lgpl.tar.gz"


### PR DESCRIPTION
Fixes #10836 and #10818

Only built and tested on a recent x86_64 nightly with openssl3.

Just below the changed lines, the typical unix lib paths are added, maybe those should also be changed to finddir calls for Haiku.