### PR TITLE
linux: publish haiku packaging for 7.0

### DIFF
--- a/net-p2p/wireshare/wireshare-7.0.recipe
+++ b/net-p2p/wireshare/wireshare-7.0.recipe
@@ -1,0 +1,50 @@
+SUMMARY="Peer-to-peer sharing for Gnutella, BitTorrent, magnet, and eD2k"
+DESCRIPTION="WireShare is a desktop peer-to-peer client for Gnutella, BitTorrent, magnet, and eD2k links."
+HOMEPAGE="https://github.com/nmatavka/hermes-wireshare"
+COPYRIGHT="2026 Hermes"
+LICENSE="GPL v3"
+REVISION="1"
+SOURCE_URI="https://github.com/nmatavka/hermes-wireshare/releases/download/release/7.0/WireShare-7.0-source.tar.gz"
+CHECKSUM_SHA256="a72fc74114335f4694de436371eac33e765d782b03bdd91aff57c1ff187ccbf3"
+SOURCE_DIR="hermes-wireshare-$portVersion"
+
+ARCHITECTURES="x86_64"
+
+PROVIDES="
+	wireshare = $portVersion
+	cmd:WireShare = $portVersion
+	"
+REQUIRES="
+	haiku
+	java:environment >= 21
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	java:environment >= 21
+	"
+BUILD_PREREQUIRES="
+	cmd:bash
+	cmd:find
+	cmd:gradle
+	cmd:java
+	cmd:sed
+	cmd:unzip
+	"
+
+BUILD()
+{
+	./gradlew --no-daemon wireShareJar
+}
+
+INSTALL()
+{
+	mkdir -p $binDir $dataDir/wireshare
+	cp WireShare.jar $dataDir/wireshare/WireShare.jar
+
+	cat > $binDir/WireShare <<EOF
+#!/bin/sh
+exec java -jar $dataDir/wireshare/WireShare.jar "\$@"
+EOF
+	chmod +x $binDir/WireShare
+}


### PR DESCRIPTION
Prepared by the local WireShare Linux rollout orchestrator.

- Target: `haiku`
- Unit: `haiku`
- Submission mode: `github_pr`