### PR TITLE
Update hikounomizu to 1.1

### DIFF
--- a/games-arcade/hikounomizu/hikounomizu-1.1.recipe
+++ b/games-arcade/hikounomizu/hikounomizu-1.1.recipe
@@ -1,15 +1,15 @@
 SUMMARY="A platform-based, anime-styled fighting game"
-DESCRIPTION="Hikou no mizu is a 2D fighting game with anime-inspired \
-graphics. Fights take place in interactive arenas of various sizes and can \
-involve up to five players on a single machine. Currently, two players are \
-playable, namely Hikou and Takino. Joysticks are supported and a simple AI \
-is included for solo playing."
+DESCRIPTION="Hikou no mizu is a 2D fighting game with anime-inspired graphics. Fights take place \
+in interactive arenas of various sizes. Both networked multiplayer and local games are possible. \
+Joysticks are supported and a simple AI is included for solo playing. Playable characters fight \
+using natural powers such as water, lightning or fire. Currently, three characters are playable: \
+Hikou, Takino and Hana."
 HOMEPAGE="https://hikounomizu.org"
-COPYRIGHT="2010-2022 Duncan Deveaux"
+COPYRIGHT="2010-2024 Duncan Deveaux"
 LICENSE="GNU GPL v3"
 REVISION="1"
-SOURCE_URI="https://download.tuxfamily.org/hnm/0.9.2/hikounomizu-0.9.2-src-withdata.tar.bz2"
-CHECKSUM_SHA256="59a97e532f2151193984a01761604971ef2cb8234ea7040e1dc36f9ee715bc39"
+SOURCE_URI="https://download.tuxfamily.org/hnm/$portVersion/hikounomizu-$portVersion-src-withdata.tar.bz2"
+CHECKSUM_SHA256="7e6128a52ab802f551c7e3eaf62757045bcc162fc3a2e7f916ece3cf584823b9"
 ADDITIONAL_FILES="hikounomizu.rdef.in"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -18,13 +18,14 @@ SECONDARY_ARCHITECTURES="x86"
 PROVIDES="
 	hikounomizu$secondaryArchSuffix = $portVersion
 	app:HikouNoMizu$secondaryArchSuffix = $portVersion
+	cmd:hikounomizud$secondaryArchSuffix = $portVersion
 	"
 
 REQUIRES="
 	haiku$secondaryArchSuffix
+	lib:libenet$secondaryArchSuffix
 	lib:libfreetype$secondaryArchSuffix
 	lib:libGL$secondaryArchSuffix
-	lib:libGLU$secondaryArchSuffix
 	lib:libogg$secondaryArchSuffix
 	lib:libopenal$secondaryArchSuffix
 	lib:libpugixml$secondaryArchSuffix
@@ -35,9 +36,9 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	devel:libenet$secondaryArchSuffix
 	devel:libfreetype$secondaryArchSuffix
 	devel:libGL$secondaryArchSuffix
-	devel:libGLU$secondaryArchSuffix
 	devel:libogg$secondaryArchSuffix
 	devel:libopenal$secondaryArchSuffix
 	devel:libpugixml$secondaryArchSuffix
@@ -66,9 +67,12 @@ INSTALL()
 	make -C build install
 	mv $appsDir/hikounomizu $appsDir/HikouNoMizu
 
+	mkdir -p $prefix/bin
+	mv $appsDir/hikounomizud $prefix/bin/hikounomizud
+
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
 	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
-	local MINOR="`echo "$portVersion" | cut -d. -f3`"
+	local MINOR="0"
 	local LONG_INFO="$SUMMARY"
 	sed \
 		-e "s|@MAJOR@|$MAJOR|" \


### PR DESCRIPTION
Update of the `games-arcade/hikounomizu` recipe to version 1.1.
It has no major changes except the dropping of GLU and the addition of enet.