### PR TITLE
bsnow: fix build for non-gcc2 systems.

### DIFF
--- a/haiku-apps/bsnow/bsnow-1.0.0.recipe
+++ b/haiku-apps/bsnow/bsnow-1.0.0.recipe
@@ -4,7 +4,7 @@ background."
 HOMEPAGE="https://github.com/HaikuArchives/BSnow"
 COPYRIGHT="2016 François Revol"
 LICENSE="MIT"
-REVISION="4"
+REVISION="5"
 srcGitRev="b135a6db0df00fb1df4e7b66786d87de142b5e4c"
 SOURCE_URI="https://github.com/HaikuArchives/BSnow/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="1764ea0ef9fc4e0bbb23ad9e12ebfcc6255cc2d78cd545d202356d4ecac1ba17"
@@ -31,12 +31,14 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	make $jobArgs
+	make OBJ_DIR=objects $jobArgs
+	make OBJ_DIR=objects $jobArgs bindcatalogs
 }
 
 INSTALL()
 {
-	mkdir -p $appsDir/BSnow
-	cp -r objects.x86-cc2-release/BSnow $appsDir/BSnow
-	addAppDeskbarSymlink $appsDir/BSnow/BSnow BSnow
+	mkdir -p $appsDir
+	cp objects/BSnow $appsDir/BSnow
+
+	addAppDeskbarSymlink $appsDir/BSnow BSnow
 }


### PR DESCRIPTION
Also, don't forget to "make bindcatalogs" for proper locale support.

----

Tested on hrev58996, x86_64 bits.