### PR TITLE
qt_creator, disable 32bit for 19.0.2

### DIFF
--- a/dev-qt/qt_creator/qt_creator-19.0.2.recipe
+++ b/dev-qt/qt_creator/qt_creator-19.0.2.recipe
@@ -14,7 +14,7 @@ PATCHES="qt_creator-$portVersion.patchset"
 ADDITIONAL_FILES="qt_creator.rdef.in"
 
 ARCHITECTURES="ALL !x86_gcc2"
-SECONDARY_ARCHITECTURES="x86"
+SECONDARY_ARCHITECTURES="!x86" # requires LLVM21!
 
 if [ "$targetArchitecture" = x86_gcc2 ]; then
 clangVer="18"


### PR DESCRIPTION
requires LLVM21, while 32bit is stuck on building for LLVM18