### PR TITLE
Fix some references to python2.7

### DIFF
--- a/dev-util/apitrace/apitrace-7.1.recipe
+++ b/dev-util/apitrace/apitrace-7.1.recipe
@@ -46,7 +46,7 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:python
+#	cmd:python
 	"
 
 BUILD()

--- a/games-strategy/0ad/0ad-0.0.23b~alpha.recipe
+++ b/games-strategy/0ad/0ad-0.0.23b~alpha.recipe
@@ -78,7 +78,7 @@ BUILD_PREREQUIRES="
 	cmd:patch
 	cmd:perl
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:python2
+#	cmd:python2
 	cmd:sed
 	cmd:which
 	cmd:xargs


### PR DESCRIPTION
Related: https://build.haiku-os.org/buildmaster/master/x86_64/logviewer.html?repo_consistency.txt
```
0ad-0.0.23b~alpha-7:
       build-prerequires "cmd:python2" of package "0ad-0.0.23b~alpha" could not be resolved

apitrace-7.1-2:
       build-prerequires "cmd:python" of package "apitrace-7.1" could not be resolved
```