### PR TITLE
ImGui port

### DIFF
--- a/gui-libs/imgui/imgui-1.92.7.recipe
+++ b/gui-libs/imgui/imgui-1.92.7.recipe
@@ -1,0 +1,80 @@
+SUMMARY="Bloat-free Graphical User interface for C++ with minimal dependencies"
+DESCRIPTION="Dear ImGui is a bloat-free graphical user interface library for C++. It outputs optimized vertex buffers \
+that you can render anytime in your 3D-pipeline-enabled application.
+It is fast, portable, renderer agnostic, and self-contained (no external dependencies)."
+HOMEPAGE="https://github.com/ocornut/imgui"
+COPYRIGHT="2026 Omar Cornut and ImGui contributors"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://github.com/ocornut/imgui/archive/refs/tags/v$portVersion.tar.gz"
+CHECKSUM_SHA256="b21b14ce1ef6dd4d85fa54f68f8449a9be94f3b453aba7fe4ea2a9764e43a5ef"
+PATCHES="imgui-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	imgui$secondaryArchSuffix = $portVersion
+	lib:libimgui$secondaryArchSuffix
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libfreetype$secondaryArchSuffix
+	lib:libglfw$secondaryArchSuffix
+	lib:libSDL3$secondaryArchSuffix
+	lib:libvulkan$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	imgui${secondaryArchSuffix}_devel = $portVersion
+	devel:libimgui$secondaryArchSuffix
+	"
+REQUIRES_devel="
+	imgui$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libfreetype$secondaryArchSuffix
+	devel:libgl$secondaryArchSuffix
+	devel:libglfw$secondaryArchSuffix
+	devel:libglu$secondaryArchSuffix
+	devel:libSDL3$secondaryArchSuffix
+	devel:libvulkan$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	"
+
+BUILD()
+{
+	freetypedir=$(finddir B_SYSTEM_DEVELOP_DIRECTORY)/headers/freetype2
+
+	cmake -Bbuild -S. $cmakeDirArgs -DCMAKE_BUILD_TYPE=Release \
+		-DFREETYPE_INCLUDE_DIR=$freetypedir \
+		-DIMGUI_BUILD_GLFW_BINDING=ON \
+		-DIMGUI_BUILD_OPENGL2_BINDING=ON \
+		-DIMGUI_BUILD_OPENGL3_BINDING=ON \
+		-DIMGUI_BUILD_SDL3_BINDING=ON \
+		-DIMGUI_BUILD_SDL3_RENDERER_BINDING=ON \
+		-DIMGUI_BUILD_SDLGPU3_BINDING=ON \
+		-DIMGUI_BUILD_VULKAN_BINDING=ON \
+		-DIMGUI_FREETYPE=ON \
+		-DBUILD_SHARED_LIBS=ON
+
+	make -C build $jobArgs
+}
+
+INSTALL()
+{
+	make -C build install
+
+	prepareInstalledDevelLib libimgui
+
+	# devel package
+	packageEntries devel \
+		$developDir \
+		$libDir/cmake
+}

--- a/gui-libs/imgui/patches/imgui-1.92.7.patchset
+++ b/gui-libs/imgui/patches/imgui-1.92.7.patchset
@@ -1,0 +1,382 @@
+From 2d202dc150c858fa7a72039dfb563805debea70c Mon Sep 17 00:00:00 2001
+From: Peppersawce <michaelpeppers89@yahoo.it>
+Date: Wed, 8 Apr 2026 12:53:18 +0200
+Subject: Copy CMake files from https://github.com/microsoft/vcpkg, with some edits
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+new file mode 100644
+index 0000000..03eefb8
+--- /dev/null
++++ b/CMakeLists.txt
+@@ -0,0 +1,317 @@
++cmake_minimum_required(VERSION 3.16)
++project(imgui CXX)
++
++set(CMAKE_DEBUG_POSTFIX d)
++
++add_library(${PROJECT_NAME} "")
++add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
++target_include_directories(
++    ${PROJECT_NAME}
++    PUBLIC
++        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR};${CMAKE_CURRENT_SOURCE_DIR}/test-engine>"
++        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
++)
++
++target_sources(
++    ${PROJECT_NAME}
++    PRIVATE
++        ${CMAKE_CURRENT_SOURCE_DIR}/imgui.cpp
++        ${CMAKE_CURRENT_SOURCE_DIR}/imgui_demo.cpp
++        ${CMAKE_CURRENT_SOURCE_DIR}/imgui_draw.cpp
++        ${CMAKE_CURRENT_SOURCE_DIR}/imgui_tables.cpp
++        ${CMAKE_CURRENT_SOURCE_DIR}/imgui_widgets.cpp
++        ${CMAKE_CURRENT_SOURCE_DIR}/misc/cpp/imgui_stdlib.cpp
++)
++
++target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
++
++if(IMGUI_BUILD_ALLEGRO5_BINDING)
++    find_package(Allegro CONFIG REQUIRED)
++    target_link_libraries(${PROJECT_NAME} PRIVATE Allegro::allegro Allegro::allegro_ttf Allegro::allegro_font Allegro::allegro_main)
++    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_allegro5.cpp)
++endif()
++
++if(IMGUI_BUILD_ANDROID_BINDING)
++    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_android.cpp)
++endif()
++
++if(IMGUI_BUILD_DX9_BINDING)
++    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_dx9.cpp)
++endif()
++
++if(IMGUI_BUILD_DX10_BINDING)
++    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_dx10.cpp)
++endif()
++
++if(IMGUI_BUILD_DX11_BINDING)
++    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_dx11.cpp)
++endif()
++
++if(IMGUI_BUILD_DX12_BINDING)
++    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_dx12.cpp)
++endif()
++
++if(IMGUI_BUILD_GLFW_BINDING)
++    if(NOT EMSCRIPTEN)
++        find_package(glfw3 CONFIG REQUIRED)
++        target_link_libraries(${PROJECT_NAME} PUBLIC glfw)
++    endif()
++    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_glfw.cpp)
++endif()
++
++if(IMGUI_BUILD_GLUT_BINDING)
++    find_package(GLUT REQUIRED)
++    target_link_libraries(${PROJECT_NAME} PUBLIC GLUT::GLUT)
++    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_glut.cpp)
++endif()
++
++if(IMGUI_BUILD_METAL_BINDING)
++    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_metal.mm)
++    set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_metal.mm PROPERTIES COMPILE_FLAGS -fobjc-weak)
++endif()
++
++if(IMGUI_BUILD_OPENGL2_BINDING)
++    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_opengl2.cpp)
++endif()
++
++if(IMGUI_BUILD_OPENGL3_BINDING)
++    if(APPLE AND (CMAKE_SYSTEM_NAME MATCHES "iOS"))
++        target_compile_definitions(${PROJECT_NAME} PRIVATE IMGUI_IMPL_OPENGL_ES3)
++        target_link_libraries(${PROJECT_NAME} PUBLIC -framework OpenGLES)
++    elseif(HAIKU)
++        target_compile_definitions(${PROJECT_NAME} PRIVATE IMGUI_IMPL_OPENGL_ES3)
++        find_path(OPENGL_INCLUDE_DIR NAMES GLES3/gl3.h REQUIRED)
++        target_include_directories(${PROJECT_NAME} PRIVATE ${OPENGL_INCLUDE_DIR})
++    endif()
++    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp)
++endif()
++
++if(IMGUI_BUILD_OSX_BINDING)
++    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_osx.mm)
++endif()
++
++if(IMGUI_BUILD_SDL3_BINDING)
++    find_package(SDL3 CONFIG REQUIRED)
++    target_link_libraries(${PROJECT_NAME} PUBLIC SDL3::SDL3)
++    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdl3.cpp)
++endif()
++
++if(IMGUI_BUILD_SDLGPU3_BINDING)
++    find_package(SDL3 CONFIG REQUIRED)
++    target_link_libraries(${PROJECT_NAME} PUBLIC SDL3::SDL3)
++    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdlgpu3.cpp)
++endif()
++
++if(IMGUI_BUILD_SDL3_RENDERER_BINDING)
++    find_package(SDL3 CONFIG REQUIRED)
++    target_link_libraries(${PROJECT_NAME} PUBLIC SDL3::SDL3)
++    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdlrenderer3.cpp)
++endif()
++
++if(IMGUI_BUILD_VULKAN_BINDING)
++    find_package(Vulkan REQUIRED)
++    target_link_libraries(${PROJECT_NAME} PUBLIC Vulkan::Vulkan)
++    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_vulkan.cpp)
++endif()
++
++if(IMGUI_BUILD_WIN32_BINDING)
++    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_win32.cpp)
++endif()
++
++if(IMGUI_BUILD_WEBGPU_BINDING)
++    find_package(Dawn CONFIG REQUIRED)
++    target_link_libraries(${PROJECT_NAME} PUBLIC dawn::webgpu_dawn)
++    target_compile_definitions(${PROJECT_NAME} PRIVATE IMGUI_IMPL_WEBGPU_BACKEND_DAWN)
++    list(APPEND WGPU_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_wgpu.cpp)
++    target_sources(${PROJECT_NAME} PRIVATE ${WGPU_SRCS})
++    if(APPLE)
++        set_source_files_properties(${WGPU_SRCS} PROPERTIES LANGUAGE OBJCXX)
++        target_link_libraries(${PROJECT_NAME} PUBLIC "-framework Foundation")
++    endif()
++endif()
++
++if(IMGUI_FREETYPE)
++    #find_package(freetype CONFIG REQUIRED)
++    target_include_directories(${PROJECT_NAME} PRIVATE ${FREETYPE_INCLUDE_DIR})
++    target_link_libraries(${PROJECT_NAME} PUBLIC freetype)
++    target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/misc/freetype/imgui_freetype.cpp)
++    target_compile_definitions(${PROJECT_NAME} PUBLIC IMGUI_ENABLE_FREETYPE)
++endif()
++
++if(IMGUI_FREETYPE_SVG)
++    find_package(plutosvg CONFIG REQUIRED)
++    target_link_libraries(${PROJECT_NAME} PUBLIC plutosvg::plutosvg)
++    target_compile_definitions(${PROJECT_NAME} PUBLIC IMGUI_ENABLE_FREETYPE_PLUTOSVG)
++endif()
++
++if(IMGUI_USE_WCHAR32)
++    target_compile_definitions(${PROJECT_NAME} PUBLIC IMGUI_USE_WCHAR32)
++endif()
++
++if(IMGUI_TEST_ENGINE)
++    find_package(Stb REQUIRED)
++    target_include_directories(${PROJECT_NAME} PRIVATE ${Stb_INCLUDE_DIR})
++    target_sources(
++        ${PROJECT_NAME}
++        PRIVATE
++            ${CMAKE_CURRENT_SOURCE_DIR}/test-engine/imgui_capture_tool.cpp
++            ${CMAKE_CURRENT_SOURCE_DIR}/test-engine/imgui_te_context.cpp
++            ${CMAKE_CURRENT_SOURCE_DIR}/test-engine/imgui_te_coroutine.cpp
++            ${CMAKE_CURRENT_SOURCE_DIR}/test-engine/imgui_te_engine.cpp
++            ${CMAKE_CURRENT_SOURCE_DIR}/test-engine/imgui_te_exporters.cpp
++            ${CMAKE_CURRENT_SOURCE_DIR}/test-engine/imgui_te_perftool.cpp
++            ${CMAKE_CURRENT_SOURCE_DIR}/test-engine/imgui_te_ui.cpp
++            ${CMAKE_CURRENT_SOURCE_DIR}/test-engine/imgui_te_utils.cpp
++    )
++endif()
++
++list(REMOVE_DUPLICATES BINDINGS_SOURCES)
++
++install(
++    TARGETS ${PROJECT_NAME}
++    EXPORT ${PROJECT_NAME}_target
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++)
++
++foreach(BINDING_TARGET ${BINDING_TARGETS})
++    install(
++        TARGETS ${BINDING_TARGET}
++        EXPORT ${PROJECT_NAME}_target
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++    )
++endforeach()
++
++if(NOT IMGUI_SKIP_HEADERS)
++    install(FILES
++        ${CMAKE_CURRENT_SOURCE_DIR}/imgui.h
++        ${CMAKE_CURRENT_SOURCE_DIR}/imconfig.h
++        ${CMAKE_CURRENT_SOURCE_DIR}/imgui_internal.h
++        ${CMAKE_CURRENT_SOURCE_DIR}/imstb_textedit.h
++        ${CMAKE_CURRENT_SOURCE_DIR}/imstb_rectpack.h
++        ${CMAKE_CURRENT_SOURCE_DIR}/imstb_truetype.h
++        ${CMAKE_CURRENT_SOURCE_DIR}/misc/cpp/imgui_stdlib.h
++        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
++    )
++
++    if(IMGUI_BUILD_ALLEGRO5_BINDING)
++        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_allegro5.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    endif()
++
++    if (IMGUI_BUILD_ANDROID_BINDING)
++        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_android.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    endif()
++
++    if(IMGUI_BUILD_DX9_BINDING)
++        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_dx9.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    endif()
++
++    if(IMGUI_BUILD_DX10_BINDING)
++        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_dx10.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    endif()
++
++    if(IMGUI_BUILD_DX11_BINDING)
++        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_dx11.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    endif()
++
++    if(IMGUI_BUILD_DX12_BINDING)
++        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_dx12.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    endif()
++
++    if(IMGUI_BUILD_GLFW_BINDING)
++        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_glfw.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    endif()
++
++    if(IMGUI_BUILD_GLUT_BINDING)
++        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_glut.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    endif()
++
++    if(IMGUI_BUILD_METAL_BINDING)
++        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_metal.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    endif()
++
++    if(IMGUI_BUILD_OPENGL2_BINDING)
++        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_opengl2.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    endif()
++
++    if(IMGUI_BUILD_OPENGL3_BINDING)
++        install(
++            FILES
++                ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_opengl3.h
++                ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_opengl3_loader.h
++            DESTINATION
++                ${CMAKE_INSTALL_INCLUDEDIR}
++        )
++    endif()
++
++    if(IMGUI_BUILD_OSX_BINDING)
++        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_osx.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    endif()
++
++    if(IMGUI_BUILD_SDL3_BINDING)
++        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdl3.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    endif()
++
++    if(IMGUI_BUILD_SDLGPU3_BINDING)
++        install(
++            FILES
++                ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdlgpu3.h
++                ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdlgpu3_shaders.h
++            DESTINATION
++                ${CMAKE_INSTALL_INCLUDEDIR}
++        )
++    endif()
++
++    if(IMGUI_BUILD_SDL3_RENDERER_BINDING)
++        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_sdlrenderer3.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    endif()
++
++    if(IMGUI_BUILD_VULKAN_BINDING)
++        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_vulkan.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    endif()
++
++    if(IMGUI_BUILD_WIN32_BINDING)
++        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_win32.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    endif()
++
++    if(IMGUI_BUILD_WEBGPU_BINDING)
++        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/backends/imgui_impl_wgpu.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    endif()
++
++    if(IMGUI_FREETYPE)
++        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/misc/freetype/imgui_freetype.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++    endif()
++
++    if(IMGUI_TEST_ENGINE)
++        install(
++            FILES
++                ${CMAKE_CURRENT_SOURCE_DIR}/test-engine/imgui_capture_tool.h
++                ${CMAKE_CURRENT_SOURCE_DIR}/test-engine/imgui_te_context.h
++                ${CMAKE_CURRENT_SOURCE_DIR}/test-engine/imgui_te_coroutine.h
++                ${CMAKE_CURRENT_SOURCE_DIR}/test-engine/imgui_te_engine.h
++                ${CMAKE_CURRENT_SOURCE_DIR}/test-engine/imgui_te_exporters.h
++                ${CMAKE_CURRENT_SOURCE_DIR}/test-engine/imgui_te_imconfig.h
++                ${CMAKE_CURRENT_SOURCE_DIR}/test-engine/imgui_te_internal.h
++                ${CMAKE_CURRENT_SOURCE_DIR}/test-engine/imgui_te_perftool.h
++                ${CMAKE_CURRENT_SOURCE_DIR}/test-engine/imgui_te_ui.h
++                ${CMAKE_CURRENT_SOURCE_DIR}/test-engine/imgui_te_utils.h
++            DESTINATION
++                ${CMAKE_INSTALL_INCLUDEDIR}
++        )
++    endif()
++endif()
++
++include(CMakePackageConfigHelpers)
++configure_package_config_file(imgui-config.cmake.in imgui-config.cmake INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/imgui)
++
++install(FILES ${CMAKE_CURRENT_BINARY_DIR}/imgui-config.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/imgui)
++
++install(
++    EXPORT ${PROJECT_NAME}_target
++    NAMESPACE ${PROJECT_NAME}::
++    FILE ${PROJECT_NAME}-targets.cmake
++    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/imgui
++)
+diff --git a/imgui-config.cmake.in b/imgui-config.cmake.in
+new file mode 100644
+index 0000000..04df5ea
+--- /dev/null
++++ b/imgui-config.cmake.in
+@@ -0,0 +1,45 @@
++cmake_policy(SET CMP0012 NEW)
++
++@PACKAGE_INIT@
++
++include(CMakeFindDependencyMacro)
++
++if (@IMGUI_BUILD_GLFW_BINDING@)
++    if (NOT "@EMSCRIPTEN@")
++        find_dependency(glfw3 CONFIG)
++    endif()
++endif()
++
++if (@IMGUI_BUILD_GLUT_BINDING@)
++    find_dependency(GLUT)
++endif()
++
++if (@IMGUI_BUILD_SDL3_BINDING@ OR @IMGUI_BUILD_SDL3_RENDERER_BINDING@ OR @IMGUI_BUILD_SDLGPU3_BINDING@)
++    find_dependency(SDL3 CONFIG)
++endif()
++
++if (@IMGUI_BUILD_VULKAN_BINDING@)
++    find_dependency(Vulkan)
++endif()
++
++if (@IMGUI_BUILD_WEBGPU_BINDING@)
++    find_dependency(Dawn)
++endif()
++
++if (@IMGUI_FREETYPE@)
++    #find_dependency(freetype CONFIG)
++endif()
++
++if (@IMGUI_FREETYPE_SVG@)
++    find_dependency(plutosvg CONFIG)
++endif()
++
++if (@IMGUI_BUILD_ALLEGRO5_BINDING@)
++    find_dependency(Allegro CONFIG)
++endif()
++
++if (@IMGUI_TEST_ENGINE@)
++    find_dependency(Stb)
++endif()
++
++include("${CMAKE_CURRENT_LIST_DIR}/imgui-targets.cmake")
+-- 
+2.52.0


### PR DESCRIPTION
This is needed by a number of potential ports (which tend to use vcpkg), the libraries themselves seem to be meant to be integrated inside apps instead so they have no build files.

Looking around for potential solutions I noticed [AUR](https://aur.archlinux.org/packages/imgui) uses vcpkg's CMake files to build it so I'm trying the same.

As such `$cmakeDirArgs` doesn't do much at the moment. I am also unsure of what to do with backends, it compiles fine without specifying any of them, I now enabled what I think would be reasonable for Haiku. Freetype doesn't seem to be detected at build time.

EDIT: Freetype is now enabled. It is not found, however, when this library is used as a dependency in CMake so it's not working as it should yet.

EDIT2: Edited CMakeLists.txt to make use of some install arguments. As for Freetype, I'm disabling all checks for it in the cmake files added for now.

Only tested on 64bit, putting this out as a WIP for now.