### PR TITLE
Upgrade sane_backends to 1.3.1

### DIFF
--- a/media-gfx/sane_backends/patches/sane_backends-1.3.1.patchset
+++ b/media-gfx/sane_backends/patches/sane_backends-1.3.1.patchset
@@ -29,9 +29,9 @@ Subject: Fix strsep redefined
 
 diff --git a/include/sane/config.h.in b/include/sane/config.h.in
 index 3ebba97..1538af9 100644
---- a/include/sane/config.h.in
-+++ b/include/sane/config.h.in
-@@ -702,11 +702,12 @@ char *strdup (const char * s);
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -754,11 +702,12 @@ char *strdup (const char * s);
  char *strndup(const char * s, size_t n);
  #endif
  

--- a/media-gfx/sane_backends/sane_backends-1.3.1.recipe
+++ b/media-gfx/sane_backends/sane_backends-1.3.1.recipe
@@ -16,10 +16,10 @@ documentation."
 HOMEPAGE="http://www.sane-project.org"
 COPYRIGHT="David Mosberger-Tang, Andy Beck"
 LICENSE="GNU LGPL v2"
-REVISION="3"
-SOURCE_URI="https://gitlab.com/sane-project/backends/uploads/110fc43336d0fb5e514f1fdc7360dd87/sane-backends-$portVersion.tar.gz"
-CHECKSUM_SHA256="f832395efcb90bb5ea8acd367a820c393dda7e0dd578b16f48928b8f5bdd0524"
-SOURCE_DIR="sane-backends-$portVersion"
+REVISION="1"
+SOURCE_URI="https://gitlab.com/sane-project/backends/-/archive/$portVersion/backends-$portVersion.tar.gz"
+CHECKSUM_SHA256="cc8796701015def1c598f97962a70d63957b9786841391cc412a606568b42b96"
+SOURCE_DIR="backends-$portVersion"
 PATCHES="sane_backends-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -73,6 +73,7 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	autoconf_archive
 	cmd:aclocal
 	cmd:autoconf
 	cmd:automake
@@ -92,6 +93,8 @@ BUILD()
 	if [ $effectiveTargetArchitecture == 'x86' ]; then
 		export CFLAGS="-DTIFF_DISABLE_DEPRECATED"
 	fi
+
+	./autogen.sh
 
 	export LIBS="-lnetwork"
 	runConfigure configure \


### PR DESCRIPTION
Upgrade sane_backends to latest released version, 1.3.1.

Due to some c++11, we now needs m4 macros from autoconf_archive.
Run ./autogen.sh script before calling configure, as required now.