### PR TITLE
yazpp: add recipe for version 1.9.0

### DIFF
--- a/dev-libs/yazpp/yazpp-1.9.0.recipe
+++ b/dev-libs/yazpp/yazpp-1.9.0.recipe
@@ -1,0 +1,114 @@
+SUMMARY="C++ toolkit for Z39.50/SRU clients and servers"
+DESCRIPTION="YAZ++ is a C++ toolkit for development of Z39.50 and SRU clients and servers. \
+It is built on top of the YAZ toolkit and provides additional C++ classes and utilities."
+HOMEPAGE="https://software.indexdata.com/yazpp/doc/"
+COPYRIGHT="1995-2025 Index Data"
+LICENSE="BSD (3-clause)"
+REVISION="1"
+SOURCE_URI="https://ftp.indexdata.com/pub/yazpp/yazpp-$portVersion.tar.gz"
+CHECKSUM_SHA256="17aa0f5b45edbfa9ee0363cb3b684e895d3d05e74024384d6c8707875621dcfc"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+libVersion=6.1.0
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+portVersionCompat="$portVersion compat >= ${portVersion%.*}"
+libZoomppVersion=6.0.0
+libZoomppVersionCompat="$libZoomppVersion compat >= ${libZoomppVersion%%.*}"
+
+PROVIDES="
+	yazpp$secondaryArchSuffix = $portVersion
+	lib:libyazpp$secondaryArchSuffix = $libVersionCompat
+	lib:libzoompp$secondaryArchSuffix = $libZoomppVersionCompat
+	"
+
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libxml2$secondaryArchSuffix
+	lib:libxslt$secondaryArchSuffix
+	lib:libyaz$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	yazpp${secondaryArchSuffix}_devel = $portVersion
+	cmd:yazpp_config$commandSuffix
+	devel:libyazpp$secondaryArchSuffix = $libVersionCompat
+	devel:libzoompp$secondaryArchSuffix = $libZoomppVersionCompat
+	"
+
+REQUIRES_devel="
+	yazpp$secondaryArchSuffix == $portVersion base
+	devel:libxml2$secondaryArchSuffix
+	devel:libxslt$secondaryArchSuffix
+	devel:libyaz$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libxml2$secondaryArchSuffix
+	devel:libxslt$secondaryArchSuffix
+	devel:libyaz$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+
+BUILD_PREREQUIRES="
+	cmd:autoconf
+	cmd:automake
+	cmd:gcc$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+defineDebugInfoPackage yazpp$secondaryArchSuffix \
+	$libDir/libyazpp.so.$libVersion \
+	$libDir/libzoompp.so.$libZoomppVersion
+
+BUILD()
+{
+	export LDFLAGS="-lnetwork"
+	autoreconf -fi
+	runConfigure --omit-dirs "binDir" ./configure \
+		--bindir=$commandBinDir \
+		--disable-static
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	# move documentation to developDocDir
+	mkdir -p $developDocDir
+	mv $dataDir/doc/yazpp/* $developDocDir
+	rm -rf $dataDir/doc
+
+	# Clean up libtool files
+	rm -f $libDir/*.la
+
+	# Prepare development libraries
+	prepareInstalledDevelLibs libyazpp libzoompp
+	fixPkgconfig
+
+	# Package development components
+	packageEntries devel \
+		$developDir \
+		$commandBinDir \
+		$dataDir/aclocal \
+		$manDir
+}
+
+TEST()
+{
+	make check
+}


### PR DESCRIPTION
YAZ++ is a C++ toolkit for development of Z39.50 and SRU clients and servers. It is built on top of the YAZ toolkit and provides additional C++ classes and utilities for building library catalog search systems.

Packages created:
- yazpp: main runtime libraries
- yazpp_devel: development headers and yazpp-config tool
- yazpp_debuginfo: debug symbols