### PR TITLE
SBCL 2.6.3

### DIFF
--- a/dev-lisp/sbcl/sbcl-2.6.3.recipe
+++ b/dev-lisp/sbcl/sbcl-2.6.3.recipe
@@ -9,7 +9,7 @@ COPYRIGHT="2002 Gerd Moellmann"
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="https://github.com/sbcl/sbcl/archive/refs/tags/sbcl-$portVersion.zip"
-CHECKSUM_SHA256="456f676108d743feb0033e1cd66a17790a1285751eeae3a961e117ae037115c2"
+CHECKSUM_SHA256="5d40361e6e881642ea83adc18c4cfa79c50cd0132096423dd37ed3780b5c4539"
 SOURCE_DIR="sbcl-sbcl-$portVersion"
 
 ARCHITECTURES="x86_64"


### PR DESCRIPTION
The version 2.6.1 was submitted but failed on Haiku buildbot. It seems just trying again would be sufficient. And I will increase REVISION next time for this.

The version 2.6.2 was broken on Haiku. SBCL fixed Haiku build by changing the code and configuration. This change is suboptimal (it relays on SBCL on Haiku x86-64) but is the easiest and working. Having no other SBCL on Haiku ports (e.g. x86) and planning none for now, this is sufficiently good solution. Otherwise many include dirs should be specified to find just one missing macro. The fix by SBCL was prepared after 2.6.2 was released.

The version 2.6.3 compiles on Haiku.