### PR TITLE
Chocolate Doom: Add Haiku paths

### DIFF
--- a/games-fps/chocolate-doom/chocolate_doom-3.1.1.recipe
+++ b/games-fps/chocolate-doom/chocolate_doom-3.1.1.recipe
@@ -22,10 +22,11 @@ COPYRIGHT="Id Software Inc. 1993-1996
 	James Haley
 	Samuel Villarreal"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/chocolate-doom/chocolate-doom/archive/refs/tags/chocolate-doom-$portVersion.tar.gz"
 CHECKSUM_SHA256="1edcc41254bdc194beb0d33e267fae306556c4d24110a1d3d3f865717f25da23"
 SOURCE_DIR="chocolate-doom-chocolate-doom-$portVersion"
+PATCHES="chocolate_doom-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -77,13 +78,8 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	nonpackdatadir=$(finddir B_USER_NONPACKAGED_DATA_DIRECTORY)
-	homedir=$(finddir B_USER_DIRECTORY)
-
 	# Avoid "multiple definition" linker errors under "src/hexen/"
 	export LDFLAGS="-z muldefs"
-	# Add specific paths via DOOMWADPATH
-	export DOOMWADPATH="$nonpackdatadir/doom:$nonpackdatadir/chocolate-doom:$homedir/doom:$(findpaths -c : B_FIND_PATH_DATA_DIRECTORY doomdata)"
 
 	# "__dummy__" is just a placeholder, because the makefiles use "$docdir/../chocolate_xxx"
 	docdir=$prefix/documentation/packages/chocolate_doom/__dummy__

--- a/games-fps/chocolate-doom/patches/chocolate_doom-3.1.1.patchset
+++ b/games-fps/chocolate-doom/patches/chocolate_doom-3.1.1.patchset
@@ -1,0 +1,33 @@
+From bb5ea5b9a2ec5d7026b7b1e2fa917a1dbbc70c19 Mon Sep 17 00:00:00 2001
+From: Peppersawce <michaelpeppers89@yahoo.it>
+Date: Tue, 30 Dec 2025 16:03:16 +0100
+Subject: Add Haiku paths
+
+
+diff --git a/src/d_iwad.c b/src/d_iwad.c
+index 5b6db20..1046534 100644
+--- a/src/d_iwad.c
++++ b/src/d_iwad.c
+@@ -663,6 +663,9 @@ static void AddXdgDirs(void)
+     // ~/.local/share/games/doom) as a user-writeable extension to
+     // the usual /usr/share/games/doom location.
+     AddIWADDir(M_StringJoin(env, "/games/doom", NULL));
++    AddIWADDir(M_StringJoin(env, "/chocolate-doom", NULL));
++    AddIWADDir(M_StringJoin(env, "/doom", NULL));
++    AddIWADDir(M_StringJoin(env, "/doomdata", NULL));
+     free(tmp_env);
+ 
+     // Quote:
+@@ -685,6 +688,9 @@ static void AddXdgDirs(void)
+     // XDG_DATA_DIRS mechanism, through which it can be overridden.
+     AddIWADPath(env, "/games/doom");
+     AddIWADPath(env, "/doom");
++    AddIWADPath(env, "/doomdata");
++    AddIWADDir("/boot/home/config/data/doomdata");
++    AddIWADDir("/boot/home/doom");
+ 
+     // The convention set by RBDOOM-3-BFG is to install Doom 3: BFG
+     // Edition into this directory, under which includes the Doom
+-- 
+2.52.0
+


### PR DESCRIPTION
After using the Chocolate Doom (& related) binaries for a while I noticed that the paths defined with `DOOMWADPATH` in the recipe weren't actually added in the game data search.

The patch included fixes that by adding the paths directly in the relevant code.