### PR TITLE
Update python's "hatchling" and "packaging"

### DIFF
--- a/dev-python/hatchling/hatchling-1.27.0.recipe
+++ b/dev-python/hatchling/hatchling-1.27.0.recipe
@@ -3,9 +3,9 @@ DESCRIPTION="This is the extensible, standards compliant build backend used by H
 HOMEPAGE="https://hatch.pypa.io/dev/history/hatchling/"
 COPYRIGHT="2021-present Ofek Lev"
 LICENSE="MIT"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/h/$portName/$portName-$portVersion.tar.gz"
-CHECKSUM_SHA256="7064631a512610b52250a4d3ff1bd81551d6d1431c4eb7b72e734df6c74f4262"
+CHECKSUM_SHA256="971c296d9819abb3811112fc52c7a9751c8d381898f36533bb16f9791e941fd6"
 
 ARCHITECTURES="any"
 

--- a/dev-python/packaging/packaging-25.0.recipe
+++ b/dev-python/packaging/packaging-25.0.recipe
@@ -4,9 +4,9 @@ version handling, specifiers, markers, requirements, tags, utilities."
 HOMEPAGE="https://pypi.python.org/pypi/packaging"
 COPYRIGHT="Donald Stufft and individual contributors"
 LICENSE="BSD (2-clause)"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://pypi.io/packages/source/${portName:0:1}/$portName/$portName-$portVersion.tar.gz"
-CHECKSUM_SHA256="026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"
+CHECKSUM_SHA256="d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"
 
 ARCHITECTURES="any"
 


### PR DESCRIPTION
In order to build yt-dlp, "hatchling" needs to be updated to v1.27. Which in turn needs a new version of "packaging" (->v25.0).