### PR TITLE
Doom Shareware: change download location, add docs

### DIFF
--- a/games-fps/doom_shareware/doom_shareware-1.9.recipe
+++ b/games-fps/doom_shareware/doom_shareware-1.9.recipe
@@ -8,9 +8,9 @@ if there are more installed a pop-up to select the preferred one will be shown."
 HOMEPAGE="https://www.doomworld.com/classicdoom/"
 COPYRIGHT="1993 - 1995 Id Software"
 LICENSE="Public Domain"
-REVISION="1"
-SOURCE_URI="https://www.doomworld.com/3ddownloads/ports/shareware_doom_iwad.zip"
-CHECKSUM_SHA256="845f4f3a449343b068a4e178f9cb018cb1f5b7d5ef09db292864ed554f612276"
+REVISION="2"
+SOURCE_URI="https://archive.org/download/DoomsharewareEpisode/DoomV1.9sw1995idSoftwareInc.action.zip"
+CHECKSUM_SHA256="63ad7609f2e951fb2198f682e1226f003946c75c00b9785fa967ffb12c6745f7"
 SOURCE_DIR=""
 ADDITIONAL_FILES="
 	doom_shareware.rdef.in
@@ -30,12 +30,13 @@ REQUIRES="
 INSTALL()
 {
 	# Pack game data
-	mkdir -p $dataDir/doomdata
-	cp DOOM1.WAD $dataDir/doomdata/doom1.wad
+	mkdir -p $dataDir/doomdata && cp DOOM1.WAD $dataDir/doomdata/doom1.wad
+
+	# Pack docs
+	mkdir -p $docDir && cp -t $docDir *.TXT ORDER.FRM
 
 	# Pack script
-	mkdir -p $appsDir/Doom-shareware
-	cp $portDir/additional-files/doom_shareware.sh $appsDir/Doom-shareware
+	mkdir -p $appsDir/Doom-shareware && cp $portDir/additional-files/doom_shareware.sh $appsDir/Doom-shareware
 	chmod +x $appsDir/Doom-shareware/doom_shareware.sh
 
 	# Generate the rdef


### PR DESCRIPTION
Apparently Doomworld doesn't want the x64 buildmaster to get DOOM1.WAD from them (exits with 403 - forbidden) even though it worked for 32 bit, so I'm changing the download location to a zip stored at the Internet Archive.

Good news is, this new download location comes with the shareware's documentation so that's being packed as well (except for those files that talk about the included Dos-only utilities, DM and DWANGO)