### PR TITLE
Libplum port

### DIFF
--- a/net-libs/libplum/libplum-0.5.1.recipe
+++ b/net-libs/libplum/libplum-0.5.1.recipe
@@ -1,0 +1,60 @@
+SUMMARY="Multi-protocol Port Mapping client library"
+DESCRIPTION="libplum (Port Lightweight and Universal Mapping) is a high-level library allowing to forward ports \
+on Network Address Translators (NAT). It is written in C without dependencies and supports \
+multiple platforms, including GNU/Linux, Android, Apple macOS, iOS, and Microsoft Windows."
+HOMEPAGE="https://github.com/paullouisageneau/libplum"
+COPYRIGHT="2025 Paul-Louis Ageneau"
+LICENSE="MPL v2.0"
+REVISION="1"
+SOURCE_URI="https://github.com/paullouisageneau/libplum/archive/refs/tags/v$portVersion.tar.gz"
+CHECKSUM_SHA256="80f2c71db5b5ae18a0ae2a0c1572f3650f502304c806f2e893b0e6dacdcf7115"
+SOURCE_DIR="libplum-$portVersion"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	libplum$secondaryArchSuffix = $portVersion
+	lib:libplum$secondaryArchSuffix
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	libplum${secondaryArchSuffix}_devel = $portVersion
+	devel:libplum$secondaryArchSuffix
+	"
+REQUIRES_devel="
+	haiku${secondaryArchSuffix}_devel
+	libplum$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libglib_2.0$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	"
+
+BUILD()
+{
+	cmake -Bbuild -S. $cmakeDirArgs \
+		-DCMAKE_BUILD_TYPE=Release
+
+	make -C build $jobArgs
+}
+
+INSTALL()
+{
+	make -C build install
+
+	prepareInstalledDevelLib libplum
+
+	# devel package
+	packageEntries devel \
+		$developDir
+}


### PR DESCRIPTION
libplum (Port Lightweight and Universal Mapping) is a high-level library allowing to forward ports on Network Address Translators (NAT).

Only tested on x64, built to be used with Warzone 2100 but it prefers using the in-source one anyway.
Of dubious utility on Haiku since at least one of the included functions (`net_get_default_gateway` in `net.c`) requires platform-specific code as afaict it doesn't work as-is.