### PR TITLE
monsterz: apply patch to fix compatibility with numpy 2.x

### DIFF
--- a/games-puzzle/monsterz/monsterz-0.7.1.recipe
+++ b/games-puzzle/monsterz/monsterz-0.7.1.recipe
@@ -11,7 +11,7 @@ Michael Speck, David White Mike Kershaw"
 LICENSE="WTFPL v2
 	GNU GPL v1
 	GNU LGPL v2"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="http://sam.zoy.org/monsterz/monsterz-$portVersion.tar.gz"
 CHECKSUM_SHA256="50828b8fa26d107bcc2bd134328f83c905b9f5e124846bdf239daf0eed34973d"
 PATCHES="monsterz-$portVersion.patchset"

--- a/games-puzzle/monsterz/patches/monsterz-0.7.1.patchset
+++ b/games-puzzle/monsterz/patches/monsterz-0.7.1.patchset
@@ -1,4 +1,4 @@
-From b77c7c42ec80df11c1c2cf60992490ef9887ba04 Mon Sep 17 00:00:00 2001
+From 2edf674080d09ef72a9bc1d722858d5995fcae8e Mon Sep 17 00:00:00 2001
 From: begasus <begasus@gmail.com>
 Date: Sat, 26 Jan 2019 16:21:26 +0100
 Subject: don't use chown
@@ -25,10 +25,10 @@ index 6db0ff8..5aa803f 100644
  
  uninstall:
 -- 
-2.37.3
+2.45.2
 
 
-From 014163efa59af7882dde46ebf75f716ccd9b3c88 Mon Sep 17 00:00:00 2001
+From 3486bae9790a8e8a55e73723a3aac59ea130ed4d Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Mon, 17 Apr 2023 00:14:53 -0300
 Subject: Fix issues with alignment on 64 bit systems.
@@ -62,10 +62,10 @@ index deee45c..fd5cb60 100755
                      alpha[y][x] = 255 - M * 2 / 3
          del pixels
 -- 
-2.37.3
+2.45.2
 
 
-From eb5389d36ed7fd91543bcb6a682dd5a3476c620e Mon Sep 17 00:00:00 2001
+From 397dcbc8a6a10c46e8cbc985d56b071a58531002 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Mon, 17 Apr 2023 00:16:34 -0300
 Subject: Fix crash on startup caused by errors in the blit() function in
@@ -110,10 +110,10 @@ index fd5cb60..1fe7336 100755
              scroll.unlock()
          system.blit(scroll, (13, 437))
 -- 
-2.37.3
+2.45.2
 
 
-From 6070027ae032e038e049812345925feee2006a45 Mon Sep 17 00:00:00 2001
+From e9cfa7445a2c19bfdee75c4d2a50ab728a50471a Mon Sep 17 00:00:00 2001
 From: A Mennucc <mennucc1@debian.org>
 Date: Mon, 17 Apr 2023 00:20:55 -0300
 Subject: Add startup animation with random monster.
@@ -204,10 +204,10 @@ index 1fe7336..15ec6f9 100755
              if self.msat[x] > 180:
                  monster = data.surprise[shapes[x]]
 -- 
-2.37.3
+2.45.2
 
 
-From 552f71d22e2f4bad5ed8c5912c5534d2511fe176 Mon Sep 17 00:00:00 2001
+From cab7fe929825007975b066143ba4306bcf75a9a9 Mon Sep 17 00:00:00 2001
 From: Markus Koschany <apo@debian.org>
 Date: Sat, 7 Nov 2015 09:43:31 +0100
 Subject: hardening
@@ -230,10 +230,10 @@ index 5aa803f..2ffd64b 100644
  bitmap: $(BITMAP)
  
 -- 
-2.37.3
+2.45.2
 
 
-From a9ba69609234b3ecc9b699fe3d389295851d84cc Mon Sep 17 00:00:00 2001
+From 5cb9b59e877c70c01ce5ff5e4b81ed761cc1ef7d Mon Sep 17 00:00:00 2001
 From: Reiner Herrmann <reiner@reiner-h.de>
 Date: Mon, 17 Apr 2023 00:22:30 -0300
 Subject: Port to Python3
@@ -1197,10 +1197,10 @@ index 15ec6f9..e7434a3 100755
      fonter = Fonter()
      monsterz = Monsterz()
 -- 
-2.37.3
+2.45.2
 
 
-From 03857b021cd27d600d3f10fcbd40503f73e23b7b Mon Sep 17 00:00:00 2001
+From 58f3f8e3da6d6d3e6466fb91faee16718d279a5b Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Mon, 17 Apr 2023 02:24:27 -0300
 Subject: Fix "configdir" location for Haiku.
@@ -1222,10 +1222,10 @@ index e7434a3..b373e81 100755
              configdir = join(expanduser('~'), '.monsterz')
          # Make sure our directory exists
 -- 
-2.37.3
+2.45.2
 
 
-From 0a08f955325b31a5569e1e898d4e852797c9b4fd Mon Sep 17 00:00:00 2001
+From 4b4b063bda9cc1cf42f4964414acd5a6ab3bc89f Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 21 Apr 2023 04:16:55 -0300
 Subject: Fix double clicking on a symlink to the script.
@@ -1262,10 +1262,10 @@ index b373e81..da294c9 100755
      main()
 -
 -- 
-2.37.3
+2.45.2
 
 
-From a56b7946e6a00f5ed9f2a6d9c0cfae91aa553115 Mon Sep 17 00:00:00 2001
+From 275d34a3b8c1e0d064063f3ba2e2d7d754813fb2 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 18 Aug 2023 05:28:47 -0300
 Subject: Reduce CPU usage by slightly worsening the aspect of the "time-bar".
@@ -1297,5 +1297,49 @@ index da294c9..7c0d383 100755
              timebar.unlock()
          system.blit(timebar, (13, 436))
 -- 
-2.37.3
+2.45.2
+
+
+From ba17939f0af90905a90dce96f4540e273a744bdb Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Wed, 25 Dec 2024 21:33:16 -0300
+Subject: Fix compatibility with numpy 2.2.1.
+
+
+diff --git a/monsterz.py b/monsterz.py
+index 7c0d383..b727a8c 100755
+--- a/monsterz.py
++++ b/monsterz.py
+@@ -116,8 +116,12 @@ def semi_grayscale(surf):
+         for y, line in enumerate(pixels):
+             for x, p in enumerate(line):
+                 r, g, b = p
+-                M = int(max(r, g, b))
+-                m = int(min(r, g, b))
++                # convert from numpy.int8 to int
++                r = r.item()
++                g = g.item()
++                b = b.item()
++                M = max(r, g, b)
++                m = min(r, g, b)
+                 val = (2 * M + r + g + b) // 5
+                 p[0] = (val + r) // 2
+                 p[1] = (val + g) // 2
+@@ -140,8 +144,12 @@ def semi_transp(surf):
+         for y, line in enumerate(pixels):
+             for x, p in enumerate(line):
+                 r, g, b = p
+-                M = int(max(r, g, b))
+-                m = int(min(r, g, b))
++                # convert from numpy.int8 to int
++                r = r.item()
++                g = g.item()
++                b = b.item()
++                M = max(r, g, b)
++                m = min(r, g, b)
+                 p[0] = (m + r) // 2
+                 p[1] = (m + g) // 2
+                 p[2] = (m + b) // 2
+-- 
+2.45.2
 


### PR DESCRIPTION
Taken from https://github.com/0-wiz-0/monsterz/commit/c76690baffe4e7588c1e3061c9baa6e9fcaf9206

----

Tested with both numpy 1.26.0 and 2.2.1 on 64 bits. Runs fine with either.

Next update to `monsterz` might be switching upstream to https://github.com/0-wiz-0/monsterz/