### PR TITLE
libid3tag: update to 0.16.3

### DIFF
--- a/media-libs/libid3tag/libid3tag-0.16.3.recipe
+++ b/media-libs/libid3tag/libid3tag-0.16.3.recipe
@@ -2,19 +2,24 @@ SUMMARY="The MAD id3tag library"
 DESCRIPTION="libid3tag is a library for reading and writing ID3 tags, both \
 ID3v1 and the various versions of ID3v2."
 HOMEPAGE="http://www.underbit.com/products/mad/"
-COPYRIGHT="2000-2004 Underbit Technologies, Inc."
+COPYRIGHT="2000-2004 Underbit Technologies, Inc.
+	2021-2024 Tenacity Team"
 LICENSE="GNU GPL v2"
-REVISION="7"
-SOURCE_URI="ftp://ftp.mars.org/pub/mpeg/libid3tag-$portVersion.tar.gz"
-CHECKSUM_SHA256="63da4f6e7997278f8a3fef4c6a372d342f705051d1eeb6a46a86b03610e26151"
+REVISION="1"
+SOURCE_URI="https://codeberg.org/tenacityteam/libid3tag/archive/$portVersion.tar.gz"
+CHECKSUM_SHA256="0561009778513a95d91dac33cee8418d6622f710450a7cb56a74636d53b588cb"
+SOURCE_DIR="libid3tag"
 PATCHES="libid3tag-$portVersion.patchset"
 
 ARCHITECTURES="all"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
+libVersion="$portVersion"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
 PROVIDES="
 	libid3tag$secondaryArchSuffix = $portVersion
-	lib:libid3tag$secondaryArchSuffix = 0.3.0 compat >= 0
+	lib:libid3tag$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -23,10 +28,10 @@ REQUIRES="
 
 PROVIDES_devel="
 	libid3tag${secondaryArchSuffix}_devel = $portVersion
-	devel:libid3tag$secondaryArchSuffix = 0.3.0 compat >= 0
+	devel:libid3tag$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
-	$portName == $portVersion base
+	libid3tag$secondaryArchSuffix == $portVersion base
 	"
 
 BUILD_REQUIRES="
@@ -34,36 +39,28 @@ BUILD_REQUIRES="
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:aclocal_1.13
-	cmd:autoconf
+	cmd:cmake
 	cmd:gcc$secondaryArchSuffix
 	cmd:gperf >= 3.1
-	cmd:libtoolize$secondaryArchSuffix
-	cmd:make
+	cmd:ninja
 	"
 
 BUILD()
 {
-	touch AUTHORS ChangeLog NEWS
-	autoreconf -vfi
-	runConfigure ./configure --disable-static
-	make
+	cmake -S . -B build -G Ninja \
+		$cmakeDirArgs \
+		-DCMAKE_BUILD_TYPE=Release
+	cmake --build build $jobArgs
 }
 
 INSTALL()
 {
-	make install
-
-	rm $libDir/libid3tag.la
+	cmake --install build
 
 	prepareInstalledDevelLib libid3tag
 	fixPkgconfig
 
 	packageEntries devel \
-		$developDir
-}
-
-TEST()
-{
-	make check
+		$developDir \
+		$libDir/cmake
 }

--- a/media-libs/libid3tag/patches/libid3tag-0.16.3.patchset
+++ b/media-libs/libid3tag/patches/libid3tag-0.16.3.patchset
@@ -1,0 +1,32 @@
+From 4785930058e5a09c03a7904b40fd211434556a3b Mon Sep 17 00:00:00 2001
+From: Schrijvers Luc <begasus@gmail.com>
+Date: Sun, 1 Dec 2024 18:24:27 +0100
+Subject: Build fix for 32bit
+
+
+diff --git a/ucs4.c b/ucs4.c
+index 9d2e02b..ea15efc 100644
+--- a/ucs4.c
++++ b/ucs4.c
+@@ -40,12 +40,14 @@ id3_length_t id3_ucs4_length(id3_ucs4_t const *ucs4)
+ 	if (!ucs4)
+ 		return 0;
+ 
+-  id3_ucs4_t const *ptr = ucs4;
++  {
++    id3_ucs4_t const *ptr = ucs4;
+ 
+-  while (*ptr)
+-    ++ptr;
++    while (*ptr)
++      ++ptr;
+ 
+-  return ptr - ucs4;
++    return ptr - ucs4;
++  }
+ }
+ 
+ /*
+-- 
+2.45.2
+


### PR DESCRIPTION
Somewhat like the follow-up to #11349 by also switching libid3tag to Tenacity's fork for the same reasons.