### PR TITLE
Genio: added dependency to noto_emoji

### DIFF
--- a/haiku-apps/genio/genio-3.1.recipe
+++ b/haiku-apps/genio/genio-3.1.recipe
@@ -15,7 +15,7 @@ HOMEPAGE="https://github.com/Genio-The-Haiku-IDE/Genio/releases"
 COPYRIGHT="2022-2024 The Genio Team"
 LICENSE="BSD (3-clause)
 	MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/Genio-The-Haiku-IDE/Genio/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="c5328a21c1334fbd493801e7e3646a697bf0e33868784fd9804739116f2ca06a"
 SOURCE_FILENAME="Genio-v$portVersion.tar.gz"
@@ -31,6 +31,7 @@ PROVIDES="
 REQUIRES="
 	haiku${secondaryArchSuffix}
 	gcc${secondaryArchSuffix}_syslibs_devel
+	noto_emoji${secondaryArchSuffix}
 	cmd:clang >= 16
 	lib:libeditorconfig$secondaryArchSuffix
 	lib:libgit2$secondaryArchSuffix
@@ -41,7 +42,7 @@ REQUIRES="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libeditorconfig$secondaryArchSuffix
-	devel:libgit2$secondaryArchSuffix >= 1.5
+	devel:libgit2$secondaryArchSuffix >= 1.8
 	devel:liblexilla$secondaryArchSuffix >= 5.2.4
 	devel:libyaml_cpp$secondaryArchSuffix >= 0.8
 	"

--- a/haiku-apps/genio/genio-3.1.recipe
+++ b/haiku-apps/genio/genio-3.1.recipe
@@ -31,7 +31,7 @@ PROVIDES="
 REQUIRES="
 	haiku${secondaryArchSuffix}
 	gcc${secondaryArchSuffix}_syslibs_devel
-	noto_emoji${secondaryArchSuffix}
+	noto_emoji
 	cmd:clang >= 16
 	lib:libeditorconfig$secondaryArchSuffix
 	lib:libgit2$secondaryArchSuffix


### PR DESCRIPTION
Genio uses a glyph only available in noto_emoji which app_server uses as fallback.

Also updated dependency to libgit2