### PR TITLE
ImGui: fix x86 build

### DIFF
--- a/gui-libs/imgui/imgui-1.92.7.recipe
+++ b/gui-libs/imgui/imgui-1.92.7.recipe
@@ -50,7 +50,7 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	freetypedir=$(finddir B_SYSTEM_DEVELOP_DIRECTORY)/headers/freetype2
+	freetypedir=$(finddir B_SYSTEM_DIRECTORY)/$relativeIncludeDir/freetype2
 
 	cmake -Bbuild -S. $cmakeDirArgs -DCMAKE_BUILD_TYPE=Release \
 		-DFREETYPE_INCLUDE_DIR=$freetypedir \


### PR DESCRIPTION
A small fix to allow ImGui to build on 32bit, currently it fails because it cannot find the freetype headers.

Not bumping up the revision as a rebuild on 64bit is not necessary.