### PR TITLE
Genio ShowDocumentation extension

### DIFF
--- a/haiku-apps/genio-extensions/genio_extensions-1.0.recipe
+++ b/haiku-apps/genio-extensions/genio_extensions-1.0.recipe
@@ -1,6 +1,6 @@
 SUMMARY="Extensions package for Genio The Haiku IDE"
-DESCRIPTION="This package contains all currently available extensions for Genio.\
-For the moment the only available extension is 'ShowDocumentation' which opens the Haiku Book"
+DESCRIPTION="This package contains all currently available extensions for Genio.
+At the moment the only available extension is 'ShowDocumentation' which opens the Haiku Book using Zeal"
 COPYRIGHT="2022-2025 The Genio Team"
 HOMEPAGE="https://github.com/Genio-The-Haiku-IDE/Genio/releases"
 LICENSE="BSD (3-clause)
@@ -21,6 +21,7 @@ PROVIDES="
 REQUIRES="
 	genio${secondaryArchSuffix} >= 3.0
 	haiku
+	haiku_pyapi_python310
 	zeal
 	"
 

--- a/haiku-apps/genio-extensions/genio_extensions-1.0.recipe
+++ b/haiku-apps/genio-extensions/genio_extensions-1.0.recipe
@@ -1,0 +1,44 @@
+SUMMARY="Extensions package for Genio The Haiku IDE"
+DESCRIPTION="This package contains all currently available extensions for Genio.\
+For the moment the only available extension is 'ShowDocumentation' which opens the Haiku Book"
+COPYRIGHT="2022-2025 The Genio Team"
+HOMEPAGE="https://github.com/Genio-The-Haiku-IDE/Genio/releases"
+LICENSE="BSD (3-clause)
+	MIT"
+REVISION="1"
+SOURCE_URI="https://github.com/Genio-The-Haiku-IDE/genio-script-extension/archive/v$portVersion.tar.gz"
+CHECKSUM_SHA256="05ab96b64ed906d7b582d4f3bd894d67aa205ddb0b5a89b9cc4c793670fecd62"
+SOURCE_FILENAME="genio-script-extension-v$portVersion.tar.gz"
+SOURCE_DIR="genio-script-extension-$portVersion"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	genio_extensions = $portVersion
+	app:ShowDocumentation.py = $portVersion
+	"
+REQUIRES="
+	genio${secondaryArchSuffix} >= 3.0
+	haiku
+	zeal
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	makefile_engine
+	cmd:make
+	"
+
+BUILD()
+{
+	build.sh ./ShowDocumentation.py
+}
+
+INSTALL()
+{
+	mkdir -p "$dataDir/Genio/extensions"
+	cp -a ShowDocumentation.py "$dataDir/Genio/extensions"
+}

--- a/haiku-apps/genio/genio_extension_showdocumentation-1.0.recipe
+++ b/haiku-apps/genio/genio_extension_showdocumentation-1.0.recipe
@@ -1,25 +1,25 @@
-SUMMARY="Extensions package for Genio The Haiku IDE"
+SUMMARY="Show Documentation extension for Genio The Haiku IDE"
 DESCRIPTION="This package contains all currently available extensions for Genio.
 At the moment the only available extension is 'ShowDocumentation' which opens the Haiku Book using Zeal"
-COPYRIGHT="2022-2025 The Genio Team"
+COPYRIGHT="2024-2025 The Genio Team"
 HOMEPAGE="https://github.com/Genio-The-Haiku-IDE/Genio/releases"
 LICENSE="BSD (3-clause)
 	MIT"
 REVISION="1"
-SOURCE_URI="https://github.com/Genio-The-Haiku-IDE/genio-script-extension/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="05ab96b64ed906d7b582d4f3bd894d67aa205ddb0b5a89b9cc4c793670fecd62"
-SOURCE_FILENAME="genio-script-extension-v$portVersion.tar.gz"
-SOURCE_DIR="genio-script-extension-$portVersion"
+SOURCE_URI="https://github.com/Genio-The-Haiku-IDE/genio-extension-showdocumentation/archive/v$portVersion.tar.gz"
+CHECKSUM_SHA256="b87a1b310f3ecaac229c1d559a02f9fb51ad7c7ac422b6fb2345ffed99c9589e"
+SOURCE_FILENAME="genio-extension-showdocumentation-v$portVersion.tar.gz"
+SOURCE_DIR="genio-extension-showdocumentation-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	genio_extensions = $portVersion
+	genio_extension_showdocumentation = $portVersion
 	app:ShowDocumentation.py = $portVersion
 	"
 REQUIRES="
-	genio${secondaryArchSuffix} >= 3.0
+	genio$secondaryArchSuffix >= 3.0
 	haiku
 	haiku_pyapi_python310
 	zeal

--- a/haiku-apps/genio/genio_extension_showdocumentation-1.0.recipe
+++ b/haiku-apps/genio/genio_extension_showdocumentation-1.0.recipe
@@ -1,5 +1,5 @@
 SUMMARY="'Show Documentation' extension for Genio The Haiku IDE"
-DESCRIPTION="This package contains the 'Show Documentation' extension for Genio The Haiku IDE."
+DESCRIPTION="Experimental 'Show Documentation' extension for Genio The Haiku IDE."
 COPYRIGHT="2024-2025 The Genio Team"
 HOMEPAGE="https://github.com/Genio-The-Haiku-IDE/Genio/releases"
 LICENSE="BSD (3-clause)
@@ -18,6 +18,7 @@ PROVIDES="
 	app:ShowDocumentation.py = $portVersion
 	"
 REQUIRES="
+	cmd:git
 	genio$secondaryArchSuffix >= 3.0
 	haiku
 	haiku_pyapi_python310
@@ -41,4 +42,10 @@ INSTALL()
 {
 	mkdir -p "$dataDir/Genio/extensions"
 	cp -a ShowDocumentation.py "$dataDir/Genio/extensions"
+	
+	# Navigate to the Zeal docsets directory
+	mkdir -p /boot/home/config/cache/Zeal/Zeal/docsets
+	cd /boot/home/config/cache/Zeal/Zeal/docsets
+	# Clone the repository
+	git clone https://github.com/Genio-The-Haiku-IDE/org.haiku.HaikuBook.docset/
 }

--- a/haiku-apps/genio/genio_extension_showdocumentation-1.0.recipe
+++ b/haiku-apps/genio/genio_extension_showdocumentation-1.0.recipe
@@ -1,6 +1,5 @@
-SUMMARY="Show Documentation extension for Genio The Haiku IDE"
-DESCRIPTION="This package contains all currently available extensions for Genio.
-At the moment the only available extension is 'ShowDocumentation' which opens the Haiku Book using Zeal"
+SUMMARY="'Show Documentation' extension for Genio The Haiku IDE"
+DESCRIPTION="This package contains the 'Show Documentation' extension for Genio The Haiku IDE."
 COPYRIGHT="2024-2025 The Genio Team"
 HOMEPAGE="https://github.com/Genio-The-Haiku-IDE/Genio/releases"
 LICENSE="BSD (3-clause)


### PR DESCRIPTION
*** DRAFT NON WORKING ***
First try packaging Genio extension "ShowDocumentation".
On install, I'm trying to use "git clone" to install the DocSet for Zeal,
but it seems it's not available inside the chroot. I declared it in the "Requires", though.
