### PR TITLE
luametatex: new recipe, version 2.11.07

### DIFF
--- a/app-text/luametatex/additional-files/luametatex_postinstall.sh
+++ b/app-text/luametatex/additional-files/luametatex_postinstall.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+notify --group "TeXLive" --title "Installation in progress" --messageID texliveInstallID --timeout 10000 "Updating TeXLive ConTeXt formats…"
+mtxrun --generate
+
+notify --group "TeXLive" --title "Installation in progress" --messageID texliveInstallID --timeout 10000 "Updating TeXLive LuaTeX ConTeXt formats…"
+mtxrun --luatex --generate
+
+notify --group "TeXLive" --title "Installation finished" --messageID texliveInstallID  "Took long enough…!"

--- a/app-text/luametatex/luametatex-2.11.07.recipe
+++ b/app-text/luametatex/luametatex-2.11.07.recipe
@@ -1,0 +1,84 @@
+SUMMARY="Next generation ConTeXt processing engine"
+DESCRIPTION="The LuaMetaTeX program is a light weight variant of LuaTeX. This program finds its \
+origin in parts of TeX (the original program, eTeX (some extensions), pdfTeX (more extensions) \
+Aleph (based on Omega, directions) and of course LuaTeX (lots of things).
+
+This is a follow up on the LuaTeX project. The source is considered part of the ConTeXt \
+distribution and managed by the ConTeXt development team and the ConTeXt user group. That way it \
+can be guaranteed that the engine and this TeX macro package work together as expected. The idea \
+is that users can easily compile the source themselves and that way have a guaranteed long term \
+(minimal) TeX based installation. Because the management scripts are in Lua, only one binary is \
+needed to serve the ConTeXt distribution.
+
+In the source code it was tried to stay close to the ancestors, LuaTeX, pdfTeX, eTeX and TeX, but \
+in the meantime due to additions there is quite some diverge. There are new primitives and \
+submechanisms, there is more control over the inner workings, font handling is mostly delegated \
+to Lua and there is no built-in backend. The code base is all-inclusive and has no (nor will \
+have) dependencies on external libraries. Performance and memory consumption have been optimized \
+and the additions (compared to LuaTeX) don’t have a negative impact."
+HOMEPAGE="https://github.com/contextgarden/luametatex"
+COPYRIGHT="Taco Hoekwater & Hans Hagen & Wolfgang Schuster"
+LICENSE="GNU GPL v2"
+REVISION="1"
+srcSvnRev="74428"
+SOURCE_URI="https://svn.tug.org:8369/texlive/trunk/Master/source/luametatex-$portVersion.tar.xz?revision=$srcSvnRev&view=co"
+CHECKSUM_SHA256="a2ed3859c2a7c842539145781e1946c034ec71d1094df946bf472937af6a9161"
+SOURCE_DIR="luametatex"
+PATCHES="luametatex-$portVersion.patchset"
+ADDITIONAL_FILES="luametatex_postinstall.sh"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+POST_INSTALL_SCRIPTS="$relativePostInstallDir/luametatex_postinstall.sh"
+
+PROVIDES="
+	luametatex$secondaryArchSuffix = $portVersion
+	cmd:context = $portVersion
+	cmd:context.lua
+	cmd:luametatex = $portVersion
+	cmd:mtxrun = $portVersion
+	cmd:mtxrun.lua
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	tex:context
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	"
+
+BUILD()
+{
+	cmake -Bbuild -S. -DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_BINDIR=$prefix/bin
+	make -C build $jobArgs
+}
+
+INSTALL()
+{
+	make -C build install
+
+	# install symlinks
+	ln -s luametatex $prefix/bin/context
+	ln -s luametatex $prefix/bin/mtxrun
+	ln -s $portPackageLinksDir/tex~context/data/texlive/texmf-dist/scripts/context/lua/context.lua \
+		$prefix/bin/context.lua
+	ln -s $portPackageLinksDir/tex~context/data/texlive/texmf-dist/scripts/context/lua/mtxrun.lua \
+		$prefix/bin/mtxrun.lua
+
+	# install post-install script
+	mkdir -p $postInstallDir
+	install -t $postInstallDir -m 755 $portDir/additional-files/luametatex_postinstall.sh
+}
+
+TEST()
+{
+	make -C build test
+}

--- a/app-text/luametatex/patches/luametatex-2.11.07.patchset
+++ b/app-text/luametatex/patches/luametatex-2.11.07.patchset
@@ -1,0 +1,105 @@
+From a4f7be808f4e48232a513b1a77b897853c1ceb31 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
+Date: Sat, 22 Mar 2025 18:51:50 +0100
+Subject: Build fixes
+
+Link with libnetwork.
+
+Rename a label which conflicts with the macro B_ERROR.
+
+diff --git a/cmake/luametatex.cmake b/cmake/luametatex.cmake
+index 85da18d..e8d89d2 100644
+--- a/cmake/luametatex.cmake
++++ b/cmake/luametatex.cmake
+@@ -76,6 +76,10 @@ if (${CMAKE_HOST_SOLARIS})
+         nsl
+         resolv
+ )
++elseif (HAIKU)
++    target_link_libraries(luametatex
++        network
++    )
+ endif()
+ 
+ if (DEFINED LMT_OPTIMIZE)
+diff --git a/source/tex/texscanning.c b/source/tex/texscanning.c
+index 43b507a..8c95ac4 100644
+--- a/source/tex/texscanning.c
++++ b/source/tex/texscanning.c
+@@ -6560,10 +6560,10 @@ static inline halfword tex_scan_aux_b(void)
+                         case d_token_l: case d_token_o:
+                             return expression_band;
+                         default:
+-                            goto B_ERROR;
++                            goto TEX_B_ERROR;
+                     }
+                 default:
+-                    goto B_ERROR;
++                    goto TEX_B_ERROR;
+             }
+             break;
+         case o_token_l: case o_token_o:
+@@ -6572,7 +6572,7 @@ static inline halfword tex_scan_aux_b(void)
+                 case r_token_l: case r_token_o:
+                     return expression_bor;
+                 default:
+-                    goto B_ERROR;
++                    goto TEX_B_ERROR;
+             }
+             break;
+         case x_token_l: case x_token_o:
+@@ -6584,10 +6584,10 @@ static inline halfword tex_scan_aux_b(void)
+                         case r_token_l: case r_token_o:
+                             return expression_bxor;
+                         default:
+-                            goto B_ERROR;
++                            goto TEX_B_ERROR;
+                     }
+                 default:
+-                    goto B_ERROR;
++                    goto TEX_B_ERROR;
+             }
+             break;
+         case s_token_l: case s_token_o:
+@@ -6599,10 +6599,10 @@ static inline halfword tex_scan_aux_b(void)
+                         case t_token_l: case t_token_o:
+                             return expression_bset;
+                         default:
+-                            goto B_ERROR;
++                            goto TEX_B_ERROR;
+                     }
+                 default:
+-                    goto B_ERROR;
++                    goto TEX_B_ERROR;
+             }
+             break;
+         case u_token_l: case u_token_o:
+@@ -6620,20 +6620,20 @@ static inline halfword tex_scan_aux_b(void)
+                                         case t_token_l: case t_token_o:
+                                             return expression_bset;
+                                         default:
+-                                            goto B_ERROR;
++                                            goto TEX_B_ERROR;
+                                     }
+                                 default:
+-                                    goto B_ERROR;
++                                    goto TEX_B_ERROR;
+                             }
+                         default:
+-                            goto B_ERROR;
++                            goto TEX_B_ERROR;
+                     }
+                 default:
+-                    goto B_ERROR;
++                    goto TEX_B_ERROR;
+             }
+             break;
+         default:
+-          B_ERROR:
++          TEX_B_ERROR:
+             tex_aux_show_keyword_error("band|bor|bxor|bset|bunset");
+             return expression_none;
+     }
+-- 
+2.48.1
+


### PR DESCRIPTION
It builds, but doesn't work yet, because it doesn't find any paths. It seems like this requires some further patching, similar to what is done for texlive and texlive_core. Note that this doesn't use libkpathsea and therefore doesn't use the already patched logic we have.

Notes about the recipe:
We use the source tarball that has been checked into TeXLive's SVN, downloaded from WebSVN, because the upstream GitHub doesn't contain the newest version yet. The official download from the website is unversioned and contains the full ConTeXt distribution, which makes it unsuitable for packaging.

The script symlinks link to the scripts installed by the "tex:context" package, therefore this package requires that. There don't exist an extra copy of the scripts in data/texmf-dist like for the ones in texlive_core do. The requires relation goes the other way round than it is between texlive_core and texlive.