### PR TITLE
Edited pkg-config file to reflect library location

### DIFF
--- a/dev-libs/libxml++/libxml++2-2.42.3.recipe
+++ b/dev-libs/libxml++/libxml++2-2.42.3.recipe
@@ -7,7 +7,7 @@ parallel-installable ABIs. This package contains libxml++-2.6."
 HOMEPAGE="https://libxmlplusplus.sourceforge.net/"
 COPYRIGHT="2004-2024 LibXML++"
 LICENSE="GNU LGPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://download.gnome.org/sources/libxml++/2.42/libxml++-$portVersion.tar.xz"
 CHECKSUM_SHA256="74b95302e24dbebc56e97048e86ad0a4121fc82a43e58d381fbe1d380e8eba04"
 SOURCE_FILENAME="libxml++-$portVersion.tar.bz2"
@@ -76,6 +76,8 @@ INSTALL()
 
 	prepareInstalledDevelLib libxml++-2.6
 	fixPkgconfig
+
+	sed -i 's|-I${libdir}/libxml++-2.6/include||g' $developDir/lib/pkgconfig/libxml++-2.6.pc
 
 	# devel package
 	packageEntries devel \


### PR DESCRIPTION
If you try to use libxml++ from a CMake project, it will fail because libxml++-2.6.pc points to a location where the libraries no longer reside (they are moved a few steps before on this same recipe). This PR fixes this.