### PR TITLE
OpenRCT2: fix nlohmann_json for 32bit

### DIFF
--- a/games-simulation/openrct2/openrct2-0.4.29.recipe
+++ b/games-simulation/openrct2/openrct2-0.4.29.recipe
@@ -55,7 +55,7 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	nlohmann_json$secondaryArchSuffix
+	nlohmann_json
 	devel:libcurl$secondaryArchSuffix
 	devel:libflac$secondaryArchSuffix
 	devel:libfontconfig$secondaryArchSuffix


### PR DESCRIPTION
Turns out I declared the nlohmann_json dependency the wrong way and that stops compilation on 32bit.
This tweak should fix it but it's likely there's more that should be tweaked for 32bit.

Not revbumping because x86_64 is unaffected