### PR TITLE
vmware_addons: should fix the build on the (beta5) buildmasters.

### DIFF
--- a/app-emulation/vmware-addons/patches/vmware_addons-1.2.2.patchset
+++ b/app-emulation/vmware-addons/patches/vmware_addons-1.2.2.patchset
@@ -1,0 +1,42 @@
+From d4830047aea1a5c7afbe2c7b025c5138ea50b8d2 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Fri, 20 Mar 2026 04:44:16 -0300
+Subject: vmware_fs: Fix build on beta5.
+
+The `dataOnly` parameter for `fsync()` was added on hrev58953.
+
+diff --git a/vmware_fs/vnode_operations.cpp b/vmware_fs/vnode_operations.cpp
+index 11f0e70..8e08651 100644
+--- a/vmware_fs/vnode_operations.cpp
++++ b/vmware_fs/vnode_operations.cpp
+@@ -284,7 +284,11 @@ vmwfs_write_stat(fs_volume* volume, fs_vnode* vnode, const struct stat* stat, ui
+ 
+ 
+ status_t
++#if B_HAIKU_VERSION <= B_HAIKU_VERSION_1_BETA_5
++vmwfs_fsync(fs_volume* _volume, fs_vnode* _node)
++#else
+ vmwfs_fsync(fs_volume* _volume, fs_vnode* _node, bool dataOnly)
++#endif
+ {
+ 	return B_OK;
+ }
+diff --git a/vmware_fs/vnode_operations.h b/vmware_fs/vnode_operations.h
+index 5e9bdfd..3d697fe 100644
+--- a/vmware_fs/vnode_operations.h
++++ b/vmware_fs/vnode_operations.h
+@@ -16,6 +16,10 @@ status_t vmwfs_read_stat(fs_volume* volume, fs_vnode* vnode, struct stat* stat);
+ status_t vmwfs_write_stat(fs_volume* volume, fs_vnode* vnode, const struct stat* stat,
+ 	uint32 statMask);
+ 
+-status_t vmwfs_fsync(fs_volume* _volume, fs_vnode* _node, bool dataOnly);
++#if B_HAIKU_VERSION <= B_HAIKU_VERSION_1_BETA_5
++	status_t vmwfs_fsync(fs_volume* _volume, fs_vnode* _node);
++#else
++	status_t vmwfs_fsync(fs_volume* _volume, fs_vnode* _node, bool dataOnly);
++#endif
+ 
+ #endif
+-- 
+2.52.0
+

--- a/app-emulation/vmware-addons/vmware_addons-1.2.2.recipe
+++ b/app-emulation/vmware-addons/vmware_addons-1.2.2.recipe
@@ -31,6 +31,7 @@ SOURCE_URI="https://github.com/HaikuArchives/VMwareAddons/archive/$srcGitRev.tar
 CHECKSUM_SHA256="64ac6bec001ec78cdc5124a427774d16b23c430f87965d4287af6c999342904a"
 SOURCE_FILENAME="VMwareAddons-$srcGitRev.tar.gz"
 SOURCE_DIR="VMwareAddons-$srcGitRev"
+PATCHES="vmware_addons-1.2.2.patchset"
 
 ARCHITECTURES="x86_64 x86_gcc2"
 


### PR DESCRIPTION
`fsync()` gained a new parameter that is not present on beta5.