### PR TITLE
ECWolf: Fix buildmaster build

### DIFF
--- a/games-arcade/ecwolf/ecwolf-1.4.1.recipe
+++ b/games-arcade/ecwolf/ecwolf-1.4.1.recipe
@@ -11,7 +11,7 @@ in one directory as one binary plays all supported games."
 HOMEPAGE="https://maniacsvault.net/ecwolf/"
 COPYRIGHT="2004-2024 the ECWolf team"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://maniacsvault.net/ecwolf/files/ecwolf/1.x/ecwolf-${portVersion}-src.tar.xz"
 CHECKSUM_SHA256="8ebd495d2806c9d0e736656970e736730a005d3b43c7f5729f52c812b22f9e2d"
 SOURCE_DIR="ecwolf-${portVersion}-src"
@@ -70,7 +70,7 @@ BUILD()
 	cmake .. $cmakeDirArgs \
 		-Wno-dev -Wno-error=dev -Wno-deprecated \
 		-DCMAKE_BUILD_TYPE=Release \
-		-DCMAKE_C_FLAGS="-D_DEFAULT_SOURCE -D_BSD_SOURCE" \
+		-DCMAKE_C_FLAGS="-D_DEFAULT_SOURCE -D_GNU_SOURCE"
 
 	make $jobArgs
 }


### PR DESCRIPTION
Making this Pull Request to try and fix the ECWolf recipe for the buildmasters, according to people more knowledgeable than me in coding stuff, currently the buildmaster requires to have both DEFAULT_SOURCE and GNU_SOURCE enabled while compiling the binary, so yeah, I hope this works :)