### PR TITLE
zlib: build without cmake. 

### DIFF
--- a/sys-libs/zlib/patches/zlib-1.3.1.patchset
+++ b/sys-libs/zlib/patches/zlib-1.3.1.patchset
@@ -1,23 +1,44 @@
-From b377ee6e36d81ad0bd845cd5eb44b2beb3879db2 Mon Sep 17 00:00:00 2001
+From 68e1b55219447e7738cf5b9221b0a2bc04618f97 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Sun, 28 Aug 2016 18:33:07 +0200
 Subject: zlib: export Haiku shared object symbols
 
 
 diff --git a/zlib.map b/zlib.map
-index b330b60..27a40f6 100644
+index 31544f2..de41ad6 100644
 --- a/zlib.map
 +++ b/zlib.map
-@@ -5,7 +5,8 @@ ZLIB_1.2.0 {
-     inflateBack;
+@@ -6,6 +6,7 @@ ZLIB_1.2.0 {
      inflateBackEnd;
      inflateBackInit_;
--    inflateCopy;
-+    inflateCopy;
+     inflateCopy;
 +    _gSharedObjectHaiku*;
    local:
      deflate_copyright;
      inflate_copyright;
 -- 
-2.42.1
+2.45.2
+
+
+From 7a74bb80187956c623282963b9950b8ae6d717f6 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Wed, 25 Sep 2024 18:48:21 -0300
+Subject: configure: make sure Haiku gets the correct LDSHARED flags.
+
+
+diff --git a/configure b/configure
+index c55098a..250d1b0 100755
+--- a/configure
++++ b/configure
+@@ -227,7 +227,7 @@ if test "$gcc" -eq 1 && ($cc -c $test.c) >> configure.log 2>&1; then
+     uname=`(uname -s || echo unknown) 2>/dev/null`
+   fi
+   case "$uname" in
+-  Linux* | linux* | *-linux* | GNU | GNU/* | solaris*)
++  Linux* | linux* | *-linux* | GNU | GNU/* | solaris* | Haiku)
+         case "$mname" in
+         *sparc*)
+             LDFLAGS="${LDFLAGS} -Wl,--no-warn-rwx-segments" ;;
+-- 
+2.45.2
 

--- a/sys-libs/zlib/zlib-1.3.1.recipe
+++ b/sys-libs/zlib/zlib-1.3.1.recipe
@@ -12,8 +12,11 @@ reduced, if necessary, at some cost in compression."
 HOMEPAGE="http://www.zlib.net/"
 COPYRIGHT="1995-2017 Jean-loup Gailly and Mark Adler"
 LICENSE="Zlib"
-REVISION="3"
-SOURCE_URI="https://zlib.net/fossils/zlib-$portVersion.tar.gz"
+REVISION="4"
+SOURCE_URI="
+	https://zlib.net/fossils/zlib-$portVersion.tar.gz
+	https://github.com/madler/zlib/releases/download/v$portVersion/zlib-$portVersion.tar.gz
+	"
 CHECKSUM_SHA256="9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
 PATCHES="zlib-$portVersion.patchset"
 
@@ -44,40 +47,35 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
-	cmd:cmake
 	cmd:gcc$secondaryArchSuffix
-	cmd:grep
 	cmd:ld$secondaryArchSuffix
 	cmd:make
 	cmd:sed
 	"
 
-PATCH()
-{
-	sed -i 's,${CMAKE_INSTALL_PREFIX}/bin',$binDir, CMakeLists.txt
-	sed -i 's,${CMAKE_INSTALL_PREFIX}/include',$includeDir, CMakeLists.txt
-	sed -i 's,${CMAKE_INSTALL_PREFIX}/lib',$libDir, CMakeLists.txt
-	sed -i 's,${CMAKE_INSTALL_PREFIX}/share/man',$manDir, CMakeLists.txt
-	sed -i 's,${CMAKE_INSTALL_PREFIX}/share/pkgconfig',$developLibDir/pkgconfig, \
-		CMakeLists.txt
-}
-
 BUILD()
 {
-	cmake -S. -Bbuild \
-		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
-		-DCMAKE_INSTALL_PREFIX:PATH=$prefix
-	make -C build $jobArgs
+	export mandir=$manDir # ./configure won't accept --mandir, but respects $mandir
+	export CFLAGS="-O2 -g -DNDEBUG" # similar to cmake's "RelWithDebugInfo" as used before.
+
+	./configure \
+		--prefix=$prefix \
+		--libdir=$libDir \
+		--includedir=$includeDir \
+		--sharedlibdir=$libDir
+
+	make $jobArgs
 }
 
 INSTALL()
 {
-	make -C build install
+	make install
 
 	# remove static library
 	rm $libDir/libz.a
 
 	prepareInstalledDevelLib libz
+	fixPkgconfig
 
 	# devel package
 	packageEntries devel \
@@ -87,5 +85,5 @@ INSTALL()
 
 TEST()
 {
-	make -C build test
+	make test
 }


### PR DESCRIPTION
~Only difference I notice is that current package revision, 1.3.1-3 (built with CMake) has a `libz.so.1` symlink to `libz.so.1.3.1` (on the base package), while this one (1.3.1-4) does not.~

~The`_devel` package content do match.~

~Adding said symlink shouldn't be too hard, if it is really necessary.~

Edit: fixed the above differences.