### PR TITLE
Make Stormlib-devel require base lib

### DIFF
--- a/dev-libs/stormlib/stormlib-9.30.recipe
+++ b/dev-libs/stormlib/stormlib-9.30.recipe
@@ -4,7 +4,7 @@ which are able to read and also to write files from/to the MPQ archives."
 HOMEPAGE="http://www.zezula.net/en/mpq/stormlib.html"
 COPYRIGHT="2003-2024 Ladislav Zezula"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/ladislav-zezula/StormLib/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="a709a6b034d206404f5297d85e474371203ff5483639955195d99b737bbf7dfe"
 SOURCE_DIR="StormLib-$portVersion"
@@ -28,6 +28,10 @@ REQUIRES="
 PROVIDES_devel="
 	stormlib${secondaryArchSuffix}_devel = $portVersion
 	devel:libstorm$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	haiku${secondaryArchSuffix}_devel
+	stormlib$secondaryArchSuffix == $portVersion base
 	"
 
 BUILD_REQUIRES="


### PR DESCRIPTION
As noted by korli, stormlib's development package should require the base library, this PR fixes that.