### PR TITLE
lgogdownloader: Fix linking against iconv.

### DIFF
--- a/games-util/lgogdownloader/lgogdownloader-3.12.recipe
+++ b/games-util/lgogdownloader/lgogdownloader-3.12.recipe
@@ -4,7 +4,7 @@ API as the official GOGDownloader"
 HOMEPAGE="https://sites.google.com/site/gogdownloader/"
 COPYRIGHT="2004 Sam Hocevar"
 LICENSE="WTFPL"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/Sude-/lgogdownloader/releases/download/v$portVersion/lgogdownloader-$portVersion.tar.gz"
 CHECKSUM_SHA256="bf3a16c1b2ff09152f9ac52ea9b52dfc0afae799ed1b370913149cec87154529"
 PATCHES="lgogdownloader-$portVersion.patchset"
@@ -25,6 +25,7 @@ REQUIRES="
 	lib:libboost_regex$secondaryArchSuffix
 	lib:libboost_system$secondaryArchSuffix
 	lib:libcurl$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
 	lib:libcss_parser$secondaryArchSuffix
 	lib:libcss_parser_pp$secondaryArchSuffix
 	lib:libhtmlcxx$secondaryArchSuffix
@@ -54,6 +55,7 @@ BUILD_REQUIRES="
 	devel:libboost_regex$secondaryArchSuffix >= 1.83.0
 	devel:libboost_system$secondaryArchSuffix >= 1.83.0
 	devel:libcurl$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
 	devel:libhtmlcxx$secondaryArchSuffix
 	devel:libjsoncpp$secondaryArchSuffix
 #	devel:libQt5WebEngine$secondaryArchSuffix

--- a/games-util/lgogdownloader/patches/lgogdownloader-3.12.patchset
+++ b/games-util/lgogdownloader/patches/lgogdownloader-3.12.patchset
@@ -1,4 +1,4 @@
-From f00c37aa618ff8b2a7753a5d7863dcd3db0eb6b9 Mon Sep 17 00:00:00 2001
+From c65d24ff976fc9914b2b92bb31e0e07844180aaf Mon Sep 17 00:00:00 2001
 From: Begasus <begasus@gmail.com>
 Date: Sat, 21 Oct 2023 21:30:55 +0200
 Subject: Fix for: help2man: can't get `--help' info (for manpage)
@@ -18,5 +18,60 @@ index 3225653..f9aa17a 100644
      MAIN_DEPENDENCY ${H2M_FILE}
  	COMMENT "Building man page"
 -- 
-2.42.0
+2.45.2
+
+
+From 1e7b59a3e8f7c7f7f532686229a7350789843f9a Mon Sep 17 00:00:00 2001
+From: "Mika T. Lindqvist" <postmaster@raasu.org>
+Date: Tue, 8 Oct 2024 11:55:27 +0000
+Subject: Fix linking with iconv.
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0fe7568..98d9fd0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -24,6 +24,7 @@ find_package(Boost
+   iostreams
+   )
+ find_package(CURL 7.55.0 REQUIRED)
++find_package(Iconv REQUIRED)
+ find_package(Jsoncpp REQUIRED)
+ find_package(Htmlcxx REQUIRED)
+ find_package(Tinyxml2 REQUIRED)
+@@ -105,6 +106,7 @@ target_include_directories(${PROJECT_NAME}
+   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+   PRIVATE ${Boost_INCLUDE_DIRS}
+   PRIVATE ${CURL_INCLUDE_DIRS}
++  PRIVATE ${ICONV_INCLUDE_DIR}
+   PRIVATE ${OAuth_INCLUDE_DIRS}
+   PRIVATE ${Jsoncpp_INCLUDE_DIRS}
+   PRIVATE ${Htmlcxx_INCLUDE_DIRS}
+@@ -116,6 +118,7 @@ target_include_directories(${PROJECT_NAME}
+ target_link_libraries(${PROJECT_NAME}
+   PRIVATE ${Boost_LIBRARIES}
+   PRIVATE ${CURL_LIBRARIES}
++  PRIVATE ${ICONV_LIBRARY}
+   PRIVATE ${OAuth_LIBRARIES}
+   PRIVATE ${Jsoncpp_LIBRARIES}
+   PRIVATE ${Htmlcxx_LIBRARIES}
+diff --git a/cmake/FindIconv.cmake b/cmake/FindIconv.cmake
+new file mode 100644
+index 0000000..2d53426
+--- /dev/null
++++ b/cmake/FindIconv.cmake
+@@ -0,0 +1,11 @@
++find_path(ICONV_INCLUDE_DIR NAMES iconv.h)
++find_library(ICONV_LIBRARY NAMES iconv libiconv)
++find_package_handle_standard_args(Iconv DEFAULT_MSG
++  ICONV_INCLUDE_DIR)
++mark_as_advanced(ICONV_INCLUDE_DIR ICONV_LIBRARY)
++
++add_library(iconv INTERFACE)
++target_include_directories(iconv SYSTEM BEFORE INTERFACE ICONV_INCLUDE_DIR)
++if(ICONV_LIBRARY)
++  target_link_libraries(iconv INTERFACE ICONV_LIBRARY)
++endif()
+--
+2.45.2
 


### PR DESCRIPTION
* Needs #11203

There is no cmake configuration files in `devel:libiconv`, so we need to override the cmake bundled `FindIconv`.