### PR TITLE
grpc: switch tests to Python 3.10. (Untested)

### DIFF
--- a/net-libs/grpc/grpc-1.53.0.recipe
+++ b/net-libs/grpc/grpc-1.53.0.recipe
@@ -24,6 +24,10 @@ libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 libCppVersion=$portVersion
 libCppVersionCompat="$libCppVersion compat >= ${libCppVersion%.*}"
 
+# Used for TESTS() only:
+pythonVersion=3.10
+pythonPackage=python${pythonVersion//.}
+
 PROVIDES="
 	grpc$secondaryArchSuffix = $portVersion
 	cmd:grpc_cpp_plugin
@@ -109,9 +113,10 @@ BUILD_PREREQUIRES="
 	cmd:ninja
 	cmd:pkg_config$secondaryArchSuffix
 	"
+
 TEST_REQUIRES="
-	cmd:python3
-	six_python39
+	cmd:python$pythonVersion
+	six_$pythonPackage
 	"
 
 BUILD()
@@ -181,5 +186,5 @@ INSTALL()
 
 TEST()
 {
-	python3 tools/run_tests/run_tests.py -l c++
+	python$pythonVersion tools/run_tests/run_tests.py -l c++
 }


### PR DESCRIPTION
Even if untested (for how long the build process is)... it can't be worse than the currently nonsensical mix of `cmd:python3` and a `_python39` package.

Not touching REVISION, as this only affects `TESTS()`.