### PR TITLE
config_autoconf: make architecture-specific because it requires gcc

### DIFF
--- a/dev-perl/config_autoconf/config_autoconf-0.320.recipe
+++ b/dev-perl/config_autoconf/config_autoconf-0.320.recipe
@@ -9,24 +9,31 @@ arguments) more Perl'ish than m4 abilities allow to the original."
 HOMEPAGE="https://metacpan.org/pod/Config::AutoConf"
 COPYRIGHT="2004-2020 Alberto Simões and Jens Rehsack"
 LICENSE="Artistic"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://cpan.metacpan.org/authors/id/A/AM/AMBS/Config-AutoConf-$portVersion.tar.gz"
 CHECKSUM_SHA256="bb57a958ef49d3f7162276dae14a7bd5af43fd1d8513231af35d665459454023"
 SOURCE_DIR="Config-AutoConf-$portVersion"
 
-ARCHITECTURES="any"
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	config_autoconf = $portVersion
+	config_autoconf$secondaryArchSuffix = $portVersion
 	"
+if [ -n "$secondaryArchSuffix" ]; then
+	PROVIDES+="
+		config_autoconf = $portVersion
+		"
+fi
 REQUIRES="
-	haiku
+	haiku$secondaryArchSuffix
 	capture_tiny
 	vendor_perl
+	cmd:gcc$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
+	haiku${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
 	cmd:make
@@ -35,16 +42,8 @@ BUILD_PREREQUIRES="
 
 TEST_REQUIRES="
 	capture_tiny
+	cmd:gcc$secondaryArchSuffix
 	"
-if [ "$targetArchitecture" = x86_gcc2 ]; then
-	TEST_REQUIRES+="
-		cmd:gcc_x86
-		"
-else
-	TEST_REQUIRES+="
-		cmd:gcc
-		"
-fi
 
 BUILD()
 {
@@ -56,7 +55,8 @@ INSTALL()
 {
 	make pure_install
 
-	# remove architecture-specific files
+	# remove architecture-specific files (this would be an "any" arch package,
+	# but isn't because of the gcc requirement)
 	cd $prefix
 	rm -r $(perl -V:vendorarch | cut -d\' -f2 | cut -d/ -f5-)
 		# cut extracts the quoted string and strips the prefix (which is perl's and not ours)


### PR DESCRIPTION
Making a PR with the potential changes discussed in IRC.

(I guess I can get away without a `REPLACES` for x86_gcc2, given that this is nearly brand-new ...)

Any comments @Begasus, @OscarL ?