### PR TITLE
Added recipe for libsdl3

### DIFF
--- a/media-libs/libsdl3/libsdl3-3.2.4.recipe
+++ b/media-libs/libsdl3/libsdl3-3.2.4.recipe
@@ -60,7 +60,7 @@ BUILD()
 INSTALL()
 {
 	ninja -C build install
-	
+
 	rm -rf $dataDir
 
 	sed -i 's,${_IMPORT_PREFIX}/lib',$developLibDir, \

--- a/media-libs/libsdl3/libsdl3-3.2.4.recipe
+++ b/media-libs/libsdl3/libsdl3-3.2.4.recipe
@@ -15,11 +15,11 @@ SOURCE_DIR="SDL3-$portVersion"
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
-libVersion="$portVersion"
+libVersion="0.2.4"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
-    libsdl3$secondaryArchSuffix = $libVersionCompat
+    libsdl3$secondaryArchSuffix = $portVersion compat >= 3.0
     lib:libsdl3$secondaryArchSuffix = $libVersionCompat
     "
 REQUIRES="
@@ -28,7 +28,7 @@ REQUIRES="
     "
 
 PROVIDES_devel="
-    libSDL3${secondaryArchSuffix}_devel = $portVersion
+    libSDL3${secondaryArchSuffix}_devel = $portVersion compat >= 3.0
     devel:libSDL3$secondaryArchSuffix = $libVersionCompat
     devel:libSDL3_test$secondaryArchSuffix = $portVersion
     "
@@ -60,7 +60,7 @@ INSTALL()
 {
     ninja -C build install
 
-    sed -i 's,${_IMPORT_PREFIX}/lib',$developDir, \
+    sed -i 's,${_IMPORT_PREFIX}/lib',$developLibDir, \
         $libDir/cmake/SDL3/SDL3testTargets-release.cmake
 
     # devel package

--- a/media-libs/libsdl3/libsdl3-3.2.4.recipe
+++ b/media-libs/libsdl3/libsdl3-3.2.4.recipe
@@ -60,6 +60,8 @@ BUILD()
 INSTALL()
 {
 	ninja -C build install
+	
+	rm -rf $dataDir
 
 	sed -i 's,${_IMPORT_PREFIX}/lib',$developLibDir, \
 		$libDir/cmake/SDL3/SDL3testTargets-release.cmake

--- a/media-libs/libsdl3/libsdl3-3.2.4.recipe
+++ b/media-libs/libsdl3/libsdl3-3.2.4.recipe
@@ -12,7 +12,7 @@ CHECKSUM_SHA256="2938328317301dfbe30176d79c251733aa5e7ec5c436c800b99ed4da7adcb0f
 SOURCE_DIR="SDL3-$portVersion"
 # PATCHES=""
 
-ARCHITECTURES="all"
+ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
@@ -26,16 +26,17 @@ REQUIRES="
     "
 
 PROVIDES_devel="
-    libsdl3${secondaryArchSuffix}_devel = $portVersion
-    devel:libsdl3$secondaryArchSuffix = 0.200.10 compat >= 0
+    libSDL3${secondaryArchSuffix}_devel = $portVersion
+    devel:libSDL3$secondaryArchSuffix = 0.200.10 compat >= 0
+    devel:libSDL3_test$secondaryArchSuffix = $portVersion
     "
 REQUIRES_devel="
-    libsdl3$secondaryArchSuffix == $portVersion base
+    libSDL3$secondaryArchSuffix == $portVersion base
     "
 
 BUILD_REQUIRES="
     haiku${secondaryArchSuffix}_devel
-    devel:libgl$secondaryArchSuffix
+    devel:libGL$secondaryArchSuffix
     # devel:libglu$secondaryArchSuffix
     "
 BUILD_PREREQUIRES="
@@ -58,12 +59,13 @@ INSTALL()
 {
     ninja -C build install
 
-    rm $libDir/libSDL3_test.a
-    rm $libDir/cmake/SDL3/SDL3testTargets-release.cmake
+    sed -i 's,${_IMPORT_PREFIX}/lib',$developDir/lib, \
+        $libDir/cmake/SDL3/SDL3testTargets-release.cmake
 
     # devel package
     prepareInstalledDevelLibs \
-        libSDL3
+        libSDL3 \
+        libSDL3_test
 
     fixPkgconfig
 

--- a/media-libs/libsdl3/libsdl3-3.2.4.recipe
+++ b/media-libs/libsdl3/libsdl3-3.2.4.recipe
@@ -1,0 +1,74 @@
+SUMMARY="Simple Direct Media Layer 3.0"
+DESCRIPTION="Simple DirectMedia Layer is a cross-platform development library \
+designed to provide low level access to audio, keyboard, mouse, joystick, and \
+graphics hardware via OpenGL and Direct3D. It is used by video playback \
+software, emulators, and popular games."
+HOMEPAGE="https://www.libsdl.org/"
+COPYRIGHT="1997-2024 Sam Lantinga"
+LICENSE="Zlib"
+REVISION="1"
+SOURCE_URI="https://www.libsdl.org/release/SDL3-$portVersion.tar.gz"
+CHECKSUM_SHA256="2938328317301dfbe30176d79c251733aa5e7ec5c436c800b99ed4da7adcb0f0"
+SOURCE_DIR="SDL3-$portVersion"
+# PATCHES=""
+
+ARCHITECTURES="all"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+    libsdl3$secondaryArchSuffix = $portVersion compat >= 3.0
+    lib:libsdl3$secondaryArchSuffix = 0.200.4 compat >= 0
+    "
+REQUIRES="
+    haiku$secondaryArchSuffix
+    lib:libGL$secondaryArchSuffix
+    # lib:libglu$secondaryArchSuffix
+    "
+
+PROVIDES_devel="
+    libsdl3${secondaryArchSuffix}_devel = $portVersion
+    devel:libsdl3$secondaryArchSuffix = 0.200.10 compat >= 0
+    "
+REQUIRES_devel="
+    libsdl3$secondaryArchSuffix == $portVersion base
+    "
+
+BUILD_REQUIRES="
+    haiku${secondaryArchSuffix}_devel
+    devel:libgl$secondaryArchSuffix
+    # devel:libglu$secondaryArchSuffix
+    "
+BUILD_PREREQUIRES="
+    cmd:cmake
+    cmd:gcc$secondaryArchSuffix
+    cmd:ld$secondaryArchSuffix
+    cmd:ninja
+    cmd:pkg_config$secondaryArchSuffix
+    "
+
+BUILD()
+{
+    cmake . -Bbuild -GNinja $cmakeDirArgs \
+        -DSDL_STATIC=OFF \
+        -DCMAKE_BUILD_TYPE=Release
+    ninja -C build
+}
+
+INSTALL()
+{
+    ninja -C build install
+
+    rm $libDir/libSDL3_test.a
+    rm $libDir/cmake/SDL3/SDL3testTargets-release.cmake
+
+    # devel package
+    prepareInstalledDevelLibs \
+        libSDL3
+
+    fixPkgconfig
+
+    packageEntries devel \
+        $developDir $dataDir $libDir/cmake
+
+    rm -rf $prefix/bin
+}

--- a/media-libs/libsdl3/libsdl3-3.2.4.recipe
+++ b/media-libs/libsdl3/libsdl3-3.2.4.recipe
@@ -4,7 +4,7 @@ designed to provide low level access to audio, keyboard, mouse, joystick, and \
 graphics hardware via OpenGL and Direct3D. It is used by video playback \
 software, emulators, and popular games."
 HOMEPAGE="https://www.libsdl.org/"
-COPYRIGHT="1997-2024 Sam Lantinga"
+COPYRIGHT="1997-2025 Sam Lantinga"
 LICENSE="Zlib"
 REVISION="1"
 SOURCE_URI="https://www.libsdl.org/release/SDL3-$portVersion.tar.gz"
@@ -15,19 +15,21 @@ SOURCE_DIR="SDL3-$portVersion"
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
+libVersion="$portVersion"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
 PROVIDES="
-    libsdl3$secondaryArchSuffix = $portVersion compat >= 3.0
-    lib:libsdl3$secondaryArchSuffix = 0.200.4 compat >= 0
+    libsdl3$secondaryArchSuffix = $libVersionCompat
+    lib:libsdl3$secondaryArchSuffix = $libVersionCompat
     "
 REQUIRES="
     haiku$secondaryArchSuffix
     lib:libGL$secondaryArchSuffix
-    # lib:libglu$secondaryArchSuffix
     "
 
 PROVIDES_devel="
     libSDL3${secondaryArchSuffix}_devel = $portVersion
-    devel:libSDL3$secondaryArchSuffix = 0.200.10 compat >= 0
+    devel:libSDL3$secondaryArchSuffix = $libVersionCompat
     devel:libSDL3_test$secondaryArchSuffix = $portVersion
     "
 REQUIRES_devel="
@@ -37,7 +39,6 @@ REQUIRES_devel="
 BUILD_REQUIRES="
     haiku${secondaryArchSuffix}_devel
     devel:libGL$secondaryArchSuffix
-    # devel:libglu$secondaryArchSuffix
     "
 BUILD_PREREQUIRES="
     cmd:cmake
@@ -59,7 +60,7 @@ INSTALL()
 {
     ninja -C build install
 
-    sed -i 's,${_IMPORT_PREFIX}/lib',$developDir/lib, \
+    sed -i 's,${_IMPORT_PREFIX}/lib',$developDir, \
         $libDir/cmake/SDL3/SDL3testTargets-release.cmake
 
     # devel package

--- a/media-libs/libsdl3/libsdl3-3.2.4.recipe
+++ b/media-libs/libsdl3/libsdl3-3.2.4.recipe
@@ -10,7 +10,7 @@ REVISION="1"
 SOURCE_URI="https://www.libsdl.org/release/SDL3-$portVersion.tar.gz"
 CHECKSUM_SHA256="2938328317301dfbe30176d79c251733aa5e7ec5c436c800b99ed4da7adcb0f0"
 SOURCE_DIR="SDL3-$portVersion"
-# PATCHES=""
+PATCHES="libsdl3-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -19,59 +19,66 @@ libVersion="0.2.4"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
-    libsdl3$secondaryArchSuffix = $portVersion compat >= 3.0
-    lib:libsdl3$secondaryArchSuffix = $libVersionCompat
-    "
+	libsdl3$secondaryArchSuffix = $portVersion compat >= 3.0
+	lib:libsdl3$secondaryArchSuffix = $libVersionCompat
+	"
 REQUIRES="
-    haiku$secondaryArchSuffix
-    lib:libGL$secondaryArchSuffix
-    "
+	haiku$secondaryArchSuffix
+	lib:libGL$secondaryArchSuffix
+	"
 
 PROVIDES_devel="
-    libSDL3${secondaryArchSuffix}_devel = $portVersion compat >= 3.0
-    devel:libSDL3$secondaryArchSuffix = $libVersionCompat
-    devel:libSDL3_test$secondaryArchSuffix = $portVersion
-    "
+	libSDL3${secondaryArchSuffix}_devel = $portVersion compat >= 3.0
+	devel:libSDL3$secondaryArchSuffix = $libVersionCompat
+	devel:libSDL3_test$secondaryArchSuffix = $portVersion
+	"
 REQUIRES_devel="
-    libSDL3$secondaryArchSuffix == $portVersion base
-    "
+	libSDL3$secondaryArchSuffix == $portVersion base
+	"
 
 BUILD_REQUIRES="
-    haiku${secondaryArchSuffix}_devel
-    devel:libGL$secondaryArchSuffix
-    "
+	haiku${secondaryArchSuffix}_devel
+	devel:libGL$secondaryArchSuffix
+	"
 BUILD_PREREQUIRES="
-    cmd:cmake
-    cmd:gcc$secondaryArchSuffix
-    cmd:ld$secondaryArchSuffix
-    cmd:ninja
-    cmd:pkg_config$secondaryArchSuffix
-    "
+	cmd:cmake
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:ninja
+	cmd:pkg_config$secondaryArchSuffix
+	"
 
 BUILD()
 {
-    cmake . -Bbuild -GNinja $cmakeDirArgs \
-        -DSDL_STATIC=OFF \
-        -DCMAKE_BUILD_TYPE=Release
-    ninja -C build
+	cmake . -Bbuild -GNinja $cmakeDirArgs \
+		-DSDL_STATIC=OFF \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DSDL_TESTS=ON
+	ninja -C build
 }
 
 INSTALL()
 {
-    ninja -C build install
+	ninja -C build install
 
-    sed -i 's,${_IMPORT_PREFIX}/lib',$developLibDir, \
-        $libDir/cmake/SDL3/SDL3testTargets-release.cmake
+	sed -i 's,${_IMPORT_PREFIX}/lib',$developLibDir, \
+		$libDir/cmake/SDL3/SDL3testTargets-release.cmake
 
-    # devel package
-    prepareInstalledDevelLibs \
-        libSDL3 \
-        libSDL3_test
+	# devel package
+	prepareInstalledDevelLibs \
+		libSDL3 \
+		libSDL3_test
 
-    fixPkgconfig
+	fixPkgconfig
 
-    packageEntries devel \
-        $developDir $dataDir $libDir/cmake
+	packageEntries devel \
+		$developDir \
+		$libDir/cmake
 
-    rm -rf $prefix/bin
+	rm -rf $prefix/bin
+}
+
+TEST()
+{
+	ctest --test-dir build
 }

--- a/media-libs/libsdl3/libsdl3-3.2.4.recipe
+++ b/media-libs/libsdl3/libsdl3-3.2.4.recipe
@@ -20,7 +20,7 @@ libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
 	libsdl3$secondaryArchSuffix = $portVersion compat >= 3.0
-	lib:libsdl3$secondaryArchSuffix = $libVersionCompat
+	lib:libSDL3$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -28,12 +28,12 @@ REQUIRES="
 	"
 
 PROVIDES_devel="
-	libSDL3${secondaryArchSuffix}_devel = $portVersion compat >= 3.0
+	libsdl3${secondaryArchSuffix}_devel = $portVersion compat >= 3.0
 	devel:libSDL3$secondaryArchSuffix = $libVersionCompat
 	devel:libSDL3_test$secondaryArchSuffix = $portVersion
 	"
 REQUIRES_devel="
-	libSDL3$secondaryArchSuffix == $portVersion base
+	libsdl3$secondaryArchSuffix == $portVersion base
 	"
 
 BUILD_REQUIRES="
@@ -74,8 +74,6 @@ INSTALL()
 	packageEntries devel \
 		$developDir \
 		$libDir/cmake
-
-	rm -rf $prefix/bin
 }
 
 TEST()

--- a/media-libs/libsdl3/patches/libsdl3-3.2.4.patchset
+++ b/media-libs/libsdl3/patches/libsdl3-3.2.4.patchset
@@ -1,0 +1,61 @@
+From d5153b1709cd05a669974bea1a6e835d9853fe55 Mon Sep 17 00:00:00 2001
+From: "Ryan C. Gordon" <icculus@icculus.org>
+Date: Wed, 12 Feb 2025 17:17:14 -0500
+Subject: haiku: Fixed keyboard input.
+
+_GetWinID() doesn't work with keyboard-related BMessages, because Haiku
+assumes you know what window has keyboard focus at the time, so these events
+don't have a `window-id` property. So when this call failed, the key event
+handler would return early.
+
+This was probably a copy/paste error that snuck in at some point, as SDL2
+doesn't have this issue.
+
+diff --git a/src/core/haiku/SDL_BApp.h b/src/core/haiku/SDL_BApp.h
+index b13b9e6..cbd3e3a 100644
+--- a/src/core/haiku/SDL_BApp.h
++++ b/src/core/haiku/SDL_BApp.h
+@@ -293,12 +293,9 @@ class SDL_BLooper : public BLooper
+ 
+     void _HandleKey(BMessage *msg)
+     {
+-        SDL_Window *win;
+-        int32 winID;
+         int32 scancode;
+-		bool down;
++        bool down;
+         if (
+-            !_GetWinID(msg, &winID) ||
+             msg->FindInt32("key-scancode", &scancode) != B_OK ||
+             msg->FindBool("key-down", &down) != B_OK) {
+             return;
+@@ -306,15 +303,17 @@ class SDL_BLooper : public BLooper
+ 
+         SDL_SendKeyboardKey(0, SDL_DEFAULT_KEYBOARD_ID, scancode, HAIKU_GetScancodeFromBeKey(scancode), down);
+ 
+-        win = GetSDLWindow(winID);
+-        if (down && SDL_TextInputActive(win)) {
+-            const int8 *keyUtf8;
+-            ssize_t count;
+-            if (msg->FindData("key-utf8", B_INT8_TYPE, (const void **)&keyUtf8, &count) == B_OK) {
+-                char text[64];
+-                SDL_zeroa(text);
+-                SDL_memcpy(text, keyUtf8, count);
+-                SDL_SendKeyboardText(text);
++        if (down) {
++            SDL_Window *win = SDL_GetKeyboardFocus();
++            if (win && SDL_TextInputActive(win)) {
++                const int8 *keyUtf8;
++                ssize_t count;
++                if (msg->FindData("key-utf8", B_INT8_TYPE, (const void **)&keyUtf8, &count) == B_OK) {
++                    char text[64];
++                    SDL_zeroa(text);
++                    SDL_memcpy(text, keyUtf8, count);
++                    SDL_SendKeyboardText(text);
++                }
+             }
+         }
+     }
+-- 
+2.45.2
+


### PR DESCRIPTION
I have added the initial recipe for libsdl3. The recipe is basically taken from the SDL2 recipe. Things related to SDL2main, sdl2-config and SDL2-2.0 are gone since they are not relevant for SDL3. SDL_main is now a header only library and there is no sdl3-config as now pkg-config provides everything (I hope a fixPkgconfig suffices for that).

Known issues:
1. ~~I have only tested in a VM but keyboard related events don't seem to be registered (I will look into this).~~

I have run the tests to check for issues but I think they don't cover all the subsystems well so some more thorough testing of the various subsystems is needed.