### PR TITLE
openjdk19: New Openjdk19 port

### DIFF
--- a/dev-lang/openjdk/openjdk19-19.0.2.1.recipe
+++ b/dev-lang/openjdk/openjdk19-19.0.2.1.recipe
@@ -201,12 +201,12 @@ INSTALL()
 	echo "JAVA_HOME=$jdkDir" > $jdkProfile
 	echo "export JAVA_HOME" >> $jdkProfile
 
-	# create a profile.d file that sets up JDK18_HOME
+	# create a profile.d file that sets up JDK19_HOME
 	jdkProfile=$dataDir/profile.d/openjdk19.sh
 	echo "JDK19_HOME=$jdkDir" > $jdkProfile
 	echo "export JDK19_HOME" >> $jdkProfile
 
-	# create a profile.d file that sets up JRE18_HOME
+	# create a profile.d file that sets up JRE19_HOME
 	jreProfile=$dataDir/profile.d/openjre19.sh
 	echo "JRE19_HOME=$(getPackagePrefix jre)/$relativeLibDir/openjdk19" > $jreProfile
 	echo "export JRE19_HOME" >> $jreProfile

--- a/dev-lang/openjdk/openjdk19-19.0.2.1.recipe
+++ b/dev-lang/openjdk/openjdk19-19.0.2.1.recipe
@@ -1,0 +1,260 @@
+SUMMARY="An open-source implementation of the Java Platform, SE"
+DESCRIPTION="OpenJDK (Open Java Development Kit) is a free and open source \
+implementation of the Java Platform, Standard Edition (Java SE). It is the \
+result of an effort Sun Microsystems began in 2006.
+
+The implementation is licensed under the GNU General Public License (GNU GPL) \
+with a linking exception. Were it not for the GPL linking exception, components \
+that linked to the Java class library would be subject to the terms of the GPL \
+license. OpenJDK is the official Java SE 8 reference implementation."
+HOMEPAGE="https://openjdk.java.net/"
+COPYRIGHT="2007-2022 Oracle and/or its affiliates."
+LICENSE="GNU GPL v2"
+REVISION="1"
+jdkBuild="jdk-${portVersion%.*}+${portVersion##*.}"
+srcGitRev="842b181d80860990f5bd0483d50372d3e33c6dd5"
+SOURCE_URI="https://github.com/Powerm1nt/jdk19u/archive/$srcGitRev.tar.gz"
+#SOURCE_URI="git+https://github.com/korli/jdk21u.git#tag=haiku-port"
+CHECKSUM_SHA256="3bfede9a24e4f8101e9bad438804cd7d7beaa08d875c6cb6e7eae593bdb74400"
+SOURCE_DIR="jdk19u-$srcGitRev"
+SOURCE_FILENAME="jdk19u-$jdkBuild-$srcGitRev.tar.gz"
+SOURCE_URI_2="https://builds.shipilev.net/jtreg/jtreg-7.3.1%2B1.zip"
+CHECKSUM_SHA256_2="29da2f7a7220c8ca4c81960ca54a1c02e1b61520dfb3188cb8dcc1d55a9ac3fb"
+SOURCE_DIR_2="jtreg"
+ADDITIONAL_FILES="
+	elf.h
+	"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
+
+DISABLE_SOURCE_PACKAGE="yes"
+	# at least as long as Ant and a complete SDK image are part of the "sources" package
+
+PROVIDES="
+	openjdk19$secondaryArchSuffix = $portVersion compat >= 19
+	java:environment = 19
+	"
+REQUIRES="
+	openjdk19${secondaryArchSuffix}_jre == $portVersion
+	"
+
+PROVIDES_default="
+	openjdk19${secondaryArchSuffix}_default = $portVersion
+	cmd:jar = $portVersion compat >= 19
+	cmd:jarsigner = $portVersion compat >= 19
+	cmd:java = $portVersion compat >= 19
+	cmd:javac = $portVersion compat >= 19
+	cmd:javadoc = $portVersion compat >= 19
+	cmd:javah = $portVersion compat >= 19
+	cmd:javap = $portVersion compat >= 19
+	cmd:jcmd = $portVersion compat >= 19
+	cmd:jconsole = $portVersion compat >= 19
+	cmd:jdb = $portVersion compat >= 19
+	cmd:jinfo = $portVersion compat >= 19
+	cmd:jmap = $portVersion compat >= 19
+	cmd:jps = $portVersion compat >= 19
+	cmd:jstack = $portVersion compat >= 19
+	cmd:jstat = $portVersion compat >= 19
+	cmd:jstatd = $portVersion compat >= 19
+	cmd:keytool = $portVersion compat >= 19
+	cmd:rmiregistry = $portVersion compat >= 19
+	cmd:serialver = $portVersion compat >= 19
+	"
+REQUIRES_default="
+	openjdk19$secondaryArchSuffix == $portVersion
+	"
+CONFLICTS_default="
+	openjdk8${secondaryArchSuffix}_default
+	openjdk9${secondaryArchSuffix}_default
+	openjdk10${secondaryArchSuffix}_default
+	openjdk11${secondaryArchSuffix}_default
+	openjdk12${secondaryArchSuffix}_default
+	openjdk13${secondaryArchSuffix}_default
+	openjdk14${secondaryArchSuffix}_default
+	openjdk15${secondaryArchSuffix}_default
+	openjdk16${secondaryArchSuffix}_default
+	openjdk17${secondaryArchSuffix}_default
+	openjdk18${secondaryArchSuffix}_default
+	"
+
+PROVIDES_jre="
+	openjdk19${secondaryArchSuffix}_jre = $portVersion compat >= 19
+	java:runtime = 19
+	"
+REQUIRES_jre="
+	haiku$secondaryArchSuffix
+	lib:libfreetype$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libjpeg$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	ca_root_certificates_java
+	dejavu
+	"
+
+SUMMARY_sources="JDK source files, demos and examples"
+PROVIDES_sources="
+	openjdk19${secondaryArchSuffix}_sources = $portVersion compat >= 19
+	"
+REQUIRES_sources="
+	openjdk19$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	java:environment == 18
+	ca_root_certificates
+	devel:libfontconfig$secondaryArchSuffix
+	devel:libfreetype$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
+	devel:libjpeg$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cpio
+	cmd:make
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:sed
+	cmd:tar
+	cmd:zip
+	cmd:gawk
+	cmd:hostname
+	cmd:find
+	cmd:unzip
+	cmd:unzipsfx
+	cmd:head
+	cmd:file
+	cmd:which
+	cmd:autoconf
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+TEST_REQUIRES="
+	cmd:true
+	"
+
+BUILD()
+{
+	source /system/data/profile.d/openjdk18.sh
+	export PATH=$JDK18_HOME/bin:$PATH
+	export COMPANY=HaikuPorts
+
+	ln -sfn $sourceDir2 jtreg
+
+	cp $portDir/additional-files/elf.h src/hotspot/share/utilities
+
+	# If ASLR is enabled, the JVM can fail to find a large enough area for
+	# the heap.
+	export DISABLE_ASLR=1
+
+	# Verify that we can allocate a large enough heap before starting.
+	java -XX:ThreadStackSize=1536 -Xmx1024M -version
+
+	freeTypeHeaders=$(finddir B_SYSTEM_HEADERS_DIRECTORY)$secondaryArchSubDir/freetype2
+	freeTypeLib=$(finddir B_SYSTEM_DEVELOP_DIRECTORY)/lib$secondaryArchSubDir
+
+	bash ./configure \
+					--with-freetype-include="${freeTypeHeaders}" \
+					--with-freetype-lib="${freeTypeLib}" \
+					--with-jtreg=./jtreg \
+					--with-version-build="${portVersion//*.}" \
+					--with-version-pre="" \
+					--with-version-opt="" \
+					--with-num-cores=2 \
+					--enable-javac-server \
+					--disable-warnings-as-errors \
+					--with-extra-cflags="-w" \
+					--with-extra-cxxflags="-w"
+
+	make images LOG=info
+}
+
+INSTALL()
+{
+	# install the generated SDK image dir
+	jdkDir=$libDir/openjdk19
+
+	mkdir -p $jdkDir
+	cp -a build/haiku-*/images/jdk/* $jdkDir
+
+	# set up the cacerts link
+	ln -sf $dataDir/ssl/java/cacerts $jdkDir/conf/security/
+
+	# symlink the executables to binDir
+	mkdir -p $prefix/bin
+	bins="jar jarsigner javac javadoc javah javap jcmd jconsole jdb jinfo \
+		jmap jps jstack jstat jstatd serialver"
+	bins_runtime="java keytool rmiregistry"
+	man_runtime=""
+	for b in $bins $bins_runtime; do
+		symlinkRelative -s $jdkDir/bin/$b $prefix/bin
+	done
+	for b in $bins_runtime; do
+		man_runtime+=" $jdkDir/man/man1/$b.1"
+	done
+
+	mkdir -p $dataDir/profile.d
+
+	# create a profile.d file that sets up JAVA_HOME
+	jdkProfile=$dataDir/profile.d/openjdk.sh
+	echo "JAVA_HOME=$jdkDir" > $jdkProfile
+	echo "export JAVA_HOME" >> $jdkProfile
+
+	# create a profile.d file that sets up JDK18_HOME
+	jdkProfile=$dataDir/profile.d/openjdk19.sh
+	echo "JDK19_HOME=$jdkDir" > $jdkProfile
+	echo "export JDK19_HOME" >> $jdkProfile
+
+	# create a profile.d file that sets up JRE18_HOME
+	jreProfile=$dataDir/profile.d/openjre19.sh
+	echo "JRE19_HOME=$(getPackagePrefix jre)/$relativeLibDir/openjdk19" > $jreProfile
+	echo "export JRE19_HOME" >> $jreProfile
+
+	find $jdkDir -name '*.diz' -o -name '*.debuginfo' -delete
+	# not for jre
+	mv $jdkDir/lib/libattach.so $jdkDir/lib/ct.sym $prefix
+
+	packageEntries sources \
+		$jdkDir/lib/src.zip \
+		$jdkDir/demo
+
+	packageEntries jre \
+		$jdkDir/bin/java \
+		$jdkDir/bin/jrunscript \
+		$jdkDir/bin/keytool \
+		$jdkDir/bin/rmiregistry \
+		$jdkDir/conf \
+		$jdkDir/legal \
+		$jdkDir/lib \
+		$jdkDir/release \
+		$dataDir/profile.d/openjre19.sh \
+		$man_runtime
+
+	mkdir -p $jdkDir/lib
+	mv $prefix/libattach.so $prefix/ct.sym $jdkDir/lib/
+
+	packageEntries default \
+		$prefix/bin \
+		$dataDir/profile.d/openjdk.sh
+}
+
+TEST()
+{
+	export DISABLE_ASLR=1
+	make test-image
+	#make test-only TEST_JOBS=1 TEST=jdk_lang # Test results: passed: 875; failed: 6; error: 2
+	#make test-only TEST_JOBS=1 TEST=jdk_util # Test results: passed: 908; failed: 4
+	make test-only JOBS=1 TEST=jdk_math # OK
+	#make test-only JOBS=1 TEST=jdk_io
+	make test-only JOBS=1 TEST=jdk_nio
+	#make test-only JOBS=1 TEST=jdk_net
+	make test-only JOBS=1 TEST=jdk_time # OK
+	#make test-only JOBS=1 TEST=jdk_rmi
+	#make test-only JOBS=1 TEST=jdk_security
+	make test-only JOBS=1 TEST=jdk_text # OK
+	#make test-only TEST_JOBS=1 TEST=jdk_management
+	#make test-only JOBS=1 TEST=jdk_instrument
+	#make test-only JOBS=1 TEST=jdk_jmx
+	#make test-only JOBS=1 TEST=jdk_jdi
+}


### PR DESCRIPTION
## openjdk19: New Openjdk19 port

### Same thing for #12188 but for jdk19u! (+1)
> i backported jdk18 haiku patches to jdk19, updated code to make jdk19 working!

(DEPENDS to #12188) to be built.

Tell me if i need to squash commit first.