### PR TITLE
gflags: Fix include directories.

### DIFF
--- a/dev-cpp/gflags/gflags-2.2.2.recipe
+++ b/dev-cpp/gflags/gflags-2.2.2.recipe
@@ -6,7 +6,7 @@ which they are used."
 HOMEPAGE="https://gflags.github.io/gflags/"
 COPYRIGHT="2006 Google Inc."
 LICENSE="BSD (3-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/gflags/gflags/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="34af2f15cf7367513b352bdcd2493ab14ce43692d2dcd9dfc499492966c64dcf"
 
@@ -69,7 +69,9 @@ INSTALL()
 	fixPkgconfig
 
 	sed -i 's,\/include,/'${relativeIncludeDir}',g' \
-		$libDir/cmake/gflags/gflags-config.cmake
+		$libDir/cmake/gflags/gflags-config.cmake \
+		$libDir/cmake/gflags/gflags-targets.cmake \
+		$libDir/cmake/gflags/gflags-nonamespace-targets.cmake
 
 	packageEntries devel \
 		$developDir \


### PR DESCRIPTION
This fixes errors when including GFlags as build dependency.