### PR TITLE
llvm12, rewrite recipe

### DIFF
--- a/sys-devel/llvm/llvm12-12.0.1.recipe
+++ b/sys-devel/llvm/llvm12-12.0.1.recipe
@@ -65,7 +65,23 @@ ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
-	llvm12$secondaryArchSuffix = $portVersion compat >= 12
+	llvm12$secondaryArchSuffix = $portVersion
+	lib:libclang$secondaryArchSuffix = $portVersion compat >= 12
+	lib:libclang_cpp$secondaryArchSuffix = $portVersion compat >= 12
+	lib:libLLVM_12$secondaryArchSuffix = 12.0.1 compat >= 12.0
+	lib:libLTO$secondaryArchSuffix = 12.0.1 compat >= 12
+	lib:libRemarks$secondaryArchSuffix = 12.0.1 compat >= 12
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+REPLACES="
+	llvm12${secondaryArchSuffix}_libs
+	"
+
+PROVIDES_devel="
+	llvm12${secondaryArchSuffix}_devel = $portVersion compat >= 12
 	cmd:bugpoint
 	cmd:diagtool
 	cmd:dsymutil
@@ -132,14 +148,12 @@ PROVIDES="
 	cmd:llvm_tblgen
 	cmd:llvm_undname
 	cmd:llvm_xray
-	cmd:obj2yaml
 	cmd:opt
 	cmd:pp_trace
 	cmd:sancov
 	cmd:sanstats
 	cmd:split_file
 	cmd:verify_uselistorder
-	cmd:yaml2obj
 	devel:libfindAllSymbols$secondaryArchSuffix
 	devel:libLLVM$secondaryArchSuffix = $portVersion compat >= 12
 	devel:libLLVM_$portVersion$secondaryArchSuffix = $portVersion compat >= 12
@@ -302,24 +316,17 @@ PROVIDES="
 	devel:libLTO$secondaryArchSuffix = $portVersion compat >= 12
 	devel:libRemarks$secondaryArchSuffix = $portVersion compat >= 12
 #	lib:BugpointPasses$secondaryArchSuffix
-	lib:CheckerDependencyHandlingAnalyzerPlugin$secondaryArchSuffix
-	lib:CheckerOptionHandlingAnalyzerPlugin$secondaryArchSuffix
+#	lib:CheckerDependencyHandlingAnalyzerPlugin$secondaryArchSuffix
+#	lib:CheckerOptionHandlingAnalyzerPlugin$secondaryArchSuffix
 #	lib:LLVMHello$secondaryArchSuffix
-	lib:SampleAnalyzerPlugin$secondaryArchSuffix
+#	lib:SampleAnalyzerPlugin$secondaryArchSuffix
 #	lib:testplugin$secondaryArchSuffix
 	"
-REQUIRES="
+REQUIRES_devel="
 	haiku$secondaryArchSuffix
-#	lib:libclang_cpp$secondaryArchSuffix
-#	lib:libLLVM_12$secondaryArchSuffix
+	lib:libclang_cpp$secondaryArchSuffix
+	lib:libLLVM_12$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
-	"
-CONFLICTS="
-	llvm$secondaryArchSuffix
-	llvm6$secondaryArchSuffix
-	llvm7$secondaryArchSuffix
-	llvm8$secondaryArchSuffix
-	llvm9$secondaryArchSuffix
 	"
 
 PROVIDES_clang="
@@ -434,17 +441,10 @@ PROVIDES_clang="
 	"
 REQUIRES_clang="
 	haiku$secondaryArchSuffix
-#	lib:libclang$secondaryArchSuffix
-#	lib:libclang_cpp$secondaryArchSuffix
-#	lib:libLLVM_12$secondaryArchSuffix
+	lib:libclang$secondaryArchSuffix
+	lib:libclang_cpp$secondaryArchSuffix
+	lib:libLLVM_12$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
-	"
-CONFLICTS_clang="
-	llvm${secondaryArchSuffix}_clang
-	llvm6${secondaryArchSuffix}_clang
-	llvm7${secondaryArchSuffix}_clang
-	llvm8${secondaryArchSuffix}_clang
-	llvm9${secondaryArchSuffix}_clang
 	"
 
 PROVIDES_clang_analysis="
@@ -457,13 +457,6 @@ PROVIDES_clang_analysis="
 REQUIRES_clang_analysis="
 	llvm12${secondaryArchSuffix}_clang == $portVersion base
 	cmd:python3
-	"
-CONFLICTS_clang_analysis="
-	llvm${secondaryArchSuffix}_clang_analysis
-	llvm6${secondaryArchSuffix}_clang_analysis
-	llvm7${secondaryArchSuffix}_clang_analysis
-	llvm8${secondaryArchSuffix}_clang_analysis
-	llvm9${secondaryArchSuffix}_clang_analysis
 	"
 
 PROVIDES_lld="
@@ -487,20 +480,7 @@ PROVIDES_lld="
 	"
 REQUIRES_lld="
 	haiku$secondaryArchSuffix
-#	lib:libLLVM_12$secondaryArchSuffix
-	"
-
-PROVIDES_libs="
-	llvm12${secondaryArchSuffix}_libs = $portVersion
-	lib:libclang$secondaryArchSuffix = $portVersion compat >= 12
-	lib:libclang_cpp$secondaryArchSuffix = $portVersion compat >= 12
-	lib:libLLVM_12$secondaryArchSuffix = 12.0.1 compat >= 12.0
-	lib:libLTO$secondaryArchSuffix = 12.0.1 compat >= 12
-	lib:libRemarks$secondaryArchSuffix = 12.0.1 compat >= 12
-	"
-REQUIRES_libs="
-	haiku$secondaryArchSuffix
-	lib:libz$secondaryArchSuffix
+	lib:libLLVM_12$secondaryArchSuffix
 	"
 
 PYTHON_PACKAGES="python310"
@@ -620,6 +600,7 @@ BUILD()
 		-DLLVM_ENABLE_RTTI=ON -DLLVM_LINK_LLVM_DYLIB=YES -DLIBUNWIND_ENABLE_STATIC=OFF \
 		-DLLVM_EXTERNAL_CLANG_TOOLS_EXTRA_SOURCE_DIR=$sourceDir/../clang-tools-extra \
 		-G Ninja \
+		-W no-dev \
 		..
 
 	ninja
@@ -787,7 +768,7 @@ INSTALL()
 		$binDir/ccc-analyzer \
 		$dataDir/scan-build \
 		$dataDir/scan-view \
-		$manDir/man1/scan-build.1
+		$manDir
 
 	# lld package
 	packageEntries lld \
@@ -798,14 +779,8 @@ INSTALL()
 		$binDir/lld-link \
 		$binDir/wasm-ld \
 		$includeDir/lld* \
-		$developLibDir/liblld*
-
-	# libs package
-	packageEntries libs \
-		$libDir/libclang* \
-		$libDir/libLLVM* \
-		$libDir/libLTO* \
-		$libDir/libRemarks*
+		$developLibDir/liblld* \
+		$libDir/cmake/lld
 
 	# python310 package
 	packageEntries python310 \
@@ -822,6 +797,17 @@ INSTALL()
 		$includeDir/libunwind*.h \
 		$includeDir/__libunwind*.h \
 		$includeDir/mach-o/compact_unwind_encoding.h
+
+	# devel package
+	packageEntries devel \
+		$binDir \
+		$dataDir/opt-viewer \
+		$developLibDir \
+		$libDir/cmake \
+		$includeDir
+
+	# cleanup empty directory
+	rm -rf $documentationDir
 }
 
 TEST()


### PR DESCRIPTION
This should fix self requires as mentioned on the riscv64 buildmaster My take on current situation: base package and llvm12_clang require sub-package llvm12_libs, which imho wrong, sub-packages should require the base package