### PR TITLE
libass: upgrade to 0.17.3 and enable libunibreak

### DIFF
--- a/media-libs/libass/libass-0.17.3.recipe
+++ b/media-libs/libass/libass-0.17.3.recipe
@@ -2,22 +2,32 @@ SUMMARY="Library for SSA/ASS subtitles rendering"
 DESCRIPTION="Libass is a portable subtitle renderer for the ASS/SSA (Advanced \
 Substation Alpha/Substation Alpha) subtitle format."
 HOMEPAGE="https://github.com/libass/libass"
-COPYRIGHT="2006-2021 libass contributors
+COPYRIGHT="2006-2022 libass contributors
 	2006 Evgeniy Stepanov
 	2011-2014 Yu Zhuohuang
-	2013 Rodger Combs
-	2015 Grigori Goronzy
-	2016 Oleg Oshmyan
-	2016 Vabishchevich Nikolay"
+	2013-2021 rcombs
+	2009-2015 Grigori Goronzy
+	2015-2016 Oleg Oshmyan
+	2014-2017 Vabishchevich Nikolay
+	2005-2024 x264 project
+	2013 Stefano Pigozzi
+	2015 Stephan Vedder
+	1994 Sun Microsystems Inc
+	1988-1993 The Regents of the University of California
+	2015-2018 Janne Grunau
+	2015 Martin Storsjo
+	2018 Two Orioles LLC
+	2018 VideoLAN and dav1d authors
+	2021 王一 Wang Yi"
 LICENSE="ISC"
 REVISION="1"
 SOURCE_URI="https://github.com/libass/libass/releases/download/$portVersion/libass-$portVersion.tar.xz"
-CHECKSUM_SHA256="f0da0bbfba476c16ae3e1cfd862256d30915911f7abaa1b16ce62ee653192784"
+CHECKSUM_SHA256="eae425da50f0015c21f7b3a9c7262a910f0218af469e22e2931462fed3c50959"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
-libVersion="9.2.1"
+libVersion="9.3.1"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="

--- a/media-libs/libass/libass-0.17.3.recipe
+++ b/media-libs/libass/libass-0.17.3.recipe
@@ -43,6 +43,7 @@ REQUIRES="
 	lib:libgraphite2$secondaryArchSuffix # required by harfbuzz
 	lib:libharfbuzz$secondaryArchSuffix
 	lib:libiconv$secondaryArchSuffix
+	lib:libunibreak$secondaryArchSuffix
 	lib:libintl$secondaryArchSuffix # required by fontconfig
 	lib:libpng16$secondaryArchSuffix # required by freetype
 	lib:libxml2$secondaryArchSuffix # required by fontconfig
@@ -58,6 +59,7 @@ REQUIRES_devel="
 	devel:libfontconfig$secondaryArchSuffix
 	devel:libfribidi$secondaryArchSuffix
 	devel:libharfbuzz$secondaryArchSuffix
+	devel:libunibreak$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
@@ -66,6 +68,7 @@ BUILD_REQUIRES="
 	devel:libfreetype$secondaryArchSuffix
 	devel:libfribidi$secondaryArchSuffix
 	devel:libharfbuzz$secondaryArchSuffix
+	devel:libunibreak$secondaryArchSuffix
 	devel:libiconv$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="


### PR DESCRIPTION
I’m not sure if revision should be bumped if the change is part of the same PR as a version bump; for now i included a bump so both commits also work in isolation