### PR TITLE
haikubench: new recipe for v1.1.0

### DIFF
--- a/app-benchmarks/haikubench/haikubench-1.1.0.recipe
+++ b/app-benchmarks/haikubench/haikubench-1.1.0.recipe
@@ -1,0 +1,63 @@
+SUMMARY="System benchmark suite for Haiku"
+DESCRIPTION="HaikuBench is a comprehensive system benchmark suite for Haiku OS. \
+It measures CPU (integer, float, multi-thread), memory (sequential read/write, \
+copy, latency), cache (L1/L2/L3), kernel primitives (semaphores, threads, ports, \
+areas, atomic ops), messaging (BMessage, BLooper), and graphics performance \
+(2D app_server drawing, OpenGL 3D, Vulkan compute).
+
+Features:
+* 20 system benchmark tests with adaptive sampling and statistical analysis
+* 24-test 2D benchmark from basic fills to software 3D teapot rendering
+* 2D hardware acceleration detection via accelerant driver identification
+* OpenGL GPU benchmark (fill rate, geometry, textures, blending, stencil)
+* Vulkan compute benchmark (optional, works with lavapipe or native drivers)
+* OpenGL teapot stress test with configurable teapot count
+* Real-time CPU/GPU temperature monitoring
+* Export results to Markdown and JSON"
+HOMEPAGE="https://github.com/atomozero/HaikuBench"
+COPYRIGHT="2025 Andrea Bernardi"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://github.com/atomozero/HaikuBench/archive/v$portVersion.tar.gz"
+CHECKSUM_SHA256="de472772cee2137ea8e94101553ea62bf2f11d1b59e892963765b1f10ceb0bc3"
+SOURCE_DIR="HaikuBench-$portVersion"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	haikubench$secondaryArchSuffix = $portVersion
+	app:HaikuBench = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libGL$secondaryArchSuffix
+	lib:libGLU$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libGL$secondaryArchSuffix
+	devel:libGLU$secondaryArchSuffix
+	vulkan_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:g++$secondaryArchSuffix
+	cmd:make
+	cmd:rc
+	"
+
+BUILD()
+{
+	make $jobArgs
+	rc -o HaikuBench.rsrc HaikuBench.rdef
+}
+
+INSTALL()
+{
+	mkdir -p $appsDir
+	cp HaikuBench $appsDir/HaikuBench
+
+	xres -o $appsDir/HaikuBench HaikuBench.rsrc
+	addAppDeskbarSymlink $appsDir/HaikuBench
+}


### PR DESCRIPTION
## Summary

New recipe for **HaikuBench**, a system benchmark suite for Haiku OS.

**Category:** `app-benchmarks/haikubench`

### What HaikuBench measures

- **CPU** — integer, float, multi-thread scaling (20 tests with adaptive sampling)
- **Memory** — sequential read/write, copy, pointer-chasing latency
- **Cache** — L1/L2/L3 bandwidth
- **Kernel** — semaphores, threads, ports, areas, atomic ops, syscall overhead
- **Messaging** — BMessage flatten/unflatten, BLooper ping-pong
- **2D Graphics** — 24 BView rendering tests across 6 difficulty levels, plus hardware acceleration detection via `BScreen::GetDeviceInfo()` and `ioctl B_GET_ACCELERANT_SIGNATURE`
- **OpenGL** — 6 GPU tests (fill rate, geometry, textures, blending, stencil, combined)
- **Vulkan** — compute shader, memory bandwidth, buffer ops (optional, loaded dynamically)

Results are exported to Markdown and JSON with statistical analysis (mean, stddev, p50, p95, CoV).

### Build dependencies

- `haiku_devel`, `mesa (devel:libGL)`, `glu (devel:libGLU)`
- `vulkan_devel` (build-time only, Vulkan is optional at runtime)

### Tested on

- Haiku x86_64, hrev59722 (R1/beta5+development)
- Intel Core i3 M 370, Intel HD Graphics (IronLake)

### Homepage

https://github.com/atomozero/HaikuBench