### PR TITLE
qpdfview, force poppler_qt5 package usage

### DIFF
--- a/app-text/qpdfview/qpdfview-0.4.18.recipe
+++ b/app-text/qpdfview/qpdfview-0.4.18.recipe
@@ -4,7 +4,7 @@ DjVuLibre, CUPS and Qt, licensed under GPL version 2 or later."
 HOMEPAGE="https://launchpad.net/qpdfview/"
 COPYRIGHT="Adam Reichold et al."
 LICENSE="GNU GPL v2"
-REVISION="7"
+REVISION="8"
 SOURCE_URI="$HOMEPAGE/trunk/$portVersion/+download/qpdfview-$portVersion.tar.gz"
 CHECKSUM_SHA256="cc642e7fa74029373ca9b9fbc29adc4883f8b455130a78ad54746d6844a0396c"
 SOURCE_DIR="qpdfview-$portVersion"
@@ -36,11 +36,11 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	poppler24${secondaryArchSuffix}_qt5_devel
 	devel:libdjvulibre$secondaryArchSuffix
 	devel:libGl$secondaryArchSuffix
 	devel:libmagic$secondaryArchSuffix
 	devel:libpoppler$secondaryArchSuffix >= 143
-	devel:libpoppler_qt5$secondaryArchSuffix
 	devel:libQt5Concurrent$secondaryArchSuffix
 	devel:libQt5Core$secondaryArchSuffix
 	devel:libQt5Gui$secondaryArchSuffix


### PR DESCRIPTION
Both poppler24 and poppler25 provide the same libVersion