### PR TITLE
librsvg, fix for 32bit build(master)

### DIFF
--- a/gnome-base/librsvg/librsvg-2.58.0.recipe
+++ b/gnome-base/librsvg/librsvg-2.58.0.recipe
@@ -87,6 +87,7 @@ BUILD_REQUIRES="
 	devel:libgio_2.0$secondaryArchSuffix
 	devel:libgirepository_1.0$secondaryArchSuffix
 	devel:libglib_2.0$secondaryArchSuffix
+	devel:libharfbuzz$secondaryArchSuffix >= 0.61121.0
 	devel:libintl$secondaryArchSuffix
 	devel:libpango_1.0$secondaryArchSuffix
 	devel:libpng16$secondaryArchSuffix


### PR DESCRIPTION
harfbuzz is indirectly pulled by freetype, make this a direct dependency