### PR TITLE
python3.12: update to version 3.12.10.

### DIFF
--- a/dev-lang/python/patches/python3.12-3.12.10.patchset
+++ b/dev-lang/python/patches/python3.12-3.12.10.patchset
@@ -1,4 +1,4 @@
-From ced60ec5539b7f2c9da08140ab83bcabc8acee1c Mon Sep 17 00:00:00 2001
+From 22e4016e3b29e96a85a4360a1d5c96bd3da896c5 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 8 Oct 2023 01:02:25 -0300
 Subject: initial Haiku patch
@@ -32,7 +32,7 @@ index 0000000..4372ee2
 +set -v
 +eval $PYTHON_FOR_BUILD ../../Tools/scripts/h2py.py -i "'(u_long)'" $HEADERS/posix/netinet/in.h
 diff --git a/Makefile.pre.in b/Makefile.pre.in
-index 689f33d..fb2195b 100644
+index 7ca3dc6..6445567 100644
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
 @@ -147,7 +147,7 @@ BINDIR=		@bindir@
@@ -239,20 +239,20 @@ index 1a02d19..63a3bd3 100644
  esac
  AC_MSG_CHECKING([for --with-libm=STRING])
 -- 
-2.45.2
+2.48.1
 
 
-From 5a4db8cc635464695177f95df45557fb08c8b8fe Mon Sep 17 00:00:00 2001
+From 3ec2248a7728a37ce7b68bc909518d3143cce4b2 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sun, 16 Apr 2017 10:05:42 +0200
 Subject: fix for negative errnos
 
 
 diff --git a/Lib/subprocess.py b/Lib/subprocess.py
-index 3ec39ca..6ae03cd 100644
+index 881a9ce..7ca34b4 100644
 --- a/Lib/subprocess.py
 +++ b/Lib/subprocess.py
-@@ -1948,6 +1948,8 @@ class Popen:
+@@ -1940,6 +1940,8 @@ class Popen:
                          SubprocessError)
                  if issubclass(child_exception_type, OSError) and hex_errno:
                      errno_num = int(hex_errno, 16)
@@ -277,10 +277,10 @@ index 35ea2ac..ccc25ed 100644
              *--cur = Py_hexdigits[saved_errno % 16];
              saved_errno /= 16;
 -- 
-2.45.2
+2.48.1
 
 
-From 110187fb1fa288006bd2f83a9bf55796fc582038 Mon Sep 17 00:00:00 2001
+From 7edd0a9045ad11aa0fbfcebf1b2d57a2f0932608 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 8 Oct 2023 20:06:31 -0300
 Subject: Implement CTypes's find_library for Haiku
@@ -374,10 +374,10 @@ index c550883..6b23423 100644
              print(cdll.LoadLibrary("libm.so"))
              print(cdll.LoadLibrary("libcrypt.so"))
 -- 
-2.45.2
+2.48.1
 
 
-From 3451f6920a611b5af13fefed644b05b708a82a0e Mon Sep 17 00:00:00 2001
+From 2720e83e5b368dd0ca745e18e0ce27476862ba3d Mon Sep 17 00:00:00 2001
 From: Philipp Wolfer <phil@parolu.io>
 Date: Mon, 23 Sep 2019 09:14:58 +0200
 Subject: webbrowser: Support for default browsers on Haiku
@@ -401,10 +401,10 @@ index 13b9e85..7d81178 100755
          # First try to use the default Windows browser
          register("windows-default", WindowsDefault)
 -- 
-2.45.2
+2.48.1
 
 
-From c8f5fd71384b15cd2a88c824de4b8a809c349a28 Mon Sep 17 00:00:00 2001
+From 0774906be0d6b3d4c13aaaa1d161183ac2c63ab4 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 4 Oct 2019 22:02:35 +0200
 Subject: since 3.8, don't reinit locks on fork.
@@ -424,10 +424,10 @@ index 22d3198..f369a88 100644
          pass  # no-op when os.register_at_fork does not exist.
  else:
 -- 
-2.45.2
+2.48.1
 
 
-From f47a1e3fd1963f75b48439573d0860a35bc8e80b Mon Sep 17 00:00:00 2001
+From a2390a2228172893b31cad29d4719570d0994cc4 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 15 May 2020 15:20:57 +0200
 Subject: handle errors returned by internal_connect()
@@ -435,10 +435,10 @@ Subject: handle errors returned by internal_connect()
 upstream bug #40628 by Ryan C. Gordon
 
 diff --git a/Modules/socketmodule.c b/Modules/socketmodule.c
-index 7f2ebba..47e56d1 100644
+index 27afd73..4ceccd9 100644
 --- a/Modules/socketmodule.c
 +++ b/Modules/socketmodule.c
-@@ -3492,7 +3492,7 @@ sock_connect(PySocketSockObject *s, PyObject *addro)
+@@ -3543,7 +3543,7 @@ sock_connect(PySocketSockObject *s, PyObject *addro)
      }
  
      res = internal_connect(s, SAS2SA(&addrbuf), addrlen, 1);
@@ -447,7 +447,7 @@ index 7f2ebba..47e56d1 100644
          return NULL;
  
      Py_RETURN_NONE;
-@@ -3523,7 +3523,7 @@ sock_connect_ex(PySocketSockObject *s, PyObject *addro)
+@@ -3574,7 +3574,7 @@ sock_connect_ex(PySocketSockObject *s, PyObject *addro)
      }
  
      res = internal_connect(s, SAS2SA(&addrbuf), addrlen, 0);
@@ -457,10 +457,10 @@ index 7f2ebba..47e56d1 100644
  
      return PyLong_FromLong((long) res);
 -- 
-2.45.2
+2.48.1
 
 
-From b122dd23f732a49fa4fa1c5d1d088693933f1a97 Mon Sep 17 00:00:00 2001
+From 322784606d6661cba4b52daa07127fdc69e81d0d Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Mon, 19 Oct 2020 18:03:09 +0200
 Subject: ttyname_r can use MAXPATHLEN
@@ -487,10 +487,10 @@ index c21c6f0..51421e1 100644
      if (buffer == NULL) {
          return PyErr_NoMemory();
 -- 
-2.45.2
+2.48.1
 
 
-From 2ea7ad4feb7d3a2bb940b102cf1bb457e6859a2d Mon Sep 17 00:00:00 2001
+From 7e896bb4cbe95dc7eb01a13793c0e5d874dc48ab Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Mon, 24 Oct 2022 20:04:10 -0300
 Subject: Lib/test: require the "largefile" usage flag for I/O heavy tests.
@@ -540,10 +540,10 @@ index 1867e8c..e4fab02 100644
                  'test requires %s bytes and a long time to run' % str(0x180000000))
          f = open(TESTFN, 'w+b')
 -- 
-2.45.2
+2.48.1
 
 
-From d2240d3f6402cc0982184a306780c8345de084cb Mon Sep 17 00:00:00 2001
+From bef6c38a8c21355ea240f4099616b6993757e2fc Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 26 Jul 2024 19:18:56 -0300
 Subject: _getuserbase(), getsitepackages(), and INSTALL_SCHEMES for Haiku.
@@ -622,7 +622,7 @@ index aed254a..d3612a0 100644
              if sys.platlibdir != "lib":
                  libdirs.append("lib")
 diff --git a/Lib/sysconfig.py b/Lib/sysconfig.py
-index 7dd63b9..e608b5e 100644
+index acc8d4d..56efaaf 100644
 --- a/Lib/sysconfig.py
 +++ b/Lib/sysconfig.py
 @@ -47,6 +47,36 @@ _INSTALL_SCHEMES = {
@@ -719,7 +719,7 @@ index 7dd63b9..e608b5e 100644
          'osx_framework_user': {
              'stdlib': '{userbase}/lib/python',
              'platstdlib': '{userbase}/lib/python',
-@@ -280,6 +339,18 @@ def _expand_vars(scheme, vars):
+@@ -287,6 +346,18 @@ def _expand_vars(scheme, vars):
  
  
  def _get_preferred_schemes():
@@ -739,7 +739,7 @@ index 7dd63b9..e608b5e 100644
          return {
              'prefix': 'nt',
 diff --git a/Lib/test/test_sysconfig.py b/Lib/test/test_sysconfig.py
-index 3468d0c..35bea57 100644
+index 67647e1..078a260 100644
 --- a/Lib/test/test_sysconfig.py
 +++ b/Lib/test/test_sysconfig.py
 @@ -353,9 +353,10 @@ class TestSysConfig(unittest.TestCase):
@@ -756,10 +756,10 @@ index 3468d0c..35bea57 100644
  
      @skip_unless_symlink
 -- 
-2.45.2
+2.48.1
 
 
-From 5e9a20c305c91090979f5d1bfe5a0717e163ca75 Mon Sep 17 00:00:00 2001
+From 1a148d78e0ae2cc8cb8fffe237b1799a7ff359bf Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 26 Jul 2024 19:01:05 -0300
 Subject: Fix location of REPL's history file.
@@ -793,10 +793,10 @@ index d3612a0..3a714a0 100644
                  readline.read_history_file(history)
              except OSError:
 -- 
-2.45.2
+2.48.1
 
 
-From 2ab0f0054255bf3b7060184e4cecba14ac6448d3 Mon Sep 17 00:00:00 2001
+From 29005f55483b312ab906ba6c1469cc43485e6811 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 8 Oct 2023 17:02:19 -0300
 Subject: Use spawn instead of fork for multiprocessing.
@@ -846,10 +846,10 @@ index de8a264..02a301e 100644
          # on macOS since macOS 10.14 (Mojave). Use spawn by default instead.
          _default_context = DefaultContext(_concrete_contexts['spawn'])
 -- 
-2.45.2
+2.48.1
 
 
-From 206c6c3cc6371c5f526ea29e5fdccfdb7ef282c8 Mon Sep 17 00:00:00 2001
+From ce5827744a01456e6ddddeb549233e93f64ca34a Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 10 Dec 2023 19:50:22 -0300
 Subject: Miscellaneous "Lib/test/" fixes for Haiku.
@@ -860,10 +860,10 @@ Content-Transfer-Encoding: 8bit
 test_fileio.py fix from "initial Haiku patch" by Jérôme Duval.
 
 diff --git a/Lib/test/datetimetester.py b/Lib/test/datetimetester.py
-index 903a43a..287624f 100644
+index b2d5750..c04a185 100644
 --- a/Lib/test/datetimetester.py
 +++ b/Lib/test/datetimetester.py
-@@ -5973,6 +5973,9 @@ def pairs(iterable):
+@@ -6020,6 +6020,9 @@ def pairs(iterable):
  
  class ZoneInfo(tzinfo):
      zoneroot = '/usr/share/zoneinfo'
@@ -886,10 +886,10 @@ index ebfcffd..0517b87 100644
                          # Somehow /dev/tty appears seekable on some BSDs
                          self.assertEqual(f.seekable(), False)
 -- 
-2.45.2
+2.48.1
 
 
-From d16a22d00038e54c32a4358a7febfca32ba93528 Mon Sep 17 00:00:00 2001
+From b6438893be1f0ea1ac6b7296cb6854abc3179296 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sat, 10 Feb 2024 06:01:25 -0300
 Subject: Fix build on nightlies, following the addition of kqueue.
@@ -952,10 +952,10 @@ index 50788e5..82fd9d9 100644
  
      /* NETDEV filter flags */
 -- 
-2.45.2
+2.48.1
 
 
-From e188d6f612aa90014e3eb4dc2591797b694f3775 Mon Sep 17 00:00:00 2001
+From cd75d6fe66da5fb1109934a27490839dbcb07a14 Mon Sep 17 00:00:00 2001
 From: Alexander von Gluck IV <kallisti5@unixzen.com>
 Date: Thu, 14 Mar 2024 12:54:33 -0500
 Subject: config.guess: Update to universal haiku arch guessing
@@ -982,10 +982,10 @@ index e81d3ae..366429c 100755
      SX-4:SUPER-UX:*:*)
  	GUESS=sx4-nec-superux$UNAME_RELEASE
 -- 
-2.45.2
+2.48.1
 
 
-From 62187db712b992fd67fefd1bfe5a4ee974f26af6 Mon Sep 17 00:00:00 2001
+From a19d0ace5469dc481adc9910b1953ac2fa574bbb Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 9 Aug 2024 13:38:28 -0300
 Subject: fix test_utf8_mode.
@@ -1005,10 +1005,10 @@ index f668810..a55a8e4 100644
          elif sys.platform.startswith("aix"):
              c_arg = arg.decode('iso-8859-1')
 -- 
-2.45.2
+2.48.1
 
 
-From 1aaae4cbef0f3e832506d71be41b06164a440dd3 Mon Sep 17 00:00:00 2001
+From b2349eb308cb3969e37d449f9b7cd7d149ad0e2b Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 9 Aug 2024 14:35:04 -0300
 Subject: Fix test_site.
@@ -1061,7 +1061,7 @@ index 3a714a0..2124aa1 100644
                                          "vendor-packages"))
          elif os.sep == '/':
 diff --git a/Lib/test/test_site.py b/Lib/test/test_site.py
-index 1a9c81d..09e612f 100644
+index 249e6b5..a575423 100644
 --- a/Lib/test/test_site.py
 +++ b/Lib/test/test_site.py
 @@ -322,7 +322,21 @@ class HelperFunctionsTests(unittest.TestCase):
@@ -1088,17 +1088,17 @@ index 1a9c81d..09e612f 100644
              if sys.platlibdir != "lib":
                  self.assertEqual(len(dirs), 2)
 -- 
-2.45.2
+2.48.1
 
 
-From 08a6fc4f113001e8601ef50eed14b9a3fd9b2f5d Mon Sep 17 00:00:00 2001
+From 4b18beee770bb7dbee777641ef9cb092b8f9bc37 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 9 Aug 2024 15:37:13 -0300
 Subject: Fix test_sysconfig.
 
 
 diff --git a/Lib/test/test_sysconfig.py b/Lib/test/test_sysconfig.py
-index 35bea57..04c136f 100644
+index 078a260..6175b08 100644
 --- a/Lib/test/test_sysconfig.py
 +++ b/Lib/test/test_sysconfig.py
 @@ -210,6 +210,19 @@ class TestSysConfig(unittest.TestCase):
@@ -1131,10 +1131,10 @@ index 35bea57..04c136f 100644
              wanted.extend(['nt_user', 'osx_framework_user', 'posix_user', 'haiku_user'])
          self.assertEqual(get_scheme_names(), tuple(sorted(wanted)))
 -- 
-2.45.2
+2.48.1
 
 
-From b9c25f918355e58eceb0a92e506ea86ce355cce5 Mon Sep 17 00:00:00 2001
+From ec939e784caadd02233ce26a469f11bc0ce3ae95 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 9 Aug 2024 15:45:45 -0300
 Subject: Fix test_compileall by skipping tests that need hardlink support.
@@ -1164,5 +1164,5 @@ index 5832f84..2e736db 100644
      # Test hardlink_dupes parameter of compileall.compile_dir()
  
 -- 
-2.45.2
+2.48.1
 

--- a/dev-lang/python/python3.12-3.12.10.recipe
+++ b/dev-lang/python/python3.12-3.12.10.recipe
@@ -13,7 +13,7 @@ LICENSE="Python"
 COPYRIGHT="1990-2025 Python Software Foundation"
 REVISION="1"
 SOURCE_URI="https://www.python.org/ftp/python/$portVersion/Python-${portVersion}.tar.xz"
-CHECKSUM_SHA256="7220835d9f90b37c006e9842a8dff4580aaca4318674f947302b8d28f3f81112"
+CHECKSUM_SHA256="07ab697474595e06f06647417d3c7fa97ded07afc1a7e4454c5639919b46eaea"
 SOURCE_DIR="Python-$portVersion"
 
 pyShortVer="${portVersion%.*}"
@@ -53,8 +53,14 @@ packageTests=false
 # Set to "false" for faster local/test builds. Around 4 to 5 times faster that way.
 optimizedBuild=true
 
+# Generally, we disable parallel builds if "optimizedBuild == true" as they can fail.
+forceParallelBuild=true
+
 # Run all tests by default. Set to "true" to make "hp --test" only run then known failing tests.
 runOnlyKnownFailingTests=false
+
+# Run only the tests that are generally excluded. Expect LOTS of hangs/crashes/etc.
+runOnlyExcludedTests=false
 
 # <<<[RECIPE OPTIONS]
 
@@ -179,7 +185,7 @@ BUILD()
 		--with-ensurepip=no \
 		--with-readline=editline \
 		--with-system-expat \
-		--with-tzpath=$dataDir/zoneinfo \
+		--with-tzpath=$(findpaths -c : B_FIND_PATH_DATA_DIRECTORY zoneinfo) \
 		--without-static-libpython
 		# --disable-test-modules interferes with the PGO tests. don't use it.
 		#
@@ -204,11 +210,13 @@ BUILD()
 	#
 	# Not using multiple jobs for make solves both the warnings and the possible error.
 
-#	if $optimizedBuild; then
-#		make -j 1
-#	else
+	if $optimizedBuild && ! $forceParallelBuild; then
+		echo "Running make with: -j 1"
+		make -j 1
+	else
+		echo "Running make with: $jobArgs"
 		make $jobArgs
-#	fi
+	fi
 }
 
 INSTALL()
@@ -288,10 +296,15 @@ INSTALL()
 # "hp --test"'s chroot. (test_sysconfig.MakefileTests.test_parse_makefile, for example).
 # Problem is "os.getcwd()" will return wrong data, causing some file operations to fail.
 
-# For reference, results on hrev57937+113 (64 bits VBox):
-# Total duration: 13 min 9 sec
-# Total tests: run=33,883 failures=222 skipped=971
-# Total test files: run=434/424 failed=15 skipped=32 resource_denied=6 rerun=16
+# For reference, results on hrev57937+129 (64 bits VMware):
+# Total duration: 10 min 30 sec
+# Total tests: run=35,223 failures=634 skipped=1,009
+# Total test files: run=448/435 failed=21 skipped=32 resource_denied=8 rerun=21
+#
+# results on hrev58812 (32 bits bare metal):
+# Total duration: 4 min 41 sec
+# Total tests: run=36,581 failures=552 skipped=1,342
+# Total test files: run=454/445 failed=17 skipped=32 resource_denied=8 rerun=17
 TEST()
 {
 	# Remove tests data left-overs, if any:
@@ -319,16 +332,11 @@ TEST()
 	)
 
 	local tests_to_exclude=(
-		# distutils is deprecated, and will be removed on 3.12.
-		-x test_distutils
-
 		# The following tests invoke the crash dialog, and unless your configure
 		# debug_server default action to "kill" or "report", they will hang waiting for
 		# user input. See comment above TEST().
-		-x test_faulthandler
-		-x test_futures # from test_asyncio. Crashes: Exception (Segment violation)
-		-x test_subprocess # tends to hang.
-		-x test_threading # tends to hang.
+		-x test_subprocess # tends to hang. Causes segfaults in several binaries it calls (/bin/true, for example).
+		-x test_threading # tends to hang. Many "IsADirectoryError" when calling "subprocess._execute_child()"
 
 		# Many of the tests hang/stall. We have two options:
 		#
@@ -346,22 +354,18 @@ TEST()
 		# Let's use Option 1, for now at least.
 
 		# These hang reliably.
-		-x test__xxsubinterpreters
-		-x test_cmd_line
-		-x test_concurrent_futures
-		-x test_eintr
-		-x test_interpreters
-		-x test_multiprocessing_fork
-		-x test_multiprocessing_forkserver
-		-x test_multiprocessing_main_handling
+		-x test_cmd_line		# "IsADirectoryError" when calling "subprocess._execute_child()"
+		-x test_concurrent_futures	# resource_tracker: process died unexpectedly
+		-x test_interpreters	# segfaults when calling: finddir B_USER_NONPACKAGED_DIRECTORY
+#		-x test_multiprocessing_main_handling	# "IsADirectoryError" when calling "subprocess._execute_child()"
 		-x test_multiprocessing_spawn
-		-x test_os
-		-x test_posix
-		-x test_random
-		-x test_socketserver
-		-x test_threaded_import # test_importlib/test_threaded_import
-		-x test_tracemalloc
-		-x test_uuid
+		-x test_os				# Causes segfaults in several binaries it calls.
+		-x test_posix			# "Invalid Argument: '@test_94495_tmpæ'" in can_chmod
+
+#		-x test_socketserver	# skipped unless "network" resource is enabled.
+		-x test_threaded_import # RECHECK. test_importlib/test_threaded_import
+#		-x test_tracemalloc		# # "IsADirectoryError" when calling "subprocess._execute_child()"
+		-x test_uuid			# Causes segfaults in several binaries it calls (ifconfig/netstat).
 
 		# "test_asyncio" doesn't seems to runs reliably, even after individually skipping
 		# all the problematic test-cases that could be identify by running them one by one.
@@ -379,65 +383,89 @@ TEST()
 	#	-i TestThreadedServer # in test_asyncio.functional
 
 		# These not always hang/stall, but they do it enough to warrant skipping for now.
-		-x test_imaplib
+		-x test_multiprocessing_fork	# resource_tracker: process died unexpectedly
+		-x test_multiprocessing_forkserver
+		-x test_imaplib	# OK on hrev58812 32 bits, hangs on beta5 64 bits.
 		-x test_signal
-		-x test_socket
+		-x test_socket	# OK on hrev58812 32 bits, hangs on beta5 64 bits.
 		-x test_ssl
-		-x test_urllib2_localnet
+		-x test_urllib2_localnet	# OK on hrev58812 32 bits, hangs on beta5 64 bits.
 
 		# 3.11
-		-x test_urllib2net
-		-x test_venv
+#		-x test_urllib2net	# skipped if "network" resource is not enabled.
+#		-x test_venv # recheck
 
 		# 3.12 Either too slow or hangs;
-		-x test_builtin
-		-x test_mailbox
-		-x test_tempfile
-		-x test_thread
+#		-x test_builtin	# failures related to "Invalid Argument: '@test_95635_tmpæ'" in write_testfile and "IsADirectoryError" when calling "subprocess._execute_child()"
+#		-x test_mailbox
+#		-x test_tempfile
+#		-x test_thread # OK on 32 bits.
 
 		# 3.12.1
-		-x test_queue
+#		-x test_queue # OK on 32 bits.
 
 		# 3.11.8 / 3.12.2 (hang on nightlies, at least)
-		-x test_httplib
-		-x test_httpservers
+		-x test_httplib		# "Invalid Argument: '@test_97280_tmpæ'" in open(os_helper.TESTFN, "wb")
 		-x test_logging
-		-x test_pydoc
-		-x test_xmlrpc
+		-x test_pydoc		# "Invalid Argument: '@test_97476_tmpæ'" in open(TESTFN, "wb")
 
 		# Fails while outputing "ResourceWarning: unclosed <ssl.SSLSocket", but takes anywhere
 		# between 1 to 3+ minutes to end (and gets re-run!). Run it manually if needed, or
 		# re-enable once those SSLSocket warninings, that also pop up on other tests, get resolved.
-		-x test_ftplib
+		-x test_ftplib	# Shouldn't be enabled unless network-resource is granted.
 
 		# 3.12.4 hang at least once on beta4.
-		-x test_importlib
+		-x test_importlib # "test_importlib crashed" in 32 bits
 
-		# 3.12.6, on beta5
-		-x test_readline # hangs when running tests in parallel (or as part of the suite, at least).
+		# 3.12.6, on beta5 (still the same in hrev58812 32 bits)
+		-x test_readline # hangs when running tests in parallel (or as part of the suite, at least). deadlocks with test_pty?
+
+		# 3.12.10
+		# -x test_glob	# hangs on hrev58812 32 bits. works on beta5 64.
+		# hang on beta5 64 bits VM:
+		-x test_httpservers
+		-x test_kqueue
+		-x test_nntplib
+		-x test_poplib
+		-x test_smtplib
+		-x test_urllib2
+		-x test_wsgiref
+		-x test_xmlrpc
 	)
 
 	local tests_that_fail=(
+		test__locale
 		test_c_locale_coercion
-		test_datetime
-		test_fcntl
-		test_genericpath # os.path.getatime() should return an int.
-		test_json # either takes almost 5 minutes, or fails right away!?
-		test_kqueue
-		test_pathlib
-		test_popen
-		test_re
-		test_readline # hangs sometimes.
-		test_shutil
-		test_tarfile # os.path.getmtime() should return an int. Also, path.stat().st_mtime and pathlib.Path(TEMPDIR).stat().st_mtime seems to be using different scales: 1723.215266 vs 1723215266.0319815
-		test_termios
-		test_time
-		test_tools
+		test_ctypes		# stupid test compares wording of error message.
+#		test_datetime	# Fails on beta5 64 intermitently.
+		test_fcntl		# "Permission denied" in test_lockf_exclusive
+		test_glob		# Fails on beta5 64 intermitently.
+#		test_genericpath # os.path.getatime() should return an int. OK on 32 bits. and 64 beta5.
+#		test_httpservers	# on beta5 64. OK on hrev58812 32 bits.
+		test_json 		# either takes almost 5 minutes, or fails right away!? "AssertionError: 13 != -2147459059"
+		test_kqueue		# fails to read "foo" from a kqeuque. may hang on 64 bits beta5. other times PASSES :-/
+		test_mailbox	# only fails on 64 bits?
+		test_multiprocessing_main_handling	# Failed at least once in beta5 64.
+#		test_pathlib	# OK on 32 bits? Fails on beta5 64 intermitently.
+		test_popen		# sign error numbers in waitstatus_to_exitcode()... "AssertionError: -42 != 42"
+		test_re			# locale related failures.
+#		test_shutil		# OK on 32 bits?
+		test_stat		# Failed on beta5 64 at least once.
+		test_strptime	# on hrev58812 32 bits at least. locale related failures. beta5 64 vm too.
+		test_sysconfig	# on hrev58812 32 bits at least, "venv" related. beta5 64 vm too.
+		test_tarfile	# uid/gid overflows in 32 bits. On 64: os.path.getmtime() should return an int. Also, path.stat().st_mtime and pathlib.Path(TEMPDIR).stat().st_mtime seems to be using different scales: 1723.215266 vs 1723215266.0319815
+		test_termios	# tcdrain/tcflow/tcflush/tcsendbreak related failures.
+		test_time		# ctime/mktime related failures.
+		test_tools		# OK on hrev58812 32 bits. Fails on beta5 64 intermitently.
+#		test_urlib2_localnet	# OK on hrev58812 32 bits. Fails on beta5 64 VM?
+		test_venv		# Fails on beta5 64.
 	)
 
 	local -x LOGNAME=buildbot # this skips tests_tools/test_freeze, copied from Gentoo's ebuild
 
-	if $runOnlyKnownFailingTests; then
+	if $runOnlyExcludedTests; then
+		make $jobArgs test EXTRATESTOPTS="${test_options[*]} ${tests_to_exclude[*]}"
+	elif $runOnlyKnownFailingTests; then
 		make $jobArgs test EXTRATESTOPTS="${test_options[*]} ${tests_that_fail[*]}"
 	else
 		# Runs the full test suite (minus the tests that we explicitly exclude).


### PR DESCRIPTION
Re-run the test suite on both bare-metal nightly 32 bits (hrev58812), and beta5 64 bits under VMware, to double check which tests still hang and which work.

Did my best to add some notes on possible causes for the failing ones.