### PR TITLE
synergy, cleanup for cmd:python (2.7)

### DIFF
--- a/x11-misc/synergy/synergy-1.5.0.recipe
+++ b/x11-misc/synergy/synergy-1.5.0.recipe
@@ -31,7 +31,7 @@ BUILD_PREREQUIRES="
 	cmd:cmake
 	cmd:gcc
 	cmd:make
-	cmd:python
+#	cmd:python
 	cmd:sh
 	"
 


### PR DESCRIPTION
Related: https://build.haiku-os.org/buildmaster/master/x86_gcc2/logviewer.html?repo_consistency.txt
```
synergy-1.5.0-2:
       build-prerequires "cmd:python" of package "synergy-1.5.0" could not be resolved
```