### PR TITLE
DevilutionX: extras package

### DIFF
--- a/games-rpg/devilutionx_extras/devilutionx_extras-v4.recipe
+++ b/games-rpg/devilutionx_extras/devilutionx_extras-v4.recipe
@@ -1,0 +1,39 @@
+SUMMARY="Language specific content which is optional for running DevilutionX"
+DESCRIPTION="This package contains some language specific content for DevilutionX:\
+
+* CJK languages and fonts support
+* Spanish language dub
+* Polish language dub
+* Russian language dub"
+HOMEPAGE="https://devilutionx.com/"
+COPYRIGHT="2023-2024 DevilutionX"
+LICENSE="SIL Open Font License v1.1"
+REVISION="1"
+SOURCE_URI="https://github.com/diasurgical/devilutionx-assets/releases/download/$portVersion/fonts.mpq#noarchive"
+CHECKSUM_SHA256="551ecee2d95b4e7807737a7794a6bacf0b4a03a91634816277b91db35ce1e259"
+SOURCE_FILENAME="fonts.mpq"
+SOURCE_URI_2="https://github.com/diasurgical/devilutionx-assets/releases/download/$portVersion/es.mpq#noarchive"
+CHECKSUM_SHA256_2="459f850ae9d833116be7bc00d6fb6ad18f017c521d72b4df453d4f3bc92fe628"
+SOURCE_FILENAME_2="es.mpq"
+SOURCE_URI_3="https://github.com/diasurgical/devilutionx-assets/releases/download/$portVersion/pl.mpq#noarchive"
+CHECKSUM_SHA256_3="715763a7e35347fd42041b35d961189c932d9d320ee29b6929106e550b0e42de"
+SOURCE_FILENAME_3="pl.mpq"
+SOURCE_URI_4="https://github.com/diasurgical/devilutionx-assets/releases/download/$portVersion/ru.mpq#noarchive"
+CHECKSUM_SHA256_4="48bfb5baeed370b565a61db5eab90214700121311a3c40e50d2671d5bac8778b"
+SOURCE_FILENAME_4="ru.mpq"
+
+ARCHITECTURES="any"
+DISABLE_SOURCE_PACKAGE="yes"
+
+PROVIDES="
+	devilutionx_extras = $portVersion
+	"
+REQUIRES="
+	app:DevilutionX
+	"
+
+INSTALL()
+{
+	# Pack data
+	mkdir -p $appsDir/devilutionx && cp -t $appsDir/devilutionx * $sourceDir{2,3,4}/*
+}


### PR DESCRIPTION
This recipe packs a couple of extra assets to be used with DevilutionX.
- CJK support
- ES,PL,RU (fan?)dubs

Tested CJK with Japanese for a bit and it looks fine.

Note: these can be built from source in theory but require porting a specific tool for it.