### PR TITLE
pycurl: recipe cleanups.

### DIFF
--- a/dev-python/pycurl/pycurl-7.45.2.recipe
+++ b/dev-python/pycurl/pycurl-7.45.2.recipe
@@ -10,7 +10,7 @@ COPYRIGHT="2001-2008 Kjetil Jacobsen
 	2013-2018 Oleg Pudeyev"
 LICENSE="GNU LGPL v2.1
 	MIT"
-REVISION="7"
+REVISION="8"
 SOURCE_URI="https://github.com/pycurl/pycurl/archive/REL_${portVersion//./_}.tar.gz"
 CHECKSUM_SHA256="1aaaf415a5affe141593b3edf6ce187a79d99fbeb65c0b18490b03edc606394c"
 SOURCE_DIR="pycurl-REL_${portVersion//./_}"
@@ -38,11 +38,11 @@ BUILD_PREREQUIRES="
 	cmd:make
 	"
 
-PYTHON_PACKAGES=(python310)
 PYTHON_VERSIONS=(3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_${pythonPackage}=\"
 		${portName}_$pythonPackage = $portVersion
@@ -54,15 +54,18 @@ for i in "${!PYTHON_PACKAGES[@]}"; do
 	fi
 	eval "REQUIRES_$pythonPackage=\"
 		haiku$secondaryArchSuffix
+		cmd:python$pythonVersion
 		lib:libcrypto$secondaryArchSuffix
 		lib:libcurl$secondaryArchSuffix
 		lib:libnghttp2$secondaryArchSuffix
-		lib:libpython$pythonVersion$secondaryArchSuffix
 		lib:libssl$secondaryArchSuffix
 		lib:libz$secondaryArchSuffix
 		\""
 	BUILD_REQUIRES+="
+		build_$pythonPackage
+		installer_$pythonPackage
 		setuptools_$pythonPackage
+		wheel_$pythonPackage
 		"
 	BUILD_PREREQUIRES+="
 		cmd:python$pythonVersion
@@ -72,19 +75,14 @@ done
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
-		installLocation="$prefix"/lib/$python/vendor-packages/
-		export PYTHONPATH="$installLocation"
 
-		rm -rf build
-		make PYTHON=$python
-		mkdir -p "$installLocation"
-
-		$python setup.py build install --root=/ --prefix="$prefix"
+		$python -m build --wheel --skip-dependency-check --no-isolation
+		$python -m installer --p $prefix dist/*-$portVersion-*.whl
 
 #		mkdir -p "$docDir"
 #		mv "$prefix"/share/doc/pycurl/* "$docDir"


### PR DESCRIPTION
- Don't REQUIRE libpython, but cmd:python3.xx instead.
- Switch from setup.py to build/intaller.