### PR TITLE
eden_emu: new recipe

### DIFF
--- a/games-emulation/eden_emu/eden_emu-0.0.4.recipe
+++ b/games-emulation/eden_emu/eden_emu-0.0.4.recipe
@@ -4,89 +4,97 @@ HOMEPAGE="https://eden-emu.dev"
 COPYRIGHT="2025 Eden Contributors"
 LICENSE="GNU GPL v3"
 REVISION="1"
-SOURCE_URI="https://git.eden-emu.dev/eden-emu/eden/archive/master.tar.gz"
-CHECKSUM_SHA256="657d9dbd9d745ff1c0b101baf5dae0444921a1c7391c2a11619886530ff51fed"
+SOURCE_URI="https://git.eden-emu.dev/eden-emu/eden/archive/v0.0.4-rc1.tar.gz"
+CHECKSUM_SHA256="081358e1730ae70626465970be82d58cb3afb21b450b194eccc90ea28fe1afdc"
 SOURCE_DIR="eden"
 # No patches, upstream promised to keep-up
 PATCHES=""
 
 ARCHITECTURES="x86_64"
+
 PROVIDES="
-        eden_emu = $portVersion
-        app:eden = $portVersion
-        "
+	eden_emu = $portVersion
+	app:eden = $portVersion
+	"
 REQUIRES="
-        haiku
-        boost1.89
-        lib:libavcodec
-        lib:libavformat
-        lib:libavutil
-        lib:libswresample
-        lib:libswscale
-        lib:libQt6Core
-        lib:libQt6DBus
-        lib:libQt6Widgets
-        lib:libQt6Core5Compat
-        lib:libenet
-        lib:libfmt
-        lib:libGL
-        lib:liblz4
-        lib:libsdl2_2.0
-        lib:libusb_1.0
-        lib:libzstd
-        lib:libssl
-        lib:nlohmann_json
-        lib:liblz4
-        lib:libopus
-        lib:libvulkan
-        lib:libquazip1_qt6
-        lib:zydis
-        lib:libzstd
-        "
+	haiku
+	boost1.89
+	lib:libavcodec
+	lib:libavformat
+	lib:libavutil
+	lib:libenet
+	lib:libfmt
+	lib:libGL
+	lib:liblz4
+	lib:libopus
+	lib:libQt6Core
+	lib:libQt6Core5Compat
+	lib:libQt6DBus
+	lib:libQt6Widgets
+	lib:libquazip1_qt6
+	lib:libSDL2_2.0
+	lib:libssl
+	lib:libswresample
+	lib:libswscale
+	lib:libusb_1.0
+	lib:libvulkan
+	lib:libzstd
+	lib:nlohmann_json
+	lib:zydis
+	"
 
 BUILD_REQUIRES="
-        haiku_devel
-        ffmpeg7_devel
-        boost1.89_devel
-        devel:libQt6Core
-        devel:libQt6DBus
-        devel:libQt6Widgets
-        devel:libQt6Core5Compat
-        devel:libenet$secondaryArchSuffix
-        devel:libfmt$secondaryArchSuffix >= 11
-        devel:libGL
-        devel:libsdl2_2.0
-        devel:libusb_1.0
-        devel:libssl
-        devel:nlohmann_json
-        devel:liblz4
-        devel:libopus
-        devel:libvulkan
-        devel:libquazip1_qt6
-        devel:libzycore
-        devel:libzydis
-        devel:libzstd
-        "
+	haiku_devel
+	ffmpeg7_devel
+	boost1.89_devel
+	devel:libenet$secondaryArchSuffix
+	devel:libfmt$secondaryArchSuffix >= 11
+	devel:libGL
+	devel:liblz4
+	devel:libopus
+	devel:libQt6Core
+	devel:libQt6Core5Compat
+	devel:libQt6DBus
+	devel:libQt6Widgets
+	devel:libquazip1_qt6
+	devel:libSDL2_2.0
+	devel:libssl
+	devel:libusb_1.0
+	devel:libvulkan
+	devel:libzstd
+	devel:libzycore
+	devel:libzydis
+	devel:nlohmann_json
+	"
 
 BUILD_PREREQUIRES="
-        cmd:cmake
-        cmd:gcc
-        cmd:ld
-        cmd:ninja
-        cmd:pkg_config
-        cmd:patch
-        "
+	cmd:cmake
+	cmd:gcc
+	cmd:ld
+	cmd:ninja
+	cmd:pkg_config
+	cmd:patch
+	cmd:glslangValidator
+	"
 
 BUILD()
 {
-        cmake -Bbuild -GNinja -S . \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DCMAKE_INSTALL_PREFIX=$appsDir/eden/ \
-                -DCMAKE_INSTALL_BINDIR=$appsDir/eden/
-        cmake --build build -t yuzu $jobArgs
+	cmake -Bbuild -GNinja -S . \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=$appsDir/eden/ \
+		-DCMAKE_INSTALL_BINDIR=$appsDir/eden/ \
+		-DENABLE_SDL2=OFF \
+		-DBUILD_TESTING=OFF \
+		-DYUZU_TESTS=OFF \
+		-DDYNARMIC_TESTS=OFF \
+		-DYUZU_USE_CPM=ON \
+		-Dmbedtls_FORCE_BUNDLED=ON \
+		-DENABLE_CUBEB=OFF \
+		-DENABLE_QT_UPDATE_CHECKER=OFF
+	cmake --build build -t yuzu $jobArgs
 }
 
 INSTALL()
 {
-        cmake --install build -t yuzu
+	cmake --install build -t yuzu
 }


### PR DESCRIPTION
- [x] audio
- [x] controls
- [ ] video (needs mesa >=24/opengl 4.6) crashes when using `glCreateProgramPipelines` (4.6 feature)
- [x] Qt6 front-end
- [ ] non-crashing glslangValidator for build process

<img width="991" height="576" alt="image" src="https://github.com/user-attachments/assets/8fb97815-c04f-44c9-a777-4cd2dead5b12" />

Everything else works (audio, controls, the CPU emulating stuff) - except video due to mesa