### PR TITLE
html5_parser: minor cleanups.

### DIFF
--- a/dev-python/html5-parser/html5_parser-0.4.10.recipe
+++ b/dev-python/html5-parser/html5_parser-0.4.10.recipe
@@ -13,7 +13,7 @@ COPYRIGHT="2017 Kovid Goyal
 	2015-2016 Kevin B. Hendricks, Stratford Ontario
 	2008-2009 Bjoern Hoehrmann"
 LICENSE="Apache v2"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/h/html5-parser/html5-parser-$portVersion.tar.gz"
 CHECKSUM_SHA256="f9294418c0da95c2d5facc19d3dc32941093a6b8e3b3e4b36cc7b5a1697fbca4"
 SOURCE_DIR="html5-parser-$portVersion"
@@ -46,16 +46,16 @@ for i in "${!PYTHON_VERSIONS[@]}"; do
 	eval "PROVIDES_$pythonPackage=\"
 		${portName}_$pythonPackage = $portVersion
 		\""
-	if [ "$targetArchitecture" = "x86_gcc2" ]; then
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
 		eval "PROVIDES_$pythonPackage+=\"
 			html5_parser_$pythonPackage = $portVersion
 			\""
 	fi
 	eval "REQUIRES_$pythonPackage=\"
 		haiku$secondaryArchSuffix
+		cmd:python$pythonVersion
 		chardet_$pythonPackage
-		lxml${secondaryArchSuffix}_$pythonPackage
-		lib:libpython$pythonVersion$secondaryArchSuffix
+		lxml_$pythonPackage
 		\""
 
 	BUILD_REQUIRES+="
@@ -65,10 +65,10 @@ for i in "${!PYTHON_VERSIONS[@]}"; do
 		cmd:python$pythonVersion
 		"
 	TEST_REQUIRES+="
-		${portName}_$pythonPackage
+		html5_parser_$pythonPackage
 		beautifulsoup4_$pythonPackage
 		chardet_$pythonPackage
-		lxml${secondaryArchSuffix}_$pythonPackage
+		lxml_$pythonPackage
 		"
 done
 
@@ -116,9 +116,8 @@ INSTALL()
 }
 
 
-
-# Reference results:
-# Ran 28 tests in 1.363s
+# Reference results on beta5 64 bits:
+# Ran 28 tests in 0.578s
 # OK (skipped=1)
 TEST()
 {


### PR DESCRIPTION
- do not REQUIRE libpython3.xx but cmd:python3.xx.
- use suffixless version for lxml_python3xx.