### PR TITLE
libvirt: disable x86_gcc2 build.

### DIFF
--- a/app-emulation/libvirt/libvirt-8.10.0.recipe
+++ b/app-emulation/libvirt/libvirt-8.10.0.recipe
@@ -14,7 +14,7 @@ systems such as GObject, CIM and SNMP."
 HOMEPAGE="https://libvirt.org/"
 COPYRIGHT="2005-2022 Daniel Veillard"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/libvirt/libvirt/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="7a5ddc97a3e0e534259b90dcdf24209ce4923a671c7c3fae7f47b1cda27ef81a"
 SOURCE_DIR="$portVersionedName"
@@ -22,8 +22,15 @@ SOURCE_URI_2="https://github.com/qemu/keycodemapdb/archive/e15649b83a78f89f57205
 CHECKSUM_SHA256_2="9567575d03438ae7c05352771522fa200e26a4d658b3b6d4b7c1235634bcce37"
 PATCHES="libvirt-$portVersion.patchset"
 
-ARCHITECTURES="all"
-SECONDARY_ARCHITECTURES="x86_gcc2 x86"
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+commandBinDir=$binDir
+commandSuffix=$secondaryArchSuffix
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
 
 GLOBAL_WRITABLE_FILES="
 	settings/libvirt/libvirt-admin.conf auto-merge
@@ -48,29 +55,29 @@ GLOBAL_WRITABLE_FILES="
 	"
 PROVIDES="
 	libvirt$secondaryArchSuffix = $portVersion
+	cmd:libvirtd$commandSuffix
+	cmd:virsh$commandSuffix
+	cmd:virt_admin$commandSuffix
+	cmd:virt_qemu_qmp_proxy$commandSuffix
+	cmd:virt_qemu_run$commandSuffix
+	cmd:virt_qemu_sev_validate$commandSuffix
+	cmd:virt_host_validate$commandSuffix
+	cmd:virt_pki_query_dn$commandSuffix
+	cmd:virt_pki_validate$commandSuffix
+	cmd:virt_ssh_helper$commandSuffix
+	cmd:virt_xml_validate$commandSuffix
+	cmd:virtlockd$commandSuffix
+	cmd:virtlogd$commandSuffix
+	cmd:virtnetworkd$commandSuffix
+	cmd:virtproxyd$commandSuffix
+	cmd:virtqemud$commandSuffix
+	cmd:virtsecretd$commandSuffix
+	cmd:virtstoraged$commandSuffix
+	cmd:virtvboxd$commandSuffix
+	lib:libvirt_admin$secondaryArchSuffix = $portVersion
+	lib:libvirt_lxc$secondaryArchSuffix = $portVersion
+	lib:libvirt_qemu$secondaryArchSuffix = $portVersion
 	lib:libvirt$secondaryArchSuffix = $portVersion
-	cmd:libvirtd$secondaryArchSuffix
-	cmd:virsh$secondaryArchSuffix
-	cmd:virt_admin$secondaryArchSuffix
-	cmd:virt_qemu_qmp_proxy$secondaryArchSuffix
-	cmd:virt_qemu_run$secondaryArchSuffix
-	cmd:virt_qemu_sev_validate$secondaryArchSuffix
-	cmd:virt_host_validate$secondaryArchSuffix
-	cmd:virt_pki_query_dn$secondaryArchSuffix
-	cmd:virt_pki_validate$secondaryArchSuffix
-	cmd:virt_ssh_helper$secondaryArchSuffix
-	cmd:virt_xml_validate$secondaryArchSuffix
-	cmd:virtlockd$secondaryArchSuffix
-	cmd:virtlogd$secondaryArchSuffix
-	cmd:virtnetworkd$secondaryArchSuffix
-	cmd:virtproxyd$secondaryArchSuffix
-	cmd:virtqemud$secondaryArchSuffix
-	cmd:virtsecretd$secondaryArchSuffix
-	cmd:virtstoraged$secondaryArchSuffix
-	cmd:virtvboxd$secondaryArchSuffix
-	lib:libvirt_admin$secondaryArchSuffix
-	lib:libvirt_lxc$secondaryArchSuffix
-	lib:libvirt_qemu$secondaryArchSuffix
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -119,18 +126,22 @@ BUILD_PREREQUIRES="
 	cmd:xsltproc
 	"
 
+TEST_REQUIRES="
+	cmd:diff
+	"
+
 BUILD()
 {
 	rm -rf src/keycodemapdb/*
 	cp -r /sources-2/keycodemapdb*/* src/keycodemapdb
 	chmod +x src/keycodemapdb/tools/keymap-gen
 
-	export CFLAGS="-DB_USE_POSITIVE_POSIX_ERRORS -D_BSD_SOURCE" 
+	export CFLAGS="-DB_USE_POSITIVE_POSIX_ERRORS -D_BSD_SOURCE"
 	export LDFLAGS="-lposix_error_mapper -lnetwork -lbsd"
 
 	meson build --buildtype=release \
-		--prefix=$prefix --libdir=$libDir --datadir=$dataDir --bindir=$binDir\
-		--includedir=$includeDir --sysconfdir=$settingsDir --sbindir=$binDir \
+		--prefix=$prefix --libdir=$libDir --datadir=$dataDir --bindir=$commandBinDir \
+		--includedir=$includeDir --sysconfdir=$settingsDir --sbindir=$commandBinDir \
 		--libexecdir=$libDir --localedir=$dataDir/locale \
 		-Dwerror=false -Dgit_werror=disabled -Ddocs=disabled -Dtests=disabled
 }
@@ -138,7 +149,7 @@ BUILD()
 INSTALL()
 {
 	ninja -C build install
-	
+
 	prepareInstalledDevelLibs libvirt
 	fixPkgconfig
 


### PR DESCRIPTION
No much point in trying to build this with GCC2, and it would be missing build and runtime dependencies anyway.

----
Untested (doesn't builds on nightlies. Needs at the very least defining `_DEFAULT_SOURCE`, but also patching for the changes in `CPU_SET_S` and co).