### PR TITLE
beautifulsoup4: clean ups.

### DIFF
--- a/dev-python/beautifulsoup4/beautifulsoup4-4.12.3.recipe
+++ b/dev-python/beautifulsoup4/beautifulsoup4-4.12.3.recipe
@@ -13,7 +13,7 @@ HOMEPAGE="https://bugs.launchpad.net/beautifulsoup/
 COPYRIGHT="2004-2015 Leonard Richardson
 	2006-2013 James Graham and other contributors"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.org/packages/source/b/beautifulsoup4/beautifulsoup4-$portVersion.tar.gz"
 CHECKSUM_SHA256="74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051"
 SOURCE_DIR="beautifulsoup4-$portVersion"
@@ -31,11 +31,11 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
+PYTHON_VERSIONS=(3.10)
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_$pythonPackage=\"
 		${portName}_$pythonPackage = $portVersion
@@ -48,27 +48,27 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 	BUILD_REQUIRES+="
 		build_$pythonPackage
 		installer_$pythonPackage
+		hatchling_$pythonPackage
 		setuptools_$pythonPackage
 		wheel_$pythonPackage
 		"
 	BUILD_PREREQUIRES+="
 		cmd:python$pythonVersion
-		hatchling_$pythonPackage
 		"
 done
 
 TEST_REQUIRES="
-	html5lib_python39
-	lxml_python39
-	soupsieve_python39
+	html5lib_python310
+	lxml_python310
+	soupsieve_python310
 	cmd:pytest
 	"
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
@@ -85,6 +85,12 @@ INSTALL()
 	done
 }
 
+# Reference results:
+# 401 passed, 263 skipped, 1 warning in 10.46s
+#
+# Skipped tests due to "soupsieve" not being found for some reason. It warns:
+# "bs4/css.py:8: UserWarning: The soupsieve package is not installed. CSS selectors cannot be used."
+# But calling 'python3 -c "from bs4 import css"' doesn't shows any warning.
 TEST()
 {
 	pytest -v


### PR DESCRIPTION
Drop Python 3.9 support (only users of this in-tree are all on 3.10).