### PR TITLE
libsoup3: fix build, add required deps to DEVEL_REQUIRES

### DIFF
--- a/net-libs/libsoup/libsoup3-3.2.2.recipe
+++ b/net-libs/libsoup/libsoup3-3.2.2.recipe
@@ -5,7 +5,7 @@ GNOME applications, and also has a synchronous API, for use in threaded applicat
 HOMEPAGE="https://wiki.gnome.org/Projects/libsoup/"
 COPYRIGHT="2005 - 2015 The GNOME Project"
 LICENSE="GNU LGPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://ftp.gnome.org/pub/GNOME/sources/libsoup/${portVersion%.*}/libsoup-$portVersion.tar.xz"
 CHECKSUM_SHA256="83673c685b910fb7d39f1f28eee5afbefb71c05798fc350ac3bf1b885e1efaa1"
 SOURCE_DIR="libsoup-$portVersion"
@@ -43,6 +43,11 @@ PROVIDES_devel="
 	"
 REQUIRES_devel="
 	libsoup3$secondaryArchSuffix == $portVersion base
+	devel:libbrotlidec$secondaryArchSuffix
+	devel:libnghttp2$secondaryArchSuffix
+	devel:libpsl$secondaryArchSuffix
+	devel:libsqlite3$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
@@ -51,6 +56,7 @@ BUILD_REQUIRES="
 	devel:libcurl$secondaryArchSuffix
 	devel:libgirepository_1.0$secondaryArchSuffix
 	devel:libglib_2.0$secondaryArchSuffix
+	devel:libnghttp2$secondaryArchSuffix
 	devel:libpsl$secondaryArchSuffix
 	devel:libsqlite3$secondaryArchSuffix
 	devel:libxml2$secondaryArchSuffix


### PR DESCRIPTION
Something is going on with libsoup (2 and 3). Both of them throws 'no required deps' on build, yet it ended up in the repo. Also, libsoup2 does not compile even after adding the deps due to something something compiler.

I did not even bump the version. I just fixed build (both for libsoup3 and other projects that depends on it), and bumped the revision.
Fixes #13260 