### PR TITLE
_python* packages: do not use Python 3.9 as "defaultVersion" anymore.

### DIFF
--- a/dev-python/babel/babel-2.12.1.recipe
+++ b/dev-python/babel/babel-2.12.1.recipe
@@ -5,7 +5,7 @@ Python applications (in particular web-based applications.)"
 HOMEPAGE="http://babel.pocoo.org/"
 COPYRIGHT="2013-2022 by the Babel Team"
 LICENSE="BSD (3-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/python-babel/babel/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="37de3435fdec7c3267430765fc3ebe05cd234e65774ff1dc42a7b3b5cd39ef97"
 SOURCE_FILENAME="babel-v$portVersion.tar.gz"
@@ -25,12 +25,11 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-defaultVersion=3.9
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
-	pythonVersion=${PYTHON_VERSIONS[$i]}
+PYTHON_VERSIONS=(3.10)
+defaultVersion=3.10
+
+for pythonVersion in ${PYTHON_VERSIONS[@]}; do
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_${pythonPackage}=\"
 		${portName}_$pythonPackage = $portVersion
@@ -60,15 +59,17 @@ done
 INSTALL()
 {
 	cp $sourceDir2/* cldr
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
-		pythonVersion=${PYTHON_VERSIONS[$i]}
+
+	for pythonVersion in ${PYTHON_VERSIONS[@]}; do
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/
 		export PYTHONPATH=$installLocation:$PYTHONPATH
+
 		mkdir -p $installLocation
 		rm -rf build
+
 		$python setup.py import_cldr build install \
 			--root=/ --prefix=$prefix
 
@@ -80,9 +81,8 @@ INSTALL()
 				ln -sr $prefix/bin/pybabel-$pythonVersion $prefix/bin/pybabel
 		fi
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python* \
 			$prefix/bin
-
 	done
 }

--- a/dev-python/breathe/breathe-4.35.0.recipe
+++ b/dev-python/breathe/breathe-4.35.0.recipe
@@ -4,7 +4,7 @@ Doxygen xml output."
 HOMEPAGE="https://github.com/michaeljones/breathe"
 COPYRIGHT="2009, Michael Jones"
 LICENSE="BSD (2-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/b/breathe/breathe-$portVersion.tar.gz"
 CHECKSUM_SHA256="5165541c3c67b6c7adde8b3ecfe895c6f7844783c4076b6d8d287e4f33d62386"
 
@@ -21,12 +21,11 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-defaultVersion=3.9
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
-	pythonVersion=${PYTHON_VERSIONS[$i]}
+PYTHON_VERSIONS=(3.10)
+defaultVersion=3.10
+
+for pythonVersion in ${PYTHON_VERSIONS[@]}; do
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_$pythonPackage=\"
 		${portName}_$pythonPackage = $portVersion
@@ -53,9 +52,8 @@ done
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
-		pythonVersion=${PYTHON_VERSIONS[$i]}
+	for pythonVersion in ${PYTHON_VERSIONS[@]}; do
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/

--- a/dev-python/fonttools/fonttools-4.40.0.recipe
+++ b/dev-python/fonttools/fonttools-4.40.0.recipe
@@ -13,7 +13,7 @@ COPYRIGHT="2017 Just van Rossum
 LICENSE="MIT
 	SIL Open Font License v1.1
 	Apache v2"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/fonttools/fonttools/archive/$portVersion.tar.gz"
 SOURCE_FILENAME="fonttools-$portVersion.tar.gz"
 CHECKSUM_SHA256="f03f5a5414587fed31d11e007e680ea522a918ea27a793a5931641ef5915bcd2"
@@ -31,12 +31,11 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-defaultVersion=3.9
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
-	pythonVersion=${PYTHON_VERSIONS[$i]}
+PYTHON_VERSIONS=(3.10)
+defaultVersion=3.10
+
+for pythonVersion in ${PYTHON_VERSIONS[@]}; do
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_${pythonPackage}=\"
 		${portName}_$pythonPackage = $portVersion
@@ -73,9 +72,8 @@ done
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
-		pythonVersion=${PYTHON_VERSIONS[$i]}
+	for pythonVersion in ${PYTHON_VERSIONS[@]}; do
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 		rm -rf build
@@ -99,7 +97,7 @@ INSTALL()
 		mv $prefix/share/man/* $manDir
 		rm -rf $prefix/share
 
-		packageEntries  $pythonPackage \
+		packageEntries $pythonPackage \
 			$prefix/lib/python* \
 			$binDir \
 			$manDir

--- a/dev-python/hatchling/hatchling-1.25.0.recipe
+++ b/dev-python/hatchling/hatchling-1.25.0.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="This is the extensible, standards compliant build backend used by H
 HOMEPAGE="https://hatch.pypa.io/dev/history/hatchling/"
 COPYRIGHT="2021-present Ofek Lev"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/h/$portName/$portName-$portVersion.tar.gz"
 CHECKSUM_SHA256="7064631a512610b52250a4d3ff1bd81551d6d1431c4eb7b72e734df6c74f4262"
 
@@ -20,12 +20,11 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-defaultVersion=3.9
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
-	pythonVersion=${PYTHON_VERSIONS[$i]}
+PYTHON_VERSIONS=(3.10)
+defaultVersion=3.10
+
+for pythonVersion in ${PYTHON_VERSIONS[@]}; do
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_$pythonPackage=\"
 		${portName}_$pythonPackage = $portVersion
@@ -62,8 +61,8 @@ done
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonVersion=${PYTHON_VERSIONS[$i]}
+	for pythonVersion in ${PYTHON_VERSIONS[@]}; do
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 		$python -m build --wheel --skip-dependency-check --no-isolation
@@ -75,7 +74,7 @@ INSTALL()
 			ln -sr $prefix/bin/hatchling-$pythonVersion $prefix/bin/hatchling
 		fi
 
-		packageEntries ${PYTHON_PACKAGES[i]} \
+		packageEntries $pythonPackage \
 			$prefix/lib/python* \
 			$prefix/bin
 	done

--- a/dev-python/nose/nose-1.3.7.recipe
+++ b/dev-python/nose/nose-1.3.7.recipe
@@ -16,7 +16,7 @@ HOMEPAGE="https://readthedocs.io/docs/nose/
 	https://github.com/nose-devs/nose"
 COPYRIGHT="2008-2010 anatoly techtonik"
 LICENSE="GNU LGPL v2.1"
-REVISION="6"
+REVISION="7"
 SOURCE_URI="https://pypi.io/packages/source/n/nose/nose-$portVersion.tar.gz"
 CHECKSUM_SHA256="f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98"
 PATCHES="
@@ -48,12 +48,11 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_PACKAGES=(python39 python310)
-PYTHON_VERSIONS=(3.9 3.10)
-defaultVersion=3.9
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
-	pythonVersion=${PYTHON_VERSIONS[i]}
+PYTHON_VERSIONS=(3.10)
+defaultVersion=3.10
+
+for pythonVersion in ${PYTHON_VERSIONS[@]}; do
+	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_$pythonPackage=\"
 		nose_$pythonPackage = $portVersion
@@ -84,9 +83,8 @@ PATCH()
 
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
-		pythonVersion=${PYTHON_VERSIONS[$i]}
+	for pythonVersion in ${PYTHON_VERSIONS[@]}; do
+		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
 		installLocation=$prefix/lib/$python/vendor-packages/


### PR DESCRIPTION
While switching to 3.10 as default, lets just drop the 3.9 versions of these packages.