### PR TITLE
Update lgogdownloader to 3.15

### DIFF
--- a/games-util/lgogdownloader/lgogdownloader-3.15.recipe
+++ b/games-util/lgogdownloader/lgogdownloader-3.15.recipe
@@ -4,9 +4,9 @@ API as the official GOGDownloader"
 HOMEPAGE="https://sites.google.com/site/gogdownloader/"
 COPYRIGHT="2004 Sam Hocevar"
 LICENSE="WTFPL"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://github.com/Sude-/lgogdownloader/releases/download/v$portVersion/lgogdownloader-$portVersion.tar.gz"
-CHECKSUM_SHA256="bf3a16c1b2ff09152f9ac52ea9b52dfc0afae799ed1b370913149cec87154529"
+CHECKSUM_SHA256="9946558bb30b72cd5ed712e7fc425eef4b2a1fd22b5475d1a998720800cd25f0"
 PATCHES="lgogdownloader-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -28,7 +28,6 @@ REQUIRES="
 	lib:libiconv$secondaryArchSuffix
 	lib:libcss_parser$secondaryArchSuffix
 	lib:libcss_parser_pp$secondaryArchSuffix
-	lib:libhtmlcxx$secondaryArchSuffix
 	lib:libjsoncpp$secondaryArchSuffix
 #	lib:libQt5Core$secondaryArchSuffix
 #	lib:libQt5Gui$secondaryArchSuffix
@@ -42,6 +41,7 @@ REQUIRES="
 #	lib:libQt5Widgets$secondaryArchSuffix
 	lib:librhash$secondaryArchSuffix
 	lib:libstdc++$secondaryArchSuffix
+	lib:libtidy$secondaryArchSuffix
 	lib:libtinyxml2$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
@@ -56,11 +56,11 @@ BUILD_REQUIRES="
 	devel:libboost_system$secondaryArchSuffix >= 1.83.0
 	devel:libcurl$secondaryArchSuffix
 	devel:libiconv$secondaryArchSuffix
-	devel:libhtmlcxx$secondaryArchSuffix
 	devel:libjsoncpp$secondaryArchSuffix
 #	devel:libQt5WebEngine$secondaryArchSuffix
 #	devel:libQt5Widgets$secondaryArchSuffix
 	devel:librhash$secondaryArchSuffix
+	devel:libtidy$secondaryArchSuffix
 	devel:libtinyxml2$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"

--- a/games-util/lgogdownloader/patches/lgogdownloader-3.15.patchset
+++ b/games-util/lgogdownloader/patches/lgogdownloader-3.15.patchset
@@ -1,34 +1,11 @@
-From c65d24ff976fc9914b2b92bb31e0e07844180aaf Mon Sep 17 00:00:00 2001
-From: Begasus <begasus@gmail.com>
-Date: Sat, 21 Oct 2023 21:30:55 +0200
-Subject: Fix for: help2man: can't get `--help' info (for manpage)
-
-
-diff --git a/man/CMakeLists.txt b/man/CMakeLists.txt
-index 3225653..f9aa17a 100644
---- a/man/CMakeLists.txt
-+++ b/man/CMakeLists.txt
-@@ -11,7 +11,7 @@ if(HELP2MAN AND GZIP)
-   set(MAN_FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.1.gz")
-   add_custom_command(
-     OUTPUT ${MAN_FILE}
--    COMMAND ${HELP2MAN} -N -i ${H2M_FILE} -o ${MAN_PAGE} "\"${PROJECT_BINARY_DIR}/${PROJECT_NAME}${CMAKE_EXECUTABLE_SUFFIX}\""
-+    COMMAND ${HELP2MAN} --no-discard-stderr -N -i ${H2M_FILE} -o ${MAN_PAGE} "\"${PROJECT_BINARY_DIR}/${PROJECT_NAME}${CMAKE_EXECUTABLE_SUFFIX}\""
-     COMMAND ${GZIP} -f -9 ${MAN_PAGE}
-     MAIN_DEPENDENCY ${H2M_FILE}
- 	COMMENT "Building man page"
--- 
-2.45.2
-
-
-From 1e7b59a3e8f7c7f7f532686229a7350789843f9a Mon Sep 17 00:00:00 2001
+From 32d09c3972fdc2ce2f061f64706167b0013292e0 Mon Sep 17 00:00:00 2001
 From: "Mika T. Lindqvist" <postmaster@raasu.org>
 Date: Tue, 8 Oct 2024 11:55:27 +0000
 Subject: Fix linking with iconv.
 
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0fe7568..98d9fd0 100644
+index 0238ae0..bd84338 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -24,6 +24,7 @@ find_package(Boost
@@ -37,24 +14,24 @@ index 0fe7568..98d9fd0 100644
  find_package(CURL 7.55.0 REQUIRED)
 +find_package(Iconv REQUIRED)
  find_package(Jsoncpp REQUIRED)
- find_package(Htmlcxx REQUIRED)
  find_package(Tinyxml2 REQUIRED)
-@@ -105,6 +106,7 @@ target_include_directories(${PROJECT_NAME}
+ find_package(Rhash REQUIRED)
+@@ -109,6 +110,7 @@ target_include_directories(${PROJECT_NAME}
    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
    PRIVATE ${Boost_INCLUDE_DIRS}
    PRIVATE ${CURL_INCLUDE_DIRS}
 +  PRIVATE ${ICONV_INCLUDE_DIR}
    PRIVATE ${OAuth_INCLUDE_DIRS}
    PRIVATE ${Jsoncpp_INCLUDE_DIRS}
-   PRIVATE ${Htmlcxx_INCLUDE_DIRS}
-@@ -116,6 +118,7 @@ target_include_directories(${PROJECT_NAME}
+   PRIVATE ${Tinyxml2_INCLUDE_DIRS}
+@@ -120,6 +122,7 @@ target_include_directories(${PROJECT_NAME}
  target_link_libraries(${PROJECT_NAME}
    PRIVATE ${Boost_LIBRARIES}
    PRIVATE ${CURL_LIBRARIES}
 +  PRIVATE ${ICONV_LIBRARY}
    PRIVATE ${OAuth_LIBRARIES}
    PRIVATE ${Jsoncpp_LIBRARIES}
-   PRIVATE ${Htmlcxx_LIBRARIES}
+   PRIVATE ${Tinyxml2_LIBRARIES}
 diff --git a/cmake/FindIconv.cmake b/cmake/FindIconv.cmake
 new file mode 100644
 index 0000000..2d53426
@@ -72,6 +49,50 @@ index 0000000..2d53426
 +if(ICONV_LIBRARY)
 +  target_link_libraries(iconv INTERFACE ICONV_LIBRARY)
 +endif()
---
+-- 
+2.45.2
+
+
+From 431c9c0968505b4f6b784de9532e8d719d0b17a1 Mon Sep 17 00:00:00 2001
+From: "Mika T. Lindqvist" <postmaster@raasu.org>
+Date: Wed, 23 Oct 2024 04:36:03 +0000
+Subject: Fix finding Tidy.
+
+
+diff --git a/cmake/FindTidy.cmake b/cmake/FindTidy.cmake
+index 6cdbaad..04e5727 100644
+--- a/cmake/FindTidy.cmake
++++ b/cmake/FindTidy.cmake
+@@ -5,27 +5,8 @@
+ #  Tidy_INCLUDE_DIRS - The tidy include directories
+ #  Tidy_LIBRARIES - The libraries needed to use tidy
+ 
+-find_package(PkgConfig)
+-pkg_check_modules(PC_TIDY tidy REQUIRED)
+-
+-find_path(TIDY_INCLUDE_DIR tidy.h
+-  HINTS
+-    ${PC_TIDY_INCLUDEDIR}
+-    ${PC_TIDY_INCLUDE_DIRS}
+-  PATH_SUFFIXES
+-    tidy
+-  PATHS
+-    ${PC_TIDY_INCLUDE_DIRS}
+-  )
+-
+-find_library(TIDY_LIBRARY tidy
+-  HINTS
+-    ${PC_TIDY_LIBDIR}
+-    ${PC_TIDY_LIBRARY_DIRS}
+-  PATHS
+-    ${PC_TIDY_LIBRARY_DIRS}
+-  )
+-
++find_path(TIDY_INCLUDE_DIR NAMES tidy.h)
++find_library(TIDY_LIBRARY NAMES tidy)
+ mark_as_advanced(TIDY_INCLUDE_DIR TIDY_LIBRARY)
+ 
+ if(TIDY_INCLUDE_DIR)
+-- 
 2.45.2
 


### PR DESCRIPTION
* No longer depends on htmlcxx
* Now requires tidy (don't use pkgconfig to find it)