### PR TITLE
ecode: Bump to 0.6.2

### DIFF
--- a/app-editors/ecode/ecode-0.6.2.recipe
+++ b/app-editors/ecode/ecode-0.6.2.recipe
@@ -5,23 +5,42 @@ eepp GUI, which provides the core technology for the editor. The project comes a
 serious project using the eepp GUI, and it's currently being developed to improve the eepp GUI \
 library as part of one of its main objectives."
 HOMEPAGE="https://github.com/SpartanJ/eepp"
-COPYRIGHT="2023 Martín Lucas Golini"
+COPYRIGHT="2024 Martín Lucas Golini"
 LICENSE="MIT"
 REVISION="1"
 SOURCE_URI="https://github.com/SpartanJ/eepp/archive/refs/tags/eepp-2.8.2.tar.gz"
 CHECKSUM_SHA256="48120634f6ab823f5b91469e100d20ee748bbd88f5da759f671d99d9ba6e0283"
 #SOURCE_FILENAME="eepp-2.8.2.tar.gz"
 SOURCE_DIR="eepp-eepp-2.8.2"
+
+# SOIL2
 srcGitRev_2="229324688c26f1e31da0171f3f5193f12253619e"
 SOURCE_URI_2="https://github.com/SpartanJ/soil2/archive/$srcGitRev_2.tar.gz"
 CHECKSUM_SHA256_2="6487667b9d0bbc72bbce80dc5bf92a365442d657e6c2b7e8f81d4c7cd2d242ea"
 SOURCE_FILENAME_2="SOIL2-$srcGitRev_2.tar.gz"
 SOURCE_DIR_2="SOIL2-$srcGitRev_2"
+
+# efsw
 srcGitRev_3="3c5bf8365858a835246dd10f047d23f2630dbe92"
 SOURCE_URI_3="https://github.com/SpartanJ/efsw/archive/$srcGitRev_3.tar.gz"
 CHECKSUM_SHA256_3="26cfd5c85656580ffb0169b6764eff88d779bcb262ed671b988d034dd2b83314"
 SOURCE_FILENAME_3="efsw-$srcGitRev_3.tar.gz"
 SOURCE_DIR_3="efsw-$srcGitRev_3"
+
+# premake-cmake
+srcGitRev_4="8e02bb91a4d0f29d7540de7357574cf3b7c454f9"
+SOURCE_URI_4="https://github.com/Jarod42/premake-cmake/archive/$srcGitRev_4.tar.gz"
+CHECKSUM_SHA256_4="0ca5cf35a93776a0aaae885fe0ddd327206135d84aba2aa3a90756de585b6945"
+SOURCE_FILENAME_4="efsw-$srcGitRev_4.tar.gz"
+SOURCE_DIR_4="premake-cmake-$srcGitRev_4"
+
+# premake-ninja
+srcGitRev_5="6c1dfe1264f03d2454bc8b4b42b072ef04d4bf37"
+SOURCE_URI_5="https://github.com/jimon/premake-ninja/archive/$srcGitRev_5.tar.gz"
+CHECKSUM_SHA256_5="003cfad9741a0cd061bbc53be95b73bc2c5a870892df735fa7dd3f6de69a2bba"
+SOURCE_FILENAME_5="efsw-$srcGitRev_5.tar.gz"
+SOURCE_DIR_5="premake-ninja-$srcGitRev_5"
+
 ADDITIONAL_FILES="ecode.rdef.in"
 
 ARCHITECTURES="!all x86_64"
@@ -52,6 +71,8 @@ BUILD()
 {
 	cp -r $sourceDir2/* src/thirdparty/SOIL2
 	cp -r $sourceDir3/* src/thirdparty/efsw
+	cp -r $sourceDir4/* premake/premake-cmake
+	cp -r $sourceDir5/* premake/premake-ninja
 	cd projects/haiku/ecode
 	./build.app.sh
 }

--- a/app-editors/ecode/ecode-0.6.2.recipe
+++ b/app-editors/ecode/ecode-0.6.2.recipe
@@ -8,18 +8,18 @@ HOMEPAGE="https://github.com/SpartanJ/eepp"
 COPYRIGHT="2023 Martín Lucas Golini"
 LICENSE="MIT"
 REVISION="1"
-SOURCE_URI="https://github.com/SpartanJ/eepp/archive/refs/tags/eepp-2.8.1.tar.gz"
-CHECKSUM_SHA256="9b247c78f7d02a8be7844ec6cccb412dedf044b2151b30632bba03ffd347d67a"
-#SOURCE_FILENAME="eepp-2.8.1.tar.gz"
-SOURCE_DIR="eepp-eepp-2.8.1"
+SOURCE_URI="https://github.com/SpartanJ/eepp/archive/refs/tags/eepp-2.8.2.tar.gz"
+CHECKSUM_SHA256="48120634f6ab823f5b91469e100d20ee748bbd88f5da759f671d99d9ba6e0283"
+#SOURCE_FILENAME="eepp-2.8.2.tar.gz"
+SOURCE_DIR="eepp-eepp-2.8.2"
 srcGitRev_2="229324688c26f1e31da0171f3f5193f12253619e"
 SOURCE_URI_2="https://github.com/SpartanJ/soil2/archive/$srcGitRev_2.tar.gz"
 CHECKSUM_SHA256_2="6487667b9d0bbc72bbce80dc5bf92a365442d657e6c2b7e8f81d4c7cd2d242ea"
 SOURCE_FILENAME_2="SOIL2-$srcGitRev_2.tar.gz"
 SOURCE_DIR_2="SOIL2-$srcGitRev_2"
-srcGitRev_3="aa4b29e5253adce75f6884573de4611869e09de8"
+srcGitRev_3="3c5bf8365858a835246dd10f047d23f2630dbe92"
 SOURCE_URI_3="https://github.com/SpartanJ/efsw/archive/$srcGitRev_3.tar.gz"
-CHECKSUM_SHA256_3="d970f17724f3e25dcd0c155bed800da59af57778d81c158cf84b8eab3e340bc8"
+CHECKSUM_SHA256_3="26cfd5c85656580ffb0169b6764eff88d779bcb262ed671b988d034dd2b83314"
 SOURCE_FILENAME_3="efsw-$srcGitRev_3.tar.gz"
 SOURCE_DIR_3="efsw-$srcGitRev_3"
 ADDITIONAL_FILES="ecode.rdef.in"
@@ -58,15 +58,15 @@ BUILD()
 
 INSTALL()
 {
-	mkdir -p $appsDir/Ecode
-	cp -rf ./projects/haiku/ecode/ecode.app/* $appsDir/Ecode
-	rm -f $appsDir/Ecode/lib/libSDL2*
-	rm -f $appsDir/Ecode/ecode.png
+	mkdir -p $appsDir/ecode
+	cp -rf ./projects/haiku/ecode/ecode.app/* $appsDir/ecode
+	rm -f $appsDir/ecode/lib/libSDL2*
+	rm -f $appsDir/ecode/ecode.png
 
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
 	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
 	local MINOR="`echo "$portVersion" | cut -d. -f3`"
-	local APP_NAME="Ecode"
+	local APP_NAME="ecode"
 	local LONG_INFO="$SUMMARY"
 	local APP_SIGNATURE="application/x-vnd.ecode"
 	sed \
@@ -78,7 +78,7 @@ INSTALL()
 		-e "s|@APP_SIGNATURE@|$APP_SIGNATURE|" \
 		$portDir/additional-files/ecode.rdef.in > ecode.rdef
 
-	addResourcesToBinaries ecode.rdef $appsDir/Ecode/ecode
+	addResourcesToBinaries ecode.rdef $appsDir/ecode/ecode
 
-	addAppDeskbarSymlink $appsDir/Ecode/ecode Ecode
+	addAppDeskbarSymlink $appsDir/ecode/ecode ecode
 }


### PR DESCRIPTION
This recipe updates to the latest ecode release. I also renamed the application since the original name is all in lower-case.