### PR TITLE
matplotlib, revbump, marksman requires this to be build with latest n…

### DIFF
--- a/dev-python/matplotlib/matplotlib-3.7.2.recipe
+++ b/dev-python/matplotlib/matplotlib-3.7.2.recipe
@@ -23,7 +23,7 @@ LICENSE="Matplotlib
 	Qhull
 	STIX
 	yorick"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/matplotlib/matplotlib/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="be06fea01c57517dbed17dd1aa8f2b3f5750c54203553f9d2096cf2e43a23b1e"
 SOURCE_FILENAME="matplotlib-$portVersion.tar.gz"


### PR DESCRIPTION
…umpy in the depot