### PR TITLE
LZDoom: fix 32bit build

### DIFF
--- a/games-fps/lzdoom/patches/lzdoom-4.14.3a.patchset
+++ b/games-fps/lzdoom/patches/lzdoom-4.14.3a.patchset
@@ -1,4 +1,4 @@
-From f5ce1b02c36137421a4b8769969810fed629e150 Mon Sep 17 00:00:00 2001
+From 0a62d4edf7cef117d702f85f380b405165711c45 Mon Sep 17 00:00:00 2001
 From: Peppersawce <michaelpeppers89@yahoo.it>
 Date: Tue, 16 Dec 2025 01:11:55 +0100
 Subject: Add some more paths
@@ -32,10 +32,11 @@ index 7b7f2d3..62e1461 100644
 2.51.0
 
 
-From 25d4a6f996f2473560cf62dfd4198781745ef6d4 Mon Sep 17 00:00:00 2001
+From 7af4e22dc686f57f9114f533e58c0f06973aceb6 Mon Sep 17 00:00:00 2001
 From: Peppersawce <michaelpeppers89@yahoo.it>
 Date: Tue, 16 Dec 2025 01:25:53 +0100
-Subject: Default video backend to Softpoly (vid_preferbackend 2) and rendermode to True-Color Software Rendering (vid_rendermode 1)
+Subject: Default video backend to Softpoly (vid_preferbackend 2) and
+ rendermode to True-Color Software Rendering (vid_rendermode 1)
 
 
 diff --git a/src/common/rendering/v_video.cpp b/src/common/rendering/v_video.cpp
@@ -52,7 +53,7 @@ index 40280e7..2a561ae 100644
  	// [SP] This may seem pointless - but I don't want to implement live switching just
  	// yet - I'm pretty sure it's going to require a lot of reinits and destructions to
 diff --git a/src/d_main.cpp b/src/d_main.cpp
-index b489150..61106a0 100644
+index b489150..4f19873 100644
 --- a/src/d_main.cpp
 +++ b/src/d_main.cpp
 @@ -228,7 +228,7 @@ CUSTOM_CVAR(Float, i_timescale, 1.0f, CVAR_NOINITCALL | CVAR_VIRTUAL)
@@ -68,7 +69,7 @@ index b489150..61106a0 100644
 2.51.0
 
 
-From a1dbc8a16740fe1f19f588853619219b3e4601f4 Mon Sep 17 00:00:00 2001
+From b500d2f035a196e35916de94950723e9b1bb82d2 Mon Sep 17 00:00:00 2001
 From: Peppersawce <michaelpeppers89@yahoo.it>
 Date: Tue, 16 Dec 2025 01:41:51 +0100
 Subject: Disable git version string
@@ -94,6 +95,30 @@ index 4ef00dc..111c05c 100644
 -	}
 +	}*/
  }
+-- 
+2.51.0
+
+
+From 460e4289ce511ce15a32598b25a4bf12cb7dd88c Mon Sep 17 00:00:00 2001
+From: Peppersawce <michaelpeppers89@yahoo.it>
+Date: Tue, 23 Dec 2025 00:52:56 +0100
+Subject: Disable assert to fix x86 build
+
+
+diff --git a/src/common/models/bonecomponents.h b/src/common/models/bonecomponents.h
+index f4f221f..826f79f 100644
+--- a/src/common/models/bonecomponents.h
++++ b/src/common/models/bonecomponents.h
+@@ -36,7 +36,9 @@ struct ModelAnim
+ 	double switchOffset = 0; // when the animation was changed -- where to interpolate the switch from
+ };
+ 
++#if !defined(__i386__)
+ static_assert(sizeof(ModelAnim) == sizeof(double) * 6);
++#endif
+ 
+ using ModelAnimFrame = std::variant<std::nullptr_t, ModelAnimFrameInterp, ModelAnimFramePrecalculatedIQM>;
+ 
 -- 
 2.51.0
 


### PR DESCRIPTION
This patch disables a static assert that fails on Haiku x86 (but doesn't on other x86 platforms)

The resulting recipe and binary were tested (for a bit) and working on a 32bit Haiku VM.

Not bumping revision because x86_64 is unaffected.