### PR TITLE
booksorg, force poppler_qt5 package usage

### DIFF
--- a/app-text/booksorg/booksorg-0.3.recipe
+++ b/app-text/booksorg/booksorg-0.3.recipe
@@ -2,7 +2,7 @@ SUMMARY="A Simple Books Organizer"
 DESCRIPTION="Application to Organize with ease your pdf book"
 COPYRIGHT="2014-2015 Abou Zakaria"
 LICENSE="GNU GPL v3"
-REVISION="6"
+REVISION="7"
 HOMEPAGE="https://sourceforge.net/projects/booksorg/"
 SOURCE_URI="https://downloads.sourceforge.net/booksorg/booksorg_${portVersion/./}.tar.gz"
 SOURCE_DIR="booksorg_${portVersion/./}"
@@ -39,9 +39,9 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	poppler24${secondaryArchSuffix}_qt5_devel
 	devel:libGL$secondaryArchSuffix
-	devel:libpoppler$secondaryArchSuffix >= 146
-	devel:libpoppler_qt5$secondaryArchSuffix
+	devel:libpoppler$secondaryArchSuffix >= 143
 	devel:libQt5Core$secondaryArchSuffix
 	devel:libQt5DBus$secondaryArchSuffix
 	devel:libQt5Gui$secondaryArchSuffix


### PR DESCRIPTION
Both poppler24 and poppler25 provide the same libVersion