### PR TITLE
SBCL 2.5.0

### DIFF
--- a/dev-lisp/sbcl/patches/sbcl-2.5.0.patchset
+++ b/dev-lisp/sbcl/patches/sbcl-2.5.0.patchset
@@ -1,0 +1,98 @@
+From 60bf55f16f5ca2581f57594b7ec11d1d315c5c3c Mon Sep 17 00:00:00 2001
+From: Alexandru Popa <alpopa@gmail.com>
+Date: Sat, 28 Dec 2024 14:51:32 +0200
+Subject: [PATCH] Haiku ASDF fix
+
+---
+ contrib/asdf/uiop.lisp | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/contrib/asdf/uiop.lisp b/contrib/asdf/uiop.lisp
+index 5e52e7745..96f490300 100644
+--- a/contrib/asdf/uiop.lisp
++++ b/contrib/asdf/uiop.lisp
+@@ -1833,7 +1833,7 @@ keywords explicitly."
+ 
+   (defun os-unix-p ()
+     "Is the underlying operating system some Unix variant?"
+-    (or (featurep '(:or :unix :cygwin)) (os-macosx-p)))
++    (or (featurep '(:or :unix :cygwin :haiku)) (os-macosx-p)))
+ 
+   (defun os-windows-p ()
+     "Is the underlying operating system Microsoft Windows?"
+@@ -1857,9 +1857,9 @@ except on ABCL where it might change between FASL compilation and runtime."
+     (loop* :with o
+            :for (feature . detect) :in '((:os-unix . os-unix-p) (:os-macosx . os-macosx-p)
+                                          (:os-windows . os-windows-p)
+-                                         (:genera . os-genera-p) (:os-oldmac . os-oldmac-p)
+-                                         (:haiku . os-haiku-p))
+-           :when (and (or (not o) (eq feature :os-macosx)) (funcall detect))
++                                         (:os-genera . os-genera-p) (:os-oldmac . os-oldmac-p)
++                                         (:os-haiku . os-haiku-p))
++           :when (and (or (not o) (eq feature :os-macosx) (eq feature :os-haiku)) (funcall detect))
+            :do (setf o feature) (pushnew feature *features*)
+            :else :do (setf *features* (remove feature *features*))
+            :finally
+-- 
+2.45.2
+
+From 91f3ff1e35e65f531ee0a8e5edd0535f2933884c Mon Sep 17 00:00:00 2001
+From: Alexandru Popa <alpopa@gmail.com>
+Date: Mon, 23 Dec 2024 14:51:37 +0200
+Subject: [PATCH] Haiku sockets fixes
+
+---
+ contrib/sb-bsd-sockets/constants-unix.lisp | 2 +-
+ contrib/sb-bsd-sockets/sockets.lisp        | 2 +-
+ contrib/sb-bsd-sockets/tests.lisp          | 2 ++
+ 3 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/contrib/sb-bsd-sockets/constants-unix.lisp b/contrib/sb-bsd-sockets/constants-unix.lisp
+index 148f660f8..7f637a299 100644
+--- a/contrib/sb-bsd-sockets/constants-unix.lisp
++++ b/contrib/sb-bsd-sockets/constants-unix.lisp
+@@ -37,7 +37,7 @@
+  (:integer EPERM "EPERM")
+  (:integer EPROTONOSUPPORT "EPROTONOSUPPORT")
+  (:integer ERANGE "ERANGE")
+- (:integer ESOCKTNOSUPPORT "ESOCKTNOSUPPORT")
++ #-haiku (:integer ESOCKTNOSUPPORT "ESOCKTNOSUPPORT")
+  (:integer ENETUNREACH "ENETUNREACH")
+  (:integer ENOTCONN "ENOTCONN")
+  (:integer EAFNOSUPPORT "EAFNOSUPPORT")
+diff --git a/contrib/sb-bsd-sockets/sockets.lisp b/contrib/sb-bsd-sockets/sockets.lisp
+index b8f265892..a02bb0815 100644
+--- a/contrib/sb-bsd-sockets/sockets.lisp
++++ b/contrib/sb-bsd-sockets/sockets.lisp
+@@ -345,7 +345,7 @@ request an input stream and get an output stream in response\)."
+ (define-socket-condition sockint::EOPNOTSUPP operation-not-supported-error)
+ (define-socket-condition sockint::EPERM operation-not-permitted-error)
+ (define-socket-condition sockint::EPROTONOSUPPORT protocol-not-supported-error)
+-(define-socket-condition sockint::ESOCKTNOSUPPORT socket-type-not-supported-error)
++#-haiku (define-socket-condition sockint::ESOCKTNOSUPPORT socket-type-not-supported-error)
+ (define-socket-condition sockint::ENETUNREACH network-unreachable-error)
+ (define-socket-condition sockint::ENOTCONN not-connected-error)
+ (define-socket-condition sockint::EAFNOSUPPORT address-family-not-supported)
+diff --git a/contrib/sb-bsd-sockets/tests.lisp b/contrib/sb-bsd-sockets/tests.lisp
+index 7ec6342a2..0ef49d827 100644
+--- a/contrib/sb-bsd-sockets/tests.lisp
++++ b/contrib/sb-bsd-sockets/tests.lisp
+@@ -78,6 +78,7 @@
+       ;; here, not socket-type-not-supported-error or
+       ;; protocol-not-supported-error.
+       ((or #+darwin socket-error
++        #+haiku address-family-not-supported
+         operation-not-supported-error
+         socket-type-not-supported-error
+         protocol-not-supported-error)
+@@ -96,6 +97,7 @@
+       ;; protocol-not-supported-error.
+       ((or
+         #+darwin socket-error
++        #+haiku address-family-not-supported
+         operation-not-supported-error
+         protocol-not-supported-error
+         socket-type-not-supported-error)
+-- 
+2.45.2
+

--- a/dev-lisp/sbcl/sbcl-2.5.0.recipe
+++ b/dev-lisp/sbcl/sbcl-2.5.0.recipe
@@ -1,0 +1,60 @@
+SUMMARY="A high performance Common Lisp compiler"
+DESCRIPTION="Steel Bank Common Lisp (SBCL) is a high performance Common \
+Lisp compiler. It is open source / free software, with a permissive license. \
+In addition to the compiler and runtime system for ANSI Common Lisp, it \
+provides an interactive environment including a debugger, a statistical \
+profiler, a code coverage tool, and many other extensions."
+HOMEPAGE="https://sbcl.org"
+COPYRIGHT="2002 Gerd Moellmann"
+LICENSE="BSD (2-clause)"
+REVISION="1"
+portVersion="2.5.0"
+SOURCE_URI="https://github.com/sbcl/sbcl/archive/refs/tags/sbcl-$portVersion.zip"
+CHECKSUM_SHA256="15fc66e96683ae76ebfbb2e8b7d2d9fb443358ada2813fba860e65f4859346d6"
+SOURCE_DIR="sbcl-sbcl-$portVersion"
+PATCHES="sbcl-2.5.0.patchset"
+
+ARCHITECTURES="x86_64"
+SECONDARY_ARCHITECTURES="?x86"
+
+PROVIDES="
+	sbcl$secondaryArchSuffix = $portVersion
+	cmd:sbcl$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libzstd$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libzstd$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:clisp
+	cmd:gcc$secondaryArchPrefix
+	cmd:git
+	cmd:make
+	cmd:rm
+	cmd:sh
+	"
+
+BUILD()
+{
+	chmod a+x *.sh
+	sh make.sh --xc-host='clisp -norc' --with-sb-core-compression --with-sb-simd-pack --with-sb-thread
+}
+
+INSTALL()
+{
+	mkdir -p $manDir
+	mkdir -p $docDir
+	INSTALL_ROOT=$prefix MAN_DIR=$manDir DOC_DIR=$docDir INFO_DIR=$infoDir sh install.sh
+}
+
+# Fails at this stage
+#TEST()
+#{
+#    cd tests
+#    ./run-tests.sh
+#}


### PR DESCRIPTION
This recipe contains upstreamed Haiku specific patches for:
- Configuration
- Runtime
- Threads support

The following patches are not (yet) upstreamed and provided with this recipe:
- BSD sockets fixes
- Fix ASDF

The tests are not analyzed deeply. Many of them fail at this stage.