### PR TITLE
allegro: fix app signature mismatch, add debuginfo.

### DIFF
--- a/media-libs/allegro/allegro-4.4.3.1.recipe
+++ b/media-libs/allegro/allegro-4.4.3.1.recipe
@@ -13,13 +13,13 @@ but has since received contributions from hundreds of people over the net."
 HOMEPAGE="https://liballeg.org/"
 COPYRIGHT="1998-2019 Shawn Hargreaves et al."
 LICENSE="Allegro"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/liballeg/allegro5/releases/download/$portVersion/allegro-$portVersion.tar.gz"
 CHECKSUM_SHA256="ec19dbc9a021244582b4819b3583ee594b50141f9fcf6944a4ed8069cbf8d4d4"
 PATCHES="allegro-$portVersion.patchset"
 
 ARCHITECTURES="all"
-SECONDARY_ARCHITECTURES="x86_gcc2 x86"
+SECONDARY_ARCHITECTURES="x86"
 
 libVersion="4.4.3"
 libVersionCompat="$libVersion compat >= 4.4"
@@ -97,9 +97,18 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
+defineDebugInfoPackage allegro$secondaryArchSuffix \
+	$libDir/liballeg.so.$libVersion \
+	$libDir/liballeggl.so.$libVersion \
+	$libDir/libjpgalleg.so.$libVersion \
+	$libDir/libloadpng.so.$libVersion \
+	$libDir/liblogg.so.$libVersion
+
 BUILD()
 {
-	cmake -Bbuild -S. -DCMAKE_BUILD_TYPE=Release \
+	cmake -B build -S . \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
 		-DCMAKE_INSTALL_PREFIX=$prefix \
 		-DDOCDIR=$docDir \
 		-DMANDIR=$manDir \
@@ -113,14 +122,20 @@ INSTALL()
 {
 	make -C build install
 
-	prepareInstalledDevelLibs liballeg liballeggl \
-		libjpgalleg libloadpng liblogg
+	prepareInstalledDevelLibs \
+		liballeg \
+		liballeggl \
+		libjpgalleg \
+		libloadpng \
+		liblogg
+
 	fixPkgconfig
 
 	packageEntries devel \
 		$binDir/allegro-config \
 		$developDir \
 		$documentationDir
+
 	packageEntries tools \
 		$binDir/
 }

--- a/media-libs/allegro/patches/allegro-4.4.3.1.patchset
+++ b/media-libs/allegro/patches/allegro-4.4.3.1.patchset
@@ -1,4 +1,4 @@
-From 71974e9d6bf87a1abc7f90c0fbf7863c6f9a96fe Mon Sep 17 00:00:00 2001
+From 56050788732681dcb87582db8b7f63d1bc36461c Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Sat, 30 Nov 2013 12:14:54 +0100
 Subject: Import Allegro 4.4.1.1 fixes that were not upstreamed.
@@ -73,10 +73,10 @@ index c6e4dad..a7c9d46 100644
            * not started from a terminal.
            */
 -- 
-2.21.0
+2.52.0
 
 
-From 3d01fbf800e38e835e2eb9e6d0538963aecbb5f1 Mon Sep 17 00:00:00 2001
+From dd3a6d68e5eaa5a790713100e3accbc84d12908d Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Thu, 25 Sep 2014 11:09:14 +0200
 Subject: Hack install dirfor binaries.
@@ -118,10 +118,10 @@ index 170c3b4..d6d1bef 100644
  
  #-----------------------------------------------------------------------------#
 -- 
-2.21.0
+2.52.0
 
 
-From 2f97014b45bf835a041d2ee48e09c792245aa8e4 Mon Sep 17 00:00:00 2001
+From e815145bfee4abe4996dd22c271bae7891360090 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Thu, 12 Nov 2015 23:02:46 +0100
 Subject: Remove useless check of the keyboard id
@@ -175,10 +175,10 @@ index 302f353..74a672f 100644
  
  
 -- 
-2.21.0
+2.52.0
 
 
-From e089fe50b65740b10337d8387ad40a9be87b25e5 Mon Sep 17 00:00:00 2001
+From 9e985a9b5ca55b06ec8c5e71b4abfb7fbbe5cb6d Mon Sep 17 00:00:00 2001
 From: begasus <begasus@gmail.com>
 Date: Sat, 11 May 2019 10:44:07 +0200
 Subject: Enabel liballeggl for Haiku
@@ -198,7 +198,7 @@ index 36cfcc3..f306586 100644
      if(NOT X11_FOUND)
  	return()
 diff --git a/addons/allegrogl/include/alleggl.h b/addons/allegrogl/include/alleggl.h
-index fa36c98..71a1d66 100644
+index fa36c98..8e64b34 100644
 --- a/addons/allegrogl/include/alleggl.h
 +++ b/addons/allegrogl/include/alleggl.h
 @@ -462,6 +462,11 @@ AGL_FUNC(void, allegro_gl_load_settings, (void));
@@ -214,5 +214,112 @@ index fa36c98..71a1d66 100644
    #warning Unknown or unsupported platform.
  #endif
 -- 
-2.21.0
+2.52.0
+
+
+From 963c40b8118db9c460c8d9123fcd71d6b2e360cc Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Mon, 5 Jan 2026 02:35:33 -0300
+Subject: Use parenthesis around negated value.
+
+
+diff --git a/src/beos/bwindow.cpp b/src/beos/bwindow.cpp
+index 61a1885..a089205 100644
+--- a/src/beos/bwindow.cpp
++++ b/src/beos/bwindow.cpp
+@@ -119,7 +119,7 @@ extern "C" void be_gfx_bwindow_release(struct BITMAP *bmp)
+  */
+ extern "C" uintptr_t _be_gfx_bwindow_read_write_bank(BITMAP *bmp, int line)
+ {
+-   if (!bmp->id & BMP_ID_LOCKED) {
++   if (!(bmp->id & BMP_ID_LOCKED)) {
+       bmp->id |= (BMP_ID_LOCKED | BMP_ID_AUTOLOCK);
+    }
+    _be_dirty_lines[bmp->y_ofs + line] = 1;
+-- 
+2.52.0
+
+
+From fc5f81dd59d968419c723d7d289e1041b22658dc Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Mon, 5 Jan 2026 06:17:19 -0300
+Subject: Attempt to get the correct app signature from resources.
+
+Also, make sure to instantiate a BeAllegroApp, if _be_allegro_app is
+null, before attempting to call Run() on it (this seems to fix the
+instant crash on startup on x86_64).
+
+diff --git a/src/beos/bsysapi.cpp b/src/beos/bsysapi.cpp
+index a7c9d46..b129450 100644
+--- a/src/beos/bsysapi.cpp
++++ b/src/beos/bsysapi.cpp
+@@ -113,8 +113,34 @@ static int32 system_thread(void *data)
+ {
+    (void)data;
+ 
+-   if (_be_allegro_app == NULL) {
+-      char sig[MAXPATHLEN] = "application/x-vnd.Allegro-";
++   if (_be_allegro_app != NULL) {
++      using_custom_allegro_app = true;
++      _be_allegro_app->Run();
++      return 0;
++   }
++
++   using_custom_allegro_app = false;
++   char* signature = NULL;
++
++   // Try getting the correct signature from the binary's resources:
++   image_info info;
++   int32 cookie = 0;
++   if (get_next_image_info(B_CURRENT_TEAM, &cookie, &info) == B_OK) {
++      BFile f(info.name, O_RDONLY);
++      if (f.InitCheck() == B_OK) {
++         BAppFileInfo app_info(&f);
++         if (app_info.InitCheck() == B_OK) {
++            char sig[B_MIME_TYPE_LENGTH];
++            if (app_info.GetSignature(sig) == B_OK)
++               signature = strndup(sig, B_MIME_TYPE_LENGTH);
++         }
++      }
++   }
++
++   // If no signature was found, try to add a "good enough one":
++   if (signature == NULL) {
++      // default application signature
++      char sig[B_MIME_TYPE_LENGTH] = "application/x-vnd.Allegro-";
+       char exe[MAXPATHLEN];
+       char *term, *p;
+ 
+@@ -123,9 +149,7 @@ static int32 system_thread(void *data)
+       strncat(sig, get_filename(exe), sizeof(sig)-1);
+       sig[sizeof(sig)-1] = '\0';
+ 
+-      _be_allegro_app = new BeAllegroApp(sig);
+-
+-      using_custom_allegro_app = false;
++      signature = strndup(sig, B_MIME_TYPE_LENGTH);
+ 
+       term = getenv("TERM");
+       if (!term || !strcmp(term, "dumb")) {
+@@ -138,16 +162,14 @@ static int32 system_thread(void *data)
+          _al_sane_strncpy(app_path, exe, MAXPATHLEN);
+       }
+    }
+-   else {
+-      using_custom_allegro_app = true;
+-   }
+ 
++   _be_allegro_app = new BeAllegroApp(signature);
++   free(signature);
+    _be_allegro_app->Run();
+ 
+    /* XXX commented out due to conflicting TRACE in Haiku
+    TRACE(PREFIX_I "system thread exited\n");
+    */
+-
+    return 0;
+ }
+ 
+-- 
+2.52.0
 


### PR DESCRIPTION
This fixes:

`Signature in rsrc doesn't match constructor arg. (application/x-vnd.Allegro-Alex4, application/x-vnd.freelunchdesign-alex4)`

Draft for now, while I try to figure out why Alex4 crashes on 64 bits (or on 32 bits with modern GCC).