### PR TITLE
argparse-manpage: new python recipe

### DIFF
--- a/dev-python/argparse-manpage/argparse_manpage-4.6.recipe
+++ b/dev-python/argparse-manpage/argparse_manpage-4.6.recipe
@@ -1,0 +1,108 @@
+SUMMARY="Automatically build man-pages for your Python project"
+DESCRIPTION="Avoid documenting your Python script arguments on two places! This is typically done \
+in an argparse.ArgumentParser help configuration (help=, description=, etc.), and also in a \
+manually crafted manual page.
+
+The good thing about an ArgumentParser objects is that it actually provides a traversable \
+\"tree-like\" structure, with all the necessary info needed to automatically generate \
+documentation, for example in a groff typesetting system (manual pages). And this is where this \
+project can help.
+
+There are two supported ways to generate the manual, either script it using the installed command \
+argparse-manpage, or via setup.py build automation (with a slight bonus of automatic manual page \
+installation with setup.py install)."
+HOMEPAGE="https://github.com/praiskup/argparse-manpage"
+COPYRIGHT="Gabriele Giammatteo
+	Pavel Raiskup"
+LICENSE="Apache v2"
+REVISION="1"
+SOURCE_URI="https://github.com/praiskup/argparse-manpage/releases/download/v$portVersion/argparse-manpage-$portVersion.tar.gz"
+CHECKSUM_SHA256="0b659d70fd142876da41c2918bd6de4d027875720b0e4672d6443b51198dbb62"
+SOURCE_DIR="argparse-manpage-$portVersion"
+
+ARCHITECTURES="any"
+
+PROVIDES="
+	$portName = $portVersion
+	"
+REQUIRES="
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+
+PYTHON_VERSIONS=(3.10)
+defaultVersion=3.10
+for i in "${!PYTHON_VERSIONS[@]}"; do
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
+
+	eval "PROVIDES_$pythonPackage=\"
+		${portName}_$pythonPackage = $portVersion
+		cmd:argparse_manpage_$pythonVersion = $portVersion
+		\""
+
+	if [ $pythonVersion = $defaultVersion ]; then
+		eval "PROVIDES_$pythonPackage+=\"
+			cmd:argparse_manpage = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cmd:python$pythonVersion
+		\""
+
+	BUILD_REQUIRES+="
+		build_$pythonPackage
+		installer_$pythonPackage
+		setuptools_$pythonPackage
+		wheel_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
+done
+
+PATCH()
+{
+	sed -i "s,share/man,$relativeManDir,g" build_manpages/build_manpages.py
+}
+
+INSTALL()
+{
+	for i in "${!PYTHON_VERSIONS[@]}"; do
+		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
+
+		python=python$pythonVersion
+
+		$python -m build --wheel --skip-dependency-check --no-isolation
+		$python -m installer -p $prefix dist/*.whl
+
+		# Version suffix all the scripts and man pages
+		for f in $binDir/*; do
+			mv $f $f-$pythonVersion
+		done
+		for f in $manDir/man1/*; do
+			mv $f ${f%.1}-$pythonVersion.1
+		done
+
+		# And provide suffix-less symlinks for the default version
+		if [ $pythonVersion = $defaultVersion ]; then
+			for f in $binDir/*; do
+				ln -sr $f ${f%-$pythonVersion}
+			done
+			for f in $manDir/man1/*; do
+				ln -sr $f ${f%-$pythonVersion.1}.1
+			done
+		fi
+
+		packageEntries $pythonPackage \
+			$prefix/lib/python* \
+			$binDir \
+			$manDir
+	done
+}


### PR DESCRIPTION
This is needed for the new version of [psutils](https://github.com/rrthomas/psutils).

Versions < 3 of psutils were written in C and Perl, for version 3 they were rewritten in Python. Currently they are shipped as part of texlive_core (in version 1.23) but I would like to "unbundle" them.

As I'm not that skilled with python recipes yet, could someone please review this? @OscarL 