### PR TITLE
intel_microcode: update to version 20240910.

### DIFF
--- a/sys-firmware/intel-microcode/intel_microcode-20240910.recipe
+++ b/sys-firmware/intel-microcode/intel_microcode-20240910.recipe
@@ -10,7 +10,7 @@ LICENSE="Intel CPU Microcode"
 REVISION="1"
 SOURCE_URI="https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/archive/microcode-$portVersion.tar.gz"
 SOURCE_DIR="Intel-Linux-Processor-Microcode-Data-Files-microcode-$portVersion"
-CHECKSUM_SHA256="9575c6d74491058bbf998c359d7f25f23655d97a31663a8ed6a98def2b0aaf2b"
+CHECKSUM_SHA256="8b7582eac7e9a691356e18b3bdcbc7b2db09494e040ec980a4a5fb6d0da261bf"
 
 ARCHITECTURES="any"
 DISABLE_SOURCE_PACKAGE="yes"


### PR DESCRIPTION
Tested on a Celeron N4020, but only after unpacking the firmware into `/system/non-packaged/` (as noticed on the syslog that the files were expected to be there).

After the unpacking, next reboot showed on the syslog:

```
KERN: ucode_load: system/non-packaged/data/firmware/intel_ucode/06-7a-08
KERN: ucode_load: microcode file read in memory
```
