### PR TITLE
poppler25.12, add version 25.12.0

### DIFF
--- a/app-text/poppler/patches/poppler-25.12.0.patchset
+++ b/app-text/poppler/patches/poppler-25.12.0.patchset
@@ -1,0 +1,23 @@
+From 55c4b96df6d0b7ed97d496002c7998a5aa51b90e Mon Sep 17 00:00:00 2001
+From: Begasus <begasus@gmail.com>
+Date: Thu, 24 Aug 2023 13:40:34 +0200
+Subject: Turn off POSITION_INDEPENDENT_CODE
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e34c963..234b826 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -19,6 +19,9 @@ set(CMAKE_TRY_COMPILE_CONFIGURATION "${_CMAKE_BUILD_TYPE_UPPER}")
+ 
+ include(MacroOptionalFindPackage)
+ find_package(PkgConfig)
++
++set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
++
+ include(TestBigEndian)
+ test_big_endian(WORDS_BIGENDIAN)
+ include(CheckFileOffsetBits)
+-- 
+2.48.1
+

--- a/app-text/poppler/poppler25.12-25.12.0.recipe
+++ b/app-text/poppler/poppler25.12-25.12.0.recipe
@@ -1,0 +1,380 @@
+SUMMARY="A PDF rendering library"
+DESCRIPTION="Poppler is a PDF rendering library based on the xpdf-3.0 code \
+base."
+HOMEPAGE="https://poppler.freedesktop.org/"
+# instead of listing all copyright holder names in here, grab the latest list from Debian
+# https://metadata.ftp-master.debian.org/changelogs//main/p/poppler/
+COPYRIGHT="1996-present xpdf3 and poppler contributors"
+LICENSE="Apache v2
+	GNU GPL v2
+	GNU GPL v3
+	poppler_24.06.0-2_copyright"
+REVISION="1"
+SOURCE_URI="https://poppler.freedesktop.org/poppler-$portVersion.tar.xz"
+CHECKSUM_SHA256="c18b40eb36b1a0c5b86e29ca054bf0770304583da4f2cdd42fe86eca6a20de48"
+SOURCE_DIR="poppler-$portVersion"
+srcGitRev_2="9d5011815a14c157ba25bb160187842fb81579a5"
+SOURCE_URI_2="https://gitlab.freedesktop.org/poppler/test/-/archive/$srcGitRev_2.tar.gz"
+CHECKSUM_SHA256_2="c4cbdbf44f1d5c1ccbd7de611e979d97b703851970819cbb021f97218a445ed2"
+PATCHES="poppler-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="155.0.0"
+libCppVersion="2.2.0"
+libGlibVersion="8.31.0"
+libQt5Version="1.39.0"
+libQt6Version="3.11.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+libCppVersionCompat="$libCppVersion compat >= ${libCppVersion%%.*}"
+libGlibVersionCompat="$libGlibVersion compat >= ${libGlibVersion%%.*}"
+libQt5VersionCompat="$libQt5Version compat >= ${libQt5Version%%.*}"
+libQt6VersionCompat="$libQt6Version compat >= ${libQt6Version%%.*}"
+
+PROVIDES="
+	poppler25.12$secondaryArchSuffix = $portVersion
+	lib:libpoppler$secondaryArchSuffix = $libVersionCompat
+	lib:libpoppler_cpp$secondaryArchSuffix = $libCppVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	poppler_data >= 0.4.12
+	lib:libcairo$secondaryArchSuffix
+	lib:libcurl$secondaryArchSuffix
+	lib:libfontconfig$secondaryArchSuffix
+	lib:libfreetype$secondaryArchSuffix
+#	lib:libgpgmepp$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libjpeg$secondaryArchSuffix
+	lib:liblcms2$secondaryArchSuffix
+	lib:libnspr4$secondaryArchSuffix
+	lib:libnss3$secondaryArchSuffix
+#	lib:libnssutil3$secondaryArchSuffix
+	lib:libopenjp2$secondaryArchSuffix
+	lib:libplc4$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
+	lib:libsmime3$secondaryArchSuffix
+	lib:libtiff$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	poppler25.12${secondaryArchSuffix}_devel = $portVersion
+	devel:libpoppler$secondaryArchSuffix = $libVersionCompat
+	devel:libpoppler_cpp$secondaryArchSuffix = $libCppVersionCompat
+	"
+REQUIRES_devel="
+	poppler25.12$secondaryArchSuffix == $portVersion base
+	devel:libcurl$secondaryArchSuffix
+	devel:libfontconfig$secondaryArchSuffix
+	devel:libfreetype$secondaryArchSuffix
+	devel:libjpeg$secondaryArchSuffix
+	devel:liblcms2$secondaryArchSuffix
+	devel:libopenjp2$secondaryArchSuffix
+	devel:libnss3$secondaryArchSuffix
+	devel:libtiff$secondaryArchSuffix
+	"
+CONFLICTS_devel="
+	poppler23${secondaryArchSuffix}_devel
+	poppler24${secondaryArchSuffix}_devel
+	poppler25${secondaryArchSuffix}_devel
+	"
+
+# GLIB
+SUMMARY_glib="$SUMMARY (glib bindings)"
+DESCRIPTION_glib="$DESCRIPTION (glib bindings)"
+
+PROVIDES_glib="
+	poppler25.12${secondaryArchSuffix}_glib = $portVersion
+	lib:libpoppler_glib$secondaryArchSuffix = $libGlibVersionCompat
+	"
+REQUIRES_glib="
+	haiku$secondaryArchSuffix
+	poppler25.12$secondaryArchSuffix == $portVersion base
+	lib:libcairo$secondaryArchSuffix
+	lib:libcurl$secondaryArchSuffix
+	lib:libfontconfig$secondaryArchSuffix
+	lib:libfreetype$secondaryArchSuffix
+	lib:libgio_2.0$secondaryArchSuffix
+	lib:libglib_2.0$secondaryArchSuffix
+	lib:libgobject_2.0$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libjpeg$secondaryArchSuffix
+	lib:liblcms2$secondaryArchSuffix
+	lib:libopenjp2$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
+	lib:libtiff$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+CONFLICTS_glib="
+	poppler22${secondaryArchSuffix}_glib
+	poppler23${secondaryArchSuffix}_glib
+	poppler24${secondaryArchSuffix}_glib
+	poppler25${secondaryArchSuffix}_glib
+	"
+PROVIDES_glib_devel="
+	poppler25.12${secondaryArchSuffix}_glib_devel = $portVersion
+	devel:libpoppler_glib$secondaryArchSuffix = $libGlibVersionCompat
+	"
+REQUIRES_glib_devel="
+	poppler25.12${secondaryArchSuffix}_devel == $portVersion
+	poppler25.12${secondaryArchSuffix}_glib == $portVersion
+	devel:libcairo$secondaryArchSuffix
+	devel:libglib_2.0$secondaryArchSuffix
+	devel:libgobject_2.0$secondaryArchSuffix
+	"
+
+# QT5
+SUMMARY_qt5="$SUMMARY (Qt5 bindings)"
+DESCRIPTION_qt5="$DESCRIPTION (Qt5 bindings)"
+
+PROVIDES_qt5="
+	poppler25.12${secondaryArchSuffix}_qt5 = $portVersion
+	lib:libpoppler_qt5$secondaryArchSuffix = $libQt5VersionCompat
+	"
+REQUIRES_qt5="
+	haiku$secondaryArchSuffix
+	poppler25.12$secondaryArchSuffix == $portVersion base
+	lib:libcurl$secondaryArchSuffix
+	lib:libfontconfig$secondaryArchSuffix
+	lib:libfreetype$secondaryArchSuffix
+	lib:libjpeg$secondaryArchSuffix
+	lib:liblcms2$secondaryArchSuffix
+	lib:libopenjp2$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
+	lib:libQt5Core$secondaryArchSuffix
+	lib:libQt5Gui$secondaryArchSuffix
+	lib:libQt5Widgets$secondaryArchSuffix
+	lib:libQt5Xml$secondaryArchSuffix
+	lib:libtiff$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+CONFLICTS_qt5="
+	poppler22${secondaryArchSuffix}_qt5
+	poppler23${secondaryArchSuffix}_qt5
+	poppler24${secondaryArchSuffix}_qt5
+	poppler25${secondaryArchSuffix}_qt5
+	"
+PROVIDES_qt5_devel="
+	poppler25.12${secondaryArchSuffix}_qt5_devel = $portVersion
+	devel:libpoppler_qt5$secondaryArchSuffix = $libQt5VersionCompat
+	"
+REQUIRES_qt5_devel="
+	poppler25.12${secondaryArchSuffix}_devel == $portVersion
+	poppler25${secondaryArchSuffix}_qt5 == $portVersion
+	"
+
+# QT6
+SUMMARY_qt6="$SUMMARY (Qt6 bindings)"
+DESCRIPTION_qt6="$DESCRIPTION (Qt6 bindings)"
+
+PROVIDES_qt6="
+	poppler25.12${secondaryArchSuffix}_qt6 = $portVersion
+	lib:libpoppler_qt6$secondaryArchSuffix = $libQt6VersionCompat
+	"
+REQUIRES_qt6="
+	haiku$secondaryArchSuffix
+	poppler25.12$secondaryArchSuffix == $portVersion base
+	lib:libcurl$secondaryArchSuffix
+	lib:libfontconfig$secondaryArchSuffix
+	lib:libfreetype$secondaryArchSuffix
+	lib:libjpeg$secondaryArchSuffix
+	lib:liblcms2$secondaryArchSuffix
+	lib:libopenjp2$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
+	lib:libQt6Core$secondaryArchSuffix
+	lib:libQt6Gui$secondaryArchSuffix
+	lib:libQt6Widgets$secondaryArchSuffix
+	lib:libQt6Xml$secondaryArchSuffix
+	lib:libtiff$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+CONFLICTS_qt6="
+	poppler22${secondaryArchSuffix}_qt6
+	poppler23${secondaryArchSuffix}_qt6
+	poppler24${secondaryArchSuffix}_qt6
+	poppler25${secondaryArchSuffix}_qt6
+	"
+PROVIDES_qt6_devel="
+	poppler25.12${secondaryArchSuffix}_qt6_devel = $portVersion
+	devel:libpoppler_qt6$secondaryArchSuffix = $libQt6VersionCompat
+	"
+REQUIRES_qt6_devel="
+	poppler25.12${secondaryArchSuffix}_devel == $portVersion
+	poppler25.12${secondaryArchSuffix}_qt6 == $portVersion
+	"
+
+SUMMARY_tools="Binaries for the poppler package"
+PROVIDES_tools="
+	poppler25.12${secondaryArchSuffix}_tools
+	cmd:pdfattach
+	cmd:pdfdetach
+	cmd:pdffonts
+	cmd:pdfimages
+	cmd:pdfinfo
+	cmd:pdfseparate
+	cmd:pdfsig
+	cmd:pdftocairo
+	cmd:pdftohtml
+	cmd:pdftoppm
+	cmd:pdftops
+	cmd:pdftotext
+	cmd:pdfunite
+	"
+REQUIRES_tools="
+	poppler25.12$secondaryArchSuffix == $portVersion base
+	haiku$secondaryArchSuffix
+	lib:libcairo$secondaryArchSuffix
+	lib:libfreetype$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:liblcms2$secondaryArchSuffix
+	"
+CONFLICTS_tools="
+	poppler23${secondaryArchSuffix}_tools
+	poppler24${secondaryArchSuffix}_tools
+	poppler25${secondaryArchSuffix}_tools
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	poppler_data >= 0.4.12
+	devel:libboost_container$secondaryArchSuffix >= 1.90.0
+	devel:libcairo$secondaryArchSuffix
+	devel:libcurl$secondaryArchSuffix
+	devel:libfontconfig$secondaryArchSuffix
+	devel:libfreetype$secondaryArchSuffix
+	devel:libgio_2.0$secondaryArchSuffix
+	devel:libglib_2.0$secondaryArchSuffix
+	devel:libgobject_2.0$secondaryArchSuffix
+#	devel:libgpgmepp$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
+	devel:libintl$secondaryArchSuffix
+	devel:libjpeg$secondaryArchSuffix
+	devel:liblcms2$secondaryArchSuffix
+	devel:libnspr4$secondaryArchSuffix
+	devel:libnss3$secondaryArchSuffix
+	devel:libopenjp2$secondaryArchSuffix
+	devel:libpng16$secondaryArchSuffix
+	devel:libQt5Core$secondaryArchSuffix
+	devel:libQt5Gui$secondaryArchSuffix
+	devel:libQt5Widgets$secondaryArchSuffix
+	devel:libQt5Xml$secondaryArchSuffix
+	devel:libQt6Core$secondaryArchSuffix
+	devel:libQt6Gui$secondaryArchSuffix
+	devel:libQt6Widgets$secondaryArchSuffix
+	devel:libQt6Xml$secondaryArchSuffix
+	devel:libtiff$secondaryArchSuffix >= 6
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:gawk
+	cmd:grep
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:make
+	cmd:msgfmt$secondaryArchSuffix
+	cmd:msgmerge$secondaryArchSuffix
+	cmd:perl
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+defineDebugInfoPackage poppler25.12$secondaryArchSuffix \
+	"$(getPackagePrefix tools)"/bin/pdfdetach \
+	"$(getPackagePrefix tools)"/bin/pdffonts \
+	"$(getPackagePrefix tools)"/bin/pdfimages \
+	"$(getPackagePrefix tools)"/bin/pdfinfo \
+	"$(getPackagePrefix tools)"/bin/pdfseparate \
+	"$(getPackagePrefix tools)"/bin/pdftocairo \
+	"$(getPackagePrefix tools)"/bin/pdftohtml \
+	"$(getPackagePrefix tools)"/bin/pdftoppm \
+	"$(getPackagePrefix tools)"/bin/pdftops \
+	"$(getPackagePrefix tools)"/bin/pdftotext \
+	"$(getPackagePrefix tools)"/bin/pdfunite \
+	"$libDir"/libpoppler.so.$libVersion \
+	"$libDir"/libpoppler-cpp.so.$libCppVersion \
+	"$(getPackagePrefix glib)/$relativeLibDir"/libpoppler-glib.so.$libGlibVersion \
+	"$(getPackagePrefix qt5)/$relativeLibDir"/libpoppler-qt5.so.$libQt5Version \
+	"$(getPackagePrefix qt6)/$relativeLibDir"/libpoppler-qt6.so.$libQt6Version
+
+BUILD()
+{
+	mkdir -p $sourceDir/../test
+	cp -R $sourceDir2/test-$srcGitRev_2/* $sourceDir/../test
+
+	cmake -B build -S. $cmakeDirArgs \
+		-DCMAKE_CXX_FLAGS="-D_BSD_SOURCE" \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_SKIP_RPATH=ON \
+		-DENABLE_UNSTABLE_API_ABI_HEADERS=ON \
+		-DENABLE_GPGME=OFF \
+		-DENABLE_NSS3=ON \
+		-DBUILD_QT5_TESTS=OFF \
+		-DBUILD_QT6_TESTS=OFF \
+		-DBUILD_CPP_TESTS=OFF \
+		-DBUILD_MANUAL_TESTS=OFF \
+		-Wno-dev
+	make -C build $jobArgs
+}
+
+INSTALL()
+{
+	make -C build install
+
+	# install poppler documentation
+	mkdir -p $docDir
+	cp $sourceDir/{COPYING*,README*} $docDir
+
+	prepareInstalledDevelLibs libpoppler \
+		libpoppler-cpp \
+		libpoppler-glib \
+		libpoppler-qt5 \
+		libpoppler-qt6
+	fixPkgconfig
+
+	mkdir -p $(dirname $includeDir)
+	mv $prefix/include $includeDir
+	rm -rf $prefix/share
+
+	# GLIB
+	packageEntries "glib" \
+		$libDir/*glib*
+	packageEntries "glib_devel" \
+		$developLibDir/*glib* \
+		$developLibDir/pkgconfig/poppler-glib.pc \
+		$includeDir/poppler/glib
+
+	# QT5
+	packageEntries "qt5" \
+		$libDir/*qt5*
+	packageEntries "qt5_devel" \
+		$developLibDir/*qt5* \
+		$developLibDir/pkgconfig/poppler-qt5.pc \
+		$includeDir/poppler/qt5
+
+	# QT6
+	packageEntries "qt6" \
+		$libDir/*qt6*
+	packageEntries "qt6_devel" \
+		$developLibDir/*qt6* \
+		$developLibDir/pkgconfig/poppler-qt6.pc \
+		$includeDir/poppler/qt6
+
+	# Tools
+	packageEntries tools \
+		$prefix/bin \
+		$manDir
+
+	# DEVEL
+	packageEntries devel \
+		$developDir
+}
+
+TEST()
+{
+	# with gpgme enabled there is one crash related to that
+	export LIBRARY_PATH="$sourceDir/build:$sourceDir/build/qt5/src:$sourceDir/build/qt6/src:$LIBRARY_PATH"
+	ctest --test-dir build --output-on-failure
+}


### PR DESCRIPTION
renaming (as done with boost) keeps 25.04 alive for now, this wills smooth out the transition to 25.12 making 25.04 obsolete in the end