### PR TITLE
lapack: disable cblas, make lapack.pc require openblas.pc.

### DIFF
--- a/sci-libs/lapack/lapack-3.10.0.recipe
+++ b/sci-libs/lapack/lapack-3.10.0.recipe
@@ -4,7 +4,7 @@ the most commonly occurring problems in numerical linear algebra."
 HOMEPAGE="http://www.netlib.org/lapack/"
 COPYRIGHT="1992-2021 The LAPACK Project"
 LICENSE="BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/Reference-LAPACK/lapack/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="328c1bea493a32cac5257d84157dc686cc3ab0b004e2bea22044e0a59f6f8a19"
 SOURCE_DIR="lapack-$portVersion"
@@ -19,7 +19,7 @@ PROVIDES="
 	lapack$secondaryArchSuffix = $portVersion
 	lib:liblapack$secondaryArchSuffix = $libVersionCompat
 	lib:liblapacke$secondaryArchSuffix = $libVersionCompat
-	lib:libcblas$secondaryArchSuffix = $libVersionCompat
+#	lib:libcblas$secondaryArchSuffix = $libVersionCompat
 	lib:libtmglib$secondaryArchSuffix = $portVersion
 	"
 REQUIRES="
@@ -33,7 +33,7 @@ PROVIDES_devel="
 	lapack${secondaryArchSuffix}_devel = $portVersion
 	devel:liblapack$secondaryArchSuffix = $libVersionCompat
 	devel:liblapacke$secondaryArchSuffix = $libVersionCompat
-	devel:libcblas$secondaryArchSuffix = $libVersionCompat
+#	devel:libcblas$secondaryArchSuffix = $libVersionCompat
 	devel:libtmglib$secondaryArchSuffix = $portVersion
 	"
 REQUIRES_devel="
@@ -58,26 +58,29 @@ TEST_REQUIRES="
 	cmd:python3
 	"
 
-defineDebugInfoPackage lapack$secondaryArchSuffix \
-	"$libDir"/liblapack.so.$libVersion \
-	"$libDir"/liblapacke.so.$libVersion \
-	"$libDir"/libtmglib.so.$libVersion \
-	"$libDir"/libcblas.so.$libVersion
+releaseType="Release"
+if [ $releaseType = "RelWithDebInfo" ]; then
+	defineDebugInfoPackage lapack$secondaryArchSuffix \
+		"$libDir"/liblapack.so.$libVersion \
+		"$libDir"/liblapacke.so.$libVersion \
+		"$libDir"/libtmglib.so.$libVersion
+	#	"$libDir"/libcblas.so.$libVersion
+fi
 
 BUILD()
 {
 	rm -rf build
 	cmake -B build -S . \
 		$cmakeDirArgs \
-		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_BUILD_TYPE=$releaseType \
 		-DCMAKE_Fortran_USE_RESPONSE_FILE_FOR_OBJECTS=1 \
 		-DCMAKE_Fortran_USE_RESPONSE_FILE_FOR_INCLUDES=1 \
 		-DUSE_OPTIMIZED_BLAS=ON \
 		-DBUILD_SHARED_LIBS=ON \
 		-DLAPACKE_WITH_TMG=ON \
-		-DCBLAS=ON \
 		-DBUILD_TESTING=ON \
 		-DBUILD_DEPRECATED=ON
+#		-DCBLAS=ON
 
 	cmake --build build $jobArgs
 }
@@ -88,13 +91,17 @@ INSTALL()
 
 	prepareInstalledDevelLibs liblapack \
 		liblapacke \
-		libcblas \
 		libtmglib
+#		libcblas
 
-	sed  -i "1i prefix=$prefix" \
-		$libDir/pkgconfig/cblas.pc \
+	sed -i "1i prefix=$prefix" \
 		$libDir/pkgconfig/lapack.pc \
 		$libDir/pkgconfig/lapacke.pc
+#		$libDir/pkgconfig/cblas.pc
+
+	# Make sure lapack.pc points to an existent .pc file.
+	sed -e "s/Requires.private: blas/Requires.private: openblas/" -i \
+		$libDir/pkgconfig/lapack.pc
 
 	fixPkgconfig
 
@@ -103,6 +110,10 @@ INSTALL()
 		$libDir/cmake
 }
 
+# Reference results on hrev57937+129 (64 bits, VMware):
+# 100% tests passed, 0 tests failed out of 94
+# Total Test time (real) = 1671.18 sec
+# (on a Phenom II X4 @ 2.8 GHz).
 TEST()
 {
 	cd build


### PR DESCRIPTION
We're making lapack rely on OpenBLAS's implementaiton of BLAS... and the latter already provides its own "cblas".

Unless we make the _devel package conflict with one another, we better disable cblas here.

Also: `lapack.pc` still referenced a "blas" .pc file (as would be the case if we wre using the lapack-provided BLAS).

Changing that to point to openblas.pc instead fixes the meson-based build of `scipy` (and with no missing symbols at runtime).

Fixes #11784.