### PR TITLE
numpy: update to version 2.2.1.

### DIFF
--- a/dev-python/numpy/numpy-2.2.1.recipe
+++ b/dev-python/numpy/numpy-2.2.1.recipe
@@ -7,12 +7,14 @@ numarray as well as an extended C-API and the ability to create arrays of \
 arbitrary type which also makes NumPy suitable for interfacing with \
 general-purpose data-base applications."
 HOMEPAGE="https://www.numpy.org/"
-COPYRIGHT="2005-2021 Travis E. Oliphant et al."
+COPYRIGHT="2005-2024, NumPy Developers."
 LICENSE="BSD (3-clause)"
-REVISION="2"
-SOURCE_URI="https://github.com/numpy/numpy/releases/download/v$portVersion/numpy-$portVersion.tar.gz"
-CHECKSUM_SHA256="f93fc78fe8bf15afe2b8d6b6499f1c73953169fad1e9a8dd086cdff3190e7fdf"
+REVISION="1"
+SOURCE_URI="https://files.pythonhosted.org/packages/source/n/numpy/numpy-$portVersion.tar.gz"
+CHECKSUM_SHA256="45681fd7128c8ad1c379f0ca0776a8b0c6583d2f69889ddac01559dfe4390918"
 SOURCE_DIR="numpy-$portVersion"
+
+PATCHES="numpy-2.2.1.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -22,16 +24,12 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libblis$secondaryArchSuffix
-	lib:libexecinfo$secondaryArchSuffix
 	lib:liblapack$secondaryArchSuffix
 	lib:libopenblas$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libblis$secondaryArchSuffix
-	devel:libexecinfo$secondaryArchSuffix
 	devel:liblapack$secondaryArchSuffix
 	devel:libopenblas$secondaryArchSuffix
 	"
@@ -46,6 +44,7 @@ for i in "${!PYTHON_VERSIONS[@]}"; do
 	eval "PROVIDES_${pythonPackage}=\"
 		${portName}_$pythonPackage = $portVersion
 		cmd:f2py_$pythonVersion
+		cmd:numpy_config_$pythonVersion
 		\""
 
 	if [ $targetArchitecture = "x86_gcc2" ]; then
@@ -58,87 +57,65 @@ for i in "${!PYTHON_VERSIONS[@]}"; do
 	if [ $pythonVersion = $defaultVersion ]; then
 		eval "PROVIDES_${pythonPackage}+=\"
 			cmd:f2py
-			cmd:f2py${pythonVersion%.*}
+			cmd:numpy_config
 			\""
 	fi
 
 	eval "REQUIRES_$pythonPackage=\"
-		haiku$secondaryArchSuffix
-		numpy$secondaryArchSuffix
+		$REQUIRES
 		cmd:cython$pythonVersion
 		cmd:python$pythonVersion
 		\""
 
 	BUILD_REQUIRES+="
-		pyproject_metadata_$pythonPackage
-		setuptools_$pythonPackage
-		tomli_$pythonPackage # for Pythonn < 3.11 only.
+		build_$pythonPackage
+		installer_$pythonPackage
+		meson_python_$pythonPackage
+		wheel_$pythonPackage
 		"
 	BUILD_PREREQUIRES+="
 		cmd:cython$pythonVersion
-		cmd:gcc$secondaryArchSuffix
-		cmd:gfortran$secondaryArchSuffix
+		cmd:g++$secondaryArchSuffix
 		cmd:python$pythonVersion
+		cmd:pkg_config$secondaryArchSuffix
 		"
 done
 
+
+BUILD()
+{
+	for i in "${!PYTHON_VERSIONS[@]}"; do
+		pythonVersion=${PYTHON_VERSIONS[$i]}
+		python=python$pythonVersion
+		$python -m build --wheel --skip-dependency-check --no-isolation
+	done
+}
+
 INSTALL()
 {
-# Check at every update in site.cfg.example!
-cat > site.cfg << EOF
-[ALL]
-libraries = execinfo,lapack,openblas
-library_dirs = /system/$relativeDevelopLibDir
-include_dirs = /system/$relativeIncludeDir
-runtime_library_dirs = /system/$relativeLibDir
-[openblas]
-libraries = openblas
-library_dirs = /system/$relativeDevelopLibDir
-include_dirs = /system/$relativeIncludeDir
-runtime_library_dirs = /system/$relativeLibDir
-[blis]
-libraries = blis
-library_dirs = /system/$relativeDevelopLibDir
-include_dirs = /system/$relativeIncludeDir/blis
-runtime_library_dirs = /system/$relativeLibDir
-EOF
-
-	rm -rf doc/sphinxext/.git
-
 	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
 		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
-		installLocation=$prefix/lib/$python/vendor-packages/
-		export PYTHONPATH=$installLocation:$PYTHONPATH
 
-		mkdir -p $installLocation
-		rm -rf build
+		# Wheel's name is in the form: "numpy-2.2.1-cp310-cp310-haiku_1_x86_64.whl"
+		$python -m installer -p $prefix dist/*-cp${pythonVersion//.}-*.whl
 
-		$python setup.py build install \
-			--root=/ --prefix=$prefix
+		# Version suffix all the scripts
+		for f in $binDir/*; do
+			mv $f $f-$pythonVersion
+		done
 
-		# Version suffix the scripts, and provide suffixless versions for the default one.
-		mv $prefix/bin/f2py $prefix/bin/f2py-$pythonVersion
+		# And provide suffix-less symlinks for the default version
 		if [ $pythonVersion = $defaultVersion ]; then
-			ln -sr $prefix/bin/f2py-$pythonVersion $prefix/bin/f2py
-			ln -sr $prefix/bin/f2py-$pythonVersion $prefix/bin/f2py3
+			for f in $binDir/*; do
+				ln -sr $f ${f%-$pythonVersion}
+			done
 		fi
 
 		packageEntries $pythonPackage \
 			$prefix/lib/python* \
 			$prefix/bin
-	done
-}
-
-TEST()
-{
-	for i in "${!PYTHON_VERSIONS[@]}"; do
-		pythonVersion=${PYTHON_VERSIONS[$i]}
-		pythonPackage=python${pythonVersion//.}
-
-		python=python$pythonVersion
-		$python runtests.py
 	done
 }

--- a/dev-python/numpy/patches/numpy-2.2.1.patchset
+++ b/dev-python/numpy/patches/numpy-2.2.1.patchset
@@ -1,0 +1,29 @@
+From a3bc3cfbeea148e308b1202d629d94872737365c Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Tue, 24 Dec 2024 15:21:22 -0300
+Subject: Fix build on Haiku.
+
+
+diff --git a/numpy/_core/src/umath/string_buffer.h b/numpy/_core/src/umath/string_buffer.h
+index ae89ede..d756a0f 100644
+--- a/numpy/_core/src/umath/string_buffer.h
++++ b/numpy/_core/src/umath/string_buffer.h
+@@ -14,6 +14,15 @@
+ #include "string_fastsearch.h"
+ #include "gil_utils.h"
+ 
++#ifdef __HAIKU__
++	#undef isalnum
++	#undef isalpha
++	#undef isdigit
++	#undef islower
++	#undef isspace
++	#undef isupper
++#endif
++
+ #define CHECK_OVERFLOW(index) if (buf + (index) >= after) return 0
+ #define MSB(val) ((val) >> 7 & 1)
+ 
+-- 
+2.45.2
+


### PR DESCRIPTION
Known incompatibilities on-tree were already solved, and I was able to build scipy 1.15.1 against this new version (updated scipy recipe still WIP).
    
If anything breaks, is surely on outdated software, and we should fix that instead of keeping numpy on an older version.
