### PR TITLE
yaddns: update to version 1.1.2.

### DIFF
--- a/net-dns/yaddns/patches/yaddns-1.1.2.patchset
+++ b/net-dns/yaddns/patches/yaddns-1.1.2.patchset
@@ -1,13 +1,13 @@
-From d10b7fed809920348adeee24fa8c83656df1bc1d Mon Sep 17 00:00:00 2001
+From 36c015ab92091ca2d3b8475423c7eb575fdbb555 Mon Sep 17 00:00:00 2001
 From: sfanxiang <sfanxiang@gmail.com>
 Date: Mon, 8 Jan 2018 10:10:48 +0000
 Subject: port to Haiku
 
 
-diff --git a/configure.in b/configure.in
-index d8c6668..fd6b42d 100644
---- a/configure.in
-+++ b/configure.in
+diff --git a/configure.ac b/configure.ac
+index 71bf5d8..2f41795 100644
+--- a/configure.ac
++++ b/configure.ac
 @@ -9,6 +9,7 @@ test ".$CFLAGS" = "." && CFLAGS=" "
  
  # programs needed to build/install
@@ -228,5 +228,5 @@ index 3d03671..baa8cef 100644
 +		$(top_builddir)/src/ifaddr.h
  check_util_LDADD = $(YADDNS_OBJS)
 -- 
-2.15.0
+2.45.2
 

--- a/net-dns/yaddns/yaddns-1.1.2.recipe
+++ b/net-dns/yaddns/yaddns-1.1.2.recipe
@@ -4,13 +4,13 @@ support and a high flexibility."
 HOMEPAGE="https://yaddns.github.io/"
 COPYRIGHT="2015 Anthony Viallard and Raphael Huck"
 LICENSE="GNU GPL v3"
-REVISION="2"
-SOURCE_URI="https://github.com/yaddns/yaddns/archive/yaddns-$portVersion.tar.gz"
-CHECKSUM_SHA256="23b527b7f71e1449746f1e39cbc3a074d58bd261a33399fb4e2d90eb63149059"
+REVISION="1"
+SOURCE_URI="https://github.com/yaddns/yaddns/archive/refs/tags/yaddns-$portVersion.tar.gz"
+CHECKSUM_SHA256="06a5c4409500ff0783c94bb825a3637e73b03072fff6cbfa6665308de67c22cd"
 SOURCE_DIR="yaddns-yaddns-$portVersion"
 PATCHES="yaddns-$portVersion.patchset"
 
-ARCHITECTURES="all !x86_gcc2 ?x86"
+ARCHITECTURES="all !x86_gcc2"
 if [ "$targetArchitecture" = x86_gcc2 ]; then
 SECONDARY_ARCHITECTURES="x86"
 fi
@@ -30,7 +30,6 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libcrypto$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:aclocal
@@ -76,6 +75,10 @@ INSTALL()
 	install etc/yaddns.conf $docDir/yaddns.conf.example
 }
 
+
+# For 1.1.2, make check fails to link due to the use of "extern" for two on yadds.h.
+# To compile tests, remove those externs, and add 'LDFLAGS="-z muldefs"' before runConfigure on BUILD().
+# For 1.1.2, tests results were: TOTAL:5 PASS: 5.
 TEST()
 {
 	LIBS="-Wl,--as-needed -lbnetapi -lnetwork" make check


### PR DESCRIPTION
Tests do not compile without some minor modifications. (added a comment about that before TEST()).

Test results are all PASS.