### PR TITLE
Opendune Home Fix

### DIFF
--- a/games-strategy/opendune/opendune-0.9.recipe
+++ b/games-strategy/opendune/opendune-0.9.recipe
@@ -18,7 +18,7 @@ SOURCE_DIR="OpenDUNE-$portVersion"
 PATCHES="opendune-$portVersion.patchset"
 ADDITIONAL_FILES="opendune.rdef"
 
-ARCHITECTURES="all !x86_gcc2 x86 x86_64"
+ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 GLOBAL_WRITABLE_FILES="

--- a/games-strategy/opendune/opendune-0.9.recipe
+++ b/games-strategy/opendune/opendune-0.9.recipe
@@ -18,7 +18,7 @@ SOURCE_DIR="OpenDUNE-$portVersion"
 PATCHES="opendune-$portVersion.patchset"
 ADDITIONAL_FILES="opendune.rdef"
 
-ARCHITECTURES="all !x86_gcc2 ?x86"
+ARCHITECTURES="all !x86_gcc2 x86 x86_64"
 SECONDARY_ARCHITECTURES="x86"
 
 GLOBAL_WRITABLE_FILES="

--- a/games-strategy/opendune/opendune-0.9.recipe
+++ b/games-strategy/opendune/opendune-0.9.recipe
@@ -61,9 +61,6 @@ defineDebugInfoPackage opendune$secondaryArchSuffix \
 BUILD()
 {
 	_dune2_data_dir=$(finddir B_USER_NONPACKAGED_DATA_DIRECTORY)/opendune
-	userdatadir=$(finddir B_USER_SETTINGS_DIRECTORY)/opendune
-
-	sed -i "s,@HAIKUSERSETTINGS@,${userdatadir},g" src/file.c
 
 	export CFLAGS="-mmmx -DDUNE_DATA_DIR='\\\"${_dune2_data_dir}\\\"'"
 	export LDFLAGS="-lstdc++"

--- a/games-strategy/opendune/opendune-0.9.recipe
+++ b/games-strategy/opendune/opendune-0.9.recipe
@@ -55,6 +55,9 @@ BUILD_PREREQUIRES="
 	cmd:which
 	"
 
+defineDebugInfoPackage opendune$secondaryArchSuffix \
+	$appsDir/OpenDUNE
+
 BUILD()
 {
 	_dune2_data_dir=$(finddir B_USER_NONPACKAGED_DATA_DIRECTORY)/opendune

--- a/games-strategy/opendune/opendune-0.9.recipe
+++ b/games-strategy/opendune/opendune-0.9.recipe
@@ -10,7 +10,7 @@ for the game to run properly."
 HOMEPAGE="http://www.opendune.org/"
 COPYRIGHT="2009-2018 OpenDUNE Developers"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/OpenDUNE/OpenDUNE/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="8d5ed67669df1f17a44c097d9b6bee4e0623ce2a37f11938ce9cd77de546d06c"
 SOURCE_FILENAME="OpenDUNE-$portVersion.tar.gz"
@@ -26,7 +26,6 @@ GLOBAL_WRITABLE_FILES="
 	"
 USER_SETTINGS_FILES="
 	settings/opendune directory
-	settings/opendune/savegames directory
 	settings/opendune/opendune.ini template settings/opendune.ini
 	"
 
@@ -59,6 +58,9 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	_dune2_data_dir=$(finddir B_USER_NONPACKAGED_DATA_DIRECTORY)/opendune
+	userdatadir=$(finddir B_USER_SETTINGS_DIRECTORY)/opendune
+
+	sed -i "s,@HAIKUSERSETTINGS@,${userdatadir},g" src/file.c
 
 	export CFLAGS="-mmmx -DDUNE_DATA_DIR='\\\"${_dune2_data_dir}\\\"'"
 	export LDFLAGS="-lstdc++"

--- a/games-strategy/opendune/patches/opendune-0.9.patchset
+++ b/games-strategy/opendune/patches/opendune-0.9.patchset
@@ -811,7 +811,7 @@ index e623ebd..d8489ae 100644
 From 9ec10dd99f95d605e7b72bea3f7dc5c99054b039 Mon Sep 17 00:00:00 2001
 From: Peppersawce <michaelpeppers89@yahoo.it>
 Date: Thu, 26 Sep 2024 23:08:31 +0200
-Subject: Hackfix (with sed) to Opendune using ~/.config to store user data
+Subject: Fix to Opendune using ~/.config to store user data
 
 
 diff --git a/src/file.c b/src/file.c
@@ -823,7 +823,7 @@ index 0b08d60..1f23cb3 100644
  			snprintf(g_personal_data_dir, sizeof(g_personal_data_dir), "%s/Library/Application Support/OpenDUNE", homedir);
  #else /* __APPLE__ */
 -			snprintf(g_personal_data_dir, sizeof(g_personal_data_dir), "%s/.config/opendune", homedir);
-+			snprintf(g_personal_data_dir, sizeof(g_personal_data_dir), "@HAIKUSERSETTINGS@");
++			snprintf(g_personal_data_dir, sizeof(g_personal_data_dir), "%s/config/settings/opendune", homedir);
  #endif /* __APPLE__ */
  		}
  #endif /* _WIN32 */

--- a/games-strategy/opendune/patches/opendune-0.9.patchset
+++ b/games-strategy/opendune/patches/opendune-0.9.patchset
@@ -1,4 +1,4 @@
-From f185f3c2a797666ce339aaf79b9742c7b948b495 Mon Sep 17 00:00:00 2001
+From fdb5eca53507d30e8354bc15ce5fc212d6079ca7 Mon Sep 17 00:00:00 2001
 From: Gabriele Baldassarre <gabriele@gabrielebaldassarre.com>
 Date: Mon, 22 Oct 2018 23:00:12 +0200
 Subject: initial set of defines for Haiku
@@ -25,10 +25,10 @@ index daac831..bdea121 100644
  		extern char *strdup (__const char *__s);
  	#endif /* __GCC__ */
 -- 
-2.28.0
+2.45.2
 
 
-From 2f50b43feb955e7d7d0159a3227973452137ed9d Mon Sep 17 00:00:00 2001
+From b2c8ac5291be92baf113f2de94b22d5c53442927 Mon Sep 17 00:00:00 2001
 From: Gabriele Baldassarre <gabriele@gabrielebaldassarre.com>
 Date: Tue, 23 Oct 2018 00:23:24 +0200
 Subject: added support for Haiku paths
@@ -134,10 +134,10 @@ index d51996a..6633c92 100644
  		/* current directory */
  		f = fopen("opendune.ini", "rb");
 -- 
-2.28.0
+2.45.2
 
 
-From c4f1da75651c9a359d65a0ea7e708265a1c6e857 Mon Sep 17 00:00:00 2001
+From 597eb5ec86f33cdbf65f1c91ede0ecfcea5ee675 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
 Date: Wed, 28 Oct 2020 14:32:14 +0100
 Subject: Use the correct endian.h
@@ -157,10 +157,10 @@ index f8e9361..f8e3e86 100644
  	#include <endian.h>
  #endif /* _WIN32 */
 -- 
-2.28.0
+2.45.2
 
 
-From a08cb09c074355a9d6d46f38ab6a3ef50f11782a Mon Sep 17 00:00:00 2001
+From 8fca25fe1e9cfbb3262a9fd0a006ac16b56aaf6b Mon Sep 17 00:00:00 2001
 From: Thomas Bernard <miniupnp@free.fr>
 Date: Thu, 9 Apr 2020 22:21:46 +0200
 Subject: -Fix: Tile_PackTile() is now a macro
@@ -206,10 +206,10 @@ index 234b08e..3f97403 100644
  				if (!Tile_IsOutOfMap(packed)) break;
  			}
 -- 
-2.28.0
+2.45.2
 
 
-From 72418d134aa04cc9f03bfec38a8cbdcd1d74cb01 Mon Sep 17 00:00:00 2001
+From ecacfc4b847804d634273a8e74ffd1f65e0cbca6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
 Date: Wed, 28 Oct 2020 16:11:07 +0100
 Subject: Remove keyboard scancode magic
@@ -249,10 +249,10 @@ index 5cfebc0..af9c209 100644
  					Video_Key_Callback(0xe0);
  					scancode &= 0x7f;
 -- 
-2.28.0
+2.45.2
 
 
-From c647b8b95190ca68126f89d8654569489ada00ff Mon Sep 17 00:00:00 2001
+From 6376964cad25c40ebd7d3ecbabaffca9d4c86032 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
 Date: Sun, 1 Nov 2020 20:19:20 +0100
 Subject: Fix: solve CTRL key disabling keyboard
@@ -272,10 +272,10 @@ index f0d3cc6..4a1b510 100644
  
  	key = Input_Keyboard_Translate(key) & 0xFF;
 -- 
-2.28.0
+2.45.2
 
 
-From 829379097c26a9be768152a92ce0309065f28fee Mon Sep 17 00:00:00 2001
+From 6c48f2329b90eb28a864112945983f09a4efd8ce Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
 Date: Thu, 29 Oct 2020 20:57:40 +0100
 Subject: Add visible error messages
@@ -454,10 +454,10 @@ index 0000000..40b2e62
 +
 +}
 -- 
-2.28.0
+2.45.2
 
 
-From fc3de30f66054de72b8fdb685af11f2a66346166 Mon Sep 17 00:00:00 2001
+From a7953a4add7c623ae36eaa4b406240ac20a94beb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
 Date: Fri, 30 Oct 2020 12:42:28 +0100
 Subject: snooze-based timer loop
@@ -551,10 +551,10 @@ index 475331d..1abade9 100644
  #endif /* !defined(TOS) && !defined(DOS) */
  #if defined(_WIN32)
 -- 
-2.28.0
+2.45.2
 
 
-From 56675fce4d121dfc328ac8f6908ef7edacf5a7de Mon Sep 17 00:00:00 2001
+From dd897ddc707d2908a8976785148375bb48db9c02 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
 Date: Sun, 1 Nov 2020 16:26:50 +0100
 Subject: Add sound
@@ -635,10 +635,10 @@ index 0b1004e..f0c6d31 100644
  	s_buffer = s_data;
  	s_status = 2;
 -- 
-2.28.0
+2.45.2
 
 
-From 9df3fac82533ba02538f7d9ae8f94dce036da524 Mon Sep 17 00:00:00 2001
+From 1f747fede5e3bcc15e2770e1df26876e4b07a252 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
 Date: Mon, 2 Nov 2020 12:43:36 +0100
 Subject: Add MIDI music
@@ -778,10 +778,10 @@ index 0000000..a2c678f
 +
 +}
 -- 
-2.28.0
+2.45.2
 
 
-From 6ee768cc16605ff5c7d1b19f682605a593544f40 Mon Sep 17 00:00:00 2001
+From 1b0f381079d68130d4962ef1fba3420e957a3c1b Mon Sep 17 00:00:00 2001
 From: begasus <begasus@gmail.com>
 Date: Wed, 11 Nov 2020 09:10:55 +0000
 Subject: Fix conflicting int types for 32bit
@@ -805,5 +805,4 @@ index e623ebd..d8489ae 100644
  assert_compile(sizeof( int8 ) == 1);
  assert_compile(sizeof(uint16) == 2);
 -- 
-2.28.0
-
+2.45.2

--- a/games-strategy/opendune/patches/opendune-0.9.patchset
+++ b/games-strategy/opendune/patches/opendune-0.9.patchset
@@ -818,15 +818,6 @@ diff --git a/src/file.c b/src/file.c
 index 0b08d60..1f23cb3 100644
 --- a/src/file.c
 +++ b/src/file.c
-@@ -42,7 +42,7 @@
- 
- #ifdef __HAIKU__
- static char g_dune_data_dir[B_PATH_NAME_LENGTH] = DUNE_DATA_DIR;
--static char g_personal_data_dir[B_PATH_NAME_LENGTH] = ".";
-+static char g_personal_data_dir[B_PATH_NAME_LENGTH] = "@HAIKUSERSETTINGS@";
- #else
- static char g_dune_data_dir[1024] = DUNE_DATA_DIR;
- static char g_personal_data_dir[1024] = ".";
 @@ -558,7 +558,7 @@ bool File_Init(void)
  #if defined(__APPLE__)
  			snprintf(g_personal_data_dir, sizeof(g_personal_data_dir), "%s/Library/Application Support/OpenDUNE", homedir);

--- a/games-strategy/opendune/patches/opendune-0.9.patchset
+++ b/games-strategy/opendune/patches/opendune-0.9.patchset
@@ -1,4 +1,4 @@
-From fdb5eca53507d30e8354bc15ce5fc212d6079ca7 Mon Sep 17 00:00:00 2001
+From aa2b1a3c793b8a7ec78ebe58aabdf1c8eb8c7003 Mon Sep 17 00:00:00 2001
 From: Gabriele Baldassarre <gabriele@gabrielebaldassarre.com>
 Date: Mon, 22 Oct 2018 23:00:12 +0200
 Subject: initial set of defines for Haiku
@@ -28,7 +28,7 @@ index daac831..bdea121 100644
 2.45.2
 
 
-From b2c8ac5291be92baf113f2de94b22d5c53442927 Mon Sep 17 00:00:00 2001
+From d9eb0e15a231bc559217e4a796ee1e66f3fe17c5 Mon Sep 17 00:00:00 2001
 From: Gabriele Baldassarre <gabriele@gabrielebaldassarre.com>
 Date: Tue, 23 Oct 2018 00:23:24 +0200
 Subject: added support for Haiku paths
@@ -137,7 +137,7 @@ index d51996a..6633c92 100644
 2.45.2
 
 
-From 597eb5ec86f33cdbf65f1c91ede0ecfcea5ee675 Mon Sep 17 00:00:00 2001
+From bc67dec6a043bc08345370885362d8af4f58ad5d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
 Date: Wed, 28 Oct 2020 14:32:14 +0100
 Subject: Use the correct endian.h
@@ -160,7 +160,7 @@ index f8e9361..f8e3e86 100644
 2.45.2
 
 
-From 8fca25fe1e9cfbb3262a9fd0a006ac16b56aaf6b Mon Sep 17 00:00:00 2001
+From 8a08fc0f64258b1c5d88cf5af2bfc92d9de4a77e Mon Sep 17 00:00:00 2001
 From: Thomas Bernard <miniupnp@free.fr>
 Date: Thu, 9 Apr 2020 22:21:46 +0200
 Subject: -Fix: Tile_PackTile() is now a macro
@@ -209,7 +209,7 @@ index 234b08e..3f97403 100644
 2.45.2
 
 
-From ecacfc4b847804d634273a8e74ffd1f65e0cbca6 Mon Sep 17 00:00:00 2001
+From fe23e9be0f33d3df9fe3cc8b9133fc1d688f02c3 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
 Date: Wed, 28 Oct 2020 16:11:07 +0100
 Subject: Remove keyboard scancode magic
@@ -252,7 +252,7 @@ index 5cfebc0..af9c209 100644
 2.45.2
 
 
-From 6376964cad25c40ebd7d3ecbabaffca9d4c86032 Mon Sep 17 00:00:00 2001
+From 9c97a72a7d646235bf7a190d4d51c9cead4a5d15 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
 Date: Sun, 1 Nov 2020 20:19:20 +0100
 Subject: Fix: solve CTRL key disabling keyboard
@@ -275,7 +275,7 @@ index f0d3cc6..4a1b510 100644
 2.45.2
 
 
-From 6c48f2329b90eb28a864112945983f09a4efd8ce Mon Sep 17 00:00:00 2001
+From 1c80ce25c567952d008ec9e8a946c0967e72072d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
 Date: Thu, 29 Oct 2020 20:57:40 +0100
 Subject: Add visible error messages
@@ -457,7 +457,7 @@ index 0000000..40b2e62
 2.45.2
 
 
-From a7953a4add7c623ae36eaa4b406240ac20a94beb Mon Sep 17 00:00:00 2001
+From 64fdcdb851c1f817e247ec624f51cbcbedd5bcc7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
 Date: Fri, 30 Oct 2020 12:42:28 +0100
 Subject: snooze-based timer loop
@@ -554,7 +554,7 @@ index 475331d..1abade9 100644
 2.45.2
 
 
-From dd897ddc707d2908a8976785148375bb48db9c02 Mon Sep 17 00:00:00 2001
+From fcef03670bf5f33934996442b8adc671fdb2f9fc Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
 Date: Sun, 1 Nov 2020 16:26:50 +0100
 Subject: Add sound
@@ -638,7 +638,7 @@ index 0b1004e..f0c6d31 100644
 2.45.2
 
 
-From 1f747fede5e3bcc15e2770e1df26876e4b07a252 Mon Sep 17 00:00:00 2001
+From 97581253b0f0c310502cc88a710bca1855870850 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
 Date: Mon, 2 Nov 2020 12:43:36 +0100
 Subject: Add MIDI music
@@ -781,7 +781,7 @@ index 0000000..a2c678f
 2.45.2
 
 
-From 1b0f381079d68130d4962ef1fba3420e957a3c1b Mon Sep 17 00:00:00 2001
+From 623c9aa0ff331b43b84630a8ad03eb3e3aa68a12 Mon Sep 17 00:00:00 2001
 From: begasus <begasus@gmail.com>
 Date: Wed, 11 Nov 2020 09:10:55 +0000
 Subject: Fix conflicting int types for 32bit
@@ -806,3 +806,36 @@ index e623ebd..d8489ae 100644
  assert_compile(sizeof(uint16) == 2);
 -- 
 2.45.2
+
+
+From 9ec10dd99f95d605e7b72bea3f7dc5c99054b039 Mon Sep 17 00:00:00 2001
+From: Peppersawce <michaelpeppers89@yahoo.it>
+Date: Thu, 26 Sep 2024 23:08:31 +0200
+Subject: Hackfix (with sed) to Opendune using ~/.config to store user data
+
+
+diff --git a/src/file.c b/src/file.c
+index 0b08d60..1f23cb3 100644
+--- a/src/file.c
++++ b/src/file.c
+@@ -42,7 +42,7 @@
+ 
+ #ifdef __HAIKU__
+ static char g_dune_data_dir[B_PATH_NAME_LENGTH] = DUNE_DATA_DIR;
+-static char g_personal_data_dir[B_PATH_NAME_LENGTH] = ".";
++static char g_personal_data_dir[B_PATH_NAME_LENGTH] = "@HAIKUSERSETTINGS@";
+ #else
+ static char g_dune_data_dir[1024] = DUNE_DATA_DIR;
+ static char g_personal_data_dir[1024] = ".";
+@@ -558,7 +558,7 @@ bool File_Init(void)
+ #if defined(__APPLE__)
+ 			snprintf(g_personal_data_dir, sizeof(g_personal_data_dir), "%s/Library/Application Support/OpenDUNE", homedir);
+ #else /* __APPLE__ */
+-			snprintf(g_personal_data_dir, sizeof(g_personal_data_dir), "%s/.config/opendune", homedir);
++			snprintf(g_personal_data_dir, sizeof(g_personal_data_dir), "@HAIKUSERSETTINGS@");
+ #endif /* __APPLE__ */
+ 		}
+ #endif /* _WIN32 */
+-- 
+2.45.2
+

--- a/games-strategy/opendune/patches/opendune-0.9.patchset
+++ b/games-strategy/opendune/patches/opendune-0.9.patchset
@@ -1,4 +1,4 @@
-From aa2b1a3c793b8a7ec78ebe58aabdf1c8eb8c7003 Mon Sep 17 00:00:00 2001
+From 4bd1c9303738b66c2ba43b3142a1ab94d567593b Mon Sep 17 00:00:00 2001
 From: Gabriele Baldassarre <gabriele@gabrielebaldassarre.com>
 Date: Mon, 22 Oct 2018 23:00:12 +0200
 Subject: initial set of defines for Haiku
@@ -28,7 +28,7 @@ index daac831..bdea121 100644
 2.45.2
 
 
-From d9eb0e15a231bc559217e4a796ee1e66f3fe17c5 Mon Sep 17 00:00:00 2001
+From 52be4b955adfcfd20865166d425812d95a0211ac Mon Sep 17 00:00:00 2001
 From: Gabriele Baldassarre <gabriele@gabrielebaldassarre.com>
 Date: Tue, 23 Oct 2018 00:23:24 +0200
 Subject: added support for Haiku paths
@@ -137,7 +137,7 @@ index d51996a..6633c92 100644
 2.45.2
 
 
-From bc67dec6a043bc08345370885362d8af4f58ad5d Mon Sep 17 00:00:00 2001
+From 5cc7b502b8487a1e0ec585238589260797123fc7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
 Date: Wed, 28 Oct 2020 14:32:14 +0100
 Subject: Use the correct endian.h
@@ -160,7 +160,7 @@ index f8e9361..f8e3e86 100644
 2.45.2
 
 
-From 8a08fc0f64258b1c5d88cf5af2bfc92d9de4a77e Mon Sep 17 00:00:00 2001
+From b1b18d345557c0e8641a389fe6ec0fc0c4321fc5 Mon Sep 17 00:00:00 2001
 From: Thomas Bernard <miniupnp@free.fr>
 Date: Thu, 9 Apr 2020 22:21:46 +0200
 Subject: -Fix: Tile_PackTile() is now a macro
@@ -209,7 +209,7 @@ index 234b08e..3f97403 100644
 2.45.2
 
 
-From fe23e9be0f33d3df9fe3cc8b9133fc1d688f02c3 Mon Sep 17 00:00:00 2001
+From 23a73560934cc7cd7bdf1418cfcde3823c1096a1 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
 Date: Wed, 28 Oct 2020 16:11:07 +0100
 Subject: Remove keyboard scancode magic
@@ -252,7 +252,7 @@ index 5cfebc0..af9c209 100644
 2.45.2
 
 
-From 9c97a72a7d646235bf7a190d4d51c9cead4a5d15 Mon Sep 17 00:00:00 2001
+From dec878a56f31b08e7dd732bc1f57747a95258f2d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
 Date: Sun, 1 Nov 2020 20:19:20 +0100
 Subject: Fix: solve CTRL key disabling keyboard
@@ -275,7 +275,7 @@ index f0d3cc6..4a1b510 100644
 2.45.2
 
 
-From 1c80ce25c567952d008ec9e8a946c0967e72072d Mon Sep 17 00:00:00 2001
+From 4d9afa47cf24f573f4bb4b508e258d86a8b8d74e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
 Date: Thu, 29 Oct 2020 20:57:40 +0100
 Subject: Add visible error messages
@@ -457,7 +457,7 @@ index 0000000..40b2e62
 2.45.2
 
 
-From 64fdcdb851c1f817e247ec624f51cbcbedd5bcc7 Mon Sep 17 00:00:00 2001
+From 99324e62e648f4ee10ac1682a55a9708244017f6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
 Date: Fri, 30 Oct 2020 12:42:28 +0100
 Subject: snooze-based timer loop
@@ -554,7 +554,7 @@ index 475331d..1abade9 100644
 2.45.2
 
 
-From fcef03670bf5f33934996442b8adc671fdb2f9fc Mon Sep 17 00:00:00 2001
+From d290c165c486368d7330a76fdfde5039a6481c01 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
 Date: Sun, 1 Nov 2020 16:26:50 +0100
 Subject: Add sound
@@ -638,7 +638,7 @@ index 0b1004e..f0c6d31 100644
 2.45.2
 
 
-From 97581253b0f0c310502cc88a710bca1855870850 Mon Sep 17 00:00:00 2001
+From 169e537c6a14423c5cc63c85dbda46175a3bac3a Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?M=C3=A1ximo=20Casta=C3=B1eda?= <antiswen@yahoo.es>
 Date: Mon, 2 Nov 2020 12:43:36 +0100
 Subject: Add MIDI music
@@ -781,7 +781,7 @@ index 0000000..a2c678f
 2.45.2
 
 
-From 623c9aa0ff331b43b84630a8ad03eb3e3aa68a12 Mon Sep 17 00:00:00 2001
+From 2060062e553d93adaf767181d52c7dbd16e4c9fd Mon Sep 17 00:00:00 2001
 From: begasus <begasus@gmail.com>
 Date: Wed, 11 Nov 2020 09:10:55 +0000
 Subject: Fix conflicting int types for 32bit
@@ -808,25 +808,36 @@ index e623ebd..d8489ae 100644
 2.45.2
 
 
-From 9ec10dd99f95d605e7b72bea3f7dc5c99054b039 Mon Sep 17 00:00:00 2001
+From 5e19fe80198f3904b8146cb5a66f4e2206f9966d Mon Sep 17 00:00:00 2001
 From: Peppersawce <michaelpeppers89@yahoo.it>
-Date: Thu, 26 Sep 2024 23:08:31 +0200
+Date: Sun, 6 Oct 2024 23:28:38 +0200
 Subject: Fix to Opendune using ~/.config to store user data
 
 
 diff --git a/src/file.c b/src/file.c
-index 0b08d60..1f23cb3 100644
+index 0b08d60..0bc7353 100644
 --- a/src/file.c
 +++ b/src/file.c
-@@ -558,7 +558,7 @@ bool File_Init(void)
+@@ -26,6 +26,8 @@
+ #include "inifile.h"
+ 
+ #ifdef __HAIKU__
++#include <FindDirectory.h>
++#include <fs_info.h>
+ #include <StorageDefs.h>
+ #endif /* HAIKU */
+ 
+@@ -557,6 +559,10 @@ bool File_Init(void)
+ 		} else {
  #if defined(__APPLE__)
  			snprintf(g_personal_data_dir, sizeof(g_personal_data_dir), "%s/Library/Application Support/OpenDUNE", homedir);
++#elif defined(__HAIKU__)
++			char buffer[B_PATH_NAME_LENGTH+10];
++			find_directory(B_USER_SETTINGS_DIRECTORY, dev_for_path("/boot"), false, buffer, B_PATH_NAME_LENGTH);
++			snprintf(g_personal_data_dir, sizeof(g_personal_data_dir), "%s/opendune", buffer);
  #else /* __APPLE__ */
--			snprintf(g_personal_data_dir, sizeof(g_personal_data_dir), "%s/.config/opendune", homedir);
-+			snprintf(g_personal_data_dir, sizeof(g_personal_data_dir), "%s/config/settings/opendune", homedir);
+ 			snprintf(g_personal_data_dir, sizeof(g_personal_data_dir), "%s/.config/opendune", homedir);
  #endif /* __APPLE__ */
- 		}
- #endif /* _WIN32 */
 -- 
 2.45.2
 


### PR DESCRIPTION
I noticed Opendune saves some stuff in `~/.config` so I went ahead and fixed it, changing all references to that with `~/config/settings/opendune`
Also removed `~/config/settings/opendune/savegames` from USER_SETTINGS_FILES as it was (and is) unused (the user can specify the save folder by editing the .ini file either way)