### PR TITLE
apache, drop --with-included-regex

### DIFF
--- a/www-servers/apache/apache-2.4.63.recipe
+++ b/www-servers/apache/apache-2.4.63.recipe
@@ -5,7 +5,7 @@ and freely-available source code implementation of an HTTP (Web) server"
 HOMEPAGE="https://httpd.apache.org/"
 COPYRIGHT="1995-2025 The Apache Software Foundation."
 LICENSE="Apache v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://archive.apache.org/dist/httpd/httpd-$portVersion.tar.bz2"
 CHECKSUM_SHA256="88fc236ab99b2864b248de7d49a008ec2afd7551e64dce8b95f58f32f94c46ab"
 SOURCE_DIR="httpd-$portVersion"
@@ -322,8 +322,7 @@ BUILD()
 		--with-apr=/$relativeBinDir \
 		--with-apr-util=/$relativeBinDir \
 		--enable-asis \
-		--enable-cgi \
-		--with-included-regex # for crashing ./conftest
+		--enable-cgi
 
 	make $jobArgs
 }


### PR DESCRIPTION
not required for fixing earlier crash