### PR TITLE
vice_libretro: new recipe

### DIFF
--- a/games-emulation/vice_libretro/additional-files/vice_x128_libretro.info.in
+++ b/games-emulation/vice_libretro/additional-files/vice_x128_libretro.info.in
@@ -1,0 +1,51 @@
+# Software Information
+display_name = "Commodore - C128 (VICE x128)"
+categories = "Emulator"
+authors = "VICE Team"
+corename = "VICE x128"
+supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vfl|vsf|nib|nbz|d2m|d4m"
+license = "GPLv2"
+permissions = ""
+display_version = "@DISPLAY_VERSION@"
+
+# Hardware Information
+manufacturer = "Commodore"
+systemname = "C128"
+systemid = "commodore_c128"
+
+# Libretro Features
+database = "Commodore - 64"
+supports_no_game = "true"
+savestate = "true"
+savestate_features = "serialized"
+cheats = "true"
+input_descriptors = "true"
+memory_descriptors = "true"
+libretro_saves = "true"
+core_options = "true"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "true"
+disk_control = "true"
+is_experimental = "false"
+
+# Firmware
+firmware_count = 5
+firmware0_desc = "vice/JiffyDOS_C128.bin (JiffyDOS C128 Kernal)"
+firmware0_path = "vice/JiffyDOS_C128.bin"
+firmware0_opt = "true"
+firmware1_desc = "vice/JiffyDOS_C64.bin (JiffyDOS C64 Kernal)"
+firmware1_path = "vice/JiffyDOS_C64.bin"
+firmware1_opt = "true"
+firmware2_desc = "vice/JiffyDOS_1541-II.bin (JiffyDOS 1541 drive BIOS)"
+firmware2_path = "vice/JiffyDOS_1541-II.bin"
+firmware2_opt = "true"
+firmware3_desc = "vice/JiffyDOS_1571_repl310654.bin (JiffyDOS 1571 drive BIOS)"
+firmware3_path = "vice/JiffyDOS_1571_repl310654.bin"
+firmware3_opt = "true"
+firmware4_desc = "vice/JiffyDOS_1581.bin (JiffyDOS 1581 drive BIOS)"
+firmware4_path = "vice/JiffyDOS_1581.bin"
+firmware4_opt = "true"
+notes = "(!) JiffyDOS_C128.bin (md5): cbbd1bbcb5e4fd8046b6030ab71fc021|(!) JiffyDOS_C64.bin (md5): be09394f0576cf81fa8bacf634daf9a2|(!) JiffyDOS_1541-II.bin (md5): 1b1e985ea5325a1f46eb7fd9681707bf|(!) JiffyDOS_1571_repl310654.bin (md5): 41c6cc528e9515ffd0ed9b180f8467c0|(!) JiffyDOS_1581.bin (md5): 20b6885c6dc2d42c38754a365b043d71"
+
+description = "The VICE x128 Commodore 64 emulator, isolated and ported to libretro. This core features a complete emulation of the internal MMU (Memory Management Unit), 80 column VDC screen, fast IEC bust emulation, 2 HMz mode, Z80 emulation plus all the features of the other VICE C64 emulation."

--- a/games-emulation/vice_libretro/additional-files/vice_x64_libretro.info.in
+++ b/games-emulation/vice_libretro/additional-files/vice_x64_libretro.info.in
@@ -1,0 +1,48 @@
+# Software Information
+display_name = "Commodore - C64 (VICE x64, fast)"
+categories = "Emulator"
+authors = "VICE Team"
+corename = "VICE x64"
+supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vfl|vsf|nib|nbz|d2m|d4m"
+license = "GPLv2"
+permissions = ""
+display_version = "@DISPLAY_VERSION@"
+
+# Hardware Information
+manufacturer = "Commodore"
+systemname = "C64"
+systemid = "commodore_c64"
+
+# Libretro Features
+database = "Commodore - 64"
+supports_no_game = "true"
+savestate = "true"
+savestate_features = "serialized"
+cheats = "true"
+input_descriptors = "true"
+memory_descriptors = "true"
+libretro_saves = "true"
+core_options = "true"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "true"
+disk_control = "true"
+is_experimental = "false"
+
+# Firmware
+firmware_count = 4
+firmware0_desc = "vice/JiffyDOS_C64.bin (JiffyDOS C64 Kernal)"
+firmware0_path = "vice/JiffyDOS_C64.bin"
+firmware0_opt = "true"
+firmware1_desc = "vice/JiffyDOS_1541-II.bin (JiffyDOS 1541 drive BIOS)"
+firmware1_path = "vice/JiffyDOS_1541-II.bin"
+firmware1_opt = "true"
+firmware2_desc = "vice/JiffyDOS_1571_repl310654.bin (JiffyDOS 1571 drive BIOS)"
+firmware2_path = "vice/JiffyDOS_1571_repl310654.bin"
+firmware2_opt = "true"
+firmware3_desc = "vice/JiffyDOS_1581.bin (JiffyDOS 1581 drive BIOS)"
+firmware3_path = "vice/JiffyDOS_1581.bin"
+firmware3_opt = "true"
+notes = "(!) JiffyDOS_C64.bin (md5): be09394f0576cf81fa8bacf634daf9a2|(!) JiffyDOS_1541-II.bin (md5): 1b1e985ea5325a1f46eb7fd9681707bf|(!) JiffyDOS_1571_repl310654.bin (md5): 41c6cc528e9515ffd0ed9b180f8467c0|(!) JiffyDOS_1581.bin (md5): 20b6885c6dc2d42c38754a365b043d71"
+
+description = "The VICE x64 (fast) Commodore 64 emulator, isolated and ported to libretro. This core features a fairly complete emulation of the VIC-II video chip, with all sprites, registers and video modes emulated in a fully cycle-accurate manner. However, the 'x64sc' core's VIC-II emulation is both cycle-based and pixel-accurate, making it a better choice for devices powerful enough to run it. Both cores include options to switch between the original 'fastSID' sound chip emulation and the slower but much more accurate 'reSID' module."

--- a/games-emulation/vice_libretro/additional-files/vice_x64dtv_libretro.info.in
+++ b/games-emulation/vice_libretro/additional-files/vice_x64dtv_libretro.info.in
@@ -1,0 +1,48 @@
+# Software Information
+display_name = "Commodore - C64DTV (VICE x64dtv)"
+categories = "Emulator"
+authors = "VICE Team"
+corename = "VICE x64dtv"
+supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vfl|vsf|nib|nbz|d2m|d4m"
+license = "GPLv2"
+permissions = ""
+display_version = "@DISPLAY_VERSION@"
+
+# Hardware Information
+manufacturer = "Commodore"
+systemname = "C64DTV"
+systemid = "commodore_c64dtv"
+
+# Libretro Features
+database = "Commodore - 64"
+supports_no_game = "true"
+savestate = "true"
+savestate_features = "serialized"
+cheats = "true"
+input_descriptors = "true"
+memory_descriptors = "true"
+libretro_saves = "true"
+core_options = "true"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "true"
+disk_control = "true"
+is_experimental = "false"
+
+# Firmware
+firmware_count = 4
+firmware0_desc = "vice/JiffyDOS_C64.bin (JiffyDOS C64 Kernal)"
+firmware0_path = "vice/JiffyDOS_C64.bin"
+firmware0_opt = "true"
+firmware1_desc = "vice/JiffyDOS_1541-II.bin (JiffyDOS 1541 drive BIOS)"
+firmware1_path = "vice/JiffyDOS_1541-II.bin"
+firmware1_opt = "true"
+firmware2_desc = "vice/JiffyDOS_1571_repl310654.bin (JiffyDOS 1571 drive BIOS)"
+firmware2_path = "vice/JiffyDOS_1571_repl310654.bin"
+firmware2_opt = "true"
+firmware3_desc = "vice/JiffyDOS_1581.bin (JiffyDOS 1581 drive BIOS)"
+firmware3_path = "vice/JiffyDOS_1581.bin"
+firmware3_opt = "true"
+notes = "(!) JiffyDOS_C64.bin (md5): be09394f0576cf81fa8bacf634daf9a2|(!) JiffyDOS_1541-II.bin (md5): 1b1e985ea5325a1f46eb7fd9681707bf|(!) JiffyDOS_1571_repl310654.bin (md5): 41c6cc528e9515ffd0ed9b180f8467c0|(!) JiffyDOS_1581.bin (md5): 20b6885c6dc2d42c38754a365b043d71"
+
+description = "The VICE C64 Direct-to-TV emulator, isolated and ported to libretro. The C64DTV emulator, called `x64dtv', features emulation of C64DTV revisions 2 and 3. The emulator is under construction, but most of the DTV specific features are already supported (with varying accuracy). "

--- a/games-emulation/vice_libretro/additional-files/vice_x64sc_libretro.info.in
+++ b/games-emulation/vice_libretro/additional-files/vice_x64sc_libretro.info.in
@@ -1,0 +1,48 @@
+# Software Information
+display_name = "Commodore - C64 (VICE x64sc, accurate)"
+categories = "Emulator"
+authors = "VICE Team"
+corename = "VICE x64sc"
+supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vfl|vsf|nib|nbz|d2m|d4m"
+license = "GPLv2"
+permissions = ""
+display_version = "@DISPLAY_VERSION@"
+
+# Hardware Information
+manufacturer = "Commodore"
+systemname = "C64"
+systemid = "commodore_c64"
+
+# Libretro Features
+database = "Commodore - 64"
+supports_no_game = "true"
+savestate = "true"
+savestate_features = "serialized"
+cheats = "true"
+input_descriptors = "true"
+memory_descriptors = "true"
+libretro_saves = "true"
+core_options = "true"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "true"
+disk_control = "true"
+is_experimental = "false"
+
+# Firmware
+firmware_count = 4
+firmware0_desc = "vice/JiffyDOS_C64.bin (JiffyDOS C64 Kernal)"
+firmware0_path = "vice/JiffyDOS_C64.bin"
+firmware0_opt = "true"
+firmware1_desc = "vice/JiffyDOS_1541-II.bin (JiffyDOS 1541 drive BIOS)"
+firmware1_path = "vice/JiffyDOS_1541-II.bin"
+firmware1_opt = "true"
+firmware2_desc = "vice/JiffyDOS_1571_repl310654.bin (JiffyDOS 1571 drive BIOS)"
+firmware2_path = "vice/JiffyDOS_1571_repl310654.bin"
+firmware2_opt = "true"
+firmware3_desc = "vice/JiffyDOS_1581.bin (JiffyDOS 1581 drive BIOS)"
+firmware3_path = "vice/JiffyDOS_1581.bin"
+firmware3_opt = "true"
+notes = "(!) JiffyDOS_C64.bin (md5): be09394f0576cf81fa8bacf634daf9a2|(!) JiffyDOS_1541-II.bin (md5): 1b1e985ea5325a1f46eb7fd9681707bf|(!) JiffyDOS_1571_repl310654.bin (md5): 41c6cc528e9515ffd0ed9b180f8467c0|(!) JiffyDOS_1581.bin (md5): 20b6885c6dc2d42c38754a365b043d71"
+
+description = "The VICE x64sc (accurate) Commodore 64 emulator, isolated and ported to libretro. This core features a cycle-based and pixel-accurate emulation of the VIC-II video chip. In contrast, the 'x64' core's VIC-II emulation is faster but less accurate, making it a better choice for devices that are not powerful enough to run this more accurate core. Both cores include options to switch between the original 'fastSID' sound chip emulation and the slower but much more accurate 'reSID' module."

--- a/games-emulation/vice_libretro/additional-files/vice_xcbm2_libretro.info.in
+++ b/games-emulation/vice_libretro/additional-files/vice_xcbm2_libretro.info.in
@@ -1,0 +1,32 @@
+# Software Information
+display_name = "Commodore - CBM-II 6x0/7x0 (VICE xcbm2)"
+categories = "Emulator"
+authors = "VICE Team"
+corename = "VICE xcbm2"
+supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vfl|vsf|nib|nbz|d2m|d4m"
+license = "GPLv2"
+permissions = ""
+display_version = "@DISPLAY_VERSION@"
+
+# Hardware Information
+manufacturer = "Commodore"
+systemname = "CBM-II"
+systemid = "commodore_cbm2"
+
+# Libretro Features
+database = "Commodore - CBM-II"
+supports_no_game = "true"
+savestate = "true"
+savestate_features = "serialized"
+cheats = "true"
+input_descriptors = "true"
+memory_descriptors = "true"
+libretro_saves = "true"
+core_options = "true"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "true"
+disk_control = "true"
+is_experimental = "false"
+
+description = "The VICE xCBM-II emulator, isolated and ported to libretro. This core emulates several types of CBM-II models that were marketed under different names in the USA and Europe, including B128 and B256, and CBM 610, CBM 620, CBM 710 and CBM 720, respectively."

--- a/games-emulation/vice_libretro/additional-files/vice_xcbm5x0_libretro.info.in
+++ b/games-emulation/vice_libretro/additional-files/vice_xcbm5x0_libretro.info.in
@@ -1,0 +1,32 @@
+# Software Information
+display_name = "Commodore - CBM-II 5x0 (VICE xcbm5x0)"
+categories = "Emulator"
+authors = "VICE Team"
+corename = "VICE xcbm5x0"
+supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vfl|vsf|nib|nbz|d2m|d4m"
+license = "GPLv2"
+permissions = ""
+display_version = "@DISPLAY_VERSION@"
+
+# Hardware Information
+manufacturer = "Commodore"
+systemname = "CBM-5x0"
+systemid = "commodore_cbm5x0"
+
+# Libretro Features
+database = "Commodore - CBM-5x0"
+supports_no_game = "true"
+savestate = "true"
+savestate_features = "serialized"
+cheats = "true"
+input_descriptors = "true"
+memory_descriptors = "true"
+libretro_saves = "true"
+core_options = "true"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "true"
+disk_control = "true"
+is_experimental = "false"
+
+description = "The VICE xcbm5x0 emulator, isolated and ported to libretro. This core provides experimental emulation for the C510 model (also known as P500) of CBM-II, which is the 'little brother' of the C600/700 machines. It runs at roughly 1 MHz and use a VIC-II chip instead of the CRTC."

--- a/games-emulation/vice_libretro/additional-files/vice_xpet_libretro.info.in
+++ b/games-emulation/vice_libretro/additional-files/vice_xpet_libretro.info.in
@@ -1,0 +1,32 @@
+# Software Information
+display_name = "Commodore - PET (VICE xpet)"
+categories = "Emulator"
+authors = "VICE Team"
+corename = "VICE xpet"
+supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vfl|vsf|nib|nbz|d2m|d4m"
+license = "GPLv2"
+permissions = ""
+display_version = "@DISPLAY_VERSION@"
+
+# Hardware Information
+manufacturer = "Commodore"
+systemname = "PET"
+systemid = "commodore_pet"
+
+# Libretro Features
+database = "Commodore - PET"
+supports_no_game = "true"
+savestate = "true"
+savestate_features = "serialized"
+cheats = "true"
+input_descriptors = "true"
+memory_descriptors = "true"
+libretro_saves = "true"
+core_options = "true"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "true"
+disk_control = "true"
+is_experimental = "false"
+
+description = "The VICE PET emulator, isolated and ported to libretro. This core emulates the 2001, 3032, 4032, 8032, 8096, 8296 and SuperPET (MicroMainFrame 9000) models, covering the whole series. Both the 40- and 80-column CRTC video chips are emulated (from the 4032 onward), but a few of the features that are not very important for average applications are not implemented yet, such as numbers of rasterlines per char and lines per screen."

--- a/games-emulation/vice_libretro/additional-files/vice_xplus4_libretro.info.in
+++ b/games-emulation/vice_libretro/additional-files/vice_xplus4_libretro.info.in
@@ -1,0 +1,32 @@
+# Software Information
+display_name = "Commodore - PLUS/4 (VICE xplus4)"
+categories = "Emulator"
+authors = "VICE Team"
+corename = "VICE xplus4"
+supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vfl|vsf|nib|nbz|d2m|d4m"
+license = "GPLv2"
+permissions = ""
+display_version = "@DISPLAY_VERSION@"
+
+# Hardware Information
+manufacturer = "Commodore"
+systemname = "PLUS/4"
+systemid = "commodore_plus4"
+
+# Libretro Features
+database = "Commodore - Plus-4"
+supports_no_game = "true"
+savestate = "true"
+savestate_features = "serialized"
+cheats = "true"
+input_descriptors = "true"
+memory_descriptors = "true"
+libretro_saves = "true"
+core_options = "true"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "true"
+disk_control = "true"
+is_experimental = "false"
+
+description = "The VICE Plus/4 emulator, isolated and ported to libretro. This core provides experimental emulation for the business-focused Plus/4 model, the name for which refers to its built-in four-application ROM resident office suite (word processor, database, spreadsheet and graphing). Internally, the Plus/4 has the same basic architecture as the Commodore 16 and 116 models and can run software designed for those models, though it is incompatible with the Commodore 64's software."

--- a/games-emulation/vice_libretro/additional-files/vice_xscpu64_libretro.info.in
+++ b/games-emulation/vice_libretro/additional-files/vice_xscpu64_libretro.info.in
@@ -1,0 +1,48 @@
+# Software Information
+display_name = "Commodore - C64 SuperCPU (VICE xscpu64)"
+categories = "Emulator"
+authors = "VICE Team"
+corename = "VICE xscpu64"
+supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vfl|vsf|nib|nbz|d2m|d4m"
+license = "GPLv2"
+permissions = ""
+display_version = "@DISPLAY_VERSION@"
+
+# Hardware Information
+manufacturer = "Commodore"
+systemname = "C64 SuperCPU"
+systemid = "commodore_c64_supercpu"
+
+# Libretro Features
+database = "Commodore - 64"
+supports_no_game = "true"
+savestate = "true"
+savestate_features = "serialized"
+cheats = "true"
+input_descriptors = "true"
+memory_descriptors = "true"
+libretro_saves = "true"
+core_options = "true"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "true"
+disk_control = "true"
+is_experimental = "false"
+
+# Firmware
+firmware_count = 4
+firmware0_desc = "vice/JiffyDOS_C64.bin (JiffyDOS C64 Kernal)"
+firmware0_path = "vice/JiffyDOS_C64.bin"
+firmware0_opt = "true"
+firmware1_desc = "vice/JiffyDOS_1541-II.bin (JiffyDOS 1541 drive BIOS)"
+firmware1_path = "vice/JiffyDOS_1541-II.bin"
+firmware1_opt = "true"
+firmware2_desc = "vice/JiffyDOS_1571_repl310654.bin (JiffyDOS 1571 drive BIOS)"
+firmware2_path = "vice/JiffyDOS_1571_repl310654.bin"
+firmware2_opt = "true"
+firmware3_desc = "vice/JiffyDOS_1581.bin (JiffyDOS 1581 drive BIOS)"
+firmware3_path = "vice/JiffyDOS_1581.bin"
+firmware3_opt = "true"
+notes = "(!) JiffyDOS_C64.bin (md5): be09394f0576cf81fa8bacf634daf9a2|(!) JiffyDOS_1541-II.bin (md5): 1b1e985ea5325a1f46eb7fd9681707bf|(!) JiffyDOS_1571_repl310654.bin (md5): 41c6cc528e9515ffd0ed9b180f8467c0|(!) JiffyDOS_1581.bin (md5): 20b6885c6dc2d42c38754a365b043d71"
+
+description = "The VICE xscpu64 emulator, isolated and ported to libretro. This core simulates a Commodore 64 equipped with a SuperCPU64 V2B, which provides a 20 MHz asynchronous single-cycle 65816 CPU core, 128 KiB static RAM, 0-16 MiB SIMM RAM and 64-512 KiB EPROM."

--- a/games-emulation/vice_libretro/additional-files/vice_xvic_libretro.info.in
+++ b/games-emulation/vice_libretro/additional-files/vice_xvic_libretro.info.in
@@ -1,0 +1,32 @@
+# Software Information
+display_name = "Commodore - VIC-20 (VICE xvic)"
+categories = "Emulator"
+authors = "VICE Team"
+corename = "VICE xvic"
+supported_extensions = "d64|d71|d80|d81|d82|g64|g41|x64|t64|tap|prg|p00|crt|bin|zip|gz|d6z|d7z|d8z|g6z|g4z|x6z|cmd|m3u|vfl|vsf|nib|nbz|d2m|d4m|20|40|60|a0|b0|rom"
+license = "GPLv2"
+permissions = ""
+display_version = "@DISPLAY_VERSION@"
+
+# Hardware Information
+manufacturer = "Commodore"
+systemname = "VIC-20"
+systemid = "commodore_vic20"
+
+# Libretro Features
+database = "Commodore - VIC-20"
+supports_no_game = "true"
+savestate = "true"
+savestate_features = "serialized"
+cheats = "true"
+input_descriptors = "true"
+memory_descriptors = "true"
+libretro_saves = "true"
+core_options = "true"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "true"
+disk_control = "true"
+is_experimental = "false"
+
+description = "The VICE VIC-20 emulator, isolated and ported to libretro. This core emulates all of the internal hardware, including the VIA chips. The VIC-I video chip is fully emulated except for NTSC interlace mode."

--- a/games-emulation/vice_libretro/vice_libretro-3.7_20240827.recipe
+++ b/games-emulation/vice_libretro/vice_libretro-3.7_20240827.recipe
@@ -1,0 +1,67 @@
+SUMMARY="A port of Vice, a Commodore 8-bit emulator to the libretro API"
+DESCRIPTION="Vice is a versatile Commodore 8-bit emulator collection \
+which emulates the C64, the C64-DTV, the C128, the VIC20, practically \
+all PET models, the PLUS4 and the CBM-II (aka C610).."
+HOMEPAGE="https://sourceforge.net/projects/vice-emu"
+COPYRIGHT="2008-2024 the Vice team, the libretro team"
+LICENSE="GNU GPL v2"
+REVISION="1"
+srcGitRev="9ac3ff5b0c3ae8f75f611898f92f2f02cb0d130d"
+SOURCE_URI="https://github.com/libretro/vice-libretro/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="f36b5352f58dc519f2102aef63befb43a6ce40d746e993cbd334126684305b41"
+SOURCE_FILENAME="vice-libretro-${portVersion/_/-}-$srcGitRev.tar.gz"
+SOURCE_DIR="vice-libretro-$srcGitRev"
+ADDITIONAL_FILES="
+  vice_x128_libretro.info.in
+  vice_x64_libretro.info.in
+  vice_x64dtv_libretro.info.in
+  vice_x64sc_libretro.info.in
+  vice_xcbm2_libretro.info.in
+  vice_xcbm5x0_libretro.info.in
+  vice_xpet_libretro.info.in
+  vice_xplus4_libretro.info.in
+  vice_xscpu64_libretro.info.in
+  vice_xvic_libretro.info.in
+  "
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	vice_libretro$secondaryArchSuffix = $portVersion
+	addon:vice_libretro$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	retroarch$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libz${secondaryArchSuffix}
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	"
+
+BUILD()
+{
+	for emutype in x64 x64dtv x64sc x128 xcbm2 xcbm5x0 xpet xplus4 xscpu64 xvic; do
+	  sed -e "s/@DISPLAY_VERSION@/v${portVersion/_/-}/" \
+		$portDir/additional-files/vice_${emutype}_libretro.info.in \
+		> vice_${emutype}_libretro.info
+          make EMUTYPE=${emutype} $jobArgs
+	done
+}
+
+INSTALL()
+{
+	install -m 0755 -d "$docDir"
+	install -m 0644 -t "$docDir" README.md
+	install -m 0755 -d "$addOnsDir"/libretro
+	for emutype in x64 x64dtv x64sc x128 xcbm2 xcbm5x0 xpet xplus4 xscpu64 xvic; do
+	  install -m 0644 -t "$addOnsDir"/libretro \
+		vice_${emutype}_libretro.info \
+		vice_${emutype}_libretro.so
+	done
+}


### PR DESCRIPTION
VICE is a Commodore 8-bit emulator. This is a new recipe, porting the libretro core.

![Screenshot_haiku64_2024-08-28_19:07:12](https://github.com/user-attachments/assets/2f4f7bd9-87e3-46e3-a562-af6817b9b46c)

![Screenshot_haiku64_2024-08-28_19:08:49](https://github.com/user-attachments/assets/b6a6ea1b-0d40-4ae6-9af0-b8282c926037)
