### PR TITLE
glew2.3, disable x86_gcc2

### DIFF
--- a/media-libs/glew/glew2.3-2.3.1.recipe
+++ b/media-libs/glew/glew2.3-2.3.1.recipe
@@ -16,8 +16,8 @@ CHECKSUM_SHA256="b64790f94b926acd7e8f84c5d6000a86cb43967bd1e688b03089079799c9e88
 SOURCE_DIR="glew-$portVersion"
 PATCHES="glew-$portVersion.patchset"
 
-ARCHITECTURES="all"
-SECONDARY_ARCHITECTURES="x86_gcc2 x86"
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 libVersion="$portVersion"
 libVersionCompat="$libVersion compat >= ${libVersion%.**}"


### PR DESCRIPTION
Since this is a new version there is no need for gcc2 support at this moment