### PR TITLE
peggy: fetch source code from codeberg.org

### DIFF
--- a/haiku-games/peggy/peggy-0.7.5.recipe
+++ b/haiku-games/peggy/peggy-0.7.5.recipe
@@ -4,7 +4,7 @@ by getting feedback about the correctness of the color pegs and their positions.
 HOMEPAGE="https://codeberg.org/andimachovec/Peggy"
 COPYRIGHT="2021-2022 Andi Machovec"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="$HOMEPAGE/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="0824a075e7d51b3394076ba3a3a323126d88f7d84d81efbfc4ee625d16d29e13"
 SOURCE_DIR="peggy"


### PR DESCRIPTION
Peggy was migrated from GitHub to Codeberg. This PR reflects the move in the recipe.