### PR TITLE
python3.13: update to version 3.13.2.

### DIFF
--- a/dev-lang/python/patches/python3.13-3.13.2.patchset
+++ b/dev-lang/python/patches/python3.13-3.13.2.patchset
@@ -1,4 +1,4 @@
-From c390e5ddb4dcd7ee5fe33f9f0bfee3663112bba5 Mon Sep 17 00:00:00 2001
+From 4ab975ca10ba220d2a90a710bc26455bc0801311 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 8 Oct 2023 01:02:25 -0300
 Subject: initial Haiku patch
@@ -22,7 +22,7 @@ index 2ba81a4..8ba7902 100644
     // See PyUnicode_DecodeFSDefaultAndSize(), PyUnicode_EncodeFSDefault(),
     // Py_DecodeLocale() and Py_EncodeLocale().
 diff --git a/Makefile.pre.in b/Makefile.pre.in
-index 03ca4cb..300f4c2 100644
+index 46a37de..1e4122d 100644
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
 @@ -149,7 +149,7 @@ BINDIR=		@bindir@
@@ -148,7 +148,7 @@ index 09fd70f..97e15d2 100644
  #include <bluetooth/bluetooth.h>
  #include <bluetooth/rfcomm.h>
 diff --git a/configure.ac b/configure.ac
-index a764028..f77214b 100644
+index 3fcb189..8e54330 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -1573,6 +1573,16 @@ if test $enable_shared = "yes"; then
@@ -176,7 +176,7 @@ index a764028..f77214b 100644
  		CYGWIN*) LN="ln -s";;
  		*) LN=ln;;
  	esac
-@@ -3587,7 +3598,7 @@ then
+@@ -3608,7 +3619,7 @@ then
  	    LINKFORSHARED="-Wl,-E -Wl,+s";;
  #	    LINKFORSHARED="-Wl,-E -Wl,+s -Wl,+b\$(BINLIBDEST)/lib-dynload";;
  	Linux-android*) LINKFORSHARED="-pie -Xlinker -export-dynamic";;
@@ -185,7 +185,7 @@ index a764028..f77214b 100644
  	# -u libsys_s pulls in all symbols in libsys
  	Darwin/*|iOS/*)
  		LINKFORSHARED="$extra_undefs -framework CoreFoundation"
-@@ -5804,6 +5815,7 @@ AC_CHECK_FUNC([__fpu_control],
+@@ -5825,6 +5836,7 @@ AC_CHECK_FUNC([__fpu_control],
  AC_SUBST([LIBM])
  case $ac_sys_system in
  Darwin) ;;
@@ -197,17 +197,17 @@ index a764028..f77214b 100644
 2.45.2
 
 
-From 6ff61441a930b2e3dc5ed1cbe6cff0012a7fd8e5 Mon Sep 17 00:00:00 2001
+From a61aa9f3ef8b7adb8945cbde570c001e2dd6fb94 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sun, 16 Apr 2017 10:05:42 +0200
 Subject: fix for negative errnos
 
 
 diff --git a/Lib/subprocess.py b/Lib/subprocess.py
-index b2dcb14..7a20db7 100644
+index 98b98be..22a88f8 100644
 --- a/Lib/subprocess.py
 +++ b/Lib/subprocess.py
-@@ -1951,6 +1951,8 @@ class Popen:
+@@ -1959,6 +1959,8 @@ class Popen:
                          SubprocessError)
                  if issubclass(child_exception_type, OSError) and hex_errno:
                      errno_num = int(hex_errno, 16)
@@ -235,7 +235,7 @@ index daec4ad..1647199 100644
 2.45.2
 
 
-From f97a10b6431b381ed13acc2dcb3b618694920f1c Mon Sep 17 00:00:00 2001
+From 2334552fda9d9218734b970fd2ed4bb08d2a2a5c Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 8 Oct 2023 20:06:31 -0300
 Subject: Implement CTypes's find_library for Haiku
@@ -332,7 +332,7 @@ index 117bf06..6301aa2 100644
 2.45.2
 
 
-From b438ba3f454c40ef6f0b86ab86e206750782baac Mon Sep 17 00:00:00 2001
+From a98dbcabc3647e19e1f198d167f4814b831b4537 Mon Sep 17 00:00:00 2001
 From: Philipp Wolfer <phil@parolu.io>
 Date: Mon, 23 Sep 2019 09:14:58 +0200
 Subject: webbrowser: Support for default browsers on Haiku
@@ -359,7 +359,7 @@ index 2f9555a..90bea57 100755
 2.45.2
 
 
-From 4c8eaa2208b385ec1b7031a7d046a05ca83799a1 Mon Sep 17 00:00:00 2001
+From c899efa98767ad3c1ac7a5dbd8e0fa223a4317b1 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 4 Oct 2019 22:02:35 +0200
 Subject: since 3.8, don't reinit locks on fork.
@@ -382,7 +382,7 @@ index aa9b79d..b99e1e0 100644
 2.45.2
 
 
-From 3150dfbd38f1d63d318b80f13caf1eb1d6391ee6 Mon Sep 17 00:00:00 2001
+From 0b6a8ba0ec22ed05aa04af578e11d956c68ed311 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 15 May 2020 15:20:57 +0200
 Subject: handle errors returned by internal_connect()
@@ -415,17 +415,17 @@ index 1c0bc79..e8d1cf2 100644
 2.45.2
 
 
-From 202daa413c01b94425fd55d54a82995055530d40 Mon Sep 17 00:00:00 2001
+From e9da56074bc25080a4ddccdd1902f2b19c4cf8bb Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Mon, 19 Oct 2020 18:03:09 +0200
 Subject: ttyname_r can use MAXPATHLEN
 
 
 diff --git a/Modules/posixmodule.c b/Modules/posixmodule.c
-index a09305c..75a52c8 100644
+index 40d0f86..140cce8 100644
 --- a/Modules/posixmodule.c
 +++ b/Modules/posixmodule.c
-@@ -3311,11 +3311,14 @@ static PyObject *
+@@ -3314,11 +3314,14 @@ static PyObject *
  os_ttyname_impl(PyObject *module, int fd)
  /*[clinic end generated code: output=c424d2e9d1cd636a input=9ff5a58b08115c55]*/
  {
@@ -445,7 +445,7 @@ index a09305c..75a52c8 100644
 2.45.2
 
 
-From 72ccb71a32892d02853877b4a64d05cb1b79fa00 Mon Sep 17 00:00:00 2001
+From 549c7dcf5aa14f0a7ee953d4485afd4e24ffe157 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Mon, 24 Oct 2022 20:04:10 -0300
 Subject: Lib/test: require the "largefile" usage flag for I/O heavy tests.
@@ -498,7 +498,7 @@ index a1cf538..c04d9e3 100644
 2.45.2
 
 
-From 666d402e3361e08604e5b7ffe4bdb4ed846bfd36 Mon Sep 17 00:00:00 2001
+From 65a73d2ac7eb72a369d73af3446a881b40658395 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sat, 27 Jul 2024 04:51:52 -0300
 Subject: _getuserbase(), getsitepackages(), and INSTALL_SCHEMES for Haiku.
@@ -577,7 +577,7 @@ index 89a81c5..3477bf6 100644
              if sys.platlibdir != "lib":
                  libdirs.append("lib")
 diff --git a/Lib/sysconfig/__init__.py b/Lib/sysconfig/__init__.py
-index ec3b638..e6bbe86 100644
+index 7bcb737..24cb0af 100644
 --- a/Lib/sysconfig/__init__.py
 +++ b/Lib/sysconfig/__init__.py
 @@ -48,6 +48,36 @@ _INSTALL_SCHEMES = {
@@ -714,7 +714,7 @@ index bf53413..80daae7 100644
 2.45.2
 
 
-From 69371788003ea8cacfdac3b4b84fe37dfcefef28 Mon Sep 17 00:00:00 2001
+From 9045cae00dda9b2a95df757c73d16a6de7ba2aed Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Mon, 12 Feb 2024 08:39:38 -0300
 Subject: Fix location of REPL's history file.
@@ -753,7 +753,7 @@ index 3477bf6..cfd4e49 100644
 2.45.2
 
 
-From 8441eae6b0dc39ed2dbd2042e96e65553e6c2086 Mon Sep 17 00:00:00 2001
+From 6e04400130cf2c45057adfb8632e05b8bcad4dfe Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 8 Oct 2023 17:02:19 -0300
 Subject: Use spawn instead of fork for multiprocessing.
@@ -806,7 +806,7 @@ index de8a264..02a301e 100644
 2.45.2
 
 
-From ff34d5fc9aba3529e5663524a8be683dee64597f Mon Sep 17 00:00:00 2001
+From f43d869f24911e4cc8feae8d58f64cc8221d6cd9 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 10 Dec 2023 19:50:22 -0300
 Subject: Miscellaneous "Lib/test/" fixes for Haiku.
@@ -846,7 +846,7 @@ index 0611d17..ce7c87d 100644
 2.45.2
 
 
-From 61910a330dad56e9371b5cd60f5f8d5a027111e2 Mon Sep 17 00:00:00 2001
+From b16f098ff737977d58c900b4c84540ed573843d7 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Mon, 12 Feb 2024 10:50:34 -0300
 Subject: Fix build on nightlies, following the addition of kqueue.
@@ -912,7 +912,7 @@ index 5bd9b77..88e29a4 100644
 2.45.2
 
 
-From 0460e4a82df9299e97aecaae76e0f0674875e681 Mon Sep 17 00:00:00 2001
+From 5009cfba6798c0ea4499f676bdcbd006d53d0e23 Mon Sep 17 00:00:00 2001
 From: Alexander von Gluck IV <kallisti5@unixzen.com>
 Date: Thu, 14 Mar 2024 12:54:33 -0500
 Subject: config.guess: Update to universal haiku arch guessing
@@ -942,7 +942,7 @@ index e81d3ae..366429c 100755
 2.45.2
 
 
-From 61f60797b4daad8bda46fa207e44a78bb1e6b0d0 Mon Sep 17 00:00:00 2001
+From d8a155ab052cb6794e6cd268a62262f198ab7ea4 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 9 Aug 2024 13:38:28 -0300
 Subject: fix test_utf8_mode.
@@ -965,7 +965,7 @@ index f668810..a55a8e4 100644
 2.45.2
 
 
-From 9b4391f96d34fde5979575ff6c8783aeba6a21a8 Mon Sep 17 00:00:00 2001
+From 538c632f81e8d62b9b9e68f9231eafd48c5b7888 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 9 Aug 2024 14:35:04 -0300
 Subject: Fix test_site.
@@ -1055,7 +1055,7 @@ index 2df17b9..332063b 100644
 2.45.2
 
 
-From 7304af9e5a5dd2f6a5fb7f367db6ff712cc18acf Mon Sep 17 00:00:00 2001
+From fb5a29ef37d19d646dde05db259802747b94d179 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 9 Aug 2024 15:37:13 -0300
 Subject: Fix test_sysconfig.
@@ -1098,7 +1098,7 @@ index 80daae7..5194c47 100644
 2.45.2
 
 
-From 3517fc45c182c10aeee265cdd99b01a977bc5aac Mon Sep 17 00:00:00 2001
+From 9501c1a9f4f4b89670a92c36404e9116f2ebbca2 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 29 Sep 2024 03:01:27 -0300
 Subject: Partially fix test_compileall by skipping tests that need hardlink
@@ -1119,10 +1119,10 @@ index 8914059..bfedd2d 100644
  
  
 diff --git a/Lib/test/test_compileall.py b/Lib/test/test_compileall.py
-index 812ff5e..834474b 100644
+index 21ecebc..632fc1c 100644
 --- a/Lib/test/test_compileall.py
 +++ b/Lib/test/test_compileall.py
-@@ -946,6 +946,7 @@ class CommandLineTestsBase:
+@@ -947,6 +947,7 @@ class CommandLineTestsBase:
          # only for more than one optimization level
          self.assertRunNotOK(self.directory, "-o 1", "--hardlink-dupes")
  
@@ -1134,7 +1134,7 @@ index 812ff5e..834474b 100644
 2.45.2
 
 
-From c1bc7f41c445834aa126df4ddb539ddf9167ebbf Mon Sep 17 00:00:00 2001
+From 15562f756b5cca4e47859d90a0bb9881c5b7649f Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Thu, 9 May 2024 15:16:26 -0300
 Subject: Fix 3.13.0 build.
@@ -1147,7 +1147,7 @@ Previous Python versions had both the time out and the "|| true".
 Some of the test run in that PGO stage sadly still fail on Haiku.
 
 diff --git a/Makefile.pre.in b/Makefile.pre.in
-index 300f4c2..fdbb877 100644
+index 1e4122d..6c9a2ef 100644
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
 @@ -752,7 +752,7 @@ profile-run-stamp:
@@ -1185,14 +1185,14 @@ index 4d3fb65..be95e7d 100644
 2.45.2
 
 
-From d74c91e332059ee3672703f7b7d9d195f26f20c9 Mon Sep 17 00:00:00 2001
+From 11cf4f8dda81d2463aa3483367ae0e36e4dcfb3e Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sat, 5 Oct 2024 07:32:17 -0300
 Subject: Avoid forcing "-g" on LTO builds, unless Py_DEBUG is defined.
 
 
 diff --git a/configure.ac b/configure.ac
-index f77214b..27003df 100644
+index 8e54330..e197041 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -2069,7 +2069,9 @@ if test "$Py_LTO" = 'true' ; then

--- a/dev-lang/python/python3.13-3.13.2.recipe
+++ b/dev-lang/python/python3.13-3.13.2.recipe
@@ -10,10 +10,10 @@ Python is free to use, even for commercial products, because of its \
 OSI-approved open source license."
 HOMEPAGE="https://www.python.org"
 LICENSE="Python"
-COPYRIGHT="1990-2024 Python Software Foundation"
+COPYRIGHT="1990-2025 Python Software Foundation"
 REVISION="1"
 SOURCE_URI="https://www.python.org/ftp/python/$portVersion/Python-$portVersion.tar.xz"
-CHECKSUM_SHA256="9cf9427bee9e2242e3877dd0f6b641c1853ca461f39d6503ce260a59c80bf0d9"
+CHECKSUM_SHA256="d984bcc57cd67caab26f7def42e523b1c015bbc5dc07836cf4f0b63fa159eb56"
 SOURCE_DIR="Python-$portVersion"
 
 pyShortVer="${portVersion%.*}"


### PR DESCRIPTION
Only smoke-tested on 64 bits beta5.