### PR TITLE
Update Wesnoth to 1.18.6

### DIFF
--- a/games-strategy/wesnoth/patches/wesnoth-1.18.6.patchset
+++ b/games-strategy/wesnoth/patches/wesnoth-1.18.6.patchset
@@ -1,7 +1,7 @@
 From 256caf7b9e6e709227de5eef279af024f0506caf Mon Sep 17 00:00:00 2001
 From: Peppersawce <michaelpeppers89@yahoo.it>
 Date: Sat, 22 Mar 2025 12:46:25 +0100
-Subject: Fix CMake build, fix server related boost issue, get Haiku version
+Subject: Fix CMake build, get Haiku version
  via uname
 
 
@@ -63,21 +63,6 @@ index 401f249..0522fd0 100644
  #else
  
  	//
-diff --git a/src/server/common/server_base.cpp b/src/server/common/server_base.cpp
-index 5fd115f..842d301 100644
---- a/src/server/common/server_base.cpp
-+++ b/src/server/common/server_base.cpp
-@@ -114,8 +114,8 @@ void server_base::serve(boost::asio::yield_context yield, boost::asio::ip::tcp::
- 			acceptor.open(endpoint.protocol());
- 			acceptor.set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
- 			acceptor.set_option(boost::asio::ip::tcp::acceptor::keep_alive(keep_alive_));
--			if(endpoint.protocol() == boost::asio::ip::tcp::v6())
--				acceptor.set_option(boost::asio::ip::v6_only(true));
-+			//if(endpoint.protocol() == boost::asio::ip::tcp::v6())
-+			//	acceptor.set_option(boost::asio::ip::v6_only(true));
- 			acceptor.bind(endpoint);
- 			acceptor.listen();
- 		}
 -- 
 2.48.1
 

--- a/games-strategy/wesnoth/wesnoth-1.18.6.recipe
+++ b/games-strategy/wesnoth/wesnoth-1.18.6.recipe
@@ -20,12 +20,12 @@ maps, and write your own scenarios or even full-blown campaigns. You can also \
 challenge up to eight friends—or strangers—and fight in epic multiplayer \
 fantasy battles."
 HOMEPAGE="http://wesnoth.org/"
-COPYRIGHT="2003-2024 The Battle for Wesnoth Project"
+COPYRIGHT="2003-2026 The Battle for Wesnoth Project"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="1"
 branch="`echo "$portVersion" | cut -b1-4`"
 SOURCE_URI="https://sourceforge.net/projects/wesnoth/files/wesnoth-$branch/wesnoth-$portVersion/wesnoth-$portVersion.tar.bz2"
-CHECKSUM_SHA256="e15db3caf446d91d389fc275f10c1a9e7ca3c6176c3b8ce94f5ee4a7a0c81bd6"
+CHECKSUM_SHA256="6bb8b17854c974bc66cb7a2574a53fe9efb4d2c138bb1373032e57788204985e"
 PATCHES="wesnoth-$portVersion.patchset"
 ADDITIONAL_FILES="
 	wesnoth.rdef.in
@@ -165,5 +165,9 @@ INSTALL()
 	chmod +x $postInstallDir/wesnoth-postinstall.sh
 
 	addResourcesToBinaries wesnoth.rdef $prefix/bin/wesnoth
-	addAppDeskbarSymlink $prefix/bin/wesnoth "Battle for Wesnoth"
+
+	# Make the app name uppercase then link it back in lowercase for cmd
+	mkdir -p $appsDir && mv $prefix/bin/wesnoth $appsDir/Wesnoth
+	ln -s $appsDir/Wesnoth $prefix/bin/wesnoth
+	addAppDeskbarSymlink $appsDir/Wesnoth "Battle for Wesnoth"
 }


### PR DESCRIPTION
Tested both the game and the dedicated server binary on dev 64bit.

I have removed a boost-related patch that is unneeded since some months ago, I am expecting this to break the dedicated server binary on Beta 5, but the main binary should still work fine there.