### PR TITLE
sdl2_image, drop cmake configuration files, still a flaw in there?

### DIFF
--- a/media-libs/sdl2_image/sdl2_image-2.8.8.recipe
+++ b/media-libs/sdl2_image/sdl2_image-2.8.8.recipe
@@ -8,7 +8,7 @@ on both libz and libjpeg."
 HOMEPAGE="https://www.libsdl.org/projects/SDL_image"
 COPYRIGHT="1997-2025 Sam Lantinga"
 LICENSE="Zlib"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://www.libsdl.org/projects/SDL_image/release/SDL2_image-$portVersion.tar.gz"
 CHECKSUM_SHA256="2213b56fdaff2220d0e38c8e420cbe1a83c87374190cba8c70af2156097ce30a"
 SOURCE_DIR="SDL2_image-$portVersion"
@@ -79,6 +79,7 @@ INSTALL()
 	make install
 
 	rm $libDir/*.{a,la}
+	rm -rf $libDir/cmake
 
 	prepareInstalledDevelLibs libSDL2_image libSDL2_image-2.0
 	fixPkgconfig


### PR DESCRIPTION
Check: https://github.com/haikuports/haikuports/pull/14072#issuecomment-4380630784