### PR TITLE
sqlitecpp: x86 fix

### DIFF
--- a/dev-db/sqlitecpp/sqlitecpp-3.3.2.recipe
+++ b/dev-db/sqlitecpp/sqlitecpp-3.3.2.recipe
@@ -35,7 +35,7 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	cmd:cmake
-	cmd:cppcheck # Optional
+	cmd:cppcheck$secondaryArchSuffix # Optional
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
 	cmd:python3 # Optional


### PR DESCRIPTION
Doesn't compile currently on x86 because it doesn't fix cppcheck's binary, this should fix it.