### PR TITLE
lxml: drop Python 3.9. Do not REQUIRE libpython3.xx.so.

### DIFF
--- a/dev-python/lxml/lxml-5.3.0.recipe
+++ b/dev-python/lxml/lxml-5.3.0.recipe
@@ -13,7 +13,7 @@ LICENSE="BSD (3-clause)
 	ElementTree
 	GNU GPL v2
 	PSF-2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/lxml/lxml/releases/download/lxml-$portVersion/lxml-$portVersion.tar.gz"
 CHECKSUM_SHA256="4e109ca30d1edec1ac60cdbe341905dc3b8f55b16855e03a54aaf59e51ec8c6f"
 SOURCE_DIR="lxml-$portVersion"
@@ -39,7 +39,7 @@ BUILD_PREREQUIRES="
 	cmd:ld$secondaryArchSuffix
 	"
 
-PYTHON_VERSIONS=(3.9 3.10)
+PYTHON_VERSIONS=(3.10)
 
 for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
@@ -58,7 +58,6 @@ for i in "${!PYTHON_VERSIONS[@]}"; do
 	eval "REQUIRES_$pythonPackage=\"
 		haiku$secondaryArchSuffix
 		cmd:python$pythonVersion
-		lib:libpython$pythonVersion$secondaryArchSuffix
 		lib:libxml2$secondaryArchSuffix
 		lib:libxslt$secondaryArchSuffix
 		lib:libz$secondaryArchSuffix


### PR DESCRIPTION
Compiled extensions do no link to libpython3.xx.so, so just depend on cmd:python for a matching version.