### PR TITLE
SBCL 2.5.4

### DIFF
--- a/dev-lisp/sbcl/sbcl-2.5.4.recipe
+++ b/dev-lisp/sbcl/sbcl-2.5.4.recipe
@@ -9,7 +9,7 @@ COPYRIGHT="2002 Gerd Moellmann"
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="https://github.com/sbcl/sbcl/archive/refs/tags/sbcl-$portVersion.zip"
-CHECKSUM_SHA256="454f9bf4c633228121b47631a8434d11decd4f021a8f36579e880e1de6904b4a"
+CHECKSUM_SHA256="71c56eccbd5ead62d4976e6f1a988a40e2282683ee00642fa8a3c31fc03c8950"
 SOURCE_DIR="sbcl-sbcl-$portVersion"
 
 ARCHITECTURES="x86_64"


### PR DESCRIPTION
Compilation with `CLISP` is available again.