### PR TITLE
qgis: change python build requirement to 3.10.

### DIFF
--- a/sci-geosciences/qgis/qgis-3.24.3.recipe
+++ b/sci-geosciences/qgis/qgis-3.24.3.recipe
@@ -101,7 +101,7 @@ BUILD_PREREQUIRES="
 	cmd:lrelease$secondaryArchSuffix >= 5
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:python3.9
+	cmd:python3.10
 	"
 
 BUILD()


### PR DESCRIPTION
Begasus confirmed it builds and runs OK (thanks!).

No rev-bump needed (not a runtime change).