### PR TITLE
Add recipe for Genio 3.1

### DIFF
--- a/haiku-apps/genio/genio-3.0.recipe
+++ b/haiku-apps/genio/genio-3.0.recipe
@@ -62,12 +62,13 @@ BUILD()
 
 INSTALL()
 {
-	install -m 0755 -d "$appsDir/Genio"
-	install -m 0755 -t "$appsDir/Genio/" app/Genio
-	cp -a data "$appsDir/Genio/"
+	install -m 0755 -d "$appsDir"
+	install -m 0755 -t "$appsDir" app/Genio
+	mkdir -p "$dataDir/Genio"
+	cp -a data "$dataDir/Genio"
 
 	mkdir -p $docDir
 	cp -r documentation/* $docDir/
 
-	addAppDeskbarSymlink $appsDir/Genio/Genio
+	addAppDeskbarSymlink $appsDir/Genio
 }

--- a/haiku-apps/genio/genio-3.0.recipe
+++ b/haiku-apps/genio/genio-3.0.recipe
@@ -65,7 +65,7 @@ INSTALL()
 	install -m 0755 -d "$appsDir"
 	install -m 0755 -t "$appsDir" app/Genio
 	mkdir -p "$dataDir/Genio"
-	cp -a data "$dataDir/Genio"
+	cp -a data/* "$dataDir/Genio"
 
 	mkdir -p $docDir
 	cp -r documentation/* $docDir/

--- a/haiku-apps/genio/genio-3.1.recipe
+++ b/haiku-apps/genio/genio-3.1.recipe
@@ -17,7 +17,7 @@ LICENSE="BSD (3-clause)
 	MIT"
 REVISION="1"
 SOURCE_URI="https://github.com/Genio-The-Haiku-IDE/Genio/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="f516042034729581684785fc6218cf3953996c2fb66236974c1d767e516a2e54"
+CHECKSUM_SHA256="0f15d1f512ff2d014bc7627a7b9b99d831f4e818527406fea92423b97019fdfe"
 SOURCE_FILENAME="Genio-v$portVersion.tar.gz"
 SOURCE_DIR="Genio-$portVersion"
 

--- a/haiku-apps/genio/genio-3.1.recipe
+++ b/haiku-apps/genio/genio-3.1.recipe
@@ -15,9 +15,9 @@ HOMEPAGE="https://github.com/Genio-The-Haiku-IDE/Genio/releases"
 COPYRIGHT="2022-2024 The Genio Team"
 LICENSE="BSD (3-clause)
 	MIT"
-REVISION="3"
+REVISION="1"
 SOURCE_URI="https://github.com/Genio-The-Haiku-IDE/Genio/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="64cb18b552a6336e22903b6fc659253bf1ad02831fb2bc4dd892e7e65023465c"
+CHECKSUM_SHA256="f516042034729581684785fc6218cf3953996c2fb66236974c1d767e516a2e54"
 SOURCE_FILENAME="Genio-v$portVersion.tar.gz"
 SOURCE_DIR="Genio-$portVersion"
 

--- a/haiku-apps/genio/genio-3.1.recipe
+++ b/haiku-apps/genio/genio-3.1.recipe
@@ -17,7 +17,7 @@ LICENSE="BSD (3-clause)
 	MIT"
 REVISION="1"
 SOURCE_URI="https://github.com/Genio-The-Haiku-IDE/Genio/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="0f15d1f512ff2d014bc7627a7b9b99d831f4e818527406fea92423b97019fdfe"
+CHECKSUM_SHA256="c5328a21c1334fbd493801e7e3646a697bf0e33868784fd9804739116f2ca06a"
 SOURCE_FILENAME="Genio-v$portVersion.tar.gz"
 SOURCE_DIR="Genio-$portVersion"
 


### PR DESCRIPTION
Hi, here's the recipe for Genio 3.1.
The executable is now put in /system/apps and data into /system/data/Genio.

