### PR TITLE
CLISP: Update ASDF to latest upstream

### DIFF
--- a/dev-lisp/clisp/clisp-2.49.95~git.recipe
+++ b/dev-lisp/clisp/clisp-2.49.95~git.recipe
@@ -15,10 +15,10 @@ COPYRIGHT="1992-1993 Bruno Haible, Michael Stoll
 	2001-2018 Sam Steingold, Bruno Haible
 	"
 LICENSE="GNU GPL v2"
-REVISION="1"
-srcGitRev="6024adde90ea7b8cffb70fd209c282ead6aa19c5"
+REVISION="2"
+srcGitRev="9ff8aedb796fbf7c47e594bfc2357b69c8e64dc9"
 SOURCE_URI="https://gitlab.com/gnu-clisp/clisp/-/archive/$srcGitRev.tar.gz"
-CHECKSUM_SHA256="fc865c36416852d27d69b09bc32cc9d1895347e0b1f7d9b7ec4d37de8cb0394f"
+CHECKSUM_SHA256="4dec02817e45c9f4a05fd31ef725728bc8da07c4c4c5b647dfb190c1d41439ce"
 SOURCE_DIR="clisp-$srcGitRev"
 
 ARCHITECTURES="all !x86_gcc2"


### PR DESCRIPTION
New recipe updates CLISP Git revision to current one. In this revision, CLISP updates upstream ASDF module that includes Haiku specific fix.

- Before this fix, :HAIKU symbol was removed from features and CLISP on Haiku was treated as CLISP on Unix.
- After this change, :HAIKU, OS-HAIKU, :UNIX and :OS-UNIX symbols are all present in features, making it clear that CLISP runs on Haiku, which is quite Unix-like.