### PR TITLE
python3.14: update to version 3.14.3.

### DIFF
--- a/dev-lang/python/patches/python3.14-3.14.3.patchset
+++ b/dev-lang/python/patches/python3.14-3.14.3.patchset
@@ -1,4 +1,4 @@
-From 5df8f2730b3ff6a6573ea5448bee059564a45c11 Mon Sep 17 00:00:00 2001
+From 3108963525a131fe0489cb6459294f3dd47e8ae6 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 8 Oct 2023 01:02:25 -0300
 Subject: initial Haiku patch
@@ -22,7 +22,7 @@ index 2c8567f..aa050cf 100644
     // See PyUnicode_DecodeFSDefaultAndSize(), PyUnicode_EncodeFSDefault(),
     // Py_DecodeLocale() and Py_EncodeLocale().
 diff --git a/Makefile.pre.in b/Makefile.pre.in
-index f29de05..33dcc0c 100644
+index 38a355a..95078ec 100644
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
 @@ -156,7 +156,7 @@ BINDIR=		@bindir@
@@ -148,7 +148,7 @@ index 63624d5..3692640 100644
  #include <bluetooth/bluetooth.h>
  #include <bluetooth/rfcomm.h>
 diff --git a/configure.ac b/configure.ac
-index bd4446e..a73e95f 100644
+index d81c76f..3f7c8f2 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -1593,6 +1593,16 @@ if test $enable_shared = "yes"; then
@@ -194,17 +194,17 @@ index bd4446e..a73e95f 100644
  esac
  AC_MSG_CHECKING([for --with-libm=STRING])
 -- 
-2.51.0
+2.52.0
 
 
-From f29db079e721c99e19d7aea10a1fe2e604eb3b6f Mon Sep 17 00:00:00 2001
+From 26078b1151d86cd51d86093cfac5e8a398b367b7 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sun, 16 Apr 2017 10:05:42 +0200
 Subject: fix for negative errnos
 
 
 diff --git a/Lib/subprocess.py b/Lib/subprocess.py
-index 6911cd8..42917f4 100644
+index 578d7b9..9be7cba 100644
 --- a/Lib/subprocess.py
 +++ b/Lib/subprocess.py
 @@ -1974,6 +1974,8 @@ class Popen:
@@ -232,10 +232,10 @@ index e0a9531..1d76b4f 100644
              *--cur = Py_hexdigits[saved_errno % 16];
              saved_errno /= 16;
 -- 
-2.51.0
+2.52.0
 
 
-From 03c163799043ea9a3f2f1b8ebe02b9d69b7eb2b1 Mon Sep 17 00:00:00 2001
+From cd9d2092ba7a2cbdbbfa18fe1bb56c014d913290 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 8 Oct 2023 20:06:31 -0300
 Subject: Implement CTypes's find_library for Haiku
@@ -329,10 +329,10 @@ index 378f121..a9136ad 100644
              print(cdll.LoadLibrary("libm.so"))
              print(cdll.LoadLibrary("libcrypt.so"))
 -- 
-2.51.0
+2.52.0
 
 
-From 4592a835f031a174218512f0f943d04ac1b562d3 Mon Sep 17 00:00:00 2001
+From 8f9ece4492e25aa3274ec87aff267cecff5fd38a Mon Sep 17 00:00:00 2001
 From: Philipp Wolfer <phil@parolu.io>
 Date: Mon, 23 Sep 2019 09:14:58 +0200
 Subject: webbrowser: Support for default browsers on Haiku
@@ -356,10 +356,10 @@ index f2e2394..b937321 100644
          # First try to use the default Windows browser
          register("windows-default", WindowsDefault)
 -- 
-2.51.0
+2.52.0
 
 
-From 6c70bcdb42dff0b3c5ef8655937139f7dd5d5a50 Mon Sep 17 00:00:00 2001
+From 636b2b9518bb026a2cb3ff56ef497de0710d87b1 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 4 Oct 2019 22:02:35 +0200
 Subject: since 3.8, don't reinit locks on fork.
@@ -379,17 +379,17 @@ index 9005f1e..28708e2 100644
          pass  # no-op when os.register_at_fork does not exist.
  else:
 -- 
-2.51.0
+2.52.0
 
 
-From 069d16b2cff8c1db9a8f22b92a224403bc555535 Mon Sep 17 00:00:00 2001
+From 01aa1d3037de4895996694d050cfc952f4116478 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Mon, 19 Oct 2020 18:03:09 +0200
 Subject: ttyname_r can use MAXPATHLEN
 
 
 diff --git a/Modules/posixmodule.c b/Modules/posixmodule.c
-index 6e878e3..fd8d5d2 100644
+index cb3a62d..a17bdd9 100644
 --- a/Modules/posixmodule.c
 +++ b/Modules/posixmodule.c
 @@ -3420,11 +3420,14 @@ static PyObject *
@@ -409,10 +409,10 @@ index 6e878e3..fd8d5d2 100644
      if (buffer == NULL) {
          return PyErr_NoMemory();
 -- 
-2.51.0
+2.52.0
 
 
-From 5e4032f24c2ea68f2a6d3ede34cb54bcfe20760a Mon Sep 17 00:00:00 2001
+From 8ae9cb4834502a5f02506a8879322c265bd520cc Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Mon, 24 Oct 2022 20:04:10 -0300
 Subject: Lib/test: require the "largefile" usage flag for I/O heavy tests.
@@ -423,7 +423,7 @@ This avoids needing several GBs of storage to run the tests
 (unless the "largefile" resource usage flag is enabled).
 
 diff --git a/Lib/test/test_io.py b/Lib/test/test_io.py
-index 6514af8..db22845 100644
+index 57b42fb..784c0d5 100644
 --- a/Lib/test/test_io.py
 +++ b/Lib/test/test_io.py
 @@ -652,7 +652,7 @@ class IOTest(unittest.TestCase):
@@ -462,10 +462,10 @@ index f468dda..4ab9157 100644
                  'test requires %s bytes and a long time to run' % str(0x180000000))
          f = open(TESTFN, 'w+b')
 -- 
-2.51.0
+2.52.0
 
 
-From 00b0c361b2f153497f85e320431c5ddee84ba135 Mon Sep 17 00:00:00 2001
+From c25dcd6b8235ea4211e300c3712716a1b4498dd1 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sat, 27 Jul 2024 04:51:52 -0300
 Subject: _getuserbase(), getsitepackages(), and INSTALL_SCHEMES for Haiku.
@@ -678,10 +678,10 @@ index 09eff11..5ef7055 100644
  
      @skip_unless_symlink
 -- 
-2.51.0
+2.52.0
 
 
-From 5fc09a894df19bb83f7b32c169f0d049a1bef068 Mon Sep 17 00:00:00 2001
+From 2778b41a21dc60f8c70c38078e5c4d5f08206f59 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Mon, 12 Feb 2024 08:39:38 -0300
 Subject: Fix location of REPL's history file.
@@ -717,10 +717,10 @@ index e6351bb..ef75d2b 100644
  
  def enablerlcompleter():
 -- 
-2.51.0
+2.52.0
 
 
-From 89d24696183a6d979bceb07dc8becf954d347558 Mon Sep 17 00:00:00 2001
+From 761034fb6d7b4e15ab28bc728947404a81065092 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 10 Dec 2023 19:50:22 -0300
 Subject: Miscellaneous "Lib/test/" fixes for Haiku.
@@ -731,7 +731,7 @@ Content-Transfer-Encoding: 8bit
 test_fileio.py fix from "initial Haiku patch" by Jérôme Duval.
 
 diff --git a/Lib/test/datetimetester.py b/Lib/test/datetimetester.py
-index aca5fbc..996297b 100644
+index 0540f94..78ffe6d 100644
 --- a/Lib/test/datetimetester.py
 +++ b/Lib/test/datetimetester.py
 @@ -6412,6 +6412,9 @@ def pairs(iterable):
@@ -757,10 +757,10 @@ index e3d54f6..efb4d03 100644
                          # Somehow /dev/tty appears seekable on some BSDs
                          self.assertEqual(f.seekable(), False)
 -- 
-2.51.0
+2.52.0
 
 
-From 388f6874b1d72ca76759a093eb9791d1d0da5937 Mon Sep 17 00:00:00 2001
+From b27fcbc337db6826142d9190228578f74c319f16 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Mon, 12 Feb 2024 10:50:34 -0300
 Subject: Fix build on nightlies, following the addition of kqueue.
@@ -823,10 +823,10 @@ index d234d50..6e16247 100644
  
      /* NETDEV filter flags */
 -- 
-2.51.0
+2.52.0
 
 
-From 881a7ba8c86cae5483d6d55cb1bcd134db942eb0 Mon Sep 17 00:00:00 2001
+From 0b44b522a34b715fa6953d68f18a5f643b392f9d Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 9 Aug 2024 13:38:28 -0300
 Subject: fix test_utf8_mode.
@@ -846,10 +846,10 @@ index f668810..a55a8e4 100644
          elif sys.platform.startswith("aix"):
              c_arg = arg.decode('iso-8859-1')
 -- 
-2.51.0
+2.52.0
 
 
-From 6555d303e702a1e50a39c869c91810a5e2e995f8 Mon Sep 17 00:00:00 2001
+From f89c6a0db2f22c2a7c195d916ae1166c00951572 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 9 Aug 2024 14:35:04 -0300
 Subject: Fix test_site.
@@ -936,10 +936,10 @@ index f8c6f37..2cf711f 100644
              if sys.platlibdir != "lib":
                  self.assertEqual(len(dirs), 2)
 -- 
-2.51.0
+2.52.0
 
 
-From fa7418472d69b3d8e1cafa284f61a36c3a623144 Mon Sep 17 00:00:00 2001
+From 861eae90afdc82b025dea22be3b2c7ed1d34d53a Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 9 Aug 2024 15:37:13 -0300
 Subject: Fix test_sysconfig.
@@ -979,10 +979,10 @@ index 5ef7055..18b1e8f 100644
              wanted.extend(['nt_user', 'osx_framework_user', 'posix_user', 'haiku_user'])
          self.assertEqual(get_scheme_names(), tuple(sorted(wanted)))
 -- 
-2.51.0
+2.52.0
 
 
-From adf8934168f7c5c29bf0ec2d64e0909de776bf12 Mon Sep 17 00:00:00 2001
+From 0bcbb2655fce38be83e3158b74348cf611a02787 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 29 Sep 2024 03:01:27 -0300
 Subject: Partially fix test_compileall by skipping tests that need hardlink
@@ -1015,10 +1015,10 @@ index 8384c18..d7e19ec 100644
          # 'a = 0' code produces the same bytecode for the 3 optimization
          # levels. All three .pyc files must have the same inode (hardlinks).
 -- 
-2.51.0
+2.52.0
 
 
-From d017266ea1452f1fffd47fd7deb2be50d29129cd Mon Sep 17 00:00:00 2001
+From 364f4e33d4d09057ddd0d94aa61eb26558b52ae1 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Thu, 9 May 2024 15:16:26 -0300
 Subject: Fix 3.13.0 build.
@@ -1031,7 +1031,7 @@ Previous Python versions had both the time out and the "|| true".
 Some of the test run in that PGO stage sadly still fail on Haiku.
 
 diff --git a/Makefile.pre.in b/Makefile.pre.in
-index 33dcc0c..523ba5b 100644
+index 95078ec..b4b5462 100644
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
 @@ -856,7 +856,7 @@ profile-run-stamp:
@@ -1066,17 +1066,17 @@ index 1598eba..88b94b6 100644
  
  #if !defined(__HAIKU__) && !defined(__APPLE__) && !defined(__CYGWIN__) && !defined(_AIX) && !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__sun) && !defined(__NetBSD__)
 -- 
-2.51.0
+2.52.0
 
 
-From d3930f2f6db3572524f54bc666d8e83ff9fc19b7 Mon Sep 17 00:00:00 2001
+From 58d2e2d102f2569217e71d15d18a63ecbcb5e5cb Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sat, 5 Oct 2024 07:32:17 -0300
 Subject: Avoid forcing "-g" on LTO builds, unless Py_DEBUG is defined.
 
 
 diff --git a/configure.ac b/configure.ac
-index a73e95f..139f96f 100644
+index 3f7c8f2..fadfeca 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -2026,7 +2026,9 @@ if test "$Py_LTO" = 'true' ; then
@@ -1091,10 +1091,10 @@ index a73e95f..139f96f 100644
  
    CFLAGS_NODIST="$CFLAGS_NODIST ${LTOCFLAGS-$LTOFLAGS}"
 -- 
-2.51.0
+2.52.0
 
 
-From 36d053ec3a1d83f52a52e7b3b55c9dd99f50416b Mon Sep 17 00:00:00 2001
+From e0c0634c9d9de3e9db963cd33f44ce80c3534117 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Thu, 13 Feb 2025 13:30:03 -0300
 Subject: Make sure we use 'spawn' on Haiku and not 'forkserver'.
@@ -1114,5 +1114,5 @@ index 051d567..4f20b24 100644
      else:
          _default_context = DefaultContext(_concrete_contexts['spawn'])
 -- 
-2.51.0
+2.52.0
 

--- a/dev-lang/python/python3.14-3.14.3.recipe
+++ b/dev-lang/python/python3.14-3.14.3.recipe
@@ -20,7 +20,7 @@ LICENSE="Python"
 COPYRIGHT="1990-2025 Python Software Foundation"
 REVISION="1"
 SOURCE_URI="https://www.python.org/ftp/python/$portVersion/Python-$portVersion.tar.xz"
-CHECKSUM_SHA256="ce543ab854bc256b61b71e9b27f831ffd1bfd60a479d639f8be7f9757cf573e9"
+CHECKSUM_SHA256="a97d5549e9ad81fe17159ed02c68774ad5d266c72f8d9a0b5a9c371fe85d902b"
 SOURCE_DIR="Python-$portVersion"
 
 pyShortVer="${portVersion%.*}"


### PR DESCRIPTION
Build tested on hrev59439 x86_64.

Not merging for now, just in case it might conflict with #13694.