### PR TITLE
rocksdb: fix build for 32-bit.

### DIFF
--- a/dev-libs/rocksdb/rocksdb-9.6.1.recipe
+++ b/dev-libs/rocksdb/rocksdb-9.6.1.recipe
@@ -12,7 +12,7 @@ and writing to more advanced operations such as merging and compaction filters."
 HOMEPAGE="https://rocksdb.org"
 COPYRIGHT="2011 Facebook, Inc."
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/facebook/rocksdb/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="98cf497c1d6d0a927142d2002a0b6b4816a0998c74fda9ae7b1bdaf6b784e895"
 SOURCE_FILENAME="v$portVersion.tar.gz"
@@ -21,6 +21,13 @@ PATCHES="rocksdb-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
+
+commandBinDir=$binDir
+commandSuffix=$secondaryArchSuffix
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
 
 PROVIDES="
 	rocksdb$secondaryArchSuffix = $portVersion
@@ -41,10 +48,10 @@ REQUIRES_devel="
 
 PROVIDES_tools="
 	rocksdb${secondaryArchSuffix}_tools = $portVersion
-	cmd:cache_bench
-	cmd:db_bench
-	cmd:ldb
-	cmd:sst_dump
+	cmd:cache_bench$commandSuffix
+	cmd:db_bench$commandSuffix
+	cmd:ldb$commandSuffix
+	cmd:sst_dump$commandSuffix
 	"
 REQUIRES_tools="
 	haiku$secondaryArchSuffix
@@ -69,11 +76,15 @@ defineDebugInfoPackage rocksdb$secondaryArchSuffix \
 
 BUILD()
 {
+	if [ "$effectiveTargetArchitecture" = x86 ]; then
+		extraFlags=-DPORTABLE=1
+	fi
+
 	mkdir -p build && cd build
 
 	cmake .. $cmakeDirArgs \
 		-DCMAKE_BUILD_TYPE='Release' \
-		-DUSE_RTTI=ON
+		-DUSE_RTTI=ON $extraFlags
 	make $jobArgs
 }
 
@@ -91,11 +102,11 @@ INSTALL()
 		$libDir/cmake
 
 	# tools package
-	mkdir -p $binDir
-	cp cache_bench $binDir
-	cp db_bench $binDir
-	cp tools/ldb $binDir
-	cp tools/sst_dump $binDir
+	mkdir -p $commandBinDir
+	cp cache_bench $commandBinDir
+	cp db_bench $commandBinDir
+	cp tools/ldb $commandBinDir
+	cp tools/sst_dump $commandBinDir
 	packageEntries tools \
-		$binDir
+		$commandBinDir
 }


### PR DESCRIPTION
* Disable unsupported optimizations for 32-bit Haiku
* Fix install directory for `tools` subpackage for 32-bit Haiku.