### PR TITLE
distcc: use Python 3.10.

### DIFF
--- a/sys-devel/distcc/distcc-3.3.5.recipe
+++ b/sys-devel/distcc/distcc-3.3.5.recipe
@@ -12,17 +12,17 @@ HOMEPAGE="http://distcc.org/"
 COPYRIGHT="2002-2004 by Martin Pool
     2005 Google Inc."
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/distcc/distcc/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="13a4b3ce49dfc853a3de550f6ccac583413946b3a2fa778ddf503a9edc8059b0"
 SOURCE_DIR="distcc-$portVersion"
 SOURCE_FILENAME="distcc-v$portVersion.tar.gz"
 PATCHES="distcc-$portVersion.patchset"
 
-ARCHITECTURES="all !x86_gcc2 ?x86"
+ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
-PYTHON_VERSION="3.9"
+PYTHON_VERSION="3.10"
 
 GLOBAL_WRITABLE_FILES="
 	settings/default/distcc keep-old
@@ -56,10 +56,13 @@ BUILD_PREREQUIRES="
 	cmd:autoconf
 	cmd:g++$secondaryArchSuffix
 	cmd:gcc$secondaryArchSuffix
-	#cmd:gdb # for testing
 	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
 	cmd:which
+	"
+
+TEST_REQUIRES="
+	cmd:gdb
 	"
 
 BUILD()
@@ -79,6 +82,10 @@ INSTALL()
 	make install
 }
 
+
+# Warning, running this tends to leave many lingering distccd processes running.
+# (you're forced to unmount after running "hp distcc --test", and need to manually
+# kill those "rouge distccd"s),
 TEST()
 {
 	make check RESTRICTED_PATH=/sources/distcc-${portVersion}:/bin


### PR DESCRIPTION
Warning, running this tends to leave many lingering distccd processes running.
(you're forced to unmount after running "hp distcc --test", and need to manually kill those "rouge distccd"s)
