### PR TITLE
vice_libretro: release bump to fix extra cores

### DIFF
--- a/games-emulation/vice_libretro/vice_libretro-3.7_20240827.recipe
+++ b/games-emulation/vice_libretro/vice_libretro-3.7_20240827.recipe
@@ -5,7 +5,7 @@ all PET models, the PLUS4 and the CBM-II (aka C610).."
 HOMEPAGE="https://sourceforge.net/projects/vice-emu"
 COPYRIGHT="2008-2024 the Vice team, the libretro team"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 srcGitRev="9ac3ff5b0c3ae8f75f611898f92f2f02cb0d130d"
 SOURCE_URI="https://github.com/libretro/vice-libretro/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="f36b5352f58dc519f2102aef63befb43a6ce40d746e993cbd334126684305b41"
@@ -48,9 +48,11 @@ BUILD()
 {
 	for emutype in x64 x64dtv x64sc x128 xcbm2 xcbm5x0 xpet xplus4 xscpu64 xvic; do
 	  sed -e "s/@DISPLAY_VERSION@/v${portVersion/_/-}/" \
-		$portDir/additional-files/vice_${emutype}_libretro.info.in \
-		> vice_${emutype}_libretro.info
-          make EMUTYPE=${emutype} $jobArgs
+	    $portDir/additional-files/vice_${emutype}_libretro.info.in \
+	    > vice_${emutype}_libretro.info
+	  make EMUTYPE=${emutype} $jobArgs && \
+	    cp vice_${emutype}_libretro.so vice_${emutype}_libretro.core && \
+	    make EMUTYPE=${emutype} $jobArgs clean
 	done
 }
 
@@ -60,8 +62,9 @@ INSTALL()
 	install -m 0644 -t "$docDir" README.md
 	install -m 0755 -d "$addOnsDir"/libretro
 	for emutype in x64 x64dtv x64sc x128 xcbm2 xcbm5x0 xpet xplus4 xscpu64 xvic; do
+          mv vice_${emutype}_libretro.core vice_${emutype}_libretro.so
 	  install -m 0644 -t "$addOnsDir"/libretro \
-		vice_${emutype}_libretro.info \
-		vice_${emutype}_libretro.so
+	    vice_${emutype}_libretro.info \
+	    vice_${emutype}_libretro.so
 	done
 }


### PR DESCRIPTION
Found out that when building the vice cores without cleaning up the intermediate files, they ended up using the wrong symbols and while building would not load at all in RetroArch. As such only the vice_x64 core would work, and none other.
Adding a clean in between each core solves the issue without sacrificing too much of the logic in the recipe.