### PR TITLE
brie: change defineDebugInfoPackage call (haikuporter change)

### DIFF
--- a/haiku-apps/brie/brie-0.4.recipe
+++ b/haiku-apps/brie/brie-0.4.recipe
@@ -31,7 +31,7 @@ BUILD_PREREQUIRES="
 	cmd:make
 	"
 
-defineDebugInfoPackage brie \
+defineDebugInfoPackage "" \
 	$appsDir/BRIE
 
 BUILD()


### PR DESCRIPTION
This is a first test and to demonstrate haikuports/haikuporter#349.

Note: if this is going to be merged, all current usages of defineDebugInfoPackage need to be changed like this. This should be doable with a mass replacement.

No revision bump is needed because the output doesn't change, only the input syntax.