### PR TITLE
qt6_jdenticon, revbump, fix cmd:qmake6$secondaryArchSuffix

### DIFF
--- a/dev-qt/qt6-jdenticon/qt6_jdenticon-0.3.1.recipe
+++ b/dev-qt/qt6-jdenticon/qt6_jdenticon-0.3.1.recipe
@@ -14,7 +14,7 @@ jdenticon-ified."
 HOMEPAGE="https://github.com/Nheko-Reborn/qt-jdenticon/"
 COPYRIGHT="2019 Joseph Donofry"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/Nheko-Reborn/qt-jdenticon/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="39fca8c8a6a95fd76419ace3ec5f0b7876044abc78b979c2632ab73b2da50b58"
 SOURCE_DIR="qt-jdenticon-$portVersion"
@@ -38,7 +38,7 @@ BUILD_REQUIRES="
 	devel:libQt6Gui$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:qmake6
+	cmd:qmake6$secondaryArchSuffix
 	cmd:g++$secondaryArchSuffix
 	cmd:make
 	"


### PR DESCRIPTION
Fix for 32bit.