### PR TITLE
abduco: do not pollute /boot/home.

### DIFF
--- a/app-misc/abduco/abduco-0.6.recipe
+++ b/app-misc/abduco/abduco-0.6.recipe
@@ -6,7 +6,7 @@ detached - run in the background - and then later reattached. Together with
 HOMEPAGE="http://www.brain-dump.org/projects/abduco"
 COPYRIGHT="2013-2016 Marc André Tanner"
 LICENSE="ISC"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://www.brain-dump.org/projects/abduco/abduco-$portVersion.tar.gz"
 CHECKSUM_SHA256="c90909e13fa95770b5afc3b59f311b3d3d2fdfae23f9569fa4f96a3e192a35f4"
 PATCHES="abduco-$portVersion.patchset"

--- a/app-misc/abduco/patches/abduco-0.6.patchset
+++ b/app-misc/abduco/patches/abduco-0.6.patchset
@@ -1,11 +1,11 @@
-From 8e72a6c7b99f91cb5e05e8fcc6edf3c30178f693 Mon Sep 17 00:00:00 2001
+From 3a1532637d5db56fbc17fcd070c2c70159bd7ea0 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Wed, 6 Aug 2025 12:40:46 -0300
 Subject: Initial Haiku patch.
 
 
 diff --git a/abduco.c b/abduco.c
-index 3c60a36..2682a13 100644
+index 3c60a36..dfc2081 100644
 --- a/abduco.c
 +++ b/abduco.c
 @@ -57,6 +57,8 @@
@@ -138,5 +138,41 @@ index 0000000..c6e466b
 +	return -1;
 +}
 -- 
-2.48.1
+2.51.0
+
+
+From 491918e8b32ab7c1074328cf214fcf0838bd9fdc Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Thu, 30 Oct 2025 02:29:13 -0300
+Subject: Quick fix to stop polluting /boot/home.
+
+
+diff --git a/abduco.1 b/abduco.1
+index 9d7e37d..9582a08 100644
+--- a/abduco.1
++++ b/abduco.1
+@@ -62,7 +62,7 @@ to succeed is used):
+ .nf
+ .PP
+ .B $ABDUCO_SOCKET_DIR/abduco
+-.B $HOME/.abduco
++.B $XDG_STATE_HOME/abduco
+ .B $TMPDIR/abduco/$USER
+ .B /tmp/abduco/$USER
+ .fi
+diff --git a/config.def.h b/config.def.h
+index 4fb3a94..e5c4a39 100644
+--- a/config.def.h
++++ b/config.def.h
+@@ -13,7 +13,7 @@ static struct Dir {
+ 	bool personal; /* if false a user owned sub directory will be created */
+ } socket_dirs[] = {
+ 	{ .env  = "ABDUCO_SOCKET_DIR", false },
+-	{ .env  = "HOME",              true  },
++	{ .env  = "XDG_STATE_HOME",    true  },
+ 	{ .env  = "TMPDIR",            false },
+ 	{ .path = "/tmp",              false },
+ };
+-- 
+2.51.0
 


### PR DESCRIPTION
Instead of creating a $HOME/.abduco dir, let it use XDG_STATE_HOME/abduco instead.