### PR TITLE
Update SDL2 to 2.32.10, SDL2-mixer to 2.8.1, SDL2-ttf to 2.24.0

### DIFF
--- a/media-libs/libsdl2/libsdl2-2.32.10.recipe
+++ b/media-libs/libsdl2/libsdl2-2.32.10.recipe
@@ -4,20 +4,20 @@ designed to provide low level access to audio, keyboard, mouse, joystick, and \
 graphics hardware via OpenGL and Direct3D. It is used by video playback \
 software, emulators, and popular games."
 HOMEPAGE="https://www.libsdl.org/"
-COPYRIGHT="1997-2024 Sam Lantinga"
+COPYRIGHT="1997-2025 Sam Lantinga"
 LICENSE="Zlib"
 REVISION="1"
-SOURCE_URI="https://www.libsdl.org/release/SDL2-$portVersion.tar.gz"
-CHECKSUM_SHA256="f59adf36a0fcf4c94198e7d3d776c1b3824211ab7aeebeb31fe19836661196aa"
-SOURCE_DIR="SDL2-$portVersion"
+SOURCE_URI="https://github.com/libsdl-org/SDL/archive/refs/tags/release-$portVersion.tar.gz"
+CHECKSUM_SHA256="03f9d7c191a837525c9cda6406af2f2e48be02b5e7eb03d949cc9f1e9ca41c8b"
 PATCHES="libsdl2-$portVersion.patchset"
+SOURCE_DIR="SDL-release-$portVersion"
 
 ARCHITECTURES="all"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	libsdl2$secondaryArchSuffix = $portVersion compat >= 2.0
-	lib:libSDL2_2.0$secondaryArchSuffix = 0.3000.10 compat >= 0
+	lib:libSDL2_2.0$secondaryArchSuffix = 0.3200.10 compat >= 0
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -28,8 +28,8 @@ REQUIRES="
 PROVIDES_devel="
 	libsdl2${secondaryArchSuffix}_devel = $portVersion compat >= 2.0
 	cmd:sdl2_config$secondaryArchSuffix = $portVersion compat >= 2.0
-	devel:libSDL2$secondaryArchSuffix = 0.3000.10 compat >= 0
-	devel:libSDL2_2.0$secondaryArchSuffix = 0.3000.10 compat >= 0
+	devel:libSDL2$secondaryArchSuffix = 0.3200.10 compat >= 0
+	devel:libSDL2_2.0$secondaryArchSuffix = 0.3200.10 compat >= 0
 	devel:libSDL2main$secondaryArchSuffix
 	"
 REQUIRES_devel="
@@ -52,7 +52,7 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	cmake . -Bbuild -GNinja $cmakeDirArgs \
-		-DSDL_STATIC=OFF -DRPATH=OFF \
+		-DSDL_STATIC=OFF -DSDL_RPATH=OFF \
 		-DCMAKE_BUILD_TYPE=Release
 	ninja -C build
 }

--- a/media-libs/libsdl2/patches/libsdl2-2.32.10.patchset
+++ b/media-libs/libsdl2/patches/libsdl2-2.32.10.patchset
@@ -1,40 +1,11 @@
-From ef71b0e087a9280dc54206fbf2553666aff78f02 Mon Sep 17 00:00:00 2001
-From: PulkoMandy <pulkomandy@pulkomandy.tk>
-Date: Sun, 24 Mar 2024 11:28:45 +0100
-Subject: Don't change current directory if started from Terminal
-
-
-diff --git a/src/main/haiku/SDL_BeApp.cc b/src/main/haiku/SDL_BeApp.cc
-index a736a9f..92f0aeb 100644
---- a/src/main/haiku/SDL_BeApp.cc
-+++ b/src/main/haiku/SDL_BeApp.cc
-@@ -118,9 +118,12 @@ static int StartBeLooper()
-         } while ((!be_app) || be_app->IsLaunching());
-     }
- 
--     /* Change working directory to that of executable */
-+     /* If started from the GUI, change working directory to that of executable.
-+      * This matches the behavior on other platforms that some SDL software expects.
-+      * If the TERM environment variable is set, we are being started from the terminal, in that
-+      * case, it is more important to preserve the current directory. */
-     app_info info;
--    if (B_OK == be_app->GetAppInfo(&info)) {
-+    if (NULL == getenv("TERM") && B_OK == be_app->GetAppInfo(&info)) {
-         entry_ref ref = info.ref;
-         BEntry entry;
-         if (B_OK == entry.SetTo(&ref)) {
--- 
-2.37.3
-
-
-From 92e4b1c11b824c07e5dca0abb4e99eedd973d1ad Mon Sep 17 00:00:00 2001
+From c607af89d12a6d1d3243665ec824fa146597376d Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Tue, 2 Apr 2024 19:02:04 +0200
 Subject: fix gcc2 ICE
 
 
 diff --git a/src/audio/SDL_audiotypecvt.c b/src/audio/SDL_audiotypecvt.c
-index 221bfbb..2192641 100644
+index 516be82..60f9d21 100644
 --- a/src/audio/SDL_audiotypecvt.c
 +++ b/src/audio/SDL_audiotypecvt.c
 @@ -310,6 +310,9 @@ static void SDLCALL SDL_Convert_F32_to_S32_Scalar(SDL_AudioCVT *cvt, SDL_AudioFo
@@ -48,10 +19,10 @@ index 221bfbb..2192641 100644
          Uint32 y, z;
          x.f32 = src[i];
 -- 
-2.37.3
+2.51.0
 
 
-From 55e83980e631737182b47180d0319b6992a58186 Mon Sep 17 00:00:00 2001
+From 52efbed639d59df4ad0b1a685cf38c82ea97f817 Mon Sep 17 00:00:00 2001
 From: PulkoMandy <pulkomandy@pulkomandy.tk>
 Date: Sun, 24 Mar 2024 16:45:42 +0100
 Subject: Use a BHandler attached to the application instead of a BLooper
@@ -67,7 +38,7 @@ which allows it to receive messages in the already existing application
 thread.
 
 diff --git a/src/main/haiku/SDL_BApp.h b/src/main/haiku/SDL_BApp.h
-index 284445d..f3a06f3 100644
+index 6027219..22130c4 100644
 --- a/src/main/haiku/SDL_BApp.h
 +++ b/src/main/haiku/SDL_BApp.h
 @@ -49,7 +49,7 @@ extern "C" {
@@ -116,7 +87,7 @@ index 284445d..f3a06f3 100644
          }
      }
 diff --git a/src/main/haiku/SDL_BeApp.cc b/src/main/haiku/SDL_BeApp.cc
-index 92f0aeb..a4aefc4 100644
+index d2a1e35..8558d05 100644
 --- a/src/main/haiku/SDL_BeApp.cc
 +++ b/src/main/haiku/SDL_BeApp.cc
 @@ -31,7 +31,7 @@
@@ -137,7 +108,7 @@ index 92f0aeb..a4aefc4 100644
  
  
  /* Default application signature */
-@@ -136,8 +136,11 @@ static int StartBeLooper()
+@@ -137,8 +137,11 @@ static int StartBeLooper()
          }
      }
  
@@ -151,7 +122,7 @@ index 92f0aeb..a4aefc4 100644
      return (0);
  }
  
-@@ -168,9 +171,6 @@ void SDL_QuitBeApp(void)
+@@ -169,9 +172,6 @@ void SDL_QuitBeApp(void)
  
      /* If the reference count reached zero, clean up the app */
      if (SDL_BeAppActive == 0) {
@@ -161,7 +132,7 @@ index 92f0aeb..a4aefc4 100644
          if (SDL_AppThread) {
              if (be_app != NULL) {       /* Not tested */
                  be_app->PostMessage(B_QUIT_REQUESTED);
-@@ -187,7 +187,7 @@ void SDL_QuitBeApp(void)
+@@ -188,7 +188,7 @@ void SDL_QuitBeApp(void)
  #endif
  
  /* SDL_BApp functions */
@@ -171,7 +142,7 @@ index 92f0aeb..a4aefc4 100644
      int32 i = _GetNumWindowSlots() - 1;
      while (i >= 0 && GetSDLWindow(i) == NULL) {
 diff --git a/src/video/haiku/SDL_BApp.h b/src/video/haiku/SDL_BApp.h
-index 284445d..f3a06f3 100644
+index 6027219..22130c4 100644
 --- a/src/video/haiku/SDL_BApp.h
 +++ b/src/video/haiku/SDL_BApp.h
 @@ -49,7 +49,7 @@ extern "C" {
@@ -220,7 +191,7 @@ index 284445d..f3a06f3 100644
          }
      }
 diff --git a/src/video/haiku/SDL_BWin.h b/src/video/haiku/SDL_BWin.h
-index f1ad1ea..716e9a9 100644
+index 4d4d4af..db21b7a 100644
 --- a/src/video/haiku/SDL_BWin.h
 +++ b/src/video/haiku/SDL_BWin.h
 @@ -125,8 +125,8 @@ class SDL_BWin : public BWindow
@@ -264,7 +235,7 @@ index f1ad1ea..716e9a9 100644
  
      /* Command methods (functions called upon by SDL) */
 diff --git a/src/video/haiku/SDL_bframebuffer.cc b/src/video/haiku/SDL_bframebuffer.cc
-index 1961cea..cfee55f 100644
+index 71e7689..0b290b1 100644
 --- a/src/video/haiku/SDL_bframebuffer.cc
 +++ b/src/video/haiku/SDL_bframebuffer.cc
 @@ -39,8 +39,8 @@ static SDL_INLINE SDL_BWin *_ToBeWin(SDL_Window *window) {
@@ -279,7 +250,7 @@ index 1961cea..cfee55f 100644
  
  int HAIKU_CreateWindowFramebuffer(_THIS, SDL_Window * window,
 diff --git a/src/video/haiku/SDL_bmodes.cc b/src/video/haiku/SDL_bmodes.cc
-index 6a162f6..956d782 100644
+index 77b9123..86c5d8a 100644
 --- a/src/video/haiku/SDL_bmodes.cc
 +++ b/src/video/haiku/SDL_bmodes.cc
 @@ -52,8 +52,8 @@ static SDL_INLINE SDL_BWin *_ToBeWin(SDL_Window *window) {
@@ -294,7 +265,7 @@ index 6a162f6..956d782 100644
  
  static SDL_INLINE display_mode * _ExtractBMode(SDL_DisplayMode *mode) {
 diff --git a/src/video/haiku/SDL_bopengl.cc b/src/video/haiku/SDL_bopengl.cc
-index d34d592..c55002e 100644
+index eada4c0..7afb5a9 100644
 --- a/src/video/haiku/SDL_bopengl.cc
 +++ b/src/video/haiku/SDL_bopengl.cc
 @@ -39,8 +39,8 @@ static SDL_INLINE SDL_BWin *_ToBeWin(SDL_Window *window) {
@@ -309,7 +280,7 @@ index d34d592..c55002e 100644
  
  /* Passing a NULL path means load pointers from the application */
 diff --git a/src/video/haiku/SDL_bwindow.cc b/src/video/haiku/SDL_bwindow.cc
-index 38863ab..36cd2f1 100644
+index 0ca751a..611022e 100644
 --- a/src/video/haiku/SDL_bwindow.cc
 +++ b/src/video/haiku/SDL_bwindow.cc
 @@ -37,8 +37,8 @@ static SDL_INLINE SDL_BWin *_ToBeWin(SDL_Window *window) {
@@ -324,5 +295,47 @@ index 38863ab..36cd2f1 100644
  
  static int _InitWindow(_THIS, SDL_Window *window) {
 -- 
-2.43.2
+2.51.0
+
+
+From b350148abc1c52e23261be7d221e679547485ab6 Mon Sep 17 00:00:00 2001
+From: Peppersawce <michaelpeppers89@yahoo.it>
+Date: Sat, 6 Dec 2025 11:35:16 +0100
+Subject: Make BUrl not 'ambiguous'
+
+
+diff --git a/src/misc/haiku/SDL_sysurl.cc b/src/misc/haiku/SDL_sysurl.cc
+index 5183234..eef47f0 100644
+--- a/src/misc/haiku/SDL_sysurl.cc
++++ b/src/misc/haiku/SDL_sysurl.cc
+@@ -24,7 +24,11 @@
+ 
+ int SDL_SYS_OpenURL(const char *url)
+ {
++#if B_HAIKU_VERSION <= B_HAIKU_VERSION_1_BETA_5
+     BUrl burl(url);
++#else
++    BUrl burl(url, true);
++#endif
+     const status_t rc = burl.OpenWithPreferredApplication(false);
+     return (rc == B_NO_ERROR) ? 0 : SDL_SetError("URL open failed (err=%d)", (int) rc);
+ }
+diff --git a/src/video/haiku/SDL_bvideo.cc b/src/video/haiku/SDL_bvideo.cc
+index d541289..14ab252 100644
+--- a/src/video/haiku/SDL_bvideo.cc
++++ b/src/video/haiku/SDL_bvideo.cc
+@@ -305,7 +305,11 @@ void HAIKU_VideoQuit(_THIS)
+ extern "C" { int HAIKU_OpenURL(const char *url); }
+ int HAIKU_OpenURL(const char *url)
+ {
++#if B_HAIKU_VERSION <= B_HAIKU_VERSION_1_BETA_5
+     BUrl burl(url);
++#else
++    BUrl burl(url, true);
++#endif
+     const status_t rc = burl.OpenWithPreferredApplication(false);
+     return (rc == B_NO_ERROR) ? 0 : SDL_SetError("URL open failed (err=%d)", (int)rc);
+ }
+-- 
+2.51.0
 

--- a/media-libs/sdl2_mixer/sdl2_mixer-2.8.1.recipe
+++ b/media-libs/sdl2_mixer/sdl2_mixer-2.8.1.recipe
@@ -5,24 +5,24 @@ number of simultaneously playing channels of 16 bit stereo audio, plus a \
 single channel of music, mixed by the popular FLAC, MikMoD MOD, Timidity MIDI, \
 Ogg Vorbis, and SMPEG MP3 libraries."
 HOMEPAGE="https://www.libsdl.org/projects/SDL_mixer/"
-COPYRIGHT="1997-2012 Sam Lantinga"
+COPYRIGHT="1997-2025 Sam Lantinga"
 LICENSE="Zlib"
 REVISION="1"
-SOURCE_URI="https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-$portVersion.tar.gz"
-CHECKSUM_SHA256="1cfb34c87b26dbdbc7afd68c4f545c0116ab5f90bbfecc5aebe2a9cb4bb31549"
-SOURCE_DIR="SDL2_mixer-$portVersion"
+SOURCE_URI="https://github.com/libsdl-org/SDL_mixer/archive/refs/tags/release-$portVersion.tar.gz"
+CHECKSUM_SHA256="63804b4b2ba503865c0853f102231aeff489b1dfc6dea4750a69e2a8ef54b2bb"
+SOURCE_DIR="SDL_mixer-release-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	sdl2_mixer$secondaryArchSuffix = $portVersion compat >= 2.0
-	lib:libSDL2_mixer_2.0$secondaryArchSuffix = 0.800.0 compat >= 0
+	lib:libSDL2_mixer_2.0$secondaryArchSuffix = 0.800.1 compat >= 0
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libflac$secondaryArchSuffix
-	lib:libfluidsynth$secondaryArchSuffix >= 2
+	lib:libfluidsynth$secondaryArchSuffix
 	lib:libmad$secondaryArchSuffix
 	lib:libmpg123$secondaryArchSuffix
 	lib:libogg$secondaryArchSuffix
@@ -33,8 +33,8 @@ REQUIRES="
 
 PROVIDES_devel="
 	sdl2_mixer${secondaryArchSuffix}_devel = $portVersion compat >= 2.0
-	devel:libSDL2_mixer$secondaryArchSuffix = 0.800.0 compat >= 0
-	devel:libSDL2_mixer_2.0$secondaryArchSuffix = 0.800.0 compat >= 0
+	devel:libSDL2_mixer$secondaryArchSuffix = 0.800.1 compat >= 0
+	devel:libSDL2_mixer_2.0$secondaryArchSuffix = 0.800.1 compat >= 0
 	"
 REQUIRES_devel="
 	sdl2_mixer$secondaryArchSuffix == $portVersion base
@@ -43,7 +43,7 @@ REQUIRES_devel="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libflac$secondaryArchSuffix
-	devel:libfluidsynth$secondaryArchSuffix >= 2
+	devel:libfluidsynth$secondaryArchSuffix
 	devel:libmad$secondaryArchSuffix
 	devel:libmpg123$secondaryArchSuffix
 	devel:libogg$secondaryArchSuffix

--- a/media-libs/sdl2_ttf/sdl2_ttf-2.24.0.recipe
+++ b/media-libs/sdl2_ttf/sdl2_ttf-2.24.0.recipe
@@ -7,17 +7,17 @@ without having to code a font rendering routine themselves. With the power of \
 outline fonts and antialiasing, high quality text output can be obtained \
 without much effort."
 HOMEPAGE="http://www.libsdl.org/projects/SDL_ttf"
-COPYRIGHT="1997-2013 Sam Lantinga"
+COPYRIGHT="1997-2025 Sam Lantinga"
 LICENSE="Zlib"
-REVISION="2"
-SOURCE_URI="http://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-$portVersion.tar.gz"
-CHECKSUM_SHA256="9dc71ed93487521b107a2c4a9ca6bf43fb62f6bddd5c26b055e6b91418a22053"
-SOURCE_DIR="SDL2_ttf-$portVersion"
+REVISION="1"
+SOURCE_URI="https://github.com/libsdl-org/SDL_ttf/archive/refs/tags/release-$portVersion.tar.gz"
+CHECKSUM_SHA256="2c45241a56203a59d66ec6b4eae9457e5675fc609376566a257391fd29d341a2"
+SOURCE_DIR="SDL_ttf-release-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
-libVersion="0.2000.2"
+libVersion="0.2400.0"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="


### PR DESCRIPTION
Tested and working on Haiku hrev59196 x86_64, should be tested everywhere else.

The part of the patch removed from SDL2 is redundant in 2.32.10.