### PR TITLE
libmd: update to version 1.1.0.

### DIFF
--- a/app-crypt/libmd/libmd-1.1.0.recipe
+++ b/app-crypt/libmd/libmd-1.1.0.recipe
@@ -24,14 +24,14 @@ LICENSE="BSD (3-clause)
 	BSD (2-clause) NetBSD
 	ISC
 	Public Domain"
-REVISION="3"
-SOURCE_URI="https://libbsd.freedesktop.org/releases/libmd-$portVersion.tar.xz"
-CHECKSUM_SHA256="e14eeb931cf85330f95ff822262d3033125488dfb2f867441e36e2d2c4a34c71"
+REVISION="1"
+SOURCE_URI="https://archive.hadrons.org/software/libmd/libmd-$portVersion.tar.xz"
+CHECKSUM_SHA256="1bd6aa42275313af3141c7cf2e5b964e8b1fd488025caf2f971f43b00776b332"
 
 ARCHITECTURES="all"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
-libVersion="0.0.2"
+libVersion="0.1.0"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
@@ -96,6 +96,8 @@ INSTALL()
 		${maybe_manDir:+"$maybe_manDir"}
 }
 
+# TOTAL: 6
+# PASS:  6
 TEST()
 {
 	make check


### PR DESCRIPTION
Nothing seems to actually use this on-tree, but old version is from 2018, and newest is from 2023.

Might be useful if someone manages to port `got` (Game of Trees).