### PR TITLE
elinks: update to version 0.19.1.

### DIFF
--- a/www-client/elinks/elinks-0.19.1.recipe
+++ b/www-client/elinks/elinks-0.19.1.recipe
@@ -8,7 +8,7 @@ COPYRIGHT="Petr Baudiš, Jonas Fonseca, Witold Filipczyk"
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://github.com/rkd77/elinks/releases/download/v$portVersion/elinks-$portVersion.tar.xz"
-CHECKSUM_SHA256="e56ef15996a1ca130789293ee6d49cbecf175c06266acfa676fa6edb271a1173"
+CHECKSUM_SHA256="31960cd471246692b84008bffec89182f25818472f86ee1a41a09bf0dad09eeb"
 
 PATCHES="elinks-$portVersion.patchset"
 
@@ -44,12 +44,11 @@ REQUIRES="
 	lib:libcrypto$secondaryArchSuffix
 	lib:libcurl$secondaryArchSuffix
 	lib:libexpat$secondaryArchSuffix
+#	lib:libevent_2.1$secondaryArchSuffix
 	lib:libintl$secondaryArchSuffix
-#	lib:liblzma$secondaryArchSuffix
 #	lib:libsmbclient$secondaryArchSuffix
 	lib:libssl$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
-	lib:libzstd$secondaryArchSuffix
 	"
 
 if $enableJSSupport; then
@@ -57,7 +56,7 @@ if $enableJSSupport; then
 		lib:libcss$secondaryArchSuffix
 		lib:libdom$secondaryArchSuffix
 		lib:libhubbub$secondaryArchSuffix
-		lib:libmujs$secondaryArchSuffix
+		#lib:libmujs$secondaryArchSuffix
 		lib:libparserutils$secondaryArchSuffix
 		lib:libsqlite3$secondaryArchSuffix
 		lib:libwapcaplet$secondaryArchSuffix
@@ -71,12 +70,11 @@ BUILD_REQUIRES="
 	devel:libcrypto$secondaryArchSuffix
 	devel:libcurl$secondaryArchSuffix
 	devel:libexpat$secondaryArchSuffix
+#	devel:libevent_2.1$secondaryArchSuffix
 	devel:libintl$secondaryArchSuffix
-#	devel:liblzma$secondaryArchSuffix
 #	devel:libsmbclient$secondaryArchSuffix
 	devel:libssl$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
-	devel:libzstd$secondaryArchSuffix
 	"
 
 if $enableJSSupport; then
@@ -84,7 +82,8 @@ if $enableJSSupport; then
 		devel:libcss$secondaryArchSuffix
 		devel:libdom$secondaryArchSuffix
 		devel:libhubbub$secondaryArchSuffix
-		devel:libmujs$secondaryArchSuffix
+		#devel:libmujs$secondaryArchSuffix
+		devel:libquickjs$secondaryArchSuffix	# for libquickjs.a
 		devel:libparserutils$secondaryArchSuffix
 		devel:libsqlite3$secondaryArchSuffix
 		devel:libwapcaplet$secondaryArchSuffix
@@ -114,7 +113,8 @@ BUILD()
 
 	maybeWithJSSupport=
 	if $enableJSSupport; then
-		maybeWithJSSupport="--with-mujs --enable-sm-scripting"
+		# maybeWithJSSupport="--with-mujs"
+		maybeWithJSSupport="--with-quickjs"
 	fi
 
 	runConfigure --omit-dirs binDir ./configure \
@@ -141,6 +141,7 @@ BUILD()
 		$maybeWithJSSupport
 
 #		--enable-smb
+#		--with-libevent
 
 	make
 }

--- a/www-client/elinks/patches/elinks-0.19.1.patchset
+++ b/www-client/elinks/patches/elinks-0.19.1.patchset
@@ -1,14 +1,14 @@
-From bd5027bbf859e3bfb87143548c6392f02e58b332 Mon Sep 17 00:00:00 2001
+From f440354c6c265786d8b86dce0f1ac9f502dd8a47 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Tue, 14 Oct 2025 11:39:26 -0300
 Subject: Set show_menu_bar_always=1 as default.
 
 
 diff --git a/src/config/options.inc b/src/config/options.inc
-index 302f79d..21c1de3 100644
+index 375855c..e4e2bd5 100644
 --- a/src/config/options.inc
 +++ b/src/config/options.inc
-@@ -1513,7 +1513,7 @@ static union option_info config_options_info[] = {
+@@ -1580,7 +1580,7 @@ static union option_info config_options_info[] = {
  		"dynamically.")),
  
  	INIT_OPT_BOOL("ui", N_("Display menu bar always"),
@@ -18,5 +18,5 @@ index 302f79d..21c1de3 100644
  
  	INIT_OPT_BOOL("ui", N_("Display status bar"),
 -- 
-2.51.0
+2.52.0
 


### PR DESCRIPTION
Tried enabling QuickJS, but same as with MuJS in the past, doens't seems to help with getting more modern websites to work, so I left it disabled.

Enabling libevent didn't seemed to do much, so left it disabled too.

Not sure if it's somehing on Haiku nightlies, but this version (and the previous) can't access haiku-os.org, and some other sites (just a blank page while "Making connection").

While seemingly less useful than plain-old "links", elinks' gopher support at least seems to work fine (same as browsing "plain old websites").