### PR TITLE
Freeciv: Recipe cleanup, fix strict build errors

### DIFF
--- a/games-strategy/freeciv/freeciv-3.1.4.recipe
+++ b/games-strategy/freeciv/freeciv-3.1.4.recipe
@@ -11,24 +11,16 @@ you do not need to own Civilization to play Freeciv."
 HOMEPAGE="http://www.freeciv.org/"
 COPYRIGHT="1996-2025 The Freeciv Team"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://downloads.sourceforge.net/sourceforge/freeciv/freeciv-$portVersion.tar.xz"
 CHECKSUM_SHA256="14999bb903c4507cc287d5a8dd1b89eee623bb41b4e01e0836567fb5f13296e4"
 PATCHES="freeciv-$portVersion.patchset"
 ADDITIONAL_FILES="
 	freeciv.rdef.in
 	"
-POST_INSTALL_SCRIPTS="$relativePostInstallDir/freeciv-postinstall.sh"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
-
-commandSuffix=$secondaryArchSuffix
-commandBinDir=$binDir
-if [ -z "${ARCHITECTURES##*!$targetArchitecture*}" ]; then
-	commandSuffix=
-	commandBinDir=$prefix/bin
-fi
 
 GLOBAL_WRITABLE_FILES="
 	settings/freeciv/database.lua keep-old
@@ -98,7 +90,7 @@ BUILD()
 {
 	AUTOCONF=: AUTOMAKE=: ACLOCAL=: CFLAGS="-O2 -pipe" \
 		runConfigure --omit-dirs binDir ./configure \
-		--bindir=$commandBinDir --enable-client=sdl2 --enable-fcmp=no \
+		--bindir=$prefix/bin --enable-client=sdl2 --enable-fcmp=no \
 		--enable-sys-lua --enable-shared --disable-static
 	make $jobArgs
 }
@@ -110,7 +102,11 @@ INSTALL()
 	rm -f $libDir/*.a $libDir/*.la
 
 	mkdir -p $appsDir
-	ln -s $commandBinDir/freeciv-sdl2 $appsDir/Freeciv
+	ln -s $prefix/bin/freeciv-sdl2 $appsDir/Freeciv
+
+	mv $prefix/share/* $dataRootDir
+	rmdir $prefix/share
+	rm -rf $dataDir/applications $dataDir/icons $dataDir/metainfo $dataDir/pixmaps
 
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
 	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
@@ -126,6 +122,4 @@ INSTALL()
 	addResourcesToBinaries freeciv.rdef $appsDir/Freeciv
 
 	addAppDeskbarSymlink $appsDir/Freeciv
-	mv $prefix/share/* $dataRootDir
-	rmdir $prefix/share
 }

--- a/games-strategy/freeciv/freeciv-3.1.4.recipe
+++ b/games-strategy/freeciv/freeciv-3.1.4.recipe
@@ -101,7 +101,7 @@ INSTALL()
 
 	mv $prefix/share/* $dataRootDir
 	rmdir $prefix/share
-	rm -rf $libDir/*.a $libDir/*.la $dataDir/applications $dataDir/icons $dataDir/metainfo $dataDir/pixmaps
+	rm -rf $libDir/*.a $libDir/*.la $dataDir/{applications,icons,metainfo,pixmaps}
 
 	mkdir -p $appsDir
 	ln -s $prefix/bin/freeciv-sdl2 $appsDir/Freeciv
@@ -117,7 +117,7 @@ INSTALL()
 		-e "s|@INTERNAL@|$INTERNAL|" \
 		$portDir/additional-files/freeciv.rdef.in > freeciv.rdef
 
-	addResourcesToBinaries freeciv.rdef $prefix/bin/freeciv-sdl2
+	addResourcesToBinaries freeciv.rdef $appsDir/Freeciv
 
  	addAppDeskbarSymlink $appsDir/Freeciv
 }

--- a/games-strategy/freeciv/freeciv-3.1.4.recipe
+++ b/games-strategy/freeciv/freeciv-3.1.4.recipe
@@ -22,6 +22,13 @@ ADDITIONAL_FILES="
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ -z "${ARCHITECTURES##*!$targetArchitecture*}" ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
 GLOBAL_WRITABLE_FILES="
 	settings/freeciv/database.lua keep-old
 	"
@@ -90,7 +97,7 @@ BUILD()
 {
 	AUTOCONF=: AUTOMAKE=: ACLOCAL=: CFLAGS="-O2 -pipe" \
 		runConfigure --omit-dirs binDir ./configure \
-		--bindir=$prefix/bin --enable-client=sdl2 --enable-fcmp=no \
+		--bindir=$commandBinDir --enable-client=sdl2 --enable-fcmp=no \
 		--enable-sys-lua --enable-shared --disable-static
 	make $jobArgs
 }

--- a/games-strategy/freeciv/freeciv-3.1.4.recipe
+++ b/games-strategy/freeciv/freeciv-3.1.4.recipe
@@ -28,7 +28,6 @@ GLOBAL_WRITABLE_FILES="
 
 PROVIDES="
 	freeciv$secondaryArchSuffix = $portVersion
-	app:FreeCiv = $portVersion
 	cmd:freeciv_manual$commandSuffix
 	cmd:freeciv_ruleup$commandSuffix
 	cmd:freeciv_sdl2$commandSuffix
@@ -101,9 +100,6 @@ INSTALL()
 
 	rm -f $libDir/*.a $libDir/*.la
 
-	mkdir -p $appsDir
-	ln -s $prefix/bin/freeciv-sdl2 $appsDir/Freeciv
-
 	mv $prefix/share/* $dataRootDir
 	rmdir $prefix/share
 	rm -rf $dataDir/applications $dataDir/icons $dataDir/metainfo $dataDir/pixmaps
@@ -119,7 +115,7 @@ INSTALL()
 		-e "s|@INTERNAL@|$INTERNAL|" \
 		$portDir/additional-files/freeciv.rdef.in > freeciv.rdef
 
-	addResourcesToBinaries freeciv.rdef $appsDir/Freeciv
+	addResourcesToBinaries freeciv.rdef $prefix/bin/freeciv-sdl2
 
-	addAppDeskbarSymlink $appsDir/Freeciv
+	addAppDeskbarSymlink $prefix/bin/freeciv-sdl2 "Freeciv"
 }

--- a/games-strategy/freeciv/freeciv-3.1.4.recipe
+++ b/games-strategy/freeciv/freeciv-3.1.4.recipe
@@ -28,6 +28,7 @@ GLOBAL_WRITABLE_FILES="
 
 PROVIDES="
 	freeciv$secondaryArchSuffix = $portVersion
+	app:FreeCiv = $portVersion
 	cmd:freeciv_manual$commandSuffix
 	cmd:freeciv_ruleup$commandSuffix
 	cmd:freeciv_sdl2$commandSuffix

--- a/games-strategy/freeciv/freeciv-3.1.4.recipe
+++ b/games-strategy/freeciv/freeciv-3.1.4.recipe
@@ -98,11 +98,12 @@ INSTALL()
 {
 	make install
 
-	rm -f $libDir/*.a $libDir/*.la
-
 	mv $prefix/share/* $dataRootDir
 	rmdir $prefix/share
-	rm -rf $dataDir/applications $dataDir/icons $dataDir/metainfo $dataDir/pixmaps
+	rm -rf $libDir/*.a $libDir/*.la $dataDir/applications $dataDir/icons $dataDir/metainfo $dataDir/pixmaps
+
+	mkdir -p $appsDir
+	ln -s $prefix/bin/freeciv-sdl2 $appsDir/Freeciv
 
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
 	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
@@ -117,5 +118,5 @@ INSTALL()
 
 	addResourcesToBinaries freeciv.rdef $prefix/bin/freeciv-sdl2
 
-	addAppDeskbarSymlink $prefix/bin/freeciv-sdl2 "Freeciv"
+ 	addAppDeskbarSymlink $appsDir/Freeciv
 }

--- a/games-strategy/freeciv/freeciv-3.1.4.recipe
+++ b/games-strategy/freeciv/freeciv-3.1.4.recipe
@@ -111,7 +111,7 @@ INSTALL()
 	rm -rf $libDir/*.a $libDir/*.la $dataDir/{applications,icons,metainfo,pixmaps}
 
 	mkdir -p $appsDir
-	ln -s $prefix/bin/freeciv-sdl2 $appsDir/Freeciv
+	ln -s $commandBinDir/freeciv-sdl2 $appsDir/Freeciv
 
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
 	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"


### PR DESCRIPTION
Some cleanup of the recipe to remove an obsolete reference to the post install script, use "$prefix/bin" and remove unnecessary linux-related files in the package.

I tested the resulting package and the files removed do not affect the Haiku build, let me know in case you think some of the removed files should stay.