### PR TITLE
automake: bump version to 1.18.1

### DIFF
--- a/dev-build/automake/automake-1.18.1.recipe
+++ b/dev-build/automake/automake-1.18.1.recipe
@@ -9,16 +9,16 @@ LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://ftpmirror.gnu.org/automake/automake-$portVersion.tar.gz
 	https://ftp.gnu.org/gnu/automake/automake-$portVersion.tar.gz"
-CHECKSUM_SHA256="397767d4db3018dd4440825b60c64258b636eaf6bf99ac8b0897f06c89310acd"
+CHECKSUM_SHA256="63e585246d0fc8772dffdee0724f2f988146d1a3f1c756a3dc5cfbefa3c01915"
 
 ARCHITECTURES="all ?arm"
 
 PROVIDES="
 	automake = $portVersion compat >= 1.13
 	cmd:aclocal = $portVersion compat >= 1.13
-	cmd:aclocal_1.17 = $portVersion compat >= 1.17
+	cmd:aclocal_1.18 = $portVersion compat >= 1.18
 	cmd:automake = $portVersion compat >= 1.13
-	cmd:automake_1.17 = $portVersion compat >= 1.17
+	cmd:automake_1.18 = $portVersion compat >= 1.18
 	"
 REQUIRES="
 	haiku
@@ -68,7 +68,7 @@ TEST_REQUIRES="
 BUILD()
 {
 	./bootstrap
-	PERL="$(which perl)" runConfigure ./configure
+	runConfigure ./configure
 	make $jobArgs
 }
 


### PR DESCRIPTION
I had to change `PERL="/bin/env perl"` to `PERL="$(which perl)"` because it complained about the PERL variable having a space. ~It's also not the latest version. Latest is 1.18.1.~ Edit: No longer the case now, it's latest