### PR TITLE
git: revert setting of "core.pager".

### DIFF
--- a/dev-vcs/git/git-2.51.0.recipe
+++ b/dev-vcs/git/git-2.51.0.recipe
@@ -10,7 +10,7 @@ workflows."
 HOMEPAGE="https://git-scm.com/"
 COPYRIGHT="2005-2025 Git Authors (see git web site for list)"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://www.kernel.org/pub/software/scm/git/git-$portVersion.tar.xz"
 CHECKSUM_SHA256="60a7c2251cc2e588d5cd87bae567260617c6de0c22dca9cdbfc4c7d2b8990b62"
 SOURCE_URI_2="https://www.kernel.org/pub/software/scm/git/git-manpages-$portVersion.tar.xz"
@@ -261,9 +261,6 @@ INSTALL()
 	# is filesystem-dependent, but supported on BeFS.
 	mkdir -p $sysconfDir
 	printf "[core]\n	untrackedCache = true\n" > $sysconfDir/gitconfig
-
-	# Allows scrolling with the mouse wheel when using the default (less) pager.
-	printf "	pager = less -+FX\n" >> $sysconfDir/gitconfig
 
 	# replace copies of git binaries with symlinks
 	cd $prefix/bin


### PR DESCRIPTION
This change is more disruptive of users expectations than what was intended (it forces using pager for all commands, even when not really needed).

Sorry for the noise.