### PR TITLE
Update Chocolate Doom to 3.1.1

### DIFF
--- a/games-fps/chocolate-doom/chocolate_doom-3.1.1.recipe
+++ b/games-fps/chocolate-doom/chocolate_doom-3.1.1.recipe
@@ -24,7 +24,7 @@ COPYRIGHT="Id Software Inc. 1993-1996
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://github.com/chocolate-doom/chocolate-doom/archive/refs/tags/chocolate-doom-$portVersion.tar.gz"
-CHECKSUM_SHA256="f2c64843dcec312032b180c3b2f34b4cb26c4dcdaa7375a1601a3b1df11ef84d"
+CHECKSUM_SHA256="1edcc41254bdc194beb0d33e267fae306556c4d24110a1d3d3f865717f25da23"
 SOURCE_DIR="chocolate-doom-chocolate-doom-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"


### PR DESCRIPTION
Only needed to change the SHA and version number. Compiles cleanly, runs fine (only tested on x64)