### PR TITLE
mold: disable parallel build.

### DIFF
--- a/sys-devel/mold/mold-2.40.4.recipe
+++ b/sys-devel/mold/mold-2.40.4.recipe
@@ -83,7 +83,7 @@ BUILD()
 
 	# Parallel builds require way too much RAM (8 GB not enough even for 3-cores, 2 *might* work).
 	# On only one core (Phenom II 2.8 GHz), a full build (LTO disabled) takes around 2 hours.
-	cmake --build build --parallel
+	cmake --build build
 }
 
 INSTALL()


### PR DESCRIPTION
Triggers out-of-mem errors too easily.