### PR TITLE
libigloo: remove unneeded build deps. Kudos to korli for the trick.

### DIFF
--- a/dev-libs/libigloo/libigloo-0.9.2.recipe
+++ b/dev-libs/libigloo/libigloo-0.9.2.recipe
@@ -7,7 +7,7 @@ base."
 HOMEPAGE="https://icecast.org/"
 COPYRIGHT="2018-2024 Philipp Schafft"
 LICENSE="GNU LGPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://downloads.xiph.org/releases/igloo/libigloo-$portVersion.tar.gz"
 CHECKSUM_SHA256="21896c2e4cb72a463250f8a7c1287d53a4b5882f438d296ca062a851a06942f8"
 SOURCE_FILENAME="libigloo-v$portVersion.tar.gz"
@@ -40,24 +40,18 @@ BUILD_REQUIRES="
 	devel:librhash$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:aclocal
-	cmd:autoreconf
 	cmd:awk
 	cmd:gcc$secondaryArchSuffix
-	cmd:libtoolize$secondaryArchSuffix	# not needed for me, but fails without it for Begasus.
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
 BUILD()
 {
-	# This should not be needed (./configure works without them if workdirs are in RAMFS).
-	# See https://github.com/haikuports/haikuporter/issues/325
-	autoreconf
-
-	runConfigure ./configure \
-		--enable-static=no
-	make
+	# "AUTOMAKE=: AUTOCONF=:" is a workaround for:
+	# https://github.com/haikuports/haikuporter/issues/325 / https://dev.haiku-os.org/ticket/19213.
+	AUTOMAKE=: AUTOCONF=: runConfigure ./configure --enable-static=no
+	make $jobArgs
 }
 
 INSTALL()


### PR DESCRIPTION
This side-steps the issue of ./configure thinking that some files got modified, and thus wanting to call automake, when the work-dirs are in a BFS volume.

See https://github.com/haikuports/haikuporter/issues/325 and https://dev.haiku-os.org/ticket/19213.