### PR TITLE
gcc-13.3.0: gcc_fortran requires gcc

### DIFF
--- a/sys-devel/gcc/gcc-13.3.0_2023_08_10.recipe
+++ b/sys-devel/gcc/gcc-13.3.0_2023_08_10.recipe
@@ -5,7 +5,7 @@ HOMEPAGE="https://gcc.gnu.org/"
 COPYRIGHT="1988-2023 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3
 	GNU LGPL v3"
-REVISION="1"
+REVISION="2"
 gccVersion="${portVersion%%_*}"
 SOURCE_URI="https://ftpmirror.gnu.org/gcc/gcc-$gccVersion/gcc-$gccVersion.tar.xz
 	https://ftp.gnu.org/gnu/gcc/gcc-$gccVersion/gcc-$gccVersion.tar.xz"
@@ -79,7 +79,8 @@ PROVIDES_fortran="
 	"
 REQUIRES_fortran="
 	haiku$secondaryArchSuffix
-	gcc${secondaryArchSuffix}_syslibs == $portVersion base
+	gcc$secondaryArchSuffix == $portVersion base
+	gcc${secondaryArchSuffix}_syslibs == $portVersion
 	"
 
 SUMMARY_jit="Library for embedding GCC inside programs and libraries"


### PR DESCRIPTION
* Without gcc as required package, requiring "cmd:gfortran" results in missing libraries

Fixes #11011