### PR TITLE
libfossil: fix build on 32 bits.

### DIFF
--- a/dev-vcs/libfossil/libfossil-2025.04.04.recipe
+++ b/dev-vcs/libfossil/libfossil-2025.04.04.recipe
@@ -18,10 +18,10 @@ HOMEPAGE="https://fossil.wanderinghorse.net/r/libfossil"
 COPYRIGHT="2013-2021 Stephan Beal, the Libfossil authors and contributors."
 LICENSE="BSD (2-clause)"
 REVISION="1"
-fossilHash="8ba26d0b75cd73ac"
-SOURCE_URI="https://fossil.wanderinghorse.net/r/libfossil/tarball/$fossilHash/libfossil-$portVersion-$fossilHash.tar.gz"
+srcFossilRev="8ba26d0b75cd73ac"
+SOURCE_URI="https://fossil.wanderinghorse.net/r/libfossil/tarball/$srcFossilRev/libfossil-$portVersion-$srcFossilRev.tar.gz"
 CHECKSUM_SHA256="4c765bf6c90f71fcea16a676f309a893f907ee9f9ec7b87585dc18194d8fe29b"
-SOURCE_DIR="$portName-$portVersion-$fossilHash"
+SOURCE_DIR="libfossil-$portVersion-$srcFossilRev"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -64,7 +64,7 @@ fossil repositories) as included in libfossil's sources (should be functionally 
 You would tipically use \`/bin/fnc\` as provided by either this package, or the \
 \"standalone/upstream\" version provided by the \`fnc\` package (but not both)."
 PROVIDES_fnc="
-	libfossil_fnc$secondaryArchSuffix = $portVersion
+	libfossil${secondaryArchSuffix}_fnc = $portVersion
 	cmd:fnc
 	"
 REQUIRES_fnc="
@@ -80,7 +80,7 @@ CONFLICTS_fnc="
 
 SUMMARY_tools="$SUMMARY (cli tools)"
 PROVIDES_tools="
-	libfossil_tools$secondaryArchSuffix = $portVersion
+	libfossil${secondaryArchSuffix}_tools = $portVersion
 	cmd:f_acat
 	cmd:f_add
 	cmd:f_adiff
@@ -125,6 +125,14 @@ BUILD()
 		--prefix=$prefix \
 		--no-debug \
 		--disable-static
+
+	# autosetup uses $(prefix)/lib, patch that when building for x86:
+	# (quick and dirty version for now, makaking autosetup make use of --libdir would be better).
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		sed -e 's|,libs,$(prefix)/lib,|,libs,$(prefix)/lib/x86,|' -i shakenmake.make
+		sed -e 's|,dlls,$(prefix)/lib,|,dlls,$(prefix)/lib/x86,|' -i shakenmake.make
+	fi
+
 	make $jobArgs
 }
 


### PR DESCRIPTION
Also, use `$srcFossilRev` as variable name for the Fossil's commit hash (as analogous to `$srcGitRev`).