### PR TITLE
Another attempt at fixing ECWolf on buildmasters

### DIFF
--- a/games-arcade/ecwolf/ecwolf-1.4.1.recipe
+++ b/games-arcade/ecwolf/ecwolf-1.4.1.recipe
@@ -11,7 +11,7 @@ in one directory as one binary plays all supported games."
 HOMEPAGE="https://maniacsvault.net/ecwolf/"
 COPYRIGHT="2004-2024 the ECWolf team"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://maniacsvault.net/ecwolf/files/ecwolf/1.x/ecwolf-${portVersion}-src.tar.xz"
 CHECKSUM_SHA256="8ebd495d2806c9d0e736656970e736730a005d3b43c7f5729f52c812b22f9e2d"
 SOURCE_DIR="ecwolf-${portVersion}-src"
@@ -70,7 +70,7 @@ BUILD()
 	cmake .. $cmakeDirArgs \
 		-Wno-dev -Wno-error=dev -Wno-deprecated \
 		-DCMAKE_BUILD_TYPE=Release \
-		-DCMAKE_C_FLAGS="-D_DEFAULT_SOURCE -D_GNU_SOURCE"
+		-DCMAKE_CXX_FLAGS="-D_DEFAULT_SOURCE -D_GNU_SOURCE"
 
 	make $jobArgs
 }

--- a/games-arcade/ecwolf/ecwolf-1.4.1.recipe
+++ b/games-arcade/ecwolf/ecwolf-1.4.1.recipe
@@ -69,7 +69,7 @@ BUILD()
 
 	cmake .. $cmakeDirArgs \
 		-Wno-dev -Wno-error=dev -Wno-deprecated \
-		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DCMAKE_CXX_FLAGS="-D_DEFAULT_SOURCE -D_GNU_SOURCE"
 
 	make $jobArgs


### PR DESCRIPTION
As @OscarL mentioned in the last, failed attempt to fix this package on buildmaster, since the build fails on a cpp file maybe the needed flags were meant to be defined as c++ flags.
To me that sounds like a good theory so... here I go again with another patch I cannot test as the problem it's meant to solve isn't reproducible here.