### PR TITLE
Smpq, revbump to build with newer stormlib

### DIFF
--- a/app-arch/smpq/smpq-1.6.recipe
+++ b/app-arch/smpq/smpq-1.6.recipe
@@ -4,7 +4,7 @@ manipulation of Blizzard MPQ archives."
 HOMEPAGE="https://launchpad.net/smpq"
 COPYRIGHT="2010-2016 Pali"
 LICENSE="GNU GPL v3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://launchpad.net/smpq/trunk/$portVersion/+download/smpq_$portVersion.orig.tar.gz"
 CHECKSUM_SHA256="b5d2dc8a5de8629b71ee5d3612b6e84d88418b86c5cd39ba315e9eb0462f18cb"
 SOURCE_DIR="smpq-$portVersion"
@@ -29,7 +29,6 @@ BUILD_REQUIRES="
 	devel:libstorm$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	devel:libzip$secondaryArchSuffix
-	lib:libstorm$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:cmake


### PR DESCRIPTION
Update Smpq's recipe after Stormlib's changes in https://github.com/haikuports/haikuports/pull/12275

Keeping it as a draft until the other PR is merged.