### PR TITLE
libarchive: update to version 3.7.9.

### DIFF
--- a/app-arch/libarchive/libarchive-3.7.9.recipe
+++ b/app-arch/libarchive/libarchive-3.7.9.recipe
@@ -23,9 +23,9 @@ or compress.
 HOMEPAGE="http://www.libarchive.org/"
 COPYRIGHT="2003-2018 Tim Kientzle"
 LICENSE="BSD (2-clause)"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="http://www.libarchive.org/downloads/libarchive-$portVersion.tar.gz"
-CHECKSUM_SHA256="df404eb7222cf30b4f8f93828677890a2986b66ff8bf39dac32a804e96ddf104"
+CHECKSUM_SHA256="aa90732c5a6bdda52fda2ad468ac98d75be981c15dde263d7b5cf6af66fd009f"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -38,15 +38,12 @@ if [ "$targetArchitecture" = x86_gcc2 ]; then
     commandBinDir=$prefix/bin
 fi
 
-libVersion="13.7.2"
+libVersion="13.7.9"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+portVersionCompat="$portVersion compat >= 3.0"
 
 PROVIDES="
-	libarchive$secondaryArchSuffix = $portVersion compat >= 3.0
-	cmd:bsdcat$commandSuffix = $portVersion compat >= 3.0
-	cmd:bsdcpio$commandSuffix = $portVersion compat >= 3.0
-	cmd:bsdtar$commandSuffix = $portVersion compat >= 3.0
-	cmd:bsdunzip$commandSuffix = $portVersion compat >= 3.0
+	libarchive$secondaryArchSuffix = $portVersionCompat
 	lib:libarchive$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
@@ -55,25 +52,37 @@ REQUIRES="
 	lib:libcrypto$secondaryArchSuffix
 	lib:libiconv$secondaryArchSuffix
 	lib:liblzma$secondaryArchSuffix
-	lib:libssl$secondaryArchSuffix
 	lib:libxml2$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
-	libarchive${secondaryArchSuffix}_devel = $portVersion compat >= 3.0
+	libarchive${secondaryArchSuffix}_devel = $portVersionCompat
 	devel:libarchive$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
 	libarchive$secondaryArchSuffix == $portVersion base
+	devel:libiconv$secondaryArchSuffix
+	devel:libcrypto$secondaryArchSuffix
+	"
+
+PROVIDES_tools="
+	libarchive${secondaryArchSuffix}_tools = $portVersionCompat
+	cmd:bsdcat$commandSuffix = $portVersionCompat
+	cmd:bsdcpio$commandSuffix = $portVersionCompat
+	cmd:bsdtar$commandSuffix = $portVersionCompat
+	cmd:bsdunzip$commandSuffix = $portVersionCompat
+	"
+REQUIRES_tools="
+	libarchive$secondaryArchSuffix == $portVersion base
+	$REQUIRES
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libbz2$secondaryArchSuffix
-	devel:libcrypto$secondaryArchSuffix >= 3
+	devel:libcrypto$secondaryArchSuffix
 	devel:liblzma$secondaryArchSuffix
-	devel:libssl$secondaryArchSuffix >= 3
 	devel:libxml2$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"
@@ -91,7 +100,7 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	autoreconf -fi
-	LDFLAGS="-lbsd" CFLAGS="-D_BSD_SOURCE" ac_cv_func_readpassphrase=yes \
+	LDFLAGS="-lbsd" CFLAGS="-D_BSD_SOURCE -O2" \
 		runConfigure --omit-dirs binDir \
 		./configure --bindir=$commandBinDir \
 		--enable-static=no
@@ -107,9 +116,20 @@ INSTALL()
 	prepareInstalledDevelLib libarchive
 	fixPkgconfig
 
+	# Search paths including the package version in them are not useful here
+	# (and they will get out-of-sync as soon as xz_utils and/or libxml2 get updated).
+	sed -e "s,-L/packages/xz_utils-[^/]*/.self/develop/lib ,," \
+		-i $developDir/lib/pkgconfig/libarchive.pc
+	sed -e "s,-L/packages/libxml2-[^/]*/.self/develop/lib ,," \
+		-i $developDir/lib/pkgconfig/libarchive.pc
+
 	packageEntries devel \
 		$developDir \
 		$manDir/man3
+
+	packageEntries tools \
+		$commandBinDir \
+		$manDir/man1
 }
 
 TEST()

--- a/app-arch/libarchive/libarchive-3.7.9.recipe
+++ b/app-arch/libarchive/libarchive-3.7.9.recipe
@@ -62,8 +62,8 @@ PROVIDES_devel="
 	"
 REQUIRES_devel="
 	libarchive$secondaryArchSuffix == $portVersion base
-	devel:libiconv$secondaryArchSuffix
 	devel:libcrypto$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
 	"
 
 PROVIDES_tools="


### PR DESCRIPTION
- Function "readpassphrase" is correctly detected now, so can remove the "ac_vc_func_*" hack.
- Added missing _devel requirements, that should fix detection/usage of libarchive via pkg-config (like for the muon recipe).
- Split commands into a _tools package.
- Removed unnecessary library search paths from libarchive.pc.