### PR TITLE
libigloo: build fix when not using RAMFS workdirs (as in builders).

### DIFF
--- a/dev-libs/libigloo/libigloo-0.9.2.recipe
+++ b/dev-libs/libigloo/libigloo-0.9.2.recipe
@@ -40,14 +40,21 @@ BUILD_REQUIRES="
 	devel:librhash$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoreconf
 	cmd:awk
 	cmd:gcc$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix	# not needed for me, but fails without it for Begasus.
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
 BUILD()
 {
+	# This should not be needed (./configure works without them if workdirs are in RAMFS).
+	# See https://github.com/haikuports/haikuporter/issues/325
+	autoreconf
+
 	runConfigure ./configure \
 		--enable-static=no
 	make


### PR DESCRIPTION
See: https://github.com/haikuports/haikuporter/issues/325.