### PR TITLE
sphinx: clean up, drop _python39 package.

### DIFF
--- a/dev-python/alabaster/alabaster-0.7.13.recipe
+++ b/dev-python/alabaster/alabaster-0.7.13.recipe
@@ -9,7 +9,7 @@ COPYRIGHT="2020 Jeff Forcier
 	2011 Kenneth Reitz
 	2010 Armin Ronacher"
 LICENSE="BSD (3-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="$HOMEPAGE/archive/refs/tags/$portVersion.tar.gz"
 CHECKSUM_SHA256="c5efad86e1bb8215d037e2890e62aa2bb5e4f13f6fa455be100413835b5bfe43"
 SOURCE_FILENAME="alabaster-$portVersion.tar.gz"
@@ -27,11 +27,11 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
+PYTHON_VERSIONS=(3.10)
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_$pythonPackage=\"
 		${portName}_$pythonPackage = $portVersion
@@ -50,9 +50,9 @@ done
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/

--- a/dev-python/sphinx-argparse/sphinx_argparse-0.4.0.recipe
+++ b/dev-python/sphinx-argparse/sphinx_argparse-0.4.0.recipe
@@ -4,7 +4,7 @@ and options"
 HOMEPAGE="https://pypi.org/project/sphinx-argparse/"
 COPYRIGHT="2013 Alex Rudakov"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/ashb/sphinx-argparse/releases/download/v0.4.0/sphinx_argparse-$portVersion-py3-none-any.whl#noarchive"
 CHECKSUM_SHA256="73bee01f7276fae2bf621ccfe4d167af7306e7288e3482005405d9f826f9b037"
 
@@ -21,11 +21,11 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
+PYTHON_VERSIONS=(3.10)
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_${pythonPackage}=\"
 		${portName}_$pythonPackage = $portVersion
@@ -34,7 +34,7 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 		haiku
 		cmd:python$pythonVersion
 		\""
-	BUILD_PREREQUIRES="$BUILD_PREREQUIRES
+	BUILD_PREREQUIRES+="
 		installer_$pythonPackage
 		cmd:python$pythonVersion
 		"
@@ -42,13 +42,14 @@ done
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 		$python -m installer -p $prefix $portName-$portVersion-py3-none-any.whl
 
-		packageEntries ${PYTHON_PACKAGES[i]} \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }

--- a/dev-python/sphinx/sphinx-7.2.6.recipe
+++ b/dev-python/sphinx/sphinx-7.2.6.recipe
@@ -21,7 +21,7 @@ extensions."
 HOMEPAGE="https://www.sphinx-doc.org/"
 COPYRIGHT="2023 Georg Brandl"
 LICENSE="BSD (2-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/sphinx-doc/sphinx/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="b41c04543148937b887097f396d7b2b54ae49d0597b68625f06ffdf702d4d917"
 PATCHES="sphinx-$portVersion.patchset"
@@ -39,13 +39,14 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
+
+PYTHON_VERSIONS=(3.10)
 defaultVersion=3.10
-defaultTestVersion="python39"
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
+defaultTestVersion=$defaultVersion
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_$pythonPackage=\"
 		${portName}_$pythonPackage = $portVersion
@@ -70,7 +71,6 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 		babel_$pythonPackage
 		docutils_$pythonPackage
 		imagesize_$pythonPackage
-		importlib_metadata_$pythonPackage # only for Python < 3.10
 		jinja_$pythonPackage
 		packaging_$pythonPackage
 		pygments_$pythonPackage
@@ -96,17 +96,20 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 done
 
 TEST_REQUIRES="
-	cython_$pythonPackage
+#	cython_$pythonPackage
 	filelock_$defaultTestVersion
 	html5lib_$defaultTestVersion
-	sphinx_$defaultTestVersion
+#	sphinx_$defaultTestVersion
+	cmd:cython$pythonVersion
+	cmd:sphinx_build
 	cmd:pytest
 	"
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 
@@ -125,7 +128,7 @@ INSTALL()
 			done
 		fi
 
-		packageEntries ${PYTHON_PACKAGES[i]} \
+		packageEntries $pythonPackage \
 			$prefix/lib/python* \
 			$prefix/bin
 	done

--- a/dev-python/sphinx_rtd_theme/sphinx_rtd_theme-1.2.1.recipe
+++ b/dev-python/sphinx_rtd_theme/sphinx_rtd_theme-1.2.1.recipe
@@ -13,7 +13,7 @@ COPYRIGHT="2013-2018 Dave Snider, Read the Docs, Inc. & contributors
 	2010-2015, Łukasz Dziedzic"
 LICENSE="MIT
 	OFL"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/s/sphinx_rtd_theme/sphinx_rtd_theme-$portVersion.tar.gz"
 CHECKSUM_SHA256="cf9a7dc0352cf179c538891cb28d6fad6391117d4e21c891776ab41dd6c8ff70"
 
@@ -30,11 +30,11 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
+PYTHON_VERSIONS=(3.10)
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_$pythonPackage=\"
 		${portName}_$pythonPackage = $portVersion
@@ -53,9 +53,9 @@ done
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/

--- a/dev-python/sphinxcontrib-applehelp/sphinxcontrib_applehelp-1.0.4.recipe
+++ b/dev-python/sphinxcontrib-applehelp/sphinxcontrib_applehelp-1.0.4.recipe
@@ -4,7 +4,7 @@ HOMEPAGE="https://www.sphinx-doc.org/
 	https://github.com/sphinx-doc/sphinxcontrib-applehelp"
 COPYRIGHT="2007-2019 by the Sphinx team"
 LICENSE="BSD (2-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.python.org/packages/source/s/sphinxcontrib-applehelp/sphinxcontrib-applehelp-$portVersion.tar.gz"
 CHECKSUM_SHA256="828f867945bbe39817c210a1abfd1bc4895c8b73fcaade56d45357a348a07d7e"
 SOURCE_DIR="sphinxcontrib-applehelp-$portVersion"
@@ -22,12 +22,12 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-defaultTestVersion="python39"
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
+PYTHON_VERSIONS=(3.10)
+defaultTestVersion=3.10
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_$pythonPackage=\"
 		${portName}_$pythonPackage = $portVersion
@@ -48,21 +48,22 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 done
 
 TEST_REQUIRES="
-	sphinx_$defaultTestVersion
+	sphinx_python$defaultTestVersion
 	cmd:pytest
 	"
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 
 		$python -m build --wheel --skip-dependency-check --no-isolation
 		$python -m installer -p $prefix dist/*.whl
 
-		packageEntries ${PYTHON_PACKAGES[i]} \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }

--- a/dev-python/sphinxcontrib-devhelp/sphinxcontrib_devhelp-1.0.2.recipe
+++ b/dev-python/sphinxcontrib-devhelp/sphinxcontrib_devhelp-1.0.2.recipe
@@ -4,7 +4,7 @@ HOMEPAGE="http://sphinx-doc.org/
 	https://github.com/sphinx-doc/sphinxcontrib-devhelp"
 COPYRIGHT="2007-2019 by the Sphinx team"
 LICENSE="BSD (2-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.python.org/packages/source/s/sphinxcontrib-devhelp/sphinxcontrib-devhelp-$portVersion.tar.gz"
 CHECKSUM_SHA256="ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"
 SOURCE_DIR="sphinxcontrib-devhelp-$portVersion"
@@ -22,12 +22,12 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-defaultTestVersion="python39"
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
+PYTHON_VERSIONS=(3.10)
+defaultTestVersion=3.10
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_$pythonPackage=\"
 		${portName}_$pythonPackage = $portVersion
@@ -48,21 +48,22 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 done
 
 TEST_REQUIRES="
-	sphinx_$defaultTestVersion
+	sphinx_python$defaultTestVersion
 	cmd:pytest
 	"
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 
 		$python -m build --wheel --skip-dependency-check --no-isolation
 		$python -m installer -p $prefix dist/*.whl
 
-		packageEntries ${PYTHON_PACKAGES[i]} \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }

--- a/dev-python/sphinxcontrib-htmlhelp/sphinxcontrib_htmlhelp-2.0.1.recipe
+++ b/dev-python/sphinxcontrib-htmlhelp/sphinxcontrib_htmlhelp-2.0.1.recipe
@@ -4,7 +4,7 @@ HOMEPAGE="https://www.sphinx-doc.org/
 	https://github.com/sphinx-doc/sphinxcontrib-htmlhelp"
 COPYRIGHT="2007-2019 by the Sphinx team"
 LICENSE="BSD (2-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.python.org/packages/source/s/sphinxcontrib-htmlhelp/sphinxcontrib-htmlhelp-$portVersion.tar.gz"
 CHECKSUM_SHA256="0cbdd302815330058422b98a113195c9249825d681e18f11e8b1f78a2f11efff"
 SOURCE_DIR="sphinxcontrib-htmlhelp-$portVersion"
@@ -22,12 +22,12 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-defaultTestVersion="python39"
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
+PYTHON_VERSIONS=(3.10)
+defaultTestVersion=3.10
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_$pythonPackage=\"
 		${portName}_$pythonPackage = $portVersion
@@ -48,22 +48,23 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 done
 
 TEST_REQUIRES="
-	html5lib_$defaultTestVersion
-	sphinx_$defaultTestVersion
+	html5lib_python$defaultTestVersion
+	sphinx_python$defaultTestVersion
 	cmd:pytest
 	"
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 
 		$python -m build --wheel --skip-dependency-check --no-isolation
 		$python -m installer -p $prefix dist/*.whl
 
-		packageEntries ${PYTHON_PACKAGES[i]} \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }

--- a/dev-python/sphinxcontrib-jquery/sphinxcontrib_jquery-4.1.recipe
+++ b/dev-python/sphinxcontrib-jquery/sphinxcontrib_jquery-4.1.recipe
@@ -6,7 +6,7 @@ HOMEPAGE="https://github.com/sphinx-contrib/jquery/
 COPYRIGHT="2022 Adam Turner"
 LICENSE="MIT
 	0BSD"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.python.org/packages/source/s/sphinxcontrib-jquery/sphinxcontrib-jquery-$portVersion.tar.gz"
 CHECKSUM_SHA256="1620739f04e36a2c779f1a131a2dfd49b2fd07351bf1968ced074365933abc7a"
 SOURCE_DIR="sphinxcontrib-jquery-$portVersion"
@@ -24,12 +24,12 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-defaultTestVersion="python39"
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
+PYTHON_VERSIONS=(3.10)
+defaultTestVersion=3.10
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_$pythonPackage=\"
 		${portName}_$pythonPackage = $portVersion
@@ -50,22 +50,23 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 done
 
 TEST_REQUIRES="
-	snowballstemmer_$defaultTestVersion
-	sphinxcontrib_jquery_$defaultTestVersion
+	snowballstemmer_python$defaultTestVersion
+	sphinxcontrib_jquery_python$defaultTestVersion
 	cmd:pytest
 	"
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 
 		$python -m build --wheel --skip-dependency-check --no-isolation
 		$python -m installer -p $prefix dist/*.whl
 
-		packageEntries ${PYTHON_PACKAGES[i]} \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }

--- a/dev-python/sphinxcontrib-jsmath/sphinxcontrib_jsmath-1.0.1.recipe
+++ b/dev-python/sphinxcontrib-jsmath/sphinxcontrib_jsmath-1.0.1.recipe
@@ -5,7 +5,7 @@ HOMEPAGE="http://sphinx-doc.org/
 	https://pypi.org/project/sphinxcontrib-jsmath/"
 COPYRIGHT="2007-2019 by the Sphinx team"
 LICENSE="BSD (2-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.python.org/packages/source/s/sphinxcontrib-jsmath/sphinxcontrib-jsmath-$portVersion.tar.gz"
 CHECKSUM_SHA256="a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"
 SOURCE_DIR="sphinxcontrib-jsmath-$portVersion"
@@ -24,12 +24,12 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-defaultTestVersion="python39"
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
+PYTHON_VERSIONS=(3.10)
+defaultTestVersion=3.10
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_$pythonPackage=\"
 		${portName}_$pythonPackage = $portVersion
@@ -50,21 +50,22 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 done
 
 TEST_REQUIRES="
-	sphinx_$defaultTestVersion
+	sphinx_python$defaultTestVersion
 	cmd:pytest
 	"
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 
 		$python -m build --wheel --skip-dependency-check --no-isolation
 		$python -m installer -p $prefix dist/*.whl
 
-		packageEntries ${PYTHON_PACKAGES[i]} \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }

--- a/dev-python/sphinxcontrib-qthelp/sphinxcontrib_qthelp-1.0.3.recipe
+++ b/dev-python/sphinxcontrib-qthelp/sphinxcontrib_qthelp-1.0.3.recipe
@@ -4,7 +4,7 @@ HOMEPAGE="http://sphinx-doc.org/
 	https://pypi.org/project/sphinxcontrib-qthelp/"
 COPYRIGHT="2007-2019 by the Sphinx team"
 LICENSE="BSD (2-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.python.org/packages/source/s/sphinxcontrib-qthelp/sphinxcontrib-qthelp-$portVersion.tar.gz"
 CHECKSUM_SHA256="4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72"
 SOURCE_DIR="sphinxcontrib-qthelp-$portVersion"
@@ -23,12 +23,12 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-defaultTestVersion="python39"
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
+PYTHON_VERSIONS=(3.10)
+defaultTestVersion=3.10
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_$pythonPackage=\"
 		${portName}_$pythonPackage = $portVersion
@@ -49,21 +49,22 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 done
 
 TEST_REQUIRES="
-	sphinx_$defaultTestVersion
+	sphinx_python$defaultTestVersion
 	cmd:pytest
 	"
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 
 		$python -m build --wheel --skip-dependency-check --no-isolation
 		$python -m installer -p $prefix dist/*.whl
 
-		packageEntries ${PYTHON_PACKAGES[i]} \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }

--- a/dev-python/sphinxcontrib-serializinghtml/sphinxcontrib_serializinghtml-1.1.5.recipe
+++ b/dev-python/sphinxcontrib-serializinghtml/sphinxcontrib_serializinghtml-1.1.5.recipe
@@ -5,7 +5,7 @@ HOMEPAGE="http://sphinx-doc.org/
 	https://pypi.org/project/sphinxcontrib-serializinghtml/"
 COPYRIGHT="2007-2019 by the Sphinx team"
 LICENSE="BSD (2-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://pypi.python.org/packages/source/s/sphinxcontrib-serializinghtml/sphinxcontrib-serializinghtml-$portVersion.tar.gz"
 CHECKSUM_SHA256="aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952"
 SOURCE_DIR="sphinxcontrib-serializinghtml-$portVersion"
@@ -23,12 +23,12 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-defaultTestVersion="python39"
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
+PYTHON_VERSIONS=(3.10)
+defaultTestVersion=3.10
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_$pythonPackage=\"
 		${portName}_$pythonPackage = $portVersion
@@ -49,21 +49,22 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 done
 
 TEST_REQUIRES="
-	sphinx_$defaultTestVersion
+	sphinx_python$defaultTestVersion
 	cmd:pytest
 	"
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 
 		$python -m build --wheel --skip-dependency-check --no-isolation
 		$python -m installer -p $prefix dist/*.whl
 
-		packageEntries ${PYTHON_PACKAGES[i]} \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }


### PR DESCRIPTION
Also cleanup and drop _python39 from related recipes:

- alabaster
- sphinx_rtd_theme
- sphinx_argparse
- sphinxcontrib_applehelp
- sphinxcontrib_devhelp
- sphinxcontrib_htmlhelp
- sphinxcontrib_jquery
- sphinxcontrib_jsmath
- sphinxcontrib_qthelp
- sphinxcontrib_serializinghtml