### PR TITLE
fossil: bump to 2.28

### DIFF
--- a/dev-vcs/fossil/fossil-2.28.recipe
+++ b/dev-vcs/fossil/fossil-2.28.recipe
@@ -10,7 +10,7 @@ HOMEPAGE="https://www.fossil-scm.org/"
 COPYRIGHT="2007 D. Richard Hipp"
 LICENSE="BSD (2-clause)"
 REVISION="1"
-SOURCE_URI="https://fossil-scm.org/home/tarball/?name=version-2.28/fossil-src-$portVersion.tar.gz"
+SOURCE_URI="https://fossil-scm.org/home/tarball/?name=version-$portVersion/fossil-src-$portVersion.tar.gz"
 CHECKSUM_SHA256="84c18824ca227e7602d2408b663c3747f754ad306ed5c73ddab959d6589538a6"
 SOURCE_DIR="fossil-src-$portVersion"
 


### PR DESCRIPTION
A new version of fossil has been released.

The IPv6 problem remains. `fossil ui` will appear to hang and possibly time-out. However, specifying the IPv4 localhost works as expected: `fossil ui --port 127.0.01:9999`.  (The _9999_ is a randomly chosen port.)

At this time, the "Change Summary" page (https://fossil-scm.org/home/doc/trunk/www/changes.wiki#v2_28) still shows "_pending_". Everywhere else has this version as "released".

I will continue to check for updates and will provide a "-2" if needed. Or if the HaikuPorts maintainers would prefer to wait a few days, that is also good with me.