### PR TITLE
kpublictransport_kf6, revert to 25.08.3

### DIFF
--- a/dev-libs/kpublictransport/kpublictransport_kf6-25.08.3.recipe
+++ b/dev-libs/kpublictransport/kpublictransport_kf6-25.08.3.recipe
@@ -25,7 +25,7 @@ COPYRIGHT="2010-2025 KDE Organisation"
 LICENSE="GNU LGPL v2"
 REVISION="1"
 SOURCE_URI="https://download.kde.org/stable/release-service/$portVersion/src/kpublictransport-$portVersion.tar.xz"
-CHECKSUM_SHA256="5dbbbfa2313950a0d4e0cb87c8c91a243de64e3786438ebe9240545057e05a35"
+CHECKSUM_SHA256="ed887df23d04a1ebd171b59c99dfaec26d62254e9a7ac4f8a7084ba301586c17"
 SOURCE_DIR="kpublictransport-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"


### PR DESCRIPTION
25.12.0 and up require Qt >= 6.8