### PR TITLE
intel_microcode: update to release 20250211.

### DIFF
--- a/sys-firmware/intel-microcode/intel_microcode-20250211.recipe
+++ b/sys-firmware/intel-microcode/intel_microcode-20250211.recipe
@@ -1,16 +1,16 @@
 SUMMARY="Intel Processor Microcode Update"
 DESCRIPTION="CPU microcode is a mechanism to correct certain errata in \
 existing systems. The normal preferred method to apply microcode updates is \
-using the system BIOS, but for a subset of Intel's processors this can be done\
- at runtime using the operating system. This package contains those processors\
- that support OS loading of microcode updates."
+using the system BIOS, but for a subset of Intel's processors this can be done \
+at runtime using the operating system. This package contains microcode updates \
+for processors where that is possible."
 HOMEPAGE="https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/"
-COPYRIGHT="2018-2024 Intel Corporation"
+COPYRIGHT="2018-2025 Intel Corporation"
 LICENSE="Intel CPU Microcode"
 REVISION="1"
 SOURCE_URI="https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/archive/microcode-$portVersion.tar.gz"
 SOURCE_DIR="Intel-Linux-Processor-Microcode-Data-Files-microcode-$portVersion"
-CHECKSUM_SHA256="8b7582eac7e9a691356e18b3bdcbc7b2db09494e040ec980a4a5fb6d0da261bf"
+CHECKSUM_SHA256="1da88b51953c9da2e20b5c94b3d7270cf87ea5babcaa56e3d6a5c9eaf11694b3"
 ADDITIONAL_FILES="intel_copy_microcode.sh"
 
 ARCHITECTURES="any"


### PR DESCRIPTION
Tested package installation on a Celeron N4020 (Gemini Lake), but microcode for that CPU hasn't changed.

More details on the [full release notes](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/main/releasenote.md).