### PR TITLE
basisu port

### DIFF
--- a/media-gfx/basisu/basisu-2.10.recipe
+++ b/media-gfx/basisu/basisu-2.10.recipe
@@ -1,0 +1,50 @@
+SUMMARY="Basis Universal GPU Texture Codec"
+DESCRIPTION="Basis Universal is an open source supercompressed LDR/HDR GPU compressed texture interchange system from Binomial LLC that supports \
+two intermediate file formats: the .KTX2 open standard from the Khronos Group, and our own ".basis" file format.
+These file formats support rapid transcoding to virtually any compressed GPU texture format released in the past ~25 years."
+HOMEPAGE="https://github.com/BinomialLLC/basis_universal"
+COPYRIGHT="2019-2026 Binomial LLC"
+LICENSE="Apache v2"
+REVISION="1"
+SOURCE_URI="https://github.com/BinomialLLC/basis_universal/archive/refs/tags/v2_1_0.tar.gz"
+CHECKSUM_SHA256="ee1dbeb4c16699b577a0c78dce337bbede268e04bd2d463946971f8cb1e9c8df"
+PATCHES="basisu-$portVersion.patchset"
+SOURCE_DIR="basis_universal-2_1_0"
+
+ARCHITECTURES="all ?x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	basisu$secondaryArchSuffix = $portVersion
+	cmd:basisu = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	#lib:libopencl$secondaryArchSuffix # Optional, OpenCL support
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	#devel:libopencl$secondaryArchSuffix # Optional, OpenCL support
+	#devel:libopencl_headers$secondaryArchSuffix # Optional, OpenCL support
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	"
+
+BUILD()
+{
+	cmake . -DCMAKE_BUILD_TYPE=Release -DEXAMPLES=OFF #-DOPENCL=ON
+
+	make $jobArgs
+}
+
+INSTALL()
+{
+	mkdir -p $prefix/bin && cp -t $prefix/bin bin/basisu
+
+	# Pack docs
+	mkdir -p $docDir && cp -t $docDir README.md
+}

--- a/media-gfx/basisu/patches/basisu-2.10.patchset
+++ b/media-gfx/basisu/patches/basisu-2.10.patchset
@@ -1,0 +1,22 @@
+From d4033d8b2c14bc17d0ee9a04f86cc6b64726356d Mon Sep 17 00:00:00 2001
+From: Peppersawce <michaelpeppers89@yahoo.it>
+Date: Sat, 17 Jan 2026 14:47:11 +0100
+Subject: Haiku fix
+
+
+diff --git a/encoder/basisu_enc.cpp b/encoder/basisu_enc.cpp
+index cccf66c..b5e3cdf 100644
+--- a/encoder/basisu_enc.cpp
++++ b/encoder/basisu_enc.cpp
+@@ -289,7 +289,7 @@ namespace basisu
+ 	{
+ 		QueryPerformanceFrequency(reinterpret_cast<LARGE_INTEGER*>(pTicks));
+ 	}
+-#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__EMSCRIPTEN__)
++#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__EMSCRIPTEN__) || defined(__HAIKU__)
+ #include <sys/time.h>
+ 	inline void query_counter(timer_ticks* pTicks)
+ 	{
+-- 
+2.52.0
+


### PR DESCRIPTION
Basisu is a texture codec tool, I'm building it as it's used when building #13170 and having it preinstalled saves a bunch of time.

The build also makes a static library but I'm not packing it atm.

Only tested on 64bit.

OpenCL support is currently disabled in the recipe. It works, but it's not actually needed or anything, it adds an extra dependency to the binary and is not available on x86_gcc2 if the recipe works there.

`-DSSE=TRUE` could be enabled for SSE4.1 support on at least x86_64 but iirc it doesn't work everywhere. @OscarL can you confirm?
`-DBUILD_X64=FALSE` should be passed to 32bit builds if CMake doesn't figure it out by itself.

Making this a draft until it's tested on 32bit (both x86 and gcc2)

Upstream does not care about Haiku patches apparently: https://github.com/BinomialLLC/basis_universal/pull/372