### PR TITLE
heictranslator: new recipe

### DIFF
--- a/haiku-apps/heictranslator/heictranslator-0.2.0.recipe
+++ b/haiku-apps/heictranslator/heictranslator-0.2.0.recipe
@@ -1,0 +1,47 @@
+SUMMARY="HEIC Translator for Haiku"
+DESCRIPTION="A Haiku Translation Kit add-on to support HEIC image viewing"
+HOMEPAGE="https://github.com/dospuntos/HEICTranslator"
+COPYRIGHT="2025 Johan Wagenheim"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://github.com/dospuntos/HEICTranslator/archive/refs/tags/v$portVersion.tar.gz"
+CHECKSUM_SHA256="645951844c89f41a0710e35d954d834cbaedae478df81a830f1f298966fd29f0"
+SOURCE_DIR="HEICTranslator-$portVersion"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	heictranslator$secondaryArchSuffix = $portVersion
+	addon:HEICTranslator = $portVersion
+	"
+REQUIRES="
+	haiku$secundaryArchSuffix
+	lib:libheif$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libheif$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	makefile_engine
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	"
+
+BUILD()
+{
+	make $jobArgs
+	rc HEICMime.rdef -o HEICMime.rsrc
+}
+
+INSTALL()
+{
+	mkdir -p $addOnsDir/Translators
+	cp objects.x86_64-cc13-release/HEICTranslator $addOnsDir/Translators/HEICTranslator
+
+	# Install MIME registration resources
+	mkdir -p $dataDir/mime_db/image
+	resattr -O -o $dataDir/mime_db/image/heic HEICMime.rsrc
+}


### PR DESCRIPTION
New recipe to install the HEIC image translator, for reading HEIC/HEIF images.

The  mime types are also added, but it appears that a reboot is needed for the MIME db to be updated?