### PR TITLE
Genio is now on Codeberg

### DIFF
--- a/haiku-apps/genio/genio-4.0.recipe
+++ b/haiku-apps/genio/genio-4.0.recipe
@@ -11,15 +11,15 @@ declaration, quick fix, format, rename)
 * User templates for quickly creating new files and projects
 * Rich editor with many features, like syntax highlighting
 * Full screen and Focus mode"
-HOMEPAGE="https://github.com/Genio-The-Haiku-IDE/Genio/releases"
+HOMEPAGE="https://codeberg.org/Genio/Genio/releases"
 COPYRIGHT="2022-2025 The Genio Team"
 LICENSE="BSD (3-clause)
 	MIT"
-REVISION="1"
-SOURCE_URI="https://github.com/Genio-The-Haiku-IDE/Genio/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="33de5cb06b625aa3c0281b5696801a54910147d2848beda35e17624504faa88e"
+REVISION="2"
+SOURCE_URI="https://codeberg.org/Genio/Genio/archive/v$portVersion.tar.gz"
+CHECKSUM_SHA256="8667ec41bd2b64a17672234ec087dd35fae45abbb23e19a56896132c0d36f82b"
 SOURCE_FILENAME="Genio-v$portVersion.tar.gz"
-SOURCE_DIR="Genio-$portVersion"
+SOURCE_DIR="genio"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"


### PR DESCRIPTION
Genio has migrated to Codeberg, adjust recipe to pull from there.
