### PR TITLE
dash: update to version 0.5.12.

### DIFF
--- a/app-shells/dash/dash-0.5.12.recipe
+++ b/app-shells/dash/dash-0.5.12.recipe
@@ -12,6 +12,15 @@ REVISION="1"
 SOURCE_URI="http://gondor.apana.org.au/~herbert/dash/files/dash-$portVersion.tar.gz"
 CHECKSUM_SHA256="6a474ac46e8b0b32916c4c60df694c82058d3297d8b385b74508030ca4a8f28a"
 
+PATCHES="
+	0007-Don-t-execute-binary-files-if-execve-returned-ENOEXE.diff
+	0009-dash-Fix-stack-overflow-from-infinite-recursion-in-s.patch
+	0010-exec-Check-executable-bit-when-searching-path.patch
+	0018-builtin-Don-t-early-exit-when-first-hash-r-is-found.patch
+	0019-builtin-Actually-accept-ulimit-r.patch
+	0021-jobs-Implement-pipefail-option.patch
+	"
+
 ARCHITECTURES="all !x86_gcc2 ?x86"
 SECONDARY_ARCHITECTURES="x86"
 

--- a/app-shells/dash/dash-0.5.12.recipe
+++ b/app-shells/dash/dash-0.5.12.recipe
@@ -10,17 +10,7 @@ COPYRIGHT="1989-1994 The Regents of the University of California
 LICENSE="GNU GPL v3"
 REVISION="1"
 SOURCE_URI="http://gondor.apana.org.au/~herbert/dash/files/dash-$portVersion.tar.gz"
-CHECKSUM_SHA256="3c663919dc5c66ec991da14c7cf7e0be8ad00f3db73986a987c118862b5f6071"
-
-SOURCE_FILENAME_2="dash-0.5.9.1-format-security.patch"
-srcGitRev_2="12ee15be33783573e73ab0ad27629daf88788121"
-SOURCE_URI_2="https://gitweb.gentoo.org/repo/gentoo.git/plain/app-shells/dash/files/$SOURCE_FILENAME_2?id=$srcGitRev_2#noarchive"
-CHECKSUM_SHA256_2="0ce7a1417b4e780f184588e761b4bea5d068c2312b23d954183076edf2f9432d"
-
-SOURCE_FILENAME_3="dash-0.5.10-dumb-echo.patch"
-srcGitRev_3="12ee15be33783573e73ab0ad27629daf88788121"
-SOURCE_URI_3="https://gitweb.gentoo.org/repo/gentoo.git/plain/app-shells/dash/files/$SOURCE_FILENAME_3?id=$srcGitRev_3#noarchive"
-CHECKSUM_SHA256_3="48c275bffa3504a9e8367fef742bb3a8d9c8bf0e221fb75ebcad14fc4d25bf9b"
+CHECKSUM_SHA256="6a474ac46e8b0b32916c4c60df694c82058d3297d8b385b74508030ca4a8f28a"
 
 ARCHITECTURES="all !x86_gcc2 ?x86"
 SECONDARY_ARCHITECTURES="x86"
@@ -38,18 +28,12 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libreadline$secondaryArchSuffix
-	lib:libncursesw$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
-	cmd:aclocal
-	cmd:autoconf
-	cmd:autoheader
-	cmd:automake
 	cmd:awk
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
@@ -58,24 +42,17 @@ BUILD_PREREQUIRES="
 defineDebugInfoPackage dash$secondaryArchSuffix \
 	"$commandBinDir"/dash
 
-PATCH()
-{
-	patch -p1 -i "$sourceDir2"/$SOURCE_FILENAME_2
-	patch -p1 -i "$sourceDir3"/$SOURCE_FILENAME_3
-}
-
 BUILD()
 {
-	runConfigure --omit-dirs binDir ./configure --bindir="$commandBinDir"
+	runConfigure --omit-dirs binDir ./configure \
+		--bindir="$commandBinDir" \
+		--disable-dependency-tracking
+
+	# libbsd.so needed for "wait3()"
 	make $jobArgs LIBS="-lbsd"
 }
 
 INSTALL()
 {
 	make install
-}
-
-TEST()
-{
-	make check
 }

--- a/app-shells/dash/patches/0007-Don-t-execute-binary-files-if-execve-returned-ENOEXE.diff
+++ b/app-shells/dash/patches/0007-Don-t-execute-binary-files-if-execve-returned-ENOEXE.diff
@@ -1,0 +1,71 @@
+From: Adam Borowski <kilobyte@angband.pl>
+Date: Tue, 24 Jan 2017 05:11:38 +0100
+Subject: Don't execute binary files if execve() returned ENOEXEC
+
+Both "dash -c foo" and "./foo" are supposed to be able to run hashbang-less
+scripts, but attempts to execute common binary files tend to be nasty:
+especially both ELF and PE tend to make dash create a bunch of files with
+unprintable names, that in turn confuse some tools up to causing data loss.
+
+Thus, let's read the first line and see if it looks like text.  This is a
+variant of the approach used by bash and zsh; mksh instead checks for
+signatures of a bunch of common file types.
+
+POSIX says: "If the executable file is not a text file, the shell may bypass
+this command execution.".
+
+Signed-off-by: Adam Borowski <kilobyte@angband.pl>
+---
+ src/exec.c | 32 ++++++++++++++++++++++++++++++++
+ 1 file changed, 32 insertions(+)
+
+diff --git a/src/exec.c b/src/exec.c
+index 87354d4..b0c1d0f 100644
+--- a/src/exec.c
++++ b/src/exec.c
+@@ -148,6 +148,36 @@ shellexec(char **argv, const char *path, int idx)
+ }
+ 
+ 
++/*
++ * Check if an executable that just failed with ENOEXEC shouldn't be
++ * considered a script (wrong-arch ELF/PE, junk accidentally set +x, etc).
++ * We check only the first line to allow binaries encapsulated in a shell
++ * script without proper quoting.  The first line, if not a hashbang, is
++ * likely to contain comments; even ancient encodings, at least popular
++ * ones, don't use 0x7f nor values below 0x1f other than whitespace (\t,
++ * \n, \v, \f, \r), ISO/IEC 2022 can have SI, SO and \e.
++ */
++STATIC int file_is_binary(const char *cmd)
++{
++	char buf[128];
++	int fd = open(cmd, O_RDONLY|O_NOCTTY);
++	if (fd == -1)
++		return 1;
++	int len = read(fd, buf, sizeof(buf));
++	close(fd);
++	for (int i = 0; i < len; ++i) {
++		char c = buf[i];
++		if (c >= 0 && c <= 8 ||
++		    c >= 16 && c <= 31 && c != 27 ||
++		    c == 0x7f)
++			return 1;
++		if (c == '\n')
++			return 0;
++	}
++	return 0;
++}
++
++
+ STATIC void
+ tryexec(char *cmd, char **argv, char **envp)
+ {
+@@ -162,6 +192,8 @@ repeat:
+ 	execve(cmd, argv, envp);
+ #endif
+ 	if (cmd != path_bshell && errno == ENOEXEC) {
++		if (file_is_binary(cmd))
++			return;
+ 		*argv-- = cmd;
+ 		*argv = cmd = path_bshell;
+ 		goto repeat;

--- a/app-shells/dash/patches/0009-dash-Fix-stack-overflow-from-infinite-recursion-in-s.patch
+++ b/app-shells/dash/patches/0009-dash-Fix-stack-overflow-from-infinite-recursion-in-s.patch
@@ -1,0 +1,51 @@
+From: Chris Lamb <lamby@debian.org>
+Date: Thu, 15 Feb 2018 20:28:25 +0000
+Subject: dash: Fix stack overflow from infinite recursion in script
+
+Bug-Debian: https://bugs.debian.org/579815
+Signed-off-by: Chris Lamb <lamby@debian.org>
+Signed-off-by: Andrej Shadura <andrew.shadura@collabora.co.uk>
+---
+ src/eval.c | 8 +++++++-
+ src/eval.h | 2 ++
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/eval.c b/src/eval.c
+index fa43b68..fc291ba 100644
+--- a/src/eval.c
++++ b/src/eval.c
+@@ -71,6 +71,7 @@ int evalskip;			/* set if we are skipping commands */
+ STATIC int skipcount;		/* number of levels to skip */
+ MKINIT int loopnest;		/* current loop nesting level */
+ static int funcline;		/* starting line number of current function, or 0 if not in a function */
++static int evalcount;		/* number of nested evalfun calls */
+ 
+ 
+ char *commandname;
+@@ -914,7 +915,12 @@ raise:
+ 		break;
+ 
+ 	case CMDFUNCTION:
+-		if (evalfun(cmdentry.u.func, argc, argv, flags))
++		if (evalcount++ >= MAX_RECURSION)
++			sh_error("Maximum function recursion depth (%d) reached",
++			         MAX_RECURSION);
++		int i = evalfun(cmdentry.u.func, argc, argv, flags);
++		evalcount--;
++		if (i)
+ 			goto raise;
+ 		break;
+ 	}
+diff --git a/src/eval.h b/src/eval.h
+index 63e7d86..38dffbd 100644
+--- a/src/eval.h
++++ b/src/eval.h
+@@ -51,6 +51,8 @@ struct backcmd {		/* result of evalbackcmd */
+ #define EV_EXIT 01		/* exit after evaluating tree */
+ #define EV_TESTED 02		/* exit status is checked; ignore -e flag */
+ 
++#define MAX_RECURSION 1000	/* maximum recursion level */
++
+ int evalstring(char *, int);
+ union node;	/* BLETCH for ansi C */
+ int evaltree(union node *, int);

--- a/app-shells/dash/patches/0010-exec-Check-executable-bit-when-searching-path.patch
+++ b/app-shells/dash/patches/0010-exec-Check-executable-bit-when-searching-path.patch
@@ -1,0 +1,116 @@
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Wed, 10 Nov 2021 07:53:03 +0100
+Subject: exec: Check executable bit when searching path
+
+This is inherited from NetBSD.  There is even a commented-out
+block of code that tried to fix this.
+
+Anyway, we now have faccessat so we can simply use it.
+
+Reported-by: Norman Ramsey <nr@cs.tufts.edu>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+
+Bug-Debian: https://bugs.debian.org/874264
+---
+ src/bltin/test.c | 10 +++-------
+ src/exec.c       | 20 +++++++-------------
+ src/exec.h       |  5 +++++
+ 3 files changed, 15 insertions(+), 20 deletions(-)
+
+diff --git a/src/bltin/test.c b/src/bltin/test.c
+index c7fc479..fd8a43b 100644
+--- a/src/bltin/test.c
++++ b/src/bltin/test.c
+@@ -18,6 +18,7 @@
+ #include <unistd.h>
+ #include <stdarg.h>
+ #include "bltin.h"
++#include "../exec.h"
+ 
+ /* test(1) accepts the following grammar:
+ 	oexpr	::= aexpr | aexpr "-o" oexpr ;
+@@ -148,11 +149,6 @@ static int isoperand(char **);
+ static int newerf(const char *, const char *);
+ static int olderf(const char *, const char *);
+ static int equalf(const char *, const char *);
+-#ifdef HAVE_FACCESSAT
+-static int test_file_access(const char *, int);
+-#else
+-static int test_access(const struct stat64 *, int);
+-#endif
+ 
+ #ifdef HAVE_FACCESSAT
+ # ifdef HAVE_TRADITIONAL_FACCESSAT
+@@ -527,7 +523,7 @@ static int has_exec_bit_set(const char *path)
+ 	return st.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH);
+ }
+ 
+-static int test_file_access(const char *path, int mode)
++int test_file_access(const char *path, int mode)
+ {
+ 	if (faccessat_confused_about_superuser() &&
+ 	    mode == X_OK && geteuid() == 0 && !has_exec_bit_set(path))
+@@ -657,7 +653,7 @@ static int test_file_access(const char *path, int mode)
+  * (euid==uid&&egid==gid), but uses st_mode for '-x' iff running as root.
+  * i.e. it does strictly conform to 1003.1-2001 (and presumably 1003.2b).
+  */
+-static int test_access(const struct stat64 *sp, int stmode)
++int test_access(const struct stat64 *sp, int stmode)
+ {
+ 	gid_t *groups;
+ 	register int n;
+diff --git a/src/exec.c b/src/exec.c
+index b0c1d0f..93424b2 100644
+--- a/src/exec.c
++++ b/src/exec.c
+@@ -490,20 +490,14 @@ loop:
+ 			stunalloc(fullname);
+ 			goto success;
+ 		}
+-#ifdef notdef
+-		/* XXX this code stops root executing stuff, and is buggy
+-		   if you need a group from the group list. */
+-		if (statb.st_uid == geteuid()) {
+-			if ((statb.st_mode & 0100) == 0)
+-				goto loop;
+-		} else if (statb.st_gid == getegid()) {
+-			if ((statb.st_mode & 010) == 0)
+-				goto loop;
+-		} else {
+-			if ((statb.st_mode & 01) == 0)
+-				goto loop;
+-		}
++		if ((statb.st_mode & 0111) != 0111 &&
++#ifdef HAVE_FACCESSAT
++		    !test_file_access(fullname, X_OK)
++#else
++		    !test_access(&statb, X_OK)
+ #endif
++		   )
++			continue;
+ 		TRACE(("searchexec \"%s\" returns \"%s\"\n", name, fullname));
+ 		if (!updatetbl) {
+ 			entry->cmdtype = CMDNORMAL;
+diff --git a/src/exec.h b/src/exec.h
+index 423b07e..8707d36 100644
+--- a/src/exec.h
++++ b/src/exec.h
+@@ -62,6 +62,8 @@ union node;
+ 
+ extern const char *pathopt;	/* set by padvance */
+ 
++struct stat64;
++
+ void shellexec(char **, const char *, int)
+     __attribute__((__noreturn__));
+ int padvance_magic(const char **path, const char *name, int magic);
+@@ -78,6 +80,9 @@ void unsetfunc(const char *);
+ int typecmd(int, char **);
+ int commandcmd(int, char **);
+ 
++int test_file_access(const char *path, int mode);
++int test_access(const struct stat64 *sp, int stmode);
++
+ static inline int padvance(const char **path, const char *name)
+ {
+ 	return padvance_magic(path, name, 1);

--- a/app-shells/dash/patches/0018-builtin-Don-t-early-exit-when-first-hash-r-is-found.patch
+++ b/app-shells/dash/patches/0018-builtin-Don-t-early-exit-when-first-hash-r-is-found.patch
@@ -1,0 +1,69 @@
+From: наб <nabijaczleweli@nabijaczleweli.xyz>
+Date: Wed, 14 Dec 2022 03:51:13 +0100
+Subject: builtin: Don't early-exit when first hash -r is found
+
+This fixes incorrectly-accepted "hash -rv" being equivalent to hash -r
+(well, hash -r[literally anything] being equivalent to hash -r)
+
+Also remove -v from the manual, it doesn't appear to have ever existed
+
+Bug-Debian: https://bugs.debian.org/819829
+---
+ src/dash.1 | 6 ++----
+ src/exec.c | 8 +++++++-
+ 2 files changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/src/dash.1 b/src/dash.1
+index 169d5df..4bb348a 100644
+--- a/src/dash.1
++++ b/src/dash.1
+@@ -1443,7 +1443,8 @@ cmd \-a \-c arg file file
+ cmd \-carg -a file file
+ cmd \-a \-carg \-\- file file
+ .Ed
+-.It hash Fl rv Ar command ...
++.It hash Op Ar command ...
++.It hash Fl r
+ The shell maintains a hash table which remembers the
+ locations of commands.
+ With no arguments whatsoever,
+@@ -1459,9 +1460,6 @@ With arguments, the
+ .Ic hash
+ command removes the specified commands from the hash table (unless
+ they are functions) and then locates them.
+-With the
+-.Fl v
+-option, hash prints the locations of the commands as it finds them.
+ The
+ .Fl r
+ option causes the hash command to delete all the entries in the hash table
+diff --git a/src/exec.c b/src/exec.c
+index 93424b2..67fa529 100644
+--- a/src/exec.c
++++ b/src/exec.c
+@@ -36,6 +36,7 @@
+ #include <sys/stat.h>
+ #include <unistd.h>
+ #include <fcntl.h>
++#include <stdbool.h>
+ #include <stdlib.h>
+ #ifdef HAVE_PATHS_H
+ #include <paths.h>
+@@ -303,11 +304,16 @@ hashcmd(int argc, char **argv)
+ 	int c;
+ 	struct cmdentry entry;
+ 	char *name;
++	bool clear;
+ 
+-	while ((c = nextopt("r")) != '\0') {
++	clear = false;
++	while ((c = nextopt("r")) != '\0')
++		clear = true;
++	if(clear) {
+ 		clearcmdentry();
+ 		return 0;
+ 	}
++
+ 	if (*argptr == NULL) {
+ 		for (pp = cmdtable ; pp < &cmdtable[CMDTABLESIZE] ; pp++) {
+ 			for (cmdp = *pp ; cmdp ; cmdp = cmdp->next) {

--- a/app-shells/dash/patches/0019-builtin-Actually-accept-ulimit-r.patch
+++ b/app-shells/dash/patches/0019-builtin-Actually-accept-ulimit-r.patch
@@ -1,0 +1,28 @@
+From: Vincent Lefevre <vincent@vinc17.net>
+Date: Fri, 16 Dec 2022 18:20:19 +0100
+Subject: builtin: Actually accept ulimit -r
+
+The original commit that added it supposes this works, but it only adds
+it to the ulimit -a listing and the manual, but doesn't allow it as an
+option.
+
+Fixes: 46abc8c6d8a5 ("[BUILTIN] Add support for ulimit -r")
+Bug-Debian: https://bugs.debian.org/975326
+---
+ src/miscbltin.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/miscbltin.c b/src/miscbltin.c
+index 5ccbbcb..e553f9e 100644
+--- a/src/miscbltin.c
++++ b/src/miscbltin.c
+@@ -440,6 +440,9 @@ ulimitcmd(int argc, char **argv)
+ #endif
+ #ifdef RLIMIT_LOCKS
+ 			       "w"
++#endif
++#ifdef RLIMIT_RTPRIO
++			       "r"
+ #endif
+ 	)) != '\0')
+ 		switch (optc) {

--- a/app-shells/dash/patches/0021-jobs-Implement-pipefail-option.patch
+++ b/app-shells/dash/patches/0021-jobs-Implement-pipefail-option.patch
@@ -1,0 +1,131 @@
+From: Chris Novakovic <chris@chrisn.me.uk>
+Date: Fri, 22 Apr 2022 22:10:13 +0100
+Subject: jobs: Implement pipefail option
+
+With the pipefail option set, a pipeline's exit status is the exit
+status of the rightmost command that failed, or zero if all commands
+succeeded.
+
+This is planned for inclusion in the next revision of POSIX [1],
+although the details are yet to be finalised. The semantics of this
+implementation are the same as those proposed in [2], which have also
+been adopted by the BSD shells.
+
+[1] https://www.austingroupbugs.net/view.php?id=789
+[2] https://www.austingroupbugs.net/view.php?id=789#c4115
+
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+---
+ src/dash.1    | 31 ++++++++++++++++++++++++-------
+ src/jobs.c    |  9 ++++++++-
+ src/options.c |  2 ++
+ src/options.h |  5 +++--
+ 4 files changed, 37 insertions(+), 10 deletions(-)
+
+diff --git a/src/dash.1 b/src/dash.1
+index 39cec2f..bfdba70 100644
+--- a/src/dash.1
++++ b/src/dash.1
+@@ -553,13 +553,17 @@ by redirection operators that are part of the command.
+ If the pipeline is not in the background (discussed later), the shell
+ waits for all commands to complete.
+ .Pp
+-If the reserved word ! does not precede the pipeline, the exit status is
+-the exit status of the last command specified in the pipeline.
+-Otherwise, the exit status is the logical NOT of the exit status of the
+-last command.
+-That is, if the last command returns zero, the exit status
+-is 1; if the last command returns greater than zero, the exit status is
+-zero.
++If the
++.Em pipefail
++option was enabled when the shell began execution of the pipeline, the
++pipeline's exit status is the exit status of the last command specified in
++the pipeline that exited with non-zero status, or zero if all commands in
++the pipeline exited with a status of zero. If the
++.Em pipefail
++option was not enabled, the pipeline's exit status is the exit status of
++the last command specified in the pipeline; the exit statuses of any other
++commands are not used. If the reserved word ! precedes the pipeline, its
++exit status is the logical NOT of the exit status described above.
+ .Pp
+ Because pipeline assignment of standard input or standard output or both
+ takes place before redirection, it can be modified by redirection.
+@@ -1836,6 +1840,19 @@ if the option is +o,
+ the settings are printed in a format suitable for
+ reinput to the shell to affect the same option settings.
+ .Pp
++In addition to the option names listed in the
++.Sx Argument List Processing
++section, the following options may be specified as arguments
++to -o or +o:
++.Bl -tag -width pipefail
++.It Em pipefail
++Derive the exit status of a pipeline from the exit statuses of all
++of the commands in the pipeline, not just the last command, as
++described in the
++.Sx Pipelines
++section.
++.El
++.Pp
+ The third use of the set command is to set the values of the shell's
+ positional parameters to the specified args.
+ To change the positional
+diff --git a/src/jobs.c b/src/jobs.c
+index f3b9ffc..78c7bc6 100644
+--- a/src/jobs.c
++++ b/src/jobs.c
+@@ -1526,8 +1526,15 @@ STATIC int
+ getstatus(struct job *job) {
+ 	int status;
+ 	int retval;
++	struct procstat *ps;
++
++	ps = job->ps + job->nprocs - 1;
++	status = ps->status;
++	if (pipefail) {
++		while (status == 0 && --ps >= job->ps)
++			status = ps->status;
++	}
+ 
+-	status = job->ps[job->nprocs - 1].status;
+ 	retval = WEXITSTATUS(status);
+ 	if (!WIFEXITED(status)) {
+ #if JOBS
+diff --git a/src/options.c b/src/options.c
+index 3158498..93ad9d6 100644
+--- a/src/options.c
++++ b/src/options.c
+@@ -80,6 +80,7 @@ static const char *const optnames[NOPTS] = {
+ 	"notify",
+ 	"nounset",
+ 	"nolog",
++	"pipefail",
+ 	"debug",
+ };
+ 
+@@ -101,6 +102,7 @@ const char optletters[NOPTS] = {
+ 	'u',
+ 	0,
+ 	0,
++	0,
+ };
+ 
+ char optlist[NOPTS];
+diff --git a/src/options.h b/src/options.h
+index 975fe33..f421316 100644
+--- a/src/options.h
++++ b/src/options.h
+@@ -60,9 +60,10 @@ struct shparam {
+ #define	bflag optlist[13]
+ #define	uflag optlist[14]
+ #define	nolog optlist[15]
+-#define	debug optlist[16]
++#define	pipefail optlist[16]
++#define	debug optlist[17]
+ 
+-#define NOPTS	17
++#define NOPTS	18
+ 
+ extern const char optletters[NOPTS];
+ extern char optlist[NOPTS];


### PR DESCRIPTION
Removed old Gentoo patches (Debian has a bunch that might be worth adding, perhaps).

Removed spurious readline dependency.

Apparently, libedit could be used instead ("--with-libedit" option of ./configure), but then it fails to compile. Easily fixed, but resulting binary still doesn't do proper line editting at all.

Removed TEST() as "make check" doesn't do anything meaningful.

Smoke tested (on beta5 64 bits) by using it to "jam -q -j4 Terminal" on Haiku's source tree (making sure dash was set as JAMSHELL, of course).