### PR TITLE
App-Benchmarks: Initial recipe for Phoronix Test Suite (pts) 10.8.4

### DIFF
--- a/app-benchmarks/pts/additional-files/pts_launcher.sh
+++ b/app-benchmarks/pts/additional-files/pts_launcher.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+Terminal -t "Phoronix test suite" /bin/sh -c "cd /boot/system/data/pts/pts-core && php phoronix-test-suite.php interactive"
+
+ 

--- a/app-benchmarks/pts/additional-files/pts_launcher.sh
+++ b/app-benchmarks/pts/additional-files/pts_launcher.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-Terminal -t "Phoronix test suite" /bin/sh -c "cd /boot/system/data/pts/pts-core && php phoronix-test-suite.php interactive"
+Terminal -t "Phoronix Test Suite" /bin/sh -c "cd /boot/system/data/pts/pts-core && php phoronix-test-suite.php interactive"
 
  

--- a/app-benchmarks/pts/pts-10.8.4.patchset
+++ b/app-benchmarks/pts/pts-10.8.4.patchset
@@ -1,54 +1,39 @@
-From c19616b2d1aaf2d0140c63d7b739e323e4244e32 Mon Sep 17 00:00:00 2001
+From 9474bc818f87a74b04eec712f4df289627ae7c82 Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
-Date: Wed, 8 Apr 2026 19:02:21 +0300
-Subject: add haiku paths for headers and shared libraries
+Date: Sun, 3 May 2026 00:42:10 +0300
+Subject: detect phodevi::is_haiku() and add df -h detection for fs
 
-diff --git a/pts-core/objects/client/pts_external_dependencies.php b/pts-core/objects/client/pts_external_dependencies.php
-index 3dd5877..e31b32a 100644
---- a/pts-core/objects/client/pts_external_dependencies.php
-+++ b/pts-core/objects/client/pts_external_dependencies.php
-@@ -192,6 +192,7 @@ class pts_external_dependencies
+
+diff --git a/pts-core/objects/phodevi/phodevi.php b/pts-core/objects/phodevi/phodevi.php
+index fc00fb9..9704468 100644
+--- a/pts-core/objects/phodevi/phodevi.php
++++ b/pts-core/objects/phodevi/phodevi.php
+@@ -42,7 +42,8 @@ class phodevi extends phodevi_base
+ 		'bsd' => false,
+ 		'hurd' => false,
+ 		'minix' => false,
+-		'windows' => false
++		'windows' => false,
++		'haiku' => false
+ 		);
  
- 		// There were some dependencies not supported on this OS or are missing from the distro's XML file
- 		if(count($required_external_dependencies) > 0 && count($dependencies_to_install) == 0 && $skip_warning_on_unmet_deps == false)
-+		
- 		{
- 			$exdep_generic_parser = new pts_exdep_generic_parser();
- 			$to_report = array();
-@@ -209,7 +210,7 @@ class pts_external_dependencies
- 			if(count($to_report) > 0)
- 			{
- 				echo PHP_EOL . 'Some additional dependencies are required, but they could not be installed automatically for your operating system.' . PHP_EOL . 'Below are the software packages that must be installed.' . PHP_EOL . PHP_EOL;
--
-+				
- 				foreach($to_report as $report)
- 				{
- 					pts_client::$display->generic_heading($report);
-@@ -499,7 +500,7 @@ class pts_external_dependencies
- 					if(substr($file[$i], -2) == '.h' || substr($file[$i], -4) == '.hpp')
- 					{
- 						// May just be a relative header file to look for...
--						$possible_paths = array_merge(array('/usr/local/include/', '/usr/target/include/', '/usr/include/'), pts_file_io::glob('/usr/include/*-linux-gnu/'));
-+						$possible_paths = array_merge(array('/boot/system/develop/headers','/boot/system/config/develop/headers','/boot/system/non-packaged/develop/headers'));
- 						foreach($possible_paths as $path)
- 						{
- 							if(self::is_present($path . '/' . $file[$i]))
-@@ -511,8 +512,8 @@ class pts_external_dependencies
- 					else if(strpos($file[$i], '.so') !== false || substr($file[$i], -2) == '.a')
- 					{
- 						// May just be a relative shared library to look for...
--						$possible_paths = array_merge(array('/usr/local/lib/', '/usr/lib/', '/usr/lib64/', '/usr/lib/arm-linux-gnueabihf/'), pts_file_io::glob('/usr/lib/*-linux-gnu/'));
--
-+						$possible_paths = array_merge(array('/boot/system/lib/', '/boot/system/non-packaged/lib', '/boot/system/develop/lib/'));
-+					
- 						if(getenv('LD_LIBRARY_PATH'))
- 						{
- 							foreach(explode(':', getenv('LD_LIBRARY_PATH')) as $path)
+ 	// A variable that modules can use to override Phodevi caching support, etc
+@@ -993,6 +994,10 @@ class phodevi extends phodevi_base
+ 	{
+ 		return self::$operating_systems['linux'];
+ 	}
++	public static function is_haiku()
++	{
++		return stripos(shell_exec('uname'),'Haiku') !== false;
++	}
+ 	public static function is_minix()
+ 	{
+ 		return self::$operating_systems['minix'];
+-- 
+2.52.0
 
 
-
-
-From da5642656128473117a1ad0384413449181771e7 Mon Sep 17 00:00:00 2001
+From b0885a7fe0a7c5d80833f9525d721a8691abbae5 Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
 Date: Mon, 27 Apr 2026 23:19:13 +0300
 Subject: install dependencies even if marked as linux
@@ -71,7 +56,7 @@ index 55e9281..e8c569c 100644
 2.52.0
 
 
-From 7262cb8599f7ba2efc0d4137c20e120a227f5f00 Mon Sep 17 00:00:00 2001
+From b42c72be6752f7e8aafc2c5455bfe4cd22efdd00 Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
 Date: Wed, 29 Apr 2026 23:01:40 +0300
 Subject: if downloaded files are marked for macosx or windows ignore them
@@ -108,7 +93,7 @@ index e8c569c..5f8aa75 100644
 2.52.0
 
 
-From 029562ac2bc404ab055d4e6ce447c7a8ca15ca98 Mon Sep 17 00:00:00 2001
+From 33d5ac526fca7dc52b813a1fe9feaae0341af230 Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
 Date: Sat, 2 May 2026 15:33:56 +0300
 Subject: remove deprecated curl_close references
@@ -157,67 +142,7 @@ index a95ff8b..a4c89b8 100644
 2.52.0
 
 
-From efe293e7a9042e08bf042ea67a5a84af6d013ce6 Mon Sep 17 00:00:00 2001
-From: brooklynakos <spyridop@yahoo.gr>
-Date: Sun, 3 May 2026 00:42:10 +0300
-Subject: detect phodevi::is_haiku() and add df -h detection
- for fs
-
-
-diff --git a/pts-core/objects/phodevi/components/phodevi_system.php b/pts-core/objects/phodevi/components/phodevi_system.php
-index ab002fd..bf37aea 100644
---- a/pts-core/objects/phodevi/components/phodevi_system.php
-+++ b/pts-core/objects/phodevi/components/phodevi_system.php
-@@ -205,6 +205,10 @@ class phodevi_system extends phodevi_device_interface
- 				}
- 			}
- 		}
-+		else if(phodevi::is_haiku())
-+		{
-+		$fs = shell_exec('df -h | grep dev | awk \'{print $1}\'');
-+		}
- 		else if(phodevi::is_bsd())
- 		{
- 			if(pts_client::executable_in_path('mount'))
-@@ -412,7 +416,7 @@ class phodevi_system extends phodevi_device_interface
- 				}
- 			}
- 		}
--
-+		
- 		if(empty($fs))
- 		{
- 			$fs = 'Unknown';
-diff --git a/pts-core/objects/phodevi/phodevi.php b/pts-core/objects/phodevi/phodevi.php
-index fc00fb9..9704468 100644
---- a/pts-core/objects/phodevi/phodevi.php
-+++ b/pts-core/objects/phodevi/phodevi.php
-@@ -42,7 +42,8 @@ class phodevi extends phodevi_base
- 		'bsd' => false,
- 		'hurd' => false,
- 		'minix' => false,
--		'windows' => false
-+		'windows' => false,
-+		'haiku' => false
- 		);
- 
- 	// A variable that modules can use to override Phodevi caching support, etc
-@@ -993,6 +994,10 @@ class phodevi extends phodevi_base
- 	{
- 		return self::$operating_systems['linux'];
- 	}
-+	public static function is_haiku()
-+	{
-+		return stripos(shell_exec('uname'),'Haiku') !== false;
-+	}
- 	public static function is_minix()
- 	{
- 		return self::$operating_systems['minix'];
--- 
-2.52.0
-
-
-From 34f9b1fc33eb76ded6c4ee6817e158cc1800294e Mon Sep 17 00:00:00 2001
+From fe2835da7a994542b51182ba5ea683f63778d6e2 Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
 Date: Tue, 5 May 2026 22:14:36 +0300
 Subject: improve hardware detection
@@ -255,25 +180,7 @@ index 2a1eb9b..89cf1d7 100644
  		else if(phodevi::is_windows())
  		{
  			$physical_cores = array_sum(phodevi_windows_parser::get_wmi_object('Win32_Processor', 'NumberOfCores', true));
-@@ -296,7 +300,8 @@ class phodevi_cpu extends phodevi_device_interface
- 	public static function cpu_scaling_governor()
- 	{
- 		$scaling_governor = false;
--
-+		
-+		
- 		if(is_file('/sys/devices/system/cpu/cpu0/cpufreq/scaling_driver'))
- 		{
- 			$scaling_governor = pts_file_io::file_get_contents('/sys/devices/system/cpu/cpu0/cpufreq/scaling_driver') . ' ';
-@@ -341,7 +346,7 @@ class phodevi_cpu extends phodevi_device_interface
- 				$scaling_governor = trim($scaling_governor) . ' (' . implode(', ', $append_notes) . ')';
- 			}
- 		}
--
-+		
- 		return trim($scaling_governor);
- 	}
- 	public static function cpu_power_management()
+
 diff --git a/pts-core/objects/phodevi/components/phodevi_gpu.php b/pts-core/objects/phodevi/components/phodevi_gpu.php
 index a6efef8..0e4de52 100644
 --- a/pts-core/objects/phodevi/components/phodevi_gpu.php
@@ -292,7 +199,7 @@ index a6efef8..0e4de52 100644
  		$resolution = implode('x', phodevi::read_property('gpu', 'screen-resolution'));
  
 diff --git a/pts-core/objects/phodevi/phodevi.php b/pts-core/objects/phodevi/phodevi.php
-index 9704468..72f227b 100644
+index 9704468..8582fd9 100644
 --- a/pts-core/objects/phodevi/phodevi.php
 +++ b/pts-core/objects/phodevi/phodevi.php
 @@ -326,7 +326,7 @@ class phodevi extends phodevi_base
@@ -326,14 +233,14 @@ index 9704468..72f227b 100644
 2.52.0
 
 
-From b63d3df923a6761462ba4463c3a5158357eaba8b Mon Sep 17 00:00:00 2001
+From 7c419eca62fd1c014b74929eda6a80486493e943 Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
 Date: Fri, 8 May 2026 14:23:05 +0300
 Subject: add memory detection
 
 
 diff --git a/pts-core/objects/phodevi/phodevi.php b/pts-core/objects/phodevi/phodevi.php
-index 72f227b..ef472ca 100644
+index 8582fd9..025c29a 100644
 --- a/pts-core/objects/phodevi/phodevi.php
 +++ b/pts-core/objects/phodevi/phodevi.php
 @@ -356,7 +356,7 @@ class phodevi extends phodevi_base
@@ -349,14 +256,14 @@ index 72f227b..ef472ca 100644
 2.52.0
 
 
-From 809dd3bdc63fa530b779b1668830a055ea2312b0 Mon Sep 17 00:00:00 2001
+From 528287c90a9add3a00e72e27d9c3424cf905e442 Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
 Date: Fri, 8 May 2026 18:23:12 +0300
 Subject: fix root,display server and supported platform properly
 
 
 diff --git a/pts-core/objects/phodevi/phodevi.php b/pts-core/objects/phodevi/phodevi.php
-index ef472ca..916e453 100644
+index 025c29a..d9590cc 100644
 --- a/pts-core/objects/phodevi/phodevi.php
 +++ b/pts-core/objects/phodevi/phodevi.php
 @@ -1034,7 +1034,7 @@ class phodevi extends phodevi_base
@@ -378,7 +285,7 @@ index ef472ca..916e453 100644
  }
  
 diff --git a/pts-core/objects/pts_test_profile.php b/pts-core/objects/pts_test_profile.php
-index 2e7e8ab..79a3352 100644
+index 82a4531..79a3352 100644
 --- a/pts-core/objects/pts_test_profile.php
 +++ b/pts-core/objects/pts_test_profile.php
 @@ -401,6 +401,10 @@ class pts_test_profile extends pts_test_profile_parser
@@ -395,10 +302,12 @@ index 2e7e8ab..79a3352 100644
 -- 
 2.52.0
 
-From 09b7c92d0c7636cb1616e11eabf177f77f62fa6c Mon Sep 17 00:00:00 2001
+
+From f96d18a478bf7be9599b3727c167c901e02b77a2 Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
 Date: Fri, 17 Apr 2026 13:18:07 +0300
-Subject:  Squash commits regarding haiku_packages
+Subject: Squash commits regarding haiku_packages
+
 
 diff --git a/pts-core/external-test-dependencies/scripts/install-haiku-packages.sh b/pts-core/external-test-dependencies/scripts/install-haiku-packages.sh
 new file mode 100755
@@ -881,4 +790,60 @@ index 0000000..31c100f
 -- 
 2.52.0
 
+
+From eccbc395a6cc5713cccd2f01b3276034ae9787e8 Mon Sep 17 00:00:00 2001
+From: brooklynakos <spyridop@yahoo.gr>
+Date: Sat, 9 May 2026 17:21:48 +0300
+Subject: fix library paths
+
+
+diff --git a/pts-core/objects/client/pts_external_dependencies.php b/pts-core/objects/client/pts_external_dependencies.php
+index 3dd5877..0cb9ca0 100644
+--- a/pts-core/objects/client/pts_external_dependencies.php
++++ b/pts-core/objects/client/pts_external_dependencies.php
+@@ -499,7 +499,7 @@ class pts_external_dependencies
+ 					if(substr($file[$i], -2) == '.h' || substr($file[$i], -4) == '.hpp')
+ 					{
+ 						// May just be a relative header file to look for...
+-						$possible_paths = array_merge(array('/usr/local/include/', '/usr/target/include/', '/usr/include/'), pts_file_io::glob('/usr/include/*-linux-gnu/'));
++						$possible_paths = array_merge(array('/boot/system/develop/headers','/boot/system/config/develop/headers','/boot/system/non-packaged/develop/headers'));
+ 						foreach($possible_paths as $path)
+ 						{
+ 							if(self::is_present($path . '/' . $file[$i]))
+@@ -511,7 +511,7 @@ class pts_external_dependencies
+ 					else if(strpos($file[$i], '.so') !== false || substr($file[$i], -2) == '.a')
+ 					{
+ 						// May just be a relative shared library to look for...
+-						$possible_paths = array_merge(array('/usr/local/lib/', '/usr/lib/', '/usr/lib64/', '/usr/lib/arm-linux-gnueabihf/'), pts_file_io::glob('/usr/lib/*-linux-gnu/'));
++						$possible_paths = array_merge(array('/boot/system/lib/', '/boot/system/non-packaged/lib', '/boot/system/develop/lib/'));
+ 
+ 						if(getenv('LD_LIBRARY_PATH'))
+ 						{
+-- 
+2.52.0
+
+
+From d96c7dedd2a522d5e8a5aa18e3159914c8308451 Mon Sep 17 00:00:00 2001
+From: brooklynakos <spyridop@yahoo.gr>
+Date: Sat, 9 May 2026 17:34:41 +0300
+Subject: print disk info
+
+
+diff --git a/pts-core/objects/phodevi/components/phodevi_system.php b/pts-core/objects/phodevi/components/phodevi_system.php
+index ab002fd..f51dd15 100644
+--- a/pts-core/objects/phodevi/components/phodevi_system.php
++++ b/pts-core/objects/phodevi/components/phodevi_system.php
+@@ -205,6 +205,10 @@ class phodevi_system extends phodevi_device_interface
+ 				}
+ 			}
+ 		}
++		else if(phodevi::is_haiku())
++		{
++		$fs = shell_exec('df -h | grep dev | awk \'{print $1}\'');
++		}
+ 		else if(phodevi::is_bsd())
+ 		{
+ 			if(pts_client::executable_in_path('mount'))
+-- 
+2.52.0
 

--- a/app-benchmarks/pts/pts-10.8.4.patchset
+++ b/app-benchmarks/pts/pts-10.8.4.patchset
@@ -1,0 +1,1341 @@
+From 269f919dbaabd20cd825b9e458312835e2033f37 Mon Sep 17 00:00:00 2001
+From: brooklynakos <spyridop@yahoo.gr>
+Date: Wed, 8 Apr 2026 19:02:21 +0300
+Subject: [PATCH] comment out OS and display server detection 
+
+diff --git a/pts-core/objects/client/pts_test_run_manager.php b/pts-core/objects/client/pts_test_run_manager.php
+index 278815c..ad48440 100644
+--- a/pts-core/objects/client/pts_test_run_manager.php
++++ b/pts-core/objects/client/pts_test_run_manager.php
+@@ -1919,8 +1919,8 @@ class pts_test_run_manager
+ 		}
+ 		else if($test_profile->is_display_required() && !phodevi::is_display_server_active())
+ 		{
+-			$test_error = 'No display server was found, skipping ' . $test_profile;
+-			$valid_test_profile = false;
++			//$test_error = 'No display server was found, skipping ' . $test_profile;
++			//$valid_test_profile = false;
+ 		}
+ 		else if($test_profile->is_network_required() && !pts_network::network_support_available())
+ 		{
+diff --git a/pts-core/objects/pts_test_profile.php b/pts-core/objects/pts_test_profile.php
+index 82a4531..2e7e8ab 100644
+--- a/pts-core/objects/pts_test_profile.php
++++ b/pts-core/objects/pts_test_profile.php
+@@ -306,8 +306,8 @@ class pts_test_profile extends pts_test_profile_parser
+ 		}
+ 		else if($this->is_test_platform_supported() == false)
+ 		{
+-			$error = $this->get_identifier() . ' is not supported by this operating system: ' . phodevi::os_under_test();
+-			$test_supported = false;
++			//$error = $this->get_identifier() . ' is not supported by this operating system: ' . phodevi::os_under_test();
++			//$test_supported = false;
+ 		}
+ 		else if($this->is_core_version_supported() == false)
+ 		{
+
+diff --git a/pts-core/objects/client/pts_test_execution.php b/pts-core/objects/client/pts_test_execution.php
+index ec28c88..d8be905 100644
+--- a/pts-core/objects/client/pts_test_execution.php
++++ b/pts-core/objects/client/pts_test_execution.php
+@@ -139,7 +139,7 @@ class pts_test_execution
+ 		{
+ 			if(phodevi::is_root() == false)
+ 			{
+-				pts_client::$display->test_run_error('This test must be run as root / administrator.');
++				//pts_client::$display->test_run_error('This test must be run as root / administrator.');
+ 			}
+ 
+ 			$execute_binary_prepend .= ' ' . PTS_CORE_STATIC_PATH . 'root-access.sh ';
+
+diff --git a/pts-core/objects/client/pts_external_dependencies.php b/pts-core/objects/client/pts_external_dependencies.php
+index 3dd5877..e2760ff 100644
+--- a/pts-core/objects/client/pts_external_dependencies.php
++++ b/pts-core/objects/client/pts_external_dependencies.php
+@@ -192,6 +192,7 @@ class pts_external_dependencies
+ 
+ 		// There were some dependencies not supported on this OS or are missing from the distro's XML file
+ 		if(count($required_external_dependencies) > 0 && count($dependencies_to_install) == 0 && $skip_warning_on_unmet_deps == false)
++		
+ 		{
+ 			$exdep_generic_parser = new pts_exdep_generic_parser();
+ 			$to_report = array();
+@@ -209,7 +210,7 @@ class pts_external_dependencies
+ 			if(count($to_report) > 0)
+ 			{
+ 				echo PHP_EOL . 'Some additional dependencies are required, but they could not be installed automatically for your operating system.' . PHP_EOL . 'Below are the software packages that must be installed.' . PHP_EOL . PHP_EOL;
+-
++				
+ 				foreach($to_report as $report)
+ 				{
+ 					pts_client::$display->generic_heading($report);
+@@ -499,7 +500,7 @@ class pts_external_dependencies
+ 					if(substr($file[$i], -2) == '.h' || substr($file[$i], -4) == '.hpp')
+ 					{
+ 						// May just be a relative header file to look for...
+-						$possible_paths = array_merge(array('/usr/local/include/', '/usr/target/include/', '/usr/include/'), pts_file_io::glob('/usr/include/*-linux-gnu/'));
++						$possible_paths = array_merge(array('/usr/local/include/', '/boot/system/develop/headers','/boot/system/config/develop/headers','/boot/system/non-packaged/develop/headers', '/usr/target/include/', '/usr/include/'), pts_file_io::glob('/usr/include/*-linux-gnu/'));
+ 						foreach($possible_paths as $path)
+ 						{
+ 							if(self::is_present($path . '/' . $file[$i]))
+@@ -511,8 +512,8 @@ class pts_external_dependencies
+ 					else if(strpos($file[$i], '.so') !== false || substr($file[$i], -2) == '.a')
+ 					{
+ 						// May just be a relative shared library to look for...
+-						$possible_paths = array_merge(array('/usr/local/lib/', '/usr/lib/', '/usr/lib64/', '/usr/lib/arm-linux-gnueabihf/'), pts_file_io::glob('/usr/lib/*-linux-gnu/'));
+-
++						$possible_paths = array_merge(array('/boot/system/lib/', '/boot/system/non-packaged/lib', '/boot/system/develop/lib/', '/usr/local/lib/', '/usr/lib/', '/usr/lib64/', '/usr/lib/arm-linux-gnueabihf/'), pts_file_io::glob('/usr/lib/*-linux-gnu/'));
++					
+ 						if(getenv('LD_LIBRARY_PATH'))
+ 						{
+ 							foreach(explode(':', getenv('LD_LIBRARY_PATH')) as $path)
+From 2312c12eab513a43e9945cd1b8ffcf71b7ac9975 Mon Sep 17 00:00:00 2001
+From: brooklynakos <spyridop@yahoo.gr>
+Date: Fri, 17 Apr 2026 13:18:07 +0300
+Subject: [PATCH] add depenencies files
+
+---
+ .../scripts/install-haiku-packages.sh         |   2 +
+ .../xml/generic-packages.xml                  | 107 ++---
+ .../xml/haiku-packages.xml                    | 435 ++++++++++++++++++
+ 3 files changed, 480 insertions(+), 64 deletions(-)
+ create mode 100755 pts-core/external-test-dependencies/scripts/install-haiku-packages.sh
+ create mode 100644 pts-core/external-test-dependencies/xml/haiku-packages.xml
+
+diff --git a/pts-core/external-test-dependencies/scripts/install-haiku-packages.sh b/pts-core/external-test-dependencies/scripts/install-haiku-packages.sh
+new file mode 100755
+index 0000000..438b227
+--- /dev/null
++++ b/pts-core/external-test-dependencies/scripts/install-haiku-packages.sh
+@@ -0,0 +1,2 @@
++#!/bin/sh
++pkgman install -y $*
+
+diff --git a/pts-core/external-test-dependencies/xml/haiku-packages.xml b/pts-core/external-test-dependencies/xml/haiku-packages.xml
+new file mode 100644
+index 0000000..b35052a
+--- /dev/null
++++ b/pts-core/external-test-dependencies/xml/haiku-packages.xml
+@@ -0,0 +1,435 @@
++<?xml version="1.0"?>
++<PhoronixTestSuite>
++	<ExternalDependencies>
++		<Information>
++			<Name>haiku</Name>
++			<Aliases>Haiku</Aliases>
++			<PackageManager>pkgman</PackageManager>
++		</Information>
++		<Package>
++			<GenericName>gtk-development</GenericName>
++			<PackageName>gtk4_devel</PackageName>
++		</Package>
++		<Package>
++			<GenericName>sdl2-development</GenericName>
++			<PackageName>libsdl2_devel libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>sdl-development</GenericName>
++			<PackageName>libsdl_devel</PackageName>
++		</Package>
++		<Package>
++			<GenericName>vulkan-development</GenericName>
++			<PackageName>vulkan-tools libvulkan-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>glut</GenericName>
++			<PackageName>freeglut3-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>csh</GenericName>
++			<PackageName>csh</PackageName>
++		</Package>
++		<Package>
++			<GenericName>libpng-development</GenericName>
++			<PackageName>libpng-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>openssl-development</GenericName>
++			<PackageName>libssl-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>build-utilities</GenericName>
++			<PackageName>build-essential autoconf</PackageName>
++			</Package>
++		<Package>
++			<GenericName>cairo-development</GenericName>
++			<PackageName>libcairo2-dev libgdk-pixbuf2.0-dev</PackageName>
++			<FileCheck>cairo/cairo.h, gdk-pixbuf-2.0/gdk-pixbuf/gdk-pixbuf.h</FileCheck>
++		</Package>
++		<Package>
++			<GenericName>xorg-development</GenericName>
++			<PackageName>xorg-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>tiff</GenericName>
++			<PackageName>libtiff5-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>bison</GenericName>
++			<PackageName>bison</PackageName>
++		</Package>
++		<Package>
++			<GenericName>flex</GenericName>
++			<PackageName>flex</PackageName>
++		</Package>
++		<Package>
++			<GenericName>imlib2-development</GenericName>
++			<PackageName>libimlib2-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>java</GenericName>
++			<PackageName>openjdk24_default</PackageName>
++		</Package>
++		<Package>
++			<GenericName>maven</GenericName>
++			<PackageName>maven</PackageName>
++		</Package>
++		<Package>
++			<GenericName>portaudio-development</GenericName>
++			<PackageName>portaudio19-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>fortran-compiler</GenericName>
++			<PackageName>gcc_fortran</PackageName>
++		</Package>
++		<Package>
++			<GenericName>glew</GenericName>
++			<PackageName>libglew-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>lib3ds</GenericName>
++			<PackageName>lib3ds-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>bc</GenericName>
++			<PackageName>bc</PackageName>
++		</Package>
++		<Package>
++			<GenericName>freeimage</GenericName>
++			<PackageName>libfreeimage3 libfreeimage-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>scons</GenericName>
++			<PackageName>scons</PackageName>
++		</Package>
++		<Package>
++			<GenericName>smartmontools</GenericName>
++			<PackageName>smartmontools</PackageName>
++		</Package>
++		<Package>
++			<GenericName>zlib-development</GenericName>
++			<PackageName>zlib1g-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>jpeg-development</GenericName>
++			<PackageName>libjpeg-dev</PackageName>
++			<FileCheck>jpeglib.h</FileCheck>
++		</Package>
++		<Package>
++			<GenericName>libaio-development</GenericName>
++			<PackageName>libaio-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>libpcre</GenericName>
++			<PackageName>libpcre</PackageName>
++		</Package>
++		<Package>
++			<GenericName>perl</GenericName>
++			<PackageName>perl perl-base perl-modules libsdl-perl libperl-dev</PackageName>
++			<FileCheck>perl</FileCheck>
++		</Package>
++		<Package>
++			<GenericName>perl-opengl</GenericName>
++			<PackageName>libopengl-perl</PackageName>
++			</Package>
++		<Package>
++			<GenericName>xorg-video</GenericName>
++			<PackageName>libxv-dev libxvmc-dev libvdpau-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>libstdcpp5</GenericName>
++			<PackageName>libstdc++5</PackageName>
++		</Package>
++		<Package>
++			<GenericName>openal-development</GenericName>
++			<PackageName>libopenal-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>vorbis-development</GenericName>
++			<PackageName>libvorbis-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>jam</GenericName>
++			<PackageName>jam</PackageName>
++		</Package>
++		<Package>
++			<GenericName>p7zip</GenericName>
++			<PackageName>p7zip-full</PackageName>
++		</Package>
++		<Package>
++			<GenericName>qt5-development</GenericName>
++			<PackageName>qml-module-qtquick2 qtdeclarative5-dev qtbase5-dev libqt5svg5-dev qttools5-dev libqca-qt5-2-dev qt5keychain-dev pyqt5-dev pyqt5-dev-tools qtpositioning5-dev</PackageName>
++			<FileCheck>qmake</FileCheck>
++		</Package>
++		<Package>
++			<GenericName>autoconf</GenericName>
++			<PackageName>autoconf</PackageName>
++		</Package>
++		<Package>
++			<GenericName>libtool</GenericName>
++			<PackageName>libtool</PackageName>
++		</Package>
++		<Package>
++			<GenericName>libevent</GenericName>
++			<PackageName>libevent</PackageName>
++		</Package>
++		<Package>
++			<GenericName>ncurses-development</GenericName>
++			<PackageName>libncurses5-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>popt</GenericName>
++			<PackageName>popt</PackageName>
++		</Package>
++		<Package>
++			<GenericName>numa-development</GenericName>
++			<PackageName>libnuma-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>curl</GenericName>
++			<PackageName>curl libcurl4-openssl-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>fftw3-development</GenericName>
++			<PackageName>libfftw3-dev fftw-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>blas-development</GenericName>
++			<PackageName>openblas</PackageName>
++			</Package>
++		<Package>
++			<GenericName>lapack-development</GenericName>
++			<PackageName>liblapack-dev liblapacke-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>atlas-development</GenericName>
++			<PackageName>libatlas-base-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>openmpi-development</GenericName>
++			<PackageName>libopenmpi-dev openmpi-bin libmpich-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>cmake</GenericName>
++			<PackageName>cmake cmake-data</PackageName>
++		</Package>
++		<Package>
++			<GenericName>boost170 devel</GenericName>
++			<PackageName>boost170</PackageName>
++			</Package>
++		<Package>
++			<GenericName>bzip2-development</GenericName>
++			<PackageName>libbz2-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>tcl</GenericName>
++			<PackageName>tcl tclsh</PackageName>
++		</Package>
++		<Package>
++			<GenericName>glibc-development</GenericName>
++			<PackageName>libc6-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>rust</GenericName>
++			<PackageName>rustc cargo</PackageName>
++		</Package>
++		<Package>
++			<GenericName>glibc-development</GenericName>
++			<PackageName>libc6-dev-i386</PackageName>
++			<ArchitectureSpecific>x86_64</ArchitectureSpecific>
++		</Package>
++		<Package>
++			<GenericName>python3.14</GenericName>
++			<PackageName>python3.14 pip</PackageName>
++			</Package>
++		<Package>
++			<GenericName>python-boost-development</GenericName>
++			<PackageName>libboost</PackageName>
++		</Package>
++		<Package>
++			<GenericName>boost-thread-development</GenericName>
++			<PackageName>libboost-thread-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>python-numpy</GenericName>
++			<PackageName>python3-numpy</PackageName>
++			</Package>
++		<Package>
++			<GenericName>yasm</GenericName>
++			<PackageName>yasm nasm</PackageName>
++		</Package>
++		<Package>
++			<GenericName>nasm</GenericName>
++			<PackageName>nasm</PackageName>
++		</Package>
++		<Package>
++			<GenericName>gmp</GenericName>
++			<PackageName>gmp</PackageName>
++		</Package>
++		<Package>
++			<GenericName>subversion</GenericName>
++			<PackageName>subversion</PackageName>
++		</Package>
++		<Package>
++			<GenericName>git</GenericName>
++			<PackageName>git-core</PackageName>
++		</Package>
++		<Package>
++			<GenericName>superlu</GenericName>
++			<PackageName>libsuperlu-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>suitesparse</GenericName>
++			<PackageName>libsuitesparse-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>dune</GenericName>
++			<PackageName>libdune-common-dev libdune-istl-dev libdune-geometry-dev libdune-grid-dev libdune-localfunctions-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>tinyxml</GenericName>
++			<PackageName>libtinyxml-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>opencl</GenericName>
++			<PackageName>opencl_headers ocl_icd ocl_icd_devel</PackageName>
++			</Package>
++		<Package>
++			<GenericName>attr</GenericName>
++			<PackageName>libattr1-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>httpd</GenericName>
++			<PackageName>apache</PackageName>
++		</Package>
++		<Package>
++			<GenericName>meson</GenericName>
++			<PackageName>meson</PackageName>
++		</Package>
++        <Package>
++			<GenericName>golang-1.18.10-1</GenericName>
++			<PackageName>golang-1.18.10-1</PackageName>
++		</Package>
++                <Package>
++			<GenericName>steam</GenericName>
++			<PackageName>steam</PackageName>
++		</Package>
++                <Package>
++			<GenericName>redis-server</GenericName>
++			<PackageName>redis-server</PackageName>
++		</Package>
++                <Package>
++			<GenericName>opencv</GenericName>
++			<PackageName>libopencv-dev</PackageName>
++		</Package>
++		<Package>
++            <GenericName>perl-digest-md5</GenericName>
++            <PackageName>libdigest-md5-file-perl libdigest-perl-md5-perl</PackageName>
++                </Package>
++		<Package>
++			<GenericName>python-scipy</GenericName>
++			<PackageName>python3-scipy</PackageName>
++		</Package>
++		<Package>
++			<GenericName>python-sklearn</GenericName>
++			<PackageName>python3-sklearn</PackageName>
++		</Package>
++		<Package>
++			<GenericName>V8</GenericName>
++			<PackageName>libv8-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>ruby</GenericName>
++			<PackageName>ruby</PackageName>
++		</Package>
++		<Package>
++			<GenericName>gimp</GenericName>
++			<PackageName>gimp</PackageName>
++		</Package>
++		<Package>
++			<GenericName>darktable</GenericName>
++			<PackageName>darktable</PackageName>
++		</Package>
++		<Package>
++			<GenericName>wine</GenericName>
++			<PackageName>wine</PackageName>
++		</Package>
++		<Package>
++			<GenericName>mongodb</GenericName>
++			<PackageName>mongodb</PackageName>
++		</Package>
++		<Package>
++			<GenericName>node-npm</GenericName>
++			<PackageName>npm</PackageName>
++		</Package>
++		<Package>
++			<GenericName>expat</GenericName>
++			<PackageName>expat</PackageName>
++		</Package>
++		<Package>
++			<GenericName>hdf5</GenericName>
++			<PackageName>libhdf5-dev libhdf5-mpi-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>libxml2</GenericName>
++			<PackageName>libxml2-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>uuid</GenericName>
++			<PackageName>uuid-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>clang</GenericName>
++			<PackageName>clang</PackageName>
++		</Package>
++		<Package>
++			<GenericName>swig</GenericName>
++			<PackageName>swig</PackageName>
++		</Package>
++		<Package>
++			<GenericName>freetype</GenericName>
++			<PackageName>libfreetype6-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>gflags</GenericName>
++			<PackageName>libgflags-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>google-benchmark</GenericName>
++			<PackageName>libbenchmark-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>snappy</GenericName>
++			<PackageName>libsnappy-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>vaapi</GenericName>
++			<PackageName>libva-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>openexr</GenericName>
++			<PackageName>libopenexr-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>glfw</GenericName>
++			<PackageName>libglfw3-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>protobuf</GenericName>
++			<PackageName>libprotobuf-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>eigen</GenericName>
++			<PackageName>libeigen3-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>erlang</GenericName>
++			<PackageName>erlang</PackageName>
++		</Package>
++		<Package>
++			<GenericName>libconfigpp</GenericName>
++			<PackageName>libconfig++-dev</PackageName>
++		</Package>
++	</ExternalDependencies>
++</PhoronixTestSuite>
+-- 
+2.52.0
+
+From fd698eaf53c607aac517ed6de1d823ed82197c55 Mon Sep 17 00:00:00 2001
+From: brooklynakos <spyridop@yahoo.gr>
+Date: Mon, 27 Apr 2026 23:19:13 +0300
+Subject: [PATCH] install dependencies even if marked as linux
+
+---
+ pts-core/objects/client/pts_test_install_request.php | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pts-core/objects/client/pts_test_install_request.php b/pts-core/objects/client/pts_test_install_request.php
+index 55e9281..e8c569c 100644
+--- a/pts-core/objects/client/pts_test_install_request.php
++++ b/pts-core/objects/client/pts_test_install_request.php
+@@ -78,7 +78,7 @@ class pts_test_install_request
+ 			$platforms = $download->get_platform_array();
+ 			if(!empty($platforms) && $do_file_checks)
+ 			{
+-				if(!in_array(phodevi::os_under_test(), $platforms) && !(phodevi::is_bsd() && in_array('Linux', $platforms) && (pts_client::executable_in_path('kldstat') && strpos(shell_exec('kldstat -n linux 2>&1'), 'linux.ko') != false)))
++				if(!in_array(phodevi::os_under_test(), $platforms) && (!phodevi::os_under_test() == 'Haiku' && in_array('Linux', $platforms)))
+ 				{
+ 					// This download does not match the operating system
+ 					continue;
+-- 
+2.52.0
+
+From 6b4adf995e4691af28a52478ce4c817b16571a9d Mon Sep 17 00:00:00 2001
+From: brooklynakos <spyridop@yahoo.gr>
+Date: Wed, 29 Apr 2026 23:01:40 +0300
+Subject: [PATCH] if downloaded files are marked for macosx or windows ignore
+ them
+
+---
+ pts-core/objects/client/pts_test_install_request.php | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/pts-core/objects/client/pts_test_install_request.php b/pts-core/objects/client/pts_test_install_request.php
+index e8c569c..5f8aa75 100644
+--- a/pts-core/objects/client/pts_test_install_request.php
++++ b/pts-core/objects/client/pts_test_install_request.php
+@@ -78,11 +78,22 @@ class pts_test_install_request
+ 			$platforms = $download->get_platform_array();
+ 			if(!empty($platforms) && $do_file_checks)
+ 			{
++				if(in_array('Windows', $platforms))
++				{
++					// If Windows then continue
++					continue;
++				}
++				if(in_array('MacOSX', $platforms))
++				{
++					// If MacOSX then continue
++					continue;
++				}
+ 				if(!in_array(phodevi::os_under_test(), $platforms) && (!phodevi::os_under_test() == 'Haiku' && in_array('Linux', $platforms)))
+ 				{
+ 					// This download does not match the operating system
+ 					continue;
+ 				}
++				
+ 			}
+ 
+ 			// Check for architecture compatibility
+-- 
+2.52.0
+
+From 838efcddacfe2f0415f82f2c305d4fcd4ea717a1 Mon Sep 17 00:00:00 2001
+From: brooklynakos <spyridop@yahoo.gr>
+Date: Thu, 30 Apr 2026 22:45:53 +0300
+Subject: [PATCH] add latest generic and haiku packages
+
+---
+ .../xml/generic-packages.xml                  |  7 --
+ .../xml/haiku-packages.xml                    | 76 +++++++++++--------
+ 2 files changed, 43 insertions(+), 40 deletions(-)
+
+diff --git a/pts-core/external-test-dependencies/xml/generic-packages.xml b/pts-core/external-test-dependencies/xml/generic-packages.xml
+index 480d28a..24c463e 100644
+--- a/pts-core/external-test-dependencies/xml/generic-packages.xml
++++ b/pts-core/external-test-dependencies/xml/generic-packages.xml
+@@ -5,13 +5,6 @@
+ 			<GenericName>common-dependencies</GenericName>
+ 			<Title>Common Dependencies For The Phoronix Test Suite</Title>
+ 		</Package>
+-		<Package>
+-			<GenericName>32bit-compatibility</GenericName>
+-			<Title>32-bit Compatibility Libraries</Title>
+-			<ArchitectureSpecific>x86_64</ArchitectureSpecific>
+-			<PossibleNames>ia32-libs</PossibleNames>
+-			<FileCheck>/usr/lib32/</FileCheck>
+-		</Package>
+ 		<Package>
+ 			<GenericName>gtk-development</GenericName>
+ 			<Title>GTK2</Title>
+diff --git a/pts-core/external-test-dependencies/xml/haiku-packages.xml b/pts-core/external-test-dependencies/xml/haiku-packages.xml
+index b35052a..d2378d4 100644
+--- a/pts-core/external-test-dependencies/xml/haiku-packages.xml
++++ b/pts-core/external-test-dependencies/xml/haiku-packages.xml
+@@ -17,6 +17,7 @@
+ 		<Package>
+ 			<GenericName>sdl-development</GenericName>
+ 			<PackageName>libsdl_devel</PackageName>
++			<FileCheck>libSDL-1.2.so.0</FileCheck>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>vulkan-development</GenericName>
+@@ -43,9 +44,9 @@
+ 			<PackageName>build-essential autoconf</PackageName>
+ 			</Package>
+ 		<Package>
+-			<GenericName>cairo-development</GenericName>
+-			<PackageName>libcairo2-dev libgdk-pixbuf2.0-dev</PackageName>
+-			<FileCheck>cairo/cairo.h, gdk-pixbuf-2.0/gdk-pixbuf/gdk-pixbuf.h</FileCheck>
++			<GenericName>cairo</GenericName>
++			<PackageName>cairo</PackageName>
++			<FileCheck>libcairo.so.2</FileCheck>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>xorg-development</GenericName>
+@@ -77,7 +78,7 @@
+ 		</Package>
+ 		<Package>
+ 			<GenericName>portaudio-development</GenericName>
+-			<PackageName>portaudio19-dev</PackageName>
++			<PackageName>portaudio_devel</PackageName>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>fortran-compiler</GenericName>
+@@ -97,7 +98,7 @@
+ 		</Package>
+ 		<Package>
+ 			<GenericName>freeimage</GenericName>
+-			<PackageName>libfreeimage3 libfreeimage-dev</PackageName>
++			<PackageName>freeimage</PackageName>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>scons</GenericName>
+@@ -147,7 +148,7 @@
+ 		</Package>
+ 		<Package>
+ 			<GenericName>vorbis-development</GenericName>
+-			<PackageName>libvorbis-dev</PackageName>
++			<PackageName>libvorbis_devel</PackageName>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>jam</GenericName>
+@@ -173,14 +174,16 @@
+ 		<Package>
+ 			<GenericName>libevent</GenericName>
+ 			<PackageName>libevent</PackageName>
++			<FileCheck>libevent-2.1.so.7</FileCheck>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>ncurses-development</GenericName>
+-			<PackageName>libncurses5-dev</PackageName>
++			<PackageName>ncurses6_devel</PackageName>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>popt</GenericName>
+ 			<PackageName>popt</PackageName>
++			<FileCheck>libpopt.so.0</FileCheck>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>numa-development</GenericName>
+@@ -197,10 +200,11 @@
+ 		<Package>
+ 			<GenericName>blas-development</GenericName>
+ 			<PackageName>openblas</PackageName>
++			<FileCheck>libopenblas.so.0</FileCheck>
+ 			</Package>
+ 		<Package>
+-			<GenericName>lapack-development</GenericName>
+-			<PackageName>liblapack-dev liblapacke-dev</PackageName>
++			<GenericName>lapack</GenericName>
++			<PackageName>lapack</PackageName>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>atlas-development</GenericName>
+@@ -215,8 +219,9 @@
+ 			<PackageName>cmake cmake-data</PackageName>
+ 		</Package>
+ 		<Package>
+-			<GenericName>boost170 devel</GenericName>
+-			<PackageName>boost170</PackageName>
++			<GenericName>boost1.90_devel</GenericName>
++			<PackageName>boost1.90_devel</PackageName>
++			<FileCheck>libboost_atomic.so.1.90.0</FileCheck>
+ 			</Package>
+ 		<Package>
+ 			<GenericName>bzip2-development</GenericName>
+@@ -224,7 +229,7 @@
+ 		</Package>
+ 		<Package>
+ 			<GenericName>tcl</GenericName>
+-			<PackageName>tcl tclsh</PackageName>
++			<PackageName>tcl</PackageName>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>glibc-development</GenericName>
+@@ -241,7 +246,9 @@
+ 		</Package>
+ 		<Package>
+ 			<GenericName>python3.14</GenericName>
+-			<PackageName>python3.14 pip</PackageName>
++			<PackageName>python3.14 pip_python310</PackageName>
++			<FileCheck>python3.14, pip</FileCheck>
++			<VirtualSuite>TRUE</VirtualSuite>
+ 			</Package>
+ 		<Package>
+ 			<GenericName>python-boost-development</GenericName>
+@@ -253,7 +260,8 @@
+ 		</Package>
+ 		<Package>
+ 			<GenericName>python-numpy</GenericName>
+-			<PackageName>python3-numpy</PackageName>
++			<PackageName>numpy_python310</PackageName>
++			<FileCheck>f2py</FileCheck>
+ 			</Package>
+ 		<Package>
+ 			<GenericName>yasm</GenericName>
+@@ -277,11 +285,12 @@
+ 		</Package>
+ 		<Package>
+ 			<GenericName>superlu</GenericName>
+-			<PackageName>libsuperlu-dev</PackageName>
++			<PackageName>superlu</PackageName>
++			<FileCheck>libsuperlu.so.5</FileCheck>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>suitesparse</GenericName>
+-			<PackageName>libsuitesparse-dev</PackageName>
++			<PackageName>suitesparse</PackageName>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>dune</GenericName>
+@@ -289,7 +298,7 @@
+ 		</Package>
+ 		<Package>
+ 			<GenericName>tinyxml</GenericName>
+-			<PackageName>libtinyxml-dev</PackageName>
++			<PackageName>tinyxml_devel</PackageName>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>opencl</GenericName>
+@@ -297,7 +306,8 @@
+ 			</Package>
+ 		<Package>
+ 			<GenericName>attr</GenericName>
+-			<PackageName>libattr1-dev</PackageName>
++			<PackageName>attr</PackageName>
++			<FileCheck>libattr.so.1</FileCheck>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>httpd</GenericName>
+@@ -316,12 +326,12 @@
+ 			<PackageName>steam</PackageName>
+ 		</Package>
+                 <Package>
+-			<GenericName>redis-server</GenericName>
+-			<PackageName>redis-server</PackageName>
++			<GenericName>redis</GenericName>
++			<PackageName>redis</PackageName>
+ 		</Package>
+                 <Package>
+ 			<GenericName>opencv</GenericName>
+-			<PackageName>libopencv-dev</PackageName>
++			<PackageName>opencv_devel</PackageName>
+ 		</Package>
+ 		<Package>
+             <GenericName>perl-digest-md5</GenericName>
+@@ -329,7 +339,7 @@
+                 </Package>
+ 		<Package>
+ 			<GenericName>python-scipy</GenericName>
+-			<PackageName>python3-scipy</PackageName>
++			<PackageName>scipy_python310 f</PackageName>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>python-sklearn</GenericName>
+@@ -369,11 +379,11 @@
+ 		</Package>
+ 		<Package>
+ 			<GenericName>hdf5</GenericName>
+-			<PackageName>libhdf5-dev libhdf5-mpi-dev</PackageName>
++			<PackageName>hdf5_devel</PackageName>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>libxml2</GenericName>
+-			<PackageName>libxml2-dev</PackageName>
++			<PackageName>libxml2_devel</PackageName>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>uuid</GenericName>
+@@ -393,15 +403,15 @@
+ 		</Package>
+ 		<Package>
+ 			<GenericName>gflags</GenericName>
+-			<PackageName>libgflags-dev</PackageName>
++			<PackageName>gflags_devel</PackageName>
+ 		</Package>
+ 		<Package>
+-			<GenericName>google-benchmark</GenericName>
+-			<PackageName>libbenchmark-dev</PackageName>
++			<GenericName>benchmark</GenericName>
++			<PackageName>benchmark</PackageName>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>snappy</GenericName>
+-			<PackageName>libsnappy-dev</PackageName>
++			<PackageName>snappy_devel</PackageName>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>vaapi</GenericName>
+@@ -409,15 +419,15 @@
+ 		</Package>
+ 		<Package>
+ 			<GenericName>openexr</GenericName>
+-			<PackageName>libopenexr-dev</PackageName>
++			<PackageName>openexr3.2_devel</PackageName>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>glfw</GenericName>
+-			<PackageName>libglfw3-dev</PackageName>
++			<PackageName>glfw</PackageName>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>protobuf</GenericName>
+-			<PackageName>libprotobuf-dev</PackageName>
++			<PackageName>protobuf_devel</PackageName>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>eigen</GenericName>
+@@ -428,8 +438,8 @@
+ 			<PackageName>erlang</PackageName>
+ 		</Package>
+ 		<Package>
+-			<GenericName>libconfigpp</GenericName>
+-			<PackageName>libconfig++-dev</PackageName>
++			<GenericName>libconfig</GenericName>
++			<PackageName>libconfig</PackageName>
+ 		</Package>
+ 	</ExternalDependencies>
+ </PhoronixTestSuite>
+-- 
+2.52.0
+
+From 307e3cbc0f5e76696eb58d2818f5d63fe08fcfc0 Mon Sep 17 00:00:00 2001
+From: brooklynakos <spyridop@yahoo.gr>
+Date: Sat, 2 May 2026 15:33:56 +0300
+Subject: [PATCH] remove deprecated curl_close references
+
+---
+ pts-core/commands/check_tests.php | 2 +-
+ pts-core/modules/pushover_net.php | 2 +-
+ pts-core/objects/pts_network.php  | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/pts-core/commands/check_tests.php b/pts-core/commands/check_tests.php
+index 0b6099f..e772548 100644
+--- a/pts-core/commands/check_tests.php
++++ b/pts-core/commands/check_tests.php
+@@ -564,7 +564,7 @@ class check_tests implements pts_option_interface
+ 				echo pts_client::cli_colored_text($identifier . " Download Time: " . $download[self::V_DOWNLOAD_TIME] . " ERROR " . $errno . " " . $download[self::V_DOWNLOAD_ERROR] . PHP_EOL, 'red', false);
+ 			}
+ 
+-			curl_close($ch);
++			//curl_close($ch);
+ 			fclose($fh);
+ 
+ 			$download[self::V_STATUS] = $info['http_code'];
+diff --git a/pts-core/modules/pushover_net.php b/pts-core/modules/pushover_net.php
+index 13b71e1..5ded821 100644
+--- a/pts-core/modules/pushover_net.php
++++ b/pts-core/modules/pushover_net.php
+@@ -89,7 +89,7 @@ class pushover_net extends pts_module_interface
+ 			'message' => $message,
+ 			)));
+ 		curl_exec($ch);
+-		curl_close($ch);
++		//curl_close($ch);
+ 	}
+ }
+ 
+diff --git a/pts-core/objects/pts_network.php b/pts-core/objects/pts_network.php
+index a95ff8b..a4c89b8 100644
+--- a/pts-core/objects/pts_network.php
++++ b/pts-core/objects/pts_network.php
+@@ -184,7 +184,7 @@ class pts_network
+ 		}
+ 
+ 		curl_exec($cr);
+-		curl_close($cr);
++		//curl_close($cr);
+ 		fclose($fh);
+ 
+ 		return true;
+-- 
+2.52.0
+
+From 9146e2e1aaeadef3422341262cf0c7762dc5ed05 Mon Sep 17 00:00:00 2001
+From: brooklynakos <spyridop@yahoo.gr>
+Date: Sun, 3 May 2026 00:42:10 +0300
+Subject: [PATCH] forcefully detect phodevi::is_haiku() as true and add df -h detection
+ for fs
+
+---
+ pts-core/objects/phodevi/components/phodevi_system.php | 6 +++++-
+ pts-core/objects/phodevi/phodevi.php                   | 7 ++++++-
+ 2 files changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/pts-core/objects/phodevi/components/phodevi_system.php b/pts-core/objects/phodevi/components/phodevi_system.php
+index ab002fd..bf37aea 100644
+--- a/pts-core/objects/phodevi/components/phodevi_system.php
++++ b/pts-core/objects/phodevi/components/phodevi_system.php
+@@ -205,6 +205,10 @@ class phodevi_system extends phodevi_device_interface
+ 				}
+ 			}
+ 		}
++		else if(phodevi::is_haiku())
++		{
++		$fs = shell_exec('df -h | grep dev | awk \'{print $1}\'');
++		}
+ 		else if(phodevi::is_bsd())
+ 		{
+ 			if(pts_client::executable_in_path('mount'))
+@@ -412,7 +416,7 @@ class phodevi_system extends phodevi_device_interface
+ 				}
+ 			}
+ 		}
+-
++		
+ 		if(empty($fs))
+ 		{
+ 			$fs = 'Unknown';
+diff --git a/pts-core/objects/phodevi/phodevi.php b/pts-core/objects/phodevi/phodevi.php
+index fc00fb9..aaaaa1c 100644
+--- a/pts-core/objects/phodevi/phodevi.php
++++ b/pts-core/objects/phodevi/phodevi.php
+@@ -42,7 +42,8 @@ class phodevi extends phodevi_base
+ 		'bsd' => false,
+ 		'hurd' => false,
+ 		'minix' => false,
+-		'windows' => false
++		'windows' => false,
++		'haiku' => false
+ 		);
+ 
+ 	// A variable that modules can use to override Phodevi caching support, etc
+@@ -993,6 +994,10 @@ class phodevi extends phodevi_base
+ 	{
+ 		return self::$operating_systems['linux'];
+ 	}
++	public static function is_haiku()
++	{
++		return stripos(shell_exec('uname'),'Haiku') !== false;
++	}
+ 	public static function is_minix()
+ 	{
+ 		return self::$operating_systems['minix'];
+-- 
+2.52.0
+
+From 501b784f0e28462febb794d6fdf396762b701982 Mon Sep 17 00:00:00 2001
+From: brooklynakos <spyridop@yahoo.gr>
+Date: Tue, 5 May 2026 22:14:36 +0300
+Subject: [PATCH] improve hardware detection
+
+---
+ pts-core/objects/phodevi/components/phodevi_audio.php | 6 ++++++
+ pts-core/objects/phodevi/components/phodevi_cpu.php   | 9 +++++++--
+ pts-core/objects/phodevi/components/phodevi_gpu.php   | 6 ++++++
+ pts-core/objects/phodevi/phodevi.php                  | 6 +++---
+ 5 files changed, 22 insertions(+), 5 deletions(-)
+
+diff --git a/pts-core/objects/phodevi/components/phodevi_audio.php b/pts-core/objects/phodevi/components/phodevi_audio.php
+index 1e80083..fa88af1 100644
+--- a/pts-core/objects/phodevi/components/phodevi_audio.php
++++ b/pts-core/objects/phodevi/components/phodevi_audio.php
+@@ -49,6 +49,12 @@ class phodevi_audio extends phodevi_device_interface
+ 				}
+ 			}
+ 		}
++		else if(phodevi::is_haiku())
++		{
++			
++					$audio = shell_exec('listdev | grep Audio | cut -c 15-50');
++					return $audio;
++				}
+ 		else if(phodevi::is_windows())
+ 		{
+ 			$win_sound = array();
+diff --git a/pts-core/objects/phodevi/components/phodevi_cpu.php b/pts-core/objects/phodevi/components/phodevi_cpu.php
+index 2a1eb9b..89cf1d7 100644
+--- a/pts-core/objects/phodevi/components/phodevi_cpu.php
++++ b/pts-core/objects/phodevi/components/phodevi_cpu.php
+@@ -217,6 +217,10 @@ class phodevi_cpu extends phodevi_device_interface
+ 		{
+ 			$physical_cores = intval(phodevi_bsd_parser::read_sysctl(array('hw.physicalcpu')));
+ 		}
++		else if(phodevi::is_haiku())
++		{
++			$physical_cores = shell_exec('sysinfo | grep -i cpu | awk \'{print $0}\' | wc -l');
++		}
+ 		else if(phodevi::is_windows())
+ 		{
+ 			$physical_cores = array_sum(phodevi_windows_parser::get_wmi_object('Win32_Processor', 'NumberOfCores', true));
+@@ -296,7 +300,8 @@ class phodevi_cpu extends phodevi_device_interface
+ 	public static function cpu_scaling_governor()
+ 	{
+ 		$scaling_governor = false;
+-
++		
++		
+ 		if(is_file('/sys/devices/system/cpu/cpu0/cpufreq/scaling_driver'))
+ 		{
+ 			$scaling_governor = pts_file_io::file_get_contents('/sys/devices/system/cpu/cpu0/cpufreq/scaling_driver') . ' ';
+@@ -341,7 +346,7 @@ class phodevi_cpu extends phodevi_device_interface
+ 				$scaling_governor = trim($scaling_governor) . ' (' . implode(', ', $append_notes) . ')';
+ 			}
+ 		}
+-
++		
+ 		return trim($scaling_governor);
+ 	}
+ 	public static function cpu_power_management()
+
+diff --git a/pts-core/objects/phodevi/components/phodevi_gpu.php b/pts-core/objects/phodevi/components/phodevi_gpu.php
+index a6efef8..0e4de52 100644
+--- a/pts-core/objects/phodevi/components/phodevi_gpu.php
++++ b/pts-core/objects/phodevi/components/phodevi_gpu.php
+@@ -472,6 +472,12 @@ class phodevi_gpu extends phodevi_device_interface
+ 	}
+ 	public static function gpu_screen_resolution_string()
+ 	{
++		if(phodevi::is_haiku())
++		{
++		$resolution=shell_exec('screenmode | cut -c 13-16,18-22 -O x');
++		return $resolution;
++		}
++		
+ 		// Return the current screen resolution
+ 		$resolution = implode('x', phodevi::read_property('gpu', 'screen-resolution'));
+ 
+diff --git a/pts-core/objects/phodevi/phodevi.php b/pts-core/objects/phodevi/phodevi.php
+index 9704468..72f227b 100644
+--- a/pts-core/objects/phodevi/phodevi.php
++++ b/pts-core/objects/phodevi/phodevi.php
+@@ -326,7 +326,7 @@ class phodevi extends phodevi_base
+ 		$thread_count = phodevi::read_property('cpu', 'thread-count');
+ 
+ 		$sys = array(
+-			'Processor' => phodevi::read_property('cpu', 'model-and-speed'),
++			'Processor' => shell_exec('sysinfo -cpu | sed -n \'1p\' | cut -c 3-49,79-85 -O @'),
+ 				array(
+ 				'Core Count' => $core_count,
+ 				'Thread Count' => !empty($core_count) && $core_count == $thread_count ? '' : $thread_count, // don't show thread count if it's same as core count
+@@ -337,7 +337,7 @@ class phodevi extends phodevi_base
+ 				'Core Family' => phodevi::read_property('cpu', 'core-family-name'),
+ 				'Scaling Driver'=> phodevi::read_property('cpu', 'scaling-governor'),
+ 				),
+-			'Graphics' => phodevi::read_name('gpu'),
++			'Graphics' => shell_exec('listdev | grep Graphics | cut -c 16-50'),
+ 				array(
+ 				'Frequency' => phodevi::read_property('gpu', 'frequency'),
+ 				'BAR1 / Visible vRAM' => phodevi::read_property('gpu', 'bar1-visible-vram'),
+@@ -358,7 +358,7 @@ class phodevi extends phodevi_base
+ 				),
+ 			'Memory' => phodevi::read_name('memory'),
+ 				array(),
+-			'Disk' => phodevi::read_name('disk'),
++			'Disk' => shell_exec('mountvolume | sed -n \'3p\' | cut -c 1-30,60-68|xargs'),
+ 				array(
+ 				'File-System' => phodevi::read_property('system', 'filesystem'),
+ 				'Mount Options' => phodevi::read_property('disk', 'mount-options-string'),
+-- 
+2.52.0
+
+From af3de2474c3f2bd3381585bd433c5cb2fdfca984 Mon Sep 17 00:00:00 2001
+From: brooklynakos <spyridop@yahoo.gr>
+Date: Fri, 8 May 2026 14:23:05 +0300
+Subject: [PATCH] add memory detection
+
+---
+ pts-core/objects/phodevi/phodevi.php | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pts-core/objects/phodevi/phodevi.php b/pts-core/objects/phodevi/phodevi.php
+index fbb5b6c..ea68293 100644
+--- a/pts-core/objects/phodevi/phodevi.php
++++ b/pts-core/objects/phodevi/phodevi.php
+@@ -356,7 +356,7 @@ class phodevi extends phodevi_base
+ 				'Network' => phodevi::read_name('network'),
+ 				'Platform Profile'=> phodevi::read_property('system', 'platform-profile'),
+ 				),
+-			'Memory' => phodevi::read_name('memory'),
++			'Memory' => shell_exec('sysinfo -mem | grep max | cut -c 50,51 |awk \'{print $0 " Gb"}\''),
+ 				array(),
+ 			'Disk' => shell_exec('mountvolume | sed -n \'3p\' | cut -c 1-30,60-68|xargs'),
+ 				array(
+-- 
+2.52.0
+
+From b96c6fa7fd8f0806f2edba017ed787352ac15945 Mon Sep 17 00:00:00 2001
+From: brooklynakos <spyridop@yahoo.gr>
+Date: Fri, 8 May 2026 15:43:37 +0300
+Subject: [PATCH] Hopefully fix rust cmake qt vulkan sdl2 perl
+
+---
+ .../xml/haiku-packages.xml                    | 21 ++++++++++---------
+ 1 file changed, 11 insertions(+), 10 deletions(-)
+
+diff --git a/pts-core/external-test-dependencies/xml/haiku-packages.xml b/pts-core/external-test-dependencies/xml/haiku-packages.xml
+index d2378d4..31c100f 100644
+--- a/pts-core/external-test-dependencies/xml/haiku-packages.xml
++++ b/pts-core/external-test-dependencies/xml/haiku-packages.xml
+@@ -12,7 +12,8 @@
+ 		</Package>
+ 		<Package>
+ 			<GenericName>sdl2-development</GenericName>
+-			<PackageName>libsdl2_devel libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev</PackageName>
++			<PackageName>sdl2_gfx_devel sdl2_image_devel sdl2_mixer_devel sdl2_ttf_devel</PackageName>
++			<FileCheck>libSDL2_image-2.0.so.0</FileCheck>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>sdl-development</GenericName>
+@@ -21,7 +22,7 @@
+ 		</Package>
+ 		<Package>
+ 			<GenericName>vulkan-development</GenericName>
+-			<PackageName>vulkan-tools libvulkan-dev</PackageName>
++			<PackageName>vulkan vulkan_devel</PackageName>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>glut</GenericName>
+@@ -127,7 +128,7 @@
+ 		</Package>
+ 		<Package>
+ 			<GenericName>perl</GenericName>
+-			<PackageName>perl perl-base perl-modules libsdl-perl libperl-dev</PackageName>
++			<PackageName>perl libsdl-perl</PackageName>
+ 			<FileCheck>perl</FileCheck>
+ 		</Package>
+ 		<Package>
+@@ -156,11 +157,11 @@
+ 		</Package>
+ 		<Package>
+ 			<GenericName>p7zip</GenericName>
+-			<PackageName>p7zip-full</PackageName>
++			<PackageName>p7zip-full</PackageName>qt6_tools_devel
+ 		</Package>
+ 		<Package>
+ 			<GenericName>qt5-development</GenericName>
+-			<PackageName>qml-module-qtquick2 qtdeclarative5-dev qtbase5-dev libqt5svg5-dev qttools5-dev libqca-qt5-2-dev qt5keychain-dev pyqt5-dev pyqt5-dev-tools qtpositioning5-dev</PackageName>
++			<PackageName>qml_box2d_qt6 qt6_declarative_devel qt6_base_devel qt6_svg_devel qttools5-dev qca_qt6_devel qtkeychain_qt6_devel pyqt5-dev pyqt6  qt6_positioning_devel</PackageName>
+ 			<FileCheck>qmake</FileCheck>
+ 		</Package>
+ 		<Package>
+@@ -216,7 +217,7 @@
+ 		</Package>
+ 		<Package>
+ 			<GenericName>cmake</GenericName>
+-			<PackageName>cmake cmake-data</PackageName>
++			<PackageName>cmake</PackageName>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>boost1.90_devel</GenericName>
+@@ -237,7 +238,7 @@
+ 		</Package>
+ 		<Package>
+ 			<GenericName>rust</GenericName>
+-			<PackageName>rustc cargo</PackageName>
++			<PackageName>rust_bin</PackageName>
+ 		</Package>
+ 		<Package>
+ 			<GenericName>glibc-development</GenericName>
+@@ -245,9 +246,9 @@
+ 			<ArchitectureSpecific>x86_64</ArchitectureSpecific>
+ 		</Package>
+ 		<Package>
+-			<GenericName>python3.14</GenericName>
+-			<PackageName>python3.14 pip_python310</PackageName>
+-			<FileCheck>python3.14, pip</FileCheck>
++			<GenericName>python</GenericName>
++			<PackageName>python3.10 pip_python310</PackageName>
++			<FileCheck>python3.10/Python.h</FileCheck>
+ 			<VirtualSuite>TRUE</VirtualSuite>
+ 			</Package>
+ 		<Package>
+-- 
+2.52.0
+
+From 4c6a6aa9454e88f97abc9d43cf782241e5020cf5 Mon Sep 17 00:00:00 2001
+From: brooklynakos <spyridop@yahoo.gr>
+Date: Fri, 8 May 2026 18:23:12 +0300
+Subject: [PATCH] fix commented out code of first patch properly
+
+---
+ pts-core/objects/client/pts_test_execution.php   | 2 +-
+ pts-core/objects/client/pts_test_run_manager.php | 4 ++--
+ pts-core/objects/phodevi/phodevi.php             | 4 ++--
+ pts-core/objects/pts_test_profile.php            | 8 ++++++--
+ 4 files changed, 11 insertions(+), 7 deletions(-)
+
+diff --git a/pts-core/objects/client/pts_test_execution.php b/pts-core/objects/client/pts_test_execution.php
+index d8be905..ec28c88 100644
+--- a/pts-core/objects/client/pts_test_execution.php
++++ b/pts-core/objects/client/pts_test_execution.php
+@@ -139,7 +139,7 @@ class pts_test_execution
+ 		{
+ 			if(phodevi::is_root() == false)
+ 			{
+-				//pts_client::$display->test_run_error('This test must be run as root / administrator.');
++				pts_client::$display->test_run_error('This test must be run as root / administrator.');
+ 			}
+ 
+ 			$execute_binary_prepend .= ' ' . PTS_CORE_STATIC_PATH . 'root-access.sh ';
+diff --git a/pts-core/objects/client/pts_test_run_manager.php b/pts-core/objects/client/pts_test_run_manager.php
+index ad48440..278815c 100644
+--- a/pts-core/objects/client/pts_test_run_manager.php
++++ b/pts-core/objects/client/pts_test_run_manager.php
+@@ -1919,8 +1919,8 @@ class pts_test_run_manager
+ 		}
+ 		else if($test_profile->is_display_required() && !phodevi::is_display_server_active())
+ 		{
+-			//$test_error = 'No display server was found, skipping ' . $test_profile;
+-			//$valid_test_profile = false;
++			$test_error = 'No display server was found, skipping ' . $test_profile;
++			$valid_test_profile = false;
+ 		}
+ 		else if($test_profile->is_network_required() && !pts_network::network_support_available())
+ 		{
+diff --git a/pts-core/objects/phodevi/phodevi.php b/pts-core/objects/phodevi/phodevi.php
+index 4a504f4..ea68293 100644
+--- a/pts-core/objects/phodevi/phodevi.php
++++ b/pts-core/objects/phodevi/phodevi.php
+@@ -1034,7 +1034,7 @@ class phodevi extends phodevi_base
+ 	}
+ 	public static function is_root()
+ 	{
+-		return phodevi::read_property('system', 'username') == 'root' || is_writable('/root');
++		return phodevi::read_property('system', 'username') == 'root' || is_writable('/root') || phodevi::is_haiku();
+ 	}
+ 	public static function is_display_server_active()
+ 	{
+@@ -1044,7 +1044,7 @@ class phodevi extends phodevi_base
+ 			return false;
+ 		}
+ 
+-		return getenv('DISPLAY') != false || getenv('WAYLAND_DISPLAY') != false || phodevi::is_windows() || phodevi::is_macos();
++		return getenv('DISPLAY') != false || getenv('WAYLAND_DISPLAY') != false || phodevi::is_windows() || phodevi::is_macos() || phodevi::is_haiku();
+ 	}
+ }
+ 
+diff --git a/pts-core/objects/pts_test_profile.php b/pts-core/objects/pts_test_profile.php
+index 2e7e8ab..79a3352 100644
+--- a/pts-core/objects/pts_test_profile.php
++++ b/pts-core/objects/pts_test_profile.php
+@@ -306,8 +306,8 @@ class pts_test_profile extends pts_test_profile_parser
+ 		}
+ 		else if($this->is_test_platform_supported() == false)
+ 		{
+-			//$error = $this->get_identifier() . ' is not supported by this operating system: ' . phodevi::os_under_test();
+-			//$test_supported = false;
++			$error = $this->get_identifier() . ' is not supported by this operating system: ' . phodevi::os_under_test();
++			$test_supported = false;
+ 		}
+ 		else if($this->is_core_version_supported() == false)
+ 		{
+@@ -401,6 +401,10 @@ class pts_test_profile extends pts_test_profile_parser
+ 				// TODO: fill in Hurd support for test profiles / see what works
+ 				$supported = true;
+ 			}
++			else if(phodevi::is_haiku())
++			{
++				$supported = true;	
++  			}
+ 			else
+ 			{
+ 				$supported = false;
+-- 
+2.52.0
+
+
+
+

--- a/app-benchmarks/pts/pts-10.8.4.patchset
+++ b/app-benchmarks/pts/pts-10.8.4.patchset
@@ -108,7 +108,7 @@ index 0b6099f..e772548 100644
  			}
  
 -			curl_close($ch);
-+			//curl_close($ch);
++			
  			fclose($fh);
  
  			$download[self::V_STATUS] = $info['http_code'];
@@ -121,7 +121,7 @@ index 13b71e1..5ded821 100644
  			)));
  		curl_exec($ch);
 -		curl_close($ch);
-+		//curl_close($ch);
++		
  	}
  }
  
@@ -134,7 +134,7 @@ index a95ff8b..a4c89b8 100644
  
  		curl_exec($cr);
 -		curl_close($cr);
-+		//curl_close($cr);
++		
  		fclose($fh);
  
  		return true;
@@ -846,4 +846,3 @@ index ab002fd..f51dd15 100644
  			if(pts_client::executable_in_path('mount'))
 -- 
 2.52.0
-

--- a/app-benchmarks/pts/pts-10.8.4.patchset
+++ b/app-benchmarks/pts/pts-10.8.4.patchset
@@ -1,55 +1,10 @@
-From 269f919dbaabd20cd825b9e458312835e2033f37 Mon Sep 17 00:00:00 2001
+From c19616b2d1aaf2d0140c63d7b739e323e4244e32 Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
 Date: Wed, 8 Apr 2026 19:02:21 +0300
-Subject: [PATCH] comment out OS and display server detection 
-
-diff --git a/pts-core/objects/client/pts_test_run_manager.php b/pts-core/objects/client/pts_test_run_manager.php
-index 278815c..ad48440 100644
---- a/pts-core/objects/client/pts_test_run_manager.php
-+++ b/pts-core/objects/client/pts_test_run_manager.php
-@@ -1919,8 +1919,8 @@ class pts_test_run_manager
- 		}
- 		else if($test_profile->is_display_required() && !phodevi::is_display_server_active())
- 		{
--			$test_error = 'No display server was found, skipping ' . $test_profile;
--			$valid_test_profile = false;
-+			//$test_error = 'No display server was found, skipping ' . $test_profile;
-+			//$valid_test_profile = false;
- 		}
- 		else if($test_profile->is_network_required() && !pts_network::network_support_available())
- 		{
-diff --git a/pts-core/objects/pts_test_profile.php b/pts-core/objects/pts_test_profile.php
-index 82a4531..2e7e8ab 100644
---- a/pts-core/objects/pts_test_profile.php
-+++ b/pts-core/objects/pts_test_profile.php
-@@ -306,8 +306,8 @@ class pts_test_profile extends pts_test_profile_parser
- 		}
- 		else if($this->is_test_platform_supported() == false)
- 		{
--			$error = $this->get_identifier() . ' is not supported by this operating system: ' . phodevi::os_under_test();
--			$test_supported = false;
-+			//$error = $this->get_identifier() . ' is not supported by this operating system: ' . phodevi::os_under_test();
-+			//$test_supported = false;
- 		}
- 		else if($this->is_core_version_supported() == false)
- 		{
-
-diff --git a/pts-core/objects/client/pts_test_execution.php b/pts-core/objects/client/pts_test_execution.php
-index ec28c88..d8be905 100644
---- a/pts-core/objects/client/pts_test_execution.php
-+++ b/pts-core/objects/client/pts_test_execution.php
-@@ -139,7 +139,7 @@ class pts_test_execution
- 		{
- 			if(phodevi::is_root() == false)
- 			{
--				pts_client::$display->test_run_error('This test must be run as root / administrator.');
-+				//pts_client::$display->test_run_error('This test must be run as root / administrator.');
- 			}
- 
- 			$execute_binary_prepend .= ' ' . PTS_CORE_STATIC_PATH . 'root-access.sh ';
+Subject: add haiku paths for headers and shared libraries
 
 diff --git a/pts-core/objects/client/pts_external_dependencies.php b/pts-core/objects/client/pts_external_dependencies.php
-index 3dd5877..e2760ff 100644
+index 3dd5877..e31b32a 100644
 --- a/pts-core/objects/client/pts_external_dependencies.php
 +++ b/pts-core/objects/client/pts_external_dependencies.php
 @@ -192,6 +192,7 @@ class pts_external_dependencies
@@ -89,18 +44,13 @@ index 3dd5877..e2760ff 100644
  						if(getenv('LD_LIBRARY_PATH'))
  						{
  							foreach(explode(':', getenv('LD_LIBRARY_PATH')) as $path)
-From 2312c12eab513a43e9945cd1b8ffcf71b7ac9975 Mon Sep 17 00:00:00 2001
+
+
+From c49671d9305574d200d1ef95372df92a572364a8 Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
 Date: Fri, 17 Apr 2026 13:18:07 +0300
-Subject: [PATCH] add depenencies files
+Subject: add depenencies files
 
----
- .../scripts/install-haiku-packages.sh         |   2 +
- .../xml/generic-packages.xml                  | 107 ++---
- .../xml/haiku-packages.xml                    | 435 ++++++++++++++++++
- 3 files changed, 480 insertions(+), 64 deletions(-)
- create mode 100755 pts-core/external-test-dependencies/scripts/install-haiku-packages.sh
- create mode 100644 pts-core/external-test-dependencies/xml/haiku-packages.xml
 
 diff --git a/pts-core/external-test-dependencies/scripts/install-haiku-packages.sh b/pts-core/external-test-dependencies/scripts/install-haiku-packages.sh
 new file mode 100755
@@ -110,7 +60,6 @@ index 0000000..438b227
 @@ -0,0 +1,2 @@
 +#!/bin/sh
 +pkgman install -y $*
-
 diff --git a/pts-core/external-test-dependencies/xml/haiku-packages.xml b/pts-core/external-test-dependencies/xml/haiku-packages.xml
 new file mode 100644
 index 0000000..b35052a
@@ -555,14 +504,12 @@ index 0000000..b35052a
 -- 
 2.52.0
 
-From fd698eaf53c607aac517ed6de1d823ed82197c55 Mon Sep 17 00:00:00 2001
+
+From da5642656128473117a1ad0384413449181771e7 Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
 Date: Mon, 27 Apr 2026 23:19:13 +0300
-Subject: [PATCH] install dependencies even if marked as linux
+Subject: install dependencies even if marked as linux
 
----
- pts-core/objects/client/pts_test_install_request.php | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/pts-core/objects/client/pts_test_install_request.php b/pts-core/objects/client/pts_test_install_request.php
 index 55e9281..e8c569c 100644
@@ -580,15 +527,12 @@ index 55e9281..e8c569c 100644
 -- 
 2.52.0
 
-From 6b4adf995e4691af28a52478ce4c817b16571a9d Mon Sep 17 00:00:00 2001
+
+From 7262cb8599f7ba2efc0d4137c20e120a227f5f00 Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
 Date: Wed, 29 Apr 2026 23:01:40 +0300
-Subject: [PATCH] if downloaded files are marked for macosx or windows ignore
- them
+Subject: if downloaded files are marked for macosx or windows ignore them
 
----
- pts-core/objects/client/pts_test_install_request.php | 11 +++++++++++
- 1 file changed, 11 insertions(+)
 
 diff --git a/pts-core/objects/client/pts_test_install_request.php b/pts-core/objects/client/pts_test_install_request.php
 index e8c569c..5f8aa75 100644
@@ -620,15 +564,12 @@ index e8c569c..5f8aa75 100644
 -- 
 2.52.0
 
-From 838efcddacfe2f0415f82f2c305d4fcd4ea717a1 Mon Sep 17 00:00:00 2001
+
+From c6f981da26ea3a11cab32b482486d6240ce30d2d Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
 Date: Thu, 30 Apr 2026 22:45:53 +0300
-Subject: [PATCH] add latest generic and haiku packages
+Subject: add latest generic and haiku packages
 
----
- .../xml/generic-packages.xml                  |  7 --
- .../xml/haiku-packages.xml                    | 76 +++++++++++--------
- 2 files changed, 43 insertions(+), 40 deletions(-)
 
 diff --git a/pts-core/external-test-dependencies/xml/generic-packages.xml b/pts-core/external-test-dependencies/xml/generic-packages.xml
 index 480d28a..24c463e 100644
@@ -900,16 +841,12 @@ index b35052a..d2378d4 100644
 -- 
 2.52.0
 
-From 307e3cbc0f5e76696eb58d2818f5d63fe08fcfc0 Mon Sep 17 00:00:00 2001
+
+From 029562ac2bc404ab055d4e6ce447c7a8ca15ca98 Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
 Date: Sat, 2 May 2026 15:33:56 +0300
-Subject: [PATCH] remove deprecated curl_close references
+Subject: remove deprecated curl_close references
 
----
- pts-core/commands/check_tests.php | 2 +-
- pts-core/modules/pushover_net.php | 2 +-
- pts-core/objects/pts_network.php  | 2 +-
- 3 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/pts-core/commands/check_tests.php b/pts-core/commands/check_tests.php
 index 0b6099f..e772548 100644
@@ -953,16 +890,13 @@ index a95ff8b..a4c89b8 100644
 -- 
 2.52.0
 
-From 9146e2e1aaeadef3422341262cf0c7762dc5ed05 Mon Sep 17 00:00:00 2001
+
+From efe293e7a9042e08bf042ea67a5a84af6d013ce6 Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
 Date: Sun, 3 May 2026 00:42:10 +0300
-Subject: [PATCH] forcefully detect phodevi::is_haiku() as true and add df -h detection
+Subject: forcefully detect phodevi::is_haiku() as true and add df -h detection
  for fs
 
----
- pts-core/objects/phodevi/components/phodevi_system.php | 6 +++++-
- pts-core/objects/phodevi/phodevi.php                   | 7 ++++++-
- 2 files changed, 11 insertions(+), 2 deletions(-)
 
 diff --git a/pts-core/objects/phodevi/components/phodevi_system.php b/pts-core/objects/phodevi/components/phodevi_system.php
 index ab002fd..bf37aea 100644
@@ -989,7 +923,7 @@ index ab002fd..bf37aea 100644
  		{
  			$fs = 'Unknown';
 diff --git a/pts-core/objects/phodevi/phodevi.php b/pts-core/objects/phodevi/phodevi.php
-index fc00fb9..aaaaa1c 100644
+index fc00fb9..9704468 100644
 --- a/pts-core/objects/phodevi/phodevi.php
 +++ b/pts-core/objects/phodevi/phodevi.php
 @@ -42,7 +42,8 @@ class phodevi extends phodevi_base
@@ -1016,20 +950,15 @@ index fc00fb9..aaaaa1c 100644
 -- 
 2.52.0
 
-From 501b784f0e28462febb794d6fdf396762b701982 Mon Sep 17 00:00:00 2001
+
+From 34f9b1fc33eb76ded6c4ee6817e158cc1800294e Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
 Date: Tue, 5 May 2026 22:14:36 +0300
-Subject: [PATCH] improve hardware detection
+Subject: improve hardware detection
 
----
- pts-core/objects/phodevi/components/phodevi_audio.php | 6 ++++++
- pts-core/objects/phodevi/components/phodevi_cpu.php   | 9 +++++++--
- pts-core/objects/phodevi/components/phodevi_gpu.php   | 6 ++++++
- pts-core/objects/phodevi/phodevi.php                  | 6 +++---
- 5 files changed, 22 insertions(+), 5 deletions(-)
 
 diff --git a/pts-core/objects/phodevi/components/phodevi_audio.php b/pts-core/objects/phodevi/components/phodevi_audio.php
-index 1e80083..fa88af1 100644
+index 1e80083..b9af3cc 100644
 --- a/pts-core/objects/phodevi/components/phodevi_audio.php
 +++ b/pts-core/objects/phodevi/components/phodevi_audio.php
 @@ -49,6 +49,12 @@ class phodevi_audio extends phodevi_device_interface
@@ -1079,7 +1008,6 @@ index 2a1eb9b..89cf1d7 100644
  		return trim($scaling_governor);
  	}
  	public static function cpu_power_management()
-
 diff --git a/pts-core/objects/phodevi/components/phodevi_gpu.php b/pts-core/objects/phodevi/components/phodevi_gpu.php
 index a6efef8..0e4de52 100644
 --- a/pts-core/objects/phodevi/components/phodevi_gpu.php
@@ -1131,17 +1059,15 @@ index 9704468..72f227b 100644
 -- 
 2.52.0
 
-From af3de2474c3f2bd3381585bd433c5cb2fdfca984 Mon Sep 17 00:00:00 2001
+
+From b63d3df923a6761462ba4463c3a5158357eaba8b Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
 Date: Fri, 8 May 2026 14:23:05 +0300
-Subject: [PATCH] add memory detection
+Subject: add memory detection
 
----
- pts-core/objects/phodevi/phodevi.php | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/pts-core/objects/phodevi/phodevi.php b/pts-core/objects/phodevi/phodevi.php
-index fbb5b6c..ea68293 100644
+index 72f227b..ef472ca 100644
 --- a/pts-core/objects/phodevi/phodevi.php
 +++ b/pts-core/objects/phodevi/phodevi.php
 @@ -356,7 +356,7 @@ class phodevi extends phodevi_base
@@ -1156,14 +1082,12 @@ index fbb5b6c..ea68293 100644
 -- 
 2.52.0
 
-From b96c6fa7fd8f0806f2edba017ed787352ac15945 Mon Sep 17 00:00:00 2001
+
+From b527336ca4dc169a4f2de3d877d97d5044ce60f5 Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
 Date: Fri, 8 May 2026 15:43:37 +0300
-Subject: [PATCH] Hopefully fix rust cmake qt vulkan sdl2 perl
+Subject: Hopefully fix rust cmake qt vulkan sdl2 perl
 
----
- .../xml/haiku-packages.xml                    | 21 ++++++++++---------
- 1 file changed, 11 insertions(+), 10 deletions(-)
 
 diff --git a/pts-core/external-test-dependencies/xml/haiku-packages.xml b/pts-core/external-test-dependencies/xml/haiku-packages.xml
 index d2378d4..31c100f 100644
@@ -1245,48 +1169,15 @@ index d2378d4..31c100f 100644
 -- 
 2.52.0
 
-From 4c6a6aa9454e88f97abc9d43cf782241e5020cf5 Mon Sep 17 00:00:00 2001
+
+From 809dd3bdc63fa530b779b1668830a055ea2312b0 Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
 Date: Fri, 8 May 2026 18:23:12 +0300
-Subject: [PATCH] fix commented out code of first patch properly
+Subject: fix root,display server and properly
 
----
- pts-core/objects/client/pts_test_execution.php   | 2 +-
- pts-core/objects/client/pts_test_run_manager.php | 4 ++--
- pts-core/objects/phodevi/phodevi.php             | 4 ++--
- pts-core/objects/pts_test_profile.php            | 8 ++++++--
- 4 files changed, 11 insertions(+), 7 deletions(-)
 
-diff --git a/pts-core/objects/client/pts_test_execution.php b/pts-core/objects/client/pts_test_execution.php
-index d8be905..ec28c88 100644
---- a/pts-core/objects/client/pts_test_execution.php
-+++ b/pts-core/objects/client/pts_test_execution.php
-@@ -139,7 +139,7 @@ class pts_test_execution
- 		{
- 			if(phodevi::is_root() == false)
- 			{
--				//pts_client::$display->test_run_error('This test must be run as root / administrator.');
-+				pts_client::$display->test_run_error('This test must be run as root / administrator.');
- 			}
- 
- 			$execute_binary_prepend .= ' ' . PTS_CORE_STATIC_PATH . 'root-access.sh ';
-diff --git a/pts-core/objects/client/pts_test_run_manager.php b/pts-core/objects/client/pts_test_run_manager.php
-index ad48440..278815c 100644
---- a/pts-core/objects/client/pts_test_run_manager.php
-+++ b/pts-core/objects/client/pts_test_run_manager.php
-@@ -1919,8 +1919,8 @@ class pts_test_run_manager
- 		}
- 		else if($test_profile->is_display_required() && !phodevi::is_display_server_active())
- 		{
--			//$test_error = 'No display server was found, skipping ' . $test_profile;
--			//$valid_test_profile = false;
-+			$test_error = 'No display server was found, skipping ' . $test_profile;
-+			$valid_test_profile = false;
- 		}
- 		else if($test_profile->is_network_required() && !pts_network::network_support_available())
- 		{
 diff --git a/pts-core/objects/phodevi/phodevi.php b/pts-core/objects/phodevi/phodevi.php
-index 4a504f4..ea68293 100644
+index ef472ca..916e453 100644
 --- a/pts-core/objects/phodevi/phodevi.php
 +++ b/pts-core/objects/phodevi/phodevi.php
 @@ -1034,7 +1034,7 @@ class phodevi extends phodevi_base
@@ -1311,17 +1202,6 @@ diff --git a/pts-core/objects/pts_test_profile.php b/pts-core/objects/pts_test_p
 index 2e7e8ab..79a3352 100644
 --- a/pts-core/objects/pts_test_profile.php
 +++ b/pts-core/objects/pts_test_profile.php
-@@ -306,8 +306,8 @@ class pts_test_profile extends pts_test_profile_parser
- 		}
- 		else if($this->is_test_platform_supported() == false)
- 		{
--			//$error = $this->get_identifier() . ' is not supported by this operating system: ' . phodevi::os_under_test();
--			//$test_supported = false;
-+			$error = $this->get_identifier() . ' is not supported by this operating system: ' . phodevi::os_under_test();
-+			$test_supported = false;
- 		}
- 		else if($this->is_core_version_supported() == false)
- 		{
 @@ -401,6 +401,10 @@ class pts_test_profile extends pts_test_profile_parser
  				// TODO: fill in Hurd support for test profiles / see what works
  				$supported = true;
@@ -1335,7 +1215,4 @@ index 2e7e8ab..79a3352 100644
  				$supported = false;
 -- 
 2.52.0
-
-
-
 

--- a/app-benchmarks/pts/pts-10.8.4.patchset
+++ b/app-benchmarks/pts/pts-10.8.4.patchset
@@ -159,9 +159,9 @@ index 1e80083..b9af3cc 100644
 +		else if(phodevi::is_haiku())
 +		{
 +			
-+					$audio = shell_exec('listdev | grep Audio | cut -c 15-50');
-+					return $audio;
-+				}
++	  $audio = shell_exec('listdev | grep Audio | cut -c 15-50');
++   return $audio;
++  }
  		else if(phodevi::is_windows())
  		{
  			$win_sound = array();

--- a/app-benchmarks/pts/pts-10.8.4.patchset
+++ b/app-benchmarks/pts/pts-10.8.4.patchset
@@ -29,7 +29,7 @@ index 3dd5877..e31b32a 100644
  					{
  						// May just be a relative header file to look for...
 -						$possible_paths = array_merge(array('/usr/local/include/', '/usr/target/include/', '/usr/include/'), pts_file_io::glob('/usr/include/*-linux-gnu/'));
-+						$possible_paths = array_merge(array('/usr/local/include/', '/boot/system/develop/headers','/boot/system/config/develop/headers','/boot/system/non-packaged/develop/headers', '/usr/target/include/', '/usr/include/'), pts_file_io::glob('/usr/include/*-linux-gnu/'));
++						$possible_paths = array_merge(array('/boot/system/develop/headers','/boot/system/config/develop/headers','/boot/system/non-packaged/develop/headers'));
  						foreach($possible_paths as $path)
  						{
  							if(self::is_present($path . '/' . $file[$i]))
@@ -39,470 +39,13 @@ index 3dd5877..e31b32a 100644
  						// May just be a relative shared library to look for...
 -						$possible_paths = array_merge(array('/usr/local/lib/', '/usr/lib/', '/usr/lib64/', '/usr/lib/arm-linux-gnueabihf/'), pts_file_io::glob('/usr/lib/*-linux-gnu/'));
 -
-+						$possible_paths = array_merge(array('/boot/system/lib/', '/boot/system/non-packaged/lib', '/boot/system/develop/lib/', '/usr/local/lib/', '/usr/lib/', '/usr/lib64/', '/usr/lib/arm-linux-gnueabihf/'), pts_file_io::glob('/usr/lib/*-linux-gnu/'));
++						$possible_paths = array_merge(array('/boot/system/lib/', '/boot/system/non-packaged/lib', '/boot/system/develop/lib/'));
 +					
  						if(getenv('LD_LIBRARY_PATH'))
  						{
  							foreach(explode(':', getenv('LD_LIBRARY_PATH')) as $path)
 
 
-From c49671d9305574d200d1ef95372df92a572364a8 Mon Sep 17 00:00:00 2001
-From: brooklynakos <spyridop@yahoo.gr>
-Date: Fri, 17 Apr 2026 13:18:07 +0300
-Subject: add depenencies files
-
-
-diff --git a/pts-core/external-test-dependencies/scripts/install-haiku-packages.sh b/pts-core/external-test-dependencies/scripts/install-haiku-packages.sh
-new file mode 100755
-index 0000000..438b227
---- /dev/null
-+++ b/pts-core/external-test-dependencies/scripts/install-haiku-packages.sh
-@@ -0,0 +1,2 @@
-+#!/bin/sh
-+pkgman install -y $*
-diff --git a/pts-core/external-test-dependencies/xml/haiku-packages.xml b/pts-core/external-test-dependencies/xml/haiku-packages.xml
-new file mode 100644
-index 0000000..b35052a
---- /dev/null
-+++ b/pts-core/external-test-dependencies/xml/haiku-packages.xml
-@@ -0,0 +1,435 @@
-+<?xml version="1.0"?>
-+<PhoronixTestSuite>
-+	<ExternalDependencies>
-+		<Information>
-+			<Name>haiku</Name>
-+			<Aliases>Haiku</Aliases>
-+			<PackageManager>pkgman</PackageManager>
-+		</Information>
-+		<Package>
-+			<GenericName>gtk-development</GenericName>
-+			<PackageName>gtk4_devel</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>sdl2-development</GenericName>
-+			<PackageName>libsdl2_devel libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>sdl-development</GenericName>
-+			<PackageName>libsdl_devel</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>vulkan-development</GenericName>
-+			<PackageName>vulkan-tools libvulkan-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>glut</GenericName>
-+			<PackageName>freeglut3-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>csh</GenericName>
-+			<PackageName>csh</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>libpng-development</GenericName>
-+			<PackageName>libpng-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>openssl-development</GenericName>
-+			<PackageName>libssl-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>build-utilities</GenericName>
-+			<PackageName>build-essential autoconf</PackageName>
-+			</Package>
-+		<Package>
-+			<GenericName>cairo-development</GenericName>
-+			<PackageName>libcairo2-dev libgdk-pixbuf2.0-dev</PackageName>
-+			<FileCheck>cairo/cairo.h, gdk-pixbuf-2.0/gdk-pixbuf/gdk-pixbuf.h</FileCheck>
-+		</Package>
-+		<Package>
-+			<GenericName>xorg-development</GenericName>
-+			<PackageName>xorg-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>tiff</GenericName>
-+			<PackageName>libtiff5-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>bison</GenericName>
-+			<PackageName>bison</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>flex</GenericName>
-+			<PackageName>flex</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>imlib2-development</GenericName>
-+			<PackageName>libimlib2-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>java</GenericName>
-+			<PackageName>openjdk24_default</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>maven</GenericName>
-+			<PackageName>maven</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>portaudio-development</GenericName>
-+			<PackageName>portaudio19-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>fortran-compiler</GenericName>
-+			<PackageName>gcc_fortran</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>glew</GenericName>
-+			<PackageName>libglew-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>lib3ds</GenericName>
-+			<PackageName>lib3ds-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>bc</GenericName>
-+			<PackageName>bc</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>freeimage</GenericName>
-+			<PackageName>libfreeimage3 libfreeimage-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>scons</GenericName>
-+			<PackageName>scons</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>smartmontools</GenericName>
-+			<PackageName>smartmontools</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>zlib-development</GenericName>
-+			<PackageName>zlib1g-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>jpeg-development</GenericName>
-+			<PackageName>libjpeg-dev</PackageName>
-+			<FileCheck>jpeglib.h</FileCheck>
-+		</Package>
-+		<Package>
-+			<GenericName>libaio-development</GenericName>
-+			<PackageName>libaio-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>libpcre</GenericName>
-+			<PackageName>libpcre</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>perl</GenericName>
-+			<PackageName>perl perl-base perl-modules libsdl-perl libperl-dev</PackageName>
-+			<FileCheck>perl</FileCheck>
-+		</Package>
-+		<Package>
-+			<GenericName>perl-opengl</GenericName>
-+			<PackageName>libopengl-perl</PackageName>
-+			</Package>
-+		<Package>
-+			<GenericName>xorg-video</GenericName>
-+			<PackageName>libxv-dev libxvmc-dev libvdpau-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>libstdcpp5</GenericName>
-+			<PackageName>libstdc++5</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>openal-development</GenericName>
-+			<PackageName>libopenal-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>vorbis-development</GenericName>
-+			<PackageName>libvorbis-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>jam</GenericName>
-+			<PackageName>jam</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>p7zip</GenericName>
-+			<PackageName>p7zip-full</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>qt5-development</GenericName>
-+			<PackageName>qml-module-qtquick2 qtdeclarative5-dev qtbase5-dev libqt5svg5-dev qttools5-dev libqca-qt5-2-dev qt5keychain-dev pyqt5-dev pyqt5-dev-tools qtpositioning5-dev</PackageName>
-+			<FileCheck>qmake</FileCheck>
-+		</Package>
-+		<Package>
-+			<GenericName>autoconf</GenericName>
-+			<PackageName>autoconf</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>libtool</GenericName>
-+			<PackageName>libtool</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>libevent</GenericName>
-+			<PackageName>libevent</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>ncurses-development</GenericName>
-+			<PackageName>libncurses5-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>popt</GenericName>
-+			<PackageName>popt</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>numa-development</GenericName>
-+			<PackageName>libnuma-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>curl</GenericName>
-+			<PackageName>curl libcurl4-openssl-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>fftw3-development</GenericName>
-+			<PackageName>libfftw3-dev fftw-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>blas-development</GenericName>
-+			<PackageName>openblas</PackageName>
-+			</Package>
-+		<Package>
-+			<GenericName>lapack-development</GenericName>
-+			<PackageName>liblapack-dev liblapacke-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>atlas-development</GenericName>
-+			<PackageName>libatlas-base-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>openmpi-development</GenericName>
-+			<PackageName>libopenmpi-dev openmpi-bin libmpich-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>cmake</GenericName>
-+			<PackageName>cmake cmake-data</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>boost170 devel</GenericName>
-+			<PackageName>boost170</PackageName>
-+			</Package>
-+		<Package>
-+			<GenericName>bzip2-development</GenericName>
-+			<PackageName>libbz2-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>tcl</GenericName>
-+			<PackageName>tcl tclsh</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>glibc-development</GenericName>
-+			<PackageName>libc6-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>rust</GenericName>
-+			<PackageName>rustc cargo</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>glibc-development</GenericName>
-+			<PackageName>libc6-dev-i386</PackageName>
-+			<ArchitectureSpecific>x86_64</ArchitectureSpecific>
-+		</Package>
-+		<Package>
-+			<GenericName>python3.14</GenericName>
-+			<PackageName>python3.14 pip</PackageName>
-+			</Package>
-+		<Package>
-+			<GenericName>python-boost-development</GenericName>
-+			<PackageName>libboost</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>boost-thread-development</GenericName>
-+			<PackageName>libboost-thread-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>python-numpy</GenericName>
-+			<PackageName>python3-numpy</PackageName>
-+			</Package>
-+		<Package>
-+			<GenericName>yasm</GenericName>
-+			<PackageName>yasm nasm</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>nasm</GenericName>
-+			<PackageName>nasm</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>gmp</GenericName>
-+			<PackageName>gmp</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>subversion</GenericName>
-+			<PackageName>subversion</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>git</GenericName>
-+			<PackageName>git-core</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>superlu</GenericName>
-+			<PackageName>libsuperlu-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>suitesparse</GenericName>
-+			<PackageName>libsuitesparse-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>dune</GenericName>
-+			<PackageName>libdune-common-dev libdune-istl-dev libdune-geometry-dev libdune-grid-dev libdune-localfunctions-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>tinyxml</GenericName>
-+			<PackageName>libtinyxml-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>opencl</GenericName>
-+			<PackageName>opencl_headers ocl_icd ocl_icd_devel</PackageName>
-+			</Package>
-+		<Package>
-+			<GenericName>attr</GenericName>
-+			<PackageName>libattr1-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>httpd</GenericName>
-+			<PackageName>apache</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>meson</GenericName>
-+			<PackageName>meson</PackageName>
-+		</Package>
-+        <Package>
-+			<GenericName>golang-1.18.10-1</GenericName>
-+			<PackageName>golang-1.18.10-1</PackageName>
-+		</Package>
-+                <Package>
-+			<GenericName>steam</GenericName>
-+			<PackageName>steam</PackageName>
-+		</Package>
-+                <Package>
-+			<GenericName>redis-server</GenericName>
-+			<PackageName>redis-server</PackageName>
-+		</Package>
-+                <Package>
-+			<GenericName>opencv</GenericName>
-+			<PackageName>libopencv-dev</PackageName>
-+		</Package>
-+		<Package>
-+            <GenericName>perl-digest-md5</GenericName>
-+            <PackageName>libdigest-md5-file-perl libdigest-perl-md5-perl</PackageName>
-+                </Package>
-+		<Package>
-+			<GenericName>python-scipy</GenericName>
-+			<PackageName>python3-scipy</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>python-sklearn</GenericName>
-+			<PackageName>python3-sklearn</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>V8</GenericName>
-+			<PackageName>libv8-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>ruby</GenericName>
-+			<PackageName>ruby</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>gimp</GenericName>
-+			<PackageName>gimp</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>darktable</GenericName>
-+			<PackageName>darktable</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>wine</GenericName>
-+			<PackageName>wine</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>mongodb</GenericName>
-+			<PackageName>mongodb</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>node-npm</GenericName>
-+			<PackageName>npm</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>expat</GenericName>
-+			<PackageName>expat</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>hdf5</GenericName>
-+			<PackageName>libhdf5-dev libhdf5-mpi-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>libxml2</GenericName>
-+			<PackageName>libxml2-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>uuid</GenericName>
-+			<PackageName>uuid-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>clang</GenericName>
-+			<PackageName>clang</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>swig</GenericName>
-+			<PackageName>swig</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>freetype</GenericName>
-+			<PackageName>libfreetype6-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>gflags</GenericName>
-+			<PackageName>libgflags-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>google-benchmark</GenericName>
-+			<PackageName>libbenchmark-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>snappy</GenericName>
-+			<PackageName>libsnappy-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>vaapi</GenericName>
-+			<PackageName>libva-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>openexr</GenericName>
-+			<PackageName>libopenexr-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>glfw</GenericName>
-+			<PackageName>libglfw3-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>protobuf</GenericName>
-+			<PackageName>libprotobuf-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>eigen</GenericName>
-+			<PackageName>libeigen3-dev</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>erlang</GenericName>
-+			<PackageName>erlang</PackageName>
-+		</Package>
-+		<Package>
-+			<GenericName>libconfigpp</GenericName>
-+			<PackageName>libconfig++-dev</PackageName>
-+		</Package>
-+	</ExternalDependencies>
-+</PhoronixTestSuite>
--- 
-2.52.0
 
 
 From da5642656128473117a1ad0384413449181771e7 Mon Sep 17 00:00:00 2001
@@ -565,283 +108,6 @@ index e8c569c..5f8aa75 100644
 2.52.0
 
 
-From c6f981da26ea3a11cab32b482486d6240ce30d2d Mon Sep 17 00:00:00 2001
-From: brooklynakos <spyridop@yahoo.gr>
-Date: Thu, 30 Apr 2026 22:45:53 +0300
-Subject: add latest generic and haiku packages
-
-
-diff --git a/pts-core/external-test-dependencies/xml/generic-packages.xml b/pts-core/external-test-dependencies/xml/generic-packages.xml
-index 480d28a..24c463e 100644
---- a/pts-core/external-test-dependencies/xml/generic-packages.xml
-+++ b/pts-core/external-test-dependencies/xml/generic-packages.xml
-@@ -5,13 +5,6 @@
- 			<GenericName>common-dependencies</GenericName>
- 			<Title>Common Dependencies For The Phoronix Test Suite</Title>
- 		</Package>
--		<Package>
--			<GenericName>32bit-compatibility</GenericName>
--			<Title>32-bit Compatibility Libraries</Title>
--			<ArchitectureSpecific>x86_64</ArchitectureSpecific>
--			<PossibleNames>ia32-libs</PossibleNames>
--			<FileCheck>/usr/lib32/</FileCheck>
--		</Package>
- 		<Package>
- 			<GenericName>gtk-development</GenericName>
- 			<Title>GTK2</Title>
-diff --git a/pts-core/external-test-dependencies/xml/haiku-packages.xml b/pts-core/external-test-dependencies/xml/haiku-packages.xml
-index b35052a..d2378d4 100644
---- a/pts-core/external-test-dependencies/xml/haiku-packages.xml
-+++ b/pts-core/external-test-dependencies/xml/haiku-packages.xml
-@@ -17,6 +17,7 @@
- 		<Package>
- 			<GenericName>sdl-development</GenericName>
- 			<PackageName>libsdl_devel</PackageName>
-+			<FileCheck>libSDL-1.2.so.0</FileCheck>
- 		</Package>
- 		<Package>
- 			<GenericName>vulkan-development</GenericName>
-@@ -43,9 +44,9 @@
- 			<PackageName>build-essential autoconf</PackageName>
- 			</Package>
- 		<Package>
--			<GenericName>cairo-development</GenericName>
--			<PackageName>libcairo2-dev libgdk-pixbuf2.0-dev</PackageName>
--			<FileCheck>cairo/cairo.h, gdk-pixbuf-2.0/gdk-pixbuf/gdk-pixbuf.h</FileCheck>
-+			<GenericName>cairo</GenericName>
-+			<PackageName>cairo</PackageName>
-+			<FileCheck>libcairo.so.2</FileCheck>
- 		</Package>
- 		<Package>
- 			<GenericName>xorg-development</GenericName>
-@@ -77,7 +78,7 @@
- 		</Package>
- 		<Package>
- 			<GenericName>portaudio-development</GenericName>
--			<PackageName>portaudio19-dev</PackageName>
-+			<PackageName>portaudio_devel</PackageName>
- 		</Package>
- 		<Package>
- 			<GenericName>fortran-compiler</GenericName>
-@@ -97,7 +98,7 @@
- 		</Package>
- 		<Package>
- 			<GenericName>freeimage</GenericName>
--			<PackageName>libfreeimage3 libfreeimage-dev</PackageName>
-+			<PackageName>freeimage</PackageName>
- 		</Package>
- 		<Package>
- 			<GenericName>scons</GenericName>
-@@ -147,7 +148,7 @@
- 		</Package>
- 		<Package>
- 			<GenericName>vorbis-development</GenericName>
--			<PackageName>libvorbis-dev</PackageName>
-+			<PackageName>libvorbis_devel</PackageName>
- 		</Package>
- 		<Package>
- 			<GenericName>jam</GenericName>
-@@ -173,14 +174,16 @@
- 		<Package>
- 			<GenericName>libevent</GenericName>
- 			<PackageName>libevent</PackageName>
-+			<FileCheck>libevent-2.1.so.7</FileCheck>
- 		</Package>
- 		<Package>
- 			<GenericName>ncurses-development</GenericName>
--			<PackageName>libncurses5-dev</PackageName>
-+			<PackageName>ncurses6_devel</PackageName>
- 		</Package>
- 		<Package>
- 			<GenericName>popt</GenericName>
- 			<PackageName>popt</PackageName>
-+			<FileCheck>libpopt.so.0</FileCheck>
- 		</Package>
- 		<Package>
- 			<GenericName>numa-development</GenericName>
-@@ -197,10 +200,11 @@
- 		<Package>
- 			<GenericName>blas-development</GenericName>
- 			<PackageName>openblas</PackageName>
-+			<FileCheck>libopenblas.so.0</FileCheck>
- 			</Package>
- 		<Package>
--			<GenericName>lapack-development</GenericName>
--			<PackageName>liblapack-dev liblapacke-dev</PackageName>
-+			<GenericName>lapack</GenericName>
-+			<PackageName>lapack</PackageName>
- 		</Package>
- 		<Package>
- 			<GenericName>atlas-development</GenericName>
-@@ -215,8 +219,9 @@
- 			<PackageName>cmake cmake-data</PackageName>
- 		</Package>
- 		<Package>
--			<GenericName>boost170 devel</GenericName>
--			<PackageName>boost170</PackageName>
-+			<GenericName>boost1.90_devel</GenericName>
-+			<PackageName>boost1.90_devel</PackageName>
-+			<FileCheck>libboost_atomic.so.1.90.0</FileCheck>
- 			</Package>
- 		<Package>
- 			<GenericName>bzip2-development</GenericName>
-@@ -224,7 +229,7 @@
- 		</Package>
- 		<Package>
- 			<GenericName>tcl</GenericName>
--			<PackageName>tcl tclsh</PackageName>
-+			<PackageName>tcl</PackageName>
- 		</Package>
- 		<Package>
- 			<GenericName>glibc-development</GenericName>
-@@ -241,7 +246,9 @@
- 		</Package>
- 		<Package>
- 			<GenericName>python3.14</GenericName>
--			<PackageName>python3.14 pip</PackageName>
-+			<PackageName>python3.14 pip_python310</PackageName>
-+			<FileCheck>python3.14, pip</FileCheck>
-+			<VirtualSuite>TRUE</VirtualSuite>
- 			</Package>
- 		<Package>
- 			<GenericName>python-boost-development</GenericName>
-@@ -253,7 +260,8 @@
- 		</Package>
- 		<Package>
- 			<GenericName>python-numpy</GenericName>
--			<PackageName>python3-numpy</PackageName>
-+			<PackageName>numpy_python310</PackageName>
-+			<FileCheck>f2py</FileCheck>
- 			</Package>
- 		<Package>
- 			<GenericName>yasm</GenericName>
-@@ -277,11 +285,12 @@
- 		</Package>
- 		<Package>
- 			<GenericName>superlu</GenericName>
--			<PackageName>libsuperlu-dev</PackageName>
-+			<PackageName>superlu</PackageName>
-+			<FileCheck>libsuperlu.so.5</FileCheck>
- 		</Package>
- 		<Package>
- 			<GenericName>suitesparse</GenericName>
--			<PackageName>libsuitesparse-dev</PackageName>
-+			<PackageName>suitesparse</PackageName>
- 		</Package>
- 		<Package>
- 			<GenericName>dune</GenericName>
-@@ -289,7 +298,7 @@
- 		</Package>
- 		<Package>
- 			<GenericName>tinyxml</GenericName>
--			<PackageName>libtinyxml-dev</PackageName>
-+			<PackageName>tinyxml_devel</PackageName>
- 		</Package>
- 		<Package>
- 			<GenericName>opencl</GenericName>
-@@ -297,7 +306,8 @@
- 			</Package>
- 		<Package>
- 			<GenericName>attr</GenericName>
--			<PackageName>libattr1-dev</PackageName>
-+			<PackageName>attr</PackageName>
-+			<FileCheck>libattr.so.1</FileCheck>
- 		</Package>
- 		<Package>
- 			<GenericName>httpd</GenericName>
-@@ -316,12 +326,12 @@
- 			<PackageName>steam</PackageName>
- 		</Package>
-                 <Package>
--			<GenericName>redis-server</GenericName>
--			<PackageName>redis-server</PackageName>
-+			<GenericName>redis</GenericName>
-+			<PackageName>redis</PackageName>
- 		</Package>
-                 <Package>
- 			<GenericName>opencv</GenericName>
--			<PackageName>libopencv-dev</PackageName>
-+			<PackageName>opencv_devel</PackageName>
- 		</Package>
- 		<Package>
-             <GenericName>perl-digest-md5</GenericName>
-@@ -329,7 +339,7 @@
-                 </Package>
- 		<Package>
- 			<GenericName>python-scipy</GenericName>
--			<PackageName>python3-scipy</PackageName>
-+			<PackageName>scipy_python310 f</PackageName>
- 		</Package>
- 		<Package>
- 			<GenericName>python-sklearn</GenericName>
-@@ -369,11 +379,11 @@
- 		</Package>
- 		<Package>
- 			<GenericName>hdf5</GenericName>
--			<PackageName>libhdf5-dev libhdf5-mpi-dev</PackageName>
-+			<PackageName>hdf5_devel</PackageName>
- 		</Package>
- 		<Package>
- 			<GenericName>libxml2</GenericName>
--			<PackageName>libxml2-dev</PackageName>
-+			<PackageName>libxml2_devel</PackageName>
- 		</Package>
- 		<Package>
- 			<GenericName>uuid</GenericName>
-@@ -393,15 +403,15 @@
- 		</Package>
- 		<Package>
- 			<GenericName>gflags</GenericName>
--			<PackageName>libgflags-dev</PackageName>
-+			<PackageName>gflags_devel</PackageName>
- 		</Package>
- 		<Package>
--			<GenericName>google-benchmark</GenericName>
--			<PackageName>libbenchmark-dev</PackageName>
-+			<GenericName>benchmark</GenericName>
-+			<PackageName>benchmark</PackageName>
- 		</Package>
- 		<Package>
- 			<GenericName>snappy</GenericName>
--			<PackageName>libsnappy-dev</PackageName>
-+			<PackageName>snappy_devel</PackageName>
- 		</Package>
- 		<Package>
- 			<GenericName>vaapi</GenericName>
-@@ -409,15 +419,15 @@
- 		</Package>
- 		<Package>
- 			<GenericName>openexr</GenericName>
--			<PackageName>libopenexr-dev</PackageName>
-+			<PackageName>openexr3.2_devel</PackageName>
- 		</Package>
- 		<Package>
- 			<GenericName>glfw</GenericName>
--			<PackageName>libglfw3-dev</PackageName>
-+			<PackageName>glfw</PackageName>
- 		</Package>
- 		<Package>
- 			<GenericName>protobuf</GenericName>
--			<PackageName>libprotobuf-dev</PackageName>
-+			<PackageName>protobuf_devel</PackageName>
- 		</Package>
- 		<Package>
- 			<GenericName>eigen</GenericName>
-@@ -428,8 +438,8 @@
- 			<PackageName>erlang</PackageName>
- 		</Package>
- 		<Package>
--			<GenericName>libconfigpp</GenericName>
--			<PackageName>libconfig++-dev</PackageName>
-+			<GenericName>libconfig</GenericName>
-+			<PackageName>libconfig</PackageName>
- 		</Package>
- 	</ExternalDependencies>
- </PhoronixTestSuite>
--- 
-2.52.0
-
-
 From 029562ac2bc404ab055d4e6ce447c7a8ca15ca98 Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
 Date: Sat, 2 May 2026 15:33:56 +0300
@@ -894,7 +160,7 @@ index a95ff8b..a4c89b8 100644
 From efe293e7a9042e08bf042ea67a5a84af6d013ce6 Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
 Date: Sun, 3 May 2026 00:42:10 +0300
-Subject: forcefully detect phodevi::is_haiku() as true and add df -h detection
+Subject: detect phodevi::is_haiku() and add df -h detection
  for fs
 
 
@@ -1043,7 +309,7 @@ index 9704468..72f227b 100644
  				'Scaling Driver'=> phodevi::read_property('cpu', 'scaling-governor'),
  				),
 -			'Graphics' => phodevi::read_name('gpu'),
-+			'Graphics' => shell_exec('listdev | grep Graphics | cut -c 16-50'),
++			'Graphics' => shell_exec('listdev | grep Adapter | cut -c 16-50'),
  				array(
  				'Frequency' => phodevi::read_property('gpu', 'frequency'),
  				'BAR1 / Visible vRAM' => phodevi::read_property('gpu', 'bar1-visible-vram'),
@@ -1083,97 +349,10 @@ index 72f227b..ef472ca 100644
 2.52.0
 
 
-From b527336ca4dc169a4f2de3d877d97d5044ce60f5 Mon Sep 17 00:00:00 2001
-From: brooklynakos <spyridop@yahoo.gr>
-Date: Fri, 8 May 2026 15:43:37 +0300
-Subject: Hopefully fix rust cmake qt vulkan sdl2 perl
-
-
-diff --git a/pts-core/external-test-dependencies/xml/haiku-packages.xml b/pts-core/external-test-dependencies/xml/haiku-packages.xml
-index d2378d4..31c100f 100644
---- a/pts-core/external-test-dependencies/xml/haiku-packages.xml
-+++ b/pts-core/external-test-dependencies/xml/haiku-packages.xml
-@@ -12,7 +12,8 @@
- 		</Package>
- 		<Package>
- 			<GenericName>sdl2-development</GenericName>
--			<PackageName>libsdl2_devel libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev</PackageName>
-+			<PackageName>sdl2_gfx_devel sdl2_image_devel sdl2_mixer_devel sdl2_ttf_devel</PackageName>
-+			<FileCheck>libSDL2_image-2.0.so.0</FileCheck>
- 		</Package>
- 		<Package>
- 			<GenericName>sdl-development</GenericName>
-@@ -21,7 +22,7 @@
- 		</Package>
- 		<Package>
- 			<GenericName>vulkan-development</GenericName>
--			<PackageName>vulkan-tools libvulkan-dev</PackageName>
-+			<PackageName>vulkan vulkan_devel</PackageName>
- 		</Package>
- 		<Package>
- 			<GenericName>glut</GenericName>
-@@ -127,7 +128,7 @@
- 		</Package>
- 		<Package>
- 			<GenericName>perl</GenericName>
--			<PackageName>perl perl-base perl-modules libsdl-perl libperl-dev</PackageName>
-+			<PackageName>perl libsdl-perl</PackageName>
- 			<FileCheck>perl</FileCheck>
- 		</Package>
- 		<Package>
-@@ -156,11 +157,11 @@
- 		</Package>
- 		<Package>
- 			<GenericName>p7zip</GenericName>
--			<PackageName>p7zip-full</PackageName>
-+			<PackageName>p7zip-full</PackageName>qt6_tools_devel
- 		</Package>
- 		<Package>
- 			<GenericName>qt5-development</GenericName>
--			<PackageName>qml-module-qtquick2 qtdeclarative5-dev qtbase5-dev libqt5svg5-dev qttools5-dev libqca-qt5-2-dev qt5keychain-dev pyqt5-dev pyqt5-dev-tools qtpositioning5-dev</PackageName>
-+			<PackageName>qml_box2d_qt6 qt6_declarative_devel qt6_base_devel qt6_svg_devel qttools5-dev qca_qt6_devel qtkeychain_qt6_devel pyqt5-dev pyqt6  qt6_positioning_devel</PackageName>
- 			<FileCheck>qmake</FileCheck>
- 		</Package>
- 		<Package>
-@@ -216,7 +217,7 @@
- 		</Package>
- 		<Package>
- 			<GenericName>cmake</GenericName>
--			<PackageName>cmake cmake-data</PackageName>
-+			<PackageName>cmake</PackageName>
- 		</Package>
- 		<Package>
- 			<GenericName>boost1.90_devel</GenericName>
-@@ -237,7 +238,7 @@
- 		</Package>
- 		<Package>
- 			<GenericName>rust</GenericName>
--			<PackageName>rustc cargo</PackageName>
-+			<PackageName>rust_bin</PackageName>
- 		</Package>
- 		<Package>
- 			<GenericName>glibc-development</GenericName>
-@@ -245,9 +246,9 @@
- 			<ArchitectureSpecific>x86_64</ArchitectureSpecific>
- 		</Package>
- 		<Package>
--			<GenericName>python3.14</GenericName>
--			<PackageName>python3.14 pip_python310</PackageName>
--			<FileCheck>python3.14, pip</FileCheck>
-+			<GenericName>python</GenericName>
-+			<PackageName>python3.10 pip_python310</PackageName>
-+			<FileCheck>python3.10/Python.h</FileCheck>
- 			<VirtualSuite>TRUE</VirtualSuite>
- 			</Package>
- 		<Package>
--- 
-2.52.0
-
-
 From 809dd3bdc63fa530b779b1668830a055ea2312b0 Mon Sep 17 00:00:00 2001
 From: brooklynakos <spyridop@yahoo.gr>
 Date: Fri, 8 May 2026 18:23:12 +0300
-Subject: fix root,display server and properly
+Subject: fix root,display server and supported platform properly
 
 
 diff --git a/pts-core/objects/phodevi/phodevi.php b/pts-core/objects/phodevi/phodevi.php
@@ -1215,4 +394,491 @@ index 2e7e8ab..79a3352 100644
  				$supported = false;
 -- 
 2.52.0
+
+From 09b7c92d0c7636cb1616e11eabf177f77f62fa6c Mon Sep 17 00:00:00 2001
+From: brooklynakos <spyridop@yahoo.gr>
+Date: Fri, 17 Apr 2026 13:18:07 +0300
+Subject:  Squash commits regarding haiku_packages
+
+diff --git a/pts-core/external-test-dependencies/scripts/install-haiku-packages.sh b/pts-core/external-test-dependencies/scripts/install-haiku-packages.sh
+new file mode 100755
+index 0000000..438b227
+--- /dev/null
++++ b/pts-core/external-test-dependencies/scripts/install-haiku-packages.sh
+@@ -0,0 +1,2 @@
++#!/bin/sh
++pkgman install -y $*
+diff --git a/pts-core/external-test-dependencies/xml/generic-packages.xml b/pts-core/external-test-dependencies/xml/generic-packages.xml
+index 480d28a..24c463e 100644
+--- a/pts-core/external-test-dependencies/xml/generic-packages.xml
++++ b/pts-core/external-test-dependencies/xml/generic-packages.xml
+@@ -5,13 +5,6 @@
+ 			<GenericName>common-dependencies</GenericName>
+ 			<Title>Common Dependencies For The Phoronix Test Suite</Title>
+ 		</Package>
+-		<Package>
+-			<GenericName>32bit-compatibility</GenericName>
+-			<Title>32-bit Compatibility Libraries</Title>
+-			<ArchitectureSpecific>x86_64</ArchitectureSpecific>
+-			<PossibleNames>ia32-libs</PossibleNames>
+-			<FileCheck>/usr/lib32/</FileCheck>
+-		</Package>
+ 		<Package>
+ 			<GenericName>gtk-development</GenericName>
+ 			<Title>GTK2</Title>
+diff --git a/pts-core/external-test-dependencies/xml/haiku-packages.xml b/pts-core/external-test-dependencies/xml/haiku-packages.xml
+new file mode 100644
+index 0000000..31c100f
+--- /dev/null
++++ b/pts-core/external-test-dependencies/xml/haiku-packages.xml
+@@ -0,0 +1,446 @@
++<?xml version="1.0"?>
++<PhoronixTestSuite>
++	<ExternalDependencies>
++		<Information>
++			<Name>haiku</Name>
++			<Aliases>Haiku</Aliases>
++			<PackageManager>pkgman</PackageManager>
++		</Information>
++		<Package>
++			<GenericName>gtk-development</GenericName>
++			<PackageName>gtk4_devel</PackageName>
++		</Package>
++		<Package>
++			<GenericName>sdl2-development</GenericName>
++			<PackageName>sdl2_gfx_devel sdl2_image_devel sdl2_mixer_devel sdl2_ttf_devel</PackageName>
++			<FileCheck>libSDL2_image-2.0.so.0</FileCheck>
++		</Package>
++		<Package>
++			<GenericName>sdl-development</GenericName>
++			<PackageName>libsdl_devel</PackageName>
++			<FileCheck>libSDL-1.2.so.0</FileCheck>
++		</Package>
++		<Package>
++			<GenericName>vulkan-development</GenericName>
++			<PackageName>vulkan vulkan_devel</PackageName>
++		</Package>
++		<Package>
++			<GenericName>glut</GenericName>
++			<PackageName>freeglut3-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>csh</GenericName>
++			<PackageName>csh</PackageName>
++		</Package>
++		<Package>
++			<GenericName>libpng-development</GenericName>
++			<PackageName>libpng-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>openssl-development</GenericName>
++			<PackageName>libssl-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>build-utilities</GenericName>
++			<PackageName>build-essential autoconf</PackageName>
++			</Package>
++		<Package>
++			<GenericName>cairo</GenericName>
++			<PackageName>cairo</PackageName>
++			<FileCheck>libcairo.so.2</FileCheck>
++		</Package>
++		<Package>
++			<GenericName>xorg-development</GenericName>
++			<PackageName>xorg-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>tiff</GenericName>
++			<PackageName>libtiff5-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>bison</GenericName>
++			<PackageName>bison</PackageName>
++		</Package>
++		<Package>
++			<GenericName>flex</GenericName>
++			<PackageName>flex</PackageName>
++		</Package>
++		<Package>
++			<GenericName>imlib2-development</GenericName>
++			<PackageName>libimlib2-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>java</GenericName>
++			<PackageName>openjdk24_default</PackageName>
++		</Package>
++		<Package>
++			<GenericName>maven</GenericName>
++			<PackageName>maven</PackageName>
++		</Package>
++		<Package>
++			<GenericName>portaudio-development</GenericName>
++			<PackageName>portaudio_devel</PackageName>
++		</Package>
++		<Package>
++			<GenericName>fortran-compiler</GenericName>
++			<PackageName>gcc_fortran</PackageName>
++		</Package>
++		<Package>
++			<GenericName>glew</GenericName>
++			<PackageName>libglew-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>lib3ds</GenericName>
++			<PackageName>lib3ds-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>bc</GenericName>
++			<PackageName>bc</PackageName>
++		</Package>
++		<Package>
++			<GenericName>freeimage</GenericName>
++			<PackageName>freeimage</PackageName>
++		</Package>
++		<Package>
++			<GenericName>scons</GenericName>
++			<PackageName>scons</PackageName>
++		</Package>
++		<Package>
++			<GenericName>smartmontools</GenericName>
++			<PackageName>smartmontools</PackageName>
++		</Package>
++		<Package>
++			<GenericName>zlib-development</GenericName>
++			<PackageName>zlib1g-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>jpeg-development</GenericName>
++			<PackageName>libjpeg-dev</PackageName>
++			<FileCheck>jpeglib.h</FileCheck>
++		</Package>
++		<Package>
++			<GenericName>libaio-development</GenericName>
++			<PackageName>libaio-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>libpcre</GenericName>
++			<PackageName>libpcre</PackageName>
++		</Package>
++		<Package>
++			<GenericName>perl</GenericName>
++			<PackageName>perl libsdl-perl</PackageName>
++			<FileCheck>perl</FileCheck>
++		</Package>
++		<Package>
++			<GenericName>perl-opengl</GenericName>
++			<PackageName>libopengl-perl</PackageName>
++			</Package>
++		<Package>
++			<GenericName>xorg-video</GenericName>
++			<PackageName>libxv-dev libxvmc-dev libvdpau-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>libstdcpp5</GenericName>
++			<PackageName>libstdc++5</PackageName>
++		</Package>
++		<Package>
++			<GenericName>openal-development</GenericName>
++			<PackageName>libopenal-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>vorbis-development</GenericName>
++			<PackageName>libvorbis_devel</PackageName>
++		</Package>
++		<Package>
++			<GenericName>jam</GenericName>
++			<PackageName>jam</PackageName>
++		</Package>
++		<Package>
++			<GenericName>p7zip</GenericName>
++			<PackageName>p7zip-full</PackageName>qt6_tools_devel
++		</Package>
++		<Package>
++			<GenericName>qt5-development</GenericName>
++			<PackageName>qml_box2d_qt6 qt6_declarative_devel qt6_base_devel qt6_svg_devel qttools5-dev qca_qt6_devel qtkeychain_qt6_devel pyqt5-dev pyqt6  qt6_positioning_devel</PackageName>
++			<FileCheck>qmake</FileCheck>
++		</Package>
++		<Package>
++			<GenericName>autoconf</GenericName>
++			<PackageName>autoconf</PackageName>
++		</Package>
++		<Package>
++			<GenericName>libtool</GenericName>
++			<PackageName>libtool</PackageName>
++		</Package>
++		<Package>
++			<GenericName>libevent</GenericName>
++			<PackageName>libevent</PackageName>
++			<FileCheck>libevent-2.1.so.7</FileCheck>
++		</Package>
++		<Package>
++			<GenericName>ncurses-development</GenericName>
++			<PackageName>ncurses6_devel</PackageName>
++		</Package>
++		<Package>
++			<GenericName>popt</GenericName>
++			<PackageName>popt</PackageName>
++			<FileCheck>libpopt.so.0</FileCheck>
++		</Package>
++		<Package>
++			<GenericName>numa-development</GenericName>
++			<PackageName>libnuma-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>curl</GenericName>
++			<PackageName>curl libcurl4-openssl-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>fftw3-development</GenericName>
++			<PackageName>libfftw3-dev fftw-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>blas-development</GenericName>
++			<PackageName>openblas</PackageName>
++			<FileCheck>libopenblas.so.0</FileCheck>
++			</Package>
++		<Package>
++			<GenericName>lapack</GenericName>
++			<PackageName>lapack</PackageName>
++		</Package>
++		<Package>
++			<GenericName>atlas-development</GenericName>
++			<PackageName>libatlas-base-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>openmpi-development</GenericName>
++			<PackageName>libopenmpi-dev openmpi-bin libmpich-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>cmake</GenericName>
++			<PackageName>cmake</PackageName>
++		</Package>
++		<Package>
++			<GenericName>boost1.90_devel</GenericName>
++			<PackageName>boost1.90_devel</PackageName>
++			<FileCheck>libboost_atomic.so.1.90.0</FileCheck>
++			</Package>
++		<Package>
++			<GenericName>bzip2-development</GenericName>
++			<PackageName>libbz2-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>tcl</GenericName>
++			<PackageName>tcl</PackageName>
++		</Package>
++		<Package>
++			<GenericName>glibc-development</GenericName>
++			<PackageName>libc6-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>rust</GenericName>
++			<PackageName>rust_bin</PackageName>
++		</Package>
++		<Package>
++			<GenericName>glibc-development</GenericName>
++			<PackageName>libc6-dev-i386</PackageName>
++			<ArchitectureSpecific>x86_64</ArchitectureSpecific>
++		</Package>
++		<Package>
++			<GenericName>python</GenericName>
++			<PackageName>python3.10 pip_python310</PackageName>
++			<FileCheck>python3.10/Python.h</FileCheck>
++			<VirtualSuite>TRUE</VirtualSuite>
++			</Package>
++		<Package>
++			<GenericName>python-boost-development</GenericName>
++			<PackageName>libboost</PackageName>
++		</Package>
++		<Package>
++			<GenericName>boost-thread-development</GenericName>
++			<PackageName>libboost-thread-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>python-numpy</GenericName>
++			<PackageName>numpy_python310</PackageName>
++			<FileCheck>f2py</FileCheck>
++			</Package>
++		<Package>
++			<GenericName>yasm</GenericName>
++			<PackageName>yasm nasm</PackageName>
++		</Package>
++		<Package>
++			<GenericName>nasm</GenericName>
++			<PackageName>nasm</PackageName>
++		</Package>
++		<Package>
++			<GenericName>gmp</GenericName>
++			<PackageName>gmp</PackageName>
++		</Package>
++		<Package>
++			<GenericName>subversion</GenericName>
++			<PackageName>subversion</PackageName>
++		</Package>
++		<Package>
++			<GenericName>git</GenericName>
++			<PackageName>git-core</PackageName>
++		</Package>
++		<Package>
++			<GenericName>superlu</GenericName>
++			<PackageName>superlu</PackageName>
++			<FileCheck>libsuperlu.so.5</FileCheck>
++		</Package>
++		<Package>
++			<GenericName>suitesparse</GenericName>
++			<PackageName>suitesparse</PackageName>
++		</Package>
++		<Package>
++			<GenericName>dune</GenericName>
++			<PackageName>libdune-common-dev libdune-istl-dev libdune-geometry-dev libdune-grid-dev libdune-localfunctions-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>tinyxml</GenericName>
++			<PackageName>tinyxml_devel</PackageName>
++		</Package>
++		<Package>
++			<GenericName>opencl</GenericName>
++			<PackageName>opencl_headers ocl_icd ocl_icd_devel</PackageName>
++			</Package>
++		<Package>
++			<GenericName>attr</GenericName>
++			<PackageName>attr</PackageName>
++			<FileCheck>libattr.so.1</FileCheck>
++		</Package>
++		<Package>
++			<GenericName>httpd</GenericName>
++			<PackageName>apache</PackageName>
++		</Package>
++		<Package>
++			<GenericName>meson</GenericName>
++			<PackageName>meson</PackageName>
++		</Package>
++        <Package>
++			<GenericName>golang-1.18.10-1</GenericName>
++			<PackageName>golang-1.18.10-1</PackageName>
++		</Package>
++                <Package>
++			<GenericName>steam</GenericName>
++			<PackageName>steam</PackageName>
++		</Package>
++                <Package>
++			<GenericName>redis</GenericName>
++			<PackageName>redis</PackageName>
++		</Package>
++                <Package>
++			<GenericName>opencv</GenericName>
++			<PackageName>opencv_devel</PackageName>
++		</Package>
++		<Package>
++            <GenericName>perl-digest-md5</GenericName>
++            <PackageName>libdigest-md5-file-perl libdigest-perl-md5-perl</PackageName>
++                </Package>
++		<Package>
++			<GenericName>python-scipy</GenericName>
++			<PackageName>scipy_python310 f</PackageName>
++		</Package>
++		<Package>
++			<GenericName>python-sklearn</GenericName>
++			<PackageName>python3-sklearn</PackageName>
++		</Package>
++		<Package>
++			<GenericName>V8</GenericName>
++			<PackageName>libv8-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>ruby</GenericName>
++			<PackageName>ruby</PackageName>
++		</Package>
++		<Package>
++			<GenericName>gimp</GenericName>
++			<PackageName>gimp</PackageName>
++		</Package>
++		<Package>
++			<GenericName>darktable</GenericName>
++			<PackageName>darktable</PackageName>
++		</Package>
++		<Package>
++			<GenericName>wine</GenericName>
++			<PackageName>wine</PackageName>
++		</Package>
++		<Package>
++			<GenericName>mongodb</GenericName>
++			<PackageName>mongodb</PackageName>
++		</Package>
++		<Package>
++			<GenericName>node-npm</GenericName>
++			<PackageName>npm</PackageName>
++		</Package>
++		<Package>
++			<GenericName>expat</GenericName>
++			<PackageName>expat</PackageName>
++		</Package>
++		<Package>
++			<GenericName>hdf5</GenericName>
++			<PackageName>hdf5_devel</PackageName>
++		</Package>
++		<Package>
++			<GenericName>libxml2</GenericName>
++			<PackageName>libxml2_devel</PackageName>
++		</Package>
++		<Package>
++			<GenericName>uuid</GenericName>
++			<PackageName>uuid-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>clang</GenericName>
++			<PackageName>clang</PackageName>
++		</Package>
++		<Package>
++			<GenericName>swig</GenericName>
++			<PackageName>swig</PackageName>
++		</Package>
++		<Package>
++			<GenericName>freetype</GenericName>
++			<PackageName>libfreetype6-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>gflags</GenericName>
++			<PackageName>gflags_devel</PackageName>
++		</Package>
++		<Package>
++			<GenericName>benchmark</GenericName>
++			<PackageName>benchmark</PackageName>
++		</Package>
++		<Package>
++			<GenericName>snappy</GenericName>
++			<PackageName>snappy_devel</PackageName>
++		</Package>
++		<Package>
++			<GenericName>vaapi</GenericName>
++			<PackageName>libva-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>openexr</GenericName>
++			<PackageName>openexr3.2_devel</PackageName>
++		</Package>
++		<Package>
++			<GenericName>glfw</GenericName>
++			<PackageName>glfw</PackageName>
++		</Package>
++		<Package>
++			<GenericName>protobuf</GenericName>
++			<PackageName>protobuf_devel</PackageName>
++		</Package>
++		<Package>
++			<GenericName>eigen</GenericName>
++			<PackageName>libeigen3-dev</PackageName>
++		</Package>
++		<Package>
++			<GenericName>erlang</GenericName>
++			<PackageName>erlang</PackageName>
++		</Package>
++		<Package>
++			<GenericName>libconfig</GenericName>
++			<PackageName>libconfig</PackageName>
++		</Package>
++	</ExternalDependencies>
++</PhoronixTestSuite>
+-- 
+2.52.0
+
 

--- a/app-benchmarks/pts/pts-10.8.4.patchset
+++ b/app-benchmarks/pts/pts-10.8.4.patchset
@@ -191,8 +191,8 @@ index a6efef8..0e4de52 100644
  	{
 +		if(phodevi::is_haiku())
 +		{
-+		$resolution=shell_exec('screenmode | cut -c 13-16,18-22 -O x');
-+		return $resolution;
++			$resolution=shell_exec('screenmode | cut -c 13-16,18-22 -O x');
++			return $resolution;
 +		}
 +		
  		// Return the current screen resolution

--- a/app-benchmarks/pts/pts-10.8.4.patchset
+++ b/app-benchmarks/pts/pts-10.8.4.patchset
@@ -731,7 +731,7 @@ index 0000000..31c100f
 +		</Package>
 +		<Package>
 +			<GenericName>uuid</GenericName>
-+			<PackageName>uuid-dev</PackageName>
++			<PackageName>libuuid_devel</PackageName>
 +		</Package>
 +		<Package>
 +			<GenericName>clang</GenericName>

--- a/app-benchmarks/pts/pts-10.8.4.patchset
+++ b/app-benchmarks/pts/pts-10.8.4.patchset
@@ -368,8 +368,8 @@ index 0000000..31c100f
 +			<PackageName>vulkan vulkan_devel</PackageName>
 +		</Package>
 +		<Package>
-+			<GenericName>glut</GenericName>
-+			<PackageName>freeglut3-dev</PackageName>
++			<GenericName>glu</GenericName>
++			<PackageName>glut_devel</PackageName>
 +		</Package>
 +		<Package>
 +			<GenericName>csh</GenericName>
@@ -488,7 +488,7 @@ index 0000000..31c100f
 +		</Package>
 +		<Package>
 +			<GenericName>openal-development</GenericName>
-+			<PackageName>libopenal-dev</PackageName>
++			<PackageName>openal_devel</PackageName>
 +		</Package>
 +		<Package>
 +			<GenericName>vorbis-development</GenericName>
@@ -569,7 +569,7 @@ index 0000000..31c100f
 +			</Package>
 +		<Package>
 +			<GenericName>bzip2-development</GenericName>
-+			<PackageName>libbz2-dev</PackageName>
++			<PackageName>bzip2_devel</PackageName>
 +		</Package>
 +		<Package>
 +			<GenericName>tcl</GenericName>
@@ -743,7 +743,7 @@ index 0000000..31c100f
 +		</Package>
 +		<Package>
 +			<GenericName>freetype</GenericName>
-+			<PackageName>libfreetype6-dev</PackageName>
++			<PackageName>freetype_devel</PackageName>
 +		</Package>
 +		<Package>
 +			<GenericName>gflags</GenericName>
@@ -775,7 +775,7 @@ index 0000000..31c100f
 +		</Package>
 +		<Package>
 +			<GenericName>eigen</GenericName>
-+			<PackageName>libeigen3-dev</PackageName>
++			<PackageName>eigen3</PackageName>
 +		</Package>
 +		<Package>
 +			<GenericName>erlang</GenericName>

--- a/app-benchmarks/pts/pts-10.8.4.recipe
+++ b/app-benchmarks/pts/pts-10.8.4.recipe
@@ -1,0 +1,44 @@
+SUMMARY="The Phoronix Test Suite testing and benchmarking platform"
+DESCRIPTION="
+The Phoronix Test Suite is the most comprehensive testing and benchmarking platform available for Linux,\
+Solaris, macOS,Windows, and BSD operating systems. The Phoronix Test Suite allows for carrying out      \
+tests in a fully automated manner from test installation to execution and reporting. All tests are meant\
+to be easily reproducible, easy-to-use, and support fully automated execution. The Phoronix Test Suite  \
+is open-source under the GNU GPLv3 license and is developed by Phoronix Media in cooperation with partners."
+HOMEPAGE="https://www.phoronix-test-suite.com/"
+COPYRIGHT=" Phoronix Media 2026"
+LICENSE="GNU GPL v3"
+REVISION="1"
+SOURCE_URI="https://github.com/phoronix-test-suite/phoronix-test-suite/archive/refs/tags/v$portVersion.tar.gz"
+CHECKSUM_SHA256="7b5da7193c0190c648fc0c7ad6cdfbde5d935e88c7bfa5e99cd3a720cd5e2c5a"
+SOURCE_DIR="phoronix-test-suite-$portVersion"
+PATCHES="pts-$portVersion.patchset"
+ADDITIONAL_FILES="
+	pts_launcher.sh
+	"
+
+ARCHITECTURES="any"
+
+PROVIDES="
+	pts = $portVersion
+	cmd:pts_launcher.sh
+	"
+REQUIRES="
+	cmd:php
+	"
+
+INSTALL()
+{
+	# Pack data
+	mkdir -p $dataDir/pts && cp -r $sourceDir/pts-core/ $dataDir/pts 
+
+	# Pack docs
+	mkdir -p $docDir/ && cp $sourceDir/*.* $docDir/
+
+	# Pack script
+	mkdir -p $prefix/bin && cp $portDir/additional-files/pts_launcher.sh $prefix/bin
+	chmod +x $prefix/bin/pts_launcher.sh 
+	
+	# Link script
+	addAppDeskbarSymlink $prefix/bin/pts_launcher.sh "Phoronix Test Suite (interactive mode)"
+}

--- a/app-benchmarks/pts/pts-10.8.4.recipe
+++ b/app-benchmarks/pts/pts-10.8.4.recipe
@@ -1,12 +1,10 @@
 SUMMARY="The Phoronix Test Suite testing and benchmarking platform"
-DESCRIPTION="
-The Phoronix Test Suite is the most comprehensive testing and benchmarking platform available for Linux, \
-Solaris, macOS,Windows, and BSD operating systems. The Phoronix Test Suite allows for carrying out       \
-tests in a fully automated manner from test installation to execution and reporting. All tests are meant \
-to be easily reproducible, easy-to-use, and support fully automated execution. The Phoronix Test Suite   \
-is open-source under the GNU GPLv3 license and is \
+DESCRIPTION="The Phoronix Test Suite is the most comprehensive testing and benchmarking platform \
+available for Linux, Solaris, macOS, Windows, and BSD operating systems. The Phoronix Test Suite \
+allows for carrying out tests in a fully automated manner from test installation to execution and \
+reporting. All tests are meant to be easily reproducible, easy-to-use, and support fully \
+automated execution. The Phoronix Test Suite is open-source under the GNU GPLv3 license and is \
 developed by Phoronix Media in cooperation with partners."
-HOMEPAGE="https://www.phoronix-test-suite.com/"
 COPYRIGHT=" Phoronix Media 2026"
 LICENSE="GNU GPL v3"
 REVISION="1"

--- a/app-benchmarks/pts/pts-10.8.4.recipe
+++ b/app-benchmarks/pts/pts-10.8.4.recipe
@@ -4,7 +4,8 @@ The Phoronix Test Suite is the most comprehensive testing and benchmarking platf
 Solaris, macOS,Windows, and BSD operating systems. The Phoronix Test Suite allows for carrying out       \
 tests in a fully automated manner from test installation to execution and reporting. All tests are meant \
 to be easily reproducible, easy-to-use, and support fully automated execution. The Phoronix Test Suite   \
-is open-source under the GNU GPLv3 license and is developed by Phoronix Media in cooperation with partners."
+is open-source under the GNU GPLv3 license and is \
+developed by Phoronix Media in cooperation with partners."
 HOMEPAGE="https://www.phoronix-test-suite.com/"
 COPYRIGHT=" Phoronix Media 2026"
 LICENSE="GNU GPL v3"
@@ -30,14 +31,14 @@ REQUIRES="
 INSTALL()
 {
 	# Pack data
-	mkdir -p $dataDir/pts && cp -r $sourceDir/pts-core/ $dataDir/pts 
+	mkdir -p $dataDir/pts && cp -r $sourceDir/pts-core/ $dataDir/pts
 
 	# Pack docs
 	mkdir -p $docDir/ && cp $sourceDir/*.* $docDir/
 
 	# Pack script
 	mkdir -p $prefix/bin && cp $portDir/additional-files/pts_launcher.sh $prefix/bin
-	chmod +x $prefix/bin/pts_launcher.sh 
+	chmod +x $prefix/bin/pts_launcher.sh
 	
 	# Link script
 	addAppDeskbarSymlink $prefix/bin/pts_launcher.sh "Phoronix Test Suite (interactive mode)"

--- a/app-benchmarks/pts/pts-10.8.4.recipe
+++ b/app-benchmarks/pts/pts-10.8.4.recipe
@@ -1,9 +1,9 @@
 SUMMARY="The Phoronix Test Suite testing and benchmarking platform"
 DESCRIPTION="
-The Phoronix Test Suite is the most comprehensive testing and benchmarking platform available for Linux,\
-Solaris, macOS,Windows, and BSD operating systems. The Phoronix Test Suite allows for carrying out      \
-tests in a fully automated manner from test installation to execution and reporting. All tests are meant\
-to be easily reproducible, easy-to-use, and support fully automated execution. The Phoronix Test Suite  \
+The Phoronix Test Suite is the most comprehensive testing and benchmarking platform available for Linux, \
+Solaris, macOS,Windows, and BSD operating systems. The Phoronix Test Suite allows for carrying out       \
+tests in a fully automated manner from test installation to execution and reporting. All tests are meant \
+to be easily reproducible, easy-to-use, and support fully automated execution. The Phoronix Test Suite   \
 is open-source under the GNU GPLv3 license and is developed by Phoronix Media in cooperation with partners."
 HOMEPAGE="https://www.phoronix-test-suite.com/"
 COPYRIGHT=" Phoronix Media 2026"

--- a/app-benchmarks/pts/pts-10.8.4.recipe
+++ b/app-benchmarks/pts/pts-10.8.4.recipe
@@ -5,6 +5,7 @@ allows for carrying out tests in a fully automated manner from test installation
 reporting. All tests are meant to be easily reproducible, easy-to-use, and support fully \
 automated execution. The Phoronix Test Suite is open-source under the GNU GPLv3 license and is \
 developed by Phoronix Media in cooperation with partners."
+HOMEPAGE="https://www.phoronix-test-suite.com/"
 COPYRIGHT=" Phoronix Media 2026"
 LICENSE="GNU GPL v3"
 REVISION="1"

--- a/app-benchmarks/pts/pts-10.8.4.recipe
+++ b/app-benchmarks/pts/pts-10.8.4.recipe
@@ -39,7 +39,7 @@ INSTALL()
 	# Pack script
 	mkdir -p $prefix/bin && cp $portDir/additional-files/pts_launcher.sh $prefix/bin
 	chmod +x $prefix/bin/pts_launcher.sh
-	
+
 	# Link script
 	addAppDeskbarSymlink $prefix/bin/pts_launcher.sh "Phoronix Test Suite (interactive mode)"
 }


### PR DESCRIPTION
Phoronix Test Suite is a php benchmark suite for Linux,MacOS,Windows and BSD that can be ported to Haiku.
It has two basic modes of operation for the user: run an individual test (currently 536 are available) or run a collection of tests.
When a user selects a test a brief hardware detection takes place and external dependencies are checked and downloaded usign pkgman.After downloading a detection of the dependency is repeated.
Not all possible dependencies can be met on Haiku resulting failing tests.
A brief list of unmet dependencies is made by me using pkgman search for reference  :
Apache Maven
AutoDesk 3DS
Boost Thread Development
CSH
Distributed and Unified Numerics Environment
Eigen
Erlang
FreeImage
GLFW
GNU C Library
GNU Standard C++ Library v3
GTK2
Imlib2
Linear Algebra Pack
Linux AIO
MongoDB
NUMA
OpenGL Utility Kit (GLUT)
OpenMPI
PERL OpenGL
Perl Interface to the MD5 Algorithm
Python Boost
Python Scipy
Python Sklearn
Ruby
SMART Monitoring Tools
Steam
Subversion
SuiteSparse
V8 JavaScript Engine
VA-API Video Acceleration API
Xv and XvMC
httpd
Assuming that dependecies are detected or downloaded ,installation needed files are downloaded next.
There are two scenarios here:
a)Test downloads source code and does a compilation or execution of some sort (make,cmake,meson,ninja,java etc) given in an installation script.
These tests tend to work ok in Haiku depending on the category of the test (Display tests are more difficult to succeed than CPU,memory,disk,Network).
b)Test downloads a premade Linux executable and tries to run it resulting a failing test.

A rough estimation is that 1/3 of the tests should be able to run but having feedback for more people using the suite will be useful and also improve the port.
