### PR TITLE
numpy: recipe clean ups, drop Python 3.9.

### DIFF
--- a/dev-python/numpy/numpy-1.26.0.recipe
+++ b/dev-python/numpy/numpy-1.26.0.recipe
@@ -9,7 +9,7 @@ general-purpose data-base applications."
 HOMEPAGE="https://www.numpy.org/"
 COPYRIGHT="2005-2021 Travis E. Oliphant et al."
 LICENSE="BSD (3-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/numpy/numpy/releases/download/v$portVersion/numpy-$portVersion.tar.gz"
 CHECKSUM_SHA256="f93fc78fe8bf15afe2b8d6b6499f1c73953169fad1e9a8dd086cdff3190e7fdf"
 SOURCE_DIR="numpy-$portVersion"
@@ -22,61 +22,65 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-#	lib:libamd$secondaryArchSuffix
 	lib:libblis$secondaryArchSuffix
 	lib:libexecinfo$secondaryArchSuffix
-#	lib:libfftw3$secondaryArchSuffix
 	lib:liblapack$secondaryArchSuffix
 	lib:libopenblas$secondaryArchSuffix
-#	lib:libumfpack$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-#	devel:cblas$secondaryArchSuffix
-#	devel:libamd$secondaryArchSuffix
 	devel:libblis$secondaryArchSuffix
 	devel:libexecinfo$secondaryArchSuffix
-#	devel:libfftw3$secondaryArchSuffix
 	devel:liblapack$secondaryArchSuffix
 	devel:libopenblas$secondaryArchSuffix
-#	devel:libumfpack$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\n\
-	cmd:f2py${pythonVersion%.*}\n\
-	cmd:f2py$pythonVersion\n\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku$secondaryArchSuffix\n\
-	numpy$secondaryArchSuffix\n\
-	cmd:cython$pythonVersion\n\
-	cmd:python$pythonVersion\
-	\""
-if [ "$targetArchitecture" = "x86_gcc2" ]; then
-	eval "PROVIDES_${pythonPackage}+=\"\n\
-		numpy_$pythonPackage = $portVersion\
+PYTHON_VERSIONS=(3.10)
+defaultVersion=3.10
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
+		cmd:f2py_$pythonVersion
 		\""
-fi
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage
-	"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:cython$pythonVersion
-	cmd:git
-	cmd:gcc$secondaryArchSuffix
-	cmd:gfortran$secondaryArchSuffix
-	cmd:pkg_config$secondaryArchSuffix
-	cmd:python$pythonVersion
-	"
-done
 
+	if [ $targetArchitecture = "x86_gcc2" ]; then
+		eval "PROVIDES_${pythonPackage}+=\"
+			numpy_$pythonPackage = $portVersion
+			\""
+	fi
+
+	# Provide f2py/f2py3 only for the default version
+	if [ $pythonVersion = $defaultVersion ]; then
+		eval "PROVIDES_${pythonPackage}+=\"
+			cmd:f2py
+			cmd:f2py${pythonVersion%.*}
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku$secondaryArchSuffix
+		numpy$secondaryArchSuffix
+		cmd:cython$pythonVersion
+		cmd:python$pythonVersion
+		\""
+
+	BUILD_REQUIRES+="
+		pyproject_metadata_$pythonPackage
+		setuptools_$pythonPackage
+		tomli_$pythonPackage # for Pythonn < 3.11 only.
+		"
+	BUILD_PREREQUIRES+="
+		cmd:cython$pythonVersion
+		cmd:gcc$secondaryArchSuffix
+		cmd:gfortran$secondaryArchSuffix
+		cmd:python$pythonVersion
+		"
+done
 
 INSTALL()
 {
@@ -97,30 +101,32 @@ libraries = blis
 library_dirs = /system/$relativeDevelopLibDir
 include_dirs = /system/$relativeIncludeDir/blis
 runtime_library_dirs = /system/$relativeLibDir
-#[amd]
-#amd_libs = amd
-#[umfpack]
-#umfpack_libs = umfpack
-#[fftw]
-#libraries = fftw3
 EOF
 
 	rm -rf doc/sphinxext/.git
 
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
-		rm -rf $prefix/bin/f2py
 
-		packageEntries  $pythonPackage \
+		# Version suffix the scripts, and provide suffixless versions for the default one.
+		mv $binDir/f2py $binDir/f2py-$pythonVersion
+		if [ $pythonVersion = $defaultVersion ]; then
+			ln -sr $binDir/f2py-$pythonVersion $binDir/f2py
+			ln -sr $binDir/f2py-$pythonVersion $binDir/f2py3
+		fi
+
+		packageEntries $pythonPackage \
 			$prefix/lib/python* \
 			$prefix/bin
 	done
@@ -128,9 +134,9 @@ EOF
 
 TEST()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 		$python runtests.py


### PR DESCRIPTION
Fixes #11512

----

This one might be short-lived (if we can move to 2.2.1 soon), but in any case, it will leave the recipe in a better state at least.