### PR TITLE
cffi: clean up recipe, drop Python 3.9.

### DIFF
--- a/dev-python/argon2-cffi-bindings/argon2_cffi_bindings-21.2.0.recipe
+++ b/dev-python/argon2-cffi-bindings/argon2_cffi_bindings-21.2.0.recipe
@@ -5,7 +5,7 @@ HOMEPAGE="https://pypi.org/project/argon2-cffi-bindings/
 	https://github.com/hynek/argon2-cffi-bindings/"
 COPYRIGHT="2021 Hynek Schlawack"
 LICENSE="MIT"
-REVISION="4"
+REVISION="5"
 pypi="184b8ccce6683b0aa2fbb7ba5683ea4b9c5763f1356347f1312c32e3c66e"
 SOURCE_URI="https://files.pythonhosted.org/packages/b9/e9/$pypi/argon2-cffi-bindings-$portVersion.tar.gz"
 CHECKSUM_SHA256="bb89ceffa6c791807d1305ceb77dbfacc5aa499891d2c55661c6459651fc39e3"
@@ -32,11 +32,11 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
+PYTHON_VERSIONS=(3.10)
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_${pythonPackage}=\"
 		${portName}_$pythonPackage = $portVersion
@@ -46,14 +46,16 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 			argon2_cffi_bindings_$pythonPackage = $portVersion
 			\""
 	fi
+
 	eval "REQUIRES_$pythonPackage=\"
 		haiku
-		cffi${secondaryArchSuffix}_$pythonPackage
+		cffi_$pythonPackage
 		cmd:python$pythonVersion
 		\""
+
 	BUILD_REQUIRES+="
-		cffi${secondaryArchSuffix}_$pythonPackage
 		build_$pythonPackage
+		cffi_$pythonPackage
 		installer_$pythonPackage
 		setuptools_scm_$pythonPackage
 		wheel_$pythonPackage
@@ -68,17 +70,16 @@ INSTALL()
 	export ARGON2_CFFI_USE_SYSTEM=1
 	export SETUPTOOLS_SCM_PRETEND_VERSION=$portVersion
 
-	for i in "${!PYTHON_PACKAGES[@]}"; do
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 
-		rm -rf dist
-
 		$python -m build --wheel --skip-dependency-check --no-isolation
-		$python -m installer --p $prefix dist/*.whl
+		$python -m installer --p $prefix dist/*-$portVersion-cp${pythonVersion//.}-*.whl
 
-		packageEntries ${PYTHON_PACKAGES[i]} \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }

--- a/dev-python/bcrypt/bcrypt-3.2.0.recipe
+++ b/dev-python/bcrypt/bcrypt-3.2.0.recipe
@@ -4,7 +4,7 @@ servers."
 HOMEPAGE="https://pypi.python.org/pypi/bcrypt"
 COPYRIGHT="2013 Donald Stufft"
 LICENSE="Apache v2"
-REVISION="6"
+REVISION="7"
 SOURCE_URI="https://pypi.io/packages/source/b/bcrypt/bcrypt-$portVersion.tar.gz"
 CHECKSUM_SHA256="5b93c1726e50a93a033c36e5ca7fdcd29a5c7395af50a6892f5d9e7c6cfbfb29"
 
@@ -25,47 +25,52 @@ BUILD_PREREQUIRES="
 	gcc$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	cffi${secondaryArchSuffix}_$pythonPackage\n\
-	cmd:python$pythonVersion\
-	\""
-if [ "$targetArchitecture" = "x86_gcc2" ]; then
-	eval "PROVIDES_${pythonPackage}+=\"\n\
-		bcrypt_$pythonPackage = $portVersion\
+PYTHON_VERSIONS=(3.10)
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
 		\""
-fi
-BUILD_REQUIRES="$BUILD_REQUIRES
-	cffi${secondaryArchSuffix}_$pythonPackage
-	setuptools_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_${pythonPackage}+=\"
+			bcrypt_$pythonPackage = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		cffi_$pythonPackage
+		cmd:python$pythonVersion
+		\""
+
+	BUILD_REQUIRES+="
+		cffi_$pythonPackage
+		build_$pythonPackage
+		installer_$pythonPackage
+		setuptools_$pythonPackage
+		wheel_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
-		installLocation=$prefix/lib/$python/vendor-packages/
-		export PYTHONPATH=$installLocation:$PYTHONPATH
 		export CFLAGS="-D_BSD_SOURCE"
-		mkdir -p $installLocation
-		rm -rf build
-		$python setup.py build install \
-			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		$python -m build --wheel --skip-dependency-check --no-isolation
+		$python -m installer --p $prefix dist/*-$portVersion-cp${pythonVersion//.}-*.whl
+
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }

--- a/dev-python/cffi/cffi-1.15.1.recipe
+++ b/dev-python/cffi/cffi-1.15.1.recipe
@@ -4,7 +4,7 @@ HOMEPAGE="https://cffi.readthedocs.io/
 	https://pypi.org/project/cffi/"
 COPYRIGHT="2012-2021 Armin Rigo, Maciej Fijalkowski"
 LICENSE="MIT"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/c/cffi/cffi-$portVersion.tar.gz"
 CHECKSUM_SHA256="d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"
 
@@ -24,76 +24,77 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
-	cmd:pkg_config$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-PYTHON_LIBSUFFIXES+=()
-for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-pythonLibSuffix=${PYTHON_LIBSUFFIXES[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku\n\
-	lib:libffi$secondaryArchSuffix\n\
-	lib:libpython$pythonVersion$pythonLibSuffix$secondaryArchSuffix\n\
-	pycparser_$pythonPackage\n\
-	cmd:python$pythonVersion\
-	\""
-if [ "$targetArchitecture" = "x86_gcc2" ]; then
-	eval "PROVIDES_${pythonPackage}+=\"\n\
-		cffi_$pythonPackage = $portVersion\
+PYTHON_VERSIONS=(3.10)
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
 		\""
-fi
-BUILD_REQUIRES="$BUILD_REQUIRES
-	setuptools_$pythonPackage
-	pycparser_$pythonPackage"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_${pythonPackage}+=\"
+			cffi_$pythonPackage = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku
+		pycparser_$pythonPackage
+		cmd:python$pythonVersion
+		lib:libffi$secondaryArchSuffix
+		\""
+
+	BUILD_REQUIRES+="
+		build_$pythonPackage
+		installer_$pythonPackage
+		setuptools_$pythonPackage
+		wheel_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
+
+	TEST_REQUIRES="
+		cffi_$pythonPackage
+		py_$pythonPackage
+		pytest_$pythonPackage
+		"
 done
 
-TEST_REQUIRES+="
-	${portName}_$pythonPackage
-	py_$pythonPackage
-	pycparser_$pythonPackage
-	pytest_$pythonPackage
-	"
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
+
 		export PYTHONPATH=$installLocation:$PYTHONPATH
 		mkdir -p $installLocation
+
 		rm -rf build
+
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }
 
+# Results for reference:
+# 6 failed, 1913 passed, 120 skipped, 4 xfailed, 567 warnings in 1034.70s (0:17:14)
+# failures are harmless, due to tests expecting dl/libm/libc names instead of what Haiku provides.
 TEST()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
-		pythonVersion=${PYTHON_VERSIONS[$i]}
-
-		cd "$sourceDir"-$pythonPackage
-
-		python=python$pythonVersion
-		echo import cffi | $python
-		$python setup.py test
-		cd testing
-		$python support.py
+	for i in "${!PYTHON_VERSIONS[@]}"; do
+		py.test c/ testing/
 	done
 }

--- a/dev-python/pycares/pycares-3.1.1.recipe
+++ b/dev-python/pycares/pycares-3.1.1.recipe
@@ -5,7 +5,7 @@ asynchronously."
 HOMEPAGE="https://pypi.python.org/pypi/pycares"
 COPYRIGHT="2017 Saúl Ibarra Corretgé"
 LICENSE="MIT"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://pypi.io/packages/source/p/pycares/pycares-$portVersion.tar.gz"
 CHECKSUM_SHA256="18dfd4fd300f570d6c4536c1d987b7b7673b2a9d14346592c5d6ed716df0d104"
 PATCHES="pycares-$portVersion.patchset"
@@ -30,47 +30,51 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku$secondaryArchSuffix\n\
-	cffi_$pythonPackage\n\
-	cmd:python$pythonVersion\
-	\""
-if [ "$targetArchitecture" = "x86_gcc2" ]; then
-	eval "PROVIDES_${pythonPackage}+=\"\n\
-		pycares_$pythonPackage = $portVersion\
+PYTHON_VERSIONS=(3.10)
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
 		\""
-fi
-BUILD_REQUIRES="$BUILD_REQUIRES
-	cffi_$pythonPackage
-	setuptools_$pythonPackage
-	"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_${pythonPackage}+=\"
+			pycares_$pythonPackage = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku$secondaryArchSuffix
+		cffi_$pythonPackage
+		cmd:python$pythonVersion
+		\""
+
+	BUILD_REQUIRES+="
+		build_$pythonPackage
+		cffi_$pythonPackage
+		installer_$pythonPackage
+		setuptools_$pythonPackage
+		wheel_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
-		installLocation=$prefix/lib/$python/vendor-packages/
-		export PYTHONPATH=$installLocation:$PYTHONPATH
-		mkdir -p $installLocation
-		rm -rf build
-		$python setup.py build install \
-			--root=/ --prefix=$prefix
 
-		packageEntries  $pythonPackage \
+		$python -m build --wheel --skip-dependency-check --no-isolation
+		$python -m installer --p $prefix dist/*-$portVersion-cp${pythonVersion//.}-*.whl
+
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }

--- a/dev-python/pynacl/pynacl-1.5.0.recipe
+++ b/dev-python/pynacl/pynacl-1.5.0.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="PyNaCl provides Python binding to the libsodium library."
 HOMEPAGE="https://pypi.python.org/pypi/PyNaCl"
 COPYRIGHT="2013,2018 Donald Stufft and individual contributors"
 LICENSE="Apache v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pypi.io/packages/source/p/pynacl/PyNaCl-$portVersion.tar.gz"
 CHECKSUM_SHA256="8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba"
 SOURCE_DIR="PyNaCl-$portVersion"
@@ -23,60 +23,60 @@ BUILD_REQUIRES="
 	devel:libsodium$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:awk
-	cmd:cmp
-	cmd:diff
 	cmd:gcc$secondaryArchSuffix
-	cmd:make
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_${pythonPackage}=\"\
-	${portName}_$pythonPackage = $portVersion\
-	\"; \
-REQUIRES_$pythonPackage=\"\
-	haiku$secondaryArchSuffix\n\
-	cffi_$pythonPackage\n\
-	cmd:python$pythonVersion\n\
-	lib:libsodium$secondaryArchSuffix\
-	\""
-if [ "$targetArchitecture" = "x86_gcc2" ]; then
-	eval "PROVIDES_${pythonPackage}+=\"\n\
-		pynacl_$pythonPackage = $portVersion\
+PYTHON_VERSIONS=(3.10)
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
+
+	eval "PROVIDES_${pythonPackage}=\"
+		${portName}_$pythonPackage = $portVersion
 		\""
-fi
-BUILD_REQUIRES="$BUILD_REQUIRES
-	cffi_$pythonPackage
-	setuptools_$pythonPackage
-	"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion
-	"
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_${pythonPackage}+=\"
+			pynacl_$pythonPackage = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku$secondaryArchSuffix
+		cffi_$pythonPackage
+		cmd:python$pythonVersion
+		lib:libsodium$secondaryArchSuffix
+		\""
+
+	BUILD_REQUIRES+="
+		build_$pythonPackage
+		cffi_$pythonPackage
+		installer_$pythonPackage
+		setuptools_$pythonPackage
+		wheel_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()
 {
 	export SODIUM_INSTALL=system
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
-		installLocation=$prefix/lib/$python/vendor-packages/
-		export PYTHONPATH=$installLocation:$PYTHONPATH
-		mkdir -p $installLocation
-		rm -rf build
-		$python setup.py build install \
-			--root=/ --prefix=$prefix
+
+		$python -m build --wheel --skip-dependency-check --no-isolation
+		$python -m installer --p $prefix dist/*-$portVersion-cp${pythonVersion//.}-*.whl
 
 		install -m 755 -d "$docDir"
 		install -m 644 -t "$docDir" README.rst
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python*
 	done
 }


### PR DESCRIPTION
On-tree recipes that depend on cffi:

- argon2_cffi_bindings
- bcrypt
- pycares
- pynacl

So we're doing the same on those too in one go.