### PR TITLE
glib2: split debuginfo

### DIFF
--- a/dev-libs/glib/glib2-2.81.0.recipe
+++ b/dev-libs/glib/glib2-2.81.0.recipe
@@ -20,7 +20,7 @@ COPYRIGHT="1995-1997  Peter Mattis, Spencer Kimball and Josh MacDonald
 	2008-2010 Collabora Ltd.
 	1995-2010 Several others"
 LICENSE="GNU LGPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://gitlab.gnome.org/GNOME/glib/-/archive/$portVersion/glib-$portVersion.tar.gz"
 CHECKSUM_SHA256="e9c311a25abb5717fb83f0f3a36daddc039e61fe37cea61cad4d0e455a6cdca0"
 SOURCE_DIR="glib-$portVersion"
@@ -182,7 +182,7 @@ BUILD_PREREQUIRES="
 	cmd:which
 	"
 
-defineDebugInfoPackage glib2$secondaryArchSuffix \
+defineDebugInfoPackage "" \
 	$commandBinDir/gapplication \
 	$commandBinDir/gdbus \
 	$commandBinDir/gi-compile-repository \
@@ -196,16 +196,24 @@ defineDebugInfoPackage glib2$secondaryArchSuffix \
 	$(getPackagePrefix devel)/bin/gobject-query \
 	$(getPackagePrefix devel)/bin/gresource \
 	$(getPackagePrefix devel)/bin/gtester \
-	$(getPackagePrefix gi)/bin/g-ir-compiler \
-	$(getPackagePrefix gi)/bin/g-ir-generate \
-	$(getPackagePrefix gi)/bin/g-ir-inspect \
 	$libDir/libgio-2.0.so.$libVersion \
-	$(getPackagePrefix gi)/$relativeLibDir/libgirepository-1.0.so.$libGiVersion \
 	$libDir/libgirepository-2.0.so.$libVersion \
 	$libDir/libglib-2.0.so.$libVersion \
 	$libDir/libgmodule-2.0.so.$libVersion \
 	$libDir/libgobject-2.0.so.$libVersion \
 	$libDir/libgthread-2.0.so.$libVersion
+
+PACKAGE_NAME_gi_debuginfo="gobject_introspection${secondaryArchSuffix}_debuginfo"
+PACKAGE_VERSION_gi_debuginfo=$PACKAGE_VERSION_gi
+
+SUMMARY_gi_debuginfo="$SUMMARY_gi (debug info)"
+DESCRIPTION_gi_debuginfo="$DESCRIPTION_gi"
+
+defineDebugInfoPackage gi \
+	$(getPackagePrefix gi)/bin/g-ir-compiler \
+	$(getPackagePrefix gi)/bin/g-ir-generate \
+	$(getPackagePrefix gi)/bin/g-ir-inspect \
+	$(getPackagePrefix gi)/$relativeLibDir/libgirepository-1.0.so.$libGiVersion
 
 PATCH()
 {


### PR DESCRIPTION
This is another, more complex example of haikuports/haikuporter#349 to also split the debuginfo package.

based on #13195