### PR TITLE
kmymoney, revbump, backport upstream patch

### DIFF
--- a/app-office/kmymoney/kmymoney-5.2.0.recipe
+++ b/app-office/kmymoney/kmymoney-5.2.0.recipe
@@ -5,10 +5,11 @@ their personal finances by providing a broad array of financial features and too
 HOMEPAGE="https://kmymoney.org/"
 COPYRIGHT="2010-2025 KDE Organisation"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://download.kde.org/stable/kmymoney/$portVersion/kmymoney-$portVersion.tar.xz"
 CHECKSUM_SHA256="f308b0a2297f22f43d9bbe46b4c7dc6aac08bd594454e635a844d06abda4d33c"
-PATCHES="kmymoney-$portVersion.patchset"
+PATCHES="kmymoney-$portVersion.patchset
+	8c4b84f290e50e62fbf90a61df8c701140a42715.patch"
 ADDITIONAL_FILES="kmymoney.rdef.in"
 
 ARCHITECTURES="all !x86_gcc2"

--- a/app-office/kmymoney/patches/8c4b84f290e50e62fbf90a61df8c701140a42715.patch
+++ b/app-office/kmymoney/patches/8c4b84f290e50e62fbf90a61df8c701140a42715.patch
@@ -1,0 +1,31 @@
+From 8c4b84f290e50e62fbf90a61df8c701140a42715 Mon Sep 17 00:00:00 2001
+From: Thomas Baumgart <thb@net-bembel.de>
+Date: Mon, 23 Jun 2025 10:15:20 +0200
+Subject: [PATCH] Port triggering actions to Qt6
+
+Qt6 requires a QAction to be enabled to be triggered programmatically.
+
+BUG: 505977
+FIXED-IN: 5.2.1
+---
+ kmymoney/kmymoney.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/kmymoney/kmymoney.cpp b/kmymoney/kmymoney.cpp
+index de03c0ddb7..582a391bfc 100644
+--- a/kmymoney/kmymoney.cpp
++++ b/kmymoney/kmymoney.cpp
+@@ -1090,7 +1090,10 @@ KMyMoneyApp::KMyMoneyApp(QWidget* parent)
+ 
+     connect(d->m_myMoneyView, &KMyMoneyView::requestActionTrigger, this, [&](eMenu::Action action) {
+         if (pActions.contains(action)) {
++            const bool enabled = pActions[action]->isEnabled();
++            pActions[action]->setEnabled(true);
+             pActions[action]->trigger();
++            pActions[action]->setEnabled(enabled);
+         }
+     });
+ 
+-- 
+GitLab
+


### PR DESCRIPTION
Qt6 requires a QAction to be enabled to be triggered programmatically.