### PR TITLE
sqlalchemy: update to version 1.3.24.

### DIFF
--- a/dev-python/sqlalchemy/sqlalchemy-1.3.24.recipe
+++ b/dev-python/sqlalchemy/sqlalchemy-1.3.24.recipe
@@ -6,11 +6,11 @@ It provides a full suite of well known enterprise-level persistence patterns, \
 designed for efficient and high-performing database access, adapted into a \
 simple and Pythonic domain language."
 HOMEPAGE="https://www.sqlalchemy.org/"
-COPYRIGHT="2006-2019 SQLAlchemy authors and contributors"
+COPYRIGHT="2005-2021 the SQLAlchemy authors and contributor"
 LICENSE="MIT"
-REVISION="6"
-SOURCE_URI="https://pypi.org/packages/source/S/SQLAlchemy/SQLAlchemy-$portVersion.tar.gz"
-CHECKSUM_SHA256="758fc8c4d6c0336e617f9f6919f9daea3ab6bb9b07005eda9a1a682e24a6cacc"
+REVISION="1"
+SOURCE_URI="https://files.pythonhosted.org/packages/source/S/SQLAlchemy/SQLAlchemy-$portVersion.tar.gz"
+CHECKSUM_SHA256="ebbb777cbf9312359b897bf81ba00dae0f5cb69fba2a18265dcc18a6f5ef7519"
 SOURCE_DIR="SQLAlchemy-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -30,15 +30,14 @@ BUILD_PREREQUIRES="
 	gcc$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
+PYTHON_VERSIONS=(3.10)
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_${pythonPackage}=\"
 		${portName}_$pythonPackage = $portVersion
-		cmd:alembic$pythonVersion
 		\""
 
 	if [ "$targetArchitecture" = x86_gcc2 ]; then
@@ -61,9 +60,9 @@ done
 
 BUILD()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		rm -rf "$sourceDir"-$pythonPackage
 		cp -a "$sourceDir" "$sourceDir"-$pythonPackage
@@ -76,16 +75,18 @@ BUILD()
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		cd "$sourceDir"-$pythonPackage
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
+
 		export PYTHONPATH=$installLocation
 		mkdir -p "$installLocation"
+
 		$python setup.py install \
 			--root=/ --prefix="$prefix"
 


### PR DESCRIPTION
This is the newest of the 1.3.x series. As this is a requirement for gertty, and that package hasn't seen development in years, better stick to an older version of sqlalchemy (1.4 *might* work? 2.x surely will not).