### PR TITLE
yacreader, force poppler_qt5 package usage

### DIFF
--- a/media-gfx/yacreader/yacreader-9.15.0.recipe
+++ b/media-gfx/yacreader/yacreader-9.15.0.recipe
@@ -18,7 +18,7 @@ number, volumen, authors and more.
 HOMEPAGE="https://www.yacreader.com/"
 COPYRIGHT="2018 Luis Ángel San Martín Rodríguez"
 LICENSE="GNU GPL v3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/YACReader/yacreader/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="d6b3a3e3d0031ff01e43bd943a40e147900c4102a96b6d49d91c0a2cc7a8137a"
 SOURCE_FILENAME="yacreader-$portVersion.tar.gz"
@@ -55,10 +55,10 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	poppler24${secondaryArchSuffix}_qt5_devel
 	devel:libgl$secondaryArchSuffix
 	devel:libglu$secondaryArchSuffix
-	devel:libpoppler$secondaryArchSuffix >= 146
-	devel:libpoppler_qt5$secondaryArchSuffix >= 1.37.0
+	devel:libpoppler$secondaryArchSuffix >= 143
 	devel:libQt5Core$secondaryArchSuffix
 	devel:libQt5Gui$secondaryArchSuffix
 	devel:libQt5Multimedia$secondaryArchSuffix


### PR DESCRIPTION
Both poppler24 and poppler25 provide the same libVersion