### PR TITLE
Alien::Build + dependencies: new perl module recipes

### DIFF
--- a/dev-perl/alien_build/alien_build-2.84.recipe
+++ b/dev-perl/alien_build/alien_build-2.84.recipe
@@ -1,0 +1,73 @@
+SUMMARY="Build external dependencies for use in CPAN"
+DESCRIPTION="This module provides tools for building external (non-CPAN) dependencies for CPAN. \
+It is mainly designed to be used at install time of a CPAN client, and work closely with \
+Alien::Base which is used at runtime."
+HOMEPAGE="https://metacpan.org/pod/Alien::Build"
+COPYRIGHT="2011-2022 by Graham Ollis"
+LICENSE="Artistic"
+REVISION="1"
+SOURCE_URI="https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/Alien-Build-$portVersion.tar.gz"
+CHECKSUM_SHA256="8e891fd3acbac39dd8fdc01376b9abff931e625be41e0910ca30ad59363b4477"
+SOURCE_DIR="Alien-Build-$portVersion"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+# This package doesn't provide a normal suffix-less version on secondaryArch because it calls
+# pkg-config at runtime. Using it in an "any" recipe would call the wrong version on x86. For
+# Alien::Build plugins use 'alien_build_plugin'. For runtime dependencies of downstream packages,
+# use 'alien_base'.
+PROVIDES="
+	alien_build$secondaryArchSuffix = $portVersion
+	alien_base = $portVersion
+	alien_build_plugin = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	capture_tiny
+	ffi_checklib
+	file_chdir
+	file_which
+	path_tiny
+	vendor_perl
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	file_which
+	"
+BUILD_PREREQUIRES="
+	cmd:make
+	cmd:perl
+	"
+
+TEST_REQUIRES="
+	capture_tiny
+	ffi_checklib
+	file_chdir
+	path_tiny
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	perl Makefile.PL PREFIX=$prefix
+	make
+}
+
+INSTALL()
+{
+	make pure_install
+
+	# remove architecture-specific files (this would be an "any" arch package,
+	# but it isn't because of pkg-config, see above)
+	cd $prefix
+	rm -r $(perl -V:vendorarch | cut -d\' -f2 | cut -d/ -f5-)
+		# cut extracts the quoted string and strips the prefix (which is perl's and not ours)
+}
+
+TEST()
+{
+	make test
+}

--- a/dev-perl/alien_build_plugin_download_gitlab/alien_build_plugin_download_gitlab-0.01.recipe
+++ b/dev-perl/alien_build_plugin_download_gitlab/alien_build_plugin_download_gitlab-0.01.recipe
@@ -1,0 +1,55 @@
+SUMMARY="Alien::Build plugin to download from GitLab"
+DESCRIPTION="This plugin is designed for downloading assets from a GitLab instance."
+HOMEPAGE="https://metacpan.org/pod/Alien::Build::Plugin::Download::GitLab"
+COPYRIGHT="2022 by Graham Ollis"
+LICENSE="Artistic"
+REVISION="1"
+SOURCE_URI="https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/Alien-Build-Plugin-Download-GitLab-$portVersion.tar.gz"
+CHECKSUM_SHA256="c1f089c8ea152a789909d48a83dbfcf2626f773daf30431c8622582b26aba902"
+SOURCE_DIR="Alien-Build-Plugin-Download-GitLab-$portVersion"
+
+ARCHITECTURES="any"
+
+PROVIDES="
+	alien_build_plugin_download_gitlab = $portVersion
+	"
+REQUIRES="
+	haiku
+	alien_build
+	uri
+	vendor_perl
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:make
+	cmd:perl
+	"
+
+TEST_REQUIRES="
+	alien_build
+	uri
+	"
+
+BUILD()
+{
+	perl Makefile.PL PREFIX=$prefix
+	make
+}
+
+INSTALL()
+{
+	make pure_install
+
+	# remove architecture-specific files
+	cd $prefix
+	rm -r $(perl -V:vendorarch | cut -d\' -f2 | cut -d/ -f5-)
+		# cut extracts the quoted string and strips the prefix (which is perl's and not ours)
+}
+
+TEST()
+{
+	make test
+}

--- a/dev-perl/ffi_checklib/ffi_checklib-0.31.recipe
+++ b/dev-perl/ffi_checklib/ffi_checklib-0.31.recipe
@@ -1,0 +1,59 @@
+SUMMARY="Check that a library is available for FFI"
+DESCRIPTION="This module checks whether a particular dynamic library is available for FFI to use. \
+It is modeled heavily on Devel::CheckLib, but will find dynamic libraries even when development \
+packages are not installed. It also provides a find_lib function that will return the full path \
+to the found dynamic library, which can be feed directly into FFI::Platypus or another FFI system.
+Although intended mainly for FFI modules via FFI::Platypus and similar, this module does not \
+actually use any FFI to do its detection and probing. This module does not have any non-core \
+runtime dependencies. The test suite does depend on Test2::Suite."
+HOMEPAGE="https://metacpan.org/pod/FFI::CheckLib"
+COPYRIGHT="2014-2022 by Graham Ollis"
+LICENSE="Artistic"
+REVISION="1"
+SOURCE_URI="https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/FFI-CheckLib-$portVersion.tar.gz"
+CHECKSUM_SHA256="04d885fc377d44896e5ea1c4ec310f979bb04f2f18658a7e7a4d509f7e80bb80"
+SOURCE_DIR="FFI-CheckLib-$portVersion"
+
+ARCHITECTURES="any"
+
+PROVIDES="
+	ffi_checklib = $portVersion
+	"
+REQUIRES="
+	haiku
+	file_which
+	vendor_perl
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:make
+	cmd:perl
+	"
+
+TEST_REQUIRES="
+	file_which
+	"
+
+BUILD()
+{
+	perl Makefile.PL PREFIX=$prefix
+	make
+}
+
+INSTALL()
+{
+	make pure_install
+
+	# remove architecture-specific files
+	cd $prefix
+	rm -r $(perl -V:vendorarch | cut -d\' -f2 | cut -d/ -f5-)
+		# cut extracts the quoted string and strips the prefix (which is perl's and not ours)
+}
+
+TEST()
+{
+	make test
+}

--- a/dev-perl/file_chdir/file_chdir-0.1011.recipe
+++ b/dev-perl/file_chdir/file_chdir-0.1011.recipe
@@ -1,0 +1,53 @@
+SUMMARY="A more sensible way to change directories"
+DESCRIPTION="Perl's chdir() has the unfortunate problem of being very, very, very global. If any \
+part of your program calls chdir() or if any library you use calls chdir(), it changes the \
+current working directory for the *whole* program.
+This sucks.
+File::chdir gives you an alternative, $CWD and @CWD. These two variables combine all the power of \
+chdir(), File::Spec and Cwd."
+HOMEPAGE="https://metacpan.org/pod/File::chdir"
+COPYRIGHT="2016 by Michael G. Schwern and David Golden"
+LICENSE="Artistic"
+REVISION="1"
+SOURCE_URI="https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/File-chdir-$portVersion.tar.gz"
+CHECKSUM_SHA256="31ebf912df48d5d681def74b9880d78b1f3aca4351a0ed1fe3570b8e03af6c79"
+SOURCE_DIR="File-chdir-$portVersion"
+
+ARCHITECTURES="any"
+
+PROVIDES="
+	file_chdir = $portVersion
+	"
+REQUIRES="
+	haiku
+	vendor_perl
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:make
+	cmd:perl
+	"
+
+BUILD()
+{
+	perl Makefile.PL PREFIX=$prefix
+	make
+}
+
+INSTALL()
+{
+	make pure_install
+
+	# remove architecture-specific files
+	cd $prefix
+	rm -r $(perl -V:vendorarch | cut -d\' -f2 | cut -d/ -f5-)
+		# cut extracts the quoted string and strips the prefix (which is perl's and not ours)
+}
+
+TEST()
+{
+	make test
+}

--- a/dev-perl/path_tiny/path_tiny-0.146.recipe
+++ b/dev-perl/path_tiny/path_tiny-0.146.recipe
@@ -1,0 +1,70 @@
+SUMMARY="File path utility"
+DESCRIPTION="This module provides a small, fast utility for working with file paths. It is \
+friendlier to use than File::Spec and provides easy access to functions from several other core \
+file handling modules. It aims to be smaller and faster than many alternatives on CPAN, while \
+helping people do many common things in consistent and less error-prone ways.
+Path::Tiny does not try to work for anything except Unix-like and Win32 platforms. Even then, it \
+might break if you try something particularly obscure or tortuous. (Quick! What does this mean: \
+///../../..//./././a//b/.././c/././? And how does it differ on Win32?)
+All paths are forced to have Unix-style forward slashes. Stringifying the object gives you back \
+the path (after some clean up).
+File input/output methods flock handles before reading or writing, as appropriate (if supported \
+by the platform and/or filesystem).
+The *_utf8 methods (slurp_utf8, lines_utf8, etc.) operate in raw mode. On Windows, that means \
+they will not have CRLF translation from the :crlf IO layer. Installing Unicode::UTF8 0.58 or \
+later will speed up *_utf8 situations in many cases and is highly recommended. Alternatively, \
+installing PerlIO::utf8_strict 0.003 or later will be used in place of the default \
+:encoding(UTF-8).
+This module depends heavily on PerlIO layers for correct operation and thus requires Perl \
+5.008001 or later."
+HOMEPAGE="https://metacpan.org/pod/Path::Tiny"
+COPYRIGHT="2014 by David Golden"
+LICENSE="Apache v2"
+REVISION="1"
+SOURCE_URI="https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/Path-Tiny-$portVersion.tar.gz"
+CHECKSUM_SHA256="861ef09bca68254e9ab24337bb6ec9d58593a792e9d68a27ee6bec2150f06741"
+SOURCE_DIR="Path-Tiny-$portVersion"
+
+ARCHITECTURES="any"
+
+PROVIDES="
+	path_tiny = $portVersion
+	"
+REQUIRES="
+	haiku
+	unicode_utf8
+	vendor_perl
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:make
+	cmd:perl
+	"
+
+TEST_REQUIRES="
+	unicode_utf8
+	"
+
+BUILD()
+{
+	perl Makefile.PL PREFIX=$prefix
+	make
+}
+
+INSTALL()
+{
+	make pure_install
+
+	# remove architecture-specific files
+	cd $prefix
+	rm -r $(perl -V:vendorarch | cut -d\' -f2 | cut -d/ -f5-)
+		# cut extracts the quoted string and strips the prefix (which is perl's and not ours)
+}
+
+TEST()
+{
+	make test
+}

--- a/dev-perl/test_fatal/test_fatal-0.017.recipe
+++ b/dev-perl/test_fatal/test_fatal-0.017.recipe
@@ -1,0 +1,56 @@
+SUMMARY="Incredibly simple helpers for testing code with exceptions"
+DESCRIPTION="Test::Fatal is an alternative to the popular Test::Exception. It does much less, but \
+should allow greater flexibility in testing exception-throwing code with about the same amount of \
+typing.
+It exports one routine by default: exception."
+HOMEPAGE="https://metacpan.org/pod/Test::Fatal"
+COPYRIGHT="2010 by Ricardo Signes"
+LICENSE="Artistic"
+REVISION="1"
+SOURCE_URI="https://cpan.metacpan.org/authors/id/R/RJ/RJBS/Test-Fatal-$portVersion.tar.gz"
+CHECKSUM_SHA256="37dfffdafb84b762efe96b02fb2aa41f37026c73e6b83590db76229697f3c4a6"
+SOURCE_DIR="Test-Fatal-$portVersion"
+
+ARCHITECTURES="any"
+
+PROVIDES="
+	test_fatal = $portVersion
+	"
+REQUIRES="
+	haiku
+	try_tiny
+	vendor_perl
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:make
+	cmd:perl
+	"
+
+TEST_REQUIRES="
+	try_tiny
+"
+
+BUILD()
+{
+	perl Makefile.PL PREFIX=$prefix
+	make
+}
+
+INSTALL()
+{
+	make pure_install
+
+	# remove architecture-specific files
+	cd $prefix
+	rm -r $(perl -V:vendorarch | cut -d\' -f2 | cut -d/ -f5-)
+		# cut extracts the quoted string and strips the prefix (which is perl's and not ours)
+}
+
+TEST()
+{
+	make test
+}

--- a/dev-perl/try_tiny/try_tiny-0.32.recipe
+++ b/dev-perl/try_tiny/try_tiny-0.32.recipe
@@ -1,0 +1,53 @@
+SUMMARY="Minimal try/catch with proper preservation of \$@"
+DESCRIPTION="This module provides bare bones try/catch/finally statements that are designed to \
+minimize common mistakes with eval blocks, and NOTHING else."
+HOMEPAGE="https://metacpan.org/pod/Try::Tiny"
+COPYRIGHT="2009 by יובל קוג'מן (Yuval Kogman)"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://cpan.metacpan.org/authors/id/E/ET/ETHER/Try-Tiny-$portVersion.tar.gz"
+CHECKSUM_SHA256="ef2d6cab0bad18e3ab1c4e6125cc5f695c7e459899f512451c8fa3ef83fa7fc0"
+SOURCE_DIR="Try-Tiny-$portVersion"
+
+ARCHITECTURES="any"
+
+PROVIDES="
+	try_tiny = $portVersion
+	"
+REQUIRES="
+	haiku
+	vendor_perl
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:make
+	cmd:perl
+	"
+
+TEST_REQUIRES="
+	capture_tiny
+	"
+
+BUILD()
+{
+	perl Makefile.PL PREFIX=$prefix
+	make
+}
+
+INSTALL()
+{
+	make pure_install
+
+	# remove architecture-specific files
+	cd $prefix
+	rm -r $(perl -V:vendorarch | cut -d\' -f2 | cut -d/ -f5-)
+		# cut extracts the quoted string and strips the prefix (which is perl's and not ours)
+}
+
+TEST()
+{
+	make test
+}

--- a/dev-perl/unicode_utf8/unicode_utf8-0.62.recipe
+++ b/dev-perl/unicode_utf8/unicode_utf8-0.62.recipe
@@ -1,0 +1,56 @@
+SUMMARY="Encoding and decoding of UTF-8 encoding form"
+DESCRIPTION="This module provides functions to encode and decode UTF-8 encoding form as specified \
+by Unicode and ISO/IEC 10646:2011."
+HOMEPAGE="https://metacpan.org/pod/Unicode::UTF8"
+COPYRIGHT="2011-2017 by Christian Hansen"
+LICENSE="Artistic"
+REVISION="1"
+SOURCE_URI="https://cpan.metacpan.org/authors/id/C/CH/CHANSEN/Unicode-UTF8-$portVersion.tar.gz"
+CHECKSUM_SHA256="fa8722d0b74696e332fddd442994436ea93d3bfc7982d4babdcedfddd657d0f6"
+SOURCE_DIR="Unicode-UTF8-$portVersion"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	unicode_utf8$secondaryArchSuffix = $portVersion
+	"
+if [ -n "$secondaryArchSuffix" ]; then
+	PROVIDES+="
+		unicode_utf8 = $portVersion
+		"
+fi
+REQUIRES="
+	haiku$secondaryArchSuffix
+	vendor_perl
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:perl
+	"
+
+TEST_REQUIRES="
+	test_fatal
+	variable_magic
+	"
+
+BUILD()
+{
+	perl Makefile.PL PREFIX=$prefix
+	make
+}
+
+INSTALL()
+{
+	make pure_install
+}
+
+TEST()
+{
+	make test
+}

--- a/dev-perl/variable_magic/variable_magic-0.64.recipe
+++ b/dev-perl/variable_magic/variable_magic-0.64.recipe
@@ -1,0 +1,53 @@
+SUMMARY="Associate user-defined magic to variables from Perl"
+DESCRIPTION="Magic is Perl's way of enhancing variables. This mechanism lets the user add extra \
+data to any variable and hook syntactical operations (such as access, assignment or destruction) \
+that can be applied to it. With this module, you can add your own magic to any variable without \
+having to write a single line of XS."
+HOMEPAGE="https://metacpan.org/pod/Variable::Magic"
+COPYRIGHT="2007,2008,2009,2010,2011,2012,2013,2014,2015,2016,2017,2022,2024 Vincent Pit"
+LICENSE="Artistic"
+REVISION="1"
+SOURCE_URI="https://cpan.metacpan.org/authors/id/V/VP/VPIT/Variable-Magic-$portVersion.tar.gz"
+CHECKSUM_SHA256="9f7853249c9ea3b4df92fb6b790c03a60680fc029f44c8bf9894dccf019516bd"
+SOURCE_DIR="Variable-Magic-$portVersion"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	variable_magic$secondaryArchSuffix = $portVersion
+	"
+if [ -n "$secondaryArchSuffix" ]; then
+	PROVIDES+="
+		variable_magic = $portVersion
+		"
+fi
+REQUIRES="
+	haiku
+	vendor_perl
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:perl
+	"
+
+BUILD()
+{
+	perl Makefile.PL PREFIX=$prefix
+	make
+}
+
+INSTALL()
+{
+	make pure_install
+}
+
+TEST()
+{
+	make test
+}


### PR DESCRIPTION
Alien::Build is a build-time dependency of one of the dependencies ([XML::LibXML](https://metacpan.org/pod/XML::LibXML)) of [Biber](https://biblatex-biber.sourceforge.net/) which I am [porting](https://github.com/jmairboeck/haikuports/tree/biber) currently. (Most of the perl packages don't have many real build time dependencies, but only runtime ones, and therefore can be built independently.)

Alien::Build would be an "any" package content-wise but requires `pkg-config` at runtime, so it can't be "any" because on x86, `pkg-config-x86` is the correct one, so at least the metadata must be different. (This is a similar situation as with the existing Alien::SDL recipe.)

Note that, for me, "dependencies" also include (mandatory) test requirements, so that the tests at least run successfully.

I'm opening this as a draft, because I want to check if this actually works (i.e. if XML::LibXML can be built). It could very well be that this requires some patching.