### PR TITLE
Krita:  fixed for R1B5 x86 build

### DIFF
--- a/media-gfx/krita/krita-5.2.6.recipe
+++ b/media-gfx/krita/krita-5.2.6.recipe
@@ -46,7 +46,7 @@ REQUIRES="
 	lib:libintl$secondaryArchSuffix
 	lib:libjpeg$secondaryArchSuffix
 	lib:libjson_c$secondaryArchSuffix
-	lib:libjxl$secondaryArchSuffix
+#	lib:libjxl$secondaryArchSuffix
 	lib:libKF5Archive$secondaryArchSuffix
 	lib:libKF5Auth$secondaryArchSuffix
 	lib:libKF5Bookmarks$secondaryArchSuffix
@@ -109,9 +109,6 @@ REQUIRES="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	extra_cmake_modules$secondaryArchSuffix
-	pyqt5$secondaryArchSuffix
-	pyqt5_python310$secondaryArchSuffix
-	pyqt5_sip$secondaryArchSuffix
 	devel:eigen$secondaryArchSuffix
 	devel:immer$secondaryArchSuffix
 	devel:lager$secondaryArchSuffix
@@ -137,7 +134,7 @@ BUILD_REQUIRES="
 	devel:libImath_3_0$secondaryArchSuffix
 	devel:libjpeg$secondaryArchSuffix
 	devel:libjson_c$secondaryArchSuffix
-	devel:libjxl$secondaryArchSuffix
+#	devel:libjxl$secondaryArchSuffix
 	devel:libKF5Archive$secondaryArchSuffix
 	devel:libKF5Auth$secondaryArchSuffix
 	devel:libKF5Bookmarks$secondaryArchSuffix

--- a/media-gfx/krita/krita-5.2.6.recipe
+++ b/media-gfx/krita/krita-5.2.6.recipe
@@ -46,7 +46,7 @@ REQUIRES="
 	lib:libintl$secondaryArchSuffix
 	lib:libjpeg$secondaryArchSuffix
 	lib:libjson_c$secondaryArchSuffix
-#	lib:libjxl$secondaryArchSuffix
+	lib:libjxl$secondaryArchSuffix
 	lib:libKF5Archive$secondaryArchSuffix
 	lib:libKF5Auth$secondaryArchSuffix
 	lib:libKF5Bookmarks$secondaryArchSuffix
@@ -134,7 +134,7 @@ BUILD_REQUIRES="
 	devel:libImath_3_0$secondaryArchSuffix
 	devel:libjpeg$secondaryArchSuffix
 	devel:libjson_c$secondaryArchSuffix
-#	devel:libjxl$secondaryArchSuffix
+	devel:libjxl$secondaryArchSuffix >= 0.11.0
 	devel:libKF5Archive$secondaryArchSuffix
 	devel:libKF5Auth$secondaryArchSuffix
 	devel:libKF5Bookmarks$secondaryArchSuffix

--- a/media-gfx/krita/krita-5.2.6.recipe
+++ b/media-gfx/krita/krita-5.2.6.recipe
@@ -134,7 +134,7 @@ BUILD_REQUIRES="
 	devel:libImath_3_0$secondaryArchSuffix
 	devel:libjpeg$secondaryArchSuffix
 	devel:libjson_c$secondaryArchSuffix
-	devel:libjxl$secondaryArchSuffix >= 0.11.0
+	devel:libjxl$secondaryArchSuffix >= 0.6.1
 	devel:libKF5Archive$secondaryArchSuffix
 	devel:libKF5Auth$secondaryArchSuffix
 	devel:libKF5Bookmarks$secondaryArchSuffix


### PR DESCRIPTION
- Retested build on hrev58455 x64 and libjxl 0.6.1.
- Fixed for x86 buildbot build.