### PR TITLE
capnproto: bump to version 1.2.0, switch to autotools

### DIFF
--- a/dev-libs/capnproto/capnproto-1.2.0.recipe
+++ b/dev-libs/capnproto/capnproto-1.2.0.recipe
@@ -5,9 +5,9 @@ HOMEPAGE="https://capnproto.org"
 COPYRIGHT="2017 Cloudflare, Inc. and contributors"
 LICENSE="MIT"
 REVISION="1"
-SOURCE_URI="https://github.com/capnproto/capnproto/archive/refs/tags/v${portVersion}.tar.gz"
-CHECKSUM_SHA256="c0a0d78a07e821f7bae26c7fcac20a9202eb3d639a673b2606b76092a1f35b6b"
-SOURCE_DIR="capnproto-$portVersion"
+SOURCE_URI="https://capnproto.org/capnproto-c++-$portVersion.tar.gz"
+CHECKSUM_SHA256="ed00e44ecbbda5186bc78a41ba64a8dc4a861b5f8d4e822959b0144ae6fd42ef"
+SOURCE_DIR="capnproto-c++-$portVersion"
 PATCHES="capnproto-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -18,17 +18,17 @@ libVersionCompat="$libVersion compat >= ${libVersion%.*}"
 
 PROVIDES="
 	capnproto$secondaryArchSuffix = $portVersion
-	lib:libcapnp$secondaryArchSuffix = $libVersionCompat
-	lib:libcapnpc$secondaryArchSuffix = $libVersionCompat
-	lib:libcapnp_json$secondaryArchSuffix = $libVersionCompat
-	lib:libcapnp_rpc$secondaryArchSuffix = $libVersionCompat
-	lib:libcapnp_websocket$secondaryArchSuffix = $libVersionCompat
-	lib:libkj$secondaryArchSuffix = $libVersionCompat
-	lib:libkj_async$secondaryArchSuffix = $libVersionCompat
-	lib:libkj_gzip$secondaryArchSuffix = $libVersionCompat
-	lib:libkj_http$secondaryArchSuffix = $libVersionCompat
-	lib:libkj_test$secondaryArchSuffix = $libVersionCompat
-	lib:libkj_tls$secondaryArchSuffix = $libVersionCompat
+	lib:libcapnp_$libVersion$secondaryArchSuffix = $libVersionCompat
+	lib:libcapnpc_$libVersion$secondaryArchSuffix = $libVersionCompat
+	lib:libcapnp_json_$libVersion$secondaryArchSuffix = $libVersionCompat
+	lib:libcapnp_rpc_$libVersion$secondaryArchSuffix = $libVersionCompat
+	lib:libcapnp_websocket_$libVersion$secondaryArchSuffix = $libVersionCompat
+	lib:libkj_$libVersion$secondaryArchSuffix = $libVersionCompat
+	lib:libkj_async_$libVersion$secondaryArchSuffix = $libVersionCompat
+	lib:libkj_gzip_$libVersion$secondaryArchSuffix = $libVersionCompat
+	lib:libkj_http_$libVersion$secondaryArchSuffix = $libVersionCompat
+	lib:libkj_test_$libVersion$secondaryArchSuffix = $libVersionCompat
+	lib:libkj_tls_$libVersion$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -38,10 +38,10 @@ REQUIRES="
 
 PROVIDES_devel="
 	capnproto${secondaryArchSuffix}_devel = $portVersion
-	cmd:capnp$secondaryArchSuffix
-	cmd:capnpc$secondaryArchSuffix
-	cmd:capnpc_c++$secondaryArchSuffix
-	cmd:capnpc_capnp$secondaryArchSuffix
+	cmd:capnp
+	cmd:capnpc
+	cmd:capnpc_c++
+	cmd:capnpc_capnp
 	devel:libcapnp$secondaryArchSuffix = $libVersionCompat
 	devel:libcapnpc$secondaryArchSuffix = $libVersionCompat
 	devel:libcapnp_json$secondaryArchSuffix = $libVersionCompat
@@ -65,27 +65,26 @@ BUILD_REQUIRES="
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:cmake
+	cmd:aclocal
+	cmd:autoconf
+	cmd:awk
 	cmd:gcc$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
 BUILD()
 {
-	cmake -B build -S . -DCMAKE_BUILD_TYPE=Release \
-		$cmakeDirArgs \
-		-DCMAKE_CXX_FLAGS="-std=c++11" \
-		-DBUILD_SHARED_LIBS=ON \
-		-DWITH_OPENSSL=ON \
-		-DBUILD_TESTING=OFF
-
-	make -C build $jobArgs
+	autoreconf -i
+	runConfigure --omit-dirs "binDir" ./configure \
+		--bindir=$prefix/bin --disable-static
+	make $jobArgs
 }
 
 INSTALL()
 {
-	make -C build install
+	make install
 
 	prepareInstalledDevelLibs \
 		libcapnp \
@@ -110,6 +109,6 @@ INSTALL()
 
 TEST()
 {
-	# 40% tests passed, 3 tests failed out of 5 (1 nuked -> iddles)
-	ctest --test-dir build --output-on-failure
+	# 1 test hangs and must be killed, a few fail
+	make check
 }

--- a/dev-libs/capnproto/patches/capnproto-1.2.0.patchset
+++ b/dev-libs/capnproto/patches/capnproto-1.2.0.patchset
@@ -1,13 +1,13 @@
-From 14cacfcf108741f8cb04194a660b241ba875c518 Mon Sep 17 00:00:00 2001
+From 391a50d852211c9358b1cb14a792d5fb43a4a456 Mon Sep 17 00:00:00 2001
 From: Han Pengfei <pengphei@qq.com>
 Date: Thu, 20 Oct 2022 02:46:51 +0000
 Subject: Fix missing pwritev
 
 
-diff --git a/c++/src/kj/filesystem-disk-unix.c++ b/c++/src/kj/filesystem-disk-unix.c++
-index 74d59fd..d290b38 100644
---- a/c++/src/kj/filesystem-disk-unix.c++
-+++ b/c++/src/kj/filesystem-disk-unix.c++
+diff --git a/src/kj/filesystem-disk-unix.c++ b/src/kj/filesystem-disk-unix.c++
+index 3b42ed8..d017203 100644
+--- a/src/kj/filesystem-disk-unix.c++
++++ b/src/kj/filesystem-disk-unix.c++
 @@ -416,7 +416,7 @@ public:
  
      static const byte ZEROS[4096] = { 0 };
@@ -18,19 +18,19 @@ index 74d59fd..d290b38 100644
      while (size > sizeof(ZEROS)) {
        write(offset, ZEROS);
 -- 
-2.45.2
+2.50.1
 
 
-From b492071b0fe3162058ecb0f1e33c2c4d1a2124ff Mon Sep 17 00:00:00 2001
+From 2cf49f68d313bbfbe1d6de2511dfaaf5693b52a5 Mon Sep 17 00:00:00 2001
 From: Han Pengfei <pengphei@qq.com>
 Date: Fri, 28 Oct 2022 02:12:30 +0000
 Subject: message: fix sizeof assert for areaspace
 
 
-diff --git a/c++/src/capnp/message.h b/c++/src/capnp/message.h
+diff --git a/src/capnp/message.h b/src/capnp/message.h
 index 983761d..2567f1e 100644
---- a/c++/src/capnp/message.h
-+++ b/c++/src/capnp/message.h
+--- a/src/capnp/message.h
++++ b/src/capnp/message.h
 @@ -127,7 +127,7 @@ public:
  private:
    ReaderOptions options;
@@ -41,34 +41,19 @@ index 983761d..2567f1e 100644
  #else
    static constexpr size_t arenaSpacePadding = 18;
 -- 
-2.45.2
+2.50.1
 
 
-From 66a0d4180908ee6028d4142c3ba5c79f1fd5fa4e Mon Sep 17 00:00:00 2001
+From 539397ada0cfdb330da942acbde2216add8b58e7 Mon Sep 17 00:00:00 2001
 From: Begasus <begasus@gmail.com>
 Date: Sat, 23 Sep 2023 13:29:21 +0200
 Subject: Fixes for building and running the tests
 
 
-diff --git a/c++/CMakeLists.txt b/c++/CMakeLists.txt
-index e2b72fe..2501907 100644
---- a/c++/CMakeLists.txt
-+++ b/c++/CMakeLists.txt
-@@ -24,6 +24,10 @@ set(INSTALL_TARGETS_DEFAULT_ARGS
-   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
- )
- 
-+if(HAIKU)
-+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lnetwork")
-+endif(HAIKU)
-+
- # Options ======================================================================
- 
- option(EXTERNAL_CAPNP "Use the system capnp binary, or the one specified in $CAPNP, instead of using the compiled one." OFF)
-diff --git a/c++/src/kj/async-unix-test.c++ b/c++/src/kj/async-unix-test.c++
+diff --git a/src/kj/async-unix-test.c++ b/src/kj/async-unix-test.c++
 index 64190c4..7873ddc 100644
---- a/c++/src/kj/async-unix-test.c++
-+++ b/c++/src/kj/async-unix-test.c++
+--- a/src/kj/async-unix-test.c++
++++ b/src/kj/async-unix-test.c++
 @@ -54,6 +54,10 @@
  #undef SIGRTMIN
  #endif
@@ -80,10 +65,10 @@ index 64190c4..7873ddc 100644
  namespace kj {
  namespace {
  
-diff --git a/c++/src/kj/filesystem-disk-unix.c++ b/c++/src/kj/filesystem-disk-unix.c++
-index d290b38..185809f 100644
---- a/c++/src/kj/filesystem-disk-unix.c++
-+++ b/c++/src/kj/filesystem-disk-unix.c++
+diff --git a/src/kj/filesystem-disk-unix.c++ b/src/kj/filesystem-disk-unix.c++
+index d017203..4f3d992 100644
+--- a/src/kj/filesystem-disk-unix.c++
++++ b/src/kj/filesystem-disk-unix.c++
 @@ -333,7 +333,7 @@ public:
    void datasync() const {
      // The presence of the _POSIX_SYNCHRONIZED_IO define is supposed to tell us that fdatasync()
@@ -93,10 +78,10 @@ index d290b38..185809f 100644
      KJ_SYSCALL(fdatasync(fd));
  #else
      this->sync();
-diff --git a/c++/src/kj/test-helpers.c++ b/c++/src/kj/test-helpers.c++
+diff --git a/src/kj/test-helpers.c++ b/src/kj/test-helpers.c++
 index 6ae8cd3..ef00d7e 100644
---- a/c++/src/kj/test-helpers.c++
-+++ b/c++/src/kj/test-helpers.c++
+--- a/src/kj/test-helpers.c++
++++ b/src/kj/test-helpers.c++
 @@ -45,7 +45,7 @@ bool hasSubstring(StringPtr haystack, StringPtr needle) {
      // Hell, doing a query for an embedded null & dispatching to strstr is still cheaper & only
      // marginally slower than the purely naiive implementation.
@@ -107,5 +92,38 @@ index 6ae8cd3..ef00d7e 100644
  #else
      // TODO(perf): This is not the best algorithm for substring matching. strstr can't be used
 -- 
-2.45.2
+2.50.1
+
+
+From c7d15b589b37e0ba95878a0e73ce13fcc5dc9f20 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
+Date: Sat, 23 Aug 2025 20:42:19 +0200
+Subject: Link with libnetwork
+
+
+diff --git a/Makefile.am b/Makefile.am
+index 1567491..c28aa3a 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -263,7 +263,7 @@ else
+ lib_LTLIBRARIES = libkj.la libkj-test.la libkj-async.la libkj-http.la $(MAYBE_KJ_TLS_LA) $(MAYBE_KJ_GZIP_LA) libcapnp.la libcapnp-rpc.la libcapnp-json.la libcapnp-websocket.la libcapnpc.la
+ endif
+ 
+-libkj_la_LIBADD = $(PTHREAD_LIBS)
++libkj_la_LIBADD = $(PTHREAD_LIBS) -lnetwork
+ libkj_la_LDFLAGS = -release $(SO_VERSION) -no-undefined
+ libkj_la_SOURCES=                                              \
+   src/kj/cidr.c++                                              \
+@@ -561,7 +561,8 @@ capnp_test_LDADD =                                             \
+   libkj-test.la                                                \
+   libkj.la                                                     \
+   $(ASYNC_LIBS)                                                \
+-  $(PTHREAD_LIBS)
++  $(PTHREAD_LIBS)                                              \
++  -lnetwork
+ 
+ endif !LITE_MODE
+ 
+-- 
+2.50.1
 


### PR DESCRIPTION
The autotools build system is the recommended one upstream, and it also includes the cmake config files, so this shouldn't be a problem.