### PR TITLE
jxltranslator: change in upstream

### DIFF
--- a/haiku-apps/jxl_translator/jxl_translator-0.1.1.recipe
+++ b/haiku-apps/jxl_translator/jxl_translator-0.1.1.recipe
@@ -45,5 +45,5 @@ INSTALL()
 	make install INSTALL_DIR=$addOnsDir/Translators
 
 	mkdir -p $dataDir/mime_db/image
-	resattr -O -o $dataDir/mime_db/image/jxl objects.$targetArchitecture-cc13-release/JXLMime.rsrc
+	resattr -O -o $dataDir/mime_db/image/jxl objects.$effectiveTargetArchitecture-cc13-release/JXLMime.rsrc
 }

--- a/haiku-apps/jxl_translator/jxl_translator-0.1.1.recipe
+++ b/haiku-apps/jxl_translator/jxl_translator-0.1.1.recipe
@@ -5,14 +5,13 @@ the JPEG-XL format.
 Using this add-on will allow any application using Haiku Data Translations \
 to read and write JPEG-XL format files.  Currently only non-animated images \
 are supported. ICC Profiles are also ignored."
-HOMEPAGE="https://github.com/wattoc/JXLTranslator"
-COPYRIGHT="2021 Craig Watson"
+HOMEPAGE="https://codeberg.org/Hanicef/JXLTranslator"
+COPYRIGHT="2021 Craig Watson / 2025 Gustaf Alhäll"
 LICENSE="MIT"
 REVISION="1"
-srcGitRev="7a0fafae0e927f647780fe2fdbdbe283ecef4638"
-SOURCE_URI="https://github.com/wattoc/JXLTranslator/archive/$srcGitRev.zip"
-CHECKSUM_SHA256="f5b2f670ee9694e88d08a8ee1ef6e473ed8d20fd0117b636bdb9e4292e2db74c"
-SOURCE_DIR="JXLTranslator-$srcGitRev"
+SOURCE_URI="https://codeberg.org/Hanicef/JXLTranslator/archive/v$portVersion.zip"
+CHECKSUM_SHA256="f0af7d282d8faaa1d3938275c140c3554412d63bd3592fd5d7a6f5f379e597f4"
+SOURCE_DIR="jxltranslator"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -23,12 +22,12 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libjxl$secondaryArchSuffix
+	libjxl0.11$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libjxl$secondaryArchSuffix
+	libjxl0.11${secondaryArchSuffix}_devel
 	"
 BUILD_PREREQUIRES="
 	makefile_engine
@@ -44,4 +43,7 @@ BUILD()
 INSTALL()
 {
 	make install INSTALL_DIR=$addOnsDir/Translators
+
+	mkdir -p $dataDir/mime_db/image
+	resattr -O -o $dataDir/mime_db/image/jxl objects.$targetArchitecture-cc13-release/JXLMime.rsrc
 }


### PR DESCRIPTION
Originally developed by Craig Watson, now updated and maintained by me after being abandoned by the original developer. The updated version actually functions with the latest version of Haiku and has numerous bug fixes related to reading and writing JPEG-XL files.

If you run into any issues or bugs with the updated port, don't hesitate to report it to me, preferrably on the Codeberg repository but anythere else I'm reachable is fine, too.