### PR TITLE
pip: use PACKAGE_NAME to specify the python version with a '.'

### DIFF
--- a/dev-python/pip/pip-23.2.1.recipe
+++ b/dev-python/pip/pip-23.2.1.recipe
@@ -9,13 +9,6 @@ CHECKSUM_SHA256="fb0bd5435b3200c602b5bf61d2d43c2f13c02e29c1707567ae7fbc514eb9faf
 
 ARCHITECTURES="any"
 
-PROVIDES="
-	$portName = $portVersion
-	"
-REQUIRES="
-	haiku
-	"
-
 BUILD_REQUIRES="
 	haiku_devel
 	"

--- a/dev-python/pip/pip-23.2.1.recipe
+++ b/dev-python/pip/pip-23.2.1.recipe
@@ -23,13 +23,14 @@ BUILD_REQUIRES="
 PYTHON_VERSIONS=(3.10)
 defaultVersion=3.10
 
-PYTHON_VERSIONS=(3.10)
-
 for pythonVersion in ${PYTHON_VERSIONS[@]}; do
 	pythonPackage=python${pythonVersion//.}
 
+	# Allows using dot in sub-package names (eg: "_python3.10" vs "_python310"):
+	eval "PACKAGE_NAME_$pythonPackage=\"pip_python$pythonVersion\""
+
 	eval "PROVIDES_$pythonPackage=\"
-		${portName}_$pythonPackage = $portVersion
+		${portName}_python$pythonVersion = $portVersion
 		cmd:pip$pythonVersion
 		\""
 
@@ -46,6 +47,8 @@ for pythonVersion in ${PYTHON_VERSIONS[@]}; do
 		setuptools_$pythonPackage
 		cmd:python$pythonVersion
 		\""
+	eval "REPLACES_$pythonPackage=\"pip_$pythonPackage\""
+
 	BUILD_REQUIRES+="
 		setuptools_$pythonPackage
 		"


### PR DESCRIPTION
In https://github.com/haikuports/haikuports/pull/6714#discussion_r827299891, @waddlesplash suggested to include the '.' in the python version part of the package name of python packages. This doesn't work directly because of bash variable name restrictions (see #6781), but it is possible using `PACKAGE_NAME`. This is theoretically supported by HaikuPorter since 2014, but hasn't been used yet.

A problem of the existing implementation was that the `packageEntries` call would have to be different, specifying the full versioned name instead of just the suffix. This is fixed by https://github.com/haikuports/haikuporter/pull/322, so this PR requires that one to be merged and deployed first.

This PR is intended to serve as an example how using `PACKAGE_NAME` for python packages would work. What do you think about this?

cc: @OscarL 