### PR TITLE
GemRB: better generated cfg

### DIFF
--- a/games-engines/gemrb/gemrb-0.9.4.recipe
+++ b/games-engines/gemrb/gemrb-0.9.4.recipe
@@ -13,7 +13,7 @@ to point GemRB to the data of the game you want to play and to customize your Ge
 HOMEPAGE="https://gemrb.org/"
 COPYRIGHT="2003-2025 The GemRB Team"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/gemrb/gemrb/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="2cb39244945d1e5ec885c4040892eea1efb6d7b183ade36f4ab2e852778e401f"
 SOURCE_FILENAME="v$portVersion.tar.gz"
@@ -27,12 +27,8 @@ POST_INSTALL_SCRIPTS="$relativePostInstallDir/gemrb-postinstall.sh"
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
-GLOBAL_WRITABLE_FILES="
-	settings/gemrb/GemRB.cfg keep-old
-	"
-USER_SETTINGS_FILES="
-	settings/gemrb directory
-	"
+GLOBAL_WRITABLE_FILES="settings/gemrb/GemRB.cfg keep-old"
+USER_SETTINGS_FILES="settings/gemrb directory"
 
 PROVIDES="
 	gemrb$secondaryArchSuffix = $portVersion
@@ -75,11 +71,7 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	mkdir -p build
-	cd build
-
-	cmake .. \
-		-Wno-dev \
+	cmake -Bbuild -S. -Wno-dev \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DCMAKE_INSTALL_PREFIX=$prefix \
 		-DBIN_DIR=$prefix/bin \
@@ -88,18 +80,17 @@ BUILD()
 		-DSYSCONF_DIR=$settingsDir/gemrb \
 		-DDOC_DIR=$docDir
 
-	make $jobArgs
+	make -C build $jobArgs
 }
 
 INSTALL()
 {
-	cd build
-	make install
+	make -C build install
 
 	# Remove leftover CMake file
 	rm -f $dataDir/gemrb/override/bg1/CMakeLists.txt
 
-	# Remove extra cfg files and setup Haiku-specific config
+	# Remove extra cfg files
 	rm -f $settingsDir/gemrb/GemRB.cfg.{sample,noinstall.sample}
 
 	# Edit Cache path
@@ -109,6 +100,10 @@ INSTALL()
 	# Edit Save path
 	savedir=$(finddir B_USER_SETTINGS_DIRECTORY)/gemrb
 	sed -i "s,#SavePath=\/mnt/windows/Programmi/Black Isle/BGII - SoA/,SavePath=${savedir},g" $settingsDir/gemrb/GemRB.cfg
+
+	# Fix wrong Data paths
+	sysdir=$(finddir B_SYSTEM_DIRECTORY)
+	sed -i "s,\/packages/${portRevisionedName}/.self,${sysdir},g" $settingsDir/gemrb/GemRB.cfg
 
 	# Generate the rdef
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"

--- a/games-engines/gemrb/gemrb-0.9.4.recipe
+++ b/games-engines/gemrb/gemrb-0.9.4.recipe
@@ -103,7 +103,7 @@ INSTALL()
 
 	# Fix wrong Data paths
 	sysdir=$(finddir B_SYSTEM_DIRECTORY)
-	sed -i "s,\/packages/${portRevisionedName}/.self,${sysdir},g" $settingsDir/gemrb/GemRB.cfg
+	sed -i "s,${prefix},${sysdir},g" $settingsDir/gemrb/GemRB.cfg
 
 	# Generate the rdef
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"


### PR DESCRIPTION
This patch edits the pre-generated lines in GemRB.cfg from having `/${prefix}/` to `/boot/system`.
These lines are disabled by default and useless in most circumstances. Still, this prevents issues like the one described in https://github.com/haikuports/haikuports/pull/12104#issuecomment-2788468483 from happening from this recipe onwards if the user activates them. (and the package has been installed system-wide)