### PR TITLE
coverage: update to version 7.6.10.

### DIFF
--- a/dev-python/coverage/coverage-7.6.10.recipe
+++ b/dev-python/coverage/coverage-7.6.10.recipe
@@ -8,7 +8,7 @@ COPYRIGHT="2001 Gareth Rees
 LICENSE="Apache v2"
 REVISION="1"
 SOURCE_URI="https://pypi.org/packages/source/c/coverage/coverage-$portVersion.tar.gz"
-CHECKSUM_SHA256="276f6077a5c61447a48d133ed13e759c09e62aff0dc84274a68dc18660104d52"
+CHECKSUM_SHA256="7fb105327c8f8f0682e29843e2ff96af9dcbe5bab8eeb4b398c6a33a16d80a23"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -29,7 +29,7 @@ BUILD_PREREQUIRES="
 	cmd:rst2man
 	"
 
-PYTHON_VERSIONS=(3.9 3.10)
+PYTHON_VERSIONS=(3.10)
 defaultVersion=3.10
 for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -57,10 +57,13 @@ for i in "${!PYTHON_VERSIONS[@]}"; do
 
 	eval "REQUIRES_$pythonPackage=\"
 		haiku$secondaryArchSuffix
-		lib:libpython$pythonVersion$secondaryArchSuffix
+		cmd:python$pythonVersion
 		\""
 	eval "BUILD_REQUIRES+=\"
+		build_$pythonPackage
+		installer_$pythonPackage
 		setuptools_$pythonPackage
+		wheel_$pythonPackage
 		\""
 	eval "BUILD_PREREQUIRES+=\"
 		cmd:python$pythonVersion
@@ -75,15 +78,8 @@ BUILD()
  	rst2html < README.rst > README.html
 
 	for i in "${!PYTHON_VERSIONS[@]}"; do
-		pythonVersion=${PYTHON_VERSIONS[$i]}
-		pythonPackage=python${pythonVersion//.}
-
-		rm -rf "$sourceDir"-$pythonPackage
-		cp -a "$sourceDir" "$sourceDir"-$pythonPackage
-		cd "$sourceDir"-$pythonPackage
-
-		python=python$pythonVersion
-		$python setup.py build
+		python=python${PYTHON_VERSIONS[$i]}
+		$python -m build --wheel --no-isolation
 	done
 }
 
@@ -93,18 +89,8 @@ INSTALL()
 		pythonVersion=${PYTHON_VERSIONS[$i]}
 		pythonPackage=python${pythonVersion//.}
 
-		cd "$sourceDir"-$pythonPackage
-
 		python=python$pythonVersion
-		installLocation=$prefix/lib/$python/vendor-packages/
-		export PYTHONPATH=$installLocation
-
-		mkdir -p "$installLocation"
-		mkdir -p $manDir/man1
-
-		$python setup.py install \
-			--optimize=1 \
-			--root=/ --prefix="$prefix"
+		$python -m installer -p $prefix dist/$portName-$portVersion-*.whl
 
 		# For non default versions, only leave "coverage-$pythonVersion"
 		if [ $pythonVersion != $defaultVersion ]; then
@@ -114,6 +100,7 @@ INSTALL()
 
 		install -m 755 -d "$docDir"
 		install -m 644 -t "$docDir" README.html
+		mkdir -p $manDir/man1
 		cp coverage.1 $manDir/man1
 
 		packageEntries $pythonPackage \


### PR DESCRIPTION
* switch to using build/installer instead of setup.py.
* drop Python 3.9 package (nothing requires it on-tree).