### PR TITLE
fuse-exfat/exfat-utils: new recipes.

### DIFF
--- a/sys-fs/exfat-utils/exfat_utils-1.4.0.recipe
+++ b/sys-fs/exfat-utils/exfat_utils-1.4.0.recipe
@@ -1,0 +1,66 @@
+SUMMARY="Group of exFAT utilities (alternative to \"exfatprogs\")"
+DESCRIPTION="The \"exfat\" project aims to provide a full featured exFAT file system \
+implementation for Unix'like systems.
+
+It consists of a FUSE module (fuse-exfat) and a set of utilities (exfat-utils).
+
+This package contains the \"exfat-utils\" commands."
+HOMEPAGE="https://github.com/relan/exfat"
+COPYRIGHT="2011-2023 Andrew Nayenko"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="https://github.com/relan/exfat/releases/download/v$portVersion/exfat-utils-$portVersion.tar.gz"
+CHECKSUM_SHA256="241575fa93104406a47e79e53e4d907bae69886f11621f70a45276c62b75bf69"
+SOURCE_DIR="exfat-utils-$portVersion"
+PATCHES="$portBaseName-$portVersion.patchset"
+
+ARCHITECTURES="?all !x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
+
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+PROVIDES="
+	$portName = $portVersion
+	cmd:exfatattrib$commandSuffix = $portVersion
+	cmd:dumpexfat$commandSuffix = $portVersion
+	cmd:exfatfsck$commandSuffix = $portVersion
+	cmd:fsck.exfat$commandSuffix = $portVersion
+	cmd:exfatlabel$commandSuffix = $portVersion
+	cmd:mkexfatfs$commandSuffix = $portVersion
+	cmd:mkfs.exfat$commandSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+CONFLICTS="
+	exfatprogs$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	export CFLAGS="-O2 -DB_USE_POSITIVE_POSIX_ERRORS"
+	export LIBS="-lposix_error_mapper"
+	runConfigure --omit-dirs sbinDir ./configure --sbindir=$commandBinDir
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make $jobArgs install
+}

--- a/sys-fs/exfat-utils/patches/exfat_utils-1.4.0.patchset
+++ b/sys-fs/exfat-utils/patches/exfat_utils-1.4.0.patchset
@@ -1,0 +1,33 @@
+From 45b3ebd0ca9742b16d7d7fa0fd3177433d135ee5 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Tue, 21 Oct 2025 23:23:56 -0300
+Subject: Initial Haiku patch.
+
+
+diff --git a/libexfat/platform.h b/libexfat/platform.h
+index 9bd125a..730e96f 100644
+--- a/libexfat/platform.h
++++ b/libexfat/platform.h
+@@ -66,7 +66,18 @@
+ #define EXFAT_LITTLE_ENDIAN __LITTLE_ENDIAN
+ #define EXFAT_BIG_ENDIAN __BIG_ENDIAN
+ 
+-#else 
++
++#elif defined(__HAIKU__)
++
++#include <ByteOrder.h>
++#define exfat_bswap16(x) B_SWAP_INT16(x)
++#define exfat_bswap32(x) B_SWAP_INT32(x)
++#define exfat_bswap64(x) B_SWAP_INT64(x)
++#define EXFAT_BYTE_ORDER __BYTE_ORDER
++#define EXFAT_LITTLE_ENDIAN __LITTLE_ENDIAN
++#define EXFAT_BIG_ENDIAN __BIG_ENDIAN
++
++#else
+ #error Unknown platform
+ #endif
+ 
+-- 
+2.51.0
+

--- a/sys-fs/fuse-exfat/fuse_exfat-1.4.0.recipe
+++ b/sys-fs/fuse-exfat/fuse_exfat-1.4.0.recipe
@@ -1,0 +1,65 @@
+SUMMARY="FUSE/UserlandFS exFAT file system module"
+DESCRIPTION="The \"exfat\" project aims to provide a full featured exFAT file system \
+implementation for Unix'like systems.
+
+It consists of a FUSE module (fuse-exfat) and a set of utilities (exfat-utils).
+
+This package contains the \"fuse-exfat\" module (with write support) for use with \
+Haiku's UserlandFS.
+
+Usage examples:
+
+> mkdir /exFAT-mount
+> mount -t userlandfs -o \"fuse-exfat ~/foobar.exfat /exFAT-mount\" /exFAT-mount
+
+To mount an exFAT volume \"image\", or:
+
+> mount -t userlandfs -o \"fuse-exfat /dev/disk/usb/0/0/0 /exFAT-mount\" /exFAT-mount
+
+To mount an exFAT formatted USB pendrive."
+HOMEPAGE="https://github.com/relan/exfat"
+COPYRIGHT="2011-2023 Andrew Nayenko"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="https://github.com/relan/exfat/releases/download/v$portVersion/fuse-exfat-$portVersion.tar.gz"
+CHECKSUM_SHA256="a1cfedc55e0e7a12c184605aa0f0bf44b24a3fb272449b20b2c8bbe6edb3001e"
+SOURCE_DIR="fuse-exfat-$portVersion"
+
+PATCHES="$portBaseName-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="!x86"
+
+PROVIDES="
+	$portName = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	userland_fs
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	userland_fs
+	"
+BUILD_PREREQUIRES="
+	cmd:awk
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	export CFLAGS="-O2 -DB_USE_POSITIVE_POSIX_ERRORS -D_FILE_OFFSET_BITS=64"
+	export LIBS="-lposix_error_mapper"
+	runConfigure ./configure
+	make $jobArgs
+}
+
+
+INSTALL()
+{
+	mkdir -p $prefix/add-ons/userlandfs
+	cp fuse/mount.exfat-fuse $prefix/add-ons/userlandfs/fuse-exfat
+}

--- a/sys-fs/fuse-exfat/patches/fuse_exfat-1.4.0.patchset
+++ b/sys-fs/fuse-exfat/patches/fuse_exfat-1.4.0.patchset
@@ -1,0 +1,86 @@
+From d845891d272148c863afe47faf2631c73993e5c1 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Tue, 21 Oct 2025 23:23:56 -0300
+Subject: Initial Haiku patch.
+
+
+diff --git a/libexfat/platform.h b/libexfat/platform.h
+index 9bd125a..730e96f 100644
+--- a/libexfat/platform.h
++++ b/libexfat/platform.h
+@@ -66,7 +66,18 @@
+ #define EXFAT_LITTLE_ENDIAN __LITTLE_ENDIAN
+ #define EXFAT_BIG_ENDIAN __BIG_ENDIAN
+ 
+-#else 
++
++#elif defined(__HAIKU__)
++
++#include <ByteOrder.h>
++#define exfat_bswap16(x) B_SWAP_INT16(x)
++#define exfat_bswap32(x) B_SWAP_INT32(x)
++#define exfat_bswap64(x) B_SWAP_INT64(x)
++#define EXFAT_BYTE_ORDER __BYTE_ORDER
++#define EXFAT_LITTLE_ENDIAN __LITTLE_ENDIAN
++#define EXFAT_BIG_ENDIAN __BIG_ENDIAN
++
++#else
+ #error Unknown platform
+ #endif
+ 
+-- 
+2.51.0
+
+
+From 9b9c05ec019fe6ba52d57fb3ae09b5746292cfed Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Fri, 7 Nov 2025 09:52:07 -0300
+Subject: Use saner permissions default values.
+
+
+diff --git a/libexfat/mount.c b/libexfat/mount.c
+index 86fb84d..ef9c7f2 100644
+--- a/libexfat/mount.c
++++ b/libexfat/mount.c
+@@ -87,6 +87,13 @@ static void parse_options(struct exfat* ef, const char* options)
+ 	ef->dmask = get_int_option(options, "dmask", 8, opt_umask);
+ 	ef->fmask = get_int_option(options, "fmask", 8, opt_umask);
+ 
++#if defined(__HAIKU__)
++	if (ef->dmask == 0)
++		ef->dmask = 18; // 0o022, so we get rwxr-xr-x (once negated in exfat_stat())
++	if (ef->fmask == 0)
++		ef->fmask = 91; // 0o133. so we get rw-r--r-- (once negated in exfat_stat())
++#endif
++
+ 	ef->uid = get_int_option(options, "uid", 10, geteuid());
+ 	ef->gid = get_int_option(options, "gid", 10, getegid());
+ 
+-- 
+2.51.0
+
+
+From 7b4dc549639e366aedd93a0b5c5a2fecdbccf030 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Mon, 10 Nov 2025 14:18:33 -0300
+Subject: Propagate R/O flag.
+
+
+diff --git a/fuse/main.c b/fuse/main.c
+index f7aacb4..95762bc 100644
+--- a/fuse/main.c
++++ b/fuse/main.c
+@@ -395,6 +395,10 @@ static int fuse_exfat_statfs(UNUSED const char* path, struct statvfs* sfs)
+ 	sfs->f_favail = sfs->f_bfree >> ef.sb->spc_bits;
+ 	sfs->f_ffree = sfs->f_bavail;
+ 
++#ifdef __HAIKU__
++	sfs->f_flag = ((ef.ro != 0) ? ST_RDONLY : 0) | ST_NOSUID;
++#endif
++
+ 	return 0;
+ }
+ 
+-- 
+2.51.0
+


### PR DESCRIPTION
Leaving "extfat-utils" disabled, its commmands mostly overlap with the ones from "exfatprogs" (already available on repos), and that seems more actively maintained.

Note: the fuse-exfat module, while working mostly OK, causes a continuable KDL panic due to an assertion failure on unmount.

https://review.haiku-os.org/c/haiku/+/9743 is my attempt to fix that on Haiku's side.

----

Opening as Draft for now, most likely until after beta6 gets released. Still, should help test the mentioned changeset at least.

Also... needs testing on x86_32 bits.