### PR TITLE
sdl3_image: disable stb backend, falling back to other libraries

### DIFF
--- a/media-libs/sdl3_image/sdl3_image-3.2.4.recipe
+++ b/media-libs/sdl3_image/sdl3_image-3.2.4.recipe
@@ -4,7 +4,7 @@ supports the following formats: BMP, GIF, JPEG, LBM, PCX, PNG, PNM, TGA, TIFF, W
 HOMEPAGE="https://github.com/libsdl-org/SDL_image"
 COPYRIGHT="1997-2025 Sam Lantinga"
 LICENSE="Zlib"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/libsdl-org/SDL_image/archive/refs/tags/release-$portVersion.tar.gz"
 CHECKSUM_SHA256="6a2f263e69d5cf0f218615e061f0d6cc1ae708e847ffe5372af98d5dd96bd037"
 SOURCE_DIR="SDL_image-release-$portVersion"
@@ -61,7 +61,8 @@ BUILD()
 {
 	cmake . -Bbuild -GNinja $cmakeDirArgs \
 		-DBUILD_SHARED_LIBS=ON \
-		-DCMAKE_BUILD_TYPE=Release
+		-DCMAKE_BUILD_TYPE=Release \
+		-DSDLIMAGE_BACKEND_STB=OFF # Allegedly slower than other options according to Gentoo, and not very secure
 	ninja -C build
 }
 


### PR DESCRIPTION
As the comment says, it is allegedly slower than using other libraries, and it has security complications - like a vuln being kept open even though it is there for 3/4 years now (link removed as it was closed in 2023? I swear, I saw one meeting this criteria), which is not good for upcoming port, an ImGui based messenger that uses sdl3_image.

Not closely tested, as no port uses sdl3_image so far. Unless I am missing something.

This somehow does not introduce even a single new dependency. This is either a mistake on our (HaikuPorts') part, or something on SDL side.