### PR TITLE
shiboken6, only enable x86_64

### DIFF
--- a/dev-python/shiboken6/shiboken6-6.10.3.recipe
+++ b/dev-python/shiboken6/shiboken6-6.10.3.recipe
@@ -17,8 +17,8 @@ CHECKSUM_SHA256="2c7462fe0cecb5b8ac0a3d92014b8d0b88bd4d9f8646709dab5286d9416f45b
 SOURCE_DIR="pyside-setup-everywhere-src-$portVersion"
 PATCHES="shiboken6-$portVersion.patchset"
 
-ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="x86"
+ARCHITECTURES="?all x86_64"
+SECONDARY_ARCHITECTURES="?x86"
 
 libVersion="$portVersion"
 libVersionCompat="$libVersion compat >= ${libVersion%.*}"


### PR DESCRIPTION
Set this to be on par with pyside6 for now.