### PR TITLE
qthaikuplugins: rebuild

### DIFF
--- a/dev-qt/qthaikuplugins/qthaikuplugins-5.15.2.38.recipe
+++ b/dev-qt/qthaikuplugins/qthaikuplugins-5.15.2.38.recipe
@@ -11,7 +11,7 @@ HOMEPAGE="https://github.com/threedeyes/qthaikuplugins/"
 COPYRIGHT="2017-2023 Gerasim Troeglazov"
 LICENSE="GNU LGPL v2.1
 	GNU LGPL v3"
-REVISION="1"
+REVISION="2"
 srcGitRev=af09b4f18b74621601f5bf9b593be0dc12de892a
 SOURCE_URI="$HOMEPAGE/archive/${srcGitRev}.tar.gz"
 CHECKSUM_SHA256="896d39b703fa8ce71aee7f4776d453ac4a85cafa022e6a408a2e95d660baaa5b"


### PR DESCRIPTION
The build in the last update didn't take latest qt5, despite seemingly being built after it.