### PR TITLE
yt_dlp: update to 2025.09.23

### DIFF
--- a/net-misc/yt_dlp/yt_dlp-2025.09.23.recipe
+++ b/net-misc/yt_dlp/yt_dlp-2025.09.23.recipe
@@ -12,7 +12,7 @@ LICENSE="Unlicense"
 REVISION="1"
 SOURCE_URI="$HOMEPAGE/releases/download/$portVersion/yt-dlp.tar.gz"
 SOURCE_FILENAME="yt-dlp-$portVersion.tar.gz"
-CHECKSUM_SHA256="71b746f537ddccdcd54352a941e9e6cd2033150b440eb14d8d15daefa4b2c855"
+CHECKSUM_SHA256="665449b23e357d923b98972123ede18d1e824a96cc56ace6088dc81161fcfddb"
 SOURCE_DIR="yt-dlp"
 
 ARCHITECTURES="any"


### PR DESCRIPTION
Don't merge.

Building fails for some reason (on Haiku Beta5). Any Pythoneer around?

This is the output:

```
* Building wheel...
Traceback (most recent call last):
  File "/packages/python3.10-3.10.18-1/.self/lib/python3.10/vendor-packages/pyproject_hooks/_in_process/_in_process.py", line 373, in <module>
    main()
  File "/packages/python3.10-3.10.18-1/.self/lib/python3.10/vendor-packages/pyproject_hooks/_in_process/_in_process.py", line 357, in main
    json_out["return_val"] = hook(**hook_input["kwargs"])
  File "/packages/python3.10-3.10.18-1/.self/lib/python3.10/vendor-packages/pyproject_hooks/_in_process/_in_process.py", line 271, in build_wheel
    return _build_backend().build_wheel(
  File "/packages/python3.10-3.10.18-1/.self/lib/python3.10/vendor-packages/hatchling/build.py", line 58, in build_wheel
    return os.path.basename(next(builder.build(directory=wheel_directory, versions=['standard'])))
  File "/packages/python3.10-3.10.18-1/.self/lib/python3.10/vendor-packages/hatchling/builders/plugin/interface.py", line 90, in build
    self.metadata.validate_fields()
  File "/packages/python3.10-3.10.18-1/.self/lib/python3.10/vendor-packages/hatchling/metadata/core.py", line 266, in validate_fields
    self.core.validate_fields()
  File "/packages/python3.10-3.10.18-1/.self/lib/python3.10/vendor-packages/hatchling/metadata/core.py", line 1376, in validate_fields
    getattr(self, attribute)
  File "/packages/python3.10-3.10.18-1/.self/lib/python3.10/vendor-packages/hatchling/metadata/core.py", line 750, in license_files
    raise TypeError(message)
TypeError: Field `project.license-files` must be a table

ERROR Backend subprocess exited when trying to invoke build_wheel
Warning: Command '['bash', '-c', '. /wrapper-script']' returned non-zero exit status 1.
cleaning 'chroot/boot' folder
keeping chroot folder /Ports/haikuports/_x86_64/net-misc/yt_dlp/work-2025.09.23 intact for inspection
Error: Build has failed - stopping.
```
