### PR TITLE
Updated to BeScreenCapture 2.9.9

### DIFF
--- a/haiku-apps/bescreencapture/bescreencapture-2.9.9.recipe
+++ b/haiku-apps/bescreencapture/bescreencapture-2.9.9.recipe
@@ -10,7 +10,7 @@ LICENSE="BSD (3-clause)
 	MIT"
 REVISION="1"
 SOURCE_URI="https://github.com/jackburton79/bescreencapture/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="038194a7cb956e225501c97e94fe7db0aba7a51e446b48040667157e9b9209aa"
+CHECKSUM_SHA256="212f74405e0b779a6f9c1e0aff7ffc49f034dcf1ee2f8cdd23d3438fad03a000"
 SOURCE_FILENAME="bescreencapture-$portVersion.tar.gz"
 
 ARCHITECTURES="all"

--- a/haiku-apps/bescreencapture/bescreencapture-2.9.9.recipe
+++ b/haiku-apps/bescreencapture/bescreencapture-2.9.9.recipe
@@ -5,12 +5,12 @@ to any media format supported in Haiku.
 BeScreenCapture can record either the entire screen, or just a section you \
 select."
 HOMEPAGE="https://github.com/jackburton79/bescreencapture/releases"
-COPYRIGHT="2014-2024 Stefano Ceccherini"
+COPYRIGHT="2014-2025 Stefano Ceccherini"
 LICENSE="BSD (3-clause)
 	MIT"
 REVISION="1"
 SOURCE_URI="https://github.com/jackburton79/bescreencapture/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="70ac92f1d48f9da0538f7024c7a138408d7b3385c334821c52f890b523b7d477"
+CHECKSUM_SHA256="038194a7cb956e225501c97e94fe7db0aba7a51e446b48040667157e9b9209aa"
 SOURCE_FILENAME="bescreencapture-$portVersion.tar.gz"
 
 ARCHITECTURES="all"


### PR DESCRIPTION
Not really a big release, although the version number could hint at one: various changes made in previous months which should handle error situations a bit better.

What's new:

    Fixed rounding of FPS during recording
    Avoid allocating a new bitmap at every frame

Full Changelog: https://github.com/jackburton79/bescreencapture/compare/v2.9.1...v2.9.9