### PR TITLE
Solve bug with segmentation violation due to recursive call to gmtime_r

### DIFF
--- a/dev-vcs/guitar/guitar-1.2.999~git.recipe
+++ b/dev-vcs/guitar/guitar-1.2.999~git.recipe
@@ -8,17 +8,20 @@ Features:
 HOMEPAGE="https://soramimi.github.io/Guitar/"
 COPYRIGHT="2023 S.Fuchita"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 srcGitRev="c7bb0f62d91c9803fd3e2f5b3017d84e6750e833"
 SOURCE_URI="https://github.com/soramimi/Guitar/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="603fceb37d82ef5ef53945694a1a339b777225f1c2ca6463ee73e32d3e19d1bb"
 SOURCE_FILENAME="Guitar-$portVersion-$srcGitRev.tar.gz"
 SOURCE_DIR="Guitar-$srcGitRev"
 ADDITIONAL_FILES="guitar.rdef.in"
-PATCHES="guitar-$portVersion.patchset"
+PATCHES="
+        guitar-$portVersion.patchset
+        haiku-dont-override-time_r.patch
+        "
 
-ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="x86 x86_64 !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86 x86_64"
 
 PROVIDES="
 	guitar$secondaryArchSuffix = $portVersion
@@ -27,7 +30,7 @@ PROVIDES="
 REQUIRES="
 	haiku$secondaryArchSuffix
 	cmd:git
-	lib:libcrypto$secondaryArchSuffix
+	openssl3
 	lib:libGL$secondaryArchSuffix
 	lib:libQt5Core$secondaryArchSuffix
 	lib:libQt5Gui$secondaryArchSuffix
@@ -40,7 +43,7 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libcrypto$secondaryArchSuffix >= 3
+	openssl3_devel
 	devel:libGL$secondaryArchSuffix
 	devel:libQt5Core$secondaryArchSuffix
 	devel:libQt5Gui$secondaryArchSuffix

--- a/dev-vcs/guitar/patches/haiku-dont-override-time_r.patch
+++ b/dev-vcs/guitar/patches/haiku-dont-override-time_r.patch
@@ -1,0 +1,41 @@
+diff --git a/filetype.pro b/filetype.pro
+index 47691c4..e4aa9ee 100644
+--- a/filetype.pro
++++ b/filetype.pro
+@@ -34,9 +34,7 @@ SOURCES += \
+ 	filetype/file/src/fsmagic.c \
+ 	filetype/file/src/funcs.c \
+ 	filetype/file/src/getline.c \
+-	filetype/file/src/gmtime_r.c \
+ 	filetype/file/src/is_tar.c \
+-	filetype/file/src/localtime_r.c \
+ 	filetype/file/src/magic.c \
+ 	filetype/file/src/pread.c \
+ 	filetype/file/src/print.c \
+diff --git a/filetype/file/src/gmtime_r.c b/filetype/file/src/gmtime_r.c
+index 7e27ed6..bc05d6c 100644
+--- a/filetype/file/src/gmtime_r.c
++++ b/filetype/file/src/gmtime_r.c
+@@ -15,5 +15,5 @@ gmtime_r(const time_t *t, struct tm *tm)
+ 	if (tmp == NULL)
+ 		return NULL;
+ 	memcpy(tm, tmp, sizeof(*tm));
+-	return tmp;
++	return tm;
+ }
+diff --git a/filetype/filetype.pri b/filetype/filetype.pri
+index 279a5de..932ef59 100644
+--- a/filetype/filetype.pri
++++ b/filetype/filetype.pri
+@@ -26,11 +26,9 @@ SOURCES += \
+ 	filetype/file/src/fsmagic.c \
+ 	filetype/file/src/funcs.c \
+ 	filetype/file/src/getline.c \
+-	filetype/file/src/gmtime_r.c \
+ 	filetype/file/src/is_csv.c \
+ 	filetype/file/src/is_json.c \
+ 	filetype/file/src/is_tar.c \
+-	filetype/file/src/localtime_r.c \
+ 	filetype/file/src/magic.c \
+ 	filetype/file/src/pread.c \
+ 	filetype/file/src/print.c \


### PR DESCRIPTION
Guitar was crashing upon startup with the attached log.

The problem was that Guitar redefined the `gmtime_r()` function, which was calling to `gmtime()`, which, in turn, was a wrapper for system-defined `gmtime_r()`. However, instead of the system `gmtime_r()`, a local version was called again. That ultimately led to the segmentation violation (well, I guess, that should stack overflow).

The solution was to avoid using locally defined `gmtime_r()` and `localtime_r()` functions. After excluding these files from the build, the crash was solved.

Additionally, I've fixed a minor bug in the implementation of `gmtime_r()`, which does not matter, because this file is now excluded from build anyway.

My patch is in a separate file; the changes in the recipe - except for the addition of the patch - were required to compile the project locally, and, probably, should **NOT** be included in haikuports, but without them the code didn't compile at my machine.

[Guitar-2976-debug-20-08-2025-09-16-48.report.txt](https://github.com/user-attachments/files/21892201/Guitar-2976-debug-20-08-2025-09-16-48.report.txt)
