### PR TITLE
boost1.90, bump 1.89.0 to 1.90.1

### DIFF
--- a/dev-libs/boost/boost1.90-1.90.0.recipe
+++ b/dev-libs/boost/boost1.90-1.90.0.recipe
@@ -5,7 +5,7 @@ pseudorandom number generation, multithreading, image processing, regular \
 expressions, and unit testing. It contains over eighty individual libraries."
 HOMEPAGE="https://www.boost.org/"
 SOURCE_URI="https://archives.boost.io/release/$portVersion/source/boost_${portVersion//./_}.tar.bz2"
-CHECKSUM_SHA256="85a33fa22621b4f314f8e85e1a5e2a9363d22e4f4992925d4bb3bc631b5a0c7a"
+CHECKSUM_SHA256="49551aff3b22cbc5c5a9ed3dbc92f0e23ea50a0f7325b0d198b705e8ee3fc305"
 REVISION="1"
 LICENSE="Boost v1.0"
 COPYRIGHT="1993-2002 Christopher Seiwald and Perforce Software, Inc.
@@ -15,7 +15,7 @@ COPYRIGHT="1993-2002 Christopher Seiwald and Perforce Software, Inc.
 	2002-2019 Rene Rivera
 	2003-2015 Vladimir Prus"
 SOURCE_DIR="boost_${portVersion//./_}"
-PATCHES="boost1.89-$portVersion.patchset"
+PATCHES="boost1.90-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -24,7 +24,7 @@ libVersion="$portVersion"
 libVersionCompat="$libVersion compat >= $libVersion"
 
 PROVIDES="
-	boost1.89$secondaryArchSuffix = $portVersion
+	boost1.90$secondaryArchSuffix = $portVersion
 	lib:libboost_atomic$secondaryArchSuffix = $libVersionCompat
 	lib:libboost_charconv$secondaryArchSuffix = $libVersionCompat
 	lib:libboost_chrono$secondaryArchSuffix = $libVersionCompat
@@ -86,15 +86,15 @@ devel_libs="
 	devel:libboost_contract$secondaryArchSuffix = $libVersionCompat
 	devel:libboost_coroutine$secondaryArchSuffix = $libVersionCompat
 	devel:libboost_date_time$secondaryArchSuffix = $libVersionCompat
-	devel:libboost_exception$secondaryArchSuffix = $libVersionCompat
+	devel:libboost_exception$secondaryArchSuffix
 	devel:libboost_fiber$secondaryArchSuffix = $libVersionCompat
 	devel:libboost_filesystem$secondaryArchSuffix = $libVersionCompat
 	devel:libboost_graph$secondaryArchSuffix = $libVersionCompat
 	devel:libboost_iostreams$secondaryArchSuffix = $libVersionCompat
 	devel:libboost_json$secondaryArchSuffix = $libVersionCompat
 	devel:libboost_locale$secondaryArchSuffix = $libVersionCompat
-	devel:libboost_log_setup$secondaryArchSuffix = $libVersionCompat
 	devel:libboost_log$secondaryArchSuffix = $libVersionCompat
+	devel:libboost_log_setup$secondaryArchSuffix = $libVersionCompat
 	devel:libboost_nowide$secondaryArchSuffix = $libVersionCompat
 	devel:libboost_prg_exec_monitor$secondaryArchSuffix = $libVersionCompat
 	devel:libboost_process$secondaryArchSuffix = $libVersionCompat
@@ -104,7 +104,7 @@ devel_libs="
 	devel:libboost_serialization$secondaryArchSuffix = $libVersionCompat
 	devel:libboost_stacktrace_basic$secondaryArchSuffix = $libVersionCompat
 	devel:libboost_stacktrace_noop$secondaryArchSuffix = $libVersionCompat
-	devel:libboost_test_exec_monitor$secondaryArchSuffix = $libVersionCompat
+	devel:libboost_test_exec_monitor$secondaryArchSuffix
 	devel:libboost_thread$secondaryArchSuffix = $libVersionCompat
 	devel:libboost_timer$secondaryArchSuffix = $libVersionCompat
 	devel:libboost_type_erasure$secondaryArchSuffix = $libVersionCompat
@@ -115,12 +115,11 @@ devel_libs="
 	"
 
 PROVIDES_devel="
-	boost1.89${secondaryArchSuffix}_devel = $portVersion
+	boost1.90${secondaryArchSuffix}_devel = $portVersion
 	$devel_libs
-	devel:libboost_config$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
-	boost1.89$secondaryArchSuffix == $portVersion base
+	boost1.90$secondaryArchSuffix == $portVersion base
 	"
 CONFLICTS_devel="
 	boost169${secondaryArchSuffix}_devel
@@ -133,11 +132,7 @@ CONFLICTS_devel="
 
 ARCHITECTURES_doc="any"
 PROVIDES_doc="
-	boost1.89_doc = $portVersion
-	"
-REPLACES_doc="
-	boost1.89_docs
-	boost1.89_x86_docs
+	boost1.90_doc = $portVersion
 	"
 
 BUILD_REQUIRES="
@@ -160,7 +155,7 @@ BUILD_PREREQUIRES="
 	cmd:which
 	"
 
-defineDebugInfoPackage boost1.89$secondaryArchSuffix \
+defineDebugInfoPackage boost1.90$secondaryArchSuffix \
 	"$libDir"/libboost_atomic.so.$libVersion \
 	"$libDir"/libboost_charconv.so.$libVersion \
 	"$libDir"/libboost_chrono.so.$libVersion \

--- a/dev-libs/boost/patches/boost1.90-1.90.0.patchset
+++ b/dev-libs/boost/patches/boost1.90-1.90.0.patchset
@@ -1,4 +1,4 @@
-From 2b795e616f40e5f0c9a8c940b8c2e25d06666678 Mon Sep 17 00:00:00 2001
+From 0fd4eaceb0dba6c882823eeea88f5978a08b2970 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@gmail.com>
 Date: Sat, 6 Aug 2016 22:27:19 +0200
 Subject: Import changes from 1.55.0: buildtools
@@ -21,10 +21,10 @@ index fb6e5da..f78bbe7 100644
  #define OSMINOR "OS=BSDI"
  #define OS_BSDI
 -- 
-2.48.1
+2.51.0
 
 
-From 44d5d1c1cce4e83ddc06e8de433f14b9655a5573 Mon Sep 17 00:00:00 2001
+From 7cc1b2eb3ed55037e7b099a0979d3d42da89e79c Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@gmail.com>
 Date: Sat, 6 Aug 2016 22:27:41 +0200
 Subject: Import changes from 1.55.0: sourcecode
@@ -44,10 +44,10 @@ index 172a601..c706e40 100644
  #elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__)
  #  define BOOST_THREAD_MACOS
 -- 
-2.50.1
+2.51.0
 
 
-From 22dce17dec3019958175f43b560ab050b4e7331a Mon Sep 17 00:00:00 2001
+From cc676f73db63241cf6e3c37379e043f3897a746a Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sat, 14 Oct 2017 11:47:09 +0200
 Subject: Haiku needs bsd and _BSD_SOURCE.
@@ -81,10 +81,10 @@ index 65a366a..1b0c014 100755
  
      intel-*)
 -- 
-2.50.1
+2.51.0
 
 
-From 9d320bebf1d70ec67ededf4470f0323dbd0ad1eb Mon Sep 17 00:00:00 2001
+From 79a33b50a20f37f589a4904df6d383cf7aef537f Mon Sep 17 00:00:00 2001
 From: Begasus <begasus@gmail.com>
 Date: Fri, 25 Aug 2023 10:15:17 +0200
 Subject: Add auto_index binary to tools
@@ -103,10 +103,10 @@ index e1391c7..a580eb1 100644
      inspect/build//inspect
      quickbook//quickbook
 -- 
-2.50.1
+2.51.0
 
 
-From a5caab0121d920ef611b976ca1edec7eea442dc4 Mon Sep 17 00:00:00 2001
+From 62f687589bef14530e794eeed96b5498902ae0f4 Mon Sep 17 00:00:00 2001
 From: Begasus <begasus@gmail.com>
 Date: Sun, 27 Aug 2023 19:13:24 +0200
 Subject: Fix missing functions to build libboost_locale
@@ -129,10 +129,10 @@ index 04244c5..e22ac4f 100644
  // thread API's not auto detected:
  //
 -- 
-2.50.1
+2.51.0
 
 
-From 4efb5fb5311f57560be1c64c13e9c3cef7069eb0 Mon Sep 17 00:00:00 2001
+From d8fb33d96633e943dbe31c13c191d77112e568b7 Mon Sep 17 00:00:00 2001
 From: Begasus <begasus@gmail.com>
 Date: Mon, 28 Aug 2023 18:08:06 +0200
 Subject: Fix building the tests
@@ -152,10 +152,10 @@ index d67d932..6406018 100644
  
  using testing ;
 -- 
-2.50.1
+2.51.0
 
 
-From a4c111b940a9780e8217903ac4abb78c6dad095a Mon Sep 17 00:00:00 2001
+From 19493386d8f7ca4bf9adf33481f8b35a29e72e5f Mon Sep 17 00:00:00 2001
 From: PulkoMandy <pulkomandy@pulkomandy.tk>
 Date: Fri, 13 Jan 2023 21:26:43 +0100
 Subject: Haiku currently doesn't have cfsetspeed
@@ -176,10 +176,10 @@ index e6a275d..7866eec 100644
  # else
    ::cfsetispeed(&storage, baud);
 -- 
-2.50.1
+2.51.0
 
 
-From 900c9d2994aa0f4b3f2949e0a07de074a23d9726 Mon Sep 17 00:00:00 2001
+From 1d5d30221298951b386a06a8613fb7382b832768 Mon Sep 17 00:00:00 2001
 From: Schrijvers Luc <begasus@gmail.com>
 Date: Sat, 6 Jul 2024 17:27:48 +0200
 Subject: build fix for sourcetrail
@@ -231,17 +231,17 @@ index 24e51fa..2836d9d 100644
 \ No newline at end of file
 +#endif //BOOST_PROCESS_V2_EXIT_CODE_HPP
 -- 
-2.50.1
+2.51.0
 
 
-From 4b09f1d89860f0d228045219aea5950836da6a5f Mon Sep 17 00:00:00 2001
+From 5aeb246b1b2b08fcf36eb5126345046de61d9595 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 20 Dec 2024 22:32:12 -0300
 Subject: Fix build issue related to dirent->d_name[].
 
 
 diff --git a/libs/filesystem/src/directory.cpp b/libs/filesystem/src/directory.cpp
-index 113fef8..baef36e 100644
+index 8ea0a59..d5250ec 100644
 --- a/libs/filesystem/src/directory.cpp
 +++ b/libs/filesystem/src/directory.cpp
 @@ -310,8 +310,13 @@ inline std::size_t get_path_max()
@@ -271,10 +271,10 @@ index 113fef8..baef36e 100644
      }
  #endif // defined(BOOST_FILESYSTEM_USE_READDIR_R)
 -- 
-2.50.1
+2.51.0
 
 
-From ef6047cd05a36aaa604f9108982eb95e5003eb93 Mon Sep 17 00:00:00 2001
+From cad861806c4c72707ac57f6f0cb004a57f5d7138 Mon Sep 17 00:00:00 2001
 From: Luc Schrijvers <begasus@gmail.com>
 Date: Fri, 4 Apr 2025 11:14:17 +0200
 Subject: No wordexpr.h on Haiku
@@ -312,10 +312,10 @@ index bf4bbfd..d7315d0 100644
  void shell::parse_()
  {
 -- 
-2.50.1
+2.51.0
 
 
-From eef62a61f558059343688360f09e6ea544bf7ca7 Mon Sep 17 00:00:00 2001
+From 558aeda7399581e45f5545ba8dfd9c6d7986df56 Mon Sep 17 00:00:00 2001
 From: Luc Schrijvers <begasus@gmail.com>
 Date: Fri, 4 Apr 2025 12:20:08 +0200
 Subject: Fixes for boost_process
@@ -344,5 +344,5 @@ index 463e9ed..7ecf9e7 100644
  shell cmd(boost::process::v2::pid_type pid, error_code & ec)
  {
 -- 
-2.50.1
+2.51.0
 


### PR DESCRIPTION
boost1.89 isn't used so far