### PR TITLE
vcs_versioning: new recipe. Required by 'setuptools_scm' >= v10.0.0.

### DIFF
--- a/dev-python/vcs-versioning/vcs_versioning-1.1.1.recipe
+++ b/dev-python/vcs-versioning/vcs_versioning-1.1.1.recipe
@@ -1,0 +1,91 @@
+SUMMARY="The blessed (Python) package to manage your versions by vcs metadata"
+DESCRIPTION="Core VCS versioning functionality extracted as a standalone library that can be used \
+independently of setuptools.
+
+(This package is a runtime dependency for the 'setuptools_scm' Python module, since v10.0.0)"
+HOMEPAGE="https://github.com/pypa/setuptools_scm"
+COPYRIGHT="2023-present Ronny Pfannschmidt"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://files.pythonhosted.org/packages/py3/${portName:0:1}/$portName/$portName-$portVersion-py3-none-any.whl#noarchive"
+CHECKSUM_SHA256="b541e2ba79fc6aaa3850f8a7f88af43d97c1c80649c01142ee4146eddbc599e4"
+
+ARCHITECTURES="any"
+
+PROVIDES="
+	$portName = $portVersion
+	"
+REQUIRES="
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+
+PYTHON_VERSIONS=(3.10 3.14)
+defaultVersion=3.10
+
+for pythonVersion in ${PYTHON_VERSIONS[@]}; do
+	pythonPackage=python${pythonVersion//.}
+
+	# Allows using dot in sub-package names (eg: "_python3.14" vs "_python314"):
+	eval "PACKAGE_NAME_$pythonPackage=${portBaseName}_python$pythonVersion"
+
+	eval "PROVIDES_$pythonPackage=\"
+		${portName}_python$pythonVersion = $portVersion
+		cmd:vcs_versioning_$pythonVersion = $portVersion
+		\""
+
+	if [ $pythonVersion = $defaultVersion ]; then
+		eval "PROVIDES_$pythonPackage+=\"
+			cmd:vcs_versioning = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage=\"
+		packaging_$pythonPackage
+		cmd:python$pythonVersion
+		\""
+
+	# only needed for Python < 3.11
+	if [ $pythonVersion = 3.10 ]; then
+		eval "REQUIRES_$pythonPackage+=\"
+			tomli_$pythonPackage
+			typing_extensions_$pythonPackage
+			\""
+	fi
+
+	BUILD_REQUIRES+="
+		installer_$pythonPackage
+		"
+	BUILD_PREREQUIRES+="
+		cmd:python$pythonVersion
+		"
+done
+
+INSTALL()
+{
+	for pythonVersion in ${PYTHON_VERSIONS[@]}; do
+		pythonPackage=python${pythonVersion//.}
+
+		python=python$pythonVersion
+		$python -m installer -p $prefix $portName-$portVersion-py3-none-any.whl
+
+		# Version suffix all the scripts
+		for f in $binDir/*; do
+			mv $f $f-$pythonVersion
+		done
+
+		# And provide suffix-less symlinks for the default version
+		if [ $pythonVersion = $defaultVersion ]; then
+			for f in $binDir/*; do
+				ln -sr $f ${f%-$pythonVersion}
+			done
+		fi
+
+		packageEntries $pythonPackage \
+			$prefix/lib/python* \
+			$binDir
+	done
+}


### PR DESCRIPTION
As this is a new recipe, I'm using "dotted package" names for both 3.10 and 3.14 (instead of using "_python310" for the former).

Tested with `setuptools_scm` 10.0.5 (will open a PR for that next), and both tested by using them to build `sip` version 6.15.3 (for both Python 3.10 and 3.14).