### PR TITLE
Update OpenJazz to release 20240919

### DIFF
--- a/games-action/openjazz/openjazz-20240919.recipe
+++ b/games-action/openjazz/openjazz-20240919.recipe
@@ -1,14 +1,14 @@
-SUMMARY="A free, open-source version of classic Jazz Jackrabbit games"
-DESCRIPTION="A free, open-source version of classic Jazz Jackrabbit games.\
-Requires the original game data to work.\
-Please put the data into the folder:\
-~/config/non-packaged/Data/openjazz"
+SUMMARY="A free, open-source version of the classic Jazz Jackrabbit games"
+DESCRIPTION="A free, open-source version of the classic Jazz Jackrabbit games. \
+Requires the original game data to work.
+Please put the data into the folder: \
+~/config/non-packaged/data/openjazz"
 HOMEPAGE="https://github.com/AlisterT/openjazz"
 COPYRIGHT="Alister Thomson"
 LICENSE="GNU GPL v2"
-REVISION="2"
-SOURCE_URI="https://github.com/AlisterT/openjazz/releases/download/$portVersion/openjazz-$portVersion.tar.xz"
-CHECKSUM_SHA256="91341adcc4908db12aad6b82d2fb0125429a26585f65d7eb32d403656313eaab"
+REVISION="1"
+SOURCE_URI="https://github.com/AlisterT/openjazz/releases/download/$portVersion/openjazz-$portVersion.tar.gz"
+CHECKSUM_SHA256="ab02b8838804f3002ec8e86bffcf38a9ea79303cba7c9eafbfb16a9b367c6482"
 SOURCE_DIR="openjazz-$portVersion"
 ADDITIONAL_FILES="openjazz.rdef"
 
@@ -34,9 +34,7 @@ BUILD_REQUIRES="
 	devel:libz
     "
 BUILD_PREREQUIRES="
-	cmd:aclocal
-	cmd:autoreconf
-	cmd:awk
+	cmd:cmake
 	cmd:gcc
 	cmd:make
 	cmd:pkg_config
@@ -44,19 +42,18 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	autoreconf -vfi
-	runConfigure --omit-dirs binDir \
-		./configure --bindir=$appsDir
-	make $jobArgs
+	cmake -Bbuild -S. $cmakeDirArgs \
+		-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_BINDIR=$appsDir
+
+	make -C build $jobArgs
 }
 
 INSTALL()
 {
-	make install
+	make -C build install
 
 	# remove unneeded data for Haiku
-	rm -rf "$dataDir"/icons
-	rm -rf "$dataDir"/applications
+	rm -rf $dataDir/{applications,icons,pixmaps}
 
 	addResourcesToBinaries \
 		$portDir/additional-files/openjazz.rdef $appsDir/OpenJazz

--- a/games-action/openjazz/openjazz-20240919.recipe
+++ b/games-action/openjazz/openjazz-20240919.recipe
@@ -12,32 +12,33 @@ CHECKSUM_SHA256="ab02b8838804f3002ec8e86bffcf38a9ea79303cba7c9eafbfb16a9b367c648
 SOURCE_DIR="openjazz-$portVersion"
 ADDITIONAL_FILES="openjazz.rdef"
 
-ARCHITECTURES="all ?x86"
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	openjazz = $portVersion
+	openjazz$secondaryArchSuffix = $portVersion
 	app:OpenJazz = $portVersion
 	"
 REQUIRES="
-	haiku
-	lib:libSDL_1.2
+	haiku$secondaryArchSuffix
+	lib:libSDL_1.2$secondaryArchSuffix
 #	lib:libxmp
-	lib:libmodplug
-	lib:libz
+	lib:libmodplug$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
     "
 
 BUILD_REQUIRES="
-    haiku_devel
-	devel:libSDL
+	haiku${secondaryArchSuffix}_devel
+	devel:libSDL$secondaryArchSuffix
 #	devel:libxmp
-	devel:libmodplug
-	devel:libz
+	devel:libmodplug$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
     "
 BUILD_PREREQUIRES="
 	cmd:cmake
-	cmd:gcc
+	cmd:gcc$secondaryArchSuffix
 	cmd:make
-	cmd:pkg_config
+	cmd:pkg_config$secondaryArchSuffix
 	"
 
 BUILD()


### PR DESCRIPTION
Updates OpenJazz to the latest release. Works on both x86 and x64.