### PR TITLE
discid: build for Python 3.11/3.12

### DIFF
--- a/dev-python/discid/discid-1.2.0.recipe
+++ b/dev-python/discid/discid-1.2.0.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="Python-discid implements Python bindings for MusicBrainz Libdiscid.
 HOMEPAGE="https://python-discid.readthedocs.io/"
 COPYRIGHT="Johannes Dewender"
 LICENSE="GNU LGPL v2.1"
-REVISION="6"
+REVISION="7"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/d/$portName/$portName-$portVersion.tar.gz"
 CHECKSUM_SHA256="cd9630bc53f5566df92819641040226e290b2047573f2c74a6e92b8eed9e86b9"
 SOURCE_DIR="discid-$portVersion"
@@ -22,8 +22,8 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
+PYTHON_PACKAGES=(python39 python310 python311 python312)
+PYTHON_VERSIONS=(3.9 3.10 3.11 3.12)
 for i in "${!PYTHON_PACKAGES[@]}"; do
 	pythonPackage=${PYTHON_PACKAGES[i]}
 	pythonVersion=${PYTHON_VERSIONS[$i]}


### PR DESCRIPTION
Another Python package to build for newer Python versions.