### PR TITLE
LZDoom: 32bit fix

### DIFF
--- a/games-fps/lzdoom/lzdoom-4.11.4.recipe
+++ b/games-fps/lzdoom/lzdoom-4.11.4.recipe
@@ -9,6 +9,7 @@ on older hardware which does not support modern OpenGL features.
 LZDoom comes with 2 optional UIs, a feature-rich one enabled by installing GTK3, \
 and a more lightweight one using KDialog.
 Running LZDoom without installed UIs from command-line will provide a simple .wad selection menu.
+These interfaces require compatible game data (.wad, .pk3 or other) to be present to work properly.
 
 The binaries will look for .wad files in:
 * ~/config/non-packaged/data/lzdoom
@@ -24,7 +25,7 @@ COPYRIGHT="
 	1997 id Software, Raven Software, and contributors
 	"
 LICENSE="GNU GPL v3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/drfrag666/lzdoom/archive/l$portVersion.tar.gz"
 CHECKSUM_SHA256="dd4fc8ea2a566cb6b614b1aede39a0cc57a4f9d81b3c0f5e74323e92aea8c05e"
 SOURCE_DIR="lzdoom-l$portVersion"

--- a/games-fps/lzdoom/patches/lzdoom-4.11.4.patchset
+++ b/games-fps/lzdoom/patches/lzdoom-4.11.4.patchset
@@ -1,4 +1,4 @@
-From 81506e0b8db5023b5c4d00e0f9cb92966c2dcce5 Mon Sep 17 00:00:00 2001
+From c3162d5458aaaf8bd9d632725aff6be56fea5433 Mon Sep 17 00:00:00 2001
 From: Peppersawce <michaelpeppers89@yahoo.it>
 Date: Sun, 2 Nov 2025 19:05:29 +0100
 Subject: Apply fixes taken from GZDoom patches
@@ -91,7 +91,7 @@ index 4ef00dc..111c05c 100644
 +	}*/
  }
 diff --git a/src/gameconfigfile.cpp b/src/gameconfigfile.cpp
-index 15a03f8..5ab910f 100644
+index 15a03f8..dd18c16 100644
 --- a/src/gameconfigfile.cpp
 +++ b/src/gameconfigfile.cpp
 @@ -107,6 +107,14 @@ FGameConfigFile::FGameConfigFile ()
@@ -109,7 +109,7 @@ index 15a03f8..5ab910f 100644
  #ifdef __APPLE__
  		SetValueForKey ("Path", user_docs.GetChars(), true);
  		SetValueForKey ("Path", user_app_support.GetChars(), true);
-@@ -132,6 +141,14 @@ FGameConfigFile::FGameConfigFile ()
+@@ -132,6 +140,14 @@ FGameConfigFile::FGameConfigFile ()
  	if (!SetSection ("FileSearch.Directories"))
  	{
  		SetSection ("FileSearch.Directories", true);
@@ -124,7 +124,7 @@ index 15a03f8..5ab910f 100644
  #ifdef __APPLE__
  		SetValueForKey ("Path", user_docs.GetChars(), true);
  		SetValueForKey ("Path", user_app_support.GetChars(), true);
-@@ -155,6 +173,10 @@ FGameConfigFile::FGameConfigFile ()
+@@ -155,6 +171,10 @@ FGameConfigFile::FGameConfigFile ()
  	if (!SetSection("SoundfontSearch.Directories"))
  	{
  		SetSection("SoundfontSearch.Directories", true);
@@ -152,7 +152,7 @@ index 9f8326f..becd527 100644
 2.51.0
 
 
-From 28ea63726322fa26c369ba4a2b01c286c2d27eb7 Mon Sep 17 00:00:00 2001
+From b6bd9498c2313411858bdfe3b8828423fb63270a Mon Sep 17 00:00:00 2001
 From: Peppersawce <michaelpeppers89@yahoo.it>
 Date: Sun, 2 Nov 2025 19:55:54 +0100
 Subject: More patches ported from GZDoom
@@ -205,7 +205,7 @@ index 01710b6..fb75230 100644
 2.51.0
 
 
-From 4048dc2916cbea65f5ed64236ac34d4804cfbb6b Mon Sep 17 00:00:00 2001
+From 9d93eebe1e098b45807bcc247015e43ba7333c12 Mon Sep 17 00:00:00 2001
 From: Peppersawce <michaelpeppers89@yahoo.it>
 Date: Mon, 3 Nov 2025 12:54:32 +0100
 Subject: Replaxe xdg-open with open
@@ -231,3 +231,62 @@ index 58a6a2f..dd2b659 100644
 -- 
 2.51.0
 
+
+From d7f391fc77737a4365a9b18a29ece72b9aef5a15 Mon Sep 17 00:00:00 2001
+From: Peppersawce <michaelpeppers89@yahoo.it>
+Date: Wed, 12 Nov 2025 11:38:16 +0100
+Subject: Fix build for x86
+
+
+diff --git a/src/common/platform/posix/sdl/sdlglvideo.cpp b/src/common/platform/posix/sdl/sdlglvideo.cpp
+index 6f1de4b..2992a21 100644
+--- a/src/common/platform/posix/sdl/sdlglvideo.cpp
++++ b/src/common/platform/posix/sdl/sdlglvideo.cpp
+@@ -452,7 +452,7 @@ DFrameBuffer *SDLVideo::CreateFrameBuffer ()
+ 				builder.RequireExtension(names[i]);
+ 			auto instance = builder.Create();
+ 
+-			VkSurfaceKHR surfacehandle = nullptr;
++			VkSurfaceKHR surfacehandle = VK_NULL_HANDLE;
+ 			if (!I_CreateVulkanSurface(instance->Instance, &surfacehandle))
+ 				VulkanError("I_CreateVulkanSurface failed");
+ 
+-- 
+2.51.0
+
+
+From a7d5831d3d6e2ac894e75ab3f9d66eb5941f51b1 Mon Sep 17 00:00:00 2001
+From: Peppersawce <michaelpeppers89@yahoo.it>
+Date: Wed, 12 Nov 2025 18:26:28 +0100
+Subject: Default video backend to Softpoly (vid_preferbackend 2)
+And rendermode to True-Color Software Rendering (vid_rendermode 1)
+
+
+diff --git a/src/common/rendering/v_video.cpp b/src/common/rendering/v_video.cpp
+index d58dd2c..d5dee82 100644
+--- a/src/common/rendering/v_video.cpp
++++ b/src/common/rendering/v_video.cpp
+@@ -94,7 +94,7 @@ CUSTOM_CVAR(Int, vid_maxfps, 200, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+ 	}
+ }
+ 
+-CUSTOM_CVAR(Int, vid_preferbackend, 3, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_NOINITCALL)
++CUSTOM_CVAR(Int, vid_preferbackend, 2, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_NOINITCALL)
+ {
+ 	// [SP] This may seem pointless - but I don't want to implement live switching just
+ 	// yet - I'm pretty sure it's going to require a lot of reinits and destructions to
+diff --git a/src/d_main.cpp b/src/d_main.cpp
+index 4214f75..1522af8 100644
+--- a/src/d_main.cpp
++++ b/src/d_main.cpp
+@@ -227,7 +227,7 @@ CUSTOM_CVAR(Float, i_timescale, 1.0f, CVAR_NOINITCALL | CVAR_VIRTUAL)
+ // PUBLIC DATA DEFINITIONS -------------------------------------------------
+ 
+ #ifndef NO_SWRENDERER
+-CUSTOM_CVAR(Int, vid_rendermode, 4, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_NOINITCALL)
++CUSTOM_CVAR(Int, vid_rendermode, 1, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_NOINITCALL)
+ {
+ 	if (self < 0 || self > 4)
+ 	{
+-- 
+2.51.0


### PR DESCRIPTION
This PR adds a small patch to LZDoom so it can build on 32bit Haiku.
It builds and runs fine as far as I can tell.

Also, the patch sets the default video to Softpoly + true color software renderer, this only affects installs without pre-existing .ini files.