### PR TITLE
pyqt_builder: drop the python39 package.

### DIFF
--- a/dev-python/pyqt_builder/pyqt_builder-1.16.4.recipe
+++ b/dev-python/pyqt_builder/pyqt_builder-1.16.4.recipe
@@ -5,7 +5,7 @@ compilation and installation of extension modules."
 HOMEPAGE="https://www.riverbankcomputing.com/software/pyqt/"
 COPYRIGHT="2020 Riverbank Computing Limited"
 LICENSE="BSD (2-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.io/packages/source/P/PyQt-builder/pyqt_builder-$portVersion.tar.gz"
 CHECKSUM_SHA256="4515e41ae379be2e54f88a89ecf47cd6e4cac43e862c4abfde18389c2666afdf"
 SOURCE_DIR="pyqt_builder-$portVersion"
@@ -23,13 +23,12 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
+PYTHON_VERSIONS=(3.10)
 defaultVersion=3.10
 
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
+for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_$pythonPackage=\"
 		${portName}_$pythonPackage = $portVersion
@@ -63,9 +62,9 @@ done
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/


### PR DESCRIPTION
A required package (sip) already dropped 3.9 support in its last recipe update (6.8.6).

Also, all users of `pyqt_builder` already require only the `_python310` version.

----

Build tested on beta5 32 bits. (should help clear a bit the buildmaster's report.txt)