### PR TITLE
SBCL 2.5.8

### DIFF
--- a/dev-lisp/sbcl/sbcl-2.5.8.recipe
+++ b/dev-lisp/sbcl/sbcl-2.5.8.recipe
@@ -9,7 +9,7 @@ COPYRIGHT="2002 Gerd Moellmann"
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="https://github.com/sbcl/sbcl/archive/refs/tags/sbcl-$portVersion.zip"
-CHECKSUM_SHA256="a74d85db32aedd668ed8993a28beaefbf81f05a16c15b20582d90b35815c700f"
+CHECKSUM_SHA256="99d31b3ece1526a3f2a5e7c5a3d42935a661cd2287301630afb28b2464412e90"
 SOURCE_DIR="sbcl-sbcl-$portVersion"
 
 ARCHITECTURES="x86_64"


### PR DESCRIPTION
Version 2.5.7, despite the fact builds locally, was not built by buildbots.

Hopefully this version 2.5.8 will be more successful. If not, I will need some assistance to debug the recipe.