### PR TITLE
libclaw, drop cmake version requirement (build launched fine with cma…

### DIFF
--- a/dev-libs/libclaw/libclaw-1.7.4.recipe
+++ b/dev-libs/libclaw/libclaw-1.7.4.recipe
@@ -68,18 +68,21 @@ BUILD_REQUIRES="
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:cmake >= 3.0
+	cmd:cmake
 	cmd:doxygen
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
 	cmd:make
 	"
 
+
 BUILD()
 {
 	cmake -Bbuild -S. -DCMAKE_BUILD_TYPE=Release \
 		-DCMAKE_INSTALL_PREFIX=$prefix \
-		-DCMAKE_CXX_FLAGS="-std=c++98"
+		-DCMAKE_CXX_FLAGS="-std=c++98" \
+		-DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+		-Wno-dev
 	make -C build $jobArgs
 }
 


### PR DESCRIPTION
…ke4)