### PR TITLE
dcraw: build as x86 on 32 bits.

### DIFF
--- a/media-gfx/dcraw/dcraw-9.28.0.recipe
+++ b/media-gfx/dcraw/dcraw-9.28.0.recipe
@@ -1,36 +1,35 @@
 SUMMARY="A command-line decoder for raw digital photos"
-DESCRIPTION="
-dcraw decodes raw photos, displays metadata, and extracts thumbnails."
-HOMEPAGE="http://www.cybercom.net/~dcoffin/dcraw/"
+DESCRIPTION="dcraw decodes raw photos, displays metadata, and extracts thumbnails."
+HOMEPAGE="http://dechifro.org/dcraw/"
 COPYRIGHT="1997-2015 Dave Coffin"
 LICENSE="GNU GPL v2"
-REVISION="2"
-SOURCE_URI="http://www.cybercom.net/~dcoffin/dcraw/archive/dcraw-$portVersion.tar.gz"
+REVISION="3"
+SOURCE_URI="http://dechifro.org/dcraw/archive/dcraw-$portVersion.tar.gz"
 CHECKSUM_SHA256="2890c3da2642cd44c5f3bfed2c9b2c1db83da5cec09cc17e0fa72e17541fb4b9"
 SOURCE_DIR="dcraw"
 
-ARCHITECTURES="all"
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	dcraw = $portVersion compat >= 9
+	dcraw$secondaryArchSuffix = $portVersion compat >= 9
 	cmd:dcraw = $portVersion compat >= 9
 	"
 REQUIRES="
-	haiku
-	lib:libjasper
-	lib:libjpeg
-	lib:liblcms2
+	haiku$secondaryArchSuffix
+	lib:libjasper$secondaryArchSuffix
+	lib:libjpeg$secondaryArchSuffix
+	lib:liblcms2$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
-	haiku_devel
-	devel:libjasper
-	devel:libjpeg
-	devel:liblcms2
+	haiku${secondaryArchSuffix}_devel
+	devel:libjasper$secondaryArchSuffix
+	devel:libjpeg$secondaryArchSuffix
+	devel:liblcms2$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	coreutils
-	cmd:gcc
+	cmd:gcc$secondaryArchSuffix
 	"
 
 BUILD()
@@ -40,7 +39,7 @@ BUILD()
 
 INSTALL()
 {
-	mkdir -p $binDir $manDir/man1
-	cp dcraw $binDir
+	mkdir -p $prefix/bin $manDir/man1
+	cp dcraw $prefix/bin
 	cp dcraw.1 $manDir/man1
 }


### PR DESCRIPTION
There's no x86_gcc2 version of the required `lib:libcms`.

----

Opening as draft, because I haven't tested it yet (removed coreutils because it should be better to explicitly require whatever `cmd:` this actually expects, if any).