### PR TITLE
torrentor: update to latest commit, and enable recipe.

### DIFF
--- a/haiku-apps/torrentor/torrentor-0.0.5~git.recipe
+++ b/haiku-apps/torrentor/torrentor-0.0.5~git.recipe
@@ -5,46 +5,48 @@ downloading data from servers, but they are sending and receiving directly \
 to/from each other."
 HOMEPAGE="https://github.com/HaikuArchives/Torrentor"
 COPYRIGHT="2012 Guido Pola"
-LICENSE="MIT"
-REVISION="5"
-srcGitRev="21784a23d210bca3d78e4fa3bed846a7bc962d39"
+LICENSE="
+	MIT
+	BSD (3-clause)
+	"
+REVISION="1"
+srcGitRev="4fe8034ba09cb43e56bd173d583608efe276df5b"
 SOURCE_URI="https://github.com/HaikuArchives/Torrentor/archive/$srcGitRev.tar.gz"
-CHECKSUM_SHA256="08e47eefe98e08360f63262548b43ea39995e2ca6514a7178ea9cc7afd7cdf8f"
+CHECKSUM_SHA256="743e71d6bb9f387edf0542b46d78de8775a883cb5a6961e247b615c7db412e43"
 SOURCE_DIR="Torrentor-$srcGitRev"
 
-ARCHITECTURES="!all !x86_gcc2"
-SECONDARY_ARCHITECTURES="!x86"
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	torrentor${secondaryArchSuffix} = $portVersion
 	app:Torrentor = $portVersion
 	"
 REQUIRES="
-	haiku${secondaryArchSuffix}
-	lib:libcurl${secondaryArchSuffix}
-	lib:libevent${secondaryArchSuffix}
-	lib:libssl${secondaryArchSuffix}
-	lib:libz${secondaryArchSuffix}
+	haiku$secondaryArchSuffix
+	lib:libcurl$secondaryArchSuffix
+	lib:libevent_2.1$secondaryArchSuffix
+	lib:libssl$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libcurl${secondaryArchSuffix}
-	devel:libevent${secondaryArchSuffix}
-	devel:libssl${secondaryArchSuffix}
-	devel:libz${secondaryArchSuffix}
+	devel:libcurl$secondaryArchSuffix
+	devel:libevent_2.1$secondaryArchSuffix
+	devel:libssl$secondaryArchSuffix >= 3
+	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	curl${secondaryArchSuffix}
-	cmd:gcc${secondaryArchSuffix}
+	cmd:gcc$secondaryArchSuffix
 	cmd:jam
-	cmd:make
 	"
 
 BUILD()
 {
 	export NDEBUG=1
-	jam $jobArgs
+	export CFLAFS="-Wno-unused-but-set-variable"
+	jam -q $jobArgs
 }
 
 INSTALL()


### PR DESCRIPTION
Not perfect, as BitTorrent protocol encryption must be kept disabled to avoid crashes related to linking to OpenSSL 3, and DHT peer exchange doesn't seems to be functional.

The latter, plus Torrentor! not allowing to add new trackers, means that only .torrent files with "fresh enough" tracker info can actually download data.

----

Tested on both 32 and 64 bits beta5. Works well enough as to be able to download the Haiku Beta5 ISOs.