### PR TITLE
perl: set site and vendor man dirs

### DIFF
--- a/dev-lang/perl/patches/perl-5.40.0.patchset
+++ b/dev-lang/perl/patches/perl-5.40.0.patchset
@@ -1,4 +1,4 @@
-From dde920b116870edc767a9af10576a248a5abcd22 Mon Sep 17 00:00:00 2001
+From 855bd385f6454d5aa9b5699f104b08997b3256a9 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sun, 22 Sep 2013 14:52:03 +0200
 Subject: Tell perl that BFS has a link count of 1
@@ -22,7 +22,7 @@ index 570f25a..81baf48 100644
 2.45.2
 
 
-From 76042fc4376ad707db26771d533bb181fc3b38b6 Mon Sep 17 00:00:00 2001
+From 0beae3ff13f99f9714e934ae9b26faf99c5a3ac9 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sun, 22 Sep 2013 14:52:53 +0200
 Subject: Haiku defines, but does not implement O_EXLOCK
@@ -46,7 +46,7 @@ index 7bcd491..85260b8 100644
 2.45.2
 
 
-From 36fa9089744ad31dd650002b06202310b1c1c55d Mon Sep 17 00:00:00 2001
+From 87e656ea565c604731a46b06a477d1003e7fd485 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sun, 22 Sep 2013 14:53:40 +0200
 Subject: haiku sets all its specifics via Configure
@@ -108,7 +108,7 @@ index 0ec7479..0f09f53 100644
 2.45.2
 
 
-From 2ee98b0339d6eb5d51c2046209df473d47f1ad77 Mon Sep 17 00:00:00 2001
+From 79ea153da6282f22bbcea6e62f1bc3b5c5e64b0b Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sun, 22 Sep 2013 14:54:15 +0200
 Subject: Tell perl that Haiku needs haikuish.h installed as well
@@ -134,7 +134,7 @@ index 3c8af53..1bbbf5b 100755
 2.45.2
 
 
-From 85a47997825bfa4c953238931af9d8f607c457b6 Mon Sep 17 00:00:00 2001
+From 9823c5079e2463bf5ab2c50294d3486038980b59 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sun, 22 Sep 2013 14:55:13 +0200
 Subject: Fix handling of exit codes on Haiku
@@ -185,7 +185,7 @@ index ce3270e..cab9a79 100644
 2.45.2
 
 
-From f586ccec51cf9df4e518c4fd811b44636101da99 Mon Sep 17 00:00:00 2001
+From e14eeccf185723c0b4e69593d17d9759a46fc423 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sat, 28 Sep 2013 13:46:42 +0200
 Subject: Adjust ExtUtils::MakeMaker for PM-Haiku.
@@ -289,7 +289,7 @@ index 0000000..81e5f99
 2.45.2
 
 
-From 5cefecb333b4b46b51df918bf0adbac0224d055f Mon Sep 17 00:00:00 2001
+From 46e78080c437d702e48fcceff03560986f5f0729 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Tue, 8 Oct 2013 22:16:37 +0200
 Subject: Avoid using -rpath for dynamic modules.
@@ -337,7 +337,7 @@ index 81e5f99..25ace13 100644
 2.45.2
 
 
-From a868e28ee01a83dab3e46239a4003b60bb2a9985 Mon Sep 17 00:00:00 2001
+From b50ebdadb02c1572f0bcbc55dab69a8ed2f4e691 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Wed, 9 Oct 2013 20:29:38 +0200
 Subject: Fix initialization check for CPAN.
@@ -367,7 +367,7 @@ index 8934f4a..1716a55 100644
 2.45.2
 
 
-From bffe5a3bcfffd0389a3e6bff48e466f79cfbdd1d Mon Sep 17 00:00:00 2001
+From 8867cf4b0c2f2f672a7fbdcf98d138b33684b408 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sun, 13 Oct 2013 17:32:50 +0200
 Subject: Add support for HAIKU_USE_VENDOR_DIRECTORIES.
@@ -443,7 +443,7 @@ index 25ace13..8a04ead 100644
 2.45.2
 
 
-From c686b18200fe8c3b9bd067ab8ac4eaa9fbb08ae7 Mon Sep 17 00:00:00 2001
+From 835d55694521b7b47ebd1176e1abed1b2996f4d1 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 9 Jun 2017 21:30:33 +0200
 Subject: disable fstack-protector for Haiku
@@ -462,7 +462,7 @@ index 0f09f53..b76c7c1 100644
 2.45.2
 
 
-From f4690e180128492d89c1db49bf5ac5a36bbf0162 Mon Sep 17 00:00:00 2001
+From a412a90df41ba357b0381efcf6df836d193d0d27 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
 Date: Sat, 22 Jun 2024 22:24:38 +0200
 Subject: disable some reentrant variants of functions which we don't have
@@ -502,7 +502,7 @@ index 4b13cc2..931eca2 100644
 2.45.2
 
 
-From 8986e0fbc38c61f67f6c6a58330c31910e5d3b3b Mon Sep 17 00:00:00 2001
+From fc36c3bd122cbf0cc0965fef56ec6ea549b7eb39 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
 Date: Sat, 22 Jun 2024 22:25:46 +0200
 Subject: disable check involving sizeof(dirent.d_name)
@@ -533,7 +533,7 @@ index 0b3d142..880a108 100644
 2.45.2
 
 
-From 1e3fb86660fbb2a63dfbff5a3e880261e877d4aa Mon Sep 17 00:00:00 2001
+From 1709231a599f429bfd638d42934c95f2c64ce9aa Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
 Date: Sun, 28 Jul 2024 21:30:57 +0200
 Subject: Reinit mutexes after a fork()
@@ -661,7 +661,7 @@ index 4053ca4..e4e9d55 100644
 2.45.2
 
 
-From 656bb387be7998de48ec31f637e605bc05162623 Mon Sep 17 00:00:00 2001
+From c7d4d1c48f68e5c4841c00244eacbab3bf4fa4c7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
 Date: Sun, 4 Aug 2024 12:14:53 +0200
 Subject: fix the using of our custom shebang for installed scripts
@@ -746,7 +746,7 @@ index 8a04ead..bd3d5fa 100644
 2.45.2
 
 
-From 9751cb49414351044173e5428a4f324c4dd256b2 Mon Sep 17 00:00:00 2001
+From af57675e2da8bece41d62ea2a61d3d2015fed64f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
 Date: Sun, 18 Aug 2024 16:42:30 +0200
 Subject: don't install the site installation directories (non-packaged)
@@ -770,6 +770,25 @@ index 1bbbf5b..7191a44 100755
  
  if (-d 'lib') {
      find({no_chdir => 1, wanted => \&installlib}, 'lib')
+-- 
+2.45.2
+
+
+From cb90febde9feaa4f6ad9b2eab67c8c51f4763ac2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
+Date: Sun, 5 Jan 2025 21:35:27 +0100
+Subject: switch C standard to gnu99, we need _DEFAULT_SOURCE
+
+
+diff --git a/hints/haiku.sh b/hints/haiku.sh
+index b76c7c1..410eea5 100644
+--- a/hints/haiku.sh
++++ b/hints/haiku.sh
+@@ -1,3 +1,3 @@
+ # haiku sets nearly all its specifics via Configure
+ 
+-ccflags="$ccflags -fno-stack-protector"
++ccflags="$ccflags -std=gnu99 -fno-stack-protector"
 -- 
 2.45.2
 

--- a/dev-lang/perl/perl-5.40.0.recipe
+++ b/dev-lang/perl/perl-5.40.0.recipe
@@ -16,7 +16,7 @@ HOMEPAGE="https://www.perl.org/"
 COPYRIGHT="1993-2024 Larry Wall and others"
 LICENSE="GNU GPL v1
 	Artistic"
-REVISION="4"
+REVISION="5"
 perlShortVersion="${portVersion%.*}"
 SOURCE_URI="http://www.cpan.org/src/perl-$portVersion.tar.gz"
 CHECKSUM_SHA256="c740348f357396327a9795d3e8323bafd0fe8a5c7835fc1cbaba0cc8dfe7161f"
@@ -98,8 +98,12 @@ BUILD()
 		-Dprivlib=$prefix/lib/perl5/$portVersion \
 		-Dsiteprefix=$prefix/non-packaged \
 		-Dsitelib=$prefix/non-packaged/lib/perl5/site_perl/$perlShortVersion \
+		-Dsiteman1dir=$prefix/non-packaged/$relativeManDir/man1 \
+		-Dsiteman3dir=$prefix/non-packaged/$relativeManDir/man3 \
 		-Dvendorprefix=$prefix \
 		-Dvendorlib=$prefix/lib/perl5/vendor_perl/$perlShortVersion \
+		-Dvendorman1dir=$manDir/man1 \
+		-Dvendorman3dir=$manDir/man3 \
 		-Dcf_email=zooey@hirschkaefer.de \
 		-Uusenm -Duseshrplib -Dusethreads -Uusemymalloc \
 		-Dlibpth="$(finddir B_USER_DEVELOP_DIRECTORY)/lib$secondaryArchSubDir $(finddir B_SYSTEM_DEVELOP_DIRECTORY)/lib$secondaryArchSubDir $(finddir B_USER_LIB_DIRECTORY)$secondaryArchSubDir $(finddir B_SYSTEM_LIB_DIRECTORY)$secondaryArchSubDir" \

--- a/dev-lang/perl/perl-5.40.0.recipe
+++ b/dev-lang/perl/perl-5.40.0.recipe
@@ -75,6 +75,15 @@ if [ "$targetArchitecture" = x86_gcc2 ]; then
 		"
 fi
 
+ARCHITECTURES_doc="any"
+
+PROVIDES_doc="
+	perl${secondaryArchSuffix}_doc = $portVersion
+	"
+REQUIRES_doc="
+	perl$secondaryArchSuffix == $portVersion base
+	"
+
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
@@ -96,6 +105,8 @@ BUILD()
 	./Configure \
 		-Dprefix=$prefix \
 		-Dprivlib=$prefix/lib/perl5/$portVersion \
+		-Dman1dir=$manDir/man1 \
+		-Dman3dir=$manDir/man3 \
 		-Dsiteprefix=$prefix/non-packaged \
 		-Dsitelib=$prefix/non-packaged/lib/perl5/site_perl/$perlShortVersion \
 		-Dsiteman1dir=$prefix/non-packaged/$relativeManDir/man1 \
@@ -127,6 +138,9 @@ INSTALL()
 {
 	make install
 	chmod a+x $prefix/bin/{perl,perlthanks}
+
+	packageEntries doc \
+		$documentationDir
 }
 
 TEST()


### PR DESCRIPTION
Otherwise, packages which install man pages will install them into $prefix/man.

----

Currently I can't build perl on x86_64 nightly (hrev58500) because miniperl crashes in strcmp during the build.