### PR TITLE
python3.13: attempt force rebuild on x86_64 builder.

### DIFF
--- a/dev-lang/python/python3.13-3.13.5.recipe
+++ b/dev-lang/python/python3.13-3.13.5.recipe
@@ -7,7 +7,14 @@ Python runs on Windows, Linux/Unix, Mac OS X, and has been ported to the Java \
 and .NET virtual machines.
 
 Python is free to use, even for commercial products, because of its \
-OSI-approved open source license."
+OSI-approved open source license.
+
+Note: to install \"pip\" for this Python version, use the following commands:
+
+> python3.13 -m ensurepip --altinstall
+> python3.13 -m pip install --upgrade pip
+
+And then you should be able to use \"pip3.13\" normally."
 HOMEPAGE="https://www.python.org"
 LICENSE="Python"
 COPYRIGHT="1990-2025 Python Software Foundation"
@@ -401,39 +408,39 @@ TEST()
 	local tests_that_fail=(
 		test__locale	# fails on 'test_alt_digits_nl_langinfo' and 'test_era_nl_langinfo'
 		test_ast		# seg-faulted at least once on 'test_recursion_direct'
-	    test_c_locale_coercion
-	    test_call		# seg-faulted at least once on 'test_super_deep' (recursion related)
-	    test_cmd		# "Bad file descriptor" on 'test_basic_completion'
-	    test_ctypes		# stupid test compares wording of error message.
-#	    test_compile	# out of memory (with 2 GB of RAM)
-	    test_datetime	# on rare ocassions, it passes.
-	    test_fcntl		# "Permission denied" in test_lockf_exclusive
-	    test_functools 	# seg-faulted at least once on 'test_lru_recursion'
-	    # test_genericpath # os.path.getatime() should return an int.
-	    # test_glob	# sometimes hangs.
-	    test_importlib	# "Invalid Argument" on _os.getcwd(). RAMFS or chroot related?
-	    test_ioctl	# B_ERROR on "fcntl.ioctl(wfd, termios.TCFLSH, termios.TCIFLUSH)"
-	    test_json	# "AssertionError: 13 != -2147459059" (errno.EPIPE)
-	    # test_kqueue # hangs (on nightlies only?).
-	    test_mailbox	# fails to clean a temp file? (os.utime() related?)
-	    test_math	# test expects to get -0.0, gets 0.0
-	    test_os		# named pipes related errors. set_get_priority, ttyname, and utime fails.
-	    test_popen	# sign error numbers in waitstatus_to_exitcode()... "AssertionError: -42 != 42"
-	    test_posix	# test_posix_fallocate and test_link_dir_fd. Operation not supported.
-	    # test_pty	# sometimes fails.
-	    test_pyrepl	# several: "module 'termios' has no attribute 'VREPRINT'". Adding hasattr(termios, 'VREPRINT') still results in error.
-	    test_re		# locale related failures.
-	    # test_readline	# hangs sometimes (when run in parallel with test_pty, I think).
-	    test_shutil		# "Operation not supported" calling "os.scandir(topfd)".
-	    # test_signal		# stupid test compares wording of strsignal(signal.SIGTERM).
-	    test_strptime	# locale related failures.
-	    test_subprocess	# "Device/File/Resource busy" calling setrlimit()
-	    test_sysconfig	# venv related failures. (ToDo, back-port patch from 3.14)
-	    test_tarfile	# os.path.getmtime() should return an int. Also, path.stat().st_mtime and pathlib.Path(TEMPDIR).stat().st_mtime seems to be using different scales: 1723.215266 vs 1723215266.0319815
-	    test_termios	# tcdrain/tcflow/tcflush/tcsendbreak related failures.
-	    test_time		# ctime/mktime related failures.
-	    test_tools		# _strptime / "%z" related.
-	    test_venv	# '/boot/system/cache/tmp/test_python_[...]/bin/python' can't find libpython3.13.so.1.0.
+		test_c_locale_coercion
+		test_call		# seg-faulted at least once on 'test_super_deep' (recursion related)
+		test_cmd		# "Bad file descriptor" on 'test_basic_completion'
+		test_ctypes		# stupid test compares wording of error message.
+#		test_compile	# out of memory (with 2 GB of RAM)
+		test_datetime	# on rare ocassions, it passes.
+		test_fcntl		# "Permission denied" in test_lockf_exclusive
+		test_functools 	# seg-faulted at least once on 'test_lru_recursion'
+		# test_genericpath # os.path.getatime() should return an int.
+		# test_glob	# sometimes hangs.
+		test_importlib	# "Invalid Argument" on _os.getcwd(). RAMFS or chroot related?
+		test_ioctl	# B_ERROR on "fcntl.ioctl(wfd, termios.TCFLSH, termios.TCIFLUSH)"
+		test_json	# "AssertionError: 13 != -2147459059" (errno.EPIPE)
+		# test_kqueue # hangs (on nightlies only?).
+		test_mailbox	# fails to clean a temp file? (os.utime() related?)
+		test_math	# test expects to get -0.0, gets 0.0
+		test_os		# named pipes related errors. set_get_priority, ttyname, and utime fails.
+		test_popen	# sign error numbers in waitstatus_to_exitcode()... "AssertionError: -42 != 42"
+		test_posix	# test_posix_fallocate and test_link_dir_fd. Operation not supported.
+		# test_pty	# sometimes fails.
+		test_pyrepl	# several: "module 'termios' has no attribute 'VREPRINT'". Adding hasattr(termios, 'VREPRINT') still results in error.
+		test_re		# locale related failures.
+		# test_readline	# hangs sometimes (when run in parallel with test_pty, I think).
+		test_shutil		# "Operation not supported" calling "os.scandir(topfd)".
+		# test_signal		# stupid test compares wording of strsignal(signal.SIGTERM).
+		test_strptime	# locale related failures.
+		test_subprocess	# "Device/File/Resource busy" calling setrlimit()
+		test_sysconfig	# venv related failures. (ToDo, back-port patch from 3.14)
+		test_tarfile	# os.path.getmtime() should return an int. Also, path.stat().st_mtime and pathlib.Path(TEMPDIR).stat().st_mtime seems to be using different scales: 1723.215266 vs 1723215266.0319815
+		test_termios	# tcdrain/tcflow/tcflush/tcsendbreak related failures.
+		test_time		# ctime/mktime related failures.
+		test_tools		# _strptime / "%z" related.
+		test_venv	# '/boot/system/cache/tmp/test_python_[...]/bin/python' can't find libpython3.13.so.1.0.
 	)
 
 	# besides the above ones, the following only fail when the workdir is in RAMFS:


### PR DESCRIPTION
- Replaced some prefix spaces with tabs.
- Added pip instructions to the package description.

Just some non-functional changes to try and trigger a new build on the x86_64 builder (might fail again if the work-dir still wasn't manually cleaned).