### PR TITLE
perl: bump to version 5.42.0

### DIFF
--- a/dev-lang/perl/patches/perl-5.42.0.patchset
+++ b/dev-lang/perl/patches/perl-5.42.0.patchset
@@ -1,4 +1,4 @@
-From 855bd385f6454d5aa9b5699f104b08997b3256a9 Mon Sep 17 00:00:00 2001
+From c174878c2db0e9518ca7ccfdcd65c373afab50ee Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sun, 22 Sep 2013 14:52:03 +0200
 Subject: Tell perl that BFS has a link count of 1
@@ -19,10 +19,10 @@ index 570f25a..81baf48 100644
    # fall-through if we can't unlink now
    _deferred_unlink($fh, $path, 0);
 -- 
-2.45.2
+2.51.0
 
 
-From 0beae3ff13f99f9714e934ae9b26faf99c5a3ac9 Mon Sep 17 00:00:00 2001
+From 6eeb97dc6245c1467c53c5909b2721c4831ef597 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sun, 22 Sep 2013 14:52:53 +0200
 Subject: Haiku defines, but does not implement O_EXLOCK
@@ -43,10 +43,10 @@ index 7bcd491..85260b8 100644
    } else {
      plan tests => 4;
 -- 
-2.45.2
+2.51.0
 
 
-From 87e656ea565c604731a46b06a477d1003e7fd485 Mon Sep 17 00:00:00 2001
+From 33ac1d6bb729288e030f0272b190554f1a6f1ff8 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sun, 22 Sep 2013 14:53:40 +0200
 Subject: haiku sets all its specifics via Configure
@@ -105,10 +105,10 @@ index 0ec7479..0f09f53 100644
 -
 +# haiku sets all its specifics via Configure
 -- 
-2.45.2
+2.51.0
 
 
-From 79ea153da6282f22bbcea6e62f1bc3b5c5e64b0b Mon Sep 17 00:00:00 2001
+From 62aa1b8465ae41d5fa16e4e67d2d774219764992 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sun, 22 Sep 2013 14:54:15 +0200
 Subject: Tell perl that Haiku needs haikuish.h installed as well
@@ -131,10 +131,10 @@ index 3c8af53..1bbbf5b 100755
  
  
 -- 
-2.45.2
+2.51.0
 
 
-From 9823c5079e2463bf5ab2c50294d3486038980b59 Mon Sep 17 00:00:00 2001
+From 5b21cfae4c7f09fdb17ec536c77b9ebe800e1615 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sun, 22 Sep 2013 14:55:13 +0200
 Subject: Fix handling of exit codes on Haiku
@@ -182,10 +182,10 @@ index ce3270e..cab9a79 100644
    }
  
 -- 
-2.45.2
+2.51.0
 
 
-From e14eeccf185723c0b4e69593d17d9759a46fc423 Mon Sep 17 00:00:00 2001
+From ed2f3899404c36a7d1a0554665ef70999190a704 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sat, 28 Sep 2013 13:46:42 +0200
 Subject: Adjust ExtUtils::MakeMaker for PM-Haiku.
@@ -196,7 +196,7 @@ Subject: Adjust ExtUtils::MakeMaker for PM-Haiku.
   for MakeMaker.
 
 diff --git a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM.pm b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM.pm
-index 554e6fb..7cccf41 100644
+index 44e76a9..401e2be 100644
 --- a/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM.pm
 +++ b/cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM.pm
 @@ -61,7 +61,8 @@ if( $^O eq 'MSWin32' ) {
@@ -286,10 +286,10 @@ index 0000000..81e5f99
 +__END__
 +
 -- 
-2.45.2
+2.51.0
 
 
-From 46e78080c437d702e48fcceff03560986f5f0729 Mon Sep 17 00:00:00 2001
+From a122f1d99320be2bff2b065ff6e8cccffab4a39b Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Tue, 8 Oct 2013 22:16:37 +0200
 Subject: Avoid using -rpath for dynamic modules.
@@ -334,10 +334,10 @@ index 81e5f99..25ace13 100644
  __END__
  
 -- 
-2.45.2
+2.51.0
 
 
-From b50ebdadb02c1572f0bcbc55dab69a8ed2f4e691 Mon Sep 17 00:00:00 2001
+From 090d92e092f369784c801171ec1aea09e7d9dac6 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Wed, 9 Oct 2013 20:29:38 +0200
 Subject: Fix initialization check for CPAN.
@@ -364,10 +364,10 @@ index 8934f4a..1716a55 100644
          && -w $Config{installarchlib}
          && -w $Config{installsitelib}
 -- 
-2.45.2
+2.51.0
 
 
-From 8867cf4b0c2f2f672a7fbdcf98d138b33684b408 Mon Sep 17 00:00:00 2001
+From 3a7bc344a5aaaeefdbd64c635c581899a95be8a9 Mon Sep 17 00:00:00 2001
 From: Oliver Tappe <zooey@hirschkaefer.de>
 Date: Sun, 13 Oct 2013 17:32:50 +0200
 Subject: Add support for HAIKU_USE_VENDOR_DIRECTORIES.
@@ -440,10 +440,10 @@ index 25ace13..8a04ead 100644
  __END__
  
 -- 
-2.45.2
+2.51.0
 
 
-From 835d55694521b7b47ebd1176e1abed1b2996f4d1 Mon Sep 17 00:00:00 2001
+From 813b5a0782edb6d8cf9e4f6ae55385ee42a5c94e Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 9 Jun 2017 21:30:33 +0200
 Subject: disable fstack-protector for Haiku
@@ -459,10 +459,10 @@ index 0f09f53..b76c7c1 100644
 +
 +ccflags="$ccflags -fno-stack-protector"
 -- 
-2.45.2
+2.51.0
 
 
-From a412a90df41ba357b0381efcf6df836d193d0d27 Mon Sep 17 00:00:00 2001
+From 06b47219c6be470c347ade4318aff860c3fd57b0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
 Date: Sat, 22 Jun 2024 22:24:38 +0200
 Subject: disable some reentrant variants of functions which we don't have
@@ -499,41 +499,10 @@ index 4b13cc2..931eca2 100644
  #    undef HAS_READDIR_R
  #    undef HAS_READDIR64_R
 -- 
-2.45.2
+2.51.0
 
 
-From fc36c3bd122cbf0cc0965fef56ec6ea549b7eb39 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
-Date: Sat, 22 Jun 2024 22:25:46 +0200
-Subject: disable check involving sizeof(dirent.d_name)
-
-This is a flexible array member and sizeof isn't allowed for these.
-
-diff --git a/sv.c b/sv.c
-index 0b3d142..880a108 100644
---- a/sv.c
-+++ b/sv.c
-@@ -14066,6 +14066,7 @@ Perl_dirp_dup(pTHX_ DIR *const dp, CLONE_PARAMS *const param)
-     pos = PerlDir_tell(dp);
-     if ((dirent = PerlDir_read(dp))) {
-         len = d_namlen(dirent);
-+#ifndef __HAIKU__
-         if (len > sizeof(dirent->d_name) && sizeof(dirent->d_name) > PTRSIZE) {
-             /* If the len is somehow magically longer than the
-              * maximum length of the directory entry, even though
-@@ -14074,6 +14075,7 @@ Perl_dirp_dup(pTHX_ DIR *const dp, CLONE_PARAMS *const param)
-             PerlDir_close(ret);
-             return (DIR*)NULL;
-         }
-+#endif
-         if (len <= sizeof smallbuf) name = smallbuf;
-         else Newx(name, len, char);
-         Move(dirent->d_name, name, len, char);
--- 
-2.45.2
-
-
-From 1709231a599f429bfd638d42934c95f2c64ce9aa Mon Sep 17 00:00:00 2001
+From 347ca2b983d641f3fea9cf5ecc2ad939a53984eb Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
 Date: Sun, 28 Jul 2024 21:30:57 +0200
 Subject: Reinit mutexes after a fork()
@@ -546,10 +515,10 @@ submitted upstream at https://github.com/Perl/perl5/issues/13237 but is
 unlikely that it will eventually be accepted.
 
 diff --git a/embed.fnc b/embed.fnc
-index 6903959..5b485d6 100644
+index 5ddab55..191f24c 100644
 --- a/embed.fnc
 +++ b/embed.fnc
-@@ -648,6 +648,7 @@ Adp	|OP *	|apply_builtin_cv_attributes				\
+@@ -679,6 +679,7 @@ Adp	|OP *	|apply_builtin_cv_attributes				\
  				|NN CV *cv				\
  				|NULLOK OP *attrlist
  CTp	|void	|atfork_lock
@@ -558,10 +527,10 @@ index 6903959..5b485d6 100644
  Cop	|SV **	|av_arylen_p	|NN AV *av
  Adp	|void	|av_clear	|NN AV *av
 diff --git a/embed.h b/embed.h
-index df70b1c..3295c71 100644
+index 9c5c2a8..f283a65 100644
 --- a/embed.h
 +++ b/embed.h
-@@ -132,6 +132,7 @@
+@@ -131,6 +131,7 @@
  # define apply_attrs_string(a,b,c,d)            Perl_apply_attrs_string(aTHX_ a,b,c,d)
  # define apply_builtin_cv_attributes(a,b)       Perl_apply_builtin_cv_attributes(aTHX_ a,b)
  # define atfork_lock                            Perl_atfork_lock
@@ -596,10 +565,10 @@ index 38951e0..c724d2f 100644
  
      PERL_SYS_FPU_INIT;
 diff --git a/proto.h b/proto.h
-index 70c3799..2129bfd 100644
+index a7e81e0..278f057 100644
 --- a/proto.h
 +++ b/proto.h
-@@ -227,6 +227,10 @@ PERL_CALLCONV void
+@@ -214,6 +214,10 @@ PERL_CALLCONV void
  Perl_atfork_lock(void);
  #define PERL_ARGS_ASSERT_ATFORK_LOCK
  
@@ -611,10 +580,10 @@ index 70c3799..2129bfd 100644
  Perl_atfork_unlock(void);
  #define PERL_ARGS_ASSERT_ATFORK_UNLOCK
 diff --git a/util.c b/util.c
-index 4053ca4..e4e9d55 100644
+index 7cf7a76..69a74ab 100644
 --- a/util.c
 +++ b/util.c
-@@ -2858,7 +2858,7 @@ Perl_atfork_lock(void)
+@@ -2847,7 +2847,7 @@ Perl_atfork_lock(void)
  #endif
  }
  
@@ -623,7 +592,7 @@ index 4053ca4..e4e9d55 100644
  void
  Perl_atfork_unlock(void)
  #if defined(USE_ITHREADS)
-@@ -2883,6 +2883,21 @@ Perl_atfork_unlock(void)
+@@ -2872,6 +2872,21 @@ Perl_atfork_unlock(void)
  #endif
  }
  
@@ -645,7 +614,7 @@ index 4053ca4..e4e9d55 100644
  /*
  =for apidoc_section $concurrency
  =for apidoc my_fork
-@@ -2903,7 +2918,10 @@ Perl_my_fork(void)
+@@ -2892,7 +2907,10 @@ Perl_my_fork(void)
  #if defined(USE_ITHREADS) && !defined(HAS_PTHREAD_ATFORK)
      atfork_lock();
      pid = fork();
@@ -658,10 +627,10 @@ index 4053ca4..e4e9d55 100644
      /* atfork_lock() and atfork_unlock() are installed as pthread_atfork()
       * handlers elsewhere in the code */
 -- 
-2.45.2
+2.51.0
 
 
-From c7d4d1c48f68e5c4841c00244eacbab3bf4fa4c7 Mon Sep 17 00:00:00 2001
+From e9e5628e72de1593e26cad3d9995a51cf319c86d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
 Date: Sun, 4 Aug 2024 12:14:53 +0200
 Subject: fix the using of our custom shebang for installed scripts
@@ -743,10 +712,10 @@ index 8a04ead..bd3d5fa 100644
  __END__
  
 -- 
-2.45.2
+2.51.0
 
 
-From af57675e2da8bece41d62ea2a61d3d2015fed64f Mon Sep 17 00:00:00 2001
+From 9ed645a8996cb36d62ad6873119711c5d0734a1e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
 Date: Sun, 18 Aug 2024 16:42:30 +0200
 Subject: don't install the site installation directories (non-packaged)
@@ -771,10 +740,10 @@ index 1bbbf5b..7191a44 100755
  if (-d 'lib') {
      find({no_chdir => 1, wanted => \&installlib}, 'lib')
 -- 
-2.45.2
+2.51.0
 
 
-From cb90febde9feaa4f6ad9b2eab67c8c51f4763ac2 Mon Sep 17 00:00:00 2001
+From 8e4e067aa1eabcd37bde3b18819f5737a4207d22 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
 Date: Sun, 5 Jan 2025 21:35:27 +0100
 Subject: switch C standard to gnu99, we need _DEFAULT_SOURCE
@@ -790,5 +759,5 @@ index b76c7c1..410eea5 100644
 -ccflags="$ccflags -fno-stack-protector"
 +ccflags="$ccflags -std=gnu99 -fno-stack-protector"
 -- 
-2.45.2
+2.51.0
 

--- a/dev-lang/perl/perl-5.42.0.recipe
+++ b/dev-lang/perl/perl-5.42.0.recipe
@@ -16,10 +16,10 @@ HOMEPAGE="https://www.perl.org/"
 COPYRIGHT="1993-2025 Larry Wall and others"
 LICENSE="GNU GPL v1
 	Artistic"
-REVISION="2"
+REVISION="1"
 perlShortVersion="${portVersion%.*}"
 SOURCE_URI="http://www.cpan.org/src/perl-$portVersion.tar.gz"
-CHECKSUM_SHA256="10d4647cfbb543a7f9ae3e5f6851ec49305232ea7621aed24c7cfbb0bef4b70d"
+CHECKSUM_SHA256="e093ef184d7f9a1b9797e2465296f55510adb6dab8842b0c3ed53329663096dc"
 PATCHES="perl-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -150,7 +150,7 @@ INSTALL()
 TEST()
 {
 #x86_64
-#Failed 51 tests out of 2678, 98.10% okay.
+#Failed 50 tests out of 2695, 98.14% okay.
 #        ../cpan/ExtUtils-MakeMaker/t/INST.t
 #        ../cpan/ExtUtils-MakeMaker/t/INST_PREFIX.t
 #        ../cpan/ExtUtils-MakeMaker/t/MM_BeOS.t
@@ -181,7 +181,6 @@ TEST()
 #        ../lib/warnings.t
 #        io/socket.t
 #        op/lc.t
-#        op/sigsystem.t
 #        op/time.t
 #        porting/regen.t
 #        re/charset.t


### PR DESCRIPTION
Everything that requires vendor_perl will have to be rebuilt with this version.