### PR TITLE
python3.14: update to version 3.14.1.

### DIFF
--- a/dev-lang/python/patches/python3.14-3.14.1.patchset
+++ b/dev-lang/python/patches/python3.14-3.14.1.patchset
@@ -1,4 +1,4 @@
-From 5736ecb92172c3b312c53fb7a316c2ae3968e2bc Mon Sep 17 00:00:00 2001
+From 5df8f2730b3ff6a6573ea5448bee059564a45c11 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 8 Oct 2023 01:02:25 -0300
 Subject: initial Haiku patch
@@ -9,10 +9,10 @@ over 3.12's sources.
 Parts of that original patch were split into specific commit/patches.
 
 diff --git a/Include/pyport.h b/Include/pyport.h
-index 3eac119..1e5df7e 100644
+index 2c8567f..aa050cf 100644
 --- a/Include/pyport.h
 +++ b/Include/pyport.h
-@@ -535,7 +535,7 @@ extern "C" {
+@@ -536,7 +536,7 @@ extern "C" {
  #  define _Py_FORCE_UTF8_LOCALE
  #endif
  
@@ -22,7 +22,7 @@ index 3eac119..1e5df7e 100644
     // See PyUnicode_DecodeFSDefaultAndSize(), PyUnicode_EncodeFSDefault(),
     // Py_DecodeLocale() and Py_EncodeLocale().
 diff --git a/Makefile.pre.in b/Makefile.pre.in
-index ba03979..97d95a8 100644
+index f29de05..33dcc0c 100644
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
 @@ -156,7 +156,7 @@ BINDIR=		@bindir@
@@ -35,10 +35,10 @@ index ba03979..97d95a8 100644
  SCRIPTDIR=	$(prefix)/$(PLATLIBDIR)
  # executable name for shebangs
 diff --git a/Modules/resource.c b/Modules/resource.c
-index 3fe18e7..d0e1872 100644
+index 2353bc6..6267d23 100644
 --- a/Modules/resource.c
 +++ b/Modules/resource.c
-@@ -126,6 +126,7 @@ resource_getrusage_impl(PyObject *module, int who)
+@@ -124,6 +124,7 @@ resource_getrusage_impl(PyObject *module, int who)
                      PyFloat_FromDouble(doubletime(ru.ru_utime)));
      PyStructSequence_SetItem(result, 1,
                      PyFloat_FromDouble(doubletime(ru.ru_stime)));
@@ -46,7 +46,7 @@ index 3fe18e7..d0e1872 100644
      PyStructSequence_SetItem(result, 2, PyLong_FromLong(ru.ru_maxrss));
      PyStructSequence_SetItem(result, 3, PyLong_FromLong(ru.ru_ixrss));
      PyStructSequence_SetItem(result, 4, PyLong_FromLong(ru.ru_idrss));
-@@ -140,6 +141,22 @@ resource_getrusage_impl(PyObject *module, int who)
+@@ -138,6 +139,22 @@ resource_getrusage_impl(PyObject *module, int who)
      PyStructSequence_SetItem(result, 13, PyLong_FromLong(ru.ru_nsignals));
      PyStructSequence_SetItem(result, 14, PyLong_FromLong(ru.ru_nvcsw));
      PyStructSequence_SetItem(result, 15, PyLong_FromLong(ru.ru_nivcsw));
@@ -69,7 +69,7 @@ index 3fe18e7..d0e1872 100644
  
      if (PyErr_Occurred()) {
          Py_DECREF(result);
-@@ -387,19 +404,19 @@ resource_exec(PyObject *module)
+@@ -410,19 +427,19 @@ resource_exec(PyObject *module)
      }
  
      /* insert constants */
@@ -93,7 +93,7 @@ index 3fe18e7..d0e1872 100644
      ADD_INT(module, RLIMIT_STACK);
  #endif
  
-@@ -411,31 +428,31 @@ resource_exec(PyObject *module)
+@@ -434,31 +451,31 @@ resource_exec(PyObject *module)
      ADD_INT(module, RLIMIT_NOFILE);
  #endif
  
@@ -148,10 +148,10 @@ index 63624d5..3692640 100644
  #include <bluetooth/bluetooth.h>
  #include <bluetooth/rfcomm.h>
 diff --git a/configure.ac b/configure.ac
-index af7a962..5e79105 100644
+index bd4446e..a73e95f 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1585,6 +1585,16 @@ if test $enable_shared = "yes"; then
+@@ -1593,6 +1593,16 @@ if test $enable_shared = "yes"; then
          PY3LIBRARY=libpython3.so
        fi
        ;;
@@ -168,7 +168,7 @@ index af7a962..5e79105 100644
      hp*|HP*)
        case `uname -m` in
          ia64)
-@@ -1702,6 +1712,7 @@ AC_PROG_MKDIR_P
+@@ -1710,6 +1720,7 @@ AC_PROG_MKDIR_P
  AC_SUBST([LN])
  if test -z "$LN" ; then
  	case $ac_sys_system in
@@ -176,7 +176,7 @@ index af7a962..5e79105 100644
  		CYGWIN*) LN="ln -s";;
  		*) LN=ln;;
  	esac
-@@ -3591,7 +3602,7 @@ then
+@@ -3599,7 +3610,7 @@ then
  	    LINKFORSHARED="-Wl,-E -Wl,+s";;
  #	    LINKFORSHARED="-Wl,-E -Wl,+s -Wl,+b\$(BINLIBDEST)/lib-dynload";;
  	Linux-android*) LINKFORSHARED="-pie -Xlinker -export-dynamic";;
@@ -185,7 +185,7 @@ index af7a962..5e79105 100644
  	# -u libsys_s pulls in all symbols in libsys
  	Darwin/*|iOS/*)
  		LINKFORSHARED="$extra_undefs -framework CoreFoundation"
-@@ -5974,6 +5985,7 @@ AC_CHECK_FUNC([__fpu_control],
+@@ -5999,6 +6010,7 @@ AC_CHECK_FUNC([__fpu_control],
  AC_SUBST([LIBM])
  case $ac_sys_system in
  Darwin) ;;
@@ -194,20 +194,20 @@ index af7a962..5e79105 100644
  esac
  AC_MSG_CHECKING([for --with-libm=STRING])
 -- 
-2.50.1
+2.51.0
 
 
-From 34d64f860ffd9c3d16275181e7b5e74f850faaa5 Mon Sep 17 00:00:00 2001
+From f29db079e721c99e19d7aea10a1fe2e604eb3b6f Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sun, 16 Apr 2017 10:05:42 +0200
 Subject: fix for negative errnos
 
 
 diff --git a/Lib/subprocess.py b/Lib/subprocess.py
-index 54c2eb5..1fa840e 100644
+index 6911cd8..42917f4 100644
 --- a/Lib/subprocess.py
 +++ b/Lib/subprocess.py
-@@ -1955,6 +1955,8 @@ class Popen:
+@@ -1974,6 +1974,8 @@ class Popen:
                          SubprocessError)
                  if issubclass(child_exception_type, OSError) and hex_errno:
                      errno_num = int(hex_errno, 16)
@@ -217,10 +217,10 @@ index 54c2eb5..1fa840e 100644
                          err_msg = ""
                          # The error must be from chdir(cwd).
 diff --git a/Modules/_posixsubprocess.c b/Modules/_posixsubprocess.c
-index b542f86..a996ebf 100644
+index e0a9531..1d76b4f 100644
 --- a/Modules/_posixsubprocess.c
 +++ b/Modules/_posixsubprocess.c
-@@ -843,6 +843,10 @@ error:
+@@ -849,6 +849,10 @@ error:
          char *cur;
          _Py_write_noraise(errpipe_write, "OSError:", 8);
          cur = hex_errno + sizeof(hex_errno);
@@ -232,10 +232,10 @@ index b542f86..a996ebf 100644
              *--cur = Py_hexdigits[saved_errno % 16];
              saved_errno /= 16;
 -- 
-2.50.1
+2.51.0
 
 
-From 135871ffc134ca7660561c610845fbd096f687b3 Mon Sep 17 00:00:00 2001
+From 03c163799043ea9a3f2f1b8ebe02b9d69b7eb2b1 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 8 Oct 2023 20:06:31 -0300
 Subject: Implement CTypes's find_library for Haiku
@@ -329,10 +329,10 @@ index 378f121..a9136ad 100644
              print(cdll.LoadLibrary("libm.so"))
              print(cdll.LoadLibrary("libcrypt.so"))
 -- 
-2.50.1
+2.51.0
 
 
-From 067d57c338bfe5239531cc46112b6aecba580eb8 Mon Sep 17 00:00:00 2001
+From 4592a835f031a174218512f0f943d04ac1b562d3 Mon Sep 17 00:00:00 2001
 From: Philipp Wolfer <phil@parolu.io>
 Date: Mon, 23 Sep 2019 09:14:58 +0200
 Subject: webbrowser: Support for default browsers on Haiku
@@ -356,17 +356,17 @@ index f2e2394..b937321 100644
          # First try to use the default Windows browser
          register("windows-default", WindowsDefault)
 -- 
-2.50.1
+2.51.0
 
 
-From c859187ff35670b6358d6f8987235465e7038d51 Mon Sep 17 00:00:00 2001
+From 6c70bcdb42dff0b3c5ef8655937139f7dd5d5a50 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 4 Oct 2019 22:02:35 +0200
 Subject: since 3.8, don't reinit locks on fork.
 
 
 diff --git a/Lib/logging/__init__.py b/Lib/logging/__init__.py
-index b95c3aa..1652f93 100644
+index 9005f1e..28708e2 100644
 --- a/Lib/logging/__init__.py
 +++ b/Lib/logging/__init__.py
 @@ -253,7 +253,7 @@ def _afterFork():
@@ -379,44 +379,20 @@ index b95c3aa..1652f93 100644
          pass  # no-op when os.register_at_fork does not exist.
  else:
 -- 
-2.50.1
+2.51.0
 
 
-From 76dd6f6f1e0b0a24400348b4cc653c2a84510d2a Mon Sep 17 00:00:00 2001
-From: Jerome Duval <jerome.duval@gmail.com>
-Date: Fri, 15 May 2020 15:20:57 +0200
-Subject: handle errors returned by internal_connect()
-
-upstream bug #40628 by Ryan C. Gordon
-
-diff --git a/Modules/socketmodule.c b/Modules/socketmodule.c
-index 92c9aa8..82cdf0e 100644
---- a/Modules/socketmodule.c
-+++ b/Modules/socketmodule.c
-@@ -3721,7 +3721,7 @@ sock_connect(PyObject *self, PyObject *addro)
-     }
- 
-     res = internal_connect(s, SAS2SA(&addrbuf), addrlen, 1);
--    if (res < 0) {
-+    if (res == -1) {
-         assert(PyErr_Occurred());
-         return NULL;
-     }
--- 
-2.50.1
-
-
-From 6af7c9bc7808652629425065d2414bf75ad2604a Mon Sep 17 00:00:00 2001
+From 069d16b2cff8c1db9a8f22b92a224403bc555535 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Mon, 19 Oct 2020 18:03:09 +0200
 Subject: ttyname_r can use MAXPATHLEN
 
 
 diff --git a/Modules/posixmodule.c b/Modules/posixmodule.c
-index e1576f8..4a459ef 100644
+index 6e878e3..fd8d5d2 100644
 --- a/Modules/posixmodule.c
 +++ b/Modules/posixmodule.c
-@@ -3421,11 +3421,14 @@ static PyObject *
+@@ -3420,11 +3420,14 @@ static PyObject *
  os_ttyname_impl(PyObject *module, int fd)
  /*[clinic end generated code: output=c424d2e9d1cd636a input=9ff5a58b08115c55]*/
  {
@@ -433,10 +409,10 @@ index e1576f8..4a459ef 100644
      if (buffer == NULL) {
          return PyErr_NoMemory();
 -- 
-2.50.1
+2.51.0
 
 
-From 86d413d5002f45b381287c61c7feca5ab484f42e Mon Sep 17 00:00:00 2001
+From 5e4032f24c2ea68f2a6d3ede34cb54bcfe20760a Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Mon, 24 Oct 2022 20:04:10 -0300
 Subject: Lib/test: require the "largefile" usage flag for I/O heavy tests.
@@ -447,7 +423,7 @@ This avoids needing several GBs of storage to run the tests
 (unless the "largefile" resource usage flag is enabled).
 
 diff --git a/Lib/test/test_io.py b/Lib/test/test_io.py
-index 0c921ff..53aa0a1 100644
+index 6514af8..db22845 100644
 --- a/Lib/test/test_io.py
 +++ b/Lib/test/test_io.py
 @@ -652,7 +652,7 @@ class IOTest(unittest.TestCase):
@@ -473,10 +449,10 @@ index 41f7b70..e4830de 100644
                   'test requires %s bytes and a long time to run' % str(size))
      else:
 diff --git a/Lib/test/test_mmap.py b/Lib/test/test_mmap.py
-index b2a299e..c80ad75 100644
+index f468dda..4ab9157 100644
 --- a/Lib/test/test_mmap.py
 +++ b/Lib/test/test_mmap.py
-@@ -1146,7 +1146,7 @@ class LargeMmapTests(unittest.TestCase):
+@@ -1188,7 +1188,7 @@ class LargeMmapTests(unittest.TestCase):
          unlink(TESTFN)
  
      def _make_test_file(self, num_zeroes, tail):
@@ -486,10 +462,10 @@ index b2a299e..c80ad75 100644
                  'test requires %s bytes and a long time to run' % str(0x180000000))
          f = open(TESTFN, 'w+b')
 -- 
-2.50.1
+2.51.0
 
 
-From 83f440d48e22dc660c533e611b32c975d42df614 Mon Sep 17 00:00:00 2001
+From 00b0c361b2f153497f85e320431c5ddee84ba135 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sat, 27 Jul 2024 04:51:52 -0300
 Subject: _getuserbase(), getsitepackages(), and INSTALL_SCHEMES for Haiku.
@@ -516,7 +492,7 @@ by me, plus:
 The idea was to have all _getuserbase()/INSTALL_SCHEMES related changes in "one place".
 
 diff --git a/Lib/site.py b/Lib/site.py
-index f932719..c1fe2a4 100644
+index aeb7c6c..e6351bb 100644
 --- a/Lib/site.py
 +++ b/Lib/site.py
 @@ -313,6 +313,14 @@ def _getuserbase():
@@ -702,10 +678,10 @@ index 09eff11..5ef7055 100644
  
      @skip_unless_symlink
 -- 
-2.50.1
+2.51.0
 
 
-From e5ea703ead5239ecbecf1a122334cd3936b23848 Mon Sep 17 00:00:00 2001
+From 5fc09a894df19bb83f7b32c169f0d049a1bef068 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Mon, 12 Feb 2024 08:39:38 -0300
 Subject: Fix location of REPL's history file.
@@ -716,7 +692,7 @@ Content-Transfer-Encoding: 8bit
 Adapted from previous patches by Jérôme Duval.
 
 diff --git a/Lib/site.py b/Lib/site.py
-index c1fe2a4..c304121 100644
+index e6351bb..ef75d2b 100644
 --- a/Lib/site.py
 +++ b/Lib/site.py
 @@ -512,8 +512,18 @@ def gethistoryfile():
@@ -741,10 +717,10 @@ index c1fe2a4..c304121 100644
  
  def enablerlcompleter():
 -- 
-2.50.1
+2.51.0
 
 
-From 8a5ea0645cb8a2b6c906eb6b90bdee82626d4244 Mon Sep 17 00:00:00 2001
+From 89d24696183a6d979bceb07dc8becf954d347558 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 10 Dec 2023 19:50:22 -0300
 Subject: Miscellaneous "Lib/test/" fixes for Haiku.
@@ -755,10 +731,10 @@ Content-Transfer-Encoding: 8bit
 test_fileio.py fix from "initial Haiku patch" by Jérôme Duval.
 
 diff --git a/Lib/test/datetimetester.py b/Lib/test/datetimetester.py
-index 1c1cbd0..75ca221 100644
+index aca5fbc..996297b 100644
 --- a/Lib/test/datetimetester.py
 +++ b/Lib/test/datetimetester.py
-@@ -6406,6 +6406,9 @@ def pairs(iterable):
+@@ -6412,6 +6412,9 @@ def pairs(iterable):
  
  class ZoneInfo(tzinfo):
      zoneroot = '/usr/share/zoneinfo'
@@ -781,10 +757,10 @@ index e3d54f6..efb4d03 100644
                          # Somehow /dev/tty appears seekable on some BSDs
                          self.assertEqual(f.seekable(), False)
 -- 
-2.50.1
+2.51.0
 
 
-From 04b0f95dc0a55853f3d025b18d080daba8a983e0 Mon Sep 17 00:00:00 2001
+From 388f6874b1d72ca76759a093eb9791d1d0da5937 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Mon, 12 Feb 2024 10:50:34 -0300
 Subject: Fix build on nightlies, following the addition of kqueue.
@@ -847,10 +823,10 @@ index d234d50..6e16247 100644
  
      /* NETDEV filter flags */
 -- 
-2.50.1
+2.51.0
 
 
-From 16529399df0341c3ec33ca35a4b1627b26fbf95d Mon Sep 17 00:00:00 2001
+From 881a7ba8c86cae5483d6d55cb1bcd134db942eb0 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 9 Aug 2024 13:38:28 -0300
 Subject: fix test_utf8_mode.
@@ -870,10 +846,10 @@ index f668810..a55a8e4 100644
          elif sys.platform.startswith("aix"):
              c_arg = arg.decode('iso-8859-1')
 -- 
-2.50.1
+2.51.0
 
 
-From 653478fff90aa34d203795024997368b5de48e85 Mon Sep 17 00:00:00 2001
+From 6555d303e702a1e50a39c869c91810a5e2e995f8 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 9 Aug 2024 14:35:04 -0300
 Subject: Fix test_site.
@@ -891,7 +867,7 @@ Lib/site.py changes should eventually be merged with previous commits.
 Leaving the changes here now for easier review.
 
 diff --git a/Lib/site.py b/Lib/site.py
-index c304121..4cf045e 100644
+index ef75d2b..6854d19 100644
 --- a/Lib/site.py
 +++ b/Lib/site.py
 @@ -314,12 +314,8 @@ def _getuserbase():
@@ -933,10 +909,10 @@ index c304121..4cf045e 100644
              libdirs = [sys.platlibdir]
              if sys.platlibdir != "lib":
 diff --git a/Lib/test/test_site.py b/Lib/test/test_site.py
-index d0e3294..1452e42 100644
+index f8c6f37..2cf711f 100644
 --- a/Lib/test/test_site.py
 +++ b/Lib/test/test_site.py
-@@ -323,7 +323,21 @@ class HelperFunctionsTests(unittest.TestCase):
+@@ -325,7 +325,21 @@ class HelperFunctionsTests(unittest.TestCase):
      def test_getsitepackages(self):
          site.PREFIXES = ['xoxo']
          dirs = site.getsitepackages()
@@ -960,10 +936,10 @@ index d0e3294..1452e42 100644
              if sys.platlibdir != "lib":
                  self.assertEqual(len(dirs), 2)
 -- 
-2.50.1
+2.51.0
 
 
-From dece042a33479b54f25d391694aadd1d9b7b80c8 Mon Sep 17 00:00:00 2001
+From fa7418472d69b3d8e1cafa284f61a36c3a623144 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 9 Aug 2024 15:37:13 -0300
 Subject: Fix test_sysconfig.
@@ -1003,10 +979,10 @@ index 5ef7055..18b1e8f 100644
              wanted.extend(['nt_user', 'osx_framework_user', 'posix_user', 'haiku_user'])
          self.assertEqual(get_scheme_names(), tuple(sorted(wanted)))
 -- 
-2.50.1
+2.51.0
 
 
-From 40197bf740f1b96f5245862f528cab9600d18614 Mon Sep 17 00:00:00 2001
+From adf8934168f7c5c29bf0ec2d64e0909de776bf12 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 29 Sep 2024 03:01:27 -0300
 Subject: Partially fix test_compileall by skipping tests that need hardlink
@@ -1039,10 +1015,10 @@ index 8384c18..d7e19ec 100644
          # 'a = 0' code produces the same bytecode for the 3 optimization
          # levels. All three .pyc files must have the same inode (hardlinks).
 -- 
-2.50.1
+2.51.0
 
 
-From d876c8c47b25d3ab1c3f792295a50e1d02598a7e Mon Sep 17 00:00:00 2001
+From d017266ea1452f1fffd47fd7deb2be50d29129cd Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Thu, 9 May 2024 15:16:26 -0300
 Subject: Fix 3.13.0 build.
@@ -1055,7 +1031,7 @@ Previous Python versions had both the time out and the "|| true".
 Some of the test run in that PGO stage sadly still fail on Haiku.
 
 diff --git a/Makefile.pre.in b/Makefile.pre.in
-index 97d95a8..cedbc83 100644
+index 33dcc0c..523ba5b 100644
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
 @@ -856,7 +856,7 @@ profile-run-stamp:
@@ -1067,7 +1043,7 @@ index 97d95a8..cedbc83 100644
  	$(LLVM_PROF_MERGER)
  	# Remove profile generation binary since we are done with it.
  	$(MAKE) clean-retain-profile
-@@ -2257,7 +2257,7 @@ $(LIBRARY_OBJS) $(MODOBJS) Programs/python.o: $(PYTHON_HEADERS)
+@@ -2261,7 +2261,7 @@ $(LIBRARY_OBJS) $(MODOBJS) Programs/python.o: $(PYTHON_HEADERS)
  TESTOPTS=	$(EXTRATESTOPTS)
  TESTPYTHON=	$(RUNSHARED) $(PYTHON_FOR_BUILD) $(TESTPYTHONOPTS)
  TESTRUNNER=	$(TESTPYTHON) -m test
@@ -1090,20 +1066,20 @@ index 1598eba..88b94b6 100644
  
  #if !defined(__HAIKU__) && !defined(__APPLE__) && !defined(__CYGWIN__) && !defined(_AIX) && !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__sun) && !defined(__NetBSD__)
 -- 
-2.50.1
+2.51.0
 
 
-From e040d48e71628cf607b352cf187206e00e88b123 Mon Sep 17 00:00:00 2001
+From d3930f2f6db3572524f54bc666d8e83ff9fc19b7 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sat, 5 Oct 2024 07:32:17 -0300
 Subject: Avoid forcing "-g" on LTO builds, unless Py_DEBUG is defined.
 
 
 diff --git a/configure.ac b/configure.ac
-index 5e79105..f61ffc9 100644
+index a73e95f..139f96f 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -2018,7 +2018,9 @@ if test "$Py_LTO" = 'true' ; then
+@@ -2026,7 +2026,9 @@ if test "$Py_LTO" = 'true' ; then
    then
        # bpo-30345: Add -g to LDFLAGS when compiling with LTO
        # to get debug symbols.
@@ -1115,10 +1091,10 @@ index 5e79105..f61ffc9 100644
  
    CFLAGS_NODIST="$CFLAGS_NODIST ${LTOCFLAGS-$LTOFLAGS}"
 -- 
-2.50.1
+2.51.0
 
 
-From be97f7d8ef678637761b58eb1e130b879c68d947 Mon Sep 17 00:00:00 2001
+From 36d053ec3a1d83f52a52e7b3b55c9dd99f50416b Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Thu, 13 Feb 2025 13:30:03 -0300
 Subject: Make sure we use 'spawn' on Haiku and not 'forkserver'.
@@ -1138,5 +1114,5 @@ index 051d567..4f20b24 100644
      else:
          _default_context = DefaultContext(_concrete_contexts['spawn'])
 -- 
-2.50.1
+2.51.0
 

--- a/dev-lang/python/python3.14-3.14.1.recipe
+++ b/dev-lang/python/python3.14-3.14.1.recipe
@@ -20,7 +20,7 @@ LICENSE="Python"
 COPYRIGHT="1990-2025 Python Software Foundation"
 REVISION="1"
 SOURCE_URI="https://www.python.org/ftp/python/$portVersion/Python-$portVersion.tar.xz"
-CHECKSUM_SHA256="2299dae542d395ce3883aca00d3c910307cd68e0b2f7336098c8e7b7eee9f3e9"
+CHECKSUM_SHA256="8dfa08b1959d9d15838a1c2dab77dc8d8ff4a553a1ed046dfacbc8095c6d42fc"
 SOURCE_DIR="Python-$portVersion"
 
 pyShortVer="${portVersion%.*}"


### PR DESCRIPTION
Removed commit from patchset got upstreamed (with a slightly different implementation).