### PR TITLE
libdbi-drivers: new recipe

### DIFF
--- a/dev-db/libdbi-drivers/libdbi_drivers-0.9.0.recipe
+++ b/dev-db/libdbi-drivers/libdbi_drivers-0.9.0.recipe
@@ -53,6 +53,6 @@ INSTALL()
 	rm -f $libDir/dbd/*.la
 
 	mkdir -p $developDocDir
-	mv $prefix/data/doc/libdbi*/* $developDocDir
-	rm -rf $prefix/data/doc
+	mv $dataDir/doc/libdbi*/* $developDocDir
+	rm -rf $dataDir/doc
 }


### PR DESCRIPTION
Last dependency for Gnucash. Only the sqlite3 backend is built (I wanted to get Gnucash running), perhaps we should discuss if we need or want some of the others.