### PR TITLE
mold: new recipe.

### DIFF
--- a/sys-devel/mold/mold-2.40.4.recipe
+++ b/sys-devel/mold/mold-2.40.4.recipe
@@ -1,0 +1,113 @@
+SUMMARY="A Modern Linker"
+DESCRIPTION="mold is a faster drop-in replacement for existing Unix linkers.
+
+It is several times quicker than the LLVM lld linker, the second-fastest open-source linker.
+
+mold aims to enhance developer productivity by minimizing build time, particularly in rapid \
+debug-edit-rebuild cycles."
+HOMEPAGE="https://github.com/rui314/mold"
+COPYRIGHT="2023 Rui Ueyama"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://github.com/rui314/mold/archive/refs/tags/v$portVersion.tar.gz"
+SOURCE_FILENAME="$portBaseName-$portVersion.tar.gz"
+CHECKSUM_SHA256="69414c702ec1084e1fa8ca16da24f167f549e5e11e9ecd5d70a8dcda6f08c249"
+
+PATCHES="$portBaseName-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
+
+# On x86_gcc2 we don't want to install the commands in bin/<arch>/, but in bin/.
+#commandBinDir=$binDir
+#if [ "$targetArchitecture" = x86_gcc2 ]; then
+#	commandBinDir=$prefix/bin
+#fi
+
+PROVIDES="
+	$portName = $portVersion
+	cmd:ld.mold$secondaryArchSuffix = $portVersion
+	cmd:mold$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libblake3$secondaryArchSuffix
+#	lib:libtbb$secondaryArchSuffix >= 12
+	lib:libzstd$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libblake3$secondaryArchSuffix
+#	devel:libtbb$secondaryArchSuffix >= 12 # let's use the bundled copy for now.
+	devel:libzstd$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:g++$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	# cmd:mold # just to test if "-D MOLD_USE_MOLD=ON" works
+	"
+
+# Some tests require QEMU
+TEST_REQUIRES="
+	# cmd:ctest # already present along cmake.
+	cmd:lddtree	# used as 'lddtree -l' in place of 'ldd'. Doesn't seems to help much.
+	"
+
+BUILD()
+{
+	# Use the new system allocator on Haiku versions that have it.
+	maybeMiMalloc=
+	hrev=$(uname -v)
+	hrev=${hrev:4:5}
+	if [ $hrev -ge 57937 ]; then
+		maybeMiMalloc="-D MOLD_USE_MIMALLOC=OFF"
+	fi
+
+	cmake -B build -S . \
+		$cmakeDirArgs \
+		-D CMAKE_BUILD_TYPE=Release \
+		-D MOLD_LTO=OFF \
+		-D MOLD_USE_MOLD=OFF \
+		-D MOLD_ENABLE_QEMU_TESTS=OFF \
+		-D MOLD_USE_SYSTEM_TBB=OFF \
+		$maybeMiMalloc
+
+#		-D CMAKE_INSTALL_BINDIR=$commandBinDir \
+
+	# Enabling LTO (at least with GCC's ld) results in out of memory on my machines.
+
+	# Parallel builds require way too much RAM (8 GB not enough even for 3-cores, 2 *might* work).
+	# On only one core (Phenom II 2.8 GHz), a full build (LTO disabled) takes around 2 hours.
+	cmake --build build --parallel
+}
+
+INSTALL()
+{
+	cmake --install build
+}
+
+
+# *** BEWARE *** 2 tests crash (calling abort()), so either exclude them from the run as done in TEST(),
+# or be sure to add a default action to debugger (on ~/config/settings/system/debug_server/settings:
+
+# executable_actions {
+#	/sources/mold-*/mold kill
+#}
+
+# crashing tests are: "x86_64-arch-x86_64-exception-mcmodel-large" and "x86_64-exception"
+# hanging test (pegs one core to 100%) is: "x86_64-mold-wrapper"
+
+# On hrev59110 (similar results on beta5), x86_64:
+# 84% tests passed, 67 tests failed out of 420
+# Total Test time (real) =  76.38 sec
+TEST()
+{
+	ctest --test-dir build --parallel -E \
+		"(x86_64-arch-x86_64-exception-mcmodel-large|x86_64-exception|x86_64-mold-wrapper)"
+#	ctest --test-dir build --rerun-failed --output-on-failure
+}

--- a/sys-devel/mold/patches/mold-2.40.4.patchset
+++ b/sys-devel/mold/patches/mold-2.40.4.patchset
@@ -1,0 +1,306 @@
+From 0557b5b04e4a08dabe1f3e684c049fafbd2c470c Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Mon, 3 Nov 2025 04:25:55 -0300
+Subject: Fix compilation errors (taken from HaikuPort's tbb-2022.3.0.patchset)
+
+Manually applied.
+
+diff --git a/third-party/tbb/include/oneapi/tbb/detail/_config.h b/third-party/tbb/include/oneapi/tbb/detail/_config.h
+index 1bcd75f..c5a268b 100644
+--- a/third-party/tbb/include/oneapi/tbb/detail/_config.h
++++ b/third-party/tbb/include/oneapi/tbb/detail/_config.h
+@@ -276,7 +276,7 @@
+     #define __TBB_CPP20_COMPARISONS_PRESENT 0
+ #endif
+ 
+-#define __TBB_RESUMABLE_TASKS                           (!__TBB_WIN8UI_SUPPORT && !__ANDROID__ && !__QNXNTO__ && (!__linux__ || __GLIBC__))
++#define __TBB_RESUMABLE_TASKS                           (!__TBB_WIN8UI_SUPPORT && !__ANDROID__ && !__HAIKU__ && !__QNXNTO__ && (!__linux__ || __GLIBC__))
+ 
+ /* This macro marks incomplete code or comments describing ideas which are considered for the future.
+  * See also for plain comment with TODO and FIXME marks for small improvement opportunities.
+diff --git a/third-party/tbb/include/oneapi/tbb/detail/_export.h b/third-party/tbb/include/oneapi/tbb/detail/_export.h
+index 24b6c08..dae3d8a 100644
+--- a/third-party/tbb/include/oneapi/tbb/detail/_export.h
++++ b/third-party/tbb/include/oneapi/tbb/detail/_export.h
+@@ -21,7 +21,7 @@
+     #define __TBB_EXPORT __declspec(dllexport)
+ #elif defined(_WIN32) // Use .def files for these
+     #define __TBB_EXPORT
+-#elif defined(__unix__) || defined(__APPLE__) // Use .def files for these
++#elif defined(__unix__) || defined(__APPLE__) || defined(__HAIKU__) // Use .def files for these
+     #define __TBB_EXPORT __attribute__ ((visibility ("default")))
+ #else
+     #error "Unknown platform/compiler"
+diff --git a/third-party/tbb/src/tbb/allocator.cpp b/third-party/tbb/src/tbb/allocator.cpp
+index 689c512..db97d0c 100644
+--- a/third-party/tbb/src/tbb/allocator.cpp
++++ b/third-party/tbb/src/tbb/allocator.cpp
+@@ -40,7 +40,7 @@
+ // memalign() and it offers nothing but overhead due to inconvenient interface. This is likely the case with other
+ // standard libraries as well, and more libraries can be added to the preprocessor check below. Unfortunately, we
+ // can't detect musl, so we simply enable memalign() on Linux and Android in general.
+-#if defined(linux) || defined(__linux) || defined(__linux__) || defined(__ANDROID__)
++#if defined(linux) || defined(__linux) || defined(__linux__) || defined(__ANDROID__) || defined(__HAIKU__)
+ #include <malloc.h> // memalign
+ #define __TBB_USE_MEMALIGN
+ #else
+@@ -121,7 +121,7 @@ static const dynamic_link_descriptor MallocLinkTable[] = {
+ #define MALLOCLIB_NAME "libtbbmalloc" DEBUG_SUFFIX ".2.dylib"
+ #elif __FreeBSD__ || __NetBSD__ || __OpenBSD__ || __sun || _AIX || __ANDROID__
+ #define MALLOCLIB_NAME "libtbbmalloc" DEBUG_SUFFIX ".so"
+-#elif __unix__  // Note that order of these #elif's is important!
++#elif __unix__ || __HAIKU__  // Note that order of these #elif's is important!
+ #define MALLOCLIB_NAME "libtbbmalloc" DEBUG_SUFFIX ".so.2"
+ #else
+ #error Unknown OS
+diff --git a/third-party/tbb/src/tbb/rml_tbb.cpp b/third-party/tbb/src/tbb/rml_tbb.cpp
+index d1cd285..6b9b731 100644
+--- a/third-party/tbb/src/tbb/rml_tbb.cpp
++++ b/third-party/tbb/src/tbb/rml_tbb.cpp
+@@ -52,7 +52,7 @@ namespace rml {
+ #define RML_SERVER_NAME "libirml" DEBUG_SUFFIX ".1.dylib"
+ #elif __FreeBSD__ || __NetBSD__ || __OpenBSD__ || __sun || _AIX
+ #define RML_SERVER_NAME "libirml" DEBUG_SUFFIX ".so"
+-#elif __unix__
++#elif __unix__ || __HAIKU__
+ #define RML_SERVER_NAME "libirml" DEBUG_SUFFIX ".so.1"
+ #else
+ #error Unknown OS
+diff --git a/third-party/tbb/src/tbbmalloc/frontend.cpp b/third-party/tbb/src/tbbmalloc/frontend.cpp
+index f05aff2..1315e33 100644
+--- a/third-party/tbb/src/tbbmalloc/frontend.cpp
++++ b/third-party/tbb/src/tbbmalloc/frontend.cpp
+@@ -776,7 +776,7 @@ static inline unsigned int highestBitPos(unsigned int n)
+     unsigned int pos;
+ #if __ARCH_x86_32||__ARCH_x86_64
+ 
+-# if __unix__||__APPLE__||__MINGW32__
++# if __unix__||__APPLE__||__MINGW32__||__HAIKU__
+     __asm__ ("bsr %1,%0" : "=r"(pos) : "r"(n));
+ # elif (_WIN32 && (!_WIN64 || __INTEL_COMPILER))
+     __asm
+diff --git a/third-party/tbb/src/tbbmalloc/tbbmalloc.cpp b/third-party/tbb/src/tbbmalloc/tbbmalloc.cpp
+index b72e03a..7b68679 100644
+--- a/third-party/tbb/src/tbbmalloc/tbbmalloc.cpp
++++ b/third-party/tbb/src/tbbmalloc/tbbmalloc.cpp
+@@ -45,7 +45,7 @@ namespace internal {
+ #define MALLOCLIB_NAME "libtbbmalloc" DEBUG_SUFFIX ".2.dylib"
+ #elif __FreeBSD__ || __NetBSD__ || __OpenBSD__ || __sun || _AIX || __ANDROID__
+ #define MALLOCLIB_NAME "libtbbmalloc" DEBUG_SUFFIX ".so"
+-#elif __unix__
++#elif __unix__ || __HAIKU__
+ #define MALLOCLIB_NAME "libtbbmalloc" DEBUG_SUFFIX  __TBB_STRING(.so.2)
+ #else
+ #error Unknown OS
+-- 
+2.51.0
+
+
+From 5be1b8f2cd06089a366a35a08c4d14a9c3e9bc52 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Mon, 3 Nov 2025 04:26:02 -0300
+Subject: Allow compilation on Haiku's revisions older than hrev58813.
+
+Older versions don't support RTLD_NOLOAD.
+
+This commit can be dropped after HaikuPorts builder (eventually)
+switch to beta6.
+
+(manually applied commit taken from from tbb-2022.3.0.patchset)
+
+diff --git a/third-party/tbb/src/tbb/dynamic_link.cpp b/third-party/tbb/src/tbb/dynamic_link.cpp
+index a21beb5..3d6a1a0 100644
+--- a/third-party/tbb/src/tbb/dynamic_link.cpp
++++ b/third-party/tbb/src/tbb/dynamic_link.cpp
+@@ -389,7 +389,14 @@ namespace r1 {
+     #endif /* !__TBB_DYNAMIC_LOAD_ENABLED */
+         // RTLD_GLOBAL - to guarantee that old TBB will find the loaded library
+         // RTLD_NOLOAD - not to load the library without the full path
++    // Work-around for building on Haiku < hrev58813.
++    #ifdef RTLD_NOLOAD
+         library_handle = dlopen(library, RTLD_LAZY | RTLD_GLOBAL | RTLD_NOLOAD);
++    #else
++        // Nay trigger benign, but spurious, runtime_loader messages when calling this.
++        // ("mold" suffers from this, for example)
++        library_handle = dlopen(library, RTLD_LAZY | RTLD_GLOBAL);
++    #endif
+ #endif /* _WIN32 */
+         if (library_handle) {
+             if (!resolve_symbols(library_handle, descriptors, required)) {
+-- 
+2.51.0
+
+
+From d72423fbd3d5c50b6721ef2bb177f736a2344fcc Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Mon, 3 Nov 2025 04:26:07 -0300
+Subject: Equate elf_x86_64_haiku to elf_x86_64.
+
+Unsure if this is really needed for normal operation, but makes the test suite
+go from 27% passed to 83%. Might be better/enough to fix the test suite instead?
+
+diff --git a/src/cmdline.cc b/src/cmdline.cc
+index 3b5e47d..427a142 100644
+--- a/src/cmdline.cc
++++ b/src/cmdline.cc
+@@ -762,7 +762,7 @@ std::vector<std::string> parse_nonpositional_args(Context<E> &ctx) {
+     } else if (read_arg("mllvm")) {
+       ctx.arg.plugin_opt.emplace_back(arg);
+     } else if (read_arg("m")) {
+-      if (arg == "elf_x86_64") {
++      if (arg == "elf_x86_64" || arg == "elf_x86_64_haiku") {
+         ctx.arg.emulation = X86_64::name;
+       } else if (arg == "elf_i386") {
+         ctx.arg.emulation = I386::name;
+-- 
+2.51.0
+
+
+From 6b19bea66fddeff7546484e61fdd2ec09f56f919 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Mon, 3 Nov 2025 04:26:11 -0300
+Subject: QnD implementation of get_self_path() on Haiku.
+
+This fixes 13 of the 15 crashes previously seen on the test suite.
+
+diff --git a/lib/filepath.cc b/lib/filepath.cc
+index 988a059..1c8f368 100644
+--- a/lib/filepath.cc
++++ b/lib/filepath.cc
+@@ -11,6 +11,11 @@
+ # include <sys/sysctl.h>
+ #endif
+ 
++#ifdef __HAIKU__
++# include <OS.h>
++# include <cstdlib>
++#endif
++
+ namespace mold {
+ 
+ // Returns the path of the mold executable itself
+@@ -34,6 +39,22 @@ std::string get_self_path() {
+   path.resize(size);
+   sysctl(mib, 4, path.data(), &size, NULL, 0);
+   return path;
++#elif __HAIKU__
++  // Quick and dirty code.
++  std::string path = "";
++
++  team_info info;
++  status_t status = get_team_info(B_CURRENT_TEAM, &info);
++  if (status != B_OK)
++    return path;
++
++  // only interested on the proc name:
++  path = info.args;
++  int n = path.find(" ");
++  if (n != std::string::npos)
++    path.resize(n);
++
++  return realpath(path.c_str(), NULL);
+ #else
+   return std::filesystem::read_symlink("/proc/self/exe").string();
+ #endif
+-- 
+2.51.0
+
+
+From e5f8408542250cd100229fe41c2caac84a3662f2 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Mon, 3 Nov 2025 04:26:17 -0300
+Subject: tests: use "lddtree -l" in place of "ldd".
+
+We don't have `cmd:ldd` on the repos, let's use the closest thing we have.
+
+Doesn't seems to make much of difference in results, though.
+
+diff --git a/test/mold-wrapper.sh b/test/mold-wrapper.sh
+index 9a4e37e..d34bb53 100755
+--- a/test/mold-wrapper.sh
++++ b/test/mold-wrapper.sh
+@@ -3,7 +3,7 @@
+ 
+ [ "$CC" = cc ] || skip
+ 
+-ldd mold-wrapper.so | grep libasan && skip
++lddtree -l mold-wrapper.so | grep libasan && skip
+ 
+ nm mold | grep '__[at]san_init' && skip
+ 
+diff --git a/test/mold-wrapper2.sh b/test/mold-wrapper2.sh
+index 2e4605b..a0adc44 100755
+--- a/test/mold-wrapper2.sh
++++ b/test/mold-wrapper2.sh
+@@ -1,7 +1,7 @@
+ #!/bin/bash
+ . $(dirname $0)/common.inc
+ 
+-ldd mold-wrapper.so | grep libasan && skip
++lddtree -l mold-wrapper.so | grep libasan && skip
+ nm mold | grep '__[at]san_init' && skip
+ 
+ ./mold -run bash -c 'echo $LD_PRELOAD' | grep -F mold-wrapper.so
+-- 
+2.51.0
+
+
+From d1e4182290a20abe321534c68b0c963980b08863 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Mon, 3 Nov 2025 04:26:21 -0300
+Subject: tests: use "/bin/ld" instead of "/usr/bin/ld".
+
+Doesn't seems to make much of difference in results, though.
+
+diff --git a/test/mold-wrapper.sh b/test/mold-wrapper.sh
+index d34bb53..815aef7 100755
+--- a/test/mold-wrapper.sh
++++ b/test/mold-wrapper.sh
+@@ -26,38 +26,38 @@ extern char **environ;
+ 
+ int main(int argc, char **argv) {
+   if (!strcmp(argv[1], "execl")) {
+-    execl("/usr/bin/ld", "/usr/bin/ld", "execl", (char *)0);
++    execl("/bin/ld", "/bin/ld", "execl", (char *)0);
+     perror("execl");
+     return 1;
+   }
+ 
+   if (!strcmp(argv[1], "execlp")) {
+-    execlp("/usr/bin/ld", "/usr/bin/ld", "execlp", (char *)0);
++    execlp("/bin/ld", "/bin/ld", "execlp", (char *)0);
+     perror("execl");
+     return 1;
+   }
+ 
+   if (!strcmp(argv[1], "execle")) {
+-    execle("/usr/bin/ld", "/usr/bin/ld", "execle", (char *)0, environ);
++    execle("/bin/ld", "/bin/ld", "execle", (char *)0, environ);
+     perror("execl");
+     return 1;
+   }
+ 
+   if (!strcmp(argv[1], "execv")) {
+-    execv("/usr/bin/ld", (char *[]){"/usr/bin/ld", "execv", (char *)0});
++    execv("/bin/ld", (char *[]){"/bin/ld", "execv", (char *)0});
+     perror("execl");
+     return 1;
+   }
+ 
+   if (!strcmp(argv[1], "execvp")) {
+-    execvp("/usr/bin/ld", (char *[]){"/usr/bin/ld", "execvp", (char *)0});
++    execvp("/bin/ld", (char *[]){"/bin/ld", "execvp", (char *)0});
+     perror("execl");
+     return 1;
+   }
+ 
+   if (!strcmp(argv[1], "execvpe")) {
+     char *env[] = {"FOO=bar", NULL};
+-    execvpe("/usr/bin/ld", (char *[]){"/usr/bin/ld", "execvpe", (char *)0}, env);
++    execvpe("/bin/ld", (char *[]){"/bin/ld", "execvpe", (char *)0}, env);
+     perror("execl");
+     return 1;
+   }
+-- 
+2.51.0
+


### PR DESCRIPTION
Seems to work OK so far (tested it using `-fuse-ld=mold`) on x86_64.

My quick tests at (repeatedly) re-linking Pe, for example, show timings like these:

- ld: 2.7 to 3 seconds (Pe binary size: 1.32 MiB).
- mold: 1.7 to 2 seconds (Pe binary size: 1.5 MiB).