### PR TITLE
adwaita_icon_theme_legacy, add new recipe

### DIFF
--- a/x11-themes/adwaita-icon-theme-legacy/adwaita_icon_theme_legacy-46.2.recipe
+++ b/x11-themes/adwaita-icon-theme-legacy/adwaita_icon_theme_legacy-46.2.recipe
@@ -1,0 +1,67 @@
+SUMMARY="GNOME default icon theme (legacy)"
+DESCRIPTION="A fullcolor icon theme providing fallback for legacy apps."
+HOMEPAGE="https://gitlab.gnome.org/GNOME/adwaita-icon-theme-legacy"
+COPYRIGHT="Ulisse Perusin
+	Riccardo Buzzotta
+	Josef Vybíral
+	Hylke Bons
+	Ricardo González
+	Lapo Calamandrei
+	Rodney Dawes
+	Luca Ferretti
+	Tuomas Kuosmanen
+	Andreas Nilsson
+	Jakub Steiner
+	Sam Hewitt"
+LICENSE="GNU LGPL v3"
+REVISION="1"
+#SOURCE_URI="https://gitlab.gnome.org/GNOME/adwaita-icon-theme-legacy/-/archive/$portVersion/adwaita-icon-theme-legacy-$portVersion.tar.bz2"
+#CHECKSUM_SHA256="2b30b08a3b534e1db40c2342c08a27bc589c737050ca969ba0456f876b4679ab"
+#SOURCE_DIR="adwaita-icon-theme-legacy-$portVersion"
+# https://gitlab.gnome.org/GNOME/adwaita-icon-theme-legacy/-/merge_requests/2
+srcGitRev="2b2eb1bbf215e73f3e6f1be79ee679b17dc43eb3"
+SOURCE_URI="https://gitlab.gnome.org/City-busz/adwaita-icon-theme-legacy/-/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="2dca774925ce937e5905c92946cbc47f7b8f0b0d5a4988ac40310547bd3610f3"
+SOURCE_DIR="adwaita-icon-theme-legacy-$srcGitRev"
+# https://gitlab.gnome.org/GNOME/adwaita-icon-theme-legacy/-/merge_requests/1
+PATCHES="1.patch"
+
+ARCHITECTURES="any"
+
+PROVIDES="
+	adwaita_icon_theme_legacy = $portVersion
+	"
+REQUIRES="
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:gtk_update_icon_cache
+	cmd:meson
+	cmd:ninja
+	cmd:pkg_config
+	"
+
+BUILD()
+{
+	meson Build \
+		--buildtype=release \
+		--prefix="$prefix" \
+		--libdir="$libDir" \
+		--includedir="$includeDir" \
+		--bindir="$commandBinDir" \
+		--libexecdir="$commandBinDir" \
+		--datadir="$dataDir" \
+		--localedir="$dataDir/locale" \
+		--sysconfdir="$settingsDir"
+
+	ninja -C Build
+}
+
+INSTALL()
+{
+	ninja install -C Build
+}

--- a/x11-themes/adwaita-icon-theme-legacy/patches/1.patch
+++ b/x11-themes/adwaita-icon-theme-legacy/patches/1.patch
@@ -1,0 +1,26 @@
+From 7075510207510fa34dc30a618974e467f7f5000f Mon Sep 17 00:00:00 2001
+From: Chris Mayo <aklhfex@gmail.com>
+Date: Sun, 26 May 2024 19:17:36 +0100
+Subject: [PATCH] Use a unique licenses directory
+
+Avoid clashing with adwaita-icon-theme.
+---
+ meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 5b4a4c0..abe27b4 100644
+--- a/meson.build
++++ b/meson.build
+@@ -7,7 +7,7 @@ pkg.generate(
+   dataonly : true,
+ )
+ 
+-licenses_dir = get_option('datadir') / 'licenses' / 'adwaita-icon-theme'
++licenses_dir = get_option('datadir') / 'licenses' / 'adwaita-icon-theme-legacy'
+ install_data('COPYING', install_dir : licenses_dir, install_tag : 'runtime')
+ install_data('COPYING_CCBYSA3', install_dir : licenses_dir, install_tag : 'runtime')
+ install_data('COPYING_LGPL', install_dir : licenses_dir, install_tag : 'runtime')
+-- 
+GitLab
+


### PR DESCRIPTION
GNOME fallback icons for legacy apps