### PR TITLE
Fix Haiku-PyAPI build on beta5

### DIFF
--- a/dev-python/haiku-pyapi/haiku_pyapi-0.4.recipe
+++ b/dev-python/haiku-pyapi/haiku_pyapi-0.4.recipe
@@ -11,9 +11,9 @@ COPYRIGHT="2023-2025 Elozor Bruce
 	2023-2026 TmTFx
 	2023 OscarL"
 LICENSE="MIT"
-REVISION="1"
+REVISION="3"
 SOURCE_URI="https://github.com/coolcoder613eb/Haiku-PyAPI/archive/refs/tags/v$portVersion.tar.gz"
-CHECKSUM_SHA256="3a03afdb89bc0b43ee861c62c5fe093a13d62698a59dd33296789ee69451fe4d"
+CHECKSUM_SHA256="fa1fd07a26a13057757de29d26d862b36a8da756983240b1f9b492fa35983590"
 SOURCE_DIR="Haiku-PyAPI-$portVersion"
 # Haiku-PyAPI needs smart_holder support from pybind11
 pybindVersion="3.0.1"


### PR DESCRIPTION
Alas, this breaks the build on beta6... To build on beta6, the `-starget_beta5=1` flag must be removed. I can't find any easy way to find out which release haiku is on to set this flag automatically. I do know about `__get_haiku_revision()` and the `BEOS:APP_VERSION` attribute of `libbe.so`, but it would take some effort on my part to use them. Ideally, I could just do something like `#if HAIKU_VERSION > 5` in C++ or else determine the Haiku version from the Jamfile and pass that to C++. I don't see any preprocessor variables that are available but I have found the `version /system/lib/libbe.so` command gives me pretty much exactly what I want. But it doesn't seem possible to use the output of a command to set a variable in a Jamfile!

Currently, I'm thinking of simply updating this script when Beta6 is released.