### PR TITLE
Revert "ixion, orcus: removed obsolete recipes."

### DIFF
--- a/dev-libs/ixion/ixion0.18-0.19.0.recipe
+++ b/dev-libs/ixion/ixion0.18-0.19.0.recipe
@@ -1,0 +1,138 @@
+SUMMARY="A general purpose formula parser and interpreter"
+DESCRIPTION="Ixion is a general purpose formula parser & interpreter that can \
+calculate multiple named targets, or \"cells\".
+The cells can be referenced from each other, and the library takes care \
+of resolving their dependencies automatically upon calculation. The caller \
+can run the calculation routine either in a single-threaded mode, or \
+a multi-threaded mode. The library also supports re-calculations where the \
+contents of one or more cells have been modified since the last calculation, \
+and a partial calculation of only the affected cells need to be calculated."
+HOMEPAGE="https://gitlab.com/ixion/ixion"
+COPYRIGHT="Kohei Yoshida et al."
+LICENSE="MPL v2.0"
+REVISION="1"
+SOURCE_URI="https://gitlab.com/ixion/ixion/-/archive/$portVersion/ixion-$portVersion.tar.bz2"
+CHECKSUM_SHA256="c8b6315bae2d33a0e18b60004d625e4a5ea8a7326364f9f0b51cd6b49bdf93e8"
+SOURCE_DIR="ixion-$portVersion"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+boostMinimumVersion=1.83.0
+
+commandBinDir=$binDir
+commandSuffix=$secondaryArchSuffix
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+soVersion="0.18"
+
+PROVIDES="
+	ixion0.18$secondaryArchSuffix = $portVersion
+	lib:libixion_$soVersion$secondaryArchSuffix = 0.0.0 compat >= 0
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libboost_filesystem$secondaryArchSuffix
+	lib:libboost_program_options$secondaryArchSuffix
+	lib:libboost_system$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	ixion0.18${secondaryArchSuffix}_devel = $portVersion
+	devel:libixion_$soVersion$secondaryArchSuffix = 0.0.0 compat >= 0
+	"
+REQUIRES_devel="
+	ixion0.18$secondaryArchSuffix == $portVersion base
+	"
+
+PROVIDES_tools="
+	ixion0.18${secondaryArchSuffix}_tools = $portVersion
+	cmd:ixion_formula_tokenizer$commandSuffix = $portVersion
+	cmd:ixion_parser$commandSuffix = $portVersion
+	cmd:ixion_sorter$commandSuffix = $portVersion
+	"
+REQUIRES_tools="
+	$REQUIRES
+	ixion0.18$secondaryArchSuffix == $portVersion base
+	"
+CONFLICTS_tools="
+	ixion${secondaryArchSuffix}_tools
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libboost_filesystem$secondaryArchSuffix >= $boostMinimumVersion
+	devel:libboost_program_options$secondaryArchSuffix >= $boostMinimumVersion
+	devel:libboost_system$secondaryArchSuffix >= $boostMinimumVersion
+	devel:libz$secondaryArchSuffix
+	devel:libspdlog$secondaryArchSuffix
+	devel:mdds$secondaryArchSuffix >= 2.1
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:automake
+	cmd:doxygen
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+defineDebugInfoPackage ixion0.18$secondaryArchSuffix \
+	"$(getPackagePrefix tools)"/bin/ixion-formula-tokenizer \
+	"$(getPackagePrefix tools)"/bin/ixion-parser \
+	"$(getPackagePrefix tools)"/bin/ixion-sorter \
+	"$libDir"/libixion-$soVersion.so.0.0.0
+
+PATCH()
+{
+	sed -i 's/-ldl//g' configure.ac
+	sed -i 's/-pthread//g' configure.ac
+	sed -i 's#$with_boost/include#$with_boost/headers#g' m4/boost.m4
+}
+
+BUILD()
+{
+	autoreconf -fi
+	export CXXFLAGS="-std=c++17"
+	BOOST_ROOT="$portPackageLinksDir"/devel~libboost_program_options/develop
+	runConfigure --omit-dirs binDir ./configure \
+		--bindir=$commandBinDir \
+		--enable-python=no
+	make $jobArgs
+
+	cd doc
+	doxygen doxygen.conf
+}
+
+INSTALL()
+{
+	make install
+
+	# documentation
+	mkdir -p $developDocDir
+	cp -r doc/_doxygen/html $developDocDir
+
+	rm -f "$libDir"/libixion-$soVersion.la
+
+	prepareInstalledDevelLib libixion-$soVersion
+	fixPkgconfig
+
+	packageEntries devel \
+		"$developDir"
+
+	packageEntries tools \
+		"$commandBinDir"
+}
+
+TEST()
+{
+	LIBRARY_PATH="$sourceDir/src/libixion/.libs${LIBRARY_PATH:+:$LIBRARY_PATH}" \
+	make check
+}

--- a/dev-libs/orcus/orcus0.18-0.19.2.recipe
+++ b/dev-libs/orcus/orcus0.18-0.19.2.recipe
@@ -1,0 +1,176 @@
+SUMMARY="A library for processing spreadsheet documents"
+DESCRIPTION="Orcus is a library that provides a collection of standalone file \
+processing filters. It is currently focused on providing filters for \
+spreadsheet documents."
+HOMEPAGE="https://gitlab.com/orcus/orcus"
+COPYRIGHT="2022 Kohei Yoshida et al."
+LICENSE="MPL v2.0"
+REVISION="1"
+SOURCE_URI="https://gitlab.com/orcus/orcus/-/archive/$portVersion/orcus-$portVersion.tar.bz2"
+CHECKSUM_SHA256="d5e443bc5dbfd2271eee792bbd7048bc3675da41007b0c410e9c8dca56433638"
+SOURCE_DIR="orcus-$portVersion"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+boostMinimumVersion=1.83.0
+
+commandBinDir=$binDir
+commandSuffix=$secondaryArchSuffix
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+soVersion="0.18"
+ixionSoVersion="0.18"
+
+PROVIDES="
+	orcus0.18$secondaryArchSuffix = $portVersion
+	lib:liborcus_$soVersion$secondaryArchSuffix = 0.0.0 compat >= 0
+	lib:liborcus_mso_$soVersion$secondaryArchSuffix = 0.0.0 compat >= 0
+	lib:liborcus_parser_$soVersion$secondaryArchSuffix = 0.0.0 compat >= 0
+	lib:liborcus_spreadsheet_model_$soVersion$secondaryArchSuffix = 0.0.0 compat >= 0
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libboost_date_time$secondaryArchSuffix
+	lib:libboost_system$secondaryArchSuffix
+	lib:libboost_filesystem$secondaryArchSuffix
+	lib:libboost_iostreams$secondaryArchSuffix
+	lib:libboost_program_options$secondaryArchSuffix
+	lib:libixion_$ixionSoVersion$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	orcus0.18${secondaryArchSuffix}_devel = $portVersion
+	devel:liborcus_$soVersion$secondaryArchSuffix = 0.0.0 compat >= 0
+	devel:liborcus_mso_$soVersion$secondaryArchSuffix = 0.0.0 compat >= 0
+	devel:liborcus_parser_$soVersion$secondaryArchSuffix = 0.0.0 compat >= 0
+	devel:liborcus_spreadsheet_model_$soVersion$secondaryArchSuffix = 0.0.0 compat >= 0
+	"
+REQUIRES_devel="
+	orcus0.18$secondaryArchSuffix == $portVersion base
+	devel:libixion_$ixionSoVersion$secondaryArchSuffix
+	"
+
+PROVIDES_tools="
+	orcus0.18${secondaryArchSuffix}_tools = $portVersion
+	cmd:orcus_css_dump$commandSuffix = $portVersion
+	cmd:orcus_csv$commandSuffix = $portVersion
+	cmd:orcus_detect$commandSuffix = $portVersion
+	cmd:orcus_gnumeric$commandSuffix = $portVersion
+	cmd:orcus_json$commandSuffix = $portVersion
+	cmd:orcus_mso_encryption$commandSuffix = $portVersion
+	cmd:orcus_ods$commandSuffix = $portVersion
+	cmd:orcus_styles_ods$commandSuffix = $portVersion
+	cmd:orcus_xls_xml$commandSuffix = $portVersion
+	cmd:orcus_xlsx$commandSuffix = $portVersion
+	cmd:orcus_xml$commandSuffix = $portVersion
+	cmd:orcus_xml_dump$commandSuffix = $portVersion
+	cmd:orcus_yaml$commandSuffix = $portVersion
+	cmd:orcus_zip_dump$commandSuffix = $portVersion
+	"
+REQUIRES_tools="
+	orcus0.18$secondaryArchSuffix == $portVersion base
+	$REQUIRES
+	"
+CONFLICTS_tools="
+	orcus${secondaryArchSuffix}_tools
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libboost_date_time$secondaryArchSuffix >= $boostMinimumVersion
+	devel:libboost_system$secondaryArchSuffix >= $boostMinimumVersion
+	devel:libboost_filesystem$secondaryArchSuffix >= $boostMinimumVersion
+	devel:libboost_iostreams$secondaryArchSuffix >= $boostMinimumVersion
+	devel:libboost_program_options$secondaryArchSuffix >= $boostMinimumVersion
+	devel:libixion_$ixionSoVersion$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	devel:mdds$secondaryArchSuffix >= 2.1
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:automake
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	# for building the documentation
+	breathe_python310
+	snowballstemmer_python310
+	sphinx_argparse_python310
+	sphinx_rtd_theme_python310
+	sphinxcontrib_jquery_python310
+	cmd:doxygen
+	cmd:sphinx_build
+	"
+
+defineDebugInfoPackage orcus0.18$secondaryArchSuffix \
+	$(getPackagePrefix tools)/bin/orcus-css-dump \
+	$(getPackagePrefix tools)/bin/orcus-csv \
+	$(getPackagePrefix tools)/bin/orcus-detect \
+	$(getPackagePrefix tools)/bin/orcus-gnumeric \
+	$(getPackagePrefix tools)/bin/orcus-json \
+	$(getPackagePrefix tools)/bin/orcus-mso-encryption \
+	$(getPackagePrefix tools)/bin/orcus-ods \
+	$(getPackagePrefix tools)/bin/orcus-styles-ods \
+	$(getPackagePrefix tools)/bin/orcus-xls-xml \
+	$(getPackagePrefix tools)/bin/orcus-xlsx \
+	$(getPackagePrefix tools)/bin/orcus-xml \
+	$(getPackagePrefix tools)/bin/orcus-yaml \
+	$(getPackagePrefix tools)/bin/orcus-zip-dump \
+	$libDir/liborcus-$soVersion.so.0.0.0 \
+	$libDir/liborcus-mso-$soVersion.so.0.0.0 \
+	$libDir/liborcus-parser-$soVersion.so.0.0.0 \
+	$libDir/liborcus-spreadsheet-model-$soVersion.so.0.0.0
+
+PATCH()
+{
+	sed -i 's/-pthread//g' configure.ac src/parser/Makefile.am
+	sed -i 's#$with_boost/include#$with_boost/headers#g' m4/boost.m4
+}
+
+BUILD()
+{
+	autoreconf -fi
+	export CXXFLAGS="-std=c++17"
+	BOOST_ROOT=$portPackageLinksDir/devel~libboost_program_options/develop
+	runConfigure --omit-dirs binDir ./configure \
+		--bindir=$commandBinDir \
+		--disable-python \
+		--disable-static
+	make $jobArgs
+	make doc
+}
+
+INSTALL()
+{
+	make install
+
+	# documentation
+	mkdir -p $developDocDir
+	cp -r doc/_doxygen/html $developDocDir
+
+	for la in "" -mso -parser -spreadsheet-model; do
+		library=liborcus$la-$soVersion
+		rm $libDir/$library.la
+		prepareInstalledDevelLib $library
+	done
+	fixPkgconfig
+
+	packageEntries devel \
+		$developDir
+
+	packageEntries tools \
+		"$commandBinDir"
+}
+
+TEST()
+{
+	make check
+}


### PR DESCRIPTION
This reverts commit 060ee1ad067eae610e5de64413627ec8200b0654.

Missed that liborcus is needed by libreoffice 24.8.1 on 64 bits.