### PR TITLE
pandas: recipe cleanup, drop _python39 package.

### DIFF
--- a/dev-python/pandas/pandas-1.3.2.recipe
+++ b/dev-python/pandas/pandas-1.3.2.recipe
@@ -9,11 +9,12 @@ COPYRIGHT="2008-2012 AQR Capital Management, LLC
 	Lambda Foundry, Inc.
 	PyData Development Team"
 LICENSE="BSD (3-clause)"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/p/pandas/pandas-$portVersion.tar.gz"
 CHECKSUM_SHA256="cbcb84d63867af3411fa063af3de64902665bb5b3d40b25b2059e40603594e87"
 
-ARCHITECTURES="all !x86_gcc2"
+# Disable for now, as this version requires cython < 3, and newer versions require numpy > 2
+ARCHITECTURES="?all !x86_gcc2"
 SECONDARY_ARCHITECTURES="?x86"
 
 PROVIDES="
@@ -21,62 +22,65 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	numpy$secondaryArchSuffix
 	"
 
-BUILD_REQUIRES="
-	haiku${secondaryArchSuffix}_devel
-	"
-BUILD_PREREQUIRES="
-	cmd:gcc$secondaryArchSuffix
-	cmd:gfortran$secondaryArchSuffix
-	cmd:pkg_config$secondaryArchSuffix
-	"
+PYTHON_VERSIONS=(3.10)
 
-PYTHON_PACKAGES=(python39)
-PYTHON_VERSIONS=(3.9)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\n\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku$secondaryArchSuffix\n\
-	numpy${secondaryArchSuffix}_$pythonPackage\n\
-	pandas$secondaryArchSuffix\n\
-	dateutil_$pythonPackage\n\
-	pytz_$pythonPackage\n\
-	cmd:python$pythonVersion\
-	\""
-BUILD_REQUIRES="$BUILD_REQUIRES
-	numpy${secondaryArchSuffix}_$pythonPackage
-	setuptools_$pythonPackage
-	dateutil_$pythonPackage
-	pytz_$pythonPackage
-	"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:cython$pythonVersion$secondaryArchSuffix
-	cmd:python$pythonVersion
-	"
+for i in "${!PYTHON_VERSIONS[@]}"; do
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_$pythonPackage+=\"
+			pandas_$pythonPackage = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku$secondaryArchSuffix
+		dateutil_$pythonPackage
+		numpy_$pythonPackage
+		pytz_$pythonPackage
+		cmd:python$pythonVersion
+		\""
+
+	BUILD_REQUIRES+="
+		haiku${secondaryArchSuffix}_devel
+		numpy_$pythonPackage
+		setuptools_$pythonPackage
+		wheel_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:cython$pythonVersion
+		cmd:gcc$secondaryArchSuffix
+#		cmd:gfortran$secondaryArchSuffix
+#		cmd:pkg_config$secondaryArchSuffix
+		cmd:python$pythonVersion
+		"
 done
 
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }


### PR DESCRIPTION
This version fails to build against Cython >= 3, but newer pandas versions require numpy > 2. So just disable it for now until the needed dependencies get sorted out.

(this should not break things on-tree, as nothing currently requires pandas)