### PR TITLE
Initial CLISP recipe

### DIFF
--- a/dev-lisp/clisp/clisp-2.49.93~git.recipe
+++ b/dev-lisp/clisp/clisp-2.49.93~git.recipe
@@ -1,0 +1,90 @@
+SUMMARY="ANSI Common Lisp Implementation"
+DESCRIPTION="GNU CLISP is an ANSI Common Lisp Implementation. \
+It is known for high portability, small image size and efficient bignums."
+HOMEPAGE="https://clisp.sourceforge.io/"
+COPYRIGHT="1992-1993 Bruno Haible, Michael Stoll
+	1994-1997 Bruno Haible, Marcus Daniels
+	1998 Bruno Haible, Pierpaolo Bernardi, Sam Steingold
+	1999-2000 Bruno Haible, Sam Steingold
+	2001-2018 Sam Steingold, Bruno Haible
+	"
+LICENSE="GNU GPL v2"
+REVISION="1"
+srcGitRev="c735dd548ba2365804bcee9c2bdd3c291657e8ae"
+SOURCE_URI="https://gitlab.com/gnu-clisp/clisp/-/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="7c29554297e5d27abd7e50fff7691b4dc2ee26bd694369b238fb368b38278bf7"
+SOURCE_DIR="clisp-$srcGitRev"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	clisp$secondaryArchSuffix = $portVersion
+	cmd:clisp$secondaryArchSuffix = $portVersion
+	cmd:clisp_link$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libsigsegv$secondaryArchSuffix
+	devel:libffcall$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
+	devel:libreadline$secondaryArchSuffix >= 8
+	devel:libintl$secondaryArchSuffix
+	devel:libunistring$secondaryArchSuffix
+	devel:libncurses$secondaryArchSuffix
+	"
+
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:cmp
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:msgfmt
+	"
+
+BUILD()
+{
+	./configure \
+		FORCE_UNSAFE_CONFIGURE=1 \
+		LDFLAGS="-lbsd -lnetwork" \
+		--with-included-regex \
+		--prefix=$prefix \
+		--datarootdir=$dataDir \
+		--bindir=$binDir \
+		--libdir=$libDir \
+		--docdir=$docDir \
+		--mandir=$manDir \
+		build-dir
+	# TODO Waiting for Haiku specific src/config.lisp
+	#sed -i 's|(defparameter *editor* "vi" "The name of the editor.")|(defparameter *editor* "/boot/system/apps/Pe/Pe" "The name of the editor.")|g' src/config.lisp
+	#sed -i 's|;; (setq *browser* :firefox)|;; (setq *browser* :firefox)\n(setq *browser* "/boot/system/apps/WebPositive")|g' src/config.lisp
+	#make
+}
+
+INSTALL()
+{
+	cd build-dir
+	make install
+	make install-modules MODULES="asdf"
+	make install-modules MODULES="rawsock"
+	#make install-modules MODULES="i18n"
+	#make install-modules MODULES="regexp"
+	#make install-modules MODULES="syscalls"
+	#make install-modules MODULES="readline"
+	#make distclean
+	cd ..
+	rm -rf build-dir
+}
+
+TEST()
+{
+	make bench -Csrc
+	# make check-tests
+	# make check-recompile # Probably not necessary
+	# make check-sacla-tests # This seems to be helpful
+	# make check-ansi-tests #Did not find it
+}

--- a/dev-lisp/clisp/clisp-2.49.93~git.recipe
+++ b/dev-lisp/clisp/clisp-2.49.93~git.recipe
@@ -20,24 +20,22 @@ SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	clisp$secondaryArchSuffix = $portVersion
-	cmd:clisp$secondaryArchSuffix = $portVersion
-	cmd:clisp_link$secondaryArchSuffix = $portVersion
+	cmd:clisp = $portVersion
+	cmd:clisp_link = $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
 	"
-
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libsigsegv$secondaryArchSuffix
 	devel:libffcall$secondaryArchSuffix
 	devel:libiconv$secondaryArchSuffix
-	devel:libreadline$secondaryArchSuffix >= 8
 	devel:libintl$secondaryArchSuffix
-	devel:libunistring$secondaryArchSuffix
 	devel:libncurses$secondaryArchSuffix
+	devel:libreadline$secondaryArchSuffix >= 8
+	devel:libsigsegv$secondaryArchSuffix
+	devel:libunistring$secondaryArchSuffix
 	"
-
 BUILD_PREREQUIRES="
 	cmd:awk
 	cmd:cmp
@@ -54,14 +52,15 @@ BUILD()
 		--with-included-regex \
 		--prefix=$prefix \
 		--datarootdir=$dataDir \
-		--bindir=$binDir \
+		--bindir=$prefix/bin \
 		--libdir=$libDir \
 		--docdir=$docDir \
 		--mandir=$manDir \
 		build-dir
-	# TODO Waiting for Haiku specific src/config.lisp
-	#sed -i 's|(defparameter *editor* "vi" "The name of the editor.")|(defparameter *editor* "/boot/system/apps/Pe/Pe" "The name of the editor.")|g' src/config.lisp
-	#sed -i 's|;; (setq *browser* :firefox)|;; (setq *browser* :firefox)\n(setq *browser* "/boot/system/apps/WebPositive")|g' src/config.lisp
+	# TODO Waiting for Haiku specific config.lisp
+	sed -i 's|"vi"|"/boot/system/apps/Pe/Pe"|g' build-dir/config.lisp
+	sed -i 's|:firefox|"/boot/system/apps/WebPositive"|g' build-dir/config.lisp
+	sed -i 's|;;[[:space:]](setq[[:space:]][*]browser[*]|(setq *browser*|g' build-dir/config.lisp
 	#make
 }
 
@@ -75,14 +74,11 @@ INSTALL()
 	#make install-modules MODULES="regexp"
 	#make install-modules MODULES="syscalls"
 	#make install-modules MODULES="readline"
-	#make distclean
-	cd ..
-	rm -rf build-dir
 }
 
 TEST()
 {
-	make bench -Csrc
+	make bench -Cbuild-dir
 	# make check-tests
 	# make check-recompile # Probably not necessary
 	# make check-sacla-tests # This seems to be helpful

--- a/dev-lisp/clisp/clisp-2.49.93~git.recipe
+++ b/dev-lisp/clisp/clisp-2.49.93~git.recipe
@@ -26,6 +26,7 @@ PROVIDES="
 REQUIRES="
 	haiku$secondaryArchSuffix
 	"
+
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libffcall$secondaryArchSuffix
@@ -51,10 +52,10 @@ BUILD()
 		LDFLAGS="-lbsd -lnetwork" \
 		--with-included-regex \
 		--prefix=$prefix \
-		--datarootdir=$dataDir \
 		--bindir=$prefix/bin \
-		--libdir=$libDir \
+		--datarootdir=$dataDir \
 		--docdir=$docDir \
+		--libdir=$libDir \
 		--mandir=$manDir \
 		build-dir
 	# TODO Waiting for Haiku specific config.lisp


### PR DESCRIPTION
Initial CLISP recipe. It contains CLISP runtime plus modules `asdf` and `rawsock`. It does not contain Haiku specific text editor and web browser applications setup. Other modules are intended to be available also here: `i18n`, `regexp`, `syscalls` and `readline`. A selection of other modules will go to a separate package.