### PR TITLE
kquickimageeditor_kf6, revbump, use newer opencv

### DIFF
--- a/media-libs/kquickimageditor/kquickimageeditor_kf6-0.6.0.recipe
+++ b/media-libs/kquickimageditor/kquickimageeditor_kf6-0.6.0.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="Plasma library and runtime components based upon KF6 and Qt6."
 HOMEPAGE="https://invent.kde.org/libraries/kquickimageeditor"
 COPYRIGHT="2010-2025 KDE Organisation"
 LICENSE="GNU LGPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://download.kde.org/stable/kquickimageeditor/kquickimageeditor-$portVersion.tar.xz"
 CHECKSUM_SHA256="11ed4ce1c164a8b6d50bbc1548b5849ab75d5fb837619b90f2cea51ed122547a"
 SOURCE_DIR="kquickimageeditor-$portVersion"
@@ -46,7 +46,7 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libopencv_core$secondaryArchSuffix
+	devel:libopencv_core$secondaryArchSuffix >= 4.13
 	# KF6
 	extra_cmake_modules$secondaryArchSuffix
 	devel:libKF6ConfigCore$secondaryArchSuffix


### PR DESCRIPTION
drops dependency for Qt5