### PR TITLE
curl, revbump for missing develop packages references

### DIFF
--- a/net-misc/curl/curl-8.10.1.recipe
+++ b/net-misc/curl/curl-8.10.1.recipe
@@ -9,7 +9,7 @@ busload of other useful tricks."
 HOMEPAGE="https://curl.haxx.se/"
 COPYRIGHT="1996-2024 Daniel Stenberg"
 LICENSE="Curl"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/curl/curl/releases/download/curl-${portVersion//\./_}/curl-$portVersion.tar.bz2"
 CHECKSUM_SHA256="3763cd97aae41dcf41950d23e87ae23b2edb2ce3a5b0cf678af058c391b6ae31"
 ADDITIONAL_FILES="curl.rdef"
@@ -48,9 +48,15 @@ PROVIDES_devel="
 REQUIRES_devel="
 	curl$secondaryArchSuffix == $portVersion base
 	devel:libnghttp2$secondaryArchSuffix
+	devel:libssh2$secondaryArchSuffix
 	devel:libssl$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"
+if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+	REQUIRES_devel+="
+		devel:libpsl$secondaryArchSuffix
+		"
+fi
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel


### PR DESCRIPTION
~> pkg-config libcurl --cflags
  Package libssh2 was not found in the pkg-config search path.