### PR TITLE
lxml: update to version 5.3.0.

### DIFF
--- a/dev-python/lxml/lxml-5.3.0.recipe
+++ b/dev-python/lxml/lxml-5.3.0.recipe
@@ -13,9 +13,9 @@ LICENSE="BSD (3-clause)
 	ElementTree
 	GNU GPL v2
 	PSF-2"
-REVISION="6"
+REVISION="1"
 SOURCE_URI="https://github.com/lxml/lxml/releases/download/lxml-$portVersion/lxml-$portVersion.tar.gz"
-CHECKSUM_SHA256="fe749b052bb7233fe5d072fcb549221a8cb1a16725c47c37e42b0b9cb3ff2c3f"
+CHECKSUM_SHA256="4e109ca30d1edec1ac60cdbe341905dc3b8f55b16855e03a54aaf59e51ec8c6f"
 SOURCE_DIR="lxml-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"


### PR DESCRIPTION
Fix crash on "import lxml.etree" related to calling xmlInitParser() too late. See: https://github.com/lxml/lxml/pull/370

---

Tested `lxml_python39` with `Sigil` (loaded even an almost 20 MB .epub), and `lxml_python310` with `hp --test gtk_doc`.

The latter has one test failing, but that's the same case with the older lxml 4.9.1.

Didn't tested with Calibre because it has way too many depedencies for my taste.