### PR TITLE
dumb0.9: enable only for GCC2, restore _devel.

### DIFF
--- a/media-libs/dumb/dumb0.9-0.9.3.recipe
+++ b/media-libs/dumb/dumb0.9-0.9.3.recipe
@@ -3,15 +3,15 @@ DESCRIPTION="DUMB is an IT, XM, S3M and MOD player library"
 HOMEPAGE="http://dumb.sourceforge.net/"
 COPYRIGHT="2001-2005 Ben Davis, Robert J Ohannessian and Julien Cugniere"
 LICENSE="DUMB-0.9.3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://downloads.sourceforge.net/project/dumb/dumb/$portVersion/dumb-$portVersion.tar.gz"
 CHECKSUM_SHA256="8d44fbc9e57f3bac9f761c3b12ce102d47d717f0dd846657fb988e0bb5d1ea33"
 SOURCE_URI_2="http://prdownloads.sourceforge.net/dumb/dumb-$portVersion-autotools.tar.gz"
 CHECKSUM_SHA256_2="9e3fa1e0932e00e31f2314cefb3ea0343ee4f850b6a8e6a6a9627a35b2dc0dbd"
 SOURCE_DIR="dumb-$portVersion"
 
-ARCHITECTURES="all"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="!all x86_gcc2"
+SECONDARY_ARCHITECTURES="!x86"
 
 PROVIDES="
 	dumb0.9$secondaryArchSuffix = $portVersion
@@ -21,6 +21,15 @@ PROVIDES="
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:liballeg$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	dumb0.9${secondaryArchSuffix}_devel = $portVersion
+	devel:libaldmb_0.9.3$secondaryArchSuffix = $portVersion compat >= 0.9
+	devel:libdumb_0.9.3$secondaryArchSuffix = $portVersion compat >= 0.9
+	"
+REQUIRES_devel="
+	dumb0.9$secondaryArchSuffix == $portVersion base
 	"
 
 BUILD_REQUIRES="
@@ -46,8 +55,7 @@ BUILD()
 	autoconf
 	touch NEWS README ChangeLog AUTHORS
 	automake --add-missing
-	runConfigure --omit-dirs "dataRootDir" ./configure \
-		--disable-static
+	runConfigure --omit-dirs "dataRootDir" ./configure --disable-static
 	make $jobArgs
 }
 
@@ -58,8 +66,16 @@ INSTALL()
 	# remove libtool file
 	rm -f $libDir/*.la
 
-	prepareInstalledDevelLibs libdumb libaldmb libdumb-0.9.3 libaldmb-0.9.3
+	# Remove symlinks "libdumb.so" and "libaldmb.so" (conflict with dumb-2.x)
+	rm -f $libDir/{libdumb,libaldmb}.so
 
-	rm -rf $developDir $binDir
+	prepareInstalledDevelLibs libdumb-0.9.3 libaldmb-0.9.3
 
+
+	# devel package
+	packageEntries devel \
+		$developDir
+
+	# Newer dumb 2.x provids a _tools package, so no need for these:
+	rm -rf $binDir
 }


### PR DESCRIPTION
This is needed to be able to rebuild "alex4".

That package crashes right away if compiled with modern GCC (on both 32 and 64 bits), at least when run on hrevs with the new allocator. In both cases there's seems to be a possible double free in liballeg.

The bug does not manifest when building a GCC2 version of alex4.

ToDo: if dumb 2.x can be built with gcc2, try moving alex4 to that version, so we can drop this older version.