### PR TITLE
flit_core: update to version 3.12.0. Add '_python3.14' package.

### DIFF
--- a/dev-python/flit-core/flit_core-3.12.0.recipe
+++ b/dev-python/flit-core/flit_core-3.12.0.recipe
@@ -4,9 +4,9 @@ The only public interface is the API specified by PEP 517, at ``flit_core.builda
 HOMEPAGE="https://pypi.org/project/flit_core/"
 COPYRIGHT="2015 Thomas Kluyver and contributors"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/f/flit-core/flit_core-$portVersion.tar.gz"
-CHECKSUM_SHA256="72ad266176c4a3fcfab5f2930d76896059851240570ce9a98733b658cb786eba"
+CHECKSUM_SHA256="18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2"
 
 ARCHITECTURES="any"
 
@@ -21,14 +21,28 @@ BUILD_REQUIRES="
 	haiku_devel
 	"
 
-PYTHON_VERSIONS=(3.10)
+PYTHON_VERSIONS=(3.10 3.14)
 
 for pythonVersion in ${PYTHON_VERSIONS[@]}; do
 	pythonPackage=python${pythonVersion//.}
 
-	eval "PROVIDES_$pythonPackage=\"
+	# Not renaming 3.10 packages to avoid needing massive packages rebuilds.
+	# No need for REPLACES then. ToDo: remove the conditional after dropping 3.10.
+	if [ $pythonVersion != 3.10 ]; then
+		# Allows using dot in sub-package names (eg: "_python3.14" vs "_python314"):
+		eval "PACKAGE_NAME_$pythonPackage=${portBaseName}_python$pythonVersion"
+
+		# We provide both dotted and dotless suffixes to avoid having to do add conditionals
+		# in BUILD_REQUIRES/REQUIRES (of other current recipes that expect dotless names).
+		eval "PROVIDES_$pythonPackage=\"
+			${portName}_python$pythonVersion = $portVersion
+			\""
+	fi
+
+	eval "PROVIDES_$pythonPackage+=\"
 		${portName}_$pythonPackage = $portVersion
 		\""
+
 	eval "REQUIRES_$pythonPackage=\"
 		haiku
 		cmd:python$pythonVersion


### PR DESCRIPTION
This is the first one on the following "dependency chain":

```
flit-core
	installer
		packaging
		pyproject_hooks
		tomli_python310
			build
				setuptools (once switched to build+installer)
		wheel
```

So ideally, PRs for these should be merged in "from left to right" order.

This marks the introduction of Python 3.14 package support (`<package_name>_python3.14`), with hopes what we can, sooner than later, switch the "default Python" on Haiku to 3.14.

FWIW, I have been running Python 3.14 as `/bin/python3` for quite a while now, with both HaikuPorter and Haiku builds working without issues, so far at least.