### PR TITLE
Iceweasel: add libevent to runtime dependency

### DIFF
--- a/www-client/iceweasel/iceweasel-128.5.0.recipe
+++ b/www-client/iceweasel/iceweasel-128.5.0.recipe
@@ -26,6 +26,7 @@ REQUIRES="
 	lib:libcairo
 	lib:libcairo_gobject
 	lib:libdbus_1
+	lib:libevent_2.1
 	lib:libgdk_3
 	lib:libgdk_pixbuf_2.0
 	lib:libglib_2.0

--- a/www-client/iceweasel/iceweasel_bin-128.5.0.recipe
+++ b/www-client/iceweasel/iceweasel_bin-128.5.0.recipe
@@ -5,7 +5,7 @@ needs of both casual and power users."
 HOMEPAGE="https://github.com/kenz-gelsoft/gecko-dev"
 COPYRIGHT="1995-2024 Mozilla Developers and Contributors"
 LICENSE="MPL v2.0"
-REVISION="2"
+REVISION="3"
 buildTag="HAIKU128_5_20241208"
 SOURCE_URI="https://github.com/kenz-gelsoft/gecko-dev/releases/download/$buildTag/Iceweasel-$portVersion.en-US.haiku-x86_64.tar.bz2#noarchive"
 CHECKSUM_SHA256="d958b7ef8feceb3f2643dfc04737ca60a02452bb0d4fefd366ff3c45bf6413a1"
@@ -25,6 +25,7 @@ REQUIRES="
 	lib:libcairo >= 2.11800.0
 	lib:libcairo_gobject >= 2.11800.0
 	lib:libdbus_1 >= 3.19.13
+	lib:libevent_2.1
 	lib:libgdk_3 >= 3.2404.30
 	lib:libgdk_pixbuf_2.0 >= 0.4200.9
 	lib:libgio_2.0 >= 0.7800.0


### PR DESCRIPTION
- no more warnings from haikuporter output