### PR TITLE
expat: Update to 2.6.4

### DIFF
--- a/dev-libs/expat/expat-2.6.4.recipe
+++ b/dev-libs/expat/expat-2.6.4.recipe
@@ -8,13 +8,13 @@ COPYRIGHT="1998-2000 Thai Open Source Software Center Ltd and Clark Cooper
 LICENSE="MIT"
 REVISION="1"
 SOURCE_URI="https://downloads.sourceforge.net/expat/expat-$portVersion.tar.bz2"
-CHECKSUM_SHA256="9c7c1b5dcbc3c237c500a8fb1493e14d9582146dd9b42aa8d3ffb856a3b927e0"
+CHECKSUM_SHA256="8dc480b796163d4436e6f1352e71800a774f73dbae213f1860b60607d2a83ada"
 PATCHES="expat-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
-libVersion=1.9.2
+libVersion=1.10.0
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 portVersionCompat="$portVersion compat >= 2.2"
 

--- a/dev-libs/expat/patches/expat-2.6.4.patchset
+++ b/dev-libs/expat/patches/expat-2.6.4.patchset
@@ -1,4 +1,4 @@
-From d98573ef248827bea8d9b93d9ad9895a1e8f447c Mon Sep 17 00:00:00 2001
+From 7f2fdf2f03142a0b39136b711e99c8bb070dcd35 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Fran=C3=A7ois=20Revol?= <revol@free.fr>
 Date: Sat, 2 Dec 2023 02:02:15 +0100
 Subject: Fix INTERFACE_INCLUDE_DIRECTORIES on Haiku
@@ -6,10 +6,10 @@ Subject: Fix INTERFACE_INCLUDE_DIRECTORIES on Haiku
 Not sure if the IMPORTED_LOCATION shouldn't be develop/lib
 
 diff --git a/Makefile.am b/Makefile.am
-index 9c2259d..a873fff 100644
+index 7d8e17c..435f7a8 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -68,6 +68,7 @@ cmakedir = $(libdir)/cmake/expat-@PACKAGE_VERSION@
+@@ -70,6 +70,7 @@ cmakedir = $(libdir)/cmake/expat-@PACKAGE_VERSION@
  
  
  _EXTRA_DIST_CMAKE = \
@@ -50,10 +50,10 @@ index 0000000..c1aad9d
 +# Commands beyond this point should not need to know the version.
 +set(CMAKE_IMPORT_FILE_VERSION)
 diff --git a/configure.ac b/configure.ac
-index a5d1ff9..02e85dc 100644
+index fffcd12..479ff5f 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -425,6 +425,7 @@ AC_SUBST([CMAKE_SHARED_LIBRARY_PREFIX])
+@@ -442,6 +442,7 @@ AC_SUBST([CMAKE_SHARED_LIBRARY_PREFIX])
  AS_CASE("${host_os}",
    [darwin*], [CMAKE_NOCONFIG_SOURCE=cmake/autotools/expat-noconfig__macos.cmake.in],
    [mingw*|cygwin*], [CMAKE_NOCONFIG_SOURCE=cmake/autotools/expat-noconfig__windows.cmake.in],
@@ -62,20 +62,20 @@ index a5d1ff9..02e85dc 100644
  AC_CONFIG_FILES([Makefile]
    [expat.pc]
 -- 
-2.37.3
+2.45.2
 
 
-From 8283c87bf2947364bf29ef84ecd532e8f58e8581 Mon Sep 17 00:00:00 2001
+From c3b1d8d9641983d9d47bcc438d16fddc494a5791 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Wed, 7 Feb 2024 18:47:27 +0100
 Subject: can't allocate so much on Haiku
 
 
 diff --git a/Makefile.in b/Makefile.in
-index f505224..6362402 100644
+index c0fcb5d..56de6c3 100644
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -466,6 +466,7 @@ nodist_cmake_DATA = \
+@@ -468,6 +468,7 @@ nodist_cmake_DATA = \
  
  cmakedir = $(libdir)/cmake/expat-@PACKAGE_VERSION@
  _EXTRA_DIST_CMAKE = \
@@ -84,10 +84,10 @@ index f505224..6362402 100644
      cmake/autotools/expat-noconfig__macos.cmake.in \
      cmake/autotools/expat-noconfig__windows.cmake.in \
 diff --git a/configure b/configure
-index a4aee82..ceeca17 100755
+index c2f7bb7..870ad18 100755
 --- a/configure
 +++ b/configure
-@@ -1780,7 +1780,7 @@ else $as_nop
+@@ -1786,7 +1786,7 @@ else $as_nop
  #define $2 innocuous_$2
  
  /* System header to define __stub macros and hopefully few prototypes,
@@ -96,7 +96,7 @@ index a4aee82..ceeca17 100755
  
  #include <limits.h>
  #undef $2
-@@ -1791,7 +1791,7 @@ else $as_nop
+@@ -1797,7 +1797,7 @@ else $as_nop
  #ifdef __cplusplus
  extern "C"
  #endif
@@ -105,7 +105,7 @@ index a4aee82..ceeca17 100755
  /* The GNU C library defines this for functions which it implements
      to always fail with ENOSYS.  Some functions are actually named
      something starting with __ and the normal name is an alias.  */
-@@ -2545,7 +2545,9 @@ struct stat;
+@@ -2551,7 +2551,9 @@ struct stat;
  /* Most of the following tests are stolen from RCS 5.7 src/conf.sh.  */
  struct buf { int x; };
  struct buf * (*rcsopen) (struct buf *, struct stat *, int);
@@ -116,7 +116,7 @@ index a4aee82..ceeca17 100755
  {
    return p[i];
  }
-@@ -2596,7 +2598,6 @@ extern int puts (const char *);
+@@ -2602,7 +2604,6 @@ extern int puts (const char *);
  extern int printf (const char *, ...);
  extern int dprintf (int, const char *, ...);
  extern void *malloc (size_t);
@@ -124,7 +124,7 @@ index a4aee82..ceeca17 100755
  
  // Check varargs macros.  These examples are taken from C99 6.10.3.5.
  // dprintf is used instead of fprintf to avoid needing to declare
-@@ -13243,14 +13244,8 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+@@ -13298,14 +13299,8 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  
  /* Override any GCC internal prototype to avoid an error.
     Use char because int might match the return type of a GCC
@@ -141,7 +141,7 @@ index a4aee82..ceeca17 100755
  int
  main (void)
  {
-@@ -13311,14 +13306,8 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+@@ -13366,14 +13361,8 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  
  /* Override any GCC internal prototype to avoid an error.
     Use char because int might match the return type of a GCC
@@ -158,7 +158,7 @@ index a4aee82..ceeca17 100755
  int
  main (void)
  {
-@@ -13361,14 +13350,8 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+@@ -13416,14 +13405,8 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  
  /* Override any GCC internal prototype to avoid an error.
     Use char because int might match the return type of a GCC
@@ -175,7 +175,7 @@ index a4aee82..ceeca17 100755
  int
  main (void)
  {
-@@ -13406,14 +13389,8 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+@@ -13461,14 +13444,8 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  
  /* Override any GCC internal prototype to avoid an error.
     Use char because int might match the return type of a GCC
@@ -192,7 +192,7 @@ index a4aee82..ceeca17 100755
  int
  main (void)
  {
-@@ -13451,14 +13428,8 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+@@ -13506,14 +13483,8 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  
  /* Override any GCC internal prototype to avoid an error.
     Use char because int might match the return type of a GCC
@@ -209,7 +209,7 @@ index a4aee82..ceeca17 100755
  int
  main (void)
  {
-@@ -14632,11 +14603,11 @@ if test x$ac_prog_cxx_stdcxx = xno
+@@ -14687,11 +14658,11 @@ if test x$ac_prog_cxx_stdcxx = xno
  then :
    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++11 features" >&5
  printf %s "checking for $CXX option to enable C++11 features... " >&6; }
@@ -223,7 +223,7 @@ index a4aee82..ceeca17 100755
  ac_save_CXX=$CXX
  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  /* end confdefs.h.  */
-@@ -14678,11 +14649,11 @@ if test x$ac_prog_cxx_stdcxx = xno
+@@ -14733,11 +14704,11 @@ if test x$ac_prog_cxx_stdcxx = xno
  then :
    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++98 features" >&5
  printf %s "checking for $CXX option to enable C++98 features... " >&6; }
@@ -237,7 +237,7 @@ index a4aee82..ceeca17 100755
  ac_save_CXX=$CXX
  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  /* end confdefs.h.  */
-@@ -18776,23 +18747,22 @@ unsigned short int ascii_mm[] =
+@@ -18866,23 +18837,22 @@ unsigned short int ascii_mm[] =
  		int use_ebcdic (int i) {
  		  return ebcdic_mm[i] + ebcdic_ii[i];
  		}
@@ -273,7 +273,7 @@ index a4aee82..ceeca17 100755
  	      if test "$ac_cv_c_bigendian" = unknown; then
  		ac_cv_c_bigendian=no
  	      else
-@@ -18801,8 +18771,7 @@ then :
+@@ -18891,8 +18861,7 @@ then :
  	      fi
  	    fi
  fi
@@ -283,7 +283,7 @@ index a4aee82..ceeca17 100755
  else $as_nop
    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  /* end confdefs.h.  */
-@@ -19454,14 +19423,8 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+@@ -19534,14 +19503,8 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  
  /* Override any GCC internal prototype to avoid an error.
     Use char because int might match the return type of a GCC
@@ -300,7 +300,7 @@ index a4aee82..ceeca17 100755
  int
  main (void)
  {
-@@ -19500,14 +19463,8 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+@@ -19580,14 +19543,8 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  
  /* Override any GCC internal prototype to avoid an error.
     Use char because int might match the return type of a GCC
@@ -317,7 +317,7 @@ index a4aee82..ceeca17 100755
  int
  main (void)
  {
-@@ -19548,14 +19505,8 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+@@ -19628,14 +19585,8 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  
  /* Override any GCC internal prototype to avoid an error.
     Use char because int might match the return type of a GCC
@@ -334,7 +334,7 @@ index a4aee82..ceeca17 100755
  int
  main (void)
  {
-@@ -19610,14 +19561,8 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+@@ -19690,14 +19641,8 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
  
  /* Override any GCC internal prototype to avoid an error.
     Use char because int might match the return type of a GCC
@@ -351,7 +351,7 @@ index a4aee82..ceeca17 100755
  int
  main (void)
  {
-@@ -20281,6 +20226,8 @@ case "${host_os}" in #(
+@@ -20407,6 +20352,8 @@ case "${host_os}" in #(
      CMAKE_NOCONFIG_SOURCE=cmake/autotools/expat-noconfig__macos.cmake.in ;; #(
    mingw*|cygwin*) :
      CMAKE_NOCONFIG_SOURCE=cmake/autotools/expat-noconfig__windows.cmake.in ;; #(
@@ -361,7 +361,7 @@ index a4aee82..ceeca17 100755
      CMAKE_NOCONFIG_SOURCE=cmake/autotools/expat-noconfig__linux.cmake.in ;;
  esac
 diff --git a/expat_config.h b/expat_config.h
-index 230e264..a5cf1d8 100644
+index 5c3e007..48d7b06 100644
 --- a/expat_config.h
 +++ b/expat_config.h
 @@ -14,7 +14,7 @@
@@ -392,10 +392,10 @@ index 230e264..a5cf1d8 100644
  /* Define to 1 if you have the <sys/param.h> header file. */
  #define HAVE_SYS_PARAM_H 1
 diff --git a/tests/basic_tests.c b/tests/basic_tests.c
-index 7112a44..3a287c7 100644
+index d38b8fd..5589c89 100644
 --- a/tests/basic_tests.c
 +++ b/tests/basic_tests.c
-@@ -2880,13 +2880,18 @@ START_TEST(test_buffer_can_grow_to_max) {
+@@ -2987,13 +2987,18 @@ START_TEST(test_buffer_can_grow_to_max) {
        "withreadabilityprettygreatithinkanywaysthisisprobablylongenoughbye><x a='"};
    const int num_prefixes = sizeof(prefixes) / sizeof(prefixes[0]);
    int maxbuf = INT_MAX / 2 + (INT_MAX & 1); // round up without overflow
@@ -416,5 +416,5 @@ index 7112a44..3a287c7 100644
    free(big);
  #endif
 -- 
-2.37.3
+2.45.2
 


### PR DESCRIPTION
* Old versions have been renamed in SourceForge downloads to discourage people from downloading vulnerable versions, so recipes are broken.