### PR TITLE
AssaultCube: build with clang_18

### DIFF
--- a/games-fps/assaultcube/assaultcube-1.3.0.2.recipe
+++ b/games-fps/assaultcube/assaultcube-1.3.0.2.recipe
@@ -49,7 +49,7 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	cmd:autoreconf
 	cmd:automake
-	cmd:clang
+	cmd:clang_18 # Use a specific clang version or else buildmasters fail
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
 	"


### PR DESCRIPTION
Trying a fix for AssaultCube on buildmasters, suggested by @Begasus. Apparently buildmasters end up using the wrong clang version during build.