### PR TITLE
spice: update to version 0.15.2.

### DIFF
--- a/app-emulation/spice/patches/spice-0.15.2.patchset
+++ b/app-emulation/spice/patches/spice-0.15.2.patchset
@@ -1,11 +1,11 @@
-From 2a354edfed18050de1ce406717a42fbf470a7d28 Mon Sep 17 00:00:00 2001
+From 1a8a8f70d8ff96038a7d5006b8d77c3486dc5664 Mon Sep 17 00:00:00 2001
 From: Han Pengfei <pengphei@qq.com>
 Date: Sun, 16 Oct 2022 01:21:46 +0000
 Subject: fix meson build
 
 
 diff --git a/meson.build b/meson.build
-index ef8b41a..be8fb23 100644
+index ab05fa5..e01509b 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -106,9 +106,11 @@ foreach dep : ['libjpeg', 'zlib']
@@ -24,17 +24,17 @@ index ef8b41a..be8fb23 100644
    foreach dep : ['ws2_32', 'shlwapi']
      spice_server_deps += compiler.find_library(dep)
 -- 
-2.37.3
+2.48.1
 
 
-From 0347fdb35895a0cdb3355280e6758842e8cd6740 Mon Sep 17 00:00:00 2001
+From 65d99279769a64db129fd8f09688f5293854045c Mon Sep 17 00:00:00 2001
 From: Han Pengfei <pengphei@qq.com>
 Date: Sun, 16 Oct 2022 02:21:30 +0000
 Subject: disable doxygen
 
 
 diff --git a/meson.build b/meson.build
-index be8fb23..e0ef1c1 100644
+index e01509b..7fc71ce 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -234,4 +234,4 @@ endif
@@ -44,17 +44,17 @@ index be8fb23..e0ef1c1 100644
 -run_target('doxy', command : './doxygen.sh')
 +#run_target('doxy', command : './doxygen.sh')
 -- 
-2.37.3
+2.48.1
 
 
-From 9267973c12021acaa71b490619ca1e043e6d0024 Mon Sep 17 00:00:00 2001
+From 6442b28c38dcfe3d37980ddc761ae32f04d09b05 Mon Sep 17 00:00:00 2001
 From: Han Pengfei <pengphei@qq.com>
 Date: Sun, 16 Oct 2022 02:32:46 +0000
 Subject: Fix SUN_LEN missing
 
 
 diff --git a/server/reds.cpp b/server/reds.cpp
-index 5e9a129..7055ccc 100644
+index 56b7709..4bf72f6 100644
 --- a/server/reds.cpp
 +++ b/server/reds.cpp
 @@ -82,6 +82,11 @@
@@ -70,10 +70,10 @@ index 5e9a129..7055ccc 100644
  
  static void reds_client_monitors_config(RedsState *reds, VDAgentMonitorsConfig *monitors_config);
 -- 
-2.37.3
+2.48.1
 
 
-From c7d147ca5c3ca91305dbf01e804626c5baecb21e Mon Sep 17 00:00:00 2001
+From bdb7a1ad27ef7eaa822f19edc99f2da52117952a Mon Sep 17 00:00:00 2001
 From: Han Pengfei <pengphei@qq.com>
 Date: Sun, 16 Oct 2022 02:36:23 +0000
 Subject: fix missing pthread_setname_np
@@ -93,10 +93,10 @@ index 912b7d5..bfc11d5 100644
  #endif
  
 -- 
-2.37.3
+2.48.1
 
 
-From 61c389486333758969e63cd70b7077b0e4afc838 Mon Sep 17 00:00:00 2001
+From afcec6d6f16774eb04c527121bf20ff5a7007e3e Mon Sep 17 00:00:00 2001
 From: Han Pengfei <pengphei@qq.com>
 Date: Mon, 17 Oct 2022 00:31:35 +0000
 Subject: meson: disable python-checks
@@ -104,7 +104,7 @@ Subject: meson: disable python-checks
 Signed-off-by: Han Pengfei <pengphei@qq.com>
 
 diff --git a/meson.build b/meson.build
-index e0ef1c1..671ae84 100644
+index 7fc71ce..10310e7 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -61,6 +61,7 @@ spice_common = subproject('spice-common',
@@ -116,23 +116,5 @@ index e0ef1c1..671ae84 100644
  spice_server_config_data.merge_from(spice_common.get_variable('spice_common_config_data'))
  spice_server_deps += spice_common.get_variable('spice_common_server_dep')
 -- 
-2.37.3
-
-
-From 1191d7bac318b1f626b455cfb1b0eaf5dd24f92a Mon Sep 17 00:00:00 2001
-From: Han Pengfei <pengphei@qq.com>
-Date: Mon, 17 Oct 2022 12:52:14 +0000
-Subject: Fix meson-dist missing
-
-Signed-off-by: Han Pengfei <pengphei@qq.com>
-
-diff --git a/build-aux/meson-dist b/build-aux/meson-dist
-new file mode 100755
-index 0000000..1a24852
---- /dev/null
-+++ b/build-aux/meson-dist
-@@ -0,0 +1 @@
-+#!/bin/sh
--- 
-2.37.3
+2.48.1
 

--- a/app-emulation/spice/spice-0.15.2.recipe
+++ b/app-emulation/spice/spice-0.15.2.recipe
@@ -5,16 +5,16 @@ These components are used to provide access to a remote machine's display and de
 HOMEPAGE="https://www.spice-space.org/"
 COPYRIGHT="2009 Red Hat, Inc"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://www.spice-space.org/download/releases/spice-server/spice-$portVersion.tar.bz2"
-CHECKSUM_SHA256="ada9af67ab321916bd7eb59e3d619a4a7796c08a28c732edfc7f02fc80b1a37a"
+CHECKSUM_SHA256="6d9eb6117f03917471c4bc10004abecff48a79fb85eb85a1c45f023377015b81"
 SOURCE_DIR="spice-$portVersion"
 PATCHES="spice-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
-libVersion="1.14.2"
+libVersion="1.14.3"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
@@ -24,7 +24,6 @@ PROVIDES="
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libglib_2.0$secondaryArchSuffix
-	#lib:libgstreamer_1.0$secondaryArchSuffix
 	lib:libjpeg$secondaryArchSuffix
 	lib:liblz4$secondaryArchSuffix
 	lib:libopus$secondaryArchSuffix
@@ -47,7 +46,6 @@ REQUIRES_devel="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libglib_2.0$secondaryArchSuffix
-	#devel:libgstreamer_1.0$secondaryArchSuffix
 	devel:libjpeg$secondaryArchSuffix
 	devel:liblz4$secondaryArchSuffix
 	devel:libopus$secondaryArchSuffix
@@ -58,8 +56,9 @@ BUILD_REQUIRES="
 	devel:libX11$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	devel:spice_protocol
-	pyparsing_python39
-	six_python39
+	# These are needed during build, even if we're not shiping spice's python modules.
+	pyparsing_python310
+	six_python310
 	"
 BUILD_PREREQUIRES="
 	cmd:awk
@@ -75,10 +74,6 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	rm -rf build
-
-	chmod +x build-aux/meson/check-spice-common
-
 	export LDFLAGS="-lnetwork -lbsd"
 
 	meson build --buildtype=release \


### PR DESCRIPTION
Builds fine on beta5 64 bits.

Apparently nothing on-tree requires this?