### PR TITLE
asymptote: new recipe, version 3.02 (part of texlive)

### DIFF
--- a/media-gfx/asymptote/additional-files/xasy.rdef.in
+++ b/media-gfx/asymptote/additional-files/xasy.rdef.in
@@ -1,0 +1,14 @@
+
+resource app_flags B_MULTIPLE_LAUNCH;
+
+resource app_version {
+	major  = @MAJOR@,
+	middle = @MIDDLE@,
+	minor  = @MINOR@,
+	variety = B_APPV_FINAL,
+	internal = 0,
+	short_info = "Asymptote GUI",
+	long_info = "2D & 3D TeX-Aware Vector Graphics editor"
+};
+
+resource app_signature "application/x-vnd.asymptote-xasy";

--- a/media-gfx/asymptote/asymptote-3.02.recipe
+++ b/media-gfx/asymptote/asymptote-3.02.recipe
@@ -1,0 +1,189 @@
+SUMMARY="2D & 3D TeX-Aware Vector Graphics Language"
+DESCRIPTION="Asymptote is a powerful descriptive vector graphics language that provides a natural \
+coordinate-based framework for technical drawing. Labels and equations are typeset with LaTeX, \
+the de-facto standard for typesetting mathematics.
+A major advantage of Asymptote over other graphics packages is that it is a programming language, \
+as opposed to just a graphics program.
+
+Features of Asymptote:
+- provides a portable standard for typesetting mathematical figures, just as TeX/LaTeX has become \
+the standard for typesetting equations;
+- generates high-quality PostScript, OpenGL, PDF, SVG, WebGL, V3D, and PRC vector graphics;
+- embeds 3D vector WebGL graphics within HTML files;
+- embeds 3D vector PRC graphics within PDF files;
+- inspired by MetaPost, with a much cleaner, powerful C++-like programming syntax and IEEE \
+floating-point numerics;
+- runs on all major platforms (UNIX, MacOS, Microsoft Windows);
+- mathematically oriented (e.g. rotation of vectors by complex multiplication);
+- LaTeX typesetting of labels (for document consistency);
+- uses the simplex method and deferred drawing to solve overall size constraint issues between \
+fixed-sized objects (labels and arrowheads) and objects that should scale with figure size;
+- fully generalizes MetaPost path construction algorithms to three dimensions;
+- compiles commands into virtual machine code for speed without sacrificing portability;
+- high-level graphics commands are implemented in the Asymptote language itself, allowing them to \
+be tailored to specific applications."
+HOMEPAGE="https://asymptote.sourceforge.io/"
+COPYRIGHT="2004-25 Andy Hammerlindl, John Bowman, and Tom Prince"
+LICENSE="GNU GPL v3
+	GNU LGPL v3"
+REVISION="1"
+SOURCE_URI="https://downloads.sourceforge.net/project/asymptote/$portVersion/asymptote-$portVersion.src.tgz"
+CHECKSUM_SHA256="6796de739dde956c30c689fb0cf3927a71147b4961a37d883933e027133fc70a"
+PATCHES="asymptote-$portVersion.patchset"
+ADDITIONAL_FILES="xasy.rdef.in"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+commandBinDir=$binDir
+commandSuffix=$secondaryArchSuffix
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+pythonPackage=python310
+
+USER_SETTINGS_FILES="
+	settings/asy directory
+	"
+
+PROVIDES="
+	asymptote$secondaryArchSuffix = $portVersion
+	cmd:asy$commandSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libboost_filesystem$secondaryArchSuffix
+	lib:libboost_thread$secondaryArchSuffix
+	lib:libcurl$secondaryArchSuffix
+	lib:libedit$secondaryArchSuffix
+	lib:libfftw3$secondaryArchSuffix
+	lib:libGL$secondaryArchSuffix
+	lib:libgsl$secondaryArchSuffix
+	lib:libgslcblas$secondaryArchSuffix
+	lib:libncursesw$secondaryArchSuffix
+	lib:libsigsegv$secondaryArchSuffix
+	lib:libtirpc$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	tex:asymptote
+	"
+
+PROVIDES_gui="
+	asymptote${secondaryArchSuffix}_gui = $portVersion
+	cmd:xasy$commandSuffix = $portVersion
+	"
+REQUIRES_gui="
+	asymptote$secondaryArchSuffix == $portVersion base
+	cson_$pythonPackage
+	numpy_$pythonPackage
+	pyqt5_$pythonPackage
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:eigen$secondaryArchSuffix
+	devel:glm
+	devel:libboost_filesystem$secondaryArchSuffix >= 1.87.0
+	devel:libboost_thread$secondaryArchSuffix >= 1.87.0
+	devel:libcurl$secondaryArchSuffix
+	devel:libedit$secondaryArchSuffix
+	devel:libfftw3$secondaryArchSuffix
+	devel:libGL$secondaryArchSuffix
+	devel:libGLU$secondaryArchSuffix
+	devel:libgsl$secondaryArchSuffix
+	devel:libgslcblas$secondaryArchSuffix
+	devel:libintl$secondaryArchSuffix
+	devel:libncursesw$secondaryArchSuffix
+	devel:libsigsegv$secondaryArchSuffix
+	devel:libtirpc$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	pyqt5_$pythonPackage
+	tex:asymptote
+	tex:latex
+	tex:type1cm
+	# The following TeX packages are needed for creating tex formats:
+	# (because of texlive packaging, all hyphenation patterns are needed,
+	# the list contains one package from each collection)
+	tex:hyphen_afrikaans
+	tex:hyphen_ancientgreek
+	tex:hyphen_arabic
+	tex:hyphen_basque
+	tex:hyphen_belarusian
+	tex:hyphen_catalan
+	tex:hyphen_chinese
+	tex:hyphen_croatian
+	tex:hyphen_czech
+	tex:hyphen_english
+	tex:hyphen_german
+	tex:hyphen_italian
+	tex:hyphen_polish
+	tex:hyphen_portuguese
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:bison$secondaryArchSuffix
+	cmd:cmake
+	cmd:gcc$secondaryArchSuffix
+	cmd:gs
+	cmd:flex
+	cmd:kpsewhich
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:python3
+	cmd:texi2dvi
+	"
+
+defineDebugInfoPackage asymptote$secondaryArchSuffix \
+	"$commandBinDir"/asy
+
+BUILD()
+{
+	mkdir -p $(finddir B_USER_SETTINGS_DIRECTORY)
+
+	export LDFLAGS="-lbe -lnetwork"
+	runConfigure --omit-dirs "binDir" ./configure \
+		--bindir=$commandBinDir \
+		--with-latex=$portPackageLinksDir/tex~asymptote/data/texlive/texmf-dist/tex/latex \
+		--with-context=$portPackageLinksDir/tex~asymptote/data/texlive/texmf-dist/tex/context/third \
+		--with-docdir=$docDir \
+		--disable-gc # it tries to use its own copy of Boehm GC, which fails, no easy way to use system package
+
+	make $jobArgs usinggit=no # because of HaikuPorter's git repo
+}
+
+INSTALL()
+{
+	make install-notexhash usinggit=no
+
+	# Preparing the attributes
+	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
+	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
+	local MINOR="`echo "$portVersion" | cut -d. -f3`"
+	sed \
+		-e "s|@MAJOR@|$MAJOR|" \
+		-e "s|@MIDDLE@|$MIDDLE|" \
+		-e "s|@MINOR@|${MINOR:-0}|" \
+		$portDir/additional-files/xasy.rdef.in > xasy.rdef
+
+	# Installing extra-attribs
+	rc xasy.rdef
+
+	settype -t application/x-vnd.Be-elfexecutable $dataDir/asymptote/GUI/xasy.py
+	resattr -o $dataDir/asymptote/GUI/xasy.py xasy.rsrc
+
+	packageEntries gui \
+		$commandBinDir/xasy \
+		$dataDir/asymptote/GUI \
+		$manDir/man1/xasy.1x
+}
+
+TEST()
+{
+	# 1 test (the Ghostscript test) fails
+
+	#export ASYMPTOTE_EPSDRIVER=eps2write
+		# doesn't help, this is apparently the default anyway
+
+	make -k check usinggit=no
+}

--- a/media-gfx/asymptote/patches/asymptote-3.02.patchset
+++ b/media-gfx/asymptote/patches/asymptote-3.02.patchset
@@ -1,0 +1,208 @@
+From 1c4626e12c898849c7dd0196f1c972c9257c8c20 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
+Date: Fri, 18 Apr 2025 20:59:28 +0200
+Subject: Haiku build fixes
+
+Use the gnu++17 C++ standard to get non-standard symbols from netdb.h
+(and fix a bug in the Makefile when using that). Patching configure
+instead of configure.ac avoids the need for autoconf.
+
+Define __BSD_VISIBLE for feenableexcept and fedisableexcept.
+
+Disable the usage of unsupported GLUT functions.
+
+Change a hard-coded -fPIE to -fPIC.
+
+diff --git a/LspCpp/CMakeLists.txt b/LspCpp/CMakeLists.txt
+index 6b12b04..8e7ebe6 100644
+--- a/LspCpp/CMakeLists.txt
++++ b/LspCpp/CMakeLists.txt
+@@ -162,7 +162,7 @@ function(lspcpp_set_target_options target)
+         set_property(TARGET ${target} PROPERTY CXX_STANDARD 14)
+     endif()
+ 
+-    set_property(TARGET ${target} PROPERTY CXX_EXTENSIONS OFF)
++    set_property(TARGET ${target} PROPERTY CXX_EXTENSIONS ON)
+ 
+     if (CMAKE_GENERATOR MATCHES "Visual Studio.*")
+         lspcpp_set_target_options_with_nuget_pkg(${target} boost 1.76.0.0)
+diff --git a/Makefile.in b/Makefile.in
+index 346ce10..b6b88ca 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -170,7 +170,7 @@ asymptote.so: $(COREFILES:=.pic.o) glew.o
+ 
+ $(LSP_ROOT)/liblspcpp.a:
+ 	$(CMAKE) -B$(LSP_ROOT) -S$(LSP_ROOT) -DCMAKE_CXX_FLAGS=\
+-	"-fPIE @OPTIONS@ @LSP_CXX_BUILD_FLAGS@" \
++	"-fPIC @OPTIONS@ @LSP_CXX_BUILD_FLAGS@" \
+ 	@LSP_CMAKE_OPTIONS@
+ 	$(MAKE) -C $(LSP_ROOT)
+ 
+@@ -209,7 +209,7 @@ GEN_PREPROCESSED_DEPFILE_BASE_ARGS = \
+     $(PYTHON) gen_preprocessed_depfile.py \
+ 	--cxx-compiler="$(CXX)" \
+ 	--additional-raw-arguments="$(OPTS)" \
+-	--cxx-standard=$(subst gnu,,$(subst c++,,$(CXX_STANDARD)))
++	--cxx-standard=$(subst gnu++,,$(subst c++,,$(CXX_STANDARD)))
+ 
+ $(SYMBOL_FILES:=.raw.i): %.raw.i: %.cc gen_preprocessed_depfile.py
+ 	@echo Generating $@ from $<
+diff --git a/configure b/configure
+index dd93b00..938a245 100755
+--- a/configure
++++ b/configure
+@@ -3325,7 +3325,7 @@ then :
+   enableval=$enable_lsp;
+ fi
+ 
+-cxxstd="c++17"
++cxxstd="gnu++17"
+ 
+ CXXFLAGS=$CXXFLAGS" -std=$cxxstd"
+ 
+diff --git a/fpu.h b/fpu.h
+index 7ca8df0..183db6d 100644
+--- a/fpu.h
++++ b/fpu.h
+@@ -6,6 +6,8 @@
+ #define __GNU_VISIBLE 1
+ #endif
+ 
++#define __BSD_VISIBLE 1
++
+ #include "common.h"
+ 
+ #ifdef HAVE_FEENABLEEXCEPT
+diff --git a/glrender.cc b/glrender.cc
+index d6da531..6ad366e 100644
+--- a/glrender.cc
++++ b/glrender.cc
+@@ -1843,7 +1843,7 @@ void init()
+   char **argv=args(cmd,true);
+   int argc=cmd.size();
+ 
+-#ifndef __APPLE__
++#if !defined(__APPLE__) && !defined(__HAIKU__)
+   glutInitContextVersion(4,0);
+   glutInitContextProfile(GLUT_CORE_PROFILE);
+ #endif
+-- 
+2.48.1
+
+
+From 7b4a3e0e61bdb276f8f34810c521a708c44f5ad1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
+Date: Sun, 20 Apr 2025 20:05:42 +0200
+Subject: Settings fixes
+
+Put settings into ~/config/settings/asy instead of ~/.asy.
+
+Use `open` by default to open external files.
+
+diff --git a/GUI/xasyOptions.py b/GUI/xasyOptions.py
+index c8ecc85..2b079fb 100644
+--- a/GUI/xasyOptions.py
++++ b/GUI/xasyOptions.py
+@@ -40,7 +40,7 @@ class xasyOptions:
+ 
+ 
+     def settingsFileLocation(self):
+-        folder = os.path.expanduser("~/.asy/")
++        folder = os.path.expanduser("~/config/settings/asy/")
+ 
+         searchOrder = ['.cson', '']
+ 
+@@ -115,7 +115,7 @@ class xasyOptions:
+         if sys.platform[:3] == 'win':  # for windows, wince, win32, etc
+             # setAsyPathFromWindowsRegistry()
+             pass
+-        folder = os.path.expanduser("~/.asy/")
++        folder = os.path.expanduser("~/config/settings/asy/")
+         defaultPath = os.path.join(folder, self.configName + '.cson')
+         shutil.copy2(self._defaultOptLocation, defaultPath)
+ 
+@@ -148,7 +148,7 @@ class xasyOpenRecent:
+             f.close()
+ 
+     def settingsFileLocation(self):
+-        folder = os.path.expanduser("~/.asy/")
++        folder = os.path.expanduser("~/config/settings/asy/")
+ 
+         currentFile = os.path.join(folder, self.configName + '.txt')
+         return os.path.normcase(currentFile)
+diff --git a/doc/asy.1 b/doc/asy.1
+index 74f427b..b68fb7d 100644
+--- a/doc/asy.1
++++ b/doc/asy.1
+@@ -22,8 +22,8 @@ can be negated by prepending
+ to the option name. 
+ Default values for most options may also be entered in the 
+ file 
+-.B .asy/config.asy
+-in the user's home directory using the long form:
++.B asy/config.asy
++in the user's settings directory using the long form:
+ .PP
+      import settings;
+      batchView=true;
+diff --git a/doc/asy.1.begin b/doc/asy.1.begin
+index 1a22329..e8a662b 100644
+--- a/doc/asy.1.begin
++++ b/doc/asy.1.begin
+@@ -22,8 +22,8 @@ can be negated by prepending
+ to the option name. 
+ Default values for most options may also be entered in the 
+ file 
+-.B .asy/config.asy
+-in the user's home directory using the long form:
++.B asy/config.asy
++in the user's settings directory using the long form:
+ .PP
+      import settings;
+      batchView=true;
+diff --git a/settings.cc b/settings.cc
+index 027cc05..ba59e7b 100644
+--- a/settings.cc
++++ b/settings.cc
+@@ -24,6 +24,11 @@
+ #include <unistd.h>
+ #endif
+ 
++#ifdef __HAIKU__
++#include <FindDirectory.h>
++#include <Path.h>
++#endif
++
+ #include "common.h"
+ 
+ #if HAVE_GNU_GETOPT_H
+@@ -114,7 +119,7 @@ bool msdos=false;
+ string HOME="HOME";
+ string docdir=ASYMPTOTE_DOCDIR;
+ const char pathSeparator=':';
+-#ifdef __APPLE__
++#if defined(__APPLE__) || defined(__HAIKU__)
+ string defaultPSViewer="open";
+ string defaultPDFViewer="open";
+ string defaultHTMLViewer="open";
+@@ -1701,7 +1706,16 @@ void initDir() {
+     initdir=Getenv("ASYMPTOTE_HOME",msdos);
+ 
+   if(initdir.empty())
++#ifdef __HAIKU__
++  {
++    BPath path;
++    status_t status=find_directory(B_USER_SETTINGS_DIRECTORY, &path);
++    if(status == B_OK)
++      initdir=path.Path()+dirsep+suffix;
++  }
++#else
+     initdir=Getenv(HOME.c_str(),msdos)+dirsep+"."+suffix;
++#endif
+ 
+ #if defined(_WIN32)
+   DWORD dirAttrib = GetFileAttributesA(initdir.c_str());
+-- 
+2.48.1
+


### PR DESCRIPTION
This is still work in progress.

It builds and probably works mostly, but isn't integrated well yet.

TODOs:
 * the default config files are stored in ~/.asy
 * the GUI doesn't work out of the box, it needs cson_python310, which we don't have yet (but is installable via pip)
 * should use `open` to open files, like on macOS (easy)
 * move the GUI symlink to $appsDir? add resources and a Deskbar symlink? (I didn't find an icon)

It probably makes sense to put the GUI into its own package to avoid the python and Qt dependencies on the main one.