### PR TITLE
Update Yamagi Quake 2 to 8.50

### DIFF
--- a/games-fps/yamagi-quake2/patches/yamagi_quake2-8.50.patchset
+++ b/games-fps/yamagi-quake2/patches/yamagi_quake2-8.50.patchset
@@ -10,38 +10,22 @@ index c4bd90f..ca48738 100644
 +++ b/src/backends/unix/system.c
 @@ -68,7 +68,7 @@ Sys_Error(char *error, ...)
  	char string[1024];
- 
+
  	/* change stdin to non blocking */
 -	fcntl(0, F_SETFL, fcntl(0, F_GETFL, 0) & ~FNDELAY);
 +	fcntl(0, F_SETFL, fcntl(0, F_GETFL, 0) & ~O_NDELAY);
- 
+
  #ifndef DEDICATED_ONLY
  	CL_Shutdown();
 @@ -97,7 +97,7 @@ Sys_Quit(void)
  	}
- 
+
  	Qcommon_Shutdown();
 -	fcntl(0, F_SETFL, fcntl(0, F_GETFL, 0) & ~FNDELAY);
 +	fcntl(0, F_SETFL, fcntl(0, F_GETFL, 0) & ~O_NDELAY);
- 
+
  	printf("------------------------------------\n");
- 
-diff --git a/src/client/input/sdl.c b/src/client/input/sdl.c
-index 051505b..f05da4e 100644
---- a/src/client/input/sdl.c
-+++ b/src/client/input/sdl.c
-@@ -1374,9 +1374,9 @@ IN_Init(void)
- 	SDL_StartTextInput();
- 
- 	/* Joystick init */
--	if (!SDL_WasInit(SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC))
-+	if (!SDL_WasInit(SDL_INIT_GAMECONTROLLER))
- 	{
--		if (SDL_Init(SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC) == -1)
-+		if (SDL_Init(SDL_INIT_GAMECONTROLLER) == -1)
- 		{
- 			Com_Printf ("Couldn't init SDL joystick: %s.\n", SDL_GetError ());
- 		}
+
 -- 
 2.28.0
 

--- a/games-fps/yamagi-quake2/yamagi_quake2-8.50.recipe
+++ b/games-fps/yamagi-quake2/yamagi_quake2-8.50.recipe
@@ -1,10 +1,16 @@
-SUMMARY="An alternative client for id Softwares Quake II"
-DESCRIPTION="Yamagi Quake II is an alternative client for id Softwares Quake \
+SUMMARY="An alternative client for id Software's Quake II"
+DESCRIPTION="Yamagi Quake II is an alternative client for id Software's Quake \
 II. Our goal is to provide the best Quake II experience possible, we strive \
 to preserve the gameplay as it was back in 1997. Thus we aim mostly for bug \
-fixes, stability and gentle enhancements were appropriate.
+fixes, stability and gentle enhancements where appropriate.
 
-Features
+The binary will look for data folders (like 'baseq2' and 'music') in \
+'/boot/home/config/settings/yq2'
+
+(Note: 'native fullscreen' in Haiku crashes on exit and when switching mods, \
+playing in windowed mode is recommended. You can load mods on startup using \
+'Quake2 +set game modname' from command line if you prefer fullscreen)
+
 Yamagi Quake II has a lot of unique features. The most notables ones are:
 
 * A modern OpenGL 3.2 renderer, providing a greatly enhanced look and feel. \
@@ -26,11 +32,14 @@ Yamagi Quake II client is very well tested and stable. The dedicated server \
 is able to run for weeks without a single restart. Last but not least the \
 code is fully 64 bit clean and highly portable."
 HOMEPAGE="https://www.yamagi.org/quake2/"
-COPYRIGHT="OpenArena Team"
+COPYRIGHT="
+	2003-2025 Yamagi Burmeister
+	1997-2001 Id Software, Inc.
+	"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://deponie.yamagi.org/quake2/quake2-$portVersion.tar.xz"
-CHECKSUM_SHA256="c7524567bf1aa6045f25619bea6e4fd9066284b3fb81863b581fb44f4f47ff65"
+CHECKSUM_SHA256="3c1492ce5bf31f3c7818e51ac58308c11c8294d8ae5efd70d3fac254d77c7179"
 SOURCE_DIR="quake2-$portVersion"
 PATCHES="yamagi_quake2-$portVersion.patchset"
 ADDITIONAL_FILES="yamagi_quake2.rdef.in"
@@ -44,6 +53,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	lib:libexecinfo$secondaryArchSuffix
 	lib:libGL$secondaryArchSuffix
 	lib:libglu$secondaryArchSuffix
 	lib:libogg$secondaryArchSuffix
@@ -55,6 +65,7 @@ REQUIRES="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libcurl$secondaryArchSuffix
+	devel:libexecinfo$secondaryArchSuffix
 	devel:libGL$secondaryArchSuffix
 	devel:libglu$secondaryArchSuffix
 	devel:libogg$secondaryArchSuffix
@@ -71,22 +82,20 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	mkdir -p build
-	cd build
-	cmake .. \
-		-DCMAKE_BUILD_TYPE=Release \
-		-DSDL2_INCLUDE_DIR=/system/$relativeIncludeDir
-	make $jobArgs
+	cmake -Bbuild -S. -DCMAKE_BUILD_TYPE=Release \
+		-DSDL2_INCLUDE_DIR=`finddir B_SYSTEM_HEADERS_DIRECTORY`${secondaryArchSubDir}/SDL2
+
+	make -C build $jobArgs
 }
 
 INSTALL()
 {
 	cd build/release
-	mkdir -p $appsDir/Quake2/baseq2
-	cp quake2 $appsDir/Quake2/Quake2
-	cp q2ded $appsDir/Quake2/Quake2_dedicated
-	cp  *.so $appsDir/Quake2/
-	cp baseq2/game.so $appsDir/Quake2/baseq2/
+	mkdir -p $appsDir/quake2/baseq2
+	cp quake2 $appsDir/quake2/Quake2
+	cp q2ded $appsDir/quake2/Quake2_dedicated
+	cp  *.so $appsDir/quake2/
+	cp baseq2/game.so $appsDir/quake2/baseq2/
 
 	local APP_SIGNATURE="application/x-vnd.yamagi_quake2"
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
@@ -102,6 +111,7 @@ INSTALL()
 		-e "s|@LONG_INFO@|$LONG_INFO|" \
 		$portDir/additional-files/yamagi_quake2.rdef.in > yamagi_quake2.rdef
 
-	addResourcesToBinaries yamagi_quake2.rdef $appsDir/Quake2/Quake2
-	addAppDeskbarSymlink $appsDir/Quake2/Quake2
+	addResourcesToBinaries yamagi_quake2.rdef $appsDir/quake2/Quake2
+	ln -s $appsDir/quake2/Quake2 $appsDir/Quake2
+	addAppDeskbarSymlink $appsDir/quake2/Quake2 "Quake II"
 }


### PR DESCRIPTION
This is an update to Yamagi Quake 2 that solves a bunch of issues. (Only tested on x86_64)

Issues fixed since 7.45:
- Copyright is correct #12212
- Fullscreen now covers the whole screen instead of being limited to a quarter of it
- The binary uses "/boot/home/config/settings/yq2" instead of "/boot/home/.yq2"
- Provided backtrace (libexecinfo) during build

Issues present in both versions:
- Binary doesn't find Curl
- Segfaults on exit / loading mods in "native fullscreen" mode (SDL2 issue?)

A part of the old patch was scrapped as the check it was supposed to modify has changed a bunch between versions, I *think* whatever issue it was supposed to prevent should not occur anymore as the binary recognizes my gamepad when it's plugged in.

Let me know if I should add some disclaimer in the package description about the fact that fullscreen is kind of broken.