### PR TITLE
libpng16: bump to 1.6.53

### DIFF
--- a/media-libs/libpng/libpng16-1.6.53.recipe
+++ b/media-libs/libpng/libpng16-1.6.53.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="libpng is the official PNG reference library. It supports almost \
 all PNG features, is extensible, and has been extensively tested for over 17 \
 years."
 HOMEPAGE="http://www.libpng.org/"
-COPYRIGHT="1995-2024 The PNG Reference Library Authors
+COPYRIGHT="1995-2025 The PNG Reference Library Authors
 	2018-2024 Cosmin Truta
 	2000-2002, 2004, 2006-2018 Glenn Randers-Pehrson
 	1996-1997 Andreas Dilger
@@ -11,7 +11,7 @@ COPYRIGHT="1995-2024 The PNG Reference Library Authors
 LICENSE="LibPNG"
 REVISION="1"
 SOURCE_URI="https://downloads.sourceforge.net/libpng/libpng-$portVersion.tar.gz"
-CHECKSUM_SHA256="ac25cafc2054cda3f6f0fe22ee9fc587024b99e01d03bd72b765824e48f39021"
+CHECKSUM_SHA256="da0b045cbb1d06a8fc9696f9441359f70645f280ff24ae453ccb7c722353654f"
 SOURCE_DIR="libpng-$portVersion"
 
 ARCHITECTURES="all"


### PR DESCRIPTION
Tested on Haiku R1B5 (hrev59242) x64. No issues.