### PR TITLE
libxml++5: applying libxml++2's pkgconfig fix

### DIFF
--- a/dev-libs/libxml++/libxml++5-5.4.0.recipe
+++ b/dev-libs/libxml++/libxml++5-5.4.0.recipe
@@ -7,7 +7,7 @@ parallel-installable ABIs. This package contains libxml++-5.0."
 HOMEPAGE="https://libxmlplusplus.sourceforge.net/"
 COPYRIGHT="2004-2024 LibXML++"
 LICENSE="GNU LGPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://download.gnome.org/sources/libxml++/5.4/libxml++-$portVersion.tar.xz"
 CHECKSUM_SHA256="e9a23c436686a94698d2138e6bcbaf849121d63bfa0f50dc34fefbfd79566848"
 SOURCE_FILENAME="libxml++-$portVersion.tar.xz"
@@ -76,6 +76,8 @@ INSTALL()
 
 	prepareInstalledDevelLib libxml++-5.0
 	fixPkgconfig
+
+	sed -i 's|-I${libdir}/libxml++-5.0/include||g' $developDir/lib/pkgconfig/libxml++-5.0.pc
 
 	# devel package
 	packageEntries devel \


### PR DESCRIPTION
Applying #11253 's fix for pkgconfig to libxml++5 as well, since, as far as I can tell, the situation would be the same for this library if used in CMake.

(Sorry for not catching this, I only tested these libraries under GNU Make & friends)