### PR TITLE
sys-auth/oath_toolkit: new recipe for version 2.6.11

### DIFF
--- a/sys-auth/oath_toolkit/oath_toolkit-2.6.11.recipe
+++ b/sys-auth/oath_toolkit/oath_toolkit-2.6.11.recipe
@@ -19,7 +19,8 @@ SECONDARY_ARCHITECTURES="x86"
 commandSuffix=$secondaryArchSuffix
 commandBinDir=$binDir
 if [ "$targetArchitecture" = x86_gcc2 ]; then
-	SECONDARY_ARCHITECTURES=""
+	commandSuffix=
+	commandBinDir=$prefix/bin
 fi
 
 libVersion="0.1.3"


### PR DESCRIPTION
OATH Toolkit provides components for one-time password authentication, including the oathtool command-line utility for HOTP and TOTP algorithms as defined in RFC 4226 and RFC 6238.