### PR TITLE
emacs: also need to handle unmapped keys

### DIFF
--- a/app-editors/emacs/emacs-30.2.recipe
+++ b/app-editors/emacs/emacs-30.2.recipe
@@ -13,7 +13,7 @@ news reader, debugger interface, calendar, and more.
 HOMEPAGE="https://gnu.org/s/emacs/"
 COPYRIGHT="2001-2025 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://ftpmirror.gnu.org/emacs/emacs-$portVersion.tar.gz"
 CHECKSUM_SHA256="1d79a4ba4d6596f302a7146843fe59cf5caec798190bcc07c907e7ba244b076d"
 ADDITIONAL_FILES="emacs.rdef.in"

--- a/app-editors/emacs/patches/emacs-30.2.patchset
+++ b/app-editors/emacs/patches/emacs-30.2.patchset
@@ -185,3 +185,50 @@ index 64abb2e..3234d69 100644
 -- 
 2.52.0
 
+From dfcf67558587115db3c643795e838ad183c2334b Mon Sep 17 00:00:00 2001
+From: Christof Meerwald <cmeerw@cmeerw.org>
+Date: Wed, 14 Jan 2026 16:29:04 +0000
+Subject: [PATCH] Also need to handle unmapped key events
+
+
+diff --git a/src/haiku_support.cc b/src/haiku_support.cc
+index 3234d69..17534f3 100644
+--- a/src/haiku_support.cc
++++ b/src/haiku_support.cc
+@@ -1080,7 +1080,8 @@ class EmacsWindow : public BWindow
+   void
+   DispatchMessage (BMessage *msg, BHandler *handler)
+   {
+-    if (msg->what == B_KEY_DOWN || msg->what == B_KEY_UP)
++    if (msg->what == B_UNMAPPED_KEY_DOWN || msg->what == B_UNMAPPED_KEY_UP ||
++	msg->what == B_KEY_DOWN || msg->what == B_KEY_UP)
+       {
+ 	struct haiku_key_event rq;
+ 
+@@ -1096,7 +1097,11 @@ class EmacsWindow : public BWindow
+ 
+ 	int32 raw, key;
+ 	int ret;
+-	msg->FindInt32 ("raw_char", &raw);
++	if (msg->FindInt32 ("raw_char", &raw) != B_OK)
++	{
++          BWindow::DispatchMessage (msg, handler);
++          return;
++	}
+ 	msg->FindInt32 ("key", &key);
+ 	msg->FindInt64 ("when", &rq.time);
+ 
+@@ -1189,7 +1194,9 @@ class EmacsWindow : public BWindow
+ 	      }
+ 	  }
+ 
+-	haiku_write (msg->what == B_KEY_DOWN ? KEY_DOWN : KEY_UP, &rq);
++	bool is_key_down = msg->what == B_KEY_DOWN ||
++			   msg->what == B_UNMAPPED_KEY_DOWN;
++	haiku_write (is_key_down ? KEY_DOWN : KEY_UP, &rq);
+       }
+     else if (msg->what == B_MOUSE_WHEEL_CHANGED)
+       {
+-- 
+2.52.0
+


### PR DESCRIPTION
If a key combination is not mapped by a keyboard layout, it generates an unmapped key event instead of a key event. That means that emacs also needs to handle those unmapped key events. A good example is Ctrl+/ on a UK or US keyboard: this should run the command "undo" in emacs, but is currently ignored as it doesn't generate any key event (only an unmapped key event).