### PR TITLE
libigloo: new recipe.

### DIFF
--- a/dev-libs/libigloo/libigloo-0.9.2.recipe
+++ b/dev-libs/libigloo/libigloo-0.9.2.recipe
@@ -1,0 +1,74 @@
+SUMMARY="A generic C framework developed and used by the Icecast project"
+DESCRIPTION="libigloo is a new generic C framework for the Icecast project.
+
+It should replace the code their existing projects share currently (known as “common/”) over time. \
+It will both provide a more uniform as well as clean, and modern interface to their shared code \
+base."
+HOMEPAGE="https://icecast.org/"
+COPYRIGHT="2018-2024 Philipp Schafft"
+LICENSE="GNU LGPL v2"
+REVISION="1"
+SOURCE_URI="https://downloads.xiph.org/releases/igloo/libigloo-$portVersion.tar.gz"
+CHECKSUM_SHA256="21896c2e4cb72a463250f8a7c1287d53a4b5882f438d296ca062a851a06942f8"
+SOURCE_FILENAME="libigloo-v$portVersion.tar.gz"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="0.0.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	libigloo$secondaryArchSuffix = $portVersion
+	lib:libigloo$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:librhash$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	libigloo${secondaryArchSuffix}_devel = $portVersion
+	devel:libigloo$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	libigloo$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:librhash$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	runConfigure ./configure \
+		--enable-static=no
+	make
+}
+
+INSTALL()
+{
+	make install
+
+	# cleanup
+	rm -f $libDir/libigloo.la
+
+	prepareInstalledDevelLib \
+		libigloo
+	fixPkgconfig
+
+	packageEntries devel \
+		$developDir
+}
+
+TEST()
+{
+	make check
+}


### PR DESCRIPTION
This will be needed when updating Icecast to >= 2.5.