### PR TITLE
html5_parser: recipe cleanup, dropping Python 3.9 support.

### DIFF
--- a/dev-python/html5-parser/html5_parser-0.4.10.recipe
+++ b/dev-python/html5-parser/html5_parser-0.4.10.recipe
@@ -13,7 +13,7 @@ COPYRIGHT="2017 Kovid Goyal
 	2015-2016 Kevin B. Hendricks, Stratford Ontario
 	2008-2009 Bjoern Hoehrmann"
 LICENSE="Apache v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/h/html5-parser/html5-parser-$portVersion.tar.gz"
 CHECKSUM_SHA256="f9294418c0da95c2d5facc19d3dc32941093a6b8e3b3e4b36cc7b5a1697fbca4"
 SOURCE_DIR="html5-parser-$portVersion"
@@ -37,11 +37,11 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
+PYTHON_VERSIONS=(3.10)
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_$pythonPackage=\"
 		${portName}_$pythonPackage = $portVersion
@@ -66,7 +66,7 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 		"
 	TEST_REQUIRES+="
 		${portName}_$pythonPackage
-		beautifulsoup_$pythonPackage
+		beautifulsoup4_$pythonPackage
 		chardet_$pythonPackage
 		lxml${secondaryArchSuffix}_$pythonPackage
 		"
@@ -75,9 +75,9 @@ done
 
 BUILD()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		rm -rf "$sourceDir"-$pythonPackage
 		cp -a "$sourceDir" "$sourceDir"-$pythonPackage
@@ -91,9 +91,9 @@ BUILD()
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		cd "$sourceDir"-$pythonPackage
 
@@ -116,11 +116,15 @@ INSTALL()
 }
 
 
+
+# Reference results:
+# Ran 28 tests in 1.363s
+# OK (skipped=1)
 TEST()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		cd "$sourceDir"-$pythonPackage
 


### PR DESCRIPTION
Only use in-tree of this is from calibre, and that's 3.10 only.

Use beautifulsoup4 for tests instead of the older "beautifulsoup" that isn't there anymore.

---

Tested by installing it, then freshly installing calibre, and making sure it was able to open and show .epub files correctly.