### PR TITLE
flit_core: drop support for Python 3.9.

### DIFF
--- a/dev-python/flit-core/flit_core-3.9.0.recipe
+++ b/dev-python/flit-core/flit_core-3.9.0.recipe
@@ -4,7 +4,7 @@ The only public interface is the API specified by PEP 517, at ``flit_core.builda
 HOMEPAGE="https://pypi.org/project/flit_core/"
 COPYRIGHT="2015 Thomas Kluyver and contributors"
 LICENSE="BSD (3-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/f/flit-core/flit_core-$portVersion.tar.gz"
 CHECKSUM_SHA256="72ad266176c4a3fcfab5f2930d76896059851240570ce9a98733b658cb786eba"
 
@@ -21,10 +21,9 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_VERSIONS=(3.9 3.10)
+PYTHON_VERSIONS=(3.10)
 
-for i in "${!PYTHON_VERSIONS[@]}"; do
-	pythonVersion=${PYTHON_VERSIONS[$i]}
+for pythonVersion in ${PYTHON_VERSIONS[@]}; do
 	pythonPackage=python${pythonVersion//.}
 
 	eval "PROVIDES_$pythonPackage=\"
@@ -42,8 +41,7 @@ done
 
 INSTALL()
 {
-	for i in "${!PYTHON_VERSIONS[@]}"; do
-		pythonVersion=${PYTHON_VERSIONS[$i]}
+	for pythonVersion in ${PYTHON_VERSIONS[@]}; do
 		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion


### PR DESCRIPTION
Should be the last recipe targetting 3.9.

We should be able to drop the package for the Python 3.9 interpreter when it reaches EOL in October 2025.