### PR TITLE
PrBoom+: Fix libdumb require, fix build for CMake > 4

### DIFF
--- a/games-fps/prboom-plus/prboom_plus-2.6.66.recipe
+++ b/games-fps/prboom-plus/prboom_plus-2.6.66.recipe
@@ -14,7 +14,7 @@ Example: 'prboom-plus -iwad /path/to/doom/doom.wad'"
 HOMEPAGE="https://github.com/coelckers/prboom-plus"
 COPYRIGHT="2016-2023 Andrey Budko et al."
 LICENSE="GNU GPL v2"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://github.com/coelckers/prboom-plus/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="4b647b4b14c3fac00711e6bf19f996bbfe37754a3b9bb5be6791f0c3fd993438"
 SOURCE_DIR="prboom-plus-$portVersion"
@@ -32,7 +32,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libdumb_0.9.3$secondaryArchSuffix # Optional, used with portmidi
+	lib:libdumb$secondaryArchSuffix # Optional, used with portmidi
 	lib:libfluidsynth$secondaryArchSuffix # Optional, for Fluidsynth MIDI
 	lib:libmad$secondaryArchSuffix
 	lib:libpcreposix$secondaryArchSuffix
@@ -74,6 +74,7 @@ BUILD()
 
 	cmake -Bbuild -S./prboom2 $cmakeDirArgs \
 		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
 		-DCMAKE_INSTALL_BINDIR="$prefix/bin" \
 		-DPRBOOMDATADIR="$dataDir/prboom-plus" \
 		-DDOOMWADDIR="$nonpackdatadir/prboom-plus"


### PR DESCRIPTION
Currently PrBoom+'s install from HaikuDepot fails on fresh installs because the package looks for libdumb0.9.3 but the game wants libdumb2. This PR is meant to fix it and also update the recipe to work with current CMake. Tested on x86_64 only.