### PR TITLE
pygame: drop spurious cmd:cython dependency.

### DIFF
--- a/dev-python/pygame/pygame-2.0.0.recipe
+++ b/dev-python/pygame/pygame-2.0.0.recipe
@@ -8,7 +8,7 @@ COPYRIGHT="2000-2004, 2007 Pete Shinners
 	2007 Richard Goedeken
 	2007-2008 Marcus von Appen"
 LICENSE="GNU LGPL v2.1"
-REVISION="6"
+REVISION="7"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/p/pygame/pygame-$portVersion.tar.gz"
 CHECKSUM_SHA256="63b038da116a643046181b02173fd894d87d2f85ecfd6aa7d5ece73c6ef501e9"
 SOURCE_DIR="pygame-$portVersion"
@@ -51,7 +51,6 @@ for i in "${!PYTHON_VERSIONS[@]}"; do
 	eval "REQUIRES_$pythonPackage=\"
 		haiku$secondaryArchSuffix
 		numpy_$pythonPackage
-		cmd:cython$pythonVersion
 		cmd:python$pythonVersion
 		lib:libfreetype$secondaryArchSuffix
 		lib:libjpeg$secondaryArchSuffix
@@ -78,7 +77,9 @@ for i in "${!PYTHON_VERSIONS[@]}"; do
 		devel:libsmpeg_0.4
 		"
 	BUILD_PREREQUIRES="
-		cmd:cython$pythonVersion
+		# cython is only really needed if the .pyx files need to be recompiled
+		# (the tarball already includes the generated .c files).
+		# cmd:cython$pythonVersion
 		cmd:gcc$secondaryArchSuffix
 		cmd:python$pythonVersion
 		cmd:pkg_config$secondaryArchSuffix


### PR DESCRIPTION
AFAICS, cython is only used by upstream devs to turn some cython code into .c files (that are already included in the tarball we use).

(Tested with the 3 on-tree games that require pygame. All work without cython).

Side note: numpy dep is documented as "optional", so we may want to remove that REQUIRES from this package, and just add it on packages that use that "extra" functionality.

PyGame's README.rst says:

"The surfarray module requires the Python NumPy package for its multidimensional numeric arrays.".