### PR TITLE
cryptography: recipe cleanups.

### DIFF
--- a/dev-python/cryptography/cryptography-3.4.8.recipe
+++ b/dev-python/cryptography/cryptography-3.4.8.recipe
@@ -8,7 +8,7 @@ HOMEPAGE="https://cryptography.io/"
 COPYRIGHT="2013-2020 The cryptography developers"
 LICENSE="Apache v2
 	BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/c/cryptography/cryptography-$portVersion.tar.gz"
 CHECKSUM_SHA256="94cc5ed4ceaefcbe5bf38c8fba6a21fc1d365bb8fb826ea1688e3370b2e24a1c"
 
@@ -34,53 +34,55 @@ BUILD_PREREQUIRES="
 	cmd:rustc$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python310)
 PYTHON_VERSIONS=(3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-pythonPackage=${PYTHON_PACKAGES[i]}
-pythonVersion=${PYTHON_VERSIONS[$i]}
-eval "PROVIDES_$pythonPackage=\"
-	${portName}_$pythonPackage = $portVersion
-	\""
-eval "REQUIRES_$pythonPackage=\"
-	haiku$secondaryArchSuffix
-	asn1crypto_$pythonPackage
-	cffi_$pythonPackage
-	idna_$pythonPackage
-	pyasn1_$pythonPackage
-	six_$pythonPackage
-	lib:libcrypto$secondaryArchSuffix
-	lib:libpython$pythonVersion$secondaryArchSuffix
-	lib:libssl$secondaryArchSuffix
-	\""
-if [ "$targetArchitecture" = "x86_gcc2" ]; then
-	eval "PROVIDES_${pythonPackage}+=\"\n\
-		cryptography_$pythonPackage = $portVersion\
+
+for i in "${!PYTHON_VERSIONS[@]}"; do
+	pythonVersion=${PYTHON_VERSIONS[$i]}
+	pythonPackage=python${pythonVersion//.}
+
+	eval "PROVIDES_$pythonPackage=\"
+		${portName}_$pythonPackage = $portVersion
 		\""
-fi
-BUILD_REQUIRES="$BUILD_REQUIRES
-	pip_$pythonPackage
-	setuptools_$pythonPackage
-	setuptools_rust_$pythonPackage
-	wheel_$pythonPackage
-	"
-BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-	cmd:python$pythonVersion"
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_${pythonPackage}+=\"
+			cryptography_$pythonPackage = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		haiku$secondaryArchSuffix
+		asn1crypto_$pythonPackage
+		cffi_$pythonPackage
+		idna_$pythonPackage
+		pyasn1_$pythonPackage
+		six_$pythonPackage
+		cmd:python$pythonVersion
+		lib:libcrypto$secondaryArchSuffix
+		lib:libssl$secondaryArchSuffix
+		\""
+
+	BUILD_REQUIRES+="
+		build_$pythonPackage
+		installer_$pythonPackage
+		setuptools_$pythonPackage
+		setuptools_rust_$pythonPackage
+		wheel_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
 done
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
+	for i in "${!PYTHON_VERSIONS[@]}"; do
 		pythonVersion=${PYTHON_VERSIONS[$i]}
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
-		installLocation=$prefix/lib/$python/vendor-packages/
-		export PYTHONPATH=$installLocation
-		mkdir -p "$installLocation"
-		$python setup.py build install \
-			--optimize=1 \
-			--root=/ --prefix="$prefix"
+
+		$python -m build --wheel --skip-dependency-check --no-isolation
+		$python -m installer --p $prefix dist/*-$portVersion-*.whl
 
 		packageEntries $pythonPackage \
 			"$prefix"/lib/$python


### PR DESCRIPTION
Do not depend on libpython3.xx.so, but on cmd:python3.xx.

Untested, as I don't have the necessary rust dependencies to build this one.