### PR TITLE
globulation2: clean up BUILD_PREREQUIRES.

### DIFF
--- a/games-strategy/globulation2/globulation2-0.9.4.4.recipe
+++ b/games-strategy/globulation2/globulation2-0.9.4.4.recipe
@@ -4,7 +4,7 @@ micromanagement by automatically assigning tasks to units."
 HOMEPAGE="https://globulation2.org/"
 COPYRIGHT="Globulation2 team"
 LICENSE="GNU GPL v3"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="http://mirror.netcologne.de/savannah/glob2/0.9.4/glob2-$portVersion.tar.gz"
 SOURCE_FILENAME="glob2-$portVersion.tar.gz"
 SOURCE_DIR="glob2-$portVersion"
@@ -56,7 +56,6 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:g++$secondaryArchSuffix
 	cmd:scons
-	python3$secondaryArchSuffix
 	"
 
 BUILD() {


### PR DESCRIPTION
Build depends only on scons, that in turns depends on a particular version of python3, but lets just not add transitive dependencies.

(we don't have a "python3" package anymore anyway).

Doing a rev-bump to let builders check the build for me.