### PR TITLE
classicube: bump version (1.3.6 -> 1.3.7)

### DIFF
--- a/games-action/classicube/classicube-1.3.7.recipe
+++ b/games-action/classicube/classicube-1.3.7.recipe
@@ -19,10 +19,9 @@ HOMEPAGE="https://www.classicube.net/"
 COPYRIGHT="2014-2022 UnknownShadow200"
 LICENSE="BSD (3-clause)"
 REVISION="1"
-srcGitRev="e8e1a7c0626b35a0fd17ac1d2359675f836e42ae"
-SOURCE_URI="https://github.com/ClassiCube/ClassiCube/archive/$srcGitRev.tar.gz"
-CHECKSUM_SHA256="94f9f4c1d40b89d3b5a30f582f3f5a3bfe9d1757f5bfb7e5de43d90a3e5c1ead"
-SOURCE_DIR="ClassiCube-$srcGitRev"
+SOURCE_URI="https://github.com/ClassiCube/ClassiCube/archive/$portVersion.tar.gz"
+CHECKSUM_SHA256="04f96eb2cc338b81a36a843b7d1f23de54ef539a80d2b793bbef69aa9043585f"
+SOURCE_DIR="ClassiCube-$portVersion"
 ADDITIONAL_FILES="
 	classicube.rdef.in
 	launcher.sh
@@ -78,7 +77,7 @@ INSTALL()
 	local APP_SIGNATURE="application/x-vnd.classicube"
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
 	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
-	local MINOR="`echo "$portVersion" | cut -d. -f3 | cut -d~ -f1`"
+	local MINOR="`echo "$portVersion" | cut -d. -f3`"
 	local LONG_INFO="$SUMMARY"
 	sed \
 		-e "s|@APP_SIGNATURE@|$APP_SIGNATURE|" \


### PR DESCRIPTION
I noticed that occasionally when holding `CTRL` + `SHIFT` to move faster in-game, the game will crash, not entirely sure why. I haven't noticed anything else right now.

![Main Menu](https://github.com/user-attachments/assets/1d92d97f-d2a1-496d-9128-8ce5238984a9)
###### (Strange/Garbled text on the main menu is gone now :tada:)

![In Game](https://github.com/user-attachments/assets/f7ac6384-1d53-4f51-9edc-6f0081f8d7a9)