### PR TITLE
ucommon: add mutex initializer

### DIFF
--- a/dev-libs/ucommon/patches/ucommon-7.0.1.patchset
+++ b/dev-libs/ucommon/patches/ucommon-7.0.1.patchset
@@ -141,3 +141,25 @@ index 077fe930..4db6bf0b 100644
 -- 
 2.19.1
 
+From 180eee6351c9c9f3a5bd1e536762c37a340acdbe Mon Sep 17 00:00:00 2001
+From: Christof Meerwald <cmeerw@cmeerw.org>
+Date: Sun, 18 Jan 2026 14:48:03 +0000
+Subject: [PATCH] Add missing mutex initializer
+
+
+diff --git a/commoncpp/thread.cpp b/commoncpp/thread.cpp
+index 815c2ec..f22a87e 100644
+--- a/commoncpp/thread.cpp
++++ b/commoncpp/thread.cpp
+@@ -318,7 +318,7 @@ bool Conditional::wait(timeout_t timeout, bool locked)
+     return result;
+ }
+ 
+-static pthread_mutex_t mlock;
++static pthread_mutex_t mlock = PTHREAD_MUTEX_INITIALIZER;
+ 
+ time_t SysTime::getTime(time_t *tloc)
+ {
+-- 
+2.52.0
+

--- a/dev-libs/ucommon/ucommon-7.0.1.recipe
+++ b/dev-libs/ucommon/ucommon-7.0.1.recipe
@@ -15,8 +15,8 @@ COPYRIGHT="2015-2017 Cherokees of Idaho
 	Leandro Melo de Sales
 	Adrien Béraud"
 LICENSE="GNU LGPL v2.1"
-REVISION="2"
-SOURCE_URI="http://git.savannah.gnu.org/cgit/commoncpp.git/snapshot/commoncpp-$portVersion.tar.gz"
+REVISION="3"
+SOURCE_URI="https://github.com/GitMirroring/commoncpp/archive/refs/tags/v7.0.1.tar.gz"
 CHECKSUM_SHA256="99fd0e2c69f24e4ca93d01a14bc3fc4e40d69576f235f80f7a8ab37c16951f3e"
 SOURCE_DIR="commoncpp-$portVersion"
 PATCHES="ucommon-$portVersion.patchset"


### PR DESCRIPTION
only Haiku seems to assert because of the missing initializer

the savannah link doesn't seem to work (any more)