### PR TITLE
dragengine-1.30.1-rev4: receipt fixed and including a small Gui launcher fix

### DIFF
--- a/games-engines/dragengine/dragengine-1.30.1.recipe
+++ b/games-engines/dragengine/dragengine-1.30.1.recipe
@@ -133,4 +133,5 @@ INSTALL()
 	packageEntries devel $developDir
 
 	mimeset -f $appsDir/DELauncher
+	addAppDeskbarSymlink $appsDir/DELauncher
 }


### PR DESCRIPTION
Changed to "$appsDir" in the final mimset.