### PR TITLE
Update GZDoom to v4

### DIFF
--- a/games-fps/gzdoom/gzdoom-4.14.3~git.recipe
+++ b/games-fps/gzdoom/gzdoom-4.14.3~git.recipe
@@ -1,0 +1,108 @@
+SUMMARY="Advanced Doom source port with OpenGL support"
+DESCRIPTION="ZDoom is a family of enhanced ports of the Doom engine for modern operating systems, with many \
+new features not found in the games as originally published by id Software.
+
+GZDoom is a feature centric port for all Doom engine games, based on ZDoom, \
+adding OpenGL and Vulkan renderers and powerful scripting capabilities.
+
+The binaries will look for .wad files in:
+* ~/config/non-packaged/data/gzdoom
+* ~/config/non-packaged/data/doomdata
+* ~/config/non-packaged/data/doom
+* /boot/system/non-packaged/data/doomdata
+* Any compatible game data package
+The binaries can be also used via command-line with the -iwad command.
+Example: 'GZDoom -iwad /path/to/doom.wad'"
+HOMEPAGE="https://zdoom.org/"
+COPYRIGHT="
+	1998-2025 ZDoom + GZDoom teams, and contributors
+	1997 id Software, Raven Software, and contributors
+	"
+LICENSE="GNU GPL v3"
+REVISION="1"
+srcGitRev="b746be8a6ba982903ce222307baa4fc26d1a91dd"
+SOURCE_URI="https://github.com/ZDoom/gzdoom/archive/$srcGitRev.zip"
+CHECKSUM_SHA256="9da46b7e304c4c5f1861086da34aacdfd1c33d5a7b28f0182005b867dacd4dd4"
+SOURCE_DIR="gzdoom-$srcGitRev"
+PATCHES="gzdoom-$portVersion.patchset"
+ADDITIONAL_FILES="gzdoom.rdef.in"
+
+# 32bit is not supported.
+ARCHITECTURES="riscv64 x86_64 ?arm64"
+
+PROVIDES="
+	gzdoom = $portVersion
+	app:GZDoom = $portVersion
+	engine:doom # Standard Doom-compatible engine
+	engine:doom_extra # Heretic, Hexen, Strife etc.
+	engine:zdoom # Can handle ZDoom-specific game data
+	"
+REQUIRES="
+	haiku
+	lib:libbz2
+	lib:libexecinfo
+	lib:libgomp
+	lib:libopenal # Optional, required for in-game audio
+	lib:libSDL2_2.0
+	lib:libvpx
+	lib:libzmusic
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	devel:libbz2
+	devel:libexecinfo
+	devel:libGL # For OpenGL renderer
+	devel:libSDL2_2.0
+	devel:libvpx
+	devel:libzmusic
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:gcc
+	cmd:git # Optional, needed for build date
+	cmd:make
+	cmd:pkg_config
+	"
+
+BUILD()
+{
+	cmake -Bbuild -S. $cmakeDirArgs \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_CXX_FLAGS="-D_GNU_SOURCE -D_BSD_SOURCE" \
+		-DCMAKE_EXE_LINKER_FLAGS="-lbsd -lnetwork" \
+		-DINSTALL_PATH=$appsDir \
+		-DINSTALL_DOCS_PATH=$docDir \
+		-DINSTALL_PK3_PATH=$dataDir/gzdoom \
+		-DINSTALL_SOUNDFONT_PATH=$dataDir/gzdoom \
+		-DDYN_GTK=OFF -DNO_GTK=ON \
+		-DVULKAN_USE_XLIB=OFF
+
+	make -C build $jobArgs
+}
+
+INSTALL()
+{
+	make -C build install
+	mv $appsDir/gzdoom $appsDir/GZDoom
+
+	# Remove *nixy desktop and cppdap files
+	rm -r $prefix/share $libDir $developDir/headers
+
+	# Generate the rdef
+	local APP_SIGNATURE="application/x-vnd.gzdoom"
+	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
+	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
+	local MINOR="`echo "$portVersion" | cut -b6`"
+	local LONG_INFO="$SUMMARY"
+	sed \
+		-e "s|@APP_SIGNATURE@|$APP_SIGNATURE|" \
+		-e "s|@MAJOR@|$MAJOR|" \
+		-e "s|@MIDDLE@|$MIDDLE|" \
+		-e "s|@MINOR@|$MINOR|" \
+		-e "s|@LONG_INFO@|$LONG_INFO|" \
+		$portDir/additional-files/gzdoom.rdef.in > gzdoom.rdef
+
+	addResourcesToBinaries gzdoom.rdef $appsDir/GZDoom
+	addAppDeskbarSymlink $appsDir/GZDoom
+}

--- a/games-fps/gzdoom/patches/gzdoom-4.14.3~git.patchset
+++ b/games-fps/gzdoom/patches/gzdoom-4.14.3~git.patchset
@@ -1,0 +1,136 @@
+From 3bcf7dfe112f7abba86484266506d881721590d4 Mon Sep 17 00:00:00 2001
+From: Peppersawce <michaelpeppers89@yahoo.it>
+Date: Tue, 1 Apr 2025 18:17:30 +0200
+Subject: Define Haiku paths
+
+
+diff --git a/src/gameconfigfile.cpp b/src/gameconfigfile.cpp
+index 3b259e8..d58d63c 100644
+--- a/src/gameconfigfile.cpp
++++ b/src/gameconfigfile.cpp
+@@ -113,6 +113,14 @@ FGameConfigFile::FGameConfigFile ()
+ 		SetSection ("IWADSearch.Directories", true);
+ 		SetValueForKey ("Path", ".", true);
+ 		SetValueForKey ("Path", "$DOOMWADDIR", true);
++		SetValueForKey ("Path", "$HOME/config/non-packaged/data/doom", true);
++		SetValueForKey ("Path", "$HOME/config/non-packaged/data/doomdata", true);
++		SetValueForKey ("Path", "$HOME/config/non-packaged/data/gzdoom", true);
++		SetValueForKey ("Path", "/boot/system/data/gzdoom", true);
++		SetValueForKey ("Path", "/boot/system/data/doomdata", true);
++		SetValueForKey ("Path", "/boot/system/non-packaged/data/doomdata", true);
++		SetValueForKey ("Path", "$HOME/config/data/gzdoom", true);
++		SetValueForKey ("Path", "$HOME/config/data/doomdata", true);
+ #ifdef __APPLE__
+ 		SetValueForKey ("Path", user_docs.GetChars(), true);
+ 		SetValueForKey ("Path", user_app_support.GetChars(), true);
+@@ -141,6 +150,14 @@ FGameConfigFile::FGameConfigFile ()
+ 	if (!SetSection ("FileSearch.Directories"))
+ 	{
+ 		SetSection ("FileSearch.Directories", true);
++		SetValueForKey ("Path", "$HOME/config/non-packaged/data/doom", true);
++		SetValueForKey ("Path", "$HOME/config/non-packaged/data/doomdata", true);
++		SetValueForKey ("Path", "$HOME/config/non-packaged/data/gzdoom", true);
++		SetValueForKey ("Path", "/boot/system/data/gzdoom", true);
++		SetValueForKey ("Path", "/boot/system/data/doomdata", true);
++		SetValueForKey ("Path", "/boot/system/non-packaged/data/doomdata", true);
++		SetValueForKey ("Path", "$HOME/config/data/gzdoom", true);
++		SetValueForKey ("Path", "$HOME/config/data/doomdata", true);
+ #ifdef __APPLE__
+ 		SetValueForKey ("Path", user_docs.GetChars(), true);
+ 		SetValueForKey ("Path", user_app_support.GetChars(), true);
+@@ -166,6 +184,10 @@ FGameConfigFile::FGameConfigFile ()
+ 	if (!SetSection("SoundfontSearch.Directories"))
+ 	{
+ 		SetSection("SoundfontSearch.Directories", true);
++		SetValueForKey ("Path", "/boot/system/data/gzdoom/soundfonts", true);
++		SetValueForKey ("Path", "/boot/system/data/gzdoom/fm_banks", true);
++		SetValueForKey ("Path", "$HOME/config/data/gzdoom/soundfonts", true);
++		SetValueForKey ("Path", "$HOME/config/data/gzdoom/fm_banks", true);
+ #ifdef __APPLE__
+ 		SetValueForKey("Path", (user_docs + "/soundfonts").GetChars(), true);
+ 		SetValueForKey("Path", (user_docs + "/fm_banks").GetChars(), true);
+-- 
+2.51.0
+
+
+From a1151cc8aa3d7ff92f610e3479befc07113b56c0 Mon Sep 17 00:00:00 2001
+From: Peppersawce <michaelpeppers89@yahoo.it>
+Date: Wed, 2 Apr 2025 16:31:04 +0200
+Subject: Disable Git version string as it is incorrect
+
+
+diff --git a/src/common/utility/gitinfo.cpp b/src/common/utility/gitinfo.cpp
+index 4ef00dc..111c05c 100644
+--- a/src/common/utility/gitinfo.cpp
++++ b/src/common/utility/gitinfo.cpp
+@@ -54,12 +54,12 @@ const char *GetGitTime()
+ 
+ const char *GetVersionString()
+ {
+-	if (GetGitDescription()[0] == '\0')
++	//if (GetGitDescription()[0] == '\0')
+ 	{
+ 		return VERSIONSTR;
+ 	}
+-	else
++	/*else
+ 	{
+ 		return GIT_DESCRIPTION;
+-	}
++	}*/
+ }
+-- 
+2.51.0
+
+
+From cacf77705ad62779170f0044d885233df5a6ba0e Mon Sep 17 00:00:00 2001
+From: Peppersawce <michaelpeppers89@yahoo.it>
+Date: Thu, 23 Oct 2025 15:42:21 +0200
+Subject: Fix ZWidget build
+
+
+diff --git a/libraries/ZWidget/CMakeLists.txt b/libraries/ZWidget/CMakeLists.txt
+index bc5f43a..9478112 100644
+--- a/libraries/ZWidget/CMakeLists.txt
++++ b/libraries/ZWidget/CMakeLists.txt
+@@ -239,6 +239,10 @@ elseif(APPLE)
+ 	set(ZWIDGET_LIBS ${CMAKE_DL_LIBS} -ldl)
+ 	set(ZWIDGET_DEFINES -DUNIX -D_UNIX)
+ 	set(ZWIDGET_LINK_OPTIONS -pthread)
++elseif(HAIKU)
++	set(ZWIDGET_LIBS ${CMAKE_DL_LIBS})
++	set(ZWIDGET_DEFINES -DUNIX -D_UNIX)
++	set(ZWIDGET_LINK_OPTIONS -pthread)
+ else()
+ 	set(ZWIDGET_SOURCES ${ZWIDGET_SOURCES} ${ZWIDGET_X11_SOURCES})
+ 	set(ZWIDGET_LIBS ${CMAKE_DL_LIBS} -lX11 -lXi)
+-- 
+2.51.0
+
+
+From 447b510d6ecccb4a53477d4381ce20b5cc81090a Mon Sep 17 00:00:00 2001
+From: Peppersawce <michaelpeppers89@yahoo.it>
+Date: Mon, 3 Nov 2025 13:28:59 +0100
+Subject: Replaxe xdg-open with open
+
+
+diff --git a/src/common/platform/posix/sdl/i_system.cpp b/src/common/platform/posix/sdl/i_system.cpp
+index b52515b..a03bf7f 100644
+--- a/src/common/platform/posix/sdl/i_system.cpp
++++ b/src/common/platform/posix/sdl/i_system.cpp
+@@ -424,7 +424,11 @@ void I_OpenShellFolder(const char* infolder)
+ 	{
+ 		if (longsavemessages)
+ 			Printf("Opening folder: %s\n", infolder);
+-		std::system("xdg-open .");
++		#ifdef __HAIKU__
++			std::system("open .");
++		#else
++			std::system("xdg-open .");
++		#endif
+ 		chdir(curdir);
+ 	}
+ 	else
+-- 
+2.51.0
+


### PR DESCRIPTION
This PR updates the GZDoom port to the latest git commit as of today. It requires #13094 to be successfully built.
Tested on x86_64. Will not compile on 32bit (they dropped support for it)

There's some good news and some bad news about it:

Good: The .wad selection UI now only freezes for a couple of seconds (on this pc), so that part of the port is fixed imo.

Bad: .wad selection UI doesn't display CJK characters (I only have Noto Sans installed for CJK, maybe the UI wants another font?)