### PR TITLE
Add net-misc/tocaia: Portable TUI Gopher client written in C89 for POSIX systems

### DIFF
--- a/net-misc/tocaia/tocaia-0.9.0.recipe
+++ b/net-misc/tocaia/tocaia-0.9.0.recipe
@@ -1,0 +1,39 @@
+SUMMARY="Portable TUI Gopher client written in C89 for POSIX systems"
+DESCRIPTION="tocaia is a minimalist and cross-platform Gopher client.\
+Built with minimal dependencies, it offers a fast, efficient, \
+and a direct browsing experience navigating the Gopherspace."
+HOMEPAGE="https://github.com/manipuladordedados/tocaia"
+COPYRIGHT="2025 Valter Nazianzeno"
+LICENSE="BSD (2-clause)"
+REVISION="1"
+SOURCE_URI="https://github.com/manipuladordedados/tocaia/archive/refs/tags/$portVersion.tar.gz"
+CHECKSUM_SHA256="be4528728d782bfac6b4dba9c7df639f2d3b888715751c25ca44310960f0c58f"
+
+ARCHITECTURES="all"
+
+PROVIDES="
+	tocaia = $portVersion
+	cmd:tocaia = $portVersion
+	"
+REQUIRES="
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc
+	cmd:make
+	"
+
+BUILD()
+{
+    make LDFLAGS="-lnetwork" $jobArgs
+}
+
+INSTALL()
+{
+	mkdir -p $binDir
+    cp tocaia $binDir
+}


### PR DESCRIPTION
Tocaia is a minimalist and cross-platform Gopher client.
Built with minimal dependencies, it offers a fast, efficient, and a direct browsing experience navigating the Gopherspace.