### PR TITLE
haikuporter: bump to version 1.3.5

### DIFF
--- a/haiku-apps/haikuporter/haikuporter-1.3.5.recipe
+++ b/haiku-apps/haikuporter/haikuporter-1.3.5.recipe
@@ -37,7 +37,6 @@ BUILD_REQUIRES="
 	build_$pythonPackage
 	flit_core_$pythonPackage
 	installer_$pythonPackage
-	wheel_$pythonPackage
 	"
 BUILD_PREREQUIRES="
 	cmd:cp


### PR DESCRIPTION
Build as a proper python package.