### PR TITLE
openjdk24: new recipe

### DIFF
--- a/dev-lang/openjdk/openjdk24-24.0.0.1.recipe
+++ b/dev-lang/openjdk/openjdk24-24.0.0.1.recipe
@@ -195,7 +195,7 @@ INSTALL()
 	for b in $bins $bins_runtime; do
 		symlinkRelative -s $jdkDir/bin/$b $prefix/bin
 	done
-	
+
 	# TODO: Manpage is broken lol
 	# for b in $bins_runtime; do
 	# 	man_runtime+=" $jdkDir/man/man1/$b.1"

--- a/dev-lang/openjdk/openjdk24-24.0.0.1.recipe
+++ b/dev-lang/openjdk/openjdk24-24.0.0.1.recipe
@@ -79,8 +79,8 @@ CONFLICTS_default="
 	openjdk19${secondaryArchSuffix}_default
 	openjdk20${secondaryArchSuffix}_default
 	openjdk21${secondaryArchSuffix}_default
-    openjdk22${secondaryArchSuffix}_default
-    openjdk23${secondaryArchSuffix}_default
+	openjdk22${secondaryArchSuffix}_default
+	openjdk23${secondaryArchSuffix}_default
 	"
 
 PROVIDES_jre="

--- a/dev-lang/openjdk/openjdk24-24.0.0.1.recipe
+++ b/dev-lang/openjdk/openjdk24-24.0.0.1.recipe
@@ -1,0 +1,267 @@
+SUMMARY="An open-source implementation of the Java Platform, SE"
+DESCRIPTION="OpenJDK (Open Java Development Kit) is a free and open source \
+implementation of the Java Platform, Standard Edition (Java SE). It is the \
+result of an effort Sun Microsystems began in 2006.
+
+The implementation is licensed under the GNU General Public License (GNU GPL) \
+with a linking exception. Were it not for the GPL linking exception, components \
+that linked to the Java class library would be subject to the terms of the GPL \
+license. OpenJDK is the official Java SE 24 reference implementation."
+HOMEPAGE="https://openjdk.java.net/"
+COPYRIGHT="2007-2024 Oracle and/or its affiliates."
+LICENSE="GNU GPL v2"
+REVISION="1"
+jdkBuild="jdk-${portVersion%.*}+${portVersion##*.}"
+srcGitRev="77532a6bfdb5e4e8559a73ebf39dd3efe761531a"
+SOURCE_URI="https://github.com/Powerm1nt/jdk24u/archive/$srcGitRev.tar.gz"
+#SOURCE_URI="git+https://github.com/korli/jdk24u.git#tag=haiku-port"
+CHECKSUM_SHA256="066d77b7756f3845e9486e0a9241d3d73afdca2549768e69b4150fec28d929f7"
+SOURCE_DIR="jdk24u-$srcGitRev"
+SOURCE_FILENAME="jdk24u-$jdkBuild-$srcGitRev.tar.gz"
+SOURCE_URI_2="https://builds.shipilev.net/jtreg/jtreg-7.5.1%2B1.zip"
+CHECKSUM_SHA256_2="cf2395d497b5f9662e398db7bfea5a9ce32d2ace8ad934564fb2f23c864cece6"
+SOURCE_DIR_2="jtreg"
+ADDITIONAL_FILES="
+	elf.h
+	"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
+
+DISABLE_SOURCE_PACKAGE="yes"
+	# at least as long as Ant and a complete SDK image are part of the "sources" package
+
+PROVIDES="
+	openjdk24$secondaryArchSuffix = $portVersion compat >= 24
+	java:environment = 24
+	"
+REQUIRES="
+	openjdk24${secondaryArchSuffix}_jre == $portVersion
+	"
+
+PROVIDES_default="
+	openjdk24${secondaryArchSuffix}_default = $portVersion
+	cmd:jar = $portVersion compat >= 24
+	cmd:jarsigner = $portVersion compat >= 24
+	cmd:java = $portVersion compat >= 24
+	cmd:javac = $portVersion compat >= 24
+	cmd:javadoc = $portVersion compat >= 24
+	cmd:javah = $portVersion compat >= 24
+	cmd:javap = $portVersion compat >= 24
+	cmd:jcmd = $portVersion compat >= 24
+	cmd:jconsole = $portVersion compat >= 24
+	cmd:jdb = $portVersion compat >= 24
+	cmd:jinfo = $portVersion compat >= 24
+	cmd:jmap = $portVersion compat >= 24
+	cmd:jps = $portVersion compat >= 24
+	cmd:jstack = $portVersion compat >= 24
+	cmd:jstat = $portVersion compat >= 24
+	cmd:jstatd = $portVersion compat >= 24
+	cmd:keytool = $portVersion compat >= 24
+	cmd:rmiregistry = $portVersion compat >= 24
+	cmd:serialver = $portVersion compat >= 24
+	"
+REQUIRES_default="
+	openjdk24$secondaryArchSuffix == $portVersion
+	"
+CONFLICTS_default="
+	openjdk8${secondaryArchSuffix}_default
+	openjdk9${secondaryArchSuffix}_default
+	openjdk10${secondaryArchSuffix}_default
+	openjdk11${secondaryArchSuffix}_default
+	openjdk12${secondaryArchSuffix}_default
+	openjdk13${secondaryArchSuffix}_default
+	openjdk14${secondaryArchSuffix}_default
+	openjdk15${secondaryArchSuffix}_default
+	openjdk16${secondaryArchSuffix}_default
+	openjdk17${secondaryArchSuffix}_default
+	openjdk18${secondaryArchSuffix}_default
+	openjdk19${secondaryArchSuffix}_default
+	openjdk20${secondaryArchSuffix}_default
+	openjdk21${secondaryArchSuffix}_default
+    openjdk22${secondaryArchSuffix}_default
+    openjdk23${secondaryArchSuffix}_default
+	"
+
+PROVIDES_jre="
+	openjdk24${secondaryArchSuffix}_jre = $portVersion compat >= 24
+	java:runtime = 24
+	"
+REQUIRES_jre="
+	haiku$secondaryArchSuffix
+	lib:libfreetype$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libjpeg$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	ca_root_certificates_java
+	dejavu
+	"
+
+SUMMARY_sources="JDK source files, demos and examples"
+PROVIDES_sources="
+	openjdk24${secondaryArchSuffix}_sources = $portVersion compat >= 24
+	"
+REQUIRES_sources="
+	openjdk24$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	java:environment == 23
+	ca_root_certificates
+	devel:libfontconfig$secondaryArchSuffix
+	devel:libfreetype$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
+	devel:libjpeg$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cpio
+	cmd:make
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:sed
+	cmd:tar
+	cmd:zip
+	cmd:gawk
+	cmd:hostname
+	cmd:find
+	cmd:unzip
+	cmd:unzipsfx
+	cmd:head
+	cmd:file
+	cmd:which
+	cmd:autoconf
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+TEST_REQUIRES="
+	cmd:true
+	"
+
+BUILD()
+{
+	source /system/data/profile.d/openjdk23.sh
+	export PATH=$JDK23_HOME/bin:$PATH
+	export COMPANY=HaikuPorts
+
+	ln -sfn $sourceDir2 jtreg
+
+	cp $portDir/additional-files/elf.h src/hotspot/share/utilities
+
+	# If ASLR is enabled, the JVM can fail to find a large enough area for
+	# the heap.
+	export DISABLE_ASLR=1
+
+	# Verify that we can allocate a large enough heap before starting.
+	java -XX:ThreadStackSize=1536 -Xmx1024M -version
+
+	freeTypeHeaders=$(finddir B_SYSTEM_HEADERS_DIRECTORY)$secondaryArchSubDir/freetype2
+	freeTypeLib=$(finddir B_SYSTEM_DEVELOP_DIRECTORY)/lib$secondaryArchSubDir
+
+	bash ./configure \
+					--with-freetype-include="${freeTypeHeaders}" \
+					--with-freetype-lib="${freeTypeLib}" \
+					--with-jtreg=./jtreg \
+					--with-version-build="${portVersion//*.}" \
+					--with-version-pre="" \
+					--with-version-opt="" \
+					--with-num-cores=2 \
+					--enable-javac-server \
+					--disable-warnings-as-errors \
+					--with-extra-cflags="-w" \
+					--with-extra-cxxflags="-w"
+
+	make images LOG=info
+}
+
+INSTALL()
+{
+	# install the generated SDK image dir
+	jdkDir=$libDir/openjdk24
+
+	mkdir -p $jdkDir
+	cp -a build/haiku-*/images/jdk/* $jdkDir
+
+	# set up the cacerts link
+	ln -sf $dataDir/ssl/java/cacerts $jdkDir/conf/security/
+
+	# symlink the executables to binDir
+	mkdir -p $prefix/bin
+	bins="jar jarsigner javac javadoc javah javap jcmd jconsole jdb jinfo \
+		jmap jps jstack jstat jstatd serialver"
+	bins_runtime="java keytool rmiregistry"
+	man_runtime=""
+	for b in $bins $bins_runtime; do
+		symlinkRelative -s $jdkDir/bin/$b $prefix/bin
+	done
+	
+	# TODO: Manpage is broken lol
+	# for b in $bins_runtime; do
+	# 	man_runtime+=" $jdkDir/man/man1/$b.1"
+	# done
+
+	mkdir -p $dataDir/profile.d
+
+	# create a profile.d file that sets up JAVA_HOME
+	jdkProfile=$dataDir/profile.d/openjdk.sh
+	echo "JAVA_HOME=$jdkDir" > $jdkProfile
+	echo "export JAVA_HOME" >> $jdkProfile
+
+	# create a profile.d file that sets up JDK24_HOME
+	jdkProfile=$dataDir/profile.d/openjdk24.sh
+	echo "JDK24_HOME=$jdkDir" > $jdkProfile
+	echo "export JDK24_HOME" >> $jdkProfile
+
+	# create a profile.d file that sets up JRE24_HOME
+	jreProfile=$dataDir/profile.d/openjre24.sh
+	echo "JRE24_HOME=$(getPackagePrefix jre)/$relativeLibDir/openjdk24" > $jreProfile
+	echo "export JRE24_HOME" >> $jreProfile
+
+	find $jdkDir -name '*.diz' -o -name '*.debuginfo' -delete
+	# not for jre
+	mv $jdkDir/lib/libattach.so $jdkDir/lib/ct.sym $prefix
+
+	packageEntries sources \
+		$jdkDir/lib/src.zip \
+		$jdkDir/demo
+
+	packageEntries jre \
+		$jdkDir/bin/java \
+		$jdkDir/bin/jrunscript \
+		$jdkDir/bin/keytool \
+		$jdkDir/bin/rmiregistry \
+		$jdkDir/conf \
+		$jdkDir/legal \
+		$jdkDir/lib \
+		$jdkDir/release \
+		$dataDir/profile.d/openjre24.sh \
+		$man_runtime
+
+	mkdir -p $jdkDir/lib
+	mv $prefix/libattach.so $prefix/ct.sym $jdkDir/lib/
+
+	packageEntries default \
+		$prefix/bin \
+		$dataDir/profile.d/openjdk.sh
+}
+
+TEST()
+{
+	export DISABLE_ASLR=1
+	make test-image
+	#make test-only TEST_JOBS=1 TEST=jdk_lang # Test results: passed: 875; failed: 6; error: 2
+	#make test-only TEST_JOBS=1 TEST=jdk_util # Test results: passed: 908; failed: 4
+	make test-only JOBS=1 TEST=jdk_math # OK
+	#make test-only JOBS=1 TEST=jdk_io
+	make test-only JOBS=1 TEST=jdk_nio
+	#make test-only JOBS=1 TEST=jdk_net
+	make test-only JOBS=1 TEST=jdk_time # OK
+	#make test-only JOBS=1 TEST=jdk_rmi
+	#make test-only JOBS=1 TEST=jdk_security
+	make test-only JOBS=1 TEST=jdk_text # OK
+	#make test-only TEST_JOBS=1 TEST=jdk_management
+	#make test-only JOBS=1 TEST=jdk_instrument
+	#make test-only JOBS=1 TEST=jdk_jmx
+	#make test-only JOBS=1 TEST=jdk_jdi
+}


### PR DESCRIPTION
## openjdk24: new recipe
- TODO: I need to port pandoc for rendering manpages
- Backported jdk23u patches
- Fixed build
- Do some tests and do some real cases tests

Ok now i can focus on another things, like porting spotifyd or patch IDEA 2025.1,
btw we have now jdk18..24 before GTA6!

![image](https://github.com/user-attachments/assets/a5af0860-f2f3-4e18-8eef-ed73b3281a51)
