### PR TITLE
sciteco_curses: updated to v2.5.2

### DIFF
--- a/app-editors/sciteco/sciteco_curses-2.5.2.recipe
+++ b/app-editors/sciteco/sciteco_curses-2.5.2.recipe
@@ -12,7 +12,7 @@ LICENSE="GNU GPL v3"
 REVISION="1"
 SOURCE_URI="https://sciteco.fmsbw.de/downloads/v$portVersion/sciteco-$portVersion.tar.gz
 	https://sourceforge.net/projects/sciteco/files/v$portVersion/sciteco-$portVersion.tar.gz"
-CHECKSUM_SHA256="cc99c6855f844f0514f2ed4879bf6a02f11eb489a3b77d88ad7f0bcfe1379fbf"
+CHECKSUM_SHA256="94149fa3371e3adff723ae933502b5983804c4e06a681c6d00b0af19c439a978"
 SOURCE_DIR="sciteco-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"


### PR DESCRIPTION
Updated recipe to the new v2.5.2 upstream release.