### PR TITLE
boost1.85: link against icu74 instead.

### DIFF
--- a/dev-libs/boost/boost1.85-1.85.0.recipe
+++ b/dev-libs/boost/boost1.85-1.85.0.recipe
@@ -6,7 +6,7 @@ expressions, and unit testing. It contains over eighty individual libraries."
 HOMEPAGE="https://www.boost.org/"
 SOURCE_URI="https://boostorg.jfrog.io/artifactory/main/release/$portVersion/source/boost_${portVersion//./_}.tar.bz2"
 CHECKSUM_SHA256="7009fe1faa1697476bdc7027703a2badb84e849b7b0baad5086b087b971f8617"
-REVISION="1"
+REVISION="2"
 LICENSE="Boost v1.0"
 COPYRIGHT="1993-2002 Christopher Seiwald and Perforce Software, Inc.
 	1998-2018 Beman Dawes
@@ -138,9 +138,9 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libbz2$secondaryArchSuffix
 	devel:libiconv$secondaryArchSuffix
-	devel:libicudata$secondaryArchSuffix >= 75
-	devel:libicui18n$secondaryArchSuffix >= 75
-	devel:libicuuc$secondaryArchSuffix >= 75
+	devel:libicudata$secondaryArchSuffix >= 74
+	devel:libicui18n$secondaryArchSuffix >= 74
+	devel:libicuuc$secondaryArchSuffix >= 74
 	devel:liblzma$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	devel:libzstd$secondaryArchSuffix

--- a/dev-libs/boost/patches/boost1.85-1.85.0.patchset
+++ b/dev-libs/boost/patches/boost1.85-1.85.0.patchset
@@ -1,4 +1,4 @@
-From fae517135255aee241f5b2781f71a4ca369b6da0 Mon Sep 17 00:00:00 2001
+From 4719c5f10a3c25c067755823ae420d956188cb1c Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@gmail.com>
 Date: Sat, 6 Aug 2016 22:27:19 +0200
 Subject: Import changes from 1.55.0: buildtools
@@ -24,7 +24,7 @@ index 4e8ffa6..646c26f 100644
 2.45.2
 
 
-From 1de8a871692781ce8306fa2cb861226692872f6f Mon Sep 17 00:00:00 2001
+From 6fc142b52e4cd6cd9ee52f0c0a9c14dd4a653a7b Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@gmail.com>
 Date: Sat, 6 Aug 2016 22:27:41 +0200
 Subject: Import changes from 1.55.0: sourcecode
@@ -47,7 +47,7 @@ index 172a601..c706e40 100644
 2.45.2
 
 
-From 256351d4fb07711b464e6294a1e42328e56c9203 Mon Sep 17 00:00:00 2001
+From d0d275d71bf429e4c620d22ead3c788c9b9c60ee Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sat, 14 Oct 2017 11:47:09 +0200
 Subject: Haiku needs bsd and _BSD_SOURCE.
@@ -84,7 +84,7 @@ index 912c947..9a04222 100755
 2.45.2
 
 
-From ed6714cee82b5c3f989a12f15f25947c443ab38a Mon Sep 17 00:00:00 2001
+From f96928da13af8cfacf7d08f5c8a1e6142d1059e0 Mon Sep 17 00:00:00 2001
 From: Begasus <begasus@gmail.com>
 Date: Fri, 25 Aug 2023 10:15:17 +0200
 Subject: Add auto_index binary to tools
@@ -106,7 +106,7 @@ index e1391c7..a580eb1 100644
 2.45.2
 
 
-From 0b05ba55aeb6ec9445bb8c6be77ec89d9e548007 Mon Sep 17 00:00:00 2001
+From 8ea67e71c939df555c66ef8c959944bbf6189ab4 Mon Sep 17 00:00:00 2001
 From: Begasus <begasus@gmail.com>
 Date: Sun, 27 Aug 2023 19:13:24 +0200
 Subject: Fix missing functions to build libboost_locale
@@ -132,7 +132,7 @@ index 04244c5..e22ac4f 100644
 2.45.2
 
 
-From 23b7f809396540e0bdd202cdd04d81eb6818c936 Mon Sep 17 00:00:00 2001
+From 3d79d002365c922ddcdc59d3902c4821f9648aca Mon Sep 17 00:00:00 2001
 From: Begasus <begasus@gmail.com>
 Date: Mon, 28 Aug 2023 18:08:06 +0200
 Subject: Fix building the tests
@@ -174,7 +174,7 @@ index 023515e..5815a3e 100644
 2.45.2
 
 
-From 2a82ec759087b5e7f25afc16df447dc833e39aeb Mon Sep 17 00:00:00 2001
+From 7e1ebde9d822b307ed3d2b89d4391cd668963897 Mon Sep 17 00:00:00 2001
 From: PulkoMandy <pulkomandy@pulkomandy.tk>
 Date: Fri, 13 Jan 2023 21:26:43 +0100
 Subject: Haiku currently doesn't have cfsetspeed
@@ -198,7 +198,7 @@ index 3fa96fd..76924d4 100644
 2.45.2
 
 
-From 2a1905df2e8b6b2122a6e7ad598ebf0a3a5c2001 Mon Sep 17 00:00:00 2001
+From 52042035419e0cc88f44b2d6a6c26bfff1b3291f Mon Sep 17 00:00:00 2001
 From: Conrad Poelman <cpgithub@stellarscience.com>
 Date: Mon, 3 Aug 2020 18:35:35 -0400
 Subject: Remove deprecated inheritance from std::iterator
@@ -259,7 +259,7 @@ index 1723a30..3f5cae8 100644
 2.45.2
 
 
-From 59901404fa734a9943310434b5c03f8923d3fc6e Mon Sep 17 00:00:00 2001
+From c55b93b70dcf474047445746984b305870861684 Mon Sep 17 00:00:00 2001
 From: Schrijvers Luc <begasus@gmail.com>
 Date: Sat, 6 Jul 2024 17:27:48 +0200
 Subject: build fix for sourcetrail
@@ -282,6 +282,46 @@ index 0f86b44..99a13dc 100644
  
  inline bool is_running(int code)
  {
+-- 
+2.45.2
+
+
+From 2111b689eecc46ca4ecdb6b5b869e9a2f001dc53 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Fri, 20 Dec 2024 22:32:12 -0300
+Subject: Fix build issue related to dirent->d_name[].
+
+
+diff --git a/libs/filesystem/src/directory.cpp b/libs/filesystem/src/directory.cpp
+index 0cf5025..9c28ada 100644
+--- a/libs/filesystem/src/directory.cpp
++++ b/libs/filesystem/src/directory.cpp
+@@ -318,8 +318,13 @@ inline std::size_t get_path_max()
+ #endif
+     }
+ 
++#ifdef __HAIKU__
++    if ((max + 1) < NAME_MAX)
++        max = NAME_MAX - 1;
++#else
+     if ((max + 1) < sizeof(dirent().d_name))
+         max = sizeof(dirent().d_name) - 1;
++#endif
+ 
+     return max;
+ }
+@@ -481,7 +486,11 @@ system::error_code dir_itr_create(boost::intrusive_ptr< detail::dir_itr_imp >& i
+             // buffer that is enough for PATH_MAX as the directory name. Still, this doesn't guarantee there won't be
+             // a buffer overrun. The readdir_r API is fundamentally flawed and we should avoid it as much as possible
+             // in favor of readdir.
++#ifdef __HAIKU__
++            extra_size = (NAME_MAX) + path_max() + 1u; // + 1 for "\0"
++#else
+             extra_size = (sizeof(dirent) - sizeof(dirent().d_name)) + path_max() + 1u; // + 1 for "\0"
++#endif
+         }
+     }
+ #endif // defined(BOOST_FILESYSTEM_USE_READDIR_R)
 -- 
 2.45.2
 


### PR DESCRIPTION
Had to add a patch to avoid a couple of instances of:

`error: invalid application of 'sizeof' to incomplete type 'char []'`

related to the `d_name` field of the `dirent` structure.

(no idea how it got build before without a patch).

----

Smoke tested by installing and executing `innoextract`, and doing `pkgman install vcmi` (but cancelling it after noticing it didn't complained about a missing ICU75 anymore).

Not 100% sure if my build-fix patch is correct. Reviewers welcomed.


Build took almost 40 minutes (work dirs on RAMFS, used `hp -G`), and I almost ran out of RAM (4 GB), so... beware.