### PR TITLE
mame: Bump to 0.279; use lld for linking; small upstream patch

### DIFF
--- a/games-emulation/mame/mame-0.279.recipe
+++ b/games-emulation/mame/mame-0.279.recipe
@@ -15,7 +15,7 @@ COPYRIGHT="1997-2024 MAMEDev and contributors"
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://github.com/mamedev/mame/archive/mame${portVersion/./}.tar.gz"
-CHECKSUM_SHA256="ca5f44a0ed834875f8420a75587706af210ff8c5922942509bc5bfef7d45c360"
+CHECKSUM_SHA256="07e2e0d8ec187b12eadba3d7917ce3227bf0c5fccec8e934d70ada4fc502130c"
 SOURCE_FILENAME="mame-$portVersion.tar.gz"
 SOURCE_DIR="mame-mame${portVersion/./}"
 PATCHES="mame-$portVersion.patchset"
@@ -97,6 +97,7 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
+	cmd:lld >= 20
 	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
@@ -125,7 +126,7 @@ defineDebugInfoPackage mame$secondaryArchSuffix \
 BUILD()
 {
 	# This is wrong on so many levels
-	SYS_LDFLAGS="-lbsd -lnetwork " # trailing space required!
+	SYS_LDFLAGS="-lbsd -lnetwork -fuse-ld=lld " # trailing space required!
 	for _i in flac libutf8proc RapidJSON sqlite3; do
 		SYS_CFLAGS+="`pkg-config $_i --cflags` "
 		SYS_LDFLAGS+="`pkg-config $_i --libs` "

--- a/games-emulation/mame/patches/mame-0.279.patchset
+++ b/games-emulation/mame/patches/mame-0.279.patchset
@@ -1,4 +1,4 @@
-From b2595df8b9656625eaab54002e6f632c94ffdcaa Mon Sep 17 00:00:00 2001
+From d80c05bdab8998d5cdf09a9f2a68e7ade688b4c6 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Wed, 10 Jun 2020 22:35:16 +1000
 Subject: Haiku patches
@@ -676,7 +676,7 @@ index f0782db..5a3a636 100644
  #define PLATFORM_WINDOWS  (1)
  #define PLATFORM_STRING   "windows"
 diff --git a/makefile b/makefile
-index 44bc6ab..e1f0206 100644
+index 35c68b9..8d7b006 100644
 --- a/makefile
 +++ b/makefile
 @@ -231,6 +231,7 @@ OS := macosx
@@ -784,7 +784,7 @@ index f5dc2e9..3098b25 100644
  #elif defined(_WIN32) || defined(SDLMAME_NO64BITIO)
  		if (lseek(m_fd, off_t(std::make_unsigned_t<off_t>(offset)), SEEK_SET) < 0)
 diff --git a/src/osd/modules/file/posixptty.cpp b/src/osd/modules/file/posixptty.cpp
-index 31604a1..73adde1 100644
+index fa12045..5f8418d 100644
 --- a/src/osd/modules/file/posixptty.cpp
 +++ b/src/osd/modules/file/posixptty.cpp
 @@ -19,6 +19,10 @@
@@ -802,7 +802,7 @@ index 31604a1..73adde1 100644
 2.48.1
 
 
-From dda7606a829c72341df7bd83247e98861d029c06 Mon Sep 17 00:00:00 2001
+From 4b63299fc415d1d280b37831d29d22230cab1492 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Thu, 11 Jun 2020 08:59:34 +1000
 Subject: Use stat Haiku
@@ -843,14 +843,14 @@ index dab8620..ceb2263 100644
 2.48.1
 
 
-From 726a041c1b4de4b916517eb00c80bbd9938156f6 Mon Sep 17 00:00:00 2001
+From 23ec00f5497f6831e6ee062101dda189b4a956d1 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Thu, 11 Jun 2020 09:00:11 +1000
 Subject: Disable ptty
 
 
 diff --git a/src/osd/modules/file/posixptty.cpp b/src/osd/modules/file/posixptty.cpp
-index 73adde1..91a399c 100644
+index 5f8418d..8838b2a 100644
 --- a/src/osd/modules/file/posixptty.cpp
 +++ b/src/osd/modules/file/posixptty.cpp
 @@ -114,7 +114,7 @@ bool posix_check_ptty_path(std::string const &path) noexcept
@@ -866,7 +866,7 @@ index 73adde1..91a399c 100644
 2.48.1
 
 
-From 03f478e6c591b8c46a662ee649f4f2ab7a2e2868 Mon Sep 17 00:00:00 2001
+From 1cc910ad79bc1cd0ea15b561d1cf03c12c30ffc8 Mon Sep 17 00:00:00 2001
 From: PulkoMandy <pulkomandy@pulkomandy.tk>
 Date: Fri, 5 Aug 2022 19:24:12 +0200
 Subject: Allow use of Qt Debugger on Haiku
@@ -905,7 +905,7 @@ index 86a7272..d79abe7 100644
 2.48.1
 
 
-From 08c1b6726c3c67116cb7324ac506aeed846fc574 Mon Sep 17 00:00:00 2001
+From f2e7748dbcd3e88cbf1dffa69f4a3e71782775d1 Mon Sep 17 00:00:00 2001
 From: Alex Brown <mail@alexbrown.info>
 Date: Sat, 14 Oct 2023 11:26:57 +0100
 Subject: toolchain.lua: set targetdir for Haiku
@@ -960,17 +960,17 @@ index c730cd7..5069f04 100644
 2.48.1
 
 
-From 82d5654831145ed941647717dc24c0c08ff3d78e Mon Sep 17 00:00:00 2001
+From cf23a77ac423df7d4ce9e1ae2c81530b870f43b4 Mon Sep 17 00:00:00 2001
 From: Alex Brown <mail@alexbrown.info>
 Date: Sat, 14 Oct 2023 09:14:19 +0100
 Subject: Set LinkSupportCircularDependencies for Haiku
 
 
 diff --git a/scripts/genie.lua b/scripts/genie.lua
-index 40368c1..fe959d6 100644
+index 4b3025b..4a156a2 100644
 --- a/scripts/genie.lua
 +++ b/scripts/genie.lua
-@@ -1174,6 +1174,11 @@ configuration { "freebsd or netbsd" }
+@@ -1186,6 +1186,11 @@ configuration { "freebsd or netbsd" }
  			"LinkSupportCircularDependencies",
  		}
  
@@ -986,7 +986,7 @@ index 40368c1..fe959d6 100644
 2.48.1
 
 
-From e0324d938e63ce5ac7d3a4bd185cae5a7086a51d Mon Sep 17 00:00:00 2001
+From 64293916bb50aff8b7d84b7a86b538f14185bc75 Mon Sep 17 00:00:00 2001
 From: PulkoMandy <pulkomandy@pulkomandy.tk>
 Date: Thu, 1 May 2025 09:47:57 +0200
 Subject: Fix search for Qt6
@@ -1041,6 +1041,81 @@ index f3a970c..544d447 100644
  		}
  	else
  		buildoptions {
+-- 
+2.48.1
+
+
+From 5f53bfea9f8f6c5cd9435a6a90085fa22951f023 Mon Sep 17 00:00:00 2001
+From: Alex Brown <github@alexbrown.info>
+Date: Fri, 1 Aug 2025 17:15:54 +0100
+Subject: Correct include order for serialvfd and macseconds (from upstream by
+ happppp)
+
+
+diff --git a/src/devices/machine/macseconds.cpp b/src/devices/machine/macseconds.cpp
+index 7ed18bc..5332590 100644
+--- a/src/devices/machine/macseconds.cpp
++++ b/src/devices/machine/macseconds.cpp
+@@ -8,11 +8,11 @@
+     (seconds since 1/1/1904 at midnight).
+ */
+ 
+-#include "dirtc.h"
+-
+ #include "emu.h"
+ #include "macseconds.h"
+ 
++#include "dirtc.h"
++
+ macseconds_interface::macseconds_interface()
+ {
+ 	// Get the current time to get the DST flag and compute the offset from GMT
+@@ -35,8 +35,7 @@ u32 macseconds_interface::get_local_seconds(system_time &systime)
+ {
+ 	const system_time::full_time &time = systime.local_time;
+ 
+-	return get_seconds(time.year - 2000, time.month + 1, time.mday, time.weekday + 1, time.hour,
+-							  time.minute, time.second);
++	return get_seconds(time.year - 2000, time.month + 1, time.mday, time.weekday + 1, time.hour, time.minute, time.second);
+ }
+ 
+ u32 macseconds_interface::get_seconds(int year, int month, int day, int day_of_week, int hour, int minute, int second)
+diff --git a/src/devices/video/serialvfd.cpp b/src/devices/video/serialvfd.cpp
+index a6ac758..5aa7508 100644
+--- a/src/devices/video/serialvfd.cpp
++++ b/src/devices/video/serialvfd.cpp
+@@ -1,8 +1,8 @@
+ // license:BSD-3-Clause
+ // copyright-holders: NaokiS
+ 
+-#include "serialvfd.h"
+ #include "emu.h"
++#include "serialvfd.h"
+ 
+ #define LOG_VFD     (1U << 1)
+ //#define VERBOSE     ( LOG_VFD )
+diff --git a/src/devices/video/serialvfd.h b/src/devices/video/serialvfd.h
+index 5c012f0..53db16c 100644
+--- a/src/devices/video/serialvfd.h
++++ b/src/devices/video/serialvfd.h
+@@ -14,8 +14,7 @@
+ 
+ #pragma once
+ 
+-class serial_vfd_device :
+-	public device_t
++class serial_vfd_device : public device_t
+ {
+ public:
+ 	serial_vfd_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
+@@ -51,7 +50,6 @@ private:
+ 	uint16_t m_buff[16];
+ 
+ 	void run_command();
+-
+ };
+ 
+ DECLARE_DEVICE_TYPE(SERIAL_VFD, serial_vfd_device)
 -- 
 2.48.1
 


### PR DESCRIPTION
This build now uses `lld` from `llvm20_lld`. It's significantly quicker than GCC's `ld`, so shouldn't tie up buildmaster for as long!

This also includes two patches from upstream (https://github.com/mamedev/mame/commit/95f7d841988286de21c03f48bfcce45b1aed7bc6 and https://github.com/mamedev/mame/commit/468dfe69a4ba94411359252fca284b69601d56d7), fixing two separate bugs that stopped MAME from compiling.