### PR TITLE
luajit: update to 2.1.1727870382 (Wed Oct 2 13:59:42 2024 +0200)

### DIFF
--- a/dev-lang/luajit/luajit-2.1.1727870382.recipe
+++ b/dev-lang/luajit/luajit-2.1.1727870382.recipe
@@ -7,9 +7,9 @@ COPYRIGHT="2005-2024 Mike Pall"
 LICENSE="MIT"
 REVISION="1"
 # Note: last component of the version is the Unix timestamp of the git commit
-srcGitRev="93e87998b24021b94de8d1c8db244444c46fb6e9"
+srcGitRev="97813fb924edf822455f91a5fbbdfdb349e5984f"
 SOURCE_URI="https://github.com/LuaJIT/LuaJIT/archive/$srcGitRev.tar.gz"
-CHECKSUM_SHA256="026eb4531cddff20acc72ec97378ccfc30326173c491d6c01834b48b42a80518"
+CHECKSUM_SHA256="cbf1647acbd340c62b9c342dae43290762efa1b26d8bf8457f143fabf8ed86c7"
 SOURCE_DIR="LuaJIT-$srcGitRev"
 PATCHES="luajit-${portVersion%.*}.patchset"
 

--- a/dev-lang/luajit/luajit-2.1.1727870382.recipe
+++ b/dev-lang/luajit/luajit-2.1.1727870382.recipe
@@ -45,7 +45,7 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	# Use amalg target as recommended on luajit homepage to get better performance
-	make $jobArgs amalg PREFIX=$prefix
+	make $jobArgs amalg PREFIX=$prefix INSTALL_SHARE="$dataDir"
 }
 
 INSTALL()

--- a/dev-lang/luajit/patches/luajit-2.1.patchset
+++ b/dev-lang/luajit/patches/luajit-2.1.patchset
@@ -1,14 +1,14 @@
-From f54e1c17085bfdc0d9934c49b14954ed45d2f6e7 Mon Sep 17 00:00:00 2001
+From 273e22f2df3a40c890e2581058dc7ec1caec6cfd Mon Sep 17 00:00:00 2001
 From: Christof Meerwald <cmeerw@cmeerw.org>
-Date: Thu, 21 Dec 2023 20:00:27 +0100
-Subject: adjust search path for Haiku
+Date: Sat, 5 Oct 2024 13:53:57 +0200
+Subject: [PATCH] adjust search path for Haiku
 
 
 diff --git a/src/luaconf.h b/src/luaconf.h
-index f47f0680..c7c58d37 100644
+index 1cf3a03..3f86b0b 100644
 --- a/src/luaconf.h
 +++ b/src/luaconf.h
-@@ -35,13 +35,19 @@
+@@ -35,12 +35,18 @@
  #ifndef LUA_LMULTILIB
  #define LUA_LMULTILIB	"lib"
  #endif
@@ -20,7 +20,6 @@ index f47f0680..c7c58d37 100644
  #define LUA_LROOT	"/usr/local"
 +#endif
  #define LUA_LUADIR	"/lua/5.1/"
- #define LUA_LJDIR	"/luajit-2.1/"
  
  #ifdef LUA_ROOT
  #define LUA_JROOT	LUA_ROOT
@@ -29,19 +28,22 @@ index f47f0680..c7c58d37 100644
  #define LUA_RCDIR	LUA_ROOT "/" LUA_MULTILIB LUA_LUADIR
  #define LUA_RLPATH	";" LUA_RLDIR "?.lua;" LUA_RLDIR "?/init.lua"
  #define LUA_RCPATH	";" LUA_RCDIR "?.so"
-@@ -51,8 +57,8 @@
- #define LUA_RCPATH
+@@ -51,11 +57,11 @@
  #endif
  
--#define LUA_JPATH	";" LUA_JROOT "/share" LUA_LJDIR "?.lua"
+ #ifndef LUA_LJDIR
+-#define LUA_LJDIR	LUA_JROOT "/share/luajit-2.1"
++#define LUA_LJDIR	LUA_JROOT "/" LUA_DATA "/luajit-2.1"
+ #endif
+ 
+ #define LUA_JPATH	";" LUA_LJDIR "/?.lua"
 -#define LUA_LLDIR	LUA_LROOT "/share" LUA_LUADIR
-+#define LUA_JPATH	";" LUA_JROOT "/" LUA_DATA LUA_LJDIR "?.lua"
 +#define LUA_LLDIR	LUA_LROOT "/" LUA_DATA LUA_LUADIR
  #define LUA_LCDIR	LUA_LROOT "/" LUA_LMULTILIB LUA_LUADIR
  #define LUA_LLPATH	";" LUA_LLDIR "?.lua;" LUA_LLDIR "?/init.lua"
  #define LUA_LCPATH1	";" LUA_LCDIR "?.so"
 -- 
-2.40.1
+2.45.2
 
 From 16d7fbeddd2988a9a92f07dd9256b647bf6fbba7 Mon Sep 17 00:00:00 2001
 From: Christof Meerwald <cmeerw@cmeerw.org>
@@ -87,4 +89,26 @@ index 3aed365d..330f5d97 100644
  FILE_A= libluajit.a
 -- 
 2.40.1
+
+From 9ab05ad072d3dfc3b0a85c509b0248afa7b429d7 Mon Sep 17 00:00:00 2001
+From: Christof Meerwald <cmeerw@cmeerw.org>
+Date: Sat, 5 Oct 2024 14:23:45 +0200
+Subject: [PATCH] fix INSTALL_SHARE in Makefile
+
+
+diff --git a/Makefile b/Makefile
+index 2511051..ea5163c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -37,7 +37,7 @@ export MULTILIB= lib
+ DPREFIX= $(DESTDIR)$(PREFIX)
+ INSTALL_BIN=   $(DPREFIX)/bin
+ INSTALL_LIB=   $(DPREFIX)/$(MULTILIB)
+-INSTALL_SHARE= $(DPREFIX)/share
++INSTALL_SHARE= $(DPREFIX)/data
+ INSTALL_DEFINC= $(DPREFIX)/include/luajit-$(MMVERSION)
+ INSTALL_INC=   $(INSTALL_DEFINC)
+ 
+-- 
+2.45.2
 

--- a/dev-lang/luajit/patches/luajit-2.1.patchset
+++ b/dev-lang/luajit/patches/luajit-2.1.patchset
@@ -90,25 +90,3 @@ index 3aed365d..330f5d97 100644
 -- 
 2.40.1
 
-From 9ab05ad072d3dfc3b0a85c509b0248afa7b429d7 Mon Sep 17 00:00:00 2001
-From: Christof Meerwald <cmeerw@cmeerw.org>
-Date: Sat, 5 Oct 2024 14:23:45 +0200
-Subject: [PATCH] fix INSTALL_SHARE in Makefile
-
-
-diff --git a/Makefile b/Makefile
-index 2511051..ea5163c 100644
---- a/Makefile
-+++ b/Makefile
-@@ -37,7 +37,7 @@ export MULTILIB= lib
- DPREFIX= $(DESTDIR)$(PREFIX)
- INSTALL_BIN=   $(DPREFIX)/bin
- INSTALL_LIB=   $(DPREFIX)/$(MULTILIB)
--INSTALL_SHARE= $(DPREFIX)/share
-+INSTALL_SHARE= $(DPREFIX)/data
- INSTALL_DEFINC= $(DPREFIX)/include/luajit-$(MMVERSION)
- INSTALL_INC=   $(INSTALL_DEFINC)
- 
--- 
-2.45.2
-


### PR DESCRIPTION
Also need to patch INSTALL_SHARE in the Makefile now to make sure the built-in luajit package path doesn't point to "share"