### PR TITLE
Update wayland-server to latest commit (20241126)

### DIFF
--- a/dev-libs/wayland-server/patches/wayland_server-0.1.20241126.patchset
+++ b/dev-libs/wayland-server/patches/wayland_server-0.1.20241126.patchset
@@ -1,14 +1,14 @@
-From 320864b75abcc3e58284d3b087791823dd6bc17e Mon Sep 17 00:00:00 2001
+From 405acab4326699894fde35f10338b6e510482f36 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Thu, 17 Nov 2022 18:57:13 +1000
 Subject: Get application signature from resources
 
 
 diff --git a/WaylandServer.cpp b/WaylandServer.cpp
-index 1c34137..0df10d2 100644
+index 7966e13..ac79fbf 100644
 --- a/WaylandServer.cpp
 +++ b/WaylandServer.cpp
-@@ -18,7 +18,12 @@
+@@ -19,7 +19,12 @@
  #include <new>
  
  #include <Application.h>
@@ -21,7 +21,7 @@ index 1c34137..0df10d2 100644
  #include "AppKitPtrs.h"
  
  
-@@ -73,7 +78,7 @@ private:
+@@ -63,7 +68,7 @@ private:
  	struct wl_client *fClient{};
  
  public:
@@ -30,7 +30,7 @@ index 1c34137..0df10d2 100644
  	virtual ~Application() = default;
  
  	void AddClient(struct wl_client *client);
-@@ -83,7 +88,7 @@ public:
+@@ -73,7 +78,7 @@ public:
  	void MessageReceived(BMessage *msg) override;
  };
  
@@ -39,7 +39,7 @@ index 1c34137..0df10d2 100644
  {
  }
  
-@@ -123,7 +128,24 @@ void Application::MessageReceived(BMessage *msg)
+@@ -113,7 +118,24 @@ void Application::MessageReceived(BMessage *msg)
  extern "C" _EXPORT int wl_ips_client_connected(void **clientOut, void *clientDisplay, client_enqueue_proc display_enqueue)
  {
  	if (be_app == NULL) {
@@ -66,5 +66,5 @@ index 1c34137..0df10d2 100644
  	}
  	if (gServerHandler.Looper() == NULL) {
 -- 
-2.37.3
+2.45.2
 

--- a/dev-libs/wayland-server/wayland_server-0.1.20241126.recipe
+++ b/dev-libs/wayland-server/wayland_server-0.1.20241126.recipe
@@ -8,9 +8,9 @@ COPYRIGHT="2022-2023 X512"
 LICENSE="GNU LGPL v2.1
 	MIT"
 REVISION="1"
-srcGitRev="1e3eb35b40bc54438594bd959b553ecd619333fc"
+srcGitRev="04eeba4d2482a929e004c6a103b7c21bef88cd40"
 SOURCE_URI="https://github.com/X547/wayland-server/archive/$srcGitRev.tar.gz"
-CHECKSUM_SHA256="bdd6a16864ebfecc97e8896f67bf91daa0bcd5e3d8854f7146e15136bf496947"
+CHECKSUM_SHA256="224d8dc904f1cfdb8cb5e7d11775302a16eec1efdbf915b1ffd600e6cd6ec124"
 PATCHES="wayland_server-$portVersion.patchset"
 SOURCE_DIR="wayland-server-$srcGitRev"
 


### PR DESCRIPTION
- Text drag&drop support
- Initial support for Firefox port
- Internal stability and performance fix