### PR TITLE
Update ECWolf to 1.4.2

### DIFF
--- a/games-arcade/ecwolf/ecwolf-1.4.2.recipe
+++ b/games-arcade/ecwolf/ecwolf-1.4.2.recipe
@@ -7,13 +7,18 @@ capabilities without the need to modify the source code.
 For players, ECWolf provides many useful features such as better \
 control binding, support for wide screen resolutions, and unlimited \
 save slots. ECWolf allows you to keep all of your game data \
-in one directory as one binary plays all supported games."
+in one directory as one binary plays all supported games.
+
+The binaries will look for compatible data files in:
+* ~/config/non-packaged/data/ecwolf
+* ~/config/settings/ecwolf
+* The current folder (when run from command-line)"
 HOMEPAGE="https://maniacsvault.net/ecwolf/"
-COPYRIGHT="2004-2024 the ECWolf team"
+COPYRIGHT="2004-2025 the ECWolf team"
 LICENSE="GNU GPL v2"
-REVISION="3"
+REVISION="1"
 SOURCE_URI="https://maniacsvault.net/ecwolf/files/ecwolf/1.x/ecwolf-${portVersion}-src.tar.xz"
-CHECKSUM_SHA256="8ebd495d2806c9d0e736656970e736730a005d3b43c7f5729f52c812b22f9e2d"
+CHECKSUM_SHA256="2121fb3fc63e532423681dcddf5d3848e19e8c6b4e2e1bfa802b16a2d42f84f5"
 SOURCE_DIR="ecwolf-${portVersion}-src"
 PATCHES="ecwolf-$portVersion.patchset"
 ADDITIONAL_FILES="ecwolf.rdef.in"
@@ -58,30 +63,28 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
-defineDebugInfoPackage ecwolf$secondaryArchSuffix \
-	$prefix/bin/ecwolf
-
 BUILD()
 {
-	export LDFLAGS="-lbsd -lnetwork"
+	# -lSDL2_mixer is needed since at least 22 Oct 2025
+	# It wasn't needed in earlier Haiku build environments
+	# So check in the future if it's still needed:
+	# https://github.com/haikuports/haikuports/issues/13089
+	export LDFLAGS="-lbsd -lnetwork -lSDL2_mixer"
 
-	mkdir -p build && cd build
-
-	cmake .. $cmakeDirArgs \
+	cmake -Bbuild -S. $cmakeDirArgs \
 		-Wno-dev -Wno-error=dev -Wno-deprecated \
-		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_BUILD_TYPE=Release -DNO_GTK=ON \
 		-DCMAKE_CXX_FLAGS="-D_DEFAULT_SOURCE -D_GNU_SOURCE"
 
-	make $jobArgs
+	make -C build $jobArgs
 }
 
 INSTALL()
 {
-	cd build && make install
+	make -C build install
 
 	# Remove *nixy desktop files
-	rm -r $dataDir/applications
-	rm -r $dataDir/icons
+	rm -r $dataDir/{applications,icons,metainfo}
 
 	# Generate the rdef
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"

--- a/games-arcade/ecwolf/patches/ecwolf-1.4.2.patchset
+++ b/games-arcade/ecwolf/patches/ecwolf-1.4.2.patchset
@@ -1,41 +1,28 @@
-From 45770a35ebe49e8bf287f9133643c08bc4cb6410 Mon Sep 17 00:00:00 2001
+From af0fc5cbb9724a89a35c3ed0e7b4d083d4d3eb3c Mon Sep 17 00:00:00 2001
 From: Peppersawce <michaelpeppers89@yahoo.it>
-Date: Sat, 28 Sep 2024 11:26:15 +0200
+Date: Wed, 22 Oct 2025 14:07:57 +0200
 Subject: Haiku patch
 
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c64a55f..b3d7ef2 100644
+index c9bbf91..61e22b6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -52,13 +52,21 @@ endif()
- 
- # Multiarch support
- if(UNIX AND NOT APPLE)
--	# We are in the games section
--	set(CMAKE_INSTALL_BINDIR "games")
-+	if (HAIKU)
-+		set(CMAKE_INSTALL_BINDIR "bin")
-+	else()
-+		# We are in the games section
-+		set(CMAKE_INSTALL_BINDIR "games")
-+	endif()
- 
+@@ -50,7 +50,11 @@ if(UNIX AND NOT APPLE)
  	include(GNUInstallDirs)
  	if(CPACK_PACKAGE_NAME)
--		# Match this to package name instead of project name
+ 		# Match this to package name instead of project name
 -		set(CMAKE_INSTALL_DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/${CPACK_PACKAGE_NAME}")
 +		if (HAIKU)
 +			set(CMAKE_INSTALL_DOCDIR "documentation/packages/${CPACK_PACKAGE_NAME}")
 +		else()
-+			# Match this to package name instead of project name
 +			set(CMAKE_INSTALL_DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/${CPACK_PACKAGE_NAME}")
 +		endif()
  	endif()
  	# GNUInstallDirs doesn't provide this, but we could use share/product_name
  	set(CMAKE_INSTALL_DATAPRODUCTDIR "${CMAKE_INSTALL_DATADIR}/${PRODUCT_DIRECTORY}")
 diff --git a/src/filesys.cpp b/src/filesys.cpp
-index ed83673..e8bc3dc 100644
+index 8eb7213..b68db7b 100644
 --- a/src/filesys.cpp
 +++ b/src/filesys.cpp
 @@ -217,11 +217,16 @@ void SetupPaths(int argc, const char * const *argv)
@@ -78,6 +65,6 @@ index ed83673..e8bc3dc 100644
  #else
  	screenshotsDir = documentsDir + "/screenshots";
  #endif
---
-2.45.2
+-- 
+2.51.0
 


### PR DESCRIPTION
Tested and working on x86_64. Part of the old patch was trimmed as it is no longer needed.

LD now requires "-lSDL2_mixer" to be set to build successfully (see #13089), this also affects the old recipe for 1.4.1.

The binary is hardcoded to look for its data in "/boot/system/data" so the package will not work when installed in "boot/home" (see patch @ filesys.cpp). A fix for that would be welcome. :)