### PR TITLE
Update weechat-4.8.1.recipe to include spell plugin

### DIFF
--- a/net-irc/weechat/weechat-4.8.1.recipe
+++ b/net-irc/weechat/weechat-4.8.1.recipe
@@ -5,7 +5,7 @@ It is highly customizable and extensible with scripts."
 HOMEPAGE="https://weechat.org/"
 COPYRIGHT="2003-2024 Sébastien Helleu"
 LICENSE="GNU GPL v3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://weechat.org/files/src/weechat-$portVersion.tar.xz"
 CHECKSUM_SHA256="e7ac1fbcc71458ed647aada8747990905cb5bfb93fd8ccccbc2a969673a4285a"
 PATCHES="weechat-$portVersion.patchset"
@@ -24,6 +24,8 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	lib:libglib_2.0$secondaryArchSuffix
+    lib:libenchant_2$secondaryArchSuffix
 	lib:libcurl$secondaryArchSuffix
 	lib:libgcrypt$secondaryArchSuffix
 	lib:libgnutls$secondaryArchSuffix


### PR DESCRIPTION
Enable spell plugin with dependencies libglib_2, libenchant_2. Changed -DENABLE_SPELL=OFF to -DENABLE_SPELL=ON
User needs to add `aspell_<dictionary>` to work