### PR TITLE
ECM, bump to 6.19.0

### DIFF
--- a/kde-frameworks/extra-cmake-modules/extra_cmake_modules-6.19.0.recipe
+++ b/kde-frameworks/extra-cmake-modules/extra_cmake_modules-6.19.0.recipe
@@ -7,9 +7,9 @@ commandline by the user."
 HOMEPAGE="https://invent.kde.org/frameworks/extra-cmake-modules"
 COPYRIGHT="2010-2025 KDE Organisation"
 LICENSE="BSD (2-clause)"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/extra-cmake-modules-$portVersion.tar.xz"
-CHECKSUM_SHA256="e881c19e335beb82326e02d000766e7ee8324d7ce8583df0f5bfd4c26998fbfe"
+CHECKSUM_SHA256="a4f0c1d8181f43e9af4b9b44696c77760b5bc9dae5bdb921f090bce664e9ca84"
 SOURCE_DIR="extra-cmake-modules-$portVersion"
 PATCHES="extra_cmake_modules-$portVersion.patchset"
 
@@ -57,8 +57,9 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	cmake -B build -S . -DCMAKE_BUILD_TYPE=Release \
-		-DSHARE_INSTALL_DIR=$dataDir/cmake/Modules \
-		-DDOC_INSTALL_DIR=$documentationDir/packages/qt6_base \
+		-DCMAKE_INSTALL_PREFIX=$prefix \
+		-DSHARE_INSTALL_DIR=$dataDir \
+		-DDOC_INSTALL_DIR=$documentationDir/packages/qt6_base/ \
 		-DMAN_INSTALL_DIR=$manDir \
 		-DBUILD_TESTING=OFF \
 		-Wno-dev
@@ -70,7 +71,7 @@ INSTALL()
 {
 	make -C build install
 
-	mv $documentationDir/packages/qt6_base/html $documentationDir/packages/extra_cmake_modules
+	mv $documentationDir/packages/qt6_base/html $documentationDir/packages/qt6_base/ECM
 
 	packageEntries doc \
 		$documentationDir

--- a/kde-frameworks/extra-cmake-modules/patches/extra_cmake_modules-6.19.0.patchset
+++ b/kde-frameworks/extra-cmake-modules/patches/extra_cmake_modules-6.19.0.patchset
@@ -1,4 +1,4 @@
-From 7d5a7af49e38ea5cd1ca4f74b704a270f2bbaf24 Mon Sep 17 00:00:00 2001
+From 47cbfb1ec77bd1dcd424ea03fdafd3fd28c79cc3 Mon Sep 17 00:00:00 2001
 From: Sergei Reznikov <diver@gelios.net>
 Date: Mon, 16 Dec 2019 16:01:30 +0300
 Subject: don't default to using debug build type on Haiku...
@@ -6,7 +6,7 @@ Subject: don't default to using debug build type on Haiku...
 if the source directory is a git clone
 
 diff --git a/kde-modules/KDECompilerSettings.cmake b/kde-modules/KDECompilerSettings.cmake
-index ad96879..624f457 100644
+index 1f6193c..b097396 100644
 --- a/kde-modules/KDECompilerSettings.cmake
 +++ b/kde-modules/KDECompilerSettings.cmake
 @@ -239,7 +239,7 @@ include("${ECM_MODULE_DIR}/ECMSourceVersionControl.cmake")
@@ -19,10 +19,10 @@ index ad96879..624f457 100644
      message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
      set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "${default_build_type}")
 -- 
-2.48.1
+2.51.0
 
 
-From 29e6fe10e09ff1310275368f58f44534888ba7f7 Mon Sep 17 00:00:00 2001
+From ef10f7e0b065ccf12b9776ed86d2309146eae5b2 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Sun, 8 May 2022 21:16:49 +1000
 Subject: Add Haiku platform check
@@ -44,10 +44,10 @@ index 7e354dd..357f4b6 100644
                  if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
                      set(_MetainfoFoundSupportedPlatform true)
 -- 
-2.48.1
+2.51.0
 
 
-From 662c18b57ff63879fc1a2c430bf0e526c99495d8 Mon Sep 17 00:00:00 2001
+From 459bd4ebc6571c6d6be0d3d1e65cc6d8192c046b Mon Sep 17 00:00:00 2001
 From: Schrijvers Luc <begasus@gmail.com>
 Date: Wed, 28 Feb 2024 11:48:23 +0100
 Subject: demote_unsupported_platform_error_to_a_warning
@@ -67,10 +67,10 @@ index 357f4b6..45152c8 100644
      endif()
  endif()
 -- 
-2.48.1
+2.51.0
 
 
-From 79dad224585107aa44356f82adb24a77f38b9e25 Mon Sep 17 00:00:00 2001
+From 5634e971c3fd3bedf5e064a394fefcf481fb1447 Mon Sep 17 00:00:00 2001
 From: Luc Schrijvers <begasus@gmail.com>
 Date: Tue, 20 May 2025 16:21:06 +0200
 Subject: Fix hardcoded paths, we don't use /usr/*
@@ -119,5 +119,112 @@ index d59c1b8..e6aa25f 100644
  set -x --path XDG_CONFIG_DIRS "@KDE_INSTALL_FULL_CONFDIR@" $XDG_CONFIG_DIRS
  
 -- 
-2.48.1
+2.51.0
+
+
+From 6b0071ce6b7cc185a0b427c3e2f9920b2a5cf1dc Mon Sep 17 00:00:00 2001
+From: Luc Schrijvers <begasus@gmail.com>
+Date: Thu, 16 Oct 2025 14:39:36 +0200
+Subject: Set QTPLUGINDIR,QMLDIR and QCHDIR for Haiku
+
+
+diff --git a/kde-modules/KDEInstallDirs5.cmake b/kde-modules/KDEInstallDirs5.cmake
+index 4550dd1..efaa13c 100644
+--- a/kde-modules/KDEInstallDirs5.cmake
++++ b/kde-modules/KDEInstallDirs5.cmake
+@@ -295,6 +295,15 @@ else()
+         set(_pluginsDirParent)
+         #androiddeployqt wants plugins right in the prefix
+     endif()
++    if (HAIKU)
++        set(_pluginsDirParent)
++        #haikudeployqt wants plugins right in the prefix
++        _define_relative(QTPLUGINDIR "${_pluginsDirParent}" "add-ons/Qt5"
++            "Qt plugins")
++
++        _define_relative(QMLDIR DATADIR "Qt5/qml"
++            "QtQuick2 imports")
++    else()
+     _define_relative(QTPLUGINDIR "${_pluginsDirParent}" "plugins"
+         "Qt plugins"
+         QT_PLUGIN_INSTALL_DIR)
+@@ -306,6 +315,7 @@ else()
+     _define_relative(QMLDIR LIBDIR "qml"
+         "QtQuick2 imports"
+         QML_INSTALL_DIR)
++    endif()
+ endif()
+ 
+ _define_relative(PLUGINDIR QTPLUGINDIR ""
+@@ -330,8 +340,16 @@ if(KDE_INSTALL_USE_QT_SYS_PATHS)
+     _define_absolute(QTQCHDIR ${qt_docs_dir}
+         "documentation bundles in QCH format for Qt-extending libraries")
+ else()
+-    _define_relative(QTQCHDIR DATAROOTDIR "doc/qch"
+-        "documentation bundles in QCH format for Qt-extending libraries")
++    set(_qchDirParent DATAROOTDIR)
++    if(HAIKU)
++    set(_qchDirParent)
++        #haikudeployqt wants documentation right in the prefix
++        _define_relative(QTQCHDIR "${_qchDirParent}" "documentation/packages/qt5_base"
++            "documentation bundles in QCH format for Qt-extending libraries")
++    else()
++        _define_relative(QTQCHDIR "${_qchDirParent}" "doc/qch"
++            "documentation bundles in QCH format for Qt-extending libraries")
++    endif()
+ endif()
+ 
+ 
+diff --git a/kde-modules/KDEInstallDirs6.cmake b/kde-modules/KDEInstallDirs6.cmake
+index b71c535..8cf8944 100644
+--- a/kde-modules/KDEInstallDirs6.cmake
++++ b/kde-modules/KDEInstallDirs6.cmake
+@@ -244,11 +244,21 @@ else()
+         set(_pluginsDirParent)
+         #androiddeployqt wants plugins right in the prefix
+     endif()
+-    _define_relative(QTPLUGINDIR "${_pluginsDirParent}" "plugins"
+-        "Qt plugins")
+-
+-    _define_relative(QMLDIR LIBDIR "qml"
+-        "QtQuick2 imports")
++    if (HAIKU)
++        set(_pluginsDirParent)
++        #haikudeployqt wants plugins right in the prefix
++        _define_relative(QTPLUGINDIR "${_pluginsDirParent}" "add-ons/Qt6"
++            "Qt plugins")
++
++        _define_relative(QMLDIR DATADIR "Qt6/qml"
++            "QtQuick2 imports")
++    else()
++        _define_relative(QTPLUGINDIR "${_pluginsDirParent}" "plugins"
++            "Qt plugins")
++
++        _define_relative(QMLDIR LIBDIR "qml"
++            "QtQuick2 imports")
++    endif()
+ endif()
+ 
+ _define_relative(PLUGINDIR QTPLUGINDIR ""
+@@ -264,8 +274,16 @@ if(KDE_INSTALL_USE_QT_SYS_PATHS)
+ 
+    _define_absolute(QTQCHDIR ${qt_docs_dir} "documentation bundles in QCH format for Qt-extending libraries")
+ else()
+-    _define_relative(QTQCHDIR DATAROOTDIR "doc/qch"
+-        "documentation bundles in QCH format for Qt-extending libraries")
++    set(_qchDirParent DATAROOTDIR)
++    if(HAIKU)
++    set(_qchDirParent)
++        #haikudeployqt wants documentation right in the prefix
++        _define_relative(QTQCHDIR "${_qchDirParent}" "documentation/packages/qt6_base"
++            "documentation bundles in QCH format for Qt-extending libraries")
++    else()
++        _define_relative(QTQCHDIR "${_qchDirParent}" "doc/qch"
++            "documentation bundles in QCH format for Qt-extending libraries")
++    endif()
+ endif()
+ 
+ 
+-- 
+2.51.0
 


### PR DESCRIPTION
This adds support for `QMLDIR`, `QTPLUGINDIR` and `QCHDIR` so these shouldn't be defined anymore in the recipes (granted that `$cmakeDirArgs` is used).
MKSPECS is a totally different thing and not covered in ECM.

Note, this is the last official release still supporting Qt6.7, starting frameworks 6.20.0 minimum required (upstream) is Qt > 6.8.