### PR TITLE
libglvnd: Update architecture specifications

### DIFF
--- a/sys-libs/libglvnd/libglvnd-1.7.0.recipe
+++ b/sys-libs/libglvnd/libglvnd-1.7.0.recipe
@@ -10,7 +10,7 @@ SOURCE_DIR="libglvnd-v$portVersion"
 CHECKSUM_SHA256="2b6e15b06aafb4c0b6e2348124808cbd9b291c647299eaaba2e3202f51ff2f3d"
 PATCHES="libglvnd-${portVersion}.patchset"
 
-ARCHITECTURES="?all !x86_gcc"
+ARCHITECTURES="?all !x86_gcc2"
 SECONDARY_ARCHITECTURES="!x86"
 
 PROVIDES="


### PR DESCRIPTION
NOTE: Don't build for x86 - keep it at Mesa 22 (for now).