### PR TITLE
qtav, fix reference to ffmpeg_devel (4)

### DIFF
--- a/media-video/qtav/qtav-1.13.0.recipe
+++ b/media-video/qtav/qtav-1.13.0.recipe
@@ -85,17 +85,18 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	ffmpeg${secondaryArchSuffix}_devel
 	devel:libass$secondaryArchSuffix
-	devel:libavcodec$secondaryArchSuffix >= 58
-	devel:libavdevice$secondaryArchSuffix >= 58
-	devel:libavfilter$secondaryArchSuffix >= 7
-	devel:libavformat$secondaryArchSuffix >= 58
-	devel:libavutil$secondaryArchSuffix >= 56
+#	devel:libavcodec$secondaryArchSuffix >= 58
+#	devel:libavdevice$secondaryArchSuffix >= 58
+#	devel:libavfilter$secondaryArchSuffix >= 7
+#	devel:libavformat$secondaryArchSuffix >= 58
+#	devel:libavutil$secondaryArchSuffix >= 56
 	devel:libgl$secondaryArchSuffix
 	devel:libopenal$secondaryArchSuffix
 #	devel:libportaudio$secondaryArchSuffix
 	devel:libQt5Core$secondaryArchSuffix
-	devel:libswresample$secondaryArchSuffix >= 3
+#	devel:libswresample$secondaryArchSuffix >= 3
 	devel:libswscale$secondaryArchSuffix
 	devel:libuchardet$secondaryArchSuffix
 	"
@@ -126,7 +127,9 @@ BUILD()
 		-DBUILD_QT5OPENGL=ON \
 		-DHAVE_PORTAUDIO=OFF \
 		-DHAVE_PULSE=OFF \
-		-DHAVE_VAAPI=OFF
+		-DHAVE_VAAPI=OFF \
+		-DCMAKE_POLICY_VERSION_MINIMUM=3.5
+
 	make -C build $jobArgs
 }
 


### PR DESCRIPTION
build errors out with either ffmpeg version here, so not revbumping also seems to be deprecated: https://www.qtav.org/blog/new-sdk.html