### PR TITLE
openjdk23: new recipe

### DIFF
--- a/dev-lang/openjdk/openjdk23-23.0.2.1.recipe
+++ b/dev-lang/openjdk/openjdk23-23.0.2.1.recipe
@@ -79,7 +79,7 @@ CONFLICTS_default="
 	openjdk19${secondaryArchSuffix}_default
 	openjdk20${secondaryArchSuffix}_default
 	openjdk21${secondaryArchSuffix}_default
-    openjdk22${secondaryArchSuffix}_default
+	openjdk22${secondaryArchSuffix}_default
 	"
 
 PROVIDES_jre="

--- a/dev-lang/openjdk/openjdk23-23.0.2.1.recipe
+++ b/dev-lang/openjdk/openjdk23-23.0.2.1.recipe
@@ -1,0 +1,264 @@
+SUMMARY="An open-source implementation of the Java Platform, SE"
+DESCRIPTION="OpenJDK (Open Java Development Kit) is a free and open source \
+implementation of the Java Platform, Standard Edition (Java SE). It is the \
+result of an effort Sun Microsystems began in 2006.
+
+The implementation is licensed under the GNU General Public License (GNU GPL) \
+with a linking exception. Were it not for the GPL linking exception, components \
+that linked to the Java class library would be subject to the terms of the GPL \
+license. OpenJDK is the official Java SE 23 reference implementation."
+HOMEPAGE="https://openjdk.java.net/"
+COPYRIGHT="2007-2024 Oracle and/or its affiliates."
+LICENSE="GNU GPL v2"
+REVISION="1"
+jdkBuild="jdk-${portVersion%.*}+${portVersion##*.}"
+srcGitRev="48f2c25bc49ccabe683915f8275d1752fcc17e30"
+SOURCE_URI="https://github.com/Powerm1nt/jdk23u/archive/$srcGitRev.tar.gz"
+#SOURCE_URI="git+https://github.com/korli/jdk23u.git#tag=haiku-port"
+CHECKSUM_SHA256="86914f6df2d023cdde9743c5c7d45d63254549c8387d227222cf1fecf5778763"
+SOURCE_DIR="jdk23u-$srcGitRev"
+SOURCE_FILENAME="jdk23u-$jdkBuild-$srcGitRev.tar.gz"
+SOURCE_URI_2="https://builds.shipilev.net/jtreg/jtreg-7.3.1%2B1.zip"
+CHECKSUM_SHA256_2="c62ba927607b5b3874454d5b0baefe56a7982021e9b6120f59d47642ef560133"
+SOURCE_DIR_2="jtreg"
+ADDITIONAL_FILES="
+	elf.h
+	"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
+
+DISABLE_SOURCE_PACKAGE="yes"
+	# at least as long as Ant and a complete SDK image are part of the "sources" package
+
+PROVIDES="
+	openjdk23$secondaryArchSuffix = $portVersion compat >= 23
+	java:environment = 23
+	"
+REQUIRES="
+	openjdk23${secondaryArchSuffix}_jre == $portVersion
+	"
+
+PROVIDES_default="
+	openjdk23${secondaryArchSuffix}_default = $portVersion
+	cmd:jar = $portVersion compat >= 23
+	cmd:jarsigner = $portVersion compat >= 23
+	cmd:java = $portVersion compat >= 23
+	cmd:javac = $portVersion compat >= 23
+	cmd:javadoc = $portVersion compat >= 23
+	cmd:javah = $portVersion compat >= 23
+	cmd:javap = $portVersion compat >= 23
+	cmd:jcmd = $portVersion compat >= 23
+	cmd:jconsole = $portVersion compat >= 23
+	cmd:jdb = $portVersion compat >= 23
+	cmd:jinfo = $portVersion compat >= 23
+	cmd:jmap = $portVersion compat >= 23
+	cmd:jps = $portVersion compat >= 23
+	cmd:jstack = $portVersion compat >= 23
+	cmd:jstat = $portVersion compat >= 23
+	cmd:jstatd = $portVersion compat >= 23
+	cmd:keytool = $portVersion compat >= 23
+	cmd:rmiregistry = $portVersion compat >= 23
+	cmd:serialver = $portVersion compat >= 23
+	"
+REQUIRES_default="
+	openjdk23$secondaryArchSuffix == $portVersion
+	"
+CONFLICTS_default="
+	openjdk8${secondaryArchSuffix}_default
+	openjdk9${secondaryArchSuffix}_default
+	openjdk10${secondaryArchSuffix}_default
+	openjdk11${secondaryArchSuffix}_default
+	openjdk12${secondaryArchSuffix}_default
+	openjdk13${secondaryArchSuffix}_default
+	openjdk14${secondaryArchSuffix}_default
+	openjdk15${secondaryArchSuffix}_default
+	openjdk16${secondaryArchSuffix}_default
+	openjdk17${secondaryArchSuffix}_default
+	openjdk18${secondaryArchSuffix}_default
+	openjdk19${secondaryArchSuffix}_default
+	openjdk20${secondaryArchSuffix}_default
+	openjdk21${secondaryArchSuffix}_default
+    openjdk22${secondaryArchSuffix}_default
+	"
+
+PROVIDES_jre="
+	openjdk23${secondaryArchSuffix}_jre = $portVersion compat >= 23
+	java:runtime = 23
+	"
+REQUIRES_jre="
+	haiku$secondaryArchSuffix
+	lib:libfreetype$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libjpeg$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	ca_root_certificates_java
+	dejavu
+	"
+
+SUMMARY_sources="JDK source files, demos and examples"
+PROVIDES_sources="
+	openjdk23${secondaryArchSuffix}_sources = $portVersion compat >= 23
+	"
+REQUIRES_sources="
+	openjdk23$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	java:environment == 22
+	ca_root_certificates
+	devel:libfontconfig$secondaryArchSuffix
+	devel:libfreetype$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
+	devel:libjpeg$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cpio
+	cmd:make
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:sed
+	cmd:tar
+	cmd:zip
+	cmd:gawk
+	cmd:hostname
+	cmd:find
+	cmd:unzip
+	cmd:unzipsfx
+	cmd:head
+	cmd:file
+	cmd:which
+	cmd:autoconf
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+TEST_REQUIRES="
+	cmd:true
+	"
+
+BUILD()
+{
+	source /system/data/profile.d/openjdk22.sh
+	export PATH=$JDK22_HOME/bin:$PATH
+	export COMPANY=HaikuPorts
+
+	ln -sfn $sourceDir2 jtreg
+
+	cp $portDir/additional-files/elf.h src/hotspot/share/utilities
+
+	# If ASLR is enabled, the JVM can fail to find a large enough area for
+	# the heap.
+	export DISABLE_ASLR=1
+
+	# Verify that we can allocate a large enough heap before starting.
+	java -XX:ThreadStackSize=1536 -Xmx1024M -version
+
+	freeTypeHeaders=$(finddir B_SYSTEM_HEADERS_DIRECTORY)$secondaryArchSubDir/freetype2
+	freeTypeLib=$(finddir B_SYSTEM_DEVELOP_DIRECTORY)/lib$secondaryArchSubDir
+
+	bash ./configure \
+					--with-freetype-include="${freeTypeHeaders}" \
+					--with-freetype-lib="${freeTypeLib}" \
+					--with-jtreg=./jtreg \
+					--with-version-build="${portVersion//*.}" \
+					--with-version-pre="" \
+					--with-version-opt="" \
+					--with-num-cores=2 \
+					--enable-javac-server \
+					--disable-warnings-as-errors \
+					--with-extra-cflags="-w" \
+					--with-extra-cxxflags="-w"
+
+	make images LOG=info
+}
+
+INSTALL()
+{
+	# install the generated SDK image dir
+	jdkDir=$libDir/openjdk23
+
+	mkdir -p $jdkDir
+	cp -a build/haiku-*/images/jdk/* $jdkDir
+
+	# set up the cacerts link
+	ln -sf $dataDir/ssl/java/cacerts $jdkDir/conf/security/
+
+	# symlink the executables to binDir
+	mkdir -p $prefix/bin
+	bins="jar jarsigner javac javadoc javah javap jcmd jconsole jdb jinfo \
+		jmap jps jstack jstat jstatd serialver"
+	bins_runtime="java keytool rmiregistry"
+	man_runtime=""
+	for b in $bins $bins_runtime; do
+		symlinkRelative -s $jdkDir/bin/$b $prefix/bin
+	done
+	for b in $bins_runtime; do
+		man_runtime+=" $jdkDir/man/man1/$b.1"
+	done
+
+	mkdir -p $dataDir/profile.d
+
+	# create a profile.d file that sets up JAVA_HOME
+	jdkProfile=$dataDir/profile.d/openjdk.sh
+	echo "JAVA_HOME=$jdkDir" > $jdkProfile
+	echo "export JAVA_HOME" >> $jdkProfile
+
+	# create a profile.d file that sets up JDK23_HOME
+	jdkProfile=$dataDir/profile.d/openjdk23.sh
+	echo "JDK23_HOME=$jdkDir" > $jdkProfile
+	echo "export JDK23_HOME" >> $jdkProfile
+
+	# create a profile.d file that sets up JRE23_HOME
+	jreProfile=$dataDir/profile.d/openjre23.sh
+	echo "JRE23_HOME=$(getPackagePrefix jre)/$relativeLibDir/openjdk23" > $jreProfile
+	echo "export JRE23_HOME" >> $jreProfile
+
+	find $jdkDir -name '*.diz' -o -name '*.debuginfo' -delete
+	# not for jre
+	mv $jdkDir/lib/libattach.so $jdkDir/lib/ct.sym $prefix
+
+	packageEntries sources \
+		$jdkDir/lib/src.zip \
+		$jdkDir/demo
+
+	packageEntries jre \
+		$jdkDir/bin/java \
+		$jdkDir/bin/jrunscript \
+		$jdkDir/bin/keytool \
+		$jdkDir/bin/rmiregistry \
+		$jdkDir/conf \
+		$jdkDir/legal \
+		$jdkDir/lib \
+		$jdkDir/release \
+		$dataDir/profile.d/openjre23.sh \
+		$man_runtime
+
+	mkdir -p $jdkDir/lib
+	mv $prefix/libattach.so $prefix/ct.sym $jdkDir/lib/
+
+	packageEntries default \
+		$prefix/bin \
+		$dataDir/profile.d/openjdk.sh
+}
+
+TEST()
+{
+	export DISABLE_ASLR=1
+	make test-image
+	#make test-only TEST_JOBS=1 TEST=jdk_lang # Test results: passed: 875; failed: 6; error: 2
+	#make test-only TEST_JOBS=1 TEST=jdk_util # Test results: passed: 908; failed: 4
+	make test-only JOBS=1 TEST=jdk_math # OK
+	#make test-only JOBS=1 TEST=jdk_io
+	make test-only JOBS=1 TEST=jdk_nio
+	#make test-only JOBS=1 TEST=jdk_net
+	make test-only JOBS=1 TEST=jdk_time # OK
+	#make test-only JOBS=1 TEST=jdk_rmi
+	#make test-only JOBS=1 TEST=jdk_security
+	make test-only JOBS=1 TEST=jdk_text # OK
+	#make test-only TEST_JOBS=1 TEST=jdk_management
+	#make test-only JOBS=1 TEST=jdk_instrument
+	#make test-only JOBS=1 TEST=jdk_jmx
+	#make test-only JOBS=1 TEST=jdk_jdi
+}


### PR DESCRIPTION
## openjdk23: new recipe
- backported jdk22u patches from it
- fixed build tooling (backported some stuff)
- do some tests
- Native Terminal stuff builtin from java still lagging behind + IDEA doesn't use the builtin API now so i need find a solution for Java Terminal PTY stuff.

![image](https://github.com/user-attachments/assets/a6d87ec4-1264-4c17-ac16-53530f64c501)
