### PR TITLE
games-board/stockfish: bump to classical (=11+patches)

### DIFF
--- a/games-board/stockfish/stockfish-classical.recipe
+++ b/games-board/stockfish/stockfish-classical.recipe
@@ -7,13 +7,13 @@ choice for information about how to use Stockfish with it."
 HOMEPAGE="https://www.stockfishchess.org/"
 COPYRIGHT="2004-2008 Tord Romstad (Glaurung author)
 	2008-2015 Marco Costalba, Joona Kiiski, Tord Romstad
-	2015-2018 Marco Costalba, Joona Kiiski, Gary Linscott, Tord Romstad"
+	2015-2020 Marco Costalba, Joona Kiiski, Gary Linscott, Tord Romstad"
 LICENSE="GNU GPL v3"
 REVISION="1"
-SOURCE_URI="https://github.com/official-stockfish/Stockfish/archive/sf_$portVersion.tar.gz"
-CHECKSUM_SHA256="d0f33765376b381868d13cc8bfd4e1fa51040074b7ab388cc93b613dd88f67c4"
+SOURCE_URI="https://github.com/official-stockfish/Stockfish/archive/SF_$portVersion.tar.gz"
+CHECKSUM_SHA256="5732fdd02808c9c6800e598c167d2104929fbd464bb931a181bbedd71897f31c"
 SOURCE_FILENAME="stockfish-$portVersion.tar.gz"
-SOURCE_DIR="Stockfish-sf_$portVersion"
+SOURCE_DIR="Stockfish-SF_$portVersion"
 
 ARCHITECTURES="all !x86_gcc2 ?arm ?ppc"
 SECONDARY_ARCHITECTURES="!x86_gcc2 x86"


### PR DESCRIPTION
Update stockfish to the classical release, this is the most advanced version of stockfish without the neural network.

Effectively it's Stockfish 11 plus patches.