### PR TITLE
Litehtml : tentative to port

### DIFF
--- a/dev-libs/litehtml/litehtml-0.9.recipe
+++ b/dev-libs/litehtml/litehtml-0.9.recipe
@@ -1,0 +1,66 @@
+SUMMARY="Lightweight HTML/CSS rendering engine"
+DESCRIPTION="
+Litehtml is lightweight HTML/CSS rendering engine. The main goal of the \
+litehtml library is to give the developers the easy way to show the HTML pages \
+in theirs applications."
+HOMEPAGE="http://www.litehtml.com/"
+COPYRIGHT="2013-2025 Aliaksei Chapyzhenka"
+LICENSE="BSD (2-clause)"
+REVISION="1"
+SOURCE_URI="https://github.com/litehtml/litehtml/archive/refs/tags/v0.9.tar.gz"
+CHECKSUM_SHA256="ef957307da15b1258a70961942840bcf54225a8d75315dcbc156186eba35b1a7"
+PATCHES="litehtml-0.9.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	litehtml$secondaryArchSuffix = $portVersion
+	lib:liblitehtml$secondaryArchSuffix
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+#PROVIDES_devel="
+#	liblitehtml${secondaryArchSuffix}_devel = $portVersion
+#	devel:libgumbo$secondaryArchSuffix
+#	devel:liblitehtml$secondaryArchSuffix
+#	"
+#REQUIRES_devel="
+#	liblitehtml$secondaryArchSuffix == $portVersion base
+#	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake >= 3.0
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	"
+
+BUILD()
+{
+	cmake -Bbuild -S. -DCMAKE_BUILD_TYPE=Release \
+		$cmakeDirArgs \
+		-DCMAKE_INSTALL_INCLUDEDIR=develop/headers \
+		-DCMAKE_INSTALL_PREFIX=$prefix \
+		-DCMAKE_INSTALL_LIBDIR=develop/lib \
+		-DLITEHTML_BUILD_TESTING=OFF
+
+	make -C build $jobArgs
+}
+
+INSTALL()
+{
+	make -C build install
+
+#	prepareInstalledDevelLibs litehtml
+
+#	packageEntries devel \
+#		$developDir \
+#		$libDir/litehtml
+}
+

--- a/dev-libs/litehtml/litehtml-0.9.recipe
+++ b/dev-libs/litehtml/litehtml-0.9.recipe
@@ -59,15 +59,8 @@ INSTALL()
 {
 	make -C build install
 
-	# copy the container for Haiku
-	mkdir -p $includeDir/containers/haiku
-	cp -r $sourceDir/containers/haiku/* $includeDir/containers/haiku/
-
-	# copy the litehtml.h
-	cp $sourceDir/include/litehtml.h $includeDir/
-
-	prepareInstalledDevelLibs liblitehtml \
-		libgumbo
+	prepareInstalledDevelLibs libgumbo \
+		liblitehtml
 
 	packageEntries devel \
 		$developDir \

--- a/dev-libs/litehtml/litehtml-0.9.recipe
+++ b/dev-libs/litehtml/litehtml-0.9.recipe
@@ -59,6 +59,13 @@ INSTALL()
 {
 	make -C build install
 
+	# copy the container for Haiku
+	mkdir -p $includeDir/containers/haiku
+	cp -r $sourceDir/containers/haiku/* $includeDir/containers/haiku/
+
+	# copy the litehtml.h
+	cp $sourceDir/include/litehtml.h $includeDir/
+
 	prepareInstalledDevelLibs liblitehtml \
 		libgumbo
 

--- a/dev-libs/litehtml/litehtml-0.9.recipe
+++ b/dev-libs/litehtml/litehtml-0.9.recipe
@@ -31,7 +31,7 @@ PROVIDES_devel="
 	devel:liblitehtml$secondaryArchSuffix
 	"
 REQUIRES_devel="
-	liblitehtml$secondaryArchSuffix == $portVersion base
+	litehtml$secondaryArchSuffix == $portVersion base
 	"
 
 BUILD_REQUIRES="

--- a/dev-libs/litehtml/litehtml-0.9.recipe
+++ b/dev-libs/litehtml/litehtml-0.9.recipe
@@ -14,6 +14,7 @@ PATCHES="litehtml-0.9.patchset"
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
+libVersion="0.0.0"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
@@ -50,9 +51,6 @@ BUILD()
 		$cmakeDirArgs \
 		-DBUILD_SHARED_LIBS=ON \
 		-DLITEHTML_BUILD_TESTING=OFF
-#		-DCMAKE_INSTALL_INCLUDEDIR=develop/headers \
-#		-DCMAKE_INSTALL_PREFIX=$prefix \
-#		-DCMAKE_INSTALL_LIBDIR=develop/lib \
 
 	make -C build $jobArgs
 }
@@ -61,7 +59,8 @@ INSTALL()
 {
 	make -C build install
 
-	prepareInstalledDevelLibs liblitehtml
+	prepareInstalledDevelLibs liblitehtml \
+		libgumbo
 
 	packageEntries devel \
 		$developDir \

--- a/dev-libs/litehtml/litehtml-0.9.recipe
+++ b/dev-libs/litehtml/litehtml-0.9.recipe
@@ -14,28 +14,31 @@ PATCHES="litehtml-0.9.patchset"
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
 PROVIDES="
 	litehtml$secondaryArchSuffix = $portVersion
+	lib:libgumbo$secondaryArchSuffix
 	lib:liblitehtml$secondaryArchSuffix
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
 	"
 
-#PROVIDES_devel="
-#	liblitehtml${secondaryArchSuffix}_devel = $portVersion
-#	devel:libgumbo$secondaryArchSuffix
-#	devel:liblitehtml$secondaryArchSuffix
-#	"
-#REQUIRES_devel="
-#	liblitehtml$secondaryArchSuffix == $portVersion base
-#	"
+PROVIDES_devel="
+	litehtml${secondaryArchSuffix}_devel = $portVersion
+	devel:libgumbo$secondaryArchSuffix
+	devel:liblitehtml$secondaryArchSuffix
+	"
+REQUIRES_devel="
+	liblitehtml$secondaryArchSuffix == $portVersion base
+	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
-	cmd:cmake >= 3.0
+	cmd:cmake
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
 	cmd:make
@@ -45,10 +48,11 @@ BUILD()
 {
 	cmake -Bbuild -S. -DCMAKE_BUILD_TYPE=Release \
 		$cmakeDirArgs \
-		-DCMAKE_INSTALL_INCLUDEDIR=develop/headers \
-		-DCMAKE_INSTALL_PREFIX=$prefix \
-		-DCMAKE_INSTALL_LIBDIR=develop/lib \
+		-DBUILD_SHARED_LIBS=ON \
 		-DLITEHTML_BUILD_TESTING=OFF
+#		-DCMAKE_INSTALL_INCLUDEDIR=develop/headers \
+#		-DCMAKE_INSTALL_PREFIX=$prefix \
+#		-DCMAKE_INSTALL_LIBDIR=develop/lib \
 
 	make -C build $jobArgs
 }
@@ -57,10 +61,10 @@ INSTALL()
 {
 	make -C build install
 
-#	prepareInstalledDevelLibs litehtml
+	prepareInstalledDevelLibs liblitehtml
 
-#	packageEntries devel \
-#		$developDir \
-#		$libDir/litehtml
+	packageEntries devel \
+		$developDir \
+		$libDir/cmake
 }
 

--- a/dev-libs/litehtml/patches/litehtml-0.9.patchset
+++ b/dev-libs/litehtml/patches/litehtml-0.9.patchset
@@ -1,4 +1,4 @@
-From 69f3c66078254e2419109a35224d4d2d2e90e9c4 Mon Sep 17 00:00:00 2001
+From 2651b01535bb7aa01b07865505fa3a2fe13600bf Mon Sep 17 00:00:00 2001
 From: DigitalBox98 <digitalbox098@gmail.com>
 Date: Wed, 5 Mar 2025 19:47:24 +0000
 Subject: Patch testing part
@@ -89,7 +89,7 @@ index 4c5c7aa..93cc878 100644
 2.45.2
 
 
-From 1cd4b797ea595f12dbb49441f856752c41dfb5cd Mon Sep 17 00:00:00 2001
+From 81cd83747142fc8dc4470cd582996df411394882 Mon Sep 17 00:00:00 2001
 From: DigitalBox98 <digitalbox098@gmail.com>
 Date: Thu, 6 Mar 2025 08:33:51 +0000
 Subject: Fix cmake
@@ -112,7 +112,7 @@ index 595689f..99ccc3e 100644
 2.45.2
 
 
-From 46c7c2dfa65a76055151b4d0707cb638a0a79ee7 Mon Sep 17 00:00:00 2001
+From 63e44a808126be68f6db44533b50e1c683c53f6c Mon Sep 17 00:00:00 2001
 From: DigitalBox98 <digitalbox098@gmail.com>
 Date: Thu, 6 Mar 2025 19:55:01 +0000
 Subject: Fix2 cmake
@@ -158,7 +158,7 @@ index 99ccc3e..abc6d04 100644
 2.45.2
 
 
-From d1831b0dcce682a7b9c7a542b4db9f31f5717122 Mon Sep 17 00:00:00 2001
+From aaece72076f1d7efd5ace908e84e919700cbfb2a Mon Sep 17 00:00:00 2001
 From: DigitalBox98 <digitalbox098@gmail.com>
 Date: Thu, 6 Mar 2025 22:48:41 +0000
 Subject: Fix gumbo
@@ -195,7 +195,7 @@ index 17843c9..1a3954a 100644
 2.45.2
 
 
-From b73a9898e1a6e5e2fcf7dad87a2a791db670764e Mon Sep 17 00:00:00 2001
+From fcfb9357904745b7b1cccad7f7a30baf3922456c Mon Sep 17 00:00:00 2001
 From: DigitalBox98 <digitalbox098@gmail.com>
 Date: Thu, 6 Mar 2025 23:23:29 +0000
 Subject: Fix2 gumbo

--- a/dev-libs/litehtml/patches/litehtml-0.9.patchset
+++ b/dev-libs/litehtml/patches/litehtml-0.9.patchset
@@ -1,0 +1,223 @@
+From 69f3c66078254e2419109a35224d4d2d2e90e9c4 Mon Sep 17 00:00:00 2001
+From: DigitalBox98 <digitalbox098@gmail.com>
+Date: Wed, 5 Mar 2025 19:47:24 +0000
+Subject: Patch testing part
+
+
+diff --git a/test/render_test.cpp b/test/render_test.cpp
+index 4c5c7aa..93cc878 100644
+--- a/test/render_test.cpp
++++ b/test/render_test.cpp
+@@ -10,6 +10,13 @@
+ #include "../containers/test/Bitmap.h"
+ using namespace std;
+ 
++#include <sys/types.h>
++#include <sys/stat.h>
++#include <unistd.h>
++#include <dirent.h>
++#include <vector>
++#include <string>
++
+ vector<string> find_htm_files();
+ void test(string filename);
+ 
+@@ -28,28 +35,41 @@ INSTANTIATE_TEST_SUITE_P(, render_test, testing::ValuesIn(find_htm_files()));
+ 
+ void error(const char* msg) { puts(msg); exit(1); }
+ 
+-void read_dir(const string& subdir, vector<string>& files)
++void read_dir(const std::string& subdir, std::vector<std::string>& files)
+ {
+-	string full_path = string(test_dir) + "/" + subdir;
+-	DIR* dir = opendir(full_path.c_str());
+-	if (!dir) error(full_path.c_str());
+-	while (dirent* ent = readdir(dir))
+-	{
+-		string name = ent->d_name;
+-		if (ent->d_type == DT_DIR)
+-		{
+-			if(name != "." && name != ".." && name[0] != '-')
+-			{
+-				read_dir(subdir + "/" + name, files);
+-			}
+-		} else if (ent->d_type == DT_REG)
+-		{
+-			if (name[0] != '-' && name.size() > 4 &&
+-				(name.substr(name.size() - 4) == ".htm" || name.substr(name.size() - 5) == ".html"))
+-				files.push_back(subdir + "/" + name);
+-		}
+-	}
+-	closedir(dir);
++    std::string full_path = std::string(test_dir) + "/" + subdir;
++    DIR* dir = opendir(full_path.c_str());
++    if (!dir) {
++        error(full_path.c_str());
++        return;
++    }
++
++    struct dirent* ent;
++    while ((ent = readdir(dir)) != nullptr)
++    {
++        std::string name = ent->d_name;
++        if (name == "." || name == ".." || name[0] == '-')
++            continue;
++
++        std::string entry_path = full_path + "/" + name;
++        struct stat st;
++        if (stat(entry_path.c_str(), &st) != 0)
++            continue;  // Impossible d'obtenir les infos, on ignore
++
++        if (S_ISDIR(st.st_mode))
++        {
++            read_dir(subdir + "/" + name, files);
++        }
++        else if (S_ISREG(st.st_mode))
++        {
++            if (name.size() > 4 &&
++                (name.substr(name.size() - 4) == ".htm" || name.substr(name.size() - 5) == ".html"))
++            {
++                files.push_back(subdir + "/" + name);
++            }
++        }
++    }
++    closedir(dir);
+ }
+ 
+ vector<string> find_htm_files()
+-- 
+2.45.2
+
+
+From 1cd4b797ea595f12dbb49441f856752c41dfb5cd Mon Sep 17 00:00:00 2001
+From: DigitalBox98 <digitalbox098@gmail.com>
+Date: Thu, 6 Mar 2025 08:33:51 +0000
+Subject: Fix cmake
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 595689f..99ccc3e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -173,7 +173,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
+ target_include_directories(${PROJECT_NAME} PUBLIC
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+-    $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
++    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR})
+ target_include_directories(${PROJECT_NAME} PRIVATE include/${PROJECT_NAME})
+ 
+ # Gumbo
+-- 
+2.45.2
+
+
+From 46c7c2dfa65a76055151b4d0707cb638a0a79ee7 Mon Sep 17 00:00:00 2001
+From: DigitalBox98 <digitalbox098@gmail.com>
+Date: Thu, 6 Mar 2025 19:55:01 +0000
+Subject: Fix2 cmake
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 99ccc3e..abc6d04 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -173,8 +173,9 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
+ target_include_directories(${PROJECT_NAME} PUBLIC
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR})
+-target_include_directories(${PROJECT_NAME} PRIVATE include/${PROJECT_NAME})
++    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
++)
++target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME})
+ 
+ # Gumbo
+ target_link_libraries(${PROJECT_NAME} PUBLIC gumbo)
+@@ -182,13 +183,13 @@ target_link_libraries(${PROJECT_NAME} PUBLIC gumbo)
+ # install and export
+ install(TARGETS ${PROJECT_NAME}
+     EXPORT litehtmlTargets
+-    RUNTIME DESTINATION bin COMPONENT libraries
+-    ARCHIVE DESTINATION lib${LIB_SUFFIX} COMPONENT libraries
+-    LIBRARY DESTINATION lib${LIB_SUFFIX} COMPONENT libraries
+-    PUBLIC_HEADER DESTINATION include/litehtml
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT libraries
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries
++    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/litehtml
+ )
+-install(FILES cmake/litehtmlConfig.cmake DESTINATION lib${LIB_SUFFIX}/cmake/litehtml)
+-install(EXPORT litehtmlTargets FILE litehtmlTargets.cmake DESTINATION lib${LIB_SUFFIX}/cmake/litehtml)
++install(FILES cmake/litehtmlConfig.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/litehtml)
++install(EXPORT litehtmlTargets FILE litehtmlTargets.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/litehtml)
+ 
+ # Tests
+ 
+-- 
+2.45.2
+
+
+From d1831b0dcce682a7b9c7a542b4db9f31f5717122 Mon Sep 17 00:00:00 2001
+From: DigitalBox98 <digitalbox098@gmail.com>
+Date: Thu, 6 Mar 2025 22:48:41 +0000
+Subject: Fix gumbo
+
+
+diff --git a/src/gumbo/CMakeLists.txt b/src/gumbo/CMakeLists.txt
+index 17843c9..1a3954a 100644
+--- a/src/gumbo/CMakeLists.txt
++++ b/src/gumbo/CMakeLists.txt
+@@ -60,9 +60,10 @@ endif()
+ 
+ # Export gumbo includes.
+ target_include_directories(${PROJECT_NAME} PUBLIC
+-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+-    $<INSTALL_INTERFACE:include>)
+-target_include_directories(${PROJECT_NAME} PRIVATE include/gumbo)
++    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
++    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
++)
++target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/gumbo)
+ 
+ # install and export
+ install(TARGETS ${PROJECT_NAME}
+@@ -70,6 +71,6 @@ install(TARGETS ${PROJECT_NAME}
+     RUNTIME DESTINATION bin COMPONENT libraries
+     ARCHIVE DESTINATION lib${LIB_SUFFIX} COMPONENT libraries
+     LIBRARY DESTINATION lib${LIB_SUFFIX} COMPONENT libraries
+-    PUBLIC_HEADER DESTINATION include/gumbo
++    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gumbo
+ )
+-install(EXPORT gumbo FILE gumboConfig.cmake DESTINATION lib${LIB_SUFFIX}/cmake/gumbo)
++install(EXPORT gumbo FILE gumboConfig.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/gumbo)
+-- 
+2.45.2
+
+
+From b73a9898e1a6e5e2fcf7dad87a2a791db670764e Mon Sep 17 00:00:00 2001
+From: DigitalBox98 <digitalbox098@gmail.com>
+Date: Thu, 6 Mar 2025 23:23:29 +0000
+Subject: Fix2 gumbo
+
+
+diff --git a/src/gumbo/CMakeLists.txt b/src/gumbo/CMakeLists.txt
+index 1a3954a..bbeca1a 100644
+--- a/src/gumbo/CMakeLists.txt
++++ b/src/gumbo/CMakeLists.txt
+@@ -68,9 +68,9 @@ target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/i
+ # install and export
+ install(TARGETS ${PROJECT_NAME}
+     EXPORT gumbo
+-    RUNTIME DESTINATION bin COMPONENT libraries
+-    ARCHIVE DESTINATION lib${LIB_SUFFIX} COMPONENT libraries
+-    LIBRARY DESTINATION lib${LIB_SUFFIX} COMPONENT libraries
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT libraries
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries
+     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gumbo
+ )
+ install(EXPORT gumbo FILE gumboConfig.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/gumbo)
+-- 
+2.45.2
+


### PR DESCRIPTION
What is working so far : 
- compilation OK
- structure of the packaging directory OK
- fix the policy errors for the devel part OK 
- generate .a lib instead of .so lib OK 
- add containers part in the include OK 
- missing litehtml.h in the include OK

What is remaining : 
- improve containers include location
- patch containers part to make it work on haiku with litehtml version 0.9 

