### PR TITLE
pyzmq: recipe clean up. Drop _python39 package.

### DIFF
--- a/dev-python/pyzmq/pyzmq-25.1.2.recipe
+++ b/dev-python/pyzmq/pyzmq-25.1.2.recipe
@@ -5,11 +5,11 @@ This package contains Python bindings for ØMQ. \
 HOMEPAGE="https://zeromq.org/"
 COPYRIGHT="2009-2019, Brian Granger, Min Ragan-Kelley"
 LICENSE="GNU LGPL v3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/zeromq/pyzmq/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="4df6361aa20dad1572ef83b441d0ef43125e86e139b30e215cad95883166ee4d"
 
-ARCHITECTURES="all !x86_gcc2 ?x86"
+ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
@@ -27,49 +27,57 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:pkg_config$secondaryArchSuffix
 	"
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-maybe_pyzmqNoSuffix=
-if [ "$targetArchitecture" = "x86_gcc2" ]; then
-	maybe_pyzmqNoSuffix="pyzmq_$pythonPackage = $portVersion"
-fi
-eval "PROVIDES_${pythonPackage}=\"\
-	pyzmq${secondaryArchSuffix}_$pythonPackage = $portVersion\n\
-	$maybe_pyzmqNoSuffix\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku$secondaryArchSuffix\n\
-	lib:libzmq$secondaryArchSuffix\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	packaging_$pythonPackage
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:cython$pythonVersion
-	cmd:python$pythonVersion"
+
+PYTHON_VERSIONS=(3.10)
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_${pythonPackage}+=\"
+			pyzmq_$pythonPackage = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku$secondaryArchSuffix
+		lib:libzmq$secondaryArchSuffix
+		cmd:python$pythonVersion
+		\""
+
+	BUILD_REQUIRES+="
+		packaging_$pythonPackage
+		setuptools_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:cython$pythonVersion
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
-		# GENERIC: all python_setuptools-based installs need this
 		python=python$pythonVersion
-		pythonVersion=$($python --version 2>&1 | sed 's/Python //' | head -c3)
+
 		installLocation=$prefix/lib/python$pythonVersion/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py install \
 			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }


### PR DESCRIPTION
Only on-tree user of this package is 3.10 only (openshot).