### PR TITLE
AssaultCube: another attempt at buildmaster fix

### DIFF
--- a/games-fps/assaultcube/assaultcube-1.3.0.2.recipe
+++ b/games-fps/assaultcube/assaultcube-1.3.0.2.recipe
@@ -49,7 +49,7 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	cmd:autoreconf
 	cmd:automake
-	cmd:clang_18 # Use a specific clang version or else buildmasters fail
+	cmd:clang >= 18
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
 	"

--- a/games-fps/assaultcube/patches/assaultcube-1.3.0.2.patchset
+++ b/games-fps/assaultcube/patches/assaultcube-1.3.0.2.patchset
@@ -1,4 +1,4 @@
-From e24ed11581a15ea18d54587b046c9d4ed82cace3 Mon Sep 17 00:00:00 2001
+From a542fe52e1bb94857b95d9829e82be80850c8be7 Mon Sep 17 00:00:00 2001
 From: Peppersawce <michaelpeppers89@yahoo.it>
 Date: Sun, 13 Apr 2025 15:01:30 +0200
 Subject: De-linuxify Makefile, remove need for X11 header, disable "No OpenGL"
@@ -6,7 +6,7 @@ Subject: De-linuxify Makefile, remove need for X11 header, disable "No OpenGL"
 
 
 diff --git a/source/src/Makefile b/source/src/Makefile
-index bf06195..d894c60 100644
+index bf06195..bd330fe 100644
 --- a/source/src/Makefile
 +++ b/source/src/Makefile
 @@ -59,9 +59,10 @@ WINDRES= windres
@@ -23,7 +23,7 @@ index bf06195..d894c60 100644
  endif
  
  CLIENT_OBJS= \
-@@ -126,10 +126,7 @@ SERVER_INCLUDES= -DSTANDALONE $(INCLUDES) -I../include
+@@ -126,10 +127,7 @@ SERVER_INCLUDES= -DSTANDALONE $(INCLUDES) -I../include
  SERVER_LIBS= -L../lib -lzdll -lenet -lws2_32 -lwinmm
  else
  SERVER_INCLUDES= -DSTANDALONE $(INCLUDES)
@@ -49,7 +49,7 @@ index 42e9039..9eb38ca 100644
      {
          startdemoplayback(newname);
 diff --git a/source/src/stream.cpp b/source/src/stream.cpp
-index 3a549c5..55453dd 100644
+index 3a549c5..9b2164c 100644
 --- a/source/src/stream.cpp
 +++ b/source/src/stream.cpp
 @@ -9,6 +9,11 @@
@@ -88,6 +88,29 @@ index 75a5128..fc9813a 100644
  #endif
  
  static int sl_sem_errorcountdummy = 0;
+-- 
+2.48.1
+
+
+From a70b549b9b8aa947a23cf118368b56f82f7f0d00 Mon Sep 17 00:00:00 2001
+From: Peppersawce <michaelpeppers89@yahoo.it>
+Date: Tue, 22 Apr 2025 16:29:38 +0200
+Subject: Fix build on buildmasters' Beta 5 (this can be reverted when buildmasters use a newer Haiku version)
+
+
+diff --git a/source/src/tools.cpp b/source/src/tools.cpp
+index fc9813a..13a9400 100644
+--- a/source/src/tools.cpp
++++ b/source/src/tools.cpp
+@@ -888,7 +888,7 @@ void *sl_createthread(int (*fn)(void *), void *data, const char *name)
+     ti->fn = fn;
+     ti->done = 0;
+     pthread_create(&(ti->handle), NULL, sl_thread_indir, ti);
+-    if(name) pthread_setname_np(ti->handle, name);
++    //if(name) pthread_setname_np(ti->handle, name);
+     return (void *) ti;
+ }
+ 
 -- 
 2.48.1
 


### PR DESCRIPTION
A patch to disable the pthread command unavailable in current buildmasters. Crossing fingers and hoping this works.

Note: the package builds fine on the latest Beta 5 version.