### PR TITLE
Omnispeak Keen4: fix 32 bit

### DIFF
--- a/games-action/omnispeak_keen4/omnispeak_keen4-1.4.recipe
+++ b/games-action/omnispeak_keen4/omnispeak_keen4-1.4.recipe
@@ -20,10 +20,7 @@ PROVIDES="
 	omnispeak_keen4 = $portVersion
 	"
 REQUIRES="
-	omnispeak$secondaryArchSuffix
-	"
-SUPPLEMENTS="
-	omnispeak$secondaryArchSuffix
+	cmd:omnispeak
 	"
 
 INSTALL()


### PR DESCRIPTION
Its requirements aren't detected on x86, this change should fix it and doesn't affect 64 bit.