### PR TITLE
mame: Bump version; use system asio; define _DEFAULT_SOURCE

### DIFF
--- a/games-emulation/mame/mame-0.270.recipe
+++ b/games-emulation/mame/mame-0.270.recipe
@@ -11,11 +11,11 @@ sister-project MESS (Multi Emulator Super System), so MAME now documents a \
 wide variety of (mostly vintage) computers, video game consoles and \
 calculators, in addition to the arcade video games that were its initial focus."
 HOMEPAGE="https://www.mamedev.org/"
-COPYRIGHT="1997-2023 MAMEDev and contributors"
+COPYRIGHT="1997-2024 MAMEDev and contributors"
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://github.com/mamedev/mame/archive/mame${portVersion/./}.tar.gz"
-CHECKSUM_SHA256="0210be24f838f565302eed057dd6a4b1a252c9e0ca3d3f0832e8a4b1cf481f3e"
+CHECKSUM_SHA256="0364b670478883902c2bc618908192b0590235b47fbe073fcac2d13b82541437"
 SOURCE_FILENAME="mame-$portVersion.tar.gz"
 SOURCE_DIR="mame-mame${portVersion/./}"
 PATCHES="mame-$portVersion.patchset"
@@ -75,6 +75,7 @@ REQUIRES="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:glm
+	devel:libasio$secondaryArchSuffix
 	devel:libexpat$secondaryArchSuffix
 	devel:libflac$secondaryArchSuffix
 	devel:libfontconfig$secondaryArchSuffix
@@ -131,7 +132,7 @@ BUILD()
 		SYS_LDFLAGS+="`pkg-config $_i --libs` "
 	done
 
-	ARCHOPTS="$SYS_CFLAGS $SYS_LDFLAGS" \
+	ARCHOPTS="$SYS_CFLAGS $SYS_LDFLAGS -D_DEFAULT_SOURCE" \
 	make \
 		REGENIE=1 \
 		IGNORE_GIT=1 \
@@ -140,6 +141,7 @@ BUILD()
 		NOWERROR=1 \
 		OPTIMIZE=$optimize \
 		USE_QTDEBUG=1 \
+		USE_SYSTEM_LIB_ASIO=1 \
 		USE_SYSTEM_LIB_EXPAT=1 \
 		USE_SYSTEM_LIB_ZLIB=1 \
 		USE_SYSTEM_LIB_JPEG=1 \

--- a/games-emulation/mame/patches/mame-0.270.patchset
+++ b/games-emulation/mame/patches/mame-0.270.patchset
@@ -1,4 +1,4 @@
-From ac90fd733fbeb6d07544aca89b0cc6eb9d3f6770 Mon Sep 17 00:00:00 2001
+From 2ab6c81fcfc9f7969cdaae0bf67559e1c57358c8 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Wed, 10 Jun 2020 22:35:16 +1000
 Subject: Haiku patches
@@ -676,7 +676,7 @@ index f0782db..5a3a636 100644
  #define PLATFORM_WINDOWS  (1)
  #define PLATFORM_STRING   "windows"
 diff --git a/makefile b/makefile
-index e15b8e4..b9554e4 100644
+index ddf8093..f0b219f 100644
 --- a/makefile
 +++ b/makefile
 @@ -224,6 +224,7 @@ GENIEOS := darwin
@@ -799,10 +799,10 @@ index 57ff069..e0ff74e 100644
  #include <termios.h>
  #include <libutil.h>
 -- 
-2.45.1
+2.45.2
 
 
-From 882fd95d351e5f48a2a7248f79181e30b8eea1f3 Mon Sep 17 00:00:00 2001
+From d890efe7931755db69e5ae9ac6237072a3203cf0 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Thu, 11 Jun 2020 08:59:34 +1000
 Subject: Use stat Haiku
@@ -840,10 +840,10 @@ index dab8620..ceb2263 100644
  					_out.type = FileType::File;
  					_out.size = UINT64_MAX;
 -- 
-2.45.1
+2.45.2
 
 
-From 97139dea7e4080109ae4fe9405f8c3d465607945 Mon Sep 17 00:00:00 2001
+From ed9a68155a960fe281b3fa9ad24df946fae03a87 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Thu, 11 Jun 2020 09:00:11 +1000
 Subject: Disable ptty
@@ -863,10 +863,10 @@ index e0ff74e..39a0a5a 100644
  #else // defined(__ANDROID__)
  	// TODO: handling of the slave path is insecure - should use ptsname_r/ttyname_r in a loop
 -- 
-2.45.1
+2.45.2
 
 
-From 3c29de7f5ae44dbd5ad32eee5edc858037d3dfee Mon Sep 17 00:00:00 2001
+From ad50ebf741c9171a9729290d53b8cf5e98451269 Mon Sep 17 00:00:00 2001
 From: PulkoMandy <pulkomandy@pulkomandy.tk>
 Date: Fri, 5 Aug 2022 19:24:12 +0200
 Subject: Allow use of Qt Debugger on Haiku
@@ -902,10 +902,10 @@ index cc31fa5..2727ce7 100644
  		local str = backtick(sdlconfigcmd() .. " --libs")
  		addlibfromstring(str)
 -- 
-2.45.1
+2.45.2
 
 
-From 5044a5cbac53dfd2b98faf5b7d727c9ee61d8df9 Mon Sep 17 00:00:00 2001
+From b4175db2c2a2e327d5f74b3454b94efa80b313e9 Mon Sep 17 00:00:00 2001
 From: Alex Brown <mail@alexbrown.info>
 Date: Sat, 14 Oct 2023 11:26:57 +0100
 Subject: toolchain.lua: set targetdir for Haiku
@@ -957,10 +957,10 @@ index 52d5146..0b67b44 100644
  		targetdir (_buildDir .. "osx_clang" .. "/bin/x64/Debug")
  
 -- 
-2.45.1
+2.45.2
 
 
-From 0ba51897a1e6e2d3325d3766028fb5eece576a4c Mon Sep 17 00:00:00 2001
+From 62f5d64c5e5e7cdbd5ecd727b6a43127533c4b60 Mon Sep 17 00:00:00 2001
 From: Alex Brown <mail@alexbrown.info>
 Date: Sat, 14 Oct 2023 09:14:19 +0100
 Subject: Set LinkSupportCircularDependencies for Haiku
@@ -983,5 +983,5 @@ index 5997782..90de339 100644
  		links {
  			"pthread",
 -- 
-2.45.1
+2.45.2
 


### PR DESCRIPTION
First release compiled on R1B5, includes the fix for https://github.com/haikuports/haikuports/issues/10402.

I've switched the package to using the version of boost asio in HaikuPorts, rather than the one bundled with MAME.

The upgrade to R1B5 required defining `_DEFAULT_SOURCE`, as per this thread: https://discuss.haiku-os.org/t/porting-issues-r1b4-vs-nightly/13968

~I've also added an upstream fix for a bug in MAME's Psion SIBO (ASIC5 serial) emulation. https://github.com/mamedev/mame/commit/67b8c40e253a5bd60681590c8d454596ec21d490~ I was able to bump the version to 0.270, which already includes this fix.

Please let me know if anything I've done here needs to be improved.