### PR TITLE
vips: new recipe.

### DIFF
--- a/media-libs/vips/vips-8.17.3.recipe
+++ b/media-libs/vips/vips-8.17.3.recipe
@@ -1,0 +1,157 @@
+SUMMARY="A fast image processing library with low memory needs"
+DESCRIPTION="libvips is a demand-driven, horizontally threaded image processing library. Compared \
+to similar libraries, libvips runs quickly and uses little memory. libvips is licensed under the \
+LGPL-2.1-or-later.
+
+It has around 300 operations covering arithmetic, histograms, convolution, morphological \
+operations, frequency filtering, colour, resampling, statistics and others. It supports a large \
+range of numeric types, from 8-bit int to 128-bit complex. Images can have any number of bands. It \
+supports a good range of image formats, including JPEG, JPEG 2000, JPEG XL, TIFF, PNG, WebP, HEIC, \
+AVIF, FITS, Matlab, OpenEXR, PDF, SVG, HDR, PPM / PGM / PFM, CSV, GIF, Analyze, NIfTI, DeepZoom, \
+and OpenSlide. It can also load images via ImageMagick or GraphicsMagick, letting it work with \
+formats like DICOM."
+HOMEPAGE="https://libvips.github.io/libvips/"
+COPYRIGHT="vips"
+LICENSE="GNU LGPL v2.1"
+REVISION="1"
+SOURCE_URI="https://github.com/libvips/libvips/releases/download/v$portVersion/vips-$portVersion.tar.xz"
+CHECKSUM_SHA256="41e9a1439cd57dcc6d4435a085e2cfe181d9da1962fa84a484f09e8b536e4b77"
+SOURCE_DIR="vips-$portVersion"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="42.19.3"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+buildDebugInfoPackages=false
+
+PROVIDES="
+	$portName = $portVersion
+	lib:libvips$secondaryArchSuffix = $libVersionCompat
+	lib:libvips_cpp$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libexpat$secondaryArchSuffix
+	lib:libgio_2.0$secondaryArchSuffix
+	lib:libglib_2.0$secondaryArchSuffix
+	lib:libgmodule_2.0$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
+	lib:libjpeg$secondaryArchSuffix
+	"
+
+PROVIDES_tools="
+	${portName}_tools = $portVersion
+	cmd:vips
+	cmd:vipsedit
+	cmd:vipsthumbnail
+	cmd:vipsheader
+	"
+REQUIRES_tools="
+	$portName == $portVersion base
+	$REQUIRES
+	"
+
+PROVIDES_devel="
+	${portName}_devel = $portVersion
+	devel:libvips$secondaryArchSuffix = $libVersionCompat
+	devel:libvips_cpp$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	$portName == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libglib_2.0$secondaryArchSuffix
+	devel:libexpat$secondaryArchSuffix
+#	devel:libz$secondaryArchSuffix			# it picks it up without this. Not linked at runtime, anyway?
+	# most/all are actually optional dependencies.
+#	"libnifti"								# NIfTI load/save
+#	"matio"									# Matlab load
+#	"openslide"								# WSI load
+#	devel:libarchive$secondaryArchSuffix	# for 'image pyramid save'
+#	devel:libcairo$secondaryArchSuffix		# pangocairo / pangoft2 # for text rendering
+#	devel:libcfitsio$secondaryArchSuffix	# for FITS load/save
+#	devel:libexif$secondaryArchSuffix		# for EXIF metadata support
+#	devel:libfftw3$secondaryArchSuffix		# faster(?) FFTs
+#	devel:libfontconfig$secondaryArchSuffix	# for font file support
+#	devel:libheif$secondaryArchSuffix		# HEIC/AVIF load/save
+#	devel:libhwy							# or liborc-0.4 for SIMD support
+#	devel:libimagequant$secondaryArchSuffix # or quantizr
+	devel:libjpeg$secondaryArchSuffix		# libjpeg_turbo / libjpeg / mozjpeg
+#	devel:libjxl$secondaryArchSuffix		# or libjxl_threads for JXL load/save
+#	devel:liblcms2$secondaryArchSuffix		# ICC profile support
+#	devel:libopenjp2$secondaryArchSuffix	# for JPEG2000 load/save
+#	devel:libopenexr$secondaryArchSuffix	# for EXR load
+#	devel:libpoppler$secondaryArchSuffix	# or "PDFium" for PDF load
+	devel:libpng$secondaryArchSuffix		# or libspng for PNG load/save
+#	devel:libraw$secondaryArchSuffix
+#	devel:librsvg$secondaryArchSuffix		# will try using imagemagick/magickcore otherwise
+#	devel:libtiff$secondaryArchSuffix		# TIFF load/save
+#	devel:libuhdr$secondaryArchSuffix
+#	devel:libwebp$secondaryArchSuffix		# for WebP load/save
+	"
+BUILD_PREREQUIRES="
+#	cmd:g-ir-scanner	# enables instrospection
+	cmd:python3			# picks it up anyway.
+	cmd:gcc$secondaryArchSuffix
+#	cmd:cmake			# uses pkg-config or cmake to find libraries
+	cmd:meson
+	cmd:msgfmt			# Gettext support. Only "en_GB" and "de" ATM. No much harm in disabling it.
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+if $buildDebugInfoPackages; then
+	# Can't split it into *_tools debuginfo :-/
+	defineDebugInfoPackage $portName \
+		$libDir/libvips.so.$libVersion \
+		$libDir/libvips-cpp.so.$libVersion \
+		$(getPackagePrefix tools)/bin/vips \
+		$(getPackagePrefix tools)/bin/vipsedit \
+		$(getPackagePrefix tools)/bin/vipsthumbnail \
+		$(getPackagePrefix tools)/bin/vipsheader
+fi
+
+BUILD()
+{
+	buildType=release
+	if $buildDebugInfoPackages; then
+		buildType=debugoptimized
+	fi
+	meson setup build . \
+		--buildtype=$buildType \
+		--prefix $prefix \
+		--libdir $libDir \
+		-D deprecated=false \
+		-D examples=true
+		# this last one builds the "tools".
+
+	meson compile -C build
+}
+
+INSTALL()
+{
+	maybeStrip=
+	if ! $buildDebugInfoPackages; then
+		maybeStrip=--strip
+	fi
+	meson install -C build --no-rebuild $maybeStrip
+
+	prepareInstalledDevelLibs libvips libvips-cpp
+	fixPkgconfig
+
+	packageEntries tools \
+		$prefix/bin \
+		$manDir
+
+	packageEntries devel \
+		$developDir
+}
+
+TEST()
+{
+	meson test -C build
+}


### PR DESCRIPTION
Not currently required by anything on-tree, but:

- could be used by "pyvips" (which should be pip-installable).
- it apparently can be used to generate thumbnails about 9 times faster than ffmpeg based thumbnailers.
- the "nip4" tool built on top of this seems to be a quite fast and powerful image processing/manipulating tool/pipeline with very low memory requirements.

---

Note: build only tested (so far) on nightlies, x86_64.