### PR TITLE
gnupg: drop _x86 suffix for commands on x86_32.

### DIFF
--- a/app-crypt/gnupg/gnupg-2.4.7.recipe
+++ b/app-crypt/gnupg/gnupg-2.4.7.recipe
@@ -29,7 +29,7 @@ LICENSE="CC0 v1.0
 	GNU GPL v3
 	GNU LGPL v2.1
 	GNU LGPL v3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://gnupg.org/ftp/gcrypt/gnupg/gnupg-$portVersion.tar.bz2"
 CHECKSUM_SHA256="7b24706e4da7e0e3b06ca068231027401f238102c41c909631349dcc3b85eb46"
 PATCHES="gnupg-$portVersion.patchset"
@@ -39,26 +39,26 @@ SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	gnupg$secondaryArchSuffix = $portVersion
-	cmd:addgnupghome$secondaryArchSuffix
-	cmd:applygnupgdefaults$secondaryArchSuffix
-	cmd:dirmngr$secondaryArchSuffix
-	cmd:dirmngr_client$secondaryArchSuffix
-	cmd:gpg$secondaryArchSuffix
-	cmd:gpg_agent$secondaryArchSuffix
-	cmd:gpg_card$secondaryArchSuffix
-	cmd:gpg_connect_agent$secondaryArchSuffix
-	cmd:gpg_mail_tube$secondaryArchSuffix
-	cmd:gpg_wks_client$secondaryArchSuffix
-	cmd:gpg_wks_server$secondaryArchSuffix
-	cmd:gpgconf$secondaryArchSuffix
-	cmd:gpgparsemail$secondaryArchSuffix
-	cmd:gpgscm$secondaryArchSuffix
-	cmd:gpgsm$secondaryArchSuffix
-	cmd:gpgsplit$secondaryArchSuffix
-	cmd:gpgtar$secondaryArchSuffix
-	cmd:gpgv$secondaryArchSuffix
-	cmd:kbxutil$secondaryArchSuffix
-	cmd:watchgnupg$secondaryArchSuffix
+	cmd:addgnupghome
+	cmd:applygnupgdefaults
+	cmd:dirmngr
+	cmd:dirmngr_client
+	cmd:gpg
+	cmd:gpg_agent
+	cmd:gpg_card
+	cmd:gpg_connect_agent
+	cmd:gpg_mail_tube
+	cmd:gpg_wks_client
+	cmd:gpg_wks_server
+	cmd:gpgconf
+	cmd:gpgparsemail
+	cmd:gpgscm
+	cmd:gpgsm
+	cmd:gpgsplit
+	cmd:gpgtar
+	cmd:gpgv
+	cmd:kbxutil
+	cmd:watchgnupg
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -124,7 +124,9 @@ TEST_REQUIRES="
 BUILD()
 {
 	AUTOPOINT=true autoreconf -vfi
-	runConfigure ./configure \
+	runConfigure --omit-dirs binDir ./configure \
+		--bindir=$prefix/bin \
+		--sbindir=$prefix/bin \
 		--libexecdir=$libDir/gnupg \
 		--with-bzip2 \
 		--disable-libdns


### PR DESCRIPTION
Did only a rev-bump, because at first I was going to update to 2.5.14 (latest on [gpupg.org](https://gnupg.org/download/index.html)), but that requires updates to libassuan and to libgpg_error, and I didn't have enough data, also, seems 2.5.15 is already "[released](https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=commit;h=7ee523ac29032292aed46612d80d847234c1afae)", but not published yet.
