### PR TITLE
tesseracttranslator: mark broken on x86_gcc2.

### DIFF
--- a/haiku-apps/tesseracttranslator/tesseracttranslator-1.0.2.recipe
+++ b/haiku-apps/tesseracttranslator/tesseracttranslator-1.0.2.recipe
@@ -3,12 +3,13 @@ DESCRIPTION="An image to text translator add-on using Tesseract OCR engine."
 HOMEPAGE="https://github.com/threedeyes/TesseractTranslator/"
 COPYRIGHT="2013-2020 3dEyes"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/threedeyes/TesseractTranslator/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="0dde3a6937f51a5846a1a69f9204ea39b5353e3248fba3f15fb3fd191be8d7f9"
 SOURCE_DIR="TesseractTranslator-$portVersion"
 
-ARCHITECTURES="all"
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	tesseracttranslator$secondaryArchSuffix = $portVersion


### PR DESCRIPTION
There's no x86_gcc2 version of the required lib:libtesseract.

----

Side note... both `addon:` and `add_on:` seem to be used on-tree as PROVIDES suffix (the former being by far the more popular, and the latter having syntax high-lighting in Pe). We should probably choose one, and stick with it, right?