### PR TITLE
SBCL 2.6.4

### DIFF
--- a/dev-lisp/sbcl/sbcl-2.6.4.recipe
+++ b/dev-lisp/sbcl/sbcl-2.6.4.recipe
@@ -9,7 +9,7 @@ COPYRIGHT="2002 Gerd Moellmann"
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="https://github.com/sbcl/sbcl/archive/refs/tags/sbcl-$portVersion.zip"
-CHECKSUM_SHA256="5d40361e6e881642ea83adc18c4cfa79c50cd0132096423dd37ed3780b5c4539"
+CHECKSUM_SHA256="52bc5544ece89eb3b135c9903ebcffc3d23b6cc8adcd3a3b4621b963243cf542"
 SOURCE_DIR="sbcl-sbcl-$portVersion"
 
 ARCHITECTURES="x86_64"
@@ -39,7 +39,7 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	chmod -R a+x *.sh
-	sh make.sh --xc-host='sbcl --noinit' --with-sb-core-compression --with-sb-simd-pack --without-sb-thread
+	sh make.sh --xc-host='sbcl --noinit' --with-sb-core-compression --with-sb-simd-pack --with-sb-thread
 }
 
 INSTALL()


### PR DESCRIPTION
The thread enabled version seems to be in pair as thread disabled one in terms of stability.

* Experimentally enable threads in SBCL