### PR TITLE
unibilium: enable build on x86

### DIFF
--- a/dev-libs/unibilium/unibilium-2.0.0.recipe
+++ b/dev-libs/unibilium/unibilium-2.0.0.recipe
@@ -9,7 +9,7 @@ REVISION="1"
 SOURCE_URI="https://github.com/mauke/unibilium/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="78997d38d4c8177c60d3d0c1aa8c53fd0806eb21825b7b335b1768d7116bc1c1"
 
-ARCHITECTURES="all ?x86_gcc2"
+ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="


### PR DESCRIPTION
allow unibilium to build on x86 (required for neovim on x86)