### PR TITLE
nim: update to 2.2.4

### DIFF
--- a/dev-lang/nim/nim-2.2.4.recipe
+++ b/dev-lang/nim/nim-2.2.4.recipe
@@ -15,7 +15,7 @@ LICENSE="MIT"
 REVISION="1"
 SOURCE_URI="https://nim-lang.org/download/nim-$portVersion.tar.xz"
 SOURCE_DIR="nim-$portVersion"
-CHECKSUM_SHA256="ce9842849c9760e487ecdd1cdadf7c0f2844cafae605401c7c72ae257644893c"
+CHECKSUM_SHA256="f82b419750fcce561f3f897a0486b180186845d76fb5d99f248ce166108189c7"
 ADDITIONAL_FILES="
 	config.nims
 	nim.rdef.in


### PR DESCRIPTION
this updates nim to release 2.2.4

```

> uname -a
Haiku shredder 1 hrev58867 May 18 2025 06:24:28 x86_64 x86_64 Haiku

> nim --version
Nim Compiler Version 2.2.4 [Haiku: amd64]
Compiled at 2025-05-19
Copyright (c) 2006-2025 by Andreas Rumpf

git hash: 5ff0501419c80a972344b4460cc0875745a63b13
active boot switches: -d:release

```

note: required an [update](https://github.com/nim-lang/nimble/pull/1398) to nimble as the nim build process relies on nimble