### PR TITLE
beezer: update to a version with SquashFS and .hpkg support.

### DIFF
--- a/haiku-apps/beezer/beezer-0.99.recipe
+++ b/haiku-apps/beezer/beezer-0.99.recipe
@@ -1,16 +1,16 @@
 SUMMARY="Archive manager similar to WinZip"
 DESCRIPTION="Beezer is an archive manager that can extract and browse, create \
 and add to archive files and also split and rejoin them. It extracts 7zip, \
-bzip2, gzip, lha, rar, tar, xz and zip files and creates 7zip, bzip2, \
+bzip2, gzip, hpkg, lha, rar, squashfs, tar, xz and zip files and creates 7zip, bzip2, \
 gzip, tar and zip archives."
 HOMEPAGE="https://github.com/Teknomancer/beezer"
 COPYRIGHT="2009-2023 Ramshankar (aka Teknomancer)
 	2011-2024 Chris Roberts"
 LICENSE="BSD (3-clause)"
-REVISION="6"
-srcGitRev="cd494ad1c1b240c32bc0e2fd2c0f4944a1c0b479"
+REVISION="7"
+srcGitRev="9c746c72da5cc13fa985865982dd669c900b876e"
 SOURCE_URI="https://github.com/Teknomancer/beezer/archive/$srcGitRev.tar.gz"
-CHECKSUM_SHA256="dcd70f3bbcdbf49097793efcd3c8df0cb086a56a36f0e3f8f9b5b5314b696436"
+CHECKSUM_SHA256="7a6d1237868cdf2a5ec4e8323fddf3cb6f35b26f21f3010de496be7ee894479e"
 SOURCE_DIR="beezer-$srcGitRev"
 
 ARCHITECTURES="all"
@@ -21,12 +21,13 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku
-	cmd:arj
 	cmd:7za
+	cmd:arj
 	cmd:bzip2
 	cmd:lha
 	cmd:tar
 	cmd:unrar
+	cmd:unsquashfs
 	cmd:unzip
 	cmd:xz
 	cmd:zip


### PR DESCRIPTION
I have been using this version for quite a few months already. I use the new .hpkg support quite a lot, so I want to just be able to install a version of Beezer that already includes that (I'm too lazy to copy my custom builds around several machines/installs :-D).