### PR TITLE
Add recipe for swig-4.4.1

### DIFF
--- a/dev-lang/swig/patches/swig-4.4.1.patchset
+++ b/dev-lang/swig/patches/swig-4.4.1.patchset
@@ -1,0 +1,22 @@
+From ca631497d514862779ef0f921651ac7bd8fd2251 Mon Sep 17 00:00:00 2001
+From: Luc Schrijvers <begasus@gmail.com>
+Date: Sun, 17 May 2026 17:02:07 +0200
+Subject: Don't use hard links, not supported on Haiku
+
+
+diff --git a/CCache/test.sh b/CCache/test.sh
+index 3c44e85..a3bf0fa 100755
+--- a/CCache/test.sh
++++ b/CCache/test.sh
+@@ -137,7 +137,7 @@ basetests() {
+     checkstat 'bad compiler arguments' 1
+ 
+     testname="c/c++"
+-    ln -f test1.c test1.ccc
++    ln -s test1.c test1.ccc
+     $CCACHE_COMPILE -c test1.ccc 2> /dev/null
+     checkstat 'not a C/C++ file' 1
+ 
+-- 
+2.52.0
+

--- a/dev-lang/swig/swig-4.4.1.recipe
+++ b/dev-lang/swig/swig-4.4.1.recipe
@@ -18,11 +18,13 @@ HOMEPAGE="http://www.swig.org/"
 COPYRIGHT="1995-1998 University of Utah and the Regents of the University of California
 		1998-2005 University of Chicago
 		2005-2006 Arizona Board of Regents (University of Arizona)
-		1995-2020 The SWIG Developers"
+		1995-2026 The SWIG Developers"
 LICENSE="SWIG"
-REVISION="2"
-SOURCE_URI="http://sourceforge.net/projects/swig/files/swig/swig-$portVersion/swig-$portVersion.tar.gz"
-CHECKSUM_SHA256="d53be9730d8d58a16bf0cbd1f8ac0c0c3e1090573168bfa151b01eb47fa906fc"
+REVISION="1"
+SOURCE_URI="https://github.com/swig/swig/archive/refs/tags/v$portVersion.tar.gz"
+SOURCE_DIR="swig-$portVersion"
+CHECKSUM_SHA256="8bf32042beb7ee1eeb5c71aa15a62513d964893f84234f2cd77e4a8e2ed41e87"
+PATCHES="swig-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -34,18 +36,20 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libpcre$secondaryArchSuffix
+	lib:libpcre2_8$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libpcre$secondaryArchSuffix
+	devel:libpcre2_8$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
+	cmd:autoconf
+	cmd:automake
 	cmd:awk
-	cmd:bison
+	cmd:bison$secondaryArchSuffix
 	cmd:g++$secondaryArchSuffix
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
@@ -56,6 +60,7 @@ BUILD_PREREQUIRES="
 BUILD()
 {
 	export LDFLAGS="-lnetwork"
+	./autogen.sh
 	runConfigure --omit-dirs binDir ./configure \
 		--bindir=$prefix/bin
 	make $jobArgs
@@ -68,5 +73,5 @@ INSTALL()
 
 TEST()
 {
-	make check
+	make VERBOSE=1 check
 }


### PR DESCRIPTION
This PR adds a recipe for Swig-4.4  - the current version of the upstream project.  

I needed this version of SWIG as it provides the ability to wrap a C++ library and output a C binding (which can then be wrapped by languages with FFI capabilities, such as Chez scheme) .  This is an approach I'm assessing as an alternative to hand writing bindings for libbe.so  

In any case, the update is significant over the currently provided version (4.0.2).  I don't know if it's the "done thing" to keep the older recipe, so I didn't remove it in this PR.    