### PR TITLE
yt_dlp and youtube_dl: cleanup recipes.

### DIFF
--- a/net-misc/youtube_dl/youtube_dl-2021.12.17.recipe
+++ b/net-misc/youtube_dl/youtube_dl-2021.12.17.recipe
@@ -9,12 +9,15 @@ HOMEPAGE="https://ytdl-org.github.io/youtube-dl/index.html
 	https://github.com/ytdl-org/youtube-dl"
 COPYRIGHT="2006-2021 youtube-dl contributors"
 LICENSE="Unlicense"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://github.com/ytdl-org/youtube-dl/releases/download/$portVersion/youtube-dl-$portVersion.tar.gz"
 CHECKSUM_SHA256="9f3b99c8b778455165b4525f21505e86c7ff565f3ac319e19733d810194135df"
 SOURCE_DIR="youtube-dl"
 
 ARCHITECTURES="any"
+
+pythonVersion=3.10
+pythonPackage=python${pythonVersion//.}
 
 PROVIDES="
 	youtube_dl = $portVersion
@@ -23,82 +26,51 @@ PROVIDES="
 REQUIRES="
 	haiku
 	ffmpeg6_tools
-	cmd:python3
+	cmd:python$pythonVersion
+	"
+
+# This recipe was previously built as if it was just a regular Python package recipe,
+# and not as a CLI program that targets a particular Python version.
+REPLACES="
+	youtube_dl_python310
 	"
 
 BUILD_REQUIRES="
 	haiku_devel
+	setuptools_$pythonPackage
 	"
 BUILD_PREREQUIRES="
 	cmd:find
 	cmd:make
+	cmd:python$pythonVersion
 	cmd:zip
 	"
 
-PYTHON_PACKAGES=(python310)
-PYTHON_VERSIONS=(3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
-	pythonVersion=${PYTHON_VERSIONS[$i]}
-	eval "\
-		PROVIDES_${pythonPackage}=\"\n\
-			${portName}_$pythonPackage = $portVersion\n\
-			cmd:youtube_dl_$pythonPackage = $portVersion\n\
-			\"; \
-		REQUIRES_$pythonPackage=\"\n\
-			haiku\n\
-			cmd:python$pythonVersion\n\
-			\"\
-		"
-
-	BUILD_REQUIRES="$BUILD_REQUIRES
-		setuptools_$pythonPackage
-		"
-	BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-		cmd:python$pythonVersion
-		"
-done
-
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
-		pythonVersion=${PYTHON_VERSIONS[$i]}
+	python=python$pythonVersion
+	installLocation="$prefix"/lib/$python/vendor-packages/
+	export PYTHONPATH="$installLocation"
 
-		python=python$pythonVersion
-		installLocation="$prefix"/lib/$python/vendor-packages/
-		export PYTHONPATH="$installLocation"
-		rm -rf build
-		mkdir -p "$installLocation"
-		$python setup.py build install --root=/ --prefix="$prefix"
+	mkdir -p "$installLocation"
+	$python setup.py build install --root=/ --prefix="$prefix"
 
-		rm -rf "$prefix"/share/man
-		mv "$binDir"/youtube-dl "$binDir"/youtube-dl-$pythonPackage
-		packageEntries $pythonPackage \
-			"$prefix"/lib/$python \
-			"$binDir"/youtube-dl-$pythonPackage
+	# Install shell completions:
+	install -d $dataDir/bash-completion/completions
+	cp youtube-dl.bash-completion $dataDir/bash-completion/completions/youtube-dl
+	install -d $dataDir/fish
+	cp youtube-dl.fish $dataDir/fish/
+	install -d $dataDir/zsh/site-functions
+	cp youtube-dl.zsh $dataDir/zsh/site-functions/_youtube-dl
 
-		# Avoid interference between the different python versions, clean any
-		# temporary files. Don't use "make clean" because it also removes
-		# things that we are not able to rebuild (docs need pandoc, for example)
-		rm youtube-dl
-	done
+	# Install man page and Readme:
+	mkdir -p $docDir $manDir
+	mv $prefix/share/man/man1 $manDir
+	mv $prefix/share/doc/youtube_dl/README.txt $docDir
 
-	make install PREFIX="$prefix" MANDIR="$manDir" SHAREDIR="$dataDir" \
-		PYTHON="/system/bin/python3"
-	install -d "$dataDir"/bash-completion "$docDir"
-	mv "$prefix"/share/doc/youtube_dl/README.txt "$docDir"
-
-	# We now have two identical files in $prefix/etc/bash_completion.d/
-	# Let's drop "youtube-dl.bash-completion" and keep "youtube-dl".
-	rm -f "$prefix"/etc/bash_completion.d/youtube-dl.bash-completion
-
-	# We need "youtube-dl" in "$dataDir/bash-completion/completions/".
-	mv "$prefix"/etc/bash_completion.d "$dataDir"/bash-completion/completions
-
-	mv "$prefix"/etc/fish "$dataDir"
-	cd "$prefix"
-	rmdir -p etc share/doc/youtube_dl
+	# Remove left over cruft:
+	rm -rf $prefix/etc
+	rm -rf $prefix/share
 }
 
 TEST()

--- a/net-misc/yt_dlp/yt_dlp-2025.02.19.recipe
+++ b/net-misc/yt_dlp/yt_dlp-2025.02.19.recipe
@@ -9,13 +9,16 @@ to download these videos by itself."
 HOMEPAGE="https://github.com/yt-dlp/yt-dlp"
 COPYRIGHT="2006-2025 youtube-dl and yt-dlp contributors"
 LICENSE="Unlicense"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/yt-dlp/yt-dlp/releases/download/$portVersion/yt-dlp.tar.gz"
 SOURCE_FILENAME="yt-dlp-$portVersion.tar.gz"
 CHECKSUM_SHA256="28a8c33e4c32bd12e16601180b9f3a43fdc2896ad5467bc6e5a9f1fa6c280e28"
 SOURCE_DIR="yt-dlp"
 
 ARCHITECTURES="any"
+
+pythonVersion=3.10
+pythonPackage=python${pythonVersion//.}
 
 PROVIDES="
 	yt_dlp = $portVersion
@@ -24,79 +27,64 @@ PROVIDES="
 REQUIRES="
 	haiku
 	ffmpeg6_tools
-	cmd:python3
+	cmd:python$pythonVersion
+	# These are listed as optional dependencies in yt_dlp's pyproject.toml:
+	# brotli_$pythonPackage
+	# brotlicffi_$pythonPackage
+	# certifi_$pythonPackage
+	# mutagen_$pythonPackage
+	# pycryptodomex_$pythonPackage
+	requests_$pythonPackage			# >=2.32.2,<3
+	# urllib3_$pythonPackage		# >=1.26.17,<3
+	# websockets_$pythonPackage		# >=13.0
+	"
+
+# This recipe was previously built as if it was just a regular Python package recipe,
+# and not as a CLI program that targets a particular Python version.
+REPLACES="
+	yt_dlp_python310
 	"
 
 BUILD_REQUIRES="
 	haiku_devel
+	build_$pythonPackage
+	hatchling_$pythonPackage
+	installer_$pythonPackage
 	"
 BUILD_PREREQUIRES="
 	cmd:find
 	cmd:make
+	cmd:python$pythonVersion
 	cmd:zip
 	"
+TEST_REQUIRES="
+	pytest_$pythonPackage
+	"
 
-PYTHON_PACKAGES=(python310)
-PYTHON_VERSIONS=(3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
-	pythonVersion=${PYTHON_VERSIONS[$i]}
-	eval "\
-		PROVIDES_${pythonPackage}=\"\n\
-			${portName}_$pythonPackage = $portVersion\n\
-			cmd:yt_dlp_$pythonPackage = $portVersion\n\
-			\"; \
-		REQUIRES_$pythonPackage=\"\n\
-			haiku\n\
-			cmd:python$pythonVersion\n\
-			requests_$pythonPackage\n\
-			\"\
-		"
-
-	BUILD_REQUIRES="$BUILD_REQUIRES
-		build_$pythonPackage
-		hatchling_$pythonPackage
-		installer_$pythonPackage
-		"
-	BUILD_PREREQUIRES="$BUILD_PREREQUIRES
-		cmd:python$pythonVersion
-		"
-	TEST_REQUIRES="
-		pytest_$pythonPackage
-		"
-done
+BUILD()
+{
+	python$pythonVersion -m build --wheel --skip-dependency-check --no-isolation
+}
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
-		pythonVersion=${PYTHON_VERSIONS[$i]}
+	python$pythonVersion -m installer -p $prefix dist/*.whl
 
-		python=python$pythonVersion
-		installLocation="$prefix"/lib/$python/vendor-packages/
-		export PYTHONPATH="$installLocation"
-		rm -rf build
-		mkdir -p "$installLocation"
-		$python -m build --wheel --no-isolation
-		$python -m installer -p $prefix dist/*.whl
+	# Install shell completions:
+	mv $prefix/share/bash-completion $dataDir
+	mv $prefix/share/fish $dataDir
+	mv $prefix/share/zsh $dataDir
 
-		rm -rf "$prefix"/share/man
-		mv "$binDir"/yt-dlp "$binDir"/yt-dlp-$pythonPackage
-		packageEntries $pythonPackage \
-			"$prefix"/lib/$python \
-			"$binDir"/yt-dlp-$pythonPackage
-	done
+	# Install man page and Readme:
+	mkdir -p $docDir $manDir
+	mv $prefix/share/man/man1 $manDir
+	mv $prefix/share/doc/yt_dlp/README.txt $docDir
 
-	make install PREFIX="$prefix" MANDIR="$manDir" SHAREDIR="$dataDir" \
-		PYTHON="/system/bin/python3" BINDIR="$binDir" DESTDIR=
-
-	install -d "$dataDir"/bash-completion "$docDir"
-	mv "$prefix"/share/doc/yt_dlp/README.txt "$docDir"
-
-	rm -rf "$prefix"/etc "$prefix"/share
+	# Remove left over cruft:
+	rm -rf $prefix/share
 }
 
 TEST()
 {
-	pytest-3.10 -v -m "not download"
+	pytest-$pythonVersion -v -m "not download"
 }


### PR DESCRIPTION
This gets rid of the `yt_dlp` vs `yt_dlp_python310` and `youtube_dl` vs `youtube_dl_python310` distinction.

We only need one of each (as there's really no need to have, say, `yt_dlp` packages for more than one Python version.

This also switches `/bin/yt-dlp` (and `/bin/youtube-dl`) from a "standalone" program (they were "pyinstaller" bundles), into a small wrapper script that calls yt_dlp's entry point from the Python module installed under vendor-packages.

~Using the "standalone" version stopped making much sense once the `requests_python310` "optional dependency" was added to the recipe.~ (edit: read the logs wrong. requests was added only to `yt_dlp_python310` previously, not to the standalone version).