### PR TITLE
alex4: fix building after changes in older libdumb.

### DIFF
--- a/games-arcade/alex4/alex4-1.0.recipe
+++ b/games-arcade/alex4/alex4-1.0.recipe
@@ -5,7 +5,7 @@ Lola from evil humans who want to make a bag of her."
 HOMEPAGE="https://sourceforge.net/projects/allegator/files/Alex4/"
 COPYRIGHT="2003 Johan Peitz"
 LICENSE="GNU GPL v2"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="http://downloads.sourceforge.net/allegator/alex4src_data.zip"
 CHECKSUM_SHA256="d266d7fba64fbfedf13240d3d0eb21b8bacbedeaa5f22b26a27d472c8d23f103"
 SOURCE_URI_2="http://downloads.sourceforge.net/allegator/alex4_beos_src.zip"
@@ -14,9 +14,6 @@ SOURCE_DIR="alex4src"
 SOURCE_DIR_2="alex4_BeOS_src"
 PATCHES="alex4-$portVersion.patchset"
 PATCHES_2="alex4-$portVersion-source2.patchset"
-# TODO: Check if it would be OK to also import the patches in:
-# http://data.gpo.zugaina.org/gamerlay/games-arcade/alex4/files/
-# and sync with alex4-1.1 in http://gpo.zugaina.org/games-arcade/alex4
 
 ARCHITECTURES="all"
 
@@ -33,9 +30,9 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku_devel
-	devel:libaldmb
+	devel:libaldmb_0.9.3
 	devel:liballeg
-	devel:libdumb
+	devel:libdumb_0.9.3
 	"
 BUILD_PREREQUIRES="
 	cmd:gcc

--- a/games-arcade/alex4/patches/alex4-1.0-source2.patchset
+++ b/games-arcade/alex4/patches/alex4-1.0-source2.patchset
@@ -1,4 +1,4 @@
-From aa5038994a06c9c957e1e9a86c8986b3faf8c74c Mon Sep 17 00:00:00 2001
+From 757ccda805b76140bc752e4dd834f14e3a4f81b7 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sun, 12 May 2019 15:15:15 +0200
 Subject: link against libaldmb.so
@@ -17,5 +17,27 @@ index d10a6e5..6c802bc 100644
  OBJECTS :=$(SOURCES:%.c=%.o)
  all:  clean compile
 -- 
-2.21.0
+2.52.0
+
+
+From c5ac04890151ec536bc64f1503ed96b15e2b2f6d Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Wed, 31 Dec 2025 02:52:07 -0300
+Subject: Fix linking to older libdumb.
+
+
+diff --git a/Makefile b/Makefile
+index 6c802bc..52bc50f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,6 +1,6 @@
+ CC=g++
+ CFLAGS=-c -O1 -c `allegro-config --cflags`
+-LDFLAGS=`allegro-config --libs` -ldumb -laldmb
++LDFLAGS=`allegro-config --libs` -ldumb-0.9.3 -laldmb-0.9.3
+ SOURCES=actor.c edit.c map.c player.c shooter.c bullet.c hisc.c options.c script.c timer.c control.c main.c particle.c scroller.c token.c
+ OBJECTS :=$(SOURCES:%.c=%.o)
+ all:  clean compile
+-- 
+2.52.0
 

--- a/games-arcade/alex4/patches/alex4-1.0.patchset
+++ b/games-arcade/alex4/patches/alex4-1.0.patchset
@@ -1,4 +1,4 @@
-From 9fdd88ae4724145d90c8ac5ba82a519a6c9e0d71 Mon Sep 17 00:00:00 2001
+From d5a27b4dc759e918339c6b56d24accb59934a221 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sun, 12 May 2019 13:04:42 +0200
 Subject: Patch from
@@ -1558,10 +1558,10 @@ index d8634f1..707855e 100644
 \ No newline at end of file
 +#endif
 -- 
-2.21.0
+2.52.0
 
 
-From 773d561c9d3d89448631ae6f853bb67cc28c34e3 Mon Sep 17 00:00:00 2001
+From 290f7db537d717960cd67d0b8eeb4bb6f1246326 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sun, 12 May 2019 15:14:44 +0200
 Subject: replace fsin,fmul,fcos with fixsin,fixmul,fixcos
@@ -1632,5 +1632,5 @@ index e906823..6005406 100644
  		}
  	
 -- 
-2.21.0
+2.52.0
 


### PR DESCRIPTION
See commit message on PR #13548 for why we still use GCC2 for this package.