### PR TITLE
speedtest_cli: use https by default.

### DIFF
--- a/net-analyzer/speedtest-cli/patches/800.patch
+++ b/net-analyzer/speedtest-cli/patches/800.patch
@@ -1,0 +1,53 @@
+From 74d662e1e00de05779c71717626bb7ec299bdf3c Mon Sep 17 00:00:00 2001
+From: Strahinja Kustudic <strahinjak@nordeus.com>
+Date: Tue, 1 Aug 2023 11:17:06 +0200
+Subject: [PATCH] Set secure connection as default
+
+Speedtest servers don't support HTTP connections anymore so I renamed
+the `--secure` parameter to `--insecure` and set it to False by default.
+---
+ speedtest.py | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/speedtest.py b/speedtest.py
+index 186b52929..59540af66 100755
+--- a/speedtest.py
++++ b/speedtest.py
+@@ -946,7 +946,7 @@ class SpeedtestResults(object):
+     """
+ 
+     def __init__(self, download=0, upload=0, ping=0, server=None, client=None,
+-                 opener=None, secure=False):
++                 opener=None, secure=True):
+         self.download = download
+         self.upload = upload
+         self.ping = ping
+@@ -1087,7 +1087,7 @@ class Speedtest(object):
+     """Class for performing standard speedtest.net testing operations"""
+ 
+     def __init__(self, config=None, source_address=None, timeout=10,
+-                 secure=False, shutdown_event=None):
++                 secure=True, shutdown_event=None):
+         self.config = {}
+ 
+         self._source_address = source_address
+@@ -1770,8 +1770,8 @@ def parse_args():
+     parser.add_argument('--source', help='Source IP address to bind to')
+     parser.add_argument('--timeout', default=10, type=PARSER_TYPE_FLOAT,
+                         help='HTTP timeout in seconds. Default 10')
+-    parser.add_argument('--secure', action='store_true',
+-                        help='Use HTTPS instead of HTTP when communicating '
++    parser.add_argument('--insecure', action='store_true', default=False,
++                        help='Use HTTP instead of HTTPS when communicating '
+                              'with speedtest.net operated servers')
+     parser.add_argument('--no-pre-allocate', dest='pre_allocate',
+                         action='store_const', default=True, const=False,
+@@ -1885,7 +1885,7 @@ def shell():
+         speedtest = Speedtest(
+             source_address=args.source,
+             timeout=args.timeout,
+-            secure=args.secure
++            secure=not args.insecure
+         )
+     except (ConfigRetrievalError,) + HTTP_ERRORS:
+         printer('Cannot retrieve speedtest configuration', error=True)

--- a/net-analyzer/speedtest-cli/speedtest_cli-2.1.3.recipe
+++ b/net-analyzer/speedtest-cli/speedtest_cli-2.1.3.recipe
@@ -12,12 +12,16 @@ and CPU and Memory capacity and speed."
 HOMEPAGE="https://github.com/sivel/speedtest-cli"
 COPYRIGHT="2012-2021 Matt Martz"
 LICENSE="Apache v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="$HOMEPAGE/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="45e3ca21c3ce3c339646100de18db8a26a27d240c29f1c9e07b6c13995a969be"
 SOURCE_FILENAME="speedtest-cli-$portVersion.tar.gz"
 SOURCE_DIR="speedtest-cli-$portVersion"
-PATCHES="0001-Python-3.10-support.patch"
+
+PATCHES="
+	0001-Python-3.10-support.patch
+	800.patch
+	"
 
 ARCHITECTURES="any"
 


### PR DESCRIPTION
Patch taken from https://github.com/sivel/speedtest-cli/pull/800