### PR TITLE
amd_microcode: update to newest version.

### DIFF
--- a/sys-firmware/amd-microcode/additional-files/amd_copy_microcode.sh
+++ b/sys-firmware/amd-microcode/additional-files/amd_copy_microcode.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+dataDir=`finddir B_SYSTEM_DATA_DIRECTORY`/firmware/amd-ucode
+targetDir=`finddir B_SYSTEM_NONPACKAGED_DATA_DIRECTORY`/firmware/amd-ucode
+mkdir -p $targetDir
+cp -p $dataDir/* $targetDir
+true

--- a/sys-firmware/amd-microcode/amd_microcode-20240710.recipe
+++ b/sys-firmware/amd-microcode/amd_microcode-20240710.recipe
@@ -15,15 +15,19 @@ SOURCE_FILENAME_2="microcode_amd_fam15h.bin"
 SOURCE_URI_3="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/amd-ucode/microcode_amd_fam16h.bin?id=8ac569dd3ca3ca685bd47ee86c1eeb6050864db3#noarchive"
 CHECKSUM_SHA256_3="e02ad653b39c975d6c52674b50f23727bb6706bab7b4e5b391a4ce229e7ff121"
 SOURCE_FILENAME_3="microcode_amd_fam16h.bin"
-SOURCE_URI_4="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/amd-ucode/microcode_amd_fam17h.bin?id=bfc33c1e308e1ebd5f216781ea0b091c2379bbb2#noarchive"
-CHECKSUM_SHA256_4="479b11f14c0f8b3e0143f358b8188c1cd82f35f89080237c1f9e21fe5589758c"
+SOURCE_URI_4="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/amd-ucode/microcode_amd_fam17h.bin?id=091bd5adf19c7ab01214c64689952acb4833b21d#noarchive"
+CHECKSUM_SHA256_4="b3f324891c224f00436b4efdcac248da1b82603694f25b6a096f6a0c590dcaf9"
 SOURCE_FILENAME_4="microcode_amd_fam17h.bin"
-SOURCE_URI_5="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/amd-ucode/microcode_amd_fam19h.bin?id=a193c6517fbfc0e7a4e2f8b06cb2742a82a8dd63#noarchive"
-CHECKSUM_SHA256_5="db44d0dae3a5bd2c86a7c5ccc1d99f3540993b59a269911acbb4f025b064f9d9"
+SOURCE_URI_5="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/amd-ucode/microcode_amd_fam19h.bin?id=091bd5adf19c7ab01214c64689952acb4833b21d#noarchive"
+CHECKSUM_SHA256_5="2ffd1f89faa306bcaacff9b55ee781dd715590394d63beb8d1741801911dcc73"
 SOURCE_FILENAME_5="microcode_amd_fam19h.bin"
+
+ADDITIONAL_FILES="amd_copy_microcode.sh"
 
 ARCHITECTURES="any"
 DISABLE_SOURCE_PACKAGE="yes"
+
+POST_INSTALL_SCRIPTS="$relativePostInstallDir/amd_copy_microcode.sh"
 
 PROVIDES="
 	amd_microcode = $portVersion
@@ -34,4 +38,8 @@ INSTALL()
 	mkdir -p $dataDir/firmware/amd-ucode
 	cp $sourceDir/* $sourceDir2/* $sourceDir3/* $sourceDir4/* $sourceDir5/* \
 		$dataDir/firmware/amd-ucode/
+
+	# install postinstallscript
+	mkdir -p $postInstallDir
+	install -t $postInstallDir $portDir/additional-files/amd_copy_microcode.sh
 }


### PR DESCRIPTION
Used 20240710 for the package version, as that matches the commit date from https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/log/amd-ucode and as that's the date the files we're using "went public", it makes the most sense to me.

----

Opening as draft, as currently, loading of AMD microcode is [facing some issues](https://dev.haiku-os.org/ticket/19198).