### PR TITLE
ZMusic port

### DIFF
--- a/media-libs/zmusic/zmusic-1.1.4~git.recipe
+++ b/media-libs/zmusic/zmusic-1.1.4~git.recipe
@@ -1,0 +1,65 @@
+SUMMARY="GZDoom's music system as a standalone library"
+DESCRIPTION="This is a music library for use with the projects GZDoom, Raze, and the newer PrBoom+."
+HOMEPAGE="https://github.com/ZDoom/ZMusic"
+COPYRIGHT="2020-2025 GZDoom team and contributors"
+LICENSE="GNU GPL v3"
+REVISION="1"
+srcGitRev="6928b8609db9b1c104c4cd4f9b163486121fb0f0"
+SOURCE_URI="https://github.com/ZDoom/ZMusic/archive/$srcGitRev.zip"
+CHECKSUM_SHA256="2a6b64d12b33f3d10e5dee7ad91753393aca2fcea0fdc109e043808af0aea85e"
+SOURCE_DIR="ZMusic-$srcGitRev"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="1.0.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	zmusic$secondaryArchSuffix = $portVersion
+	lib:libzmusic$secondaryArchSuffix = $libVersionCompat
+	lib:libzmusiclite$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libglib_2.0$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	zmusic${secondaryArchSuffix}_devel = $portVersion
+	devel:libzmusic$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	haiku${secondaryArchSuffix}_devel
+	zmusic$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libglib_2.0$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	cmake -Bbuild -S. $cmakeDirArgs \
+		-DCMAKE_BUILD_TYPE=Release
+
+	make -C build $jobArgs
+}
+
+INSTALL()
+{
+	make -C build install
+
+	prepareInstalledDevelLib libzmusic
+
+	# devel package
+	packageEntries devel \
+		$developDir
+}


### PR DESCRIPTION
Tested and working on x64, used to compile the latest GZDoom and Raze. It also mentions PrBoom+ but I don't see a way of using it for that.
Using latest git because 1.1.3 is too old to compile current GZDoom.