### PR TITLE
beezer: force squashfs_tools to load in BUILD_PREREQUIRES

### DIFF
--- a/haiku-apps/beezer/beezer-0.99.recipe
+++ b/haiku-apps/beezer/beezer-0.99.recipe
@@ -7,7 +7,7 @@ HOMEPAGE="https://github.com/Teknomancer/beezer"
 COPYRIGHT="2009-2023 Ramshankar (aka Teknomancer)
 	2011-2024 Chris Roberts"
 LICENSE="BSD (3-clause)"
-REVISION="7"
+REVISION="8"
 srcGitRev="9c746c72da5cc13fa985865982dd669c900b876e"
 SOURCE_URI="https://github.com/Teknomancer/beezer/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="7a6d1237868cdf2a5ec4e8323fddf3cb6f35b26f21f3010de496be7ee894479e"
@@ -42,13 +42,14 @@ BUILD_PREREQUIRES="
 	cmd:gcc
 	cmd:make
 	cmd:sphinx_build
+	# we need squashfs_tools for the mime_db entry
+	cmd:unsquashfs
 	"
 
 BUILD()
 {
-	#TODO separate debug package
 	cmake -B build -S Source \
-		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_BUILD_TYPE=Release \
 		-DSTRICT_WARNINGS=OFF \
 		-DBEEZER_OVERRIDE_ATTR_GIT="$srcGitRev"
 


### PR DESCRIPTION
This allows registering the squashfsimage filetype which Beezer handles. Related to #11542