### PR TITLE
sys-libs/timezone_data: install leap-seconds.list

### DIFF
--- a/sys-libs/timezone_data/timezone_data-2023c.recipe
+++ b/sys-libs/timezone_data/timezone_data-2023c.recipe
@@ -11,7 +11,7 @@ LICENSE="
 	Public Domain
 	BSD (3-clause)
 	"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://data.iana.org/time-zones/releases/tzdb-$portVersion.tar.lz"
 CHECKSUM_SHA256="08fd090f1a16d522ae4e9247445056f4155002239e5be760b31ba0376d2e632c"
 SOURCE_DIR="tzdb-$portVersion"
@@ -59,6 +59,7 @@ INSTALL()
 		ZICDIR=$binDir \
 		MANDIR=$manDir \
 		install
+	cp leap-seconds.list $dataDir/zoneinfo
 
 	prepareInstalledDevelLibs libtz
 }


### PR DESCRIPTION
This is required by some software, in particular the [Hare programming language](https://harelang.org/documentation/install/packaging.html).