### PR TITLE
nextcloud_client: bump to version 3.13.3, fix docDir on x86

### DIFF
--- a/net-misc/nextcloud-client/nextcloud_client-3.13.3.recipe
+++ b/net-misc/nextcloud-client/nextcloud_client-3.13.3.recipe
@@ -3,9 +3,9 @@ DESCRIPTION="This Nextcloud client is a tool to synchronize files with a Nextclo
 HOMEPAGE="https://nextcloud.com"
 COPYRIGHT="Nextcloud GmbH"
 LICENSE="GNU GPL v2"
-REVISION="6"
+REVISION="1"
 SOURCE_URI="https://github.com/nextcloud/desktop/archive/refs/tags/v$portVersion.tar.gz"
-CHECKSUM_SHA256="9f60a6707d31e82357780dff11168ede88d1f859481a22f2d04c827e656f3fba"
+CHECKSUM_SHA256="4f1b0ffae207a8ab29d10f9cb6d51e107263cf45d138234bd8be1554eb12661f"
 SOURCE_DIR="desktop-$portVersion"
 PATCHES="nextcloud_client-$portVersion.patchset"
 ADDITIONAL_FILES="nextcloud_client.rdef.in"
@@ -141,6 +141,7 @@ BUILD()
 	cmake -B build -S . $cmakeDirArgs \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DCMAKE_INSTALL_BINDIR=$commandBinDir \
+		-DCMAKE_INSTALL_DOCDIR=$documentationDir/packages/nextcloud_client \
 		-DINCLUDE_INSTALL_DIR=$includeDir \
 		-DSYSCONF_INSTALL_DIR=$settingsDir \
 		-DBUILD_TESTING=OFF \

--- a/net-misc/nextcloud-client/patches/nextcloud_client-3.13.3.patchset
+++ b/net-misc/nextcloud-client/patches/nextcloud_client-3.13.3.patchset
@@ -1,14 +1,18 @@
-From e4a85ae5822d5bbde0671edecd8d3ec1646994b8 Mon Sep 17 00:00:00 2001
+From 820ab1c2ecff99f6468fee8d8d7475dea562b168 Mon Sep 17 00:00:00 2001
 From: Daniel Weber <weberd@outlook.de>
 Date: Sat, 3 Feb 2024 23:59:04 +0100
-Subject: Adapt Patch to 3.11.1
+Subject: Adapt Patch to 3.13.3
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 
+Co-authored-by: Joachim Mairböck <j.mairboeck@gmail.com>
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 9d65f50..c70470c 100644
+index 6877335..5aed29d 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -206,7 +206,7 @@ if(BUILD_CLIENT)
+@@ -214,7 +214,7 @@ if(BUILD_CLIENT)
          find_package(Sparkle)
      endif()
  
@@ -18,10 +22,10 @@ index 9d65f50..c70470c 100644
      endif()
      find_package(Sphinx)
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index bf3ff9a..27f170b 100644
+index cf1e130..bc49b27 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -68,7 +68,7 @@ if(NOT TOKEN_AUTH_ONLY)
+@@ -70,7 +70,7 @@ if(NOT TOKEN_AUTH_ONLY)
  endif()
  
  # TODO: Mingw64 7.3 might also need to be excluded here as it seems to not automatically link libssp
@@ -48,7 +52,7 @@ index 1265427..586ff66 100644
          ${CMAKE_CURRENT_LIST_DIR}/utility_unix.cpp
      )
 diff --git a/src/common/utility.cpp b/src/common/utility.cpp
-index e4eff93..6e1656a 100644
+index b95d40d..b9b9a5c 100644
 --- a/src/common/utility.cpp
 +++ b/src/common/utility.cpp
 @@ -45,6 +45,12 @@
@@ -83,10 +87,10 @@ index e4eff93..6e1656a 100644
      if (statvfs(path.toLocal8Bit().data(), &stat) == 0) {
          return (qint64)stat.f_bavail * stat.f_frsize;
 diff --git a/src/common/utility.h b/src/common/utility.h
-index bd62a5d..889d850 100644
+index d8c8a19..2eaccf9 100644
 --- a/src/common/utility.h
 +++ b/src/common/utility.h
-@@ -134,6 +134,7 @@ namespace Utility {
+@@ -146,6 +146,7 @@ namespace Utility {
      inline bool isUnix();
      inline bool isLinux(); // use with care
      inline bool isBSD(); // use with care, does not match OS X
@@ -94,7 +98,7 @@ index bd62a5d..889d850 100644
  
      OCSYNC_EXPORT QString platformName();
      // crash helper for --debug
-@@ -341,5 +342,14 @@ inline bool Utility::isBSD()
+@@ -356,5 +357,14 @@ inline bool Utility::isBSD()
  #endif
  }
  
@@ -111,10 +115,10 @@ index bd62a5d..889d850 100644
  #endif // UTILITY_H
 diff --git a/src/common/utility_haiku.cpp b/src/common/utility_haiku.cpp
 new file mode 100644
-index 0000000..7017f15
+index 0000000..997443d
 --- /dev/null
 +++ b/src/common/utility_haiku.cpp
-@@ -0,0 +1,125 @@
+@@ -0,0 +1,131 @@
 +/*
 + * Copyright (C) by Klaas Freitag <freitag@owncloud.com>
 + * Copyright (C) by Daniel Molkentin <danimo@owncloud.com>
@@ -150,6 +154,12 @@ index 0000000..7017f15
 +#include <Path.h>
 +
 +namespace OCC {
++
++QVector<Utility::ProcessInfosForOpenFile> Utility::queryProcessInfosKeepingFileOpen(const QString &filePath)
++{
++    Q_UNUSED(filePath)
++    return {};
++}
 +
 +void Utility::setupFavLink(const QString &folder)
 +{
@@ -267,10 +277,10 @@ index 8307859..b21d12c 100644
  
  /* tchar definitions for clean win32 filenames */
 diff --git a/src/gui/CMakeLists.txt b/src/gui/CMakeLists.txt
-index 1968683..8c5af95 100644
+index 6e4acf2..ccf958a 100644
 --- a/src/gui/CMakeLists.txt
 +++ b/src/gui/CMakeLists.txt
-@@ -311,7 +311,7 @@ IF( APPLE )
+@@ -339,7 +339,7 @@ IF( APPLE )
     endif()
  ENDIF()
  
@@ -279,7 +289,7 @@ index 1968683..8c5af95 100644
  set(client_SRCS ${client_SRCS} folderwatcher_linux.cpp)
  ENDIF()
  IF( WIN32 )
-@@ -320,6 +320,9 @@ ENDIF()
+@@ -348,6 +348,9 @@ ENDIF()
  IF( APPLE )
  list(APPEND client_SRCS folderwatcher_mac.cpp)
  ENDIF()
@@ -289,16 +299,16 @@ index 1968683..8c5af95 100644
  
  set(3rdparty_SRC
      ../3rdparty/QProgressIndicator/QProgressIndicator.h
-@@ -537,6 +540,7 @@ target_link_libraries(nextcloudCore
-   Qt5::Quick
+@@ -566,6 +569,7 @@ target_link_libraries(nextcloudCore
    Qt5::QuickControls2
+   Qt5::QuickWidgets
    KF5::Archive
 +  be
    )
  
- add_subdirectory(socketapi)
+ if(KF5GuiAddons_FOUND)
 diff --git a/src/gui/folderwatcher.cpp b/src/gui/folderwatcher.cpp
-index 0743646..0ed8ae5 100644
+index 93c2334..e4a6a5d 100644
 --- a/src/gui/folderwatcher.cpp
 +++ b/src/gui/folderwatcher.cpp
 @@ -23,6 +23,8 @@
@@ -310,7 +320,7 @@ index 0743646..0ed8ae5 100644
  #elif defined(Q_OS_UNIX)
  #include "folderwatcher_linux.h"
  #endif
-@@ -128,6 +130,10 @@ void FolderWatcher::startNotificatonTest(const QString &path)
+@@ -101,6 +103,10 @@ void FolderWatcher::startNotificatonTest(const QString &path)
      return;
  #endif
  
@@ -547,10 +557,10 @@ index 0000000..56535ed
 +};
 +}
 diff --git a/src/gui/socketapi/socketapi.cpp b/src/gui/socketapi/socketapi.cpp
-index 1df11cf..0eb993d 100644
+index 38e516c..b746de5 100644
 --- a/src/gui/socketapi/socketapi.cpp
 +++ b/src/gui/socketapi/socketapi.cpp
-@@ -265,7 +265,7 @@ SocketApi::SocketApi(QObject *parent)
+@@ -281,7 +281,7 @@ SocketApi::SocketApi(QObject *parent)
          _system(QStringLiteral("pluginkit"), { QStringLiteral("-e"), QStringLiteral("use"), QStringLiteral("-i"), QStringLiteral(APPLICATION_REV_DOMAIN ".FinderSyncExt") });
  
  #endif
@@ -560,7 +570,7 @@ index 1df11cf..0eb993d 100644
          runtimeDir = QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation);
          socketPath = runtimeDir + "/" + Theme::instance()->appName() + "/socket";
 diff --git a/src/gui/tray/Window.qml b/src/gui/tray/Window.qml
-index 75380d5..3d8fdc7 100644
+index 7d94526..eca69fe 100644
 --- a/src/gui/tray/Window.qml
 +++ b/src/gui/tray/Window.qml
 @@ -80,7 +80,7 @@ ApplicationWindow {
@@ -591,18 +601,18 @@ index 75380d5..3d8fdc7 100644
          id: userStatusDrawer
          width: parent.width
 diff --git a/src/libsync/filesystem.cpp b/src/libsync/filesystem.cpp
-index 7c58c7b..a52a9af 100644
+index 0eb66c4..f77739a 100644
 --- a/src/libsync/filesystem.cpp
 +++ b/src/libsync/filesystem.cpp
-@@ -20,6 +20,7 @@
+@@ -24,6 +24,7 @@
  #include <QDir>
  #include <QDirIterator>
  #include <QCoreApplication>
 +#include <sys/time.h>
  
- #include "csync.h"
- #include "vio/csync_vio_local.h"
-@@ -74,7 +75,7 @@ bool FileSystem::setModTime(const QString &filename, time_t modTime)
+ #include <array>
+ #include <string_view>
+@@ -199,7 +200,7 @@ bool FileSystem::setModTime(const QString &filename, time_t modTime)
      struct timeval times[2];
      times[0].tv_sec = times[1].tv_sec = modTime;
      times[0].tv_usec = times[1].tv_usec = 0;
@@ -612,10 +622,10 @@ index 7c58c7b..a52a9af 100644
          qCWarning(lcFileSystem) << "Error setting mtime for" << filename
                                  << "failed: rc" << rc << ", errno:" << errno;
 diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
-index 44396f2..1293fb7 100644
+index 3ba407e..a49cd55 100644
 --- a/test/CMakeLists.txt
 +++ b/test/CMakeLists.txt
-@@ -93,7 +93,7 @@ else()
+@@ -94,7 +94,7 @@ else()
      nextcloud_build_test(E2eFileTransfer)
  endif()
  
@@ -625,10 +635,10 @@ index 44396f2..1293fb7 100644
  endif(UNIX AND NOT APPLE)
  
 diff --git a/test/testfolderwatcher.cpp b/test/testfolderwatcher.cpp
-index d57358d..7770d2f 100644
+index 2e61470..4689e0f 100644
 --- a/test/testfolderwatcher.cpp
 +++ b/test/testfolderwatcher.cpp
-@@ -264,7 +264,7 @@ private slots:
+@@ -379,7 +379,7 @@ private slots:
      }
  };
  
@@ -638,20 +648,20 @@ index d57358d..7770d2f 100644
  #else
      QTEST_GUILESS_MAIN(TestFolderWatcher)
 -- 
-2.45.2
+2.50.1
 
 
-From 9a4e91bed5ea9973de0c80fd104480b8839d56d0 Mon Sep 17 00:00:00 2001
+From 5b59205a55df9f64b9c8e2b052d94b2607b19a20 Mon Sep 17 00:00:00 2001
 From: Daniel Weber <daniel.weber@vivaldi.net>
 Date: Sun, 4 Feb 2024 00:09:35 +0100
 Subject: Haiku not Apple
 
 
 diff --git a/src/gui/CMakeLists.txt b/src/gui/CMakeLists.txt
-index 8c5af95..e24b838 100644
+index ccf958a..4d9c050 100644
 --- a/src/gui/CMakeLists.txt
 +++ b/src/gui/CMakeLists.txt
-@@ -320,7 +320,7 @@ ENDIF()
+@@ -348,7 +348,7 @@ ENDIF()
  IF( APPLE )
  list(APPEND client_SRCS folderwatcher_mac.cpp)
  ENDIF()
@@ -661,10 +671,10 @@ index 8c5af95..e24b838 100644
  ENDIF()
  
 -- 
-2.45.2
+2.50.1
 
 
-From 99f0f0e4da567f235d6616ce159fba1d77ee538d Mon Sep 17 00:00:00 2001
+From 21b04282cea823514db02ed1f717161ddc0fa529 Mon Sep 17 00:00:00 2001
 From: Schrijvers Luc <begasus@gmail.com>
 Date: Tue, 27 Aug 2024 09:30:26 +0200
 Subject: Fix documantation path
@@ -694,5 +704,5 @@ index 4e9b638..0a09650 100644
 \ No newline at end of file
 +endif(SPHINX_FOUND)
 -- 
-2.45.2
+2.50.1
 


### PR DESCRIPTION
This is the last version using Qt 5. (with 3.14 they switched to Qt 6)

Can someone maybe test this? I don't have a NextCloud server to test with.