### PR TITLE
mc: update project links and license

### DIFF
--- a/app-misc/mc/mc-4.8.32.recipe
+++ b/app-misc/mc/mc-4.8.32.recipe
@@ -8,7 +8,7 @@ archives to be manipulated like real files."
 HOMEPAGE="https://midnight-commander.org"
 COPYRIGHT="1994-2025, Free Software Foundation"
 LICENSE="GNU GPL v3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://ftp.osuosl.org/pub/midnightcommander/mc-$portVersion.tar.xz"
 CHECKSUM_SHA256="4ddc83d1ede9af2363b3eab987f54b87cf6619324110ce2d3a0e70944d1359fe"
 PATCHES="mc-$portVersion.patchset"
@@ -73,7 +73,7 @@ PATCH()
 BUILD()
 {
 	# -Wno-cpp is to avoid major()/minor()/makedev() warnings.
-	CFLAGS="-D_BSD_SOURCE -D_XOPEN_SOURCE_EXTENDED -Wno-cpp" \
+	CFLAGS="-D_BSD_SOURCE -D_XOPEN_SOURCE_EXTENDED -Wno-cpp -O2" \
 	LIBS="-lnetwork -lbsd" \
 	runConfigure --omit-dirs binDir ./configure \
 		--bindir="$commandBinDir" \

--- a/app-misc/mc/mc-4.8.32.recipe
+++ b/app-misc/mc/mc-4.8.32.recipe
@@ -5,11 +5,11 @@ includes an internal editor with syntax highlighting and an internal viewer \
 with support for binary files. Also included is Virtual Filesystem (VFS), \
 that allows files on remote systems (e.g. FTP, SSH servers) and files inside \
 archives to be manipulated like real files."
-HOMEPAGE="https://www.midnight-commander.org/"
-COPYRIGHT="1994-2019, Free Software Foundation"
-LICENSE="GNU GPL v2"
+HOMEPAGE="https://midnight-commander.org"
+COPYRIGHT="1994-2025, Free Software Foundation"
+LICENSE="GNU GPL v3"
 REVISION="1"
-SOURCE_URI="http://ftp.midnight-commander.org/mc-$portVersion.tar.xz"
+SOURCE_URI="https://ftp.osuosl.org/pub/midnightcommander/mc-$portVersion.tar.xz"
 CHECKSUM_SHA256="4ddc83d1ede9af2363b3eab987f54b87cf6619324110ce2d3a0e70944d1359fe"
 PATCHES="mc-$portVersion.patchset"
 


### PR DESCRIPTION
Hello,

I'm preparing the migration to a new website. As part of this, we will be dropping the www prefix. Also, the site will be statically hosted on GitHub and will no longer support outdated redirects. I have updated the package source to use our official OSU OSL mirror directly.

Thank you!

P.S. We have also been using GPLv3 for quite some time now...