### PR TITLE
raptor, revbump for openssl, add Arch patch for libxml2

### DIFF
--- a/media-libs/raptor/patches/raptor-2.0.15-libxml2-2.11.patch?h=lib32-raptor
+++ b/media-libs/raptor/patches/raptor-2.0.15-libxml2-2.11.patch?h=lib32-raptor
@@ -1,0 +1,30 @@
+https://bugs.gentoo.org/906227
+https://github.com/dajobe/raptor/issues/59
+https://github.com/dajobe/raptor/pull/58
+
+From 4dbc4c1da2a033c497d84a1291c46f416a9cac51 Mon Sep 17 00:00:00 2001
+From: David Anes <david.anes@suse.com>
+Date: Thu, 4 May 2023 11:54:02 +0200
+Subject: [PATCH] Remove the access to entities 'checked' private symbol for
+ libxml2 2.11.0
+
+Since version 2.11.0, some private symbols that were never intended
+as public API/ABI have been removed from libxml2, therefore the field
+'checked' is no longer present and raptor fails to build in this
+scenario.
+--- a/src/raptor_libxml.c
++++ b/src/raptor_libxml.c
+@@ -246,10 +246,11 @@ raptor_libxml_getEntity(void* user_data, const xmlChar *name)
+     
+     ret->owner = 1;
+ 
+-#if LIBXML_VERSION >= 20627
++#if LIBXML_VERSION >= 20627 && LIBXML_VERSION < 21100
+     /* Checked field was released in 2.6.27 on 2006-10-25
+      * http://git.gnome.org/browse/libxml2/commit/?id=a37a6ad91a61d168ecc4b29263def3363fff4da6
+      *
++     * and was later removed in version 2.11.0
+      */
+ 
+     /* Mark this entity as having been checked - never do this again */
+

--- a/media-libs/raptor/raptor-2.0.15.recipe
+++ b/media-libs/raptor/raptor-2.0.15.recipe
@@ -16,6 +16,7 @@ REVISION="9"
 SOURCE_URI="http://download.librdf.org/source/raptor2-$portVersion.tar.gz"
 CHECKSUM_SHA256="ada7f0ba54787b33485d090d3d2680533520cd4426d2f7fb4782dd4a6a1480ed"
 SOURCE_DIR="raptor2-$portVersion"
+PATCHES="raptor-2.0.15-libxml2-2.11.patch?h=lib32-raptor"
 
 ARCHITECTURES="all"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
@@ -29,6 +30,7 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libcrypto$secondaryArchSuffix # deps for libcurl
 	lib:libcurl$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
 	lib:libssl$secondaryArchSuffix # deps for libcurl
 	lib:libxml2$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix # deps for libxml2
@@ -46,6 +48,8 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libcurl$secondaryArchSuffix
 	devel:libglib_2.0$secondaryArchSuffix
+	# force openssl3 even if not needed for building
+	devel:libssl$secondaryArchSuffix >= 3
 	devel:libxml2$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="


### PR DESCRIPTION
From: https://aur.archlinux.org/cgit/aur.git/tree/raptor-2.0.15-libxml2-2.11.patch?h=lib32-raptor