### PR TITLE
nim: update to 2.0.8

### DIFF
--- a/dev-lang/nim/nim-2.0.8.recipe
+++ b/dev-lang/nim/nim-2.0.8.recipe
@@ -15,7 +15,7 @@ LICENSE="MIT"
 REVISION="1"
 SOURCE_URI="https://nim-lang.org/download/nim-$portVersion.tar.xz"
 SOURCE_DIR="nim-$portVersion"
-CHECKSUM_SHA256="71526bd07439dc8e378fa1a6eb407eda1298f1f3d4df4476dca0e3ca3cbe3f09"
+CHECKSUM_SHA256="5702da844700d3129db73170b5c606adbdfb87e82b816c0d91107ea20a65df16"
 ADDITIONAL_FILES="
 	config.nims
 	nim.rdef.in


### PR DESCRIPTION
this updates nim to release 2.0.8

```
~> uname -a
Haiku shredder 1 hrev58146 Sep 18 2024 06:37:00 x86_64 x86_64 Haiku

~> nim -v
Nim Compiler Version 2.0.8 [Haiku: amd64]
Compiled at 2024-09-19
Copyright (c) 2006-2023 by Andreas Rumpf

git hash: de8282bca5fab25ada92987099e3304278ab3d14
active boot switches: -d:release

```