### PR TITLE
DevilutionX: "home" install fix

### DIFF
--- a/games-rpg/devilutionx/devilutionx-1.5.4.recipe
+++ b/games-rpg/devilutionx/devilutionx-1.5.4.recipe
@@ -7,7 +7,7 @@ Visit the homepage for more info, a FAQ, controller mappings, etc."
 HOMEPAGE="https://github.com/diasurgical/devilutionX"
 COPYRIGHT="2025 DevilutionX"
 LICENSE="Sustainable Use License"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/diasurgical/devilutionX/archive/$portVersion.zip"
 CHECKSUM_SHA256="850ca8af8c0c86c9224be469f80e25f7fafdfc70bc29388ac0ab5a4c5e29da2c"
 SOURCE_DIR="DevilutionX-$portVersion"
@@ -55,9 +55,6 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
-defineDebugInfoPackage devilutionx$secondaryArchSuffix \
-	$appsDir/DevilutionX/devilutionx
-
 BUILD()
 {
 	export CXXFLAGS="-D_DEFAULT_SOURCE -Wall -w"
@@ -66,7 +63,7 @@ BUILD()
 	mkdir -p build && cd build
 
 	cmake .. $cmakeDirArgs \
-		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_BUILD_TYPE=Release \
 		-DDISABLE_ZERO_TIER=ON \
 		-DDISABLE_LTO=ON \
 		-DBUILD_TESTING=OFF \

--- a/games-rpg/devilutionx/patches/devilutionx-1.5.4.patchset
+++ b/games-rpg/devilutionx/patches/devilutionx-1.5.4.patchset
@@ -1,38 +1,49 @@
-From ed8b4cbd54401c07eec9cd040db9bec18b742110 Mon Sep 17 00:00:00 2001
+From 3f57fb3eb9dcd7ecf532ddccdb78c047e7bbc411 Mon Sep 17 00:00:00 2001
 From: Peppersawce <michaelpeppers89@yahoo.it>
-Date: Sun, 6 Oct 2024 23:00:09 +0200
-Subject: Define Haiku assets path
+Date: Mon, 14 Apr 2025 23:17:00 +0200
+Subject: Define Haiku assets paths (better version)
 
 
 diff --git a/Source/utils/paths.cpp b/Source/utils/paths.cpp
-index e803436..79c1619 100644
+index 9635ac3..9ca00a9 100644
 --- a/Source/utils/paths.cpp
 +++ b/Source/utils/paths.cpp
-@@ -7,6 +7,11 @@
+@@ -11,6 +11,12 @@
  #include "utils/log.hpp"
  #include "utils/sdl_ptrs.h"
 
 +#ifdef __HAIKU__
 +#include <FindDirectory.h>
 +#include <fs_info.h>
++#include <dirent.h>
 +#endif
 +
  #ifdef __IPHONEOS__
  #include "platform/ios/ios_paths.h"
  #endif
-@@ -113,6 +118,12 @@ const std::string &ConfigPath()
-
+@@ -118,7 +123,21 @@ const std::string &ConfigPath()
  const std::string &AssetsPath()
  {
-+#if defined(__HAIKU__)
-+	char buffer[B_PATH_NAME_LENGTH+10];
-+	find_directory(B_SYSTEM_DATA_DIRECTORY, dev_for_path("/boot"), false, buffer, B_PATH_NAME_LENGTH);
-+	strcat(buffer, "/devilutionx/");
-+	assetsPath.emplace(strdup(buffer));
-+#endif
  	if (!assetsPath) {
- #if __EMSCRIPTEN__
+-#if __EMSCRIPTEN__
++#if defined(__HAIKU__)
++		// Look in system first (system-wide install)
++		char buffer[B_PATH_NAME_LENGTH + 10];
++		find_directory(B_SYSTEM_DATA_DIRECTORY, dev_for_path("/boot"), false, buffer, B_PATH_NAME_LENGTH);
++		strcat(buffer, "/devilutionx/");
++		if (opendir(buffer)) {
++			assetsPath.emplace(strdup(buffer));
++		} else {
++			// Then look in user data (home-data install)
++			char homedata[B_PATH_NAME_LENGTH + 10];
++			find_directory(B_USER_DATA_DIRECTORY, dev_for_path("/boot"), false, homedata, B_PATH_NAME_LENGTH);
++			strcat(homedata, "/devilutionx/");
++			assetsPath.emplace(strdup(homedata));
++		}
++#elif  __EMSCRIPTEN__
  		assetsPath.emplace("assets/");
---
-2.45.2
+ #elif defined(NXDK)
+ 		assetsPath.emplace("D:\\assets\\");
+-- 
+2.48.1
 


### PR DESCRIPTION
The current package would only work if installed system-wide, so I expanded DevilutionX's patch a bit. 
After this patch it will look into "system/data" first, then fall back to "home/data", so both cases are covered.