### PR TITLE
brotli: minor clean up, drop Python 3.9.

### DIFF
--- a/app-arch/brotli/brotli-1.1.0.recipe
+++ b/app-arch/brotli/brotli-1.1.0.recipe
@@ -7,7 +7,7 @@ methods. It is similar in speed with deflate but offers more dense compression."
 HOMEPAGE="https://github.com/google/brotli"
 COPYRIGHT="2009, 2010, 2013-2023 Brotli Authors"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/google/brotli/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="e720a6ca29428b803f4ad165371771f5398faba397edf6778837a18599ea13ff"
 SOURCE_FILENAME="brotli-$portVersion.tar.gz"
@@ -54,18 +54,18 @@ BUILD_PREREQUIRES="
 	cmd:make
 	"
 
-PYTHON_PACKAGES+=(python310)
 PYTHON_VERSIONS+=(3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_${pythonPackage}=\"
 		${portName}_$pythonPackage = $portVersion
 		\""
 	eval "REQUIRES_$pythonPackage=\"
 		haiku$secondaryArchSuffix
-		lib:libpython$pythonVersion$secondaryArchSuffix
+		cmd:python$pythonVersion
 		\""
 	BUILD_REQUIRES+="
 		setuptools_$pythonPackage
@@ -74,7 +74,6 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 		cmd:python$pythonVersion
 		"
 done
-
 
 BUILD()
 {
@@ -89,21 +88,19 @@ BUILD()
 	make -C build $jobArgs
 }
 
-
 INSTALL()
 {
 	make -C build install
 
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
 
 		mkdir -p $installLocation
-		rm -rf build
 
 		$python setup.py build install \
 			--root=/ --prefix=$prefix
@@ -124,14 +121,14 @@ INSTALL()
 		"$developDir"
 }
 
-
 TEST()
 {
-
-	for i in "${!PYTHON_PACKAGES[@]}"; do
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
 
 		python=python$pythonVersion
 		$python setup.py test
 	done
+
+	ctest --test-dir build --output-on-failure
 }


### PR DESCRIPTION
As current TEST() produces no output, tried modifing it in several ways: calling ctest, make -C tests test, etc, etc. Mostly got zero test runs, except once that I got:

> 0% tests passed, 14 tests failed out of 14

but couldn't reproduce :-/

Help on figuring out what's the proper way to execute tests much appreciated.

Smoke tested on beta5 64 bits, both on `python3.10` and with `links` (that requires brotli).

----
UPDATE: fixed silly mistake an now TEST() runs OK.