### PR TITLE
perl: fix doc subpackage (after haikuporter changes)

### DIFF
--- a/dev-lang/perl/perl-5.40.2.recipe
+++ b/dev-lang/perl/perl-5.40.2.recipe
@@ -16,7 +16,7 @@ HOMEPAGE="https://www.perl.org/"
 COPYRIGHT="1993-2025 Larry Wall and others"
 LICENSE="GNU GPL v1
 	Artistic"
-REVISION="1"
+REVISION="2"
 perlShortVersion="${portVersion%.*}"
 SOURCE_URI="http://www.cpan.org/src/perl-$portVersion.tar.gz"
 CHECKSUM_SHA256="10d4647cfbb543a7f9ae3e5f6851ec49305232ea7621aed24c7cfbb0bef4b70d"
@@ -78,10 +78,14 @@ fi
 ARCHITECTURES_doc="any"
 
 PROVIDES_doc="
-	perl${secondaryArchSuffix}_doc = $portVersion
+	perl_doc = $portVersion
 	"
 REQUIRES_doc="
-	perl$secondaryArchSuffix == $portVersion base
+	cmd:perl == $portVersion base
+	"
+
+REPLACES_doc="
+	perl_x86_doc
 	"
 
 BUILD_REQUIRES="


### PR DESCRIPTION
This contains the needed changes for the perl package after https://github.com/haikuports/haikuporter/pull/321 is merged and deployed on the builders.

This is just an example for now, there are a few more affected packages.