### PR TITLE
pyenet: recipe cleanup. Drop _python39 package.

### DIFF
--- a/dev-python/pyenet/pyenet-20221216.recipe
+++ b/dev-python/pyenet/pyenet-20221216.recipe
@@ -7,7 +7,7 @@ HOMEPAGE="https://github.com/aresch/pyenet"
 LICENSE="BSD (3-clause)
 	MIT"
 COPYRIGHT="2003 Scott Robinson; 2009,2010 Andrew Resch"
-REVISION="1"
+REVISION="2"
 srcGitRev="e2b7544ff7d57fe421bdf4563d958e0fcb496d9f"
 SOURCE_URI="https://github.com/aresch/pyenet/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="a23ec1a8f8373aabcbb68d32fff0a8088205eeb1ee3f945853c738927143cd7e"
@@ -24,24 +24,27 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
+PYTHON_VERSIONS=(3.10)
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_$pythonPackage=\"
 		${portName}_$pythonPackage = $portVersion
 		\""
-	eval "REQUIRES_$pythonPackage=\"
-		haiku
-		cmd:python$pythonVersion
-		\""
+
 	if [ "$targetArchitecture" = "x86_gcc2" ]; then
 		eval "PROVIDES_${pythonPackage}+=\"
 			pyenet_$pythonPackage = $portVersion
 			\""
 	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cmd:python$pythonVersion
+		\""
+
 	BUILD_REQUIRES+="
 		haiku${secondaryArchSuffix}_devel
 		devel:libenet$secondaryArchSuffix
@@ -55,9 +58,9 @@ done
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/


### PR DESCRIPTION
Nothing currently uses it on-tree.

Only known user, "unknown-horizons", is broken on-tree, upstream is porting the game to Godot, and considers current engine "dead".