### PR TITLE
gemrb: fix build on 32 bits.

### DIFF
--- a/games-engines/gemrb/gemrb-0.9.3.recipe
+++ b/games-engines/gemrb/gemrb-0.9.3.recipe
@@ -8,7 +8,7 @@ to Linux/Unix, MacOS X, Windows (and Haiku) with some enhancements.
 HOMEPAGE="https://gemrb.org/"
 COPYRIGHT="2003-2024 The GemRB Team"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/gemrb/gemrb/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="71bb16a77b84cd873d5582af675357c0cb94bbc64d54fac2e3397b366ac2adde"
 SOURCE_FILENAME="v$portVersion.tar.gz"
@@ -19,7 +19,7 @@ ADDITIONAL_FILES="
 	"
 POST_INSTALL_SCRIPTS="$relativePostInstallDir/gemrb-postinstall.sh"
 
-ARCHITECTURES="?all !x86_gcc2 x86_64"
+ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 GLOBAL_WRITABLE_FILES="
@@ -69,7 +69,7 @@ BUILD_PREREQUIRES="
 	"
 
 defineDebugInfoPackage gemrb$secondaryArchSuffix \
-	$binDir/gemrb
+	$prefix/bin/gemrb
 
 BUILD()
 {
@@ -77,10 +77,10 @@ BUILD()
 	cd build
 
 	cmake .. \
-		$cmakeDirArgs \
 		-Wno-dev \
 		-DCMAKE_BUILD_TYPE=Release \
-		-DBIN_DIR=$binDir \
+		-DCMAKE_INSTALL_PREFIX=$prefix \
+		-DBIN_DIR=$prefix/bin \
 		-DDATA_DIR=$dataDir/gemrb \
 		-DMAN_DIR=$manDir/man6 \
 		-DSYSCONF_DIR=$settingsDir/gemrb \
@@ -120,6 +120,6 @@ INSTALL()
 	cp $portDir/additional-files/gemrb-postinstall.sh $postInstallDir
 	chmod +x $postInstallDir/gemrb-postinstall.sh
 
-	addResourcesToBinaries gemrb.rdef $binDir/gemrb
-	addAppDeskbarSymlink $binDir/gemrb "GemRB"
+	addResourcesToBinaries gemrb.rdef $prefix/bin/gemrb
+	addAppDeskbarSymlink $prefix/bin/gemrb "GemRB"
 }


### PR DESCRIPTION
Well, current build succeded, but [log shows](https://build.haiku-os.org/buildmaster/master/x86_gcc2/logviewer.html?buildruns/6908/builds/84508.log):

```
Warning: POLICY WARNING: no matching provides "cmd:extend2da.py_x86" for "bin/extend2da.py-x86"
Warning: POLICY WARNING: no matching provides "cmd:gemrb_x86" for "bin/gemrb-x86"
```