### PR TITLE
intel_microcode: update to version 20250512.

### DIFF
--- a/sys-firmware/intel-microcode/intel_microcode-20250512.recipe
+++ b/sys-firmware/intel-microcode/intel_microcode-20250512.recipe
@@ -10,7 +10,7 @@ LICENSE="Intel CPU Microcode"
 REVISION="1"
 SOURCE_URI="https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/archive/microcode-$portVersion.tar.gz"
 SOURCE_DIR="Intel-Linux-Processor-Microcode-Data-Files-microcode-$portVersion"
-CHECKSUM_SHA256="1da88b51953c9da2e20b5c94b3d7270cf87ea5babcaa56e3d6a5c9eaf11694b3"
+CHECKSUM_SHA256="041af7d2f5791a47c1e914abd7d6255de4d4fc61b0f8e49ada6ee7014bcc3614"
 ADDITIONAL_FILES="intel_copy_microcode.sh"
 
 ARCHITECTURES="any"


### PR DESCRIPTION
Tested working on a Celeron N4020 (microcode updates from 0xc to 0x26).