### PR TITLE
sciteco_curses: new recipe (v2.5.1)

### DIFF
--- a/app-editors/sciteco/sciteco_curses-2.5.1.recipe
+++ b/app-editors/sciteco/sciteco_curses-2.5.1.recipe
@@ -1,0 +1,77 @@
+SUMMARY="Scintilla-based Text Editor and Corrector (curses interface)"
+DESCRIPTION="SciTECO is an interactive text editor and text processing language. \
+It is inspired by Video TECO and DEC TECO-11, but incorporates many unique new ideas. \
+In SciTECO's paradigm the user inserts into an immediately executed command-line \
+which in turn performs the text processing operations. \
+All operations can be undone by \"rubbing out\" (deleting) from the command-line. \
+
+This package contains the curses (terminal) version of SciTECO."
+HOMEPAGE="https://sciteco.fmsbw.de/"
+COPYRIGHT="2012-2026 Robin Haberkorn"
+LICENSE="GNU GPL v3"
+REVISION="1"
+SOURCE_URI="https://sciteco.fmsbw.de/downloads/v$portVersion/sciteco-$portVersion.tar.gz
+	https://sourceforge.net/projects/sciteco/files/v$portVersion/sciteco-$portVersion.tar.gz"
+CHECKSUM_SHA256="cc99c6855f844f0514f2ed4879bf6a02f11eb489a3b77d88ad7f0bcfe1379fbf"
+SOURCE_DIR="sciteco-$portVersion"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	sciteco_curses$secondaryArchSuffix = $portVersion
+	cmd:grosciteco.tes = $portVersion
+	cmd:sciteco = $portVersion
+	cmd:tedoc.tes = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libglib_2.0$secondaryArchSuffix
+	lib:libgmodule_2.0$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libncurses$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libglib_2.0$secondaryArchSuffix
+	devel:libgmodule_2.0$secondaryArchSuffix
+	devel:libncurses$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:g++$secondaryArchSuffix
+	cmd:gcc$secondaryArchSuffix
+	cmd:groff
+	cmd:m4
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:sed
+	"
+
+BUILD()
+{
+	# Once we support an --enable-lto site-config-option, we should rather use that.
+	export CFLAGS="-O2 -flto"
+	export CXXFLAGS="-O2 -flto"
+	export LDFLAGS="-O2 -flto"
+	export AR=gcc-ar
+	export NM=gcc-nm
+	export RANLIB=gcc-ranlib
+
+	runConfigure --omit-dirs "binDir" \
+		./configure --bindir=$prefix/bin --with-interface=ncurses
+
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+}
+
+TEST()
+{
+	make check
+}


### PR DESCRIPTION
Currently only the ncurses version is built. SciTECO can be built against GTK 3, but is unusable with the GTK from HaikuPorts, due to Haiku-specific bugs. Anyway, in the future there might be a recipe for Gtk as well and it would be called `sciteco_gtk`, which is consistent with other ports (e.g. FreeBSD and Debian: `sciteco-gtk`).

Open questions:

1. Usually SciTECO releases are built with LTO (Link-time Optimization). This doesn't currently work on Haiku. Also, I don't know whether it is acceptable to enable this by default on a per-recipe basis. So LTO is left commented-out.
2. This recipe also won't work when cross-compiling as you have to bootstrap with a natively-built SciTECO. I am unsure whether recipes have to support cross-compilation. Perhaps you can point me to examples of recipes with a bootstrapping phase - how do I detect cross-compilation?