### PR TITLE
quickjs: new recipe.

### DIFF
--- a/dev-lang/quickjs/patches/quickjs-2025.09.13.2.patchset
+++ b/dev-lang/quickjs/patches/quickjs-2025.09.13.2.patchset
@@ -1,0 +1,90 @@
+From e3cdc02c01716190bbb8d0bf73b736e135b5225d Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Tue, 11 Nov 2025 06:24:05 -0300
+Subject: Haiku build fixes.
+
+
+diff --git a/Makefile b/Makefile
+index 3b1c745..633ef68 100644
+--- a/Makefile
++++ b/Makefile
+@@ -22,6 +22,9 @@
+ # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ # THE SOFTWARE.
+ 
++ifeq ($(shell uname -s),Haiku)
++CONFIG_HAIKU=y
++endif
+ ifeq ($(shell uname -s),Darwin)
+ CONFIG_DARWIN=y
+ endif
+@@ -246,8 +249,10 @@ QJS_OBJS=$(OBJDIR)/qjs.o $(OBJDIR)/repl.o $(QJS_LIB_OBJS)
+ HOST_LIBS=-lm -ldl -lpthread
+ LIBS=-lm -lpthread
+ ifndef CONFIG_WIN32
++ifndef CONFIG_HAIKU
+ LIBS+=-ldl
+ endif
++endif
+ LIBS+=$(EXTRA_LIBS)
+ 
+ $(OBJDIR):
+diff --git a/qjsc.c b/qjsc.c
+index e55ca61..56f3687 100644
+--- a/qjsc.c
++++ b/qjsc.c
+@@ -502,7 +502,9 @@ static int output_executable(const char *out_filename, const char *cfilename,
+              lib_dir, bn_suffix, lto_suffix);
+     *arg++ = libjsname;
+     *arg++ = "-lm";
++#ifndef __HAIKU__
+     *arg++ = "-ldl";
++#endif
+     *arg++ = "-lpthread";
+     *arg = NULL;
+ 
+-- 
+2.50.1
+
+
+From 3aa7dbe07431a5e5330dfe750ec29e6adbef74c2 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Tue, 11 Nov 2025 06:44:53 -0300
+Subject: Fix install locations.
+
+
+diff --git a/Makefile b/Makefile
+index 633ef68..dc28717 100644
+--- a/Makefile
++++ b/Makefile
+@@ -47,6 +47,8 @@ endif
+ 
+ # installation directory
+ PREFIX?=/usr/local
++LIBDIR?=$(PREFIX)/lib/quickjs
++HEADERSDIR?=$(PREFIX)/include
+ 
+ # use the gprof profiler
+ #CONFIG_PROFILE=y
+@@ -373,13 +375,13 @@ install: all
+ 	mkdir -p "$(DESTDIR)$(PREFIX)/bin"
+ 	$(STRIP) qjs$(EXE) qjsc$(EXE)
+ 	install -m755 qjs$(EXE) qjsc$(EXE) "$(DESTDIR)$(PREFIX)/bin"
+-	mkdir -p "$(DESTDIR)$(PREFIX)/lib/quickjs"
+-	install -m644 libquickjs.a "$(DESTDIR)$(PREFIX)/lib/quickjs"
++	mkdir -p "$(DESTDIR)$(LIBDIR)"
++	install -m644 libquickjs.a "$(DESTDIR)$(LIBDIR)"
+ ifdef CONFIG_LTO
+-	install -m644 libquickjs.lto.a "$(DESTDIR)$(PREFIX)/lib/quickjs"
++	install -m644 libquickjs.lto.a "$(DESTDIR)$(LIBDIR)"
+ endif
+-	mkdir -p "$(DESTDIR)$(PREFIX)/include/quickjs"
+-	install -m644 quickjs.h quickjs-libc.h "$(DESTDIR)$(PREFIX)/include/quickjs"
++	mkdir -p "$(DESTDIR)$(HEADERSDIR)/quickjs"
++	install -m644 quickjs.h quickjs-libc.h "$(DESTDIR)$(HEADERSDIR)/quickjs"
+ 
+ ###############################################################################
+ # examples
+-- 
+2.50.1
+

--- a/dev-lang/quickjs/quickjs-2025.09.13.2.recipe
+++ b/dev-lang/quickjs/quickjs-2025.09.13.2.recipe
@@ -1,0 +1,112 @@
+SUMMARY="Small and embeddable Javascript engine"
+DESCRIPTION="QuickJS is a small and embeddable Javascript engine. It supports the ES2023 \
+specification including modules, asynchronous generators, proxies and BigInt.
+
+Main Features:
+
+* Small and easily embeddable: just a few C files, no external dependency, 367 KiB of x86 code \
+for a simple hello world program.
+* Fast interpreter with very low startup time: runs the 78000 tests of the ECMAScript Test Suite \
+in about 2 minutes on a single core of a desktop PC. The complete life cycle of a runtime \
+instance completes in less than 300 microseconds.
+* Almost complete ES2023 support including modules, asynchronous generators and full Annex B \
+support (legacy web compatibility).
+* Passes nearly 100% of the ECMAScript Test Suite tests when selecting the ES2023 features (see \
+test262.fyi).
+* Can compile Javascript sources to executables with no external dependency.
+* Garbage collection using reference counting (to reduce memory usage and have deterministic \
+behavior) with cycle removal.
+* Command line interpreter with contextual colorization implemented in Javascript.
+* Small built-in standard library with C library wrappers.
+"
+HOMEPAGE="https://bellard.org/quickjs/"
+COPYRIGHT="2017-2021 Fabrice Bellard
+	2017-2021 Charlie Gordon"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://bellard.org/quickjs/quickjs-${portVersion//./-}.tar.xz"
+CHECKSUM_SHA256="996c6b5018fc955ad4d06426d0e9cb713685a00c825aa5c0418bd53f7df8b0b4"
+_version=${portVersion//./-}
+SOURCE_DIR="quickjs-${_version%-*}"
+PATCHES="quickjs-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	$portName = $portVersion
+	cmd:qjs = $portVersion
+	cmd:qjsc = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	${portName}_devel = $portVersion
+	devel:libquickjs$secondaryArchSuffix = $portVersion
+	devel:libquickjs.lto$secondaryArchSuffix = $portVersion
+	"
+REQUIRES_devel="
+	$portName == $portVersion base
+	"
+
+ARCHITECTURES_doc="any"
+PROVIDES_doc="
+	${portBaseName}_doc
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	"
+
+BUILD()
+{
+	CONFIG_LTO=y \
+		make $jobArgs
+}
+
+INSTALL()
+{
+	CONFIG_LTO=y \
+	PREFIX=$prefix \
+	LIBDIR=$developLibDir \
+	HEADERSDIR=$developDir \
+		make install
+
+	# devel package
+	packageEntries devel \
+		$developDir
+
+	# doc package
+	install -d $documentationDir/packages/$portBaseName
+	install -t $documentationDir/packages/$portBaseName doc/quickjs.pdf
+	install -t $documentationDir/packages/$portBaseName doc/quickjs.html
+
+	packageEntries doc \
+		$documentationDir
+}
+
+
+# On hrev59057 x86_32 (VMWare), got:
+# Error: assertion failed: got number:|29256|, expected number:|29312| (order of operations / precision in MakeTime)
+#     at throw_error (tests/test_builtin.js:8:20)
+#     at assert (tests/test_builtin.js:46:16)
+#     at test_date (tests/test_builtin.js:694:15)
+#     at <eval> (tests/test_builtin.js:1174:10)
+# make: *** [Makefile:455: test] Error 1
+#
+# On hrev59110 x86_64 (VMware), got:
+# Error: assertion failed: got |false|, expected |true|
+#     at assert (tests/test_std.js:17:16)
+#     at test_os (tests/test_std.js:236:11)
+#     at <anonymous> (tests/test_std.js:330:8)
+# make: *** [Makefile:460: test] Error 1
+TEST()
+{
+	make test $jobArgs
+}


### PR DESCRIPTION
Motivation to add it: yt-dlp requires a Javascript engine to be able to download from Youtube now, and all the other supported "js backends" are either very large (node, deno, bun), or slower (quickjs-ng), in comparison to this one.

----

Opening as draft for now, as I haven't yet confirmed if it works OK with yt-dlp on Haiku (it works fine on other platforms).

Also, only tested builds on 32 and 64 bits nightlies.