### PR TITLE
libopenshot, fix build for 32bit

### DIFF
--- a/media-libs/libopenshot/libopenshot-0.3.2.recipe
+++ b/media-libs/libopenshot/libopenshot-0.3.2.recipe
@@ -87,7 +87,7 @@ BUILD_REQUIRES="
 	devel:libjsoncpp$secondaryArchSuffix
 	devel:liblcms2$secondaryArchSuffix
 	devel:libMagick++_7.Q16HDRI$secondaryArchSuffix
-	devel:libopencv_core$secondaryArchSuffix
+	devel:libopencv_core$secondaryArchSuffix >= 4.8
 	devel:libopenshot_audio$secondaryArchSuffix
 	devel:libprotobuf$secondaryArchSuffix
 	devel:libQt5Core$secondaryArchSuffix


### PR DESCRIPTION
New libopencv is split to avoid dependency for Qt5, don't use this here