### PR TITLE
git: update to version 2.51.0.

### DIFF
--- a/dev-vcs/git/git-2.51.0.recipe
+++ b/dev-vcs/git/git-2.51.0.recipe
@@ -12,18 +12,18 @@ COPYRIGHT="2005-2025 Git Authors (see git web site for list)"
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://www.kernel.org/pub/software/scm/git/git-$portVersion.tar.xz"
-CHECKSUM_SHA256="7e3e6c36decbd8f1eedd14d42db6674be03671c2204864befa2a41756c5c8fc4"
+CHECKSUM_SHA256="60a7c2251cc2e588d5cd87bae567260617c6de0c22dca9cdbfc4c7d2b8990b62"
 SOURCE_URI_2="https://www.kernel.org/pub/software/scm/git/git-manpages-$portVersion.tar.xz"
-CHECKSUM_SHA256_2="7dd86882bbc22bef8852924de96b9cb378aad8532089e301c82093da3e7c5478"
+CHECKSUM_SHA256_2="c10aea63316865ace762078a6e67fc3cf117b11a5c9d4a2a52cb3762ae22ed35"
 SOURCE_URI_3="https://www.kernel.org/pub/software/scm/git/git-htmldocs-$portVersion.tar.xz"
-CHECKSUM_SHA256_3="d15ccd1518b822e317d14b63de4444bb288909294f117cbbfa385c60ab739bca"
+CHECKSUM_SHA256_3="dd33897c676ea140d57a652758e458756fa93582801cfd1d7e1f62acd5fa7580"
 PATCHES="git-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 GLOBAL_WRITABLE_FILES="
-	settings/gitconfig keep-old
+	settings/gitconfig auto-merge
 	"
 USER_SETTINGS_FILES="
 	settings/git directory
@@ -260,7 +260,10 @@ INSTALL()
 	# efficient method of determining whether the cache is out of date. This
 	# is filesystem-dependent, but supported on BeFS.
 	mkdir -p $sysconfDir
-	printf "[core]\n	untrackedCache = true" > $sysconfDir/gitconfig
+	printf "[core]\n	untrackedCache = true\n" > $sysconfDir/gitconfig
+
+	# Allows scrolling with the mouse wheel when using the default (less) pager.
+	printf "	pager = less -+FX\n" >> $sysconfDir/gitconfig
 
 	# replace copies of git binaries with symlinks
 	cd $prefix/bin

--- a/dev-vcs/git/patches/git-2.51.0.patchset
+++ b/dev-vcs/git/patches/git-2.51.0.patchset
@@ -1,4 +1,4 @@
-From 102f99f9d7cb64b395624382e61ef28e1145efc2 Mon Sep 17 00:00:00 2001
+From b13d9ec2bf2d2401c49f061cd1c7b94d1ebb5386 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Thu, 7 Aug 2025 00:10:27 -0300
 Subject: git-web--browse.sh: use "open" on Haiku
@@ -23,17 +23,17 @@ index ae15253..0f95000 100755
  		init_browser_path $i
  		if type "$browser_path" > /dev/null 2>&1; then
 -- 
-2.48.1
+2.50.1
 
 
-From 8563acff85b61f400ca5bdcc63018aae3079d0e9 Mon Sep 17 00:00:00 2001
+From c9ef343a0724d893a976303843749104de1a30ef Mon Sep 17 00:00:00 2001
 From: Ingo Weinhold <ingo_weinhold@gmx.de>
 Date: Mon, 19 Jan 2015 15:37:16 -0500
 Subject: On Haiku use the user settings directory instead of HOME
 
 
 diff --git a/path.c b/path.c
-index 3b598b2..e3a9475 100644
+index 7f56eaf..7f017de 100644
 --- a/path.c
 +++ b/path.c
 @@ -19,6 +19,11 @@
@@ -69,20 +69,20 @@ index 3b598b2..e3a9475 100644
  	home = getenv("HOME");
  	if (home)
 -- 
-2.48.1
+2.50.1
 
 
-From 8f3679bb9f7473fa99fe4eefff653f112acce87d Mon Sep 17 00:00:00 2001
+From 5a71b32a14defcda4aeb69447a71e5e89a028491 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Mon, 19 Jan 2015 15:50:09 -0500
 Subject: Ensure config-directory exists before using it.
 
 
 diff --git a/config.c b/config.c
-index e2ee0cb..e05c2ca 100644
+index 97ffef4..6fa81af 100644
 --- a/config.c
 +++ b/config.c
-@@ -3197,6 +3197,14 @@ int repo_config_set_multivar_in_file_gently(struct repository *r,
+@@ -2680,6 +2680,14 @@ int repo_config_set_multivar_in_file_gently(struct repository *r,
  	if (!config_filename)
  		config_filename = filename_buf = repo_git_path(r, "config");
  
@@ -98,10 +98,10 @@ index e2ee0cb..e05c2ca 100644
  	 * The lock serves a purpose in addition to locking: the new
  	 * contents of .git/config will be written into it.
 -- 
-2.48.1
+2.50.1
 
 
-From ff1cbc99e6fe8aba815078b0d86f26a86492ec75 Mon Sep 17 00:00:00 2001
+From 6d006ee7f5a3281c7a197a87c2327e2b105ba784 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Sun, 14 Feb 2016 10:32:12 +0100
 Subject: Move credential cache to the config directory.
@@ -122,10 +122,10 @@ index 7f733cb..65319f5 100644
  		socket = xstrfmt("%s/socket", old_dir);
  	else
 -- 
-2.48.1
+2.50.1
 
 
-From bb83687ff6879eb6d011ea248f70e940bdd10f7c Mon Sep 17 00:00:00 2001
+From 2c19b3447b1800b6c7c250192dccfff610aa984c Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 24 May 2024 15:15:25 -0300
 Subject: config: use "xdg_config" even if "user_config" does not exist
@@ -133,10 +133,10 @@ Subject: config: use "xdg_config" even if "user_config" does not exist
 Based on the previous patch by: sfanxiang <sfanxiang@gmail.com>
 
 diff --git a/config.c b/config.c
-index e05c2ca..14b9ffd 100644
+index 6fa81af..ef0ebf0 100644
 --- a/config.c
 +++ b/config.c
-@@ -1984,18 +1984,12 @@ char *git_global_config(void)
+@@ -1466,18 +1466,12 @@ char *git_global_config(void)
  	char *user_config, *xdg_config;
  
  	git_global_config_paths(&user_config, &xdg_config);
@@ -161,17 +161,17 @@ index e05c2ca..14b9ffd 100644
  }
  
 -- 
-2.48.1
+2.50.1
 
 
-From 0ed9dc6e7aee57ec600c86f9111b1c39c2df3e0d Mon Sep 17 00:00:00 2001
+From ca3fa0463a6fc9967f43ac6ec2ca7d1b5196cf1b Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 29 Nov 2019 21:46:54 +0100
 Subject: ignore test failures.
 
 
 diff --git a/t/Makefile b/t/Makefile
-index 791e0a0..7929fdd 100644
+index 757674e..98c5703 100644
 --- a/t/Makefile
 +++ b/t/Makefile
 @@ -79,7 +79,7 @@ prove: pre-clean $(TEST_LINT)
@@ -184,29 +184,29 @@ index 791e0a0..7929fdd 100644
  $(UNIT_TESTS):
  	@echo "*** $@ ***"; $@
 -- 
-2.48.1
+2.50.1
 
 
-From 91a39212e8d76177fe5342582937b599c62cdb21 Mon Sep 17 00:00:00 2001
+From 29a490ca6a49254df9fdd711d938e160abe10d4a Mon Sep 17 00:00:00 2001
 From: Augustin Cavalier <waddlesplash@gmail.com>
 Date: Wed, 17 Nov 2021 18:11:17 -0500
 Subject: git-gui: Use symbolic links.
 
 
 diff --git a/git-gui/Makefile b/git-gui/Makefile
-index 8672dd2..77cf3bd 100644
+index 27bbe05..5dc7d03 100644
 --- a/git-gui/Makefile
 +++ b/git-gui/Makefile
-@@ -57,7 +57,7 @@ INSTALL_X1 =
- INSTALL_A0 = find # space is required here
- INSTALL_A1 = | cpio -pud
+@@ -54,7 +54,7 @@ INSTALL_R1 =
+ INSTALL_X0 = $(INSTALL) -m 755 # space is required here
+ INSTALL_X1 =
  INSTALL_L0 = rm -f # space is required here
 -INSTALL_L1 = && ln # space is required here
 +INSTALL_L1 = && ln -s # space is required here
  INSTALL_L2 =
  INSTALL_L3 =
  
-@@ -86,7 +86,7 @@ ifndef V
+@@ -81,7 +81,7 @@ ifndef V
  	INSTALL_L0 = dst=
  	INSTALL_L1 = && src=
  	INSTALL_L2 = && dst=
@@ -216,10 +216,10 @@ index 8672dd2..77cf3bd 100644
  	CLEAN_DST = echo ' ' UNINSTALL
  	REMOVE_D0 = dir=
 -- 
-2.48.1
+2.50.1
 
 
-From ae1f13c6d2977776fbf3668c90d06b02461930f8 Mon Sep 17 00:00:00 2001
+From dc19431a9394cec46c2116040d6ca30d0e7ec47b Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 28 Feb 2025 15:50:56 -0300
 Subject: Workaround for HaikuPorts issue #11131.
@@ -244,10 +244,10 @@ index 8d08a61..3664663 100644
  	textdomain("git");
  
 -- 
-2.48.1
+2.50.1
 
 
-From be2345db2d9e2cfbdd2e82f1671907258b3f2acf Mon Sep 17 00:00:00 2001
+From 87f6ef3916b644fb05b6b60374838c3c6da14768 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Wed, 6 Aug 2025 23:56:38 -0300
 Subject: Use `python3` as hashbang for the generated gitweb.py.
@@ -267,5 +267,5 @@ index 7b44f70..7da5219 100755
  import sys
  
 -- 
-2.48.1
+2.50.1
 


### PR DESCRIPTION
Besides upstream changes (see [release notes](https://lore.kernel.org/git/xmqqikikk1hr.fsf@gitster.g/)), this PR adds a minor convenience:

Mouse scroll wheel should now work while using the default pager (`less`). Was already possible by using other pagers, like `most`, but that's not installed by default.