### PR TITLE
apr: update to version 1.7.6.

### DIFF
--- a/dev-libs/apr/apr-1.7.6.recipe
+++ b/dev-libs/apr/apr-1.7.6.recipe
@@ -22,17 +22,17 @@ following:
 - thread and process management
 - various data structures (tables, hashes, priority queues, etc.)"
 HOMEPAGE="http://apr.apache.org/"
-COPYRIGHT="2012 The Apache Software Foundation"
+COPYRIGHT="2025 The Apache Software Foundation"
 LICENSE="Apache v2"
 REVISION="1"
-SOURCE_URI="http://archive.apache.org/dist/apr/apr-$portVersion.tar.gz"
-CHECKSUM_SHA256="3375fa365d67bcf945e52b52cba07abea57ef530f40b281ffbe977a9251361db"
+SOURCE_URI="http://archive.apache.org/dist/apr/apr-$portVersion.tar.bz2"
+CHECKSUM_SHA256="49030d92d2575da735791b496dc322f3ce5cff9494779ba8cc28c7f46c5deb32"
 PATCHES="apr-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
-libVersion="0.7.5"
+libVersion="0.7.6"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="

--- a/dev-libs/apr/patches/apr-1.7.6.patchset
+++ b/dev-libs/apr/patches/apr-1.7.6.patchset
@@ -1,4 +1,4 @@
-From df0446b83d56d131d757d385515aec231f0d1ba7 Mon Sep 17 00:00:00 2001
+From 693ec8a2e7631a213040c4fa5aa692a581a30e17 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sat, 15 Jul 2017 13:50:02 +0200
 Subject: apply 1.5.2 patch.
@@ -48,10 +48,10 @@ index b0457e2..d22a48f 100644
        AC_CHECK_LIB(truerand, main)
        AC_SEARCH_LIBS(modf, m)
 -- 
-2.45.2
+2.52.0
 
 
-From ba67b73a165228d4f5b5f182ba56b5042ee5ca79 Mon Sep 17 00:00:00 2001
+From 4892ad984cb67df2121179262061c9fa6b65db4f Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Mon, 25 Apr 2022 21:18:48 +0200
 Subject: Haiku: decide to use standard POSIX methods
@@ -84,10 +84,10 @@ index d22a48f..f74ecd9 100644
  AC_DEFINE_UNQUOTED($ac_decision)
  
 -- 
-2.45.2
+2.52.0
 
 
-From 20af3a6d0b0755cd57332290193ff8ac60080dd4 Mon Sep 17 00:00:00 2001
+From 6f50d4b5f39739e5a63346f89f2e2f2268948346 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Tue, 26 Apr 2022 14:42:58 +0200
 Subject: fix checking if fcntl returns EACCES when F_SETLK is already held
@@ -112,10 +112,10 @@ index f74ecd9..71fbea7 100644
  
  int lockit() {
 -- 
-2.45.2
+2.52.0
 
 
-From 057c23002e572f951e5877a5d2cad9e32605f452 Mon Sep 17 00:00:00 2001
+From da3a22b0edce708c412a3a54accf48ed82d2c2a7 Mon Sep 17 00:00:00 2001
 From: PulkoMandy <pulkomandy@pulkomandy.tk>
 Date: Sun, 15 Sep 2024 10:46:58 +0200
 Subject: Fix named shared memory
@@ -139,5 +139,5 @@ index 71fbea7..20944d6 100644
          # AIX cannot lseek() shared memory, and we always truncate/lseek together
          APR_DECISION_OVERRIDE(USE_SHMEM_SHMGET)
 -- 
-2.45.2
+2.52.0
 


### PR DESCRIPTION
Build and run `hp apr --test` on x86_64 hrev59712.

Smoke tested by installing apr-1.7.6, and running some basic `svn` version 1.14.5 commands on a subversion repo I had lying around still.

Related: #14120