### PR TITLE
Update sdl2_net to 2.2.0

### DIFF
--- a/media-libs/sdl2_net/sdl2_net-2.2.0.recipe
+++ b/media-libs/sdl2_net/sdl2_net-2.2.0.recipe
@@ -5,11 +5,11 @@ and almost as portable. It allows a programmer to use network functionality \
 without having to code different things for different platforms. It also \
 simplyfies the handling of network connections and data transfer."
 HOMEPAGE="http://www.libsdl.org/projects/SDL_net/"
-COPYRIGHT="1997-2012 Sam Lantinga"
+COPYRIGHT="1997-2022 Sam Lantinga"
 LICENSE="Zlib"
-REVISION="4"
+REVISION="1"
 SOURCE_URI="https://www.libsdl.org/projects/SDL_net/release/SDL2_net-$portVersion.tar.gz"
-CHECKSUM_SHA256="15ce8a7e5a23dafe8177c8df6e6c79b6749a03fff1e8196742d3571657609d21"
+CHECKSUM_SHA256="4e4a891988316271974ff4e9585ed1ef729a123d22c08bd473129179dc857feb"
 SOURCE_DIR="SDL2_net-$portVersion"
 
 ARCHITECTURES="all"
@@ -17,7 +17,7 @@ SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
 PROVIDES="
 	sdl2_net$secondaryArchSuffix = $portVersion compat >= 2.0
-	lib:libSDL2_net_2.0$secondaryArchSuffix = 0.0.1 compat >= 0
+	lib:libSDL2_net_2.0$secondaryArchSuffix = 0.200.0 compat >= 0
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -28,7 +28,7 @@ REQUIRES="
 PROVIDES_devel="
 	sdl2_net${secondaryArchSuffix}_devel = $portVersion compat >= 2.0
 	devel:libSDL2_net$secondaryArchSuffix = $portVersion compat >= 2.0
-	devel:libSDL2_net_2.0$secondaryArchSuffix = 0.0.1 compat >= 0
+	devel:libSDL2_net_2.0$secondaryArchSuffix = 0.200.0 compat >= 0
 	"
 REQUIRES_devel="
 	sdl2_net$secondaryArchSuffix == $portVersion base
@@ -39,9 +39,7 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	cmd:aclocal
-	cmd:autoconf
-	cmd:automake
+	cmd:cmake
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
 	cmd:libtool
@@ -51,23 +49,20 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	touch INSTALL NEWS README AUTHORS ChangeLog
-	libtoolize --force --copy --install
-	aclocal --force --install -I acinclude
-	autoconf
-	automake --add-missing
-	runConfigure ./configure --disable-static
-	make $jobArgs
+	export LDFLAGS="-lnetwork"
+
+	cmake . -Bbuild $cmakeDirArgs \
+		-DCMAKE_BUILD_TYPE=Release
+
+	make -C build $jobArgs
 }
 
 INSTALL()
 {
-	make install
+	make -C build install
 
 	prepareInstalledDevelLibs libSDL2_net libSDL2_net-2.0
 	fixPkgconfig
-
-	rm $developLibDir/*.la
 
 	packageEntries devel \
 			$developDir


### PR DESCRIPTION
This recipe updates sdl2_net to 2.2.0, only tested on dev 64bit.

I built this because I needed the cmake configuration files for it and the old version doesn't provide them.