### PR TITLE
PrBoom+, fix 32bit build

### DIFF
--- a/games-fps/prboom-plus/prboom_plus-2.6.66.recipe
+++ b/games-fps/prboom-plus/prboom_plus-2.6.66.recipe
@@ -12,7 +12,7 @@ Example: 'prboom-plus -iwad ~/config/non-packaged/data/doom/doom.wad'"
 HOMEPAGE="https://github.com/coelckers/prboom-plus"
 COPYRIGHT="2016-2023 Andrey Budko et al."
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/coelckers/prboom-plus/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="4b647b4b14c3fac00711e6bf19f996bbfe37754a3b9bb5be6791f0c3fd993438"
 SOURCE_DIR="prboom-plus-$portVersion"
@@ -77,7 +77,7 @@ BUILD()
 
 	cmake ../prboom2 $cmakeDirArgs \
 		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
-		-DCMAKE_INSTALL_BIN="$prefix/bin" \
+		-DCMAKE_INSTALL_BINDIR="$prefix/bin" \
 		-DPRBOOMDATADIR="$dataDir/prboom-plus" \
 		-DDOOMWADDIR="$nonpackdatadir/prboom-plus"
 


### PR DESCRIPTION
The current PrBoom+ recipe gets stuck on 32 bit because of a wrong path, this updated recipe should fix that, build on 32 bit is untested but it works fine in x86-64