### PR TITLE
emacs: fixed the alt-key problem

### DIFF
--- a/app-editors/emacs/emacs-30.1.recipe
+++ b/app-editors/emacs/emacs-30.1.recipe
@@ -13,7 +13,7 @@ news reader, debugger interface, calendar, and more.
 HOMEPAGE="https://gnu.org/s/emacs/"
 COPYRIGHT="2001-2025 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://ftpmirror.gnu.org/emacs/emacs-$portVersion.tar.gz"
 CHECKSUM_SHA256="54404782ea5de37e8fcc4391fa9d4a41359a4ba9689b541f6bc97dd1ac283f6c"
 ADDITIONAL_FILES="emacs.rdef.in"

--- a/app-editors/emacs/patches/emacs-30.1.patchset
+++ b/app-editors/emacs/patches/emacs-30.1.patchset
@@ -1,4 +1,4 @@
-From f0a79ed3efc3f2b63a7115b41010b835529c64a5 Mon Sep 17 00:00:00 2001
+From 3f052c39ec8335691c0b9d63cdc743235e8687d5 Mon Sep 17 00:00:00 2001
 From: Chris Roberts <cpr420@gmail.com>
 Date: Sun, 30 Jul 2023 01:14:33 -0600
 Subject: disable `be-resources` when building from HaikuPorts
@@ -9,10 +9,10 @@ the haiku_datatranslators package active when building which causes
 file.
 
 diff --git a/src/Makefile.in b/src/Makefile.in
-index 9bc53c0..a3e467b 100644
+index b5d88eb..5b0c42c 100644
 --- a/src/Makefile.in
 +++ b/src/Makefile.in
-@@ -632,8 +632,8 @@ endif
+@@ -673,8 +673,8 @@ endif
  ifeq ($(HAVE_BE_APP),yes)
  Emacs: emacs$(EXEEXT) $(libsrc)/be-resources
  	$(AM_V_GEN) cp -f emacs$(EXEEXT) $@
@@ -24,5 +24,123 @@ index 9bc53c0..a3e467b 100644
  	$(AM_V_GEN) cp -f $(pdmp) $@
  endif
 -- 
-2.39.2
+2.45.2
+
+
+From a051077da617a62c7580eb9504044a75e30ff36a Mon Sep 17 00:00:00 2001
+From: Vincent Filou <vincent.filou@gmail.com>
+Date: Sun, 9 Nov 2025 19:02:38 +0000
+Subject: alt key fix
+
+
+diff --git a/src/haiku_support.cc b/src/haiku_support.cc
+index 782e9a3..64abb2e 100644
+--- a/src/haiku_support.cc
++++ b/src/haiku_support.cc
+@@ -427,6 +427,40 @@ map_caps (uint32_t kc, uint32_t *ch)
+   key_map_lock.Unlock ();
+ }
+ 
++static void
++map_option (uint32_t kc, uint32_t *ch)
++{
++  if (!key_map_lock.Lock ())
++    gui_abort ("Failed to lock keymap");
++  if (!key_map)
++    get_key_map (&key_map, &key_chars);
++  if (!key_map)
++    return;
++  if (kc >= 128)
++    return;
++
++  int32_t m = key_map->option_map[kc];
++  map_key (key_chars, m, ch);
++  key_map_lock.Unlock ();
++}
++
++static void
++map_shift_option (uint32_t kc, uint32_t *ch)
++{
++  if (!key_map_lock.Lock ())
++    gui_abort ("Failed to lock keymap");
++  if (!key_map)
++    get_key_map (&key_map, &key_chars);
++  if (!key_map)
++    return;
++  if (kc >= 128)
++    return;
++
++  int32_t m = key_map->option_shift_map[kc];
++  map_key (key_chars, m, ch);
++  key_map_lock.Unlock ();
++}
++
+ static void
+ map_caps_shift (uint32_t kc, uint32_t *ch)
+ {
+@@ -1087,7 +1121,7 @@ class EmacsWindow : public BWindow
+ 	if (mods & B_COMMAND_KEY)
+ 	  rq.modifiers |= HAIKU_MODIFIER_ALT;
+ 
+-	if (mods & B_OPTION_KEY)
++	if (mods & B_LEFT_OPTION_KEY)
+ 	  rq.modifiers |= HAIKU_MODIFIER_SUPER;
+ 
+ 	/* mods & B_SHIFT_KEY should be inverted if keycode is
+@@ -1137,14 +1171,21 @@ class EmacsWindow : public BWindow
+ 		if (mods & B_CAPS_LOCK)
+ 		  map_caps_shift (key, &rq.multibyte_char);
+ 		else
+-		  map_shift (key, &rq.multibyte_char);
++		  if(mods & B_RIGHT_OPTION_KEY)
++			map_shift_option(key, &rq.multibyte_char);
++		  else
++			map_shift (key, &rq.multibyte_char);
+ 	      }
+ 	    else
+ 	      {
+-		if (mods & B_CAPS_LOCK)
+-		  map_caps (key, &rq.multibyte_char);
+-		else
+-		  map_normal (key, &rq.multibyte_char);
++			if(mods & B_RIGHT_OPTION_KEY)
++				map_option(key, &rq.multibyte_char);
++			else{
++				if (mods & B_CAPS_LOCK)
++					map_caps (key, &rq.multibyte_char);
++				else
++					map_normal (key, &rq.multibyte_char);
++			}
+ 	      }
+ 	  }
+ 
+@@ -1167,7 +1208,7 @@ class EmacsWindow : public BWindow
+ 	if (mods & B_COMMAND_KEY)
+ 	  rq.modifiers |= HAIKU_MODIFIER_ALT;
+ 
+-	if (mods & B_OPTION_KEY)
++	if (mods & B_LEFT_OPTION_KEY)
+ 	  rq.modifiers |= HAIKU_MODIFIER_SUPER;
+ 
+ 	float dx, dy;
+@@ -2013,7 +2054,7 @@ class EmacsView : public BView
+     if (mods & B_COMMAND_KEY)
+       rq.modifiers |= HAIKU_MODIFIER_ALT;
+ 
+-    if (mods & B_OPTION_KEY)
++    if (mods & B_LEFT_OPTION_KEY)
+       rq.modifiers |= HAIKU_MODIFIER_SUPER;
+ 
+     if (!scroll_bar)
+@@ -2100,7 +2141,7 @@ class EmacsView : public BView
+     if (mods & B_COMMAND_KEY)
+       rq.modifiers |= HAIKU_MODIFIER_ALT;
+ 
+-    if (mods & B_OPTION_KEY)
++    if (mods & B_LEFT_OPTION_KEY)
+       rq.modifiers |= HAIKU_MODIFIER_SUPER;
+ 
+     rq.time = when;
+-- 
+2.45.2
 


### PR DESCRIPTION
See https://www.gnu.org/software/emacs/manual/html_node/emacs/Haiku-Basics.html

"Emacs is incapable of receiving unusual modifier keys such as Hyper under Haiku, or to receive accented characters produced from the system Super key map."

Distinguish between left and right option keys.  The right can be used for accents, the left for 'super'