### PR TITLE
libsndfile, bump version

### DIFF
--- a/media-libs/libsndfile/libsndfile-1.2.2.recipe
+++ b/media-libs/libsndfile/libsndfile-1.2.2.recipe
@@ -2,36 +2,29 @@ SUMMARY="C library for reading and writing of sampled sound"
 DESCRIPTION="libsndfile is a library of C routines for reading and writing \
 files containing sampled audio data."
 HOMEPAGE="http://libsndfile.github.io/libsndfile/"
-COPYRIGHT="1999-2021 Erik de Castro Lopo"
+COPYRIGHT="1999-2021 Erik de Castro Lopo
+	2021-current the libsndfile team"
 LICENSE="GNU LGPL v2.1"
-REVISION="4"
+REVISION="1"
 SOURCE_URI="https://github.com/libsndfile/libsndfile/releases/download/$portVersion/libsndfile-$portVersion.tar.xz"
-CHECKSUM_SHA256="0f98e101c0f7c850a71225fb5feaf33b106227b3d331333ddc9bacee190bcf41"
+CHECKSUM_SHA256="3799ca9924d3125038880367bf1468e53a1b7e3686a934f098b7e1d286cdb80e"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
-libVersion="1.0.34"
+libVersion="1.0.37"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
 	libsndfile$secondaryArchSuffix = $portVersion compat >= 1
-	cmd:sndfile_cmp$secondaryArchSuffix
-	cmd:sndfile_concat$secondaryArchSuffix
-	cmd:sndfile_convert$secondaryArchSuffix
-	cmd:sndfile_deinterleave$secondaryArchSuffix
-	cmd:sndfile_info$secondaryArchSuffix
-	cmd:sndfile_interleave$secondaryArchSuffix
-	cmd:sndfile_metadata_get$secondaryArchSuffix
-	cmd:sndfile_metadata_set$secondaryArchSuffix
-	cmd:sndfile_play$secondaryArchSuffix
-	cmd:sndfile_salvage$secondaryArchSuffix
 	lib:libsndfile$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libflac$secondaryArchSuffix
 	lib:libogg$secondaryArchSuffix
+	lib:libmp3lame$secondaryArchSuffix
+	lib:libmpg123$secondaryArchSuffix
 	lib:libopus$secondaryArchSuffix
 	lib:libspeex$secondaryArchSuffix
 	lib:libvorbis$secondaryArchSuffix
@@ -49,9 +42,28 @@ REQUIRES_devel="
 	devel:libvorbis$secondaryArchSuffix
 	"
 
+PROVIDES_tools="
+	libsndfile${secondaryArchSuffix}_tools = $portVersion compat >= 1
+	cmd:sndfile_cmp$secondaryArchSuffix
+	cmd:sndfile_concat$secondaryArchSuffix
+	cmd:sndfile_convert$secondaryArchSuffix
+	cmd:sndfile_deinterleave$secondaryArchSuffix
+	cmd:sndfile_info$secondaryArchSuffix
+	cmd:sndfile_interleave$secondaryArchSuffix
+	cmd:sndfile_metadata_get$secondaryArchSuffix
+	cmd:sndfile_metadata_set$secondaryArchSuffix
+	cmd:sndfile_play$secondaryArchSuffix
+	cmd:sndfile_salvage$secondaryArchSuffix
+	"
+REQUIRES_tools="
+	libsndfile$secondaryArchSuffix == $portVersion base
+	"
+
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libflac$secondaryArchSuffix >= 12
+	devel:libflac$secondaryArchSuffix
+	devel:libmp3lame$secondaryArchSuffix
+	devel:libmpg123$secondaryArchSuffix
 	devel:libogg$secondaryArchSuffix
 	devel:libopus$secondaryArchSuffix
 	devel:libspeex$secondaryArchSuffix
@@ -60,7 +72,6 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	cmd:cmake
 	cmd:gcc$secondaryArchSuffix
-	cmd:ld$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
 	cmd:python3
@@ -71,9 +82,13 @@ BUILD()
 	if [ $effectiveTargetArchitecture = x86_gcc2 ]; then
 		export CFLAGS=-O1
 	fi
-	cmake -Bbuild -S. $cmakeDirArgs \
-		  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-		  -DBUILD_SHARED_LIBS=TRUE
+	cmake -B build -S . -DCMAKE_BUILD_TYPE=Release \
+		$cmakeDirArgs \
+		-DBUILD_SHARED_LIBS=ON \
+		-DBUILD_TESTING=OFF \
+		-DBUILD_EXAMPLES=OFF \
+		-Wno-dev
+
 	make -C build $jobArgs
 }
 
@@ -84,8 +99,20 @@ INSTALL()
 	prepareInstalledDevelLib libsndfile
 	fixPkgconfig
 
+	# tools package
+	packageEntries tools \
+		$binDir \
+		$manDir
+
 	# devel package
 	packageEntries devel \
 		$developDir \
+		$documentationDir \
 		$libDir/cmake
+}
+
+TEST()
+{
+	# to run the tests enable them and disable shared library
+	ctest --test-dir build --output-on-failure
 }


### PR DESCRIPTION
Fixes requirement reported by the buildmasters:
```
requires "devel:libflac >= 12.0.0" of package "libsndfile_devel-1.1.0-4" could not be resolved
```