### PR TITLE
ec2drv: update to latest commit.

### DIFF
--- a/dev-embedded/ec2drv/ec2drv-20250614.recipe
+++ b/dev-embedded/ec2drv/ec2drv-20250614.recipe
@@ -4,15 +4,15 @@ EC2, EC3, EC5, EC6 debug adapters."
 HOMEPAGE="https://github.com/paragonRobotics/ec2-new"
 COPYRIGHT="2006 Ricky White"
 LICENSE="GNU GPL v2"
-REVISION="2"
-srcGitRev="e8848813272fb8c85cc497c57d8fb643a6dd169e"
+REVISION="1"
+srcGitRev="ae91fec64442fec9f2296bff6513a611433fa76f"
 SOURCE_URI="https://github.com/paragonRobotics/ec2-new/archive/$srcGitRev.tar.gz"
-CHECKSUM_SHA256="9c5552a3140a43159de3ce4cf3abfe119cc58e3eafcfacd1564a496b1cf2ffb8"
+CHECKSUM_SHA256="3c7683b4536e8dff06444da4a75a0c20165401a52f25b913aeb38f18dfcb28d3"
 SOURCE_FILENAME="ec2-new-$portVersion-$srcGitRev.tar.gz"
 SOURCE_DIR="ec2-new-$srcGitRev"
 PATCHES="ec2drv-$portVersion.patchset"
 
-ARCHITECTURES="?all !x86_gcc2"
+ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 commandSuffix=$secondaryArchSuffix
@@ -31,6 +31,7 @@ PROVIDES="
 	cmd:ec2readfw$commandSuffix
 	cmd:ec2test_any$commandSuffix
 	cmd:ec2writeflash$commandSuffix
+	cmd:newcdb$commandSuffix
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -45,15 +46,16 @@ BUILD_PREREQUIRES="
 	cmd:cmake
 	cmd:gcc$secondaryArchSuffix
 	cmd:ninja
-	cmd:python
+	cmd:python3
 	"
 
 BUILD()
 {
-	mkdir -p build
-	cd build
-	cmake .. -GNinja $cmakeDirArgs
-	ninja
+	# none of $cmakeDirArgs gets actually used.
+	cmake -B build -S . -G Ninja \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_POLICY_VERSION_MINIMUM=3.11
+	ninja -C build
 }
 
 INSTALL()

--- a/dev-embedded/ec2drv/patches/ec2drv-20250614.patchset
+++ b/dev-embedded/ec2drv/patches/ec2drv-20250614.patchset
@@ -1,24 +1,4 @@
-From 4d3142a06baa820186fb26eb441baab091a41715 Mon Sep 17 00:00:00 2001
-From: Adrien Destugues <pulkomandy@pulkomandy.tk>
-Date: Sun, 12 Aug 2018 15:24:16 +0200
-Subject: Fix python path
-
-
-diff --git a/src/ec2drv/csv2c.py b/src/ec2drv/csv2c.py
-index 65ca8f6..029a473 100755
---- a/src/ec2drv/csv2c.py
-+++ b/src/ec2drv/csv2c.py
-@@ -1,4 +1,4 @@
--#!/usr/bin/python
-+#!python
- # cvs2c
- # csv converter for devices table to c table
- #
--- 
-2.16.4
-
-
-From c84048849d8d96e1523478e8e360ce9922bac966 Mon Sep 17 00:00:00 2001
+From bede3c632660efd91b18d40db2425865869bd47b Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Sun, 12 Aug 2018 15:24:24 +0200
 Subject: Do not use "read_port"
@@ -133,10 +113,10 @@ index e3cac94..c4d1f6d 100644
  //	printf("checksum = 0x%04x\n",cksum);
  	DUMP_FUNC();
 diff --git a/src/ec2drv/c2_mode.c b/src/ec2drv/c2_mode.c
-index 3e69e3f..38c1851 100644
+index 89e306a..530aa6e 100644
 --- a/src/ec2drv/c2_mode.c
 +++ b/src/ec2drv/c2_mode.c
-@@ -15,7 +15,7 @@ uint8_t c2_special_read( EC2DRV *obj, uint8_t sfr)
+@@ -16,7 +16,7 @@ uint8_t c2_special_read( EC2DRV *obj, uint8_t sfr)
  	cmd[2] = 1;
  
  	write_port( obj, (char*)cmd, 3 );
@@ -145,7 +125,7 @@ index 3e69e3f..38c1851 100644
  
  	return buf[0];
  }
-@@ -31,7 +31,7 @@ void c2_special_write( EC2DRV *obj, uint8_t sfr, uint8_t value )
+@@ -32,7 +32,7 @@ void c2_special_write( EC2DRV *obj, uint8_t sfr, uint8_t value )
  	cmd[2] = 1;
  	cmd[3] = value & 0xff;
  	write_port( obj, (char*)cmd, 4 );
@@ -154,7 +134,7 @@ index 3e69e3f..38c1851 100644
  }
  
  /** Perform opperations necessary before any flash write or erase
-@@ -145,7 +145,7 @@ uint16_t c2_device_id( EC2DRV *obj )
+@@ -176,7 +176,7 @@ uint16_t c2_device_id( EC2DRV *obj )
  	// this appeared in new versions of IDE but seems to have no effect for F310	
  	// EC2 chokes on this!!!!		trx(obj,"\xfe\x08",2,"\x0d",1);
  	write_port( obj,"\x22", 1 );	// request device id (C2 mode)
@@ -163,7 +143,7 @@ index 3e69e3f..38c1851 100644
  	return buf[0]<<8 | buf[1];
  }
  
-@@ -156,7 +156,7 @@ uint16_t c2_unique_device_id( EC2DRV *obj )
+@@ -187,7 +187,7 @@ uint16_t c2_derivative_id( EC2DRV *obj )
  
  //	ec2_target_halt(obj);	// halt needed otherwise device may return garbage!
  	write_port(obj,"\x23",1);
@@ -172,7 +152,7 @@ index 3e69e3f..38c1851 100644
  	dev_id = buf[1];
  //	print_buf( buf,3);
  //	ec2_target_halt(obj);	// halt needed otherwise device may return garbage!
-@@ -189,7 +189,7 @@ void c2_erase_flash( EC2DRV *obj )
+@@ -225,7 +225,7 @@ void c2_erase_flash( EC2DRV *obj )
  	printf("Start erase3\n");
  	write_port( obj, "\x3C",1);			// Erase entire device
  	printf("Start erase4\n");
@@ -181,7 +161,7 @@ index 3e69e3f..38c1851 100644
  	printf("Start erase5\n");
  	flash_write_post(obj);
  	printf("Start erase6\n");
-@@ -418,7 +418,7 @@ BOOL c2_read_flash( EC2DRV *obj, uint8_t *buf, uint32_t start_addr, int len, BOO
+@@ -504,7 +504,7 @@ BOOL c2_read_flash( EC2DRV *obj, uint8_t *buf, uint32_t start_addr, int len, BOO
  		cmd[2] = high;
  		cmd[3] = l;
  		write_port( obj, (char*)cmd, 4 );
@@ -190,7 +170,7 @@ index 3e69e3f..38c1851 100644
  		if (buf[i+cmd[3]] != 0x0d)
  			return FALSE;
  		i+=l;
-@@ -474,7 +474,7 @@ BOOL c2_read_xdata_emif( EC2DRV *obj, char *buf, int start_addr, int len )
+@@ -563,7 +563,7 @@ BOOL c2_read_xdata_emif( EC2DRV *obj, char *buf, int start_addr, int len )
  		block_len = (len-cnt)>block_len_max ? block_len_max : len-cnt;
  		cmd[3] = block_len;
  		write_port( obj, cmd, 4 );
@@ -199,7 +179,7 @@ index 3e69e3f..38c1851 100644
  		addr += block_len;
  		cnt += block_len;
  	}
-@@ -521,7 +521,7 @@ BOOL c2_read_xdata_F350( EC2DRV *obj, char *buf, int start_addr, int len )
+@@ -610,7 +610,7 @@ BOOL c2_read_xdata_F350( EC2DRV *obj, char *buf, int start_addr, int len )
  		cmd[2] = 0x00;
  		cmd[3] = (len-ofs)>=max_read_len ? max_read_len : (len-ofs);
  		write_port( obj, (char*)cmd, 4 );
@@ -208,7 +188,7 @@ index 3e69e3f..38c1851 100644
  	}
  
  	// restore SFR page register
-@@ -578,12 +578,12 @@ BOOL c2_write_xdata_emif( EC2DRV *obj, char *buf, int start_addr, int len )
+@@ -667,12 +667,12 @@ BOOL c2_write_xdata_emif( EC2DRV *obj, char *buf, int start_addr, int len )
  			// split write over 2 USB writes
  			write_port( obj, cmd, 0x3f );
  			write_port( obj, &cmd[cmd_len+0x3b], 1 );
@@ -223,7 +203,7 @@ index 3e69e3f..38c1851 100644
  		}
  		addr += block_len;
  		cnt += block_len;
-@@ -605,9 +605,9 @@ void c2_read_ram( EC2DRV *obj, char *buf, int start_addr, int len )
+@@ -694,9 +694,9 @@ void c2_read_ram( EC2DRV *obj, char *buf, int start_addr, int len )
  		//T 28 24 02		R 7C 00
  		//T 28 26 02		R 00 00
  	write_port( obj,"\x28\x24\x02",3 );
@@ -235,7 +215,7 @@ index 3e69e3f..38c1851 100644
  	if( start_addr<3 )
  	{
  		memcpy( &buf[0], &tmp[start_addr], 3-start_addr );
-@@ -627,7 +627,7 @@ void c2_read_ram_sfr( EC2DRV *obj, char *buf, int start_addr, int len, BOOL sfr
+@@ -716,7 +716,7 @@ void c2_read_ram_sfr( EC2DRV *obj, char *buf, int start_addr, int len, BOOL sfr
  		cmd[1] = start_addr+i;
  		cmd[2] = len-i >= block_len ? block_len : len-i;
  		write_port( obj, (char*)cmd, 3 );
@@ -244,7 +224,7 @@ index 3e69e3f..38c1851 100644
  	}
  }
  
-@@ -753,12 +753,12 @@ BOOL c2_write_xdata_F35x( EC2DRV *obj, char *buf, int start_addr, int len )
+@@ -842,12 +842,12 @@ BOOL c2_write_xdata_F35x( EC2DRV *obj, char *buf, int start_addr, int len )
  			// split write over 2 USB writes
  			write_port( obj, cmd, 0x3f );
  			write_port( obj, &cmd[cmd_len+0x3b], 1 );
@@ -259,7 +239,7 @@ index 3e69e3f..38c1851 100644
  		}
  		addr += block_len;
  		cnt += block_len;
-@@ -937,7 +937,7 @@ BOOL c2_target_halt_poll( EC2DRV *obj )
+@@ -1026,7 +1026,7 @@ BOOL c2_target_halt_poll( EC2DRV *obj )
  	char buf[2];
  	write_port( obj, "\x27", 1 );
  	//write_port( obj, "\x27\x00", 2 );
@@ -269,7 +249,7 @@ index 3e69e3f..38c1851 100644
  }
  
 diff --git a/src/ec2drv/ec2drv.c b/src/ec2drv/ec2drv.c
-index adb3ab6..5468e5d 100644
+index c5c9923..b74888f 100644
 --- a/src/ec2drv/ec2drv.c
 +++ b/src/ec2drv/ec2drv.c
 @@ -29,6 +29,7 @@
@@ -280,7 +260,7 @@ index adb3ab6..5468e5d 100644
  #include "ec2drv.h"
  #include "config.h"
  #include "boot.h"
-@@ -1107,7 +1108,7 @@ void read_active_regs( EC2DRV *obj, char *buf )
+@@ -1167,7 +1168,7 @@ void read_active_regs( EC2DRV *obj, char *buf )
  
  	// R0-R1
  	write_port( obj, "\x02\x02\x24\x02", 4 );
@@ -289,7 +269,7 @@ index adb3ab6..5468e5d 100644
  }
  
  /** Read the targets program counter
-@@ -1122,12 +1123,12 @@ uint16_t ec2_read_pc( EC2DRV *obj )
+@@ -1182,12 +1183,12 @@ uint16_t ec2_read_pc( EC2DRV *obj )
  	if( obj->mode==JTAG )
  	{
  		write_port( obj, "\x02\x02\x20\x02", 4 );
@@ -304,7 +284,7 @@ index adb3ab6..5468e5d 100644
  	}
  	return ((buf[1]<<8) | buf[0]);
  }
-@@ -1182,7 +1183,7 @@ uint16_t ec2_step( EC2DRV *obj )
+@@ -1242,7 +1243,7 @@ uint16_t ec2_step( EC2DRV *obj )
  		trx( obj, "\x13\x00", 2, "\x01", 1 );	// very similar to 1/2 a target_halt command,  test to see if stopped...
  		
  		write_port( obj, "\x02\x02\x20\x02", 4 );
@@ -313,7 +293,7 @@ index adb3ab6..5468e5d 100644
  		return (uint8_t)buf[0] | ((uint8_t)buf[1]<<8);
  	}
  	else if( obj->mode==C2 )
-@@ -1654,7 +1655,7 @@ BOOL trx( EC2DRV *obj, char *txbuf, int txlen, char *rxexpect, int rxlen )
+@@ -1730,7 +1731,7 @@ BOOL trx( EC2DRV *obj, char *txbuf, int txlen, char *rxexpect, int rxlen )
  {
  	char rxbuf[256];
  	write_port( obj, txbuf, txlen );
@@ -322,7 +302,7 @@ index adb3ab6..5468e5d 100644
  		return memcmp( rxbuf, rxexpect, rxlen )==0 ? TRUE : FALSE;
  	else
  		return FALSE;
-@@ -1781,7 +1782,7 @@ BOOL write_port( EC2DRV *obj, char *buf, int len )
+@@ -1857,7 +1858,7 @@ BOOL write_port( EC2DRV *obj, char *buf, int len )
  	}
  }
  
@@ -331,7 +311,7 @@ index adb3ab6..5468e5d 100644
  {
  	if( obj->dbg_adaptor==EC3 )
  	{
-@@ -1790,7 +1791,7 @@ int read_port_ch( EC2DRV *obj )
+@@ -1866,7 +1867,7 @@ int read_port_ch( EC2DRV *obj )
  	else
  	{
  		char ch;
@@ -340,7 +320,7 @@ index adb3ab6..5468e5d 100644
  			return ch;
  		else
  			return -1;
-@@ -1803,9 +1804,9 @@ int read_port_ch( EC2DRV *obj )
+@@ -1879,9 +1880,9 @@ int read_port_ch( EC2DRV *obj )
  	\param len		Number of bytes to read.
  	\returns		TRUE on success, FALSE on timeout ro failure.
  */
@@ -352,7 +332,7 @@ index adb3ab6..5468e5d 100644
  }
  		
  
-@@ -1816,7 +1817,7 @@ BOOL read_port( EC2DRV *obj, char *buf, int len )
+@@ -1892,7 +1893,7 @@ BOOL read_port( EC2DRV *obj, char *buf, int len )
  	\param ms		Number of milliseconds beefore a timeout will occur.
  	\returns		TRUE on success, FALSE on timeout ro failure.
  */
@@ -362,10 +342,10 @@ index adb3ab6..5468e5d 100644
  	if( obj->dbg_adaptor==EC3 )
  	{
 diff --git a/src/ec2drv/ec2drv.h b/src/ec2drv/ec2drv.h
-index 95cb94e..5975807 100644
+index f46160c..8e99c91 100644
 --- a/src/ec2drv/ec2drv.h
 +++ b/src/ec2drv/ec2drv.h
-@@ -131,9 +131,9 @@ BOOL ec2_write_raw_sfr(EC2DRV *obj, uint8_t addr, uint8_t value );
+@@ -134,9 +134,9 @@ BOOL ec2_write_raw_sfr(EC2DRV *obj, uint8_t addr, uint8_t value );
  BOOL trx( EC2DRV *obj, char *txbuf, int txlen, char *rxexpect, int rxlen );
  BOOL write_port_ch( EC2DRV *obj, char ch );
  BOOL write_port( EC2DRV *obj, char *buf, int len );
@@ -379,7 +359,7 @@ index 95cb94e..5975807 100644
  void set_flash_addr_jtag( EC2DRV *obj, uint32_t addr );
  void ec2_core_suspend( EC2DRV *obj );
 diff --git a/src/ec2drv/jtag_mode.c b/src/ec2drv/jtag_mode.c
-index 7004cff..7ccaff7 100644
+index 3e39382..e7606d7 100644
 --- a/src/ec2drv/jtag_mode.c
 +++ b/src/ec2drv/jtag_mode.c
 @@ -26,7 +26,7 @@ uint16_t jtag_device_id( EC2DRV *obj )
@@ -391,7 +371,7 @@ index 7004cff..7ccaff7 100644
  	return buf[2]<<8 | 0;	// no rev id known yet
  }
  
-@@ -39,7 +39,7 @@ uint16_t jtag_unique_device_id( EC2DRV *obj )
+@@ -39,7 +39,7 @@ uint16_t jtag_derivative_id( EC2DRV *obj )
  	ec2_target_halt(obj);	// halt needed otherwise device may return garbage!
  	trx(obj,"\x10\x00",2,"\x07\x0D",2);
  	write_port(obj,"\x0C\x02\x80\x12",4);
@@ -539,5 +519,26 @@ index 7004cff..7ccaff7 100644
  
  
 -- 
-2.16.4
+2.50.1
+
+
+From 61bce21489ceb78d4b7c73d188107cf3471789e8 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Sat, 30 Aug 2025 05:42:55 -0300
+Subject: fix linking issue with newcdb.
+
+
+diff --git a/src/newcdb/CMakeLists.txt b/src/newcdb/CMakeLists.txt
+index de4c781..0c9412c 100644
+--- a/src/newcdb/CMakeLists.txt
++++ b/src/newcdb/CMakeLists.txt
+@@ -23,5 +23,5 @@ set(NEWCDB_SRC
+ )
+ 
+ add_executable(newcdb ${NEWCDB_SRC})
+-target_link_libraries(newcdb ec2drv dbgcore)
++target_link_libraries(newcdb ec2drv dbgcore network)
+ 
+-- 
+2.50.1
 


### PR DESCRIPTION
Smoke tested on beta5 x86 64 bits, and on hrev58999 x86 32 bits.

The `ec2adapters` command crashes while apparently trying to list connected USB devices, I had none.

Recipe update looks straight forward enough, but will need someone else to test it properly. Perhaps @pulkomandy?