### PR TITLE
cmake: fix detection of secondary arch

### DIFF
--- a/dev-build/cmake/cmake-3.28.3.recipe
+++ b/dev-build/cmake/cmake-3.28.3.recipe
@@ -91,6 +91,8 @@ defineDebugInfoPackage cmake$secondaryArchSuffix \
 
 BUILD()
 {
+	export LDFLAGS="-lbsd"
+
 	# not an autotools configure
 	./configure --prefix=$prefix \
 		--datadir=/$relativeDataDir/cmake \

--- a/dev-build/cmake/cmake-3.28.3.recipe
+++ b/dev-build/cmake/cmake-3.28.3.recipe
@@ -7,7 +7,7 @@ of your choice."
 HOMEPAGE="https://cmake.org/"
 COPYRIGHT="2002-2023 Kitware, Inc., Insight Consortium"
 LICENSE="CMake"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://cmake.org/files/v${portVersion%.*}/cmake-$portVersion.tar.gz"
 CHECKSUM_SHA256="72b7570e5c8593de6ac4ab433b73eab18c5fb328880460c86ce32608141ad5c1"
 PATCHES="cmake-$portVersion.patchset"
@@ -37,37 +37,12 @@ REQUIRES="
 	lib:libz$secondaryArchSuffix
 	"
 
-SUMMARY_gui="$SUMMARY (gui)"
-DESCRIPTION_gui="$DESCRIPTION (gui)"
-
-PROVIDES_gui="
-	cmake${secondaryArchSuffix}_gui = $portVersion
-	cmd:cmake_gui = $portVersionCompat
-	"
-REQUIRES_gui="
-	haiku$secondaryArchSuffix
-	cmake$secondaryArchSuffix == $portVersion base
-	lib:libcppdap$secondaryArchSuffix
-	lib:libcurl$secondaryArchSuffix
-	lib:libjsoncpp$secondaryArchSuffix
-	lib:libQt5Core$secondaryArchSuffix
-	lib:libQt5Gui$secondaryArchSuffix
-	lib:libQt5Widgets$secondaryArchSuffix
-	lib:librhash$secondaryArchSuffix
-	lib:libstdc++$secondaryArchSuffix
-	lib:libuv$secondaryArchSuffix
-	lib:libz$secondaryArchSuffix
-	"
-
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libcurl$secondaryArchSuffix
 	devel:libcppdap$secondaryArchSuffix
 	devel:libjsoncpp$secondaryArchSuffix >= 25
 	devel:libncurses$secondaryArchSuffix
-	devel:libQt5Core$secondaryArchSuffix
-	devel:libQt5Gui$secondaryArchSuffix
-	devel:libQt5Widgets$secondaryArchSuffix
 	devel:librhash$secondaryArchSuffix
 	devel:libuv$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
@@ -86,8 +61,7 @@ defineDebugInfoPackage cmake$secondaryArchSuffix \
 	$prefix/bin/ccmake \
 	$prefix/bin/cmake \
 	$prefix/bin/cpack \
-	$prefix/bin/ctest \
-	"$(getPackagePrefix gui)/bin"/cmake-gui
+	$prefix/bin/ctest
 
 BUILD()
 {
@@ -105,7 +79,6 @@ BUILD()
 		--system-jsoncpp \
 		--system-librhash \
 		--system-libuv \
-		--qt-gui \
 		--parallel=${jobArgs#-j}
 
 	make $jobArgs
@@ -114,222 +87,12 @@ BUILD()
 INSTALL()
 {
 	make install
-
-	# No way to tell this to configure...
-	rm -rf $dataDir/{applications,emacs,icons,mime,vim}
-
-	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
-	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
-	local MINOR="`echo "$portVersion" | cut -d. -f3`"
-	local APP_NAME="CMake-GUI"
-	local LONG_INFO="$SUMMARY"
-	local APP_SIGNATURE="application/x-vnd.cmake-gui"
-	sed \
-		-e "s|@MAJOR@|$MAJOR|" \
-		-e "s|@MIDDLE@|$MIDDLE|" \
-		-e "s|@MINOR@|$MINOR|" \
-		-e "s|@LONG_INFO@|$LONG_INFO|" \
-		-e "s|@APP_NAME@|$APP_NAME|" \
-		-e "s|@APP_SIGNATURE@|$APP_SIGNATURE|" \
-		$portDir/additional-files/cmake.rdef.in > cmake.rdef
-
-	addResourcesToBinaries cmake.rdef $prefix/bin/cmake-gui
-
-	addAppDeskbarSymlink $prefix/bin/cmake-gui CMake-GUI
-
-	# GUI
-	packageEntries "gui" \
-		$prefix/bin/cmake-gui \
-		$dataDir/deskbar
 }
 
 TEST()
 {
 #x86_64
 #72% tests passed, 183 tests failed out of 664
-#          6 - kwsys.testSystemTools (Failed)
-#         26 - FindPackageTest (Failed)
-#         58 - ExportImport (Failed)
-#         66 - StagingPrefix (Failed)
-#         81 - Module.ExternalData (Failed)
-#        142 - InstallMode-COPY (Failed)
-#        143 - InstallMode-REL_SYMLINK (Failed)
-#        144 - InstallMode-REL_SYMLINK_OR_COPY (Failed)
-#        145 - InstallMode-ABS_SYMLINK (Failed)
-#        146 - InstallMode-ABS_SYMLINK_OR_COPY (Failed)
-#        147 - InstallMode-SYMLINK (Failed)
-#        148 - InstallMode-SYMLINK_OR_COPY (Failed)
-#        249 - CTestTestTimeout (Failed)
-#        280 - CMakeLib.testUVProcessChain (Failed)
-#        318 - RunCMake.CMP0019 (Failed)
-#        319 - RunCMake.CMP0022 (Failed)
-#        320 - RunCMake.CMP0026 (Failed)
-#        322 - RunCMake.CMP0037 (Failed)
-#        323 - RunCMake.CMP0038 (Failed)
-#        324 - RunCMake.CMP0039 (Failed)
-#        325 - RunCMake.CMP0040 (Failed)
-#        326 - RunCMake.CMP0041 (Failed)
-#        327 - RunCMake.CMP0043 (Failed)
-#        328 - RunCMake.CMP0045 (Failed)
-#        329 - RunCMake.CMP0046 (Failed)
-#        330 - RunCMake.CMP0049 (Failed)
-#        331 - RunCMake.CMP0050 (Failed)
-#        332 - RunCMake.CMP0051 (Failed)
-#        333 - RunCMake.CMP0053 (Failed)
-#        334 - RunCMake.CMP0054 (Failed)
-#        335 - RunCMake.CMP0055 (Failed)
-#        336 - RunCMake.CMP0057 (Failed)
-#        337 - RunCMake.CMP0059 (Failed)
-#        338 - RunCMake.CMP0060 (Failed)
-#        339 - RunCMake.CMP0064 (Failed)
-#        340 - RunCMake.CMP0069 (Failed)
-#        341 - RunCMake.CMP0081 (Failed)
-#        342 - RunCMake.CMP0102 (Failed)
-#        343 - RunCMake.CMP0106 (Failed)
-#        344 - RunCMake.CMP0111 (Failed)
-#        345 - RunCMake.CMP0115 (Failed)
-#        346 - RunCMake.CMP0118 (Failed)
-#        347 - RunCMake.CMP0119 (Failed)
-#        348 - RunCMake.CMP0121 (Failed)
-#        351 - RunCMake.CMP0135 (Failed)
-#        352 - RunCMake.CMP0139 (Failed)
-#        353 - RunCMake.CMP0152 (Failed)
-#        354 - RunCMake.CMP0153 (Failed)
-#        355 - RunCMake.CMP0065 (Failed)
-#        356 - RunCMake.Make (Failed)
-#        357 - RunCMake.CTest (Failed)
-#        359 - RunCMake.ABI (Failed)
-#        361 - RunCMake.AutogenQt5 (Failed)
-#        362 - RunCMake.BuildDepends (Timeout)
-#        364 - RunCMake.CMakeDependentOption (Failed)
-#        368 - RunCMake.CompilerChange (Failed)
-#        369 - RunCMake.CompilerNotFound (Failed)
-#        371 - RunCMake.Configure (Failed)
-#        372 - RunCMake.DisallowedCommands (Failed)
-#        376 - RunCMake.ExternalData (Failed)
-#        378 - RunCMake.FPHSA (Failed)
-#        379 - RunCMake.FileAPI (Failed)
-#        380 - RunCMake.FindBoost (Failed)
-#        382 - RunCMake.FindOpenGL (Failed)
-#        387 - RunCMake.GenEx-LINK_LANGUAGE (Failed)
-#        388 - RunCMake.GenEx-LINK_LANG_AND_ID (Failed)
-#        391 - RunCMake.GenEx-LINK_LIBRARY (Failed)
-#        392 - RunCMake.GenEx-LINK_GROUP (Failed)
-#        393 - RunCMake.GenEx-TARGET_FILE (Failed)
-#        395 - RunCMake.GenEx-GENEX_EVAL (Failed)
-#        396 - RunCMake.GenEx-TARGET_PROPERTY (Failed)
-#        399 - RunCMake.GenEx-PATH_EQUAL (Failed)
-#        401 - RunCMake.GeneratorExpression (Failed)
-#        403 - RunCMake.GeneratorInstance (Failed)
-#        404 - RunCMake.GeneratorPlatform (Failed)
-#        405 - RunCMake.GeneratorToolset (Failed)
-#        406 - RunCMake.GetPrerequisites (Failed)
-#        407 - RunCMake.GNUInstallDirs (Failed)
-#        410 - RunCMake.Languages (Failed)
-#        411 - RunCMake.LinkItemValidation (Failed)
-#        413 - RunCMake.ObjectLibrary (Failed)
-#        416 - RunCMake.RuntimePath (Failed)
-#        418 - RunCMake.Swift (Failed)
-#        420 - RunCMake.TargetObjects (Failed)
-#        421 - RunCMake.TargetProperties (Failed)
-#        422 - RunCMake.ToolchainFile (Failed)
-#        423 - RunCMake.find_dependency (Failed)
-#        424 - RunCMake.CompileDefinitions (Failed)
-#        426 - RunCMake.CompileFeatures (Failed)
-#        428 - RunCMake.PolicyScope (Failed)
-#        430 - RunCMake.WriteCompilerDetectionHeader (Failed)
-#        433 - RunCMake.VisibilityPreset (Failed)
-#        434 - RunCMake.CompatibleInterface (Failed)
-#        435 - RunCMake.Syntax (Failed)
-#        437 - RunCMake.MaxRecursionDepth (Failed)
-#        438 - RunCMake.add_custom_command (Failed)
-#        439 - RunCMake.add_custom_target (Failed)
-#        441 - RunCMake.add_executable (Failed)
-#        442 - RunCMake.add_library (Failed)
-#        443 - RunCMake.add_subdirectory (Failed)
-#        444 - RunCMake.add_test (Failed)
-#        445 - RunCMake.build_command (Failed)
-#        446 - RunCMake.execute_process (Failed)
-#        447 - RunCMake.export (Failed)
-#        448 - RunCMake.cmake_host_system_information (Failed)
-#        449 - RunCMake.cmake_language (Failed)
-#        450 - RunCMake.cmake_minimum_required (Failed)
-#        451 - RunCMake.cmake_parse_arguments (Failed)
-#        467 - RunCMake.define_property (Failed)
-#        468 - RunCMake.file (Failed)
-#        469 - RunCMake.file-CHMOD (Failed)
-#        470 - RunCMake.file-DOWNLOAD (Failed)
-#        471 - RunCMake.file-RPATH (Failed)
-#        472 - RunCMake.find_file (Failed)
-#        473 - RunCMake.find_library (Failed)
-#        474 - RunCMake.find_package (Failed)
-#        475 - RunCMake.find_path (Failed)
-#        476 - RunCMake.find_program (Failed)
-#        477 - RunCMake.foreach (Failed)
-#        480 - RunCMake.get_filename_component (Failed)
-#        481 - RunCMake.get_property (Failed)
-#        482 - RunCMake.if (Failed)
-#        483 - RunCMake.include (Failed)
-#        484 - RunCMake.include_directories (Failed)
-#        486 - RunCMake.list (Failed)
-#        487 - RunCMake.load_cache (Failed)
-#        488 - RunCMake.math (Failed)
-#        489 - RunCMake.message (Failed)
-#        490 - RunCMake.option (Failed)
-#        492 - RunCMake.project (Failed)
-#        493 - RunCMake.project_injected (Failed)
-#        497 - RunCMake.separate_arguments (Failed)
-#        498 - RunCMake.set_property (Failed)
-#        499 - RunCMake.string (Failed)
-#        501 - RunCMake.BundleUtilities (Failed)
-#        502 - RunCMake.try_compile (Failed)
-#        503 - RunCMake.try_run (Failed)
-#        504 - RunCMake.set (Failed)
-#        505 - RunCMake.variable_watch (Failed)
-#        506 - RunCMake.while (Failed)
-#        509 - RunCMake.alias_targets (Failed)
-#        510 - RunCMake.InterfaceLibrary (Failed)
-#        511 - RunCMake.no_install_prefix (Failed)
-#        512 - RunCMake.configure_file (Failed)
-#        513 - RunCMake.CTestTimeout (Failed)
-#        516 - RunCMake.CXXModules (Failed)
-#        519 - RunCMake.File_Archive (Failed)
-#        520 - RunCMake.File_Configure (Failed)
-#        521 - RunCMake.File_Generate (Failed)
-#        522 - RunCMake.ExportWithoutLanguage (Failed)
-#        524 - RunCMake.target_link_libraries (Failed)
-#        528 - RunCMake.target_link_libraries-LINK_LIBRARY (Failed)
-#        529 - RunCMake.target_link_libraries-LINK_GROUP (Failed)
-#        534 - RunCMake.target_compile_features (Failed)
-#        535 - RunCMake.target_compile_options (Failed)
-#        537 - RunCMake.target_sources (Failed)
-#        539 - RunCMake.CheckSourceCompiles (Failed)
-#        540 - RunCMake.CheckSourceRuns (Failed)
-#        541 - RunCMake.CheckModules (Failed)
-#        542 - RunCMake.CheckIPOSupported (Failed)
-#        543 - RunCMake.CommandLine (Failed)
-#        545 - RunCMake.install (Failed)
-#        546 - RunCMake.file-GET_RUNTIME_DEPENDENCIES (Failed)
-#        548 - RunCMake.CPackConfig (Failed)
-#        550 - RunCMake.ExternalProject (Failed)
-#        553 - RunCMake.CTestCommandLine (Failed)
-#        556 - RunCMake.IfacePaths_INCDIRS (Failed)
-#        568 - RunCMake.CPack_7Z (Failed)
-#        569 - RunCMake.CPack_TBZ2 (Failed)
-#        570 - RunCMake.CPack_TGZ (Failed)
-#        571 - RunCMake.CPack_TXZ (Failed)
-#        572 - RunCMake.CPack_TZ (Failed)
-#        573 - RunCMake.CPack_ZIP (Failed)
-#        574 - RunCMake.CPack_STGZ (Failed)
-#        575 - RunCMake.CPack_External (Failed)
-#        580 - RunCMake.UnityBuild (Failed)
-#        581 - RunCMake.CMakePresets (Failed)
-#        582 - RunCMake.CMakePresetsBuild (Failed)
-#        583 - RunCMake.CMakePresetsTest (Failed)
-#        584 - RunCMake.CMakePresetsPackage (Failed)
-#        585 - RunCMake.CMakePresetsWorkflow (Failed)
-#        586 - RunCMake.VerifyHeaderSets (Failed)
-#        587 - RunCMake.set_tests_properties (Failed)
 	cp bin/ctest Bootstrap.cmk/
 	make test VERBOSE=1 ARGS="$jobArgs"
 }

--- a/dev-build/cmake/patches/cmake-3.28.3.patchset
+++ b/dev-build/cmake/patches/cmake-3.28.3.patchset
@@ -1,4 +1,4 @@
-From d11f934441fa7630881fc76fd86217addea4fefb Mon Sep 17 00:00:00 2001
+From 33ea1830a803f66c59f38589805e43656faca0e7 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Sat, 24 Mar 2018 14:19:43 +0100
 Subject: Fix search path for Lua headers.
@@ -18,10 +18,10 @@ index 405a7a7..f7fa477 100644
    ~/Library/Frameworks
    /Library/Frameworks
 -- 
-2.42.1
+2.45.2
 
 
-From 5a31441dba597acdfe41aabd049565afc924a1e3 Mon Sep 17 00:00:00 2001
+From 32a31d4fa17df1ccb37779ceeb6d8fddcccfd503 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sat, 7 Sep 2019 17:29:56 +0200
 Subject: links against libnetwork
@@ -42,10 +42,10 @@ index 115c354..84a9759 100755
  fi
  if test "x${bootstrap_system_libuv}" = "x"; then
 -- 
-2.42.1
+2.45.2
 
 
-From 853d17e4b682fdeaeda1da342c12f946e123f0e9 Mon Sep 17 00:00:00 2001
+From 680263a7958afb47452a72170386bdb136e7772f Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sat, 7 Sep 2019 23:46:47 +0200
 Subject: bootstrap uses cmlibuv
@@ -77,45 +77,46 @@ index d0b0e00..e7ed773 100644
    return 0;
  }
 -- 
-2.42.1
+2.45.2
 
 
-From 208ce84930cb4056529bbc535e41a9c3ac0d4700 Mon Sep 17 00:00:00 2001
+From 4cbd1a41b7a2f3c65ac37c3e8b629f39d6142165 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sat, 21 Sep 2019 15:30:44 +0200
-Subject: also detect secondary arch with clang.
+Subject: Haiku: Improve secondary arch detection
 
+Find the directory when it's not the last in the list.
 
 diff --git a/Modules/Platform/Haiku.cmake b/Modules/Platform/Haiku.cmake
-index 7d9a737..e5ccf3f 100644
+index 7d9a737..74b17f5 100644
 --- a/Modules/Platform/Haiku.cmake
 +++ b/Modules/Platform/Haiku.cmake
-@@ -35,6 +35,10 @@ execute_process(
+@@ -33,8 +33,8 @@ execute_process(
+   RESULT_VARIABLE _HAIKU_SEARCH_DIRS_FOUND
+   OUTPUT_STRIP_TRAILING_WHITESPACE)
  
- string(REGEX MATCH "libraries: =?([^\n]*:)?/boot/system/develop/lib/([^/]*)/?(:?\n+)" _dummy "${_HAIKU_SEARCH_DIRS}\n")
- set(CMAKE_HAIKU_SECONDARY_ARCH "${CMAKE_MATCH_2}")
-+if(NOT CMAKE_HAIKU_SECONDARY_ARCH)
-+  string(REGEX MATCH "libraries: =?([^\n]*:)?/system/lib/([^/]*)/?(:?\n+)" _dummy "${_HAIKU_SEARCH_DIRS}\n")
-+  set(CMAKE_HAIKU_SECONDARY_ARCH "${CMAKE_MATCH_2}")
-+endif()
+-string(REGEX MATCH "libraries: =?([^\n]*:)?/boot/system/develop/lib/([^/]*)/?(:?\n+)" _dummy "${_HAIKU_SEARCH_DIRS}\n")
+-set(CMAKE_HAIKU_SECONDARY_ARCH "${CMAKE_MATCH_2}")
++string(REGEX MATCH "libraries: =?([^\n]*:)?(/boot)?/system(/develop)?/lib/([^/]*)/?(:|\n)" _dummy "${_HAIKU_SEARCH_DIRS}\n")
++set(CMAKE_HAIKU_SECONDARY_ARCH "${CMAKE_MATCH_4}")
  
  if(NOT CMAKE_HAIKU_SECONDARY_ARCH)
    set(CMAKE_HAIKU_SECONDARY_ARCH_SUBDIR "")
 -- 
-2.42.1
+2.45.2
 
 
-From 744100d4791a76fe32c59870035e40a919400462 Mon Sep 17 00:00:00 2001
+From 8e6bbdda1cc04596408fc7f570db19a5ba68f9ed Mon Sep 17 00:00:00 2001
 From: Augustin Cavalier <waddlesplash@gmail.com>
 Date: Fri, 21 Feb 2020 15:38:39 -0500
 Subject: Modules/Haiku: Set CMAKE_SYSTEM_FRAMEWORK_PATH.
 
 
 diff --git a/Modules/Platform/Haiku.cmake b/Modules/Platform/Haiku.cmake
-index e5ccf3f..c8f4b8d 100644
+index 74b17f5..41d77bb 100644
 --- a/Modules/Platform/Haiku.cmake
 +++ b/Modules/Platform/Haiku.cmake
-@@ -121,6 +121,9 @@ LIST(APPEND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
+@@ -117,6 +117,9 @@ LIST(APPEND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
  
  LIST(APPEND CMAKE_SYSTEM_LIBRARY_PATH ${CMAKE_HAIKU_DEVELOP_LIB_DIRECTORIES})
  
@@ -126,10 +127,10 @@ index e5ccf3f..c8f4b8d 100644
    set(CMAKE_INSTALL_PREFIX "/boot/system" CACHE PATH
      "Install path prefix, prepended onto install directories." FORCE)
 -- 
-2.42.1
+2.45.2
 
 
-From c2b4a6e9638714eaf8b8b32236d1b44143c14acb Mon Sep 17 00:00:00 2001
+From 8595fba610744bca2548d931f8c514f488b54f70 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Thu, 15 Apr 2021 21:09:12 +0200
 Subject: disable dependency tracking for older GNU compilers
@@ -151,10 +152,10 @@ index d01054b..7a5271c 100644
  
    # define flags for linker depfile generation
 -- 
-2.42.1
+2.45.2
 
 
-From bb22485844ea6b11af849bcda1d8a44d659563e7 Mon Sep 17 00:00:00 2001
+From d8e0aafe7a6a1781a5aa6cf389eaf2d451160a81 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Wed, 20 Oct 2021 14:28:22 +0200
 Subject: Haiku: fix install dirs, let FindPackage search in data/
@@ -195,10 +196,10 @@ index 30458cd..68fecef 100644
    auto cmnGen = cmEnumPathSegmentsGenerator{ common };
    auto cmakeGen = cmAppendPathSegmentGenerator{ "cmake"_s };
 -- 
-2.42.1
+2.45.2
 
 
-From aae457bc3e9cfd685c48fb1086d69f3d920b7057 Mon Sep 17 00:00:00 2001
+From 037d60c2bfb59e6c1f81d4d2867cbb7940b10ba1 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Wed, 23 Feb 2022 13:44:06 +0100
 Subject: Disable weak symbols; they do not seem to behave correctly.
@@ -218,10 +219,10 @@ index 485cadf..95dc81b 100644
  #else
  #  define ZSTD_HAVE_WEAK_SYMBOLS 0
 -- 
-2.42.1
+2.45.2
 
 
-From ea82f9ac2459bb1931f77e40d2774954acd4562b Mon Sep 17 00:00:00 2001
+From 0eb4e7b228a05f80d0490af279d073fa9b73c081 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 9 Feb 2024 13:48:22 +0100
 Subject: Haiku: enable debugger
@@ -255,5 +256,35 @@ index 1bc855e..93378da 100644
  
  # Check if we can build the Mach-O parser.
 -- 
-2.42.1
+2.45.2
+
+
+From da893309fde0ec42448f3105387b123bcb194c14 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
+Date: Sat, 31 Aug 2024 21:52:20 +0200
+Subject: Fix build for non-x86 arches
+
+
+diff --git a/Source/kwsys/SystemInformation.cxx b/Source/kwsys/SystemInformation.cxx
+index 369ff9a..84d5d65 100644
+--- a/Source/kwsys/SystemInformation.cxx
++++ b/Source/kwsys/SystemInformation.cxx
+@@ -4998,6 +4998,7 @@ bool SystemInformationImplementation::QueryHaikuInfo()
+   this->TotalVirtualMemory = 0;
+   this->AvailableVirtualMemory = 0;
+ 
++#if defined(__i386__) || defined(__x86_64__)
+   // Retrieve cpuid_info union for cpu 0
+   cpuid_info cpu_info;
+   get_cpuid(&cpu_info, 0, 0);
+@@ -5033,6 +5034,7 @@ bool SystemInformationImplementation::QueryHaikuInfo()
+ 
+   // Chip Extended Model
+   this->ChipID.ExtendedModel = cpu_info.eax_1.extended_model;
++#endif
+ 
+   // Get ChipID.ProcessorName from other information already gathered
+   this->RetrieveClassicalCPUIdentity();
+-- 
+2.45.2
 


### PR DESCRIPTION
/boot/system/lib/x86 may not be the last path in the list, as is the case with clang after packaged version 12.

Related: #10864

Doesn't build due to an unrelated problem, though. `arc4random_buf` is not detected, but while compiling Utilities/cmlibarchive/libarchive/archive_random.c stdlib.h does include it, leading to a redefinition. Don't know where and how to add _DEFAULT_SOURCE and libbsd, all that I've tried has failed. But then I don't know cmake.