### PR TITLE
libxml++: Fix stray config header

### DIFF
--- a/dev-libs/libxml++/libxml++2-2.42.3.recipe
+++ b/dev-libs/libxml++/libxml++2-2.42.3.recipe
@@ -70,7 +70,7 @@ BUILD()
 INSTALL()
 {
 	ninja -C buildmeson install
-	
+
 	cp $libDir/libxml++-2.6/include/libxml++config.h $developDir/headers/libxml++-2.6
 	rm -r $libDir/libxml++-2.6/include
 

--- a/dev-libs/libxml++/libxml++2-2.42.3.recipe
+++ b/dev-libs/libxml++/libxml++2-2.42.3.recipe
@@ -71,8 +71,8 @@ INSTALL()
 {
 	ninja -C buildmeson install
 
-	cp $libDir/libxml++-2.6/include/libxml++config.h $developDir/headers/libxml++-2.6
-	rm -r $libDir/libxml++-2.6/include
+	mv $libDir/libxml++-2.6/include/libxml++config.h $includeDir/libxml++-2.6
+	rmdir $libDir/libxml++-2.6/include
 
 	prepareInstalledDevelLib libxml++-2.6
 	fixPkgconfig

--- a/dev-libs/libxml++/libxml++2-2.42.3.recipe
+++ b/dev-libs/libxml++/libxml++2-2.42.3.recipe
@@ -7,7 +7,7 @@ parallel-installable ABIs. This package contains libxml++-2.6."
 HOMEPAGE="https://libxmlplusplus.sourceforge.net/"
 COPYRIGHT="2004-2024 LibXML++"
 LICENSE="GNU LGPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://download.gnome.org/sources/libxml++/2.42/libxml++-$portVersion.tar.xz"
 CHECKSUM_SHA256="74b95302e24dbebc56e97048e86ad0a4121fc82a43e58d381fbe1d380e8eba04"
 SOURCE_FILENAME="libxml++-$portVersion.tar.bz2"
@@ -70,6 +70,9 @@ BUILD()
 INSTALL()
 {
 	ninja -C buildmeson install
+	
+	cp $libDir/libxml++-2.6/include/libxml++config.h $developDir/headers/libxml++-2.6
+	rm -r $libDir/libxml++-2.6/include
 
 	prepareInstalledDevelLib libxml++-2.6
 	fixPkgconfig

--- a/dev-libs/libxml++/libxml++5-5.4.0.recipe
+++ b/dev-libs/libxml++/libxml++5-5.4.0.recipe
@@ -72,7 +72,7 @@ INSTALL()
 	ninja -C buildmeson install
 
 	mv $libDir/libxml++-5.0/include/libxml++config.h $includeDir/libxml++-5.0
-	rmdirr $libDir/libxml++-5.0/include
+	rmdir $libDir/libxml++-5.0/include
 
 	prepareInstalledDevelLib libxml++-5.0
 	fixPkgconfig

--- a/dev-libs/libxml++/libxml++5-5.4.0.recipe
+++ b/dev-libs/libxml++/libxml++5-5.4.0.recipe
@@ -7,7 +7,7 @@ parallel-installable ABIs. This package contains libxml++-5.0."
 HOMEPAGE="https://libxmlplusplus.sourceforge.net/"
 COPYRIGHT="2004-2024 LibXML++"
 LICENSE="GNU LGPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://download.gnome.org/sources/libxml++/5.4/libxml++-$portVersion.tar.xz"
 CHECKSUM_SHA256="e9a23c436686a94698d2138e6bcbaf849121d63bfa0f50dc34fefbfd79566848"
 SOURCE_FILENAME="libxml++-$portVersion.tar.xz"
@@ -70,6 +70,9 @@ BUILD()
 INSTALL()
 {
 	ninja -C buildmeson install
+
+	cp $libDir/libxml++-5.0/include/libxml++config.h $developDir/headers/libxml++-5.0
+	rm -r $libDir/libxml++-5.0/include
 
 	prepareInstalledDevelLib libxml++-5.0
 	fixPkgconfig

--- a/dev-libs/libxml++/libxml++5-5.4.0.recipe
+++ b/dev-libs/libxml++/libxml++5-5.4.0.recipe
@@ -71,8 +71,8 @@ INSTALL()
 {
 	ninja -C buildmeson install
 
-	cp $libDir/libxml++-5.0/include/libxml++config.h $developDir/headers/libxml++-5.0
-	rm -r $libDir/libxml++-5.0/include
+	mv $libDir/libxml++-5.0/include/libxml++config.h $includeDir/libxml++-5.0
+	rmdirr $libDir/libxml++-5.0/include
 
 	prepareInstalledDevelLib libxml++-5.0
 	fixPkgconfig


### PR DESCRIPTION
Well, I missed a header while making recipes for these libs so the dev packages error out at compile time when used as dependencies. This patch moves the needed header and fixes the issue. :)