### PR TITLE
pippo: add recipe for 0.1.0~git

### DIFF
--- a/haiku-apps/pippo/patches/pippo-0.1.0~git.patchset
+++ b/haiku-apps/pippo/patches/pippo-0.1.0~git.patchset
@@ -1,0 +1,52 @@
+From ac256841988a0af9c639fa6dd4c5949121d28daf Mon Sep 17 00:00:00 2001
+From: atomozero <atomozero@users.noreply.github.com>
+Date: Tue, 19 May 2026 16:59:43 +0200
+Subject: [PATCH] Adapt paths for HPKG packaging
+
+- LaunchDaemon: use /system/apps/ path instead of non-packaged
+- PippoApp: add B_SYSTEM_DATA_DIRECTORY as third dataset search path
+---
+ data/launch/pippo      | 2 +-
+ src/pippo/PippoApp.cpp | 8 ++++++++
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/data/launch/pippo b/data/launch/pippo
+index bfbe02a..b323913 100644
+--- a/data/launch/pippo
++++ b/data/launch/pippo
+@@ -1,5 +1,5 @@
+ service x-vnd.Hay-Pippo {
+-	launch /system/non-packaged/apps/Pippo
++	launch /system/apps/Pippo
+ 	port pippo_mcp_port {
+ 		capacity 100
+ 	}
+diff --git a/src/pippo/PippoApp.cpp b/src/pippo/PippoApp.cpp
+index ed5134a..92c85d4 100644
+--- a/src/pippo/PippoApp.cpp
++++ b/src/pippo/PippoApp.cpp
+@@ -113,6 +113,7 @@ PippoApp::ReadyToRun()
+ 
+ 	// Load Haiku BeAPI documentation dataset
+ 	// Search order: 1) settings/pippo/dataset.jsonl  2) app directory
++	//               3) system data directory (HPKG install)
+ 	BPath docsPath;
+ 	find_directory(B_USER_SETTINGS_DIRECTORY, &docsPath);
+ 	docsPath.Append(kSettingsDir);
+@@ -129,6 +130,13 @@ PippoApp::ReadyToRun()
+ 		appPath.Append("data/dataset.jsonl");
+ 		docsErr = fDispatcher->LoadDocs(appPath.Path());
+ 	}
++	if (docsErr != B_OK) {
++		// Try system data directory (for HPKG installs)
++		BPath sysDataPath;
++		find_directory(B_SYSTEM_DATA_DIRECTORY, &sysDataPath);
++		sysDataPath.Append("pippo/dataset.jsonl");
++		docsErr = fDispatcher->LoadDocs(sysDataPath.Path());
++	}
+ 	if (docsErr != B_OK)
+ 		fprintf(stderr, "PippoApp: dataset.jsonl not found, "
+ 			"haiku_docs tool will return empty results\n");
+-- 
+2.52.0
+

--- a/haiku-apps/pippo/pippo-0.1.0~git.recipe
+++ b/haiku-apps/pippo/pippo-0.1.0~git.recipe
@@ -41,8 +41,6 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
-	cmd:rc
-	cmd:xres
 	"
 
 BUILD()

--- a/haiku-apps/pippo/pippo-0.1.0~git.recipe
+++ b/haiku-apps/pippo/pippo-0.1.0~git.recipe
@@ -1,0 +1,76 @@
+SUMMARY="Native MCP server for Haiku OS"
+DESCRIPTION="Pippo is a native MCP (Model Context Protocol) server for \
+Haiku OS that exposes the operating system's unique capabilities as tools \
+invocable by LLM clients over HTTP+SSE on localhost:2607.
+
+It lets LLM clients control Haiku applications via scripting, manipulate \
+BeFS extended attributes, run filesystem queries (including live queries), \
+inject synthetic input events, manage the clipboard, and search BeAPI \
+documentation — all through native Haiku APIs.
+
+Components:
+* Pippo — main MCP server (BApplication with embedded HTTP server)
+* hay_input — input_server device add-on for synthetic mouse/keyboard events
+* PippoReplicant — Deskbar replicant showing live stats and status"
+HOMEPAGE="https://codeberg.org/atomozero/Pippo"
+COPYRIGHT="2026 Andrea Bernardi"
+LICENSE="MIT"
+REVISION="1"
+srcGitRev="bfccdec5cd2b898195c3071bc9f1cec7a8cf5acb"
+SOURCE_URI="https://codeberg.org/atomozero/Pippo/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="1842c1ab7b12b5218d254b2afd3dfc2b7917bacee3998ab1269c603e5fbf6da3"
+SOURCE_FILENAME="Pippo-$portVersion-$srcGitRev.tar.gz"
+SOURCE_DIR="pippo"
+PATCHES="pippo-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+PROVIDES="
+	pippo$secondaryArchSuffix = $portVersion
+	app:Pippo = $portVersion
+	add_on:hay_input = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:rc
+	cmd:xres
+	"
+
+BUILD()
+{
+	make $jobArgs
+}
+
+INSTALL()
+{
+	# Main server binary
+	mkdir -p $appsDir
+	cp Pippo $appsDir/Pippo
+
+	# input_server device add-on
+	mkdir -p $addOnsDir/input_server/devices
+	cp hay_input $addOnsDir/input_server/devices/hay_input
+
+	# Deskbar replicant shared library
+	mkdir -p $addOnsDir/Tracker
+	cp PippoReplicant $addOnsDir/Tracker/PippoReplicant
+
+	# BeAPI documentation dataset
+	mkdir -p $dataDir/pippo
+	cp data/dataset.jsonl $dataDir/pippo/dataset.jsonl
+
+	# LaunchDaemon configuration
+	mkdir -p $dataDir/launch
+	cp data/launch/pippo $dataDir/launch/pippo
+
+	addAppDeskbarSymlink $appsDir/Pippo
+}


### PR DESCRIPTION
New recipe for Pippo, a native MCP (Model Context Protocol) server for Haiku OS.

Exposes Haiku's unique capabilities (app scripting, BeFS attributes, filesystem queries, input injection, clipboard) as tools callable over HTTP+SSE.

Includes:
- Main server binary
- input_server device add-on (hay_input)
- Deskbar replicant with live stats
- BeAPI documentation dataset
- LaunchDaemon configuration
- Patchset to adapt paths for HPKG packaging

Build tested manually on x86_64.