### PR TITLE
noto_serif_cjk: switch to variable width fonts, cleanup

### DIFF
--- a/media-fonts/noto_serif_cjk/noto_serif_cjk-2.003.recipe
+++ b/media-fonts/noto_serif_cjk/noto_serif_cjk-2.003.recipe
@@ -1,102 +1,288 @@
 SUMMARY="The Noto serif font for CJK languages"
-DESCRIPTION="The Noto serif fonts have superseded the Droid fonts, which were \
+baseDescription="The Noto serif fonts have superseded the Droid fonts, which were \
 originally designed for the use in Google's Android. Noto's aim is to be a \
 free for everyone, with beautiful glyphs for all languages, looking good \
 especially when multiple styles and weights and even languages are mixed on \
 a page.
-
+"
+DESCRIPTION="$baseDescription
 This package supports Japanese, Korean and simple/traditional Chinese.
-Included are various weights and two 'monospaced' typefaces ('regular' and \
-'bold')."
+Included is the Serif font as variable-width typeface."
 HOMEPAGE="https://www.google.com/get/noto/"
 COPYRIGHT="2017 Google Inc."
 LICENSE="SIL Open Font License v1.1"
-REVISION="1"
-# Japanese
-SOURCE_URI="https://github.com/googlefonts/noto-cjk/releases/download/Serif$portVersion/07_NotoSerifCJKjp.zip"
-CHECKSUM_SHA256="d7e956584f1e9417a0a72de22bfc33103d7dea78c9f84e5876920eb35ef40a13"
+REVISION="2"
+SOURCE_URI="https://github.com/notofonts/noto-cjk/releases/download/Serif$portVersion/02_NotoSerifCJK-OTF-VF.zip"
+CHECKSUM_SHA256="7898cfb54156cc0d8a2f2c00d5645c573ff367d03d29085bb495966d99d2529e"
 SOURCE_DIR=""
-# Korean
-SOURCE_URI_2="https://github.com/googlefonts/noto-cjk/releases/download/Serif$portVersion/08_NotoSerifCJKkr.zip"
-CHECKSUM_SHA256_2="2132d84616ea55b2b6073bd7b3da5ccd90e59e61fdeab681107d33ab099be367"
-# Simplified Chinese
-SOURCE_URI_3="https://github.com/googlefonts/noto-cjk/releases/download/Serif$portVersion/09_NotoSerifCJKsc.zip"
-CHECKSUM_SHA256_3="4bcdbff95cedfb6a4c0640403f0de8b69480d869331c24c8eff91f7bb834df04"
-# Traditional Chinese
-SOURCE_URI_4="https://github.com/googlefonts/noto-cjk/releases/download/Serif$portVersion/10_NotoSerifCJKtc.zip"
-CHECKSUM_SHA256_4="b4aa07b217532c5859b3674d53588671e7e4f340054fc30e9bf417ee3b1aa4d4"
-# Traditional Chinese Hongkong
-SOURCE_URI_5="https://github.com/googlefonts/noto-cjk/releases/download/Serif$portVersion/11_NotoSerifCJKhk.zip"
-CHECKSUM_SHA256_5="2eaf73871cbc53e72bb1021d760eb64b395955d33fdc560964e15b429a64c288"
+SOURCE_FILENAME="02_NotoSerifCJK-OTF-VF-$portVersion.zip"
+
+SOURCE_URI_2="https://github.com/notofonts/noto-cjk/releases/download/Serif$portVersion/05_NotoSerifCJKOTF.zip"
+CHECKSUM_SHA256_2="9a8475c8272209e3e98fa8818b802d80f6b3016b3df77eb7d0893c0c7ae54245"
+SOURCE_DIR_2=""
+SOURCE_FILENAME_2="05_NotoSerifCJKOTF-$portVersion.zip"
+
+SOURCE_URI_3="https://github.com/notofonts/noto-cjk/releases/download/Serif$portVersion/06_NotoSerifCJKSubsetOTF.zip"
+CHECKSUM_SHA256_3="f9e052b4de3c62cef2c6fec0fe4bef42ca3a05e9571264d5eee614b14a8fbfe5"
+SOURCE_DIR_3=""
+SOURCE_FILENAME_3="06_NotoSerifCJKSubsetOTF-$portVersion.zip"
 
 ARCHITECTURES="any"
 DISABLE_SOURCE_PACKAGE="yes"
 
-# noto_serif_cjk-$portVersion-any.hpkg is intentionally empty and can be removed.
-PROVIDES="
-	noto_serif_cjk=$portVersion	# empty. ToDo: prevent creating empty hpkg
-	"
-REQUIRES=""
-
 SUMMARY_jp="The Noto serif font for CJK languages (default Japanese)"
 PROVIDES_jp="
-	noto_serif_cjk_jp=$portVersion	# Japanese default
+	noto_serif_cjk_jp = $portVersion
 	"
-REQUIRES_jp=""
+
+PACKAGE_NAME_subset_jp="noto_serif_jp"
+SUMMARY_subset_jp="The Noto serif font for Japanese only"
+DESCRIPTION_subset_jp="$baseDescription
+This package supports Japanese.
+Included is the Serif font as variable-width typeface."
+PROVIDES_subset_jp="
+	noto_serif_jp = $portVersion
+	"
+
+SUMMARY_jp_static="The Noto serif font for CJK languages (default Japanese, static version)"
+DESCRIPTION_jp_static="$baseDescription
+This package supports Japanese, Korean and simple/traditional Chinese.
+Included are various weights of the Serif font."
+PROVIDES_jp_static="
+	noto_serif_cjk_jp_static = $portVersion
+	"
+CONFLICTS_jp_static="
+	noto_serif_cjk_jp
+	"
+
+PACKAGE_NAME_subset_jp_static="noto_serif_jp_static"
+SUMMARY_subset_jp_static="The Noto serif font for Japanese only (static version)"
+DESCRIPTION_subset_jp_static="$baseDescription
+This package supports Japanese.
+Included are various weights of the Serif font."
+PROVIDES_subset_jp_static="
+	noto_serif_jp_static = $portVersion
+	"
+CONFLICTS_subset_jp_static="
+	noto_serif_jp
+	"
 
 SUMMARY_kr="The Noto serif font for CJK languages (default Korean)"
 PROVIDES_kr="
-	noto_serif_cjk_kr=$portVersion	# Korean default
+	noto_serif_cjk_kr = $portVersion
 	"
-REQUIRES_kr=""
+
+PACKAGE_NAME_subset_kr="noto_serif_kr"
+SUMMARY_subset_kr="The Noto serif font for Korean only"
+DESCRIPTION_subset_kr="$baseDescription
+This package supports Korean.
+Included is the Serif font as variable-width typeface."
+PROVIDES_subset_kr="
+	noto_serif_kr = $portVersion
+	"
+
+SUMMARY_kr_static="The Noto serif font for CJK languages (default Korean, static version)"
+DESCRIPTION_kr_static="$baseDescription
+This package supports Japanese, Korean and simple/traditional Chinese.
+Included are various weights of the Serif font."
+PROVIDES_kr_static="
+	noto_serif_cjk_kr_static = $portVersion
+	"
+CONFLICTS_kr_static="
+	noto_serif_cjk_kr
+	"
+
+PACKAGE_NAME_subset_kr_static="noto_serif_kr_static"
+SUMMARY_subset_kr_static="The Noto serif font for Korean only (static version)"
+DESCRIPTION_subset_kr_static="$baseDescription
+This package supports Korean.
+Included are various weights of the Serif font."
+PROVIDES_subset_kr_static="
+	noto_serif_kr_static = $portVersion
+	"
+CONFLICTS_subset_kr_static="
+	noto_serif_kr
+	"
 
 SUMMARY_sc="The Noto serif font for CJK languages (default Simplified Chinese)"
 PROVIDES_sc="
-	noto_serif_cjk_sc=$portVersion	# Simplified Chinese default
+	noto_serif_cjk_sc = $portVersion
 	"
-REQUIRES_sc=""
+
+PACKAGE_NAME_subset_sc="noto_serif_sc"
+SUMMARY_subset_sc="The Noto serif font for Simplified Chinese only"
+DESCRIPTION_subset_sc="$baseDescription
+This package supports Simplified Chinese.
+Included is the Serif font as variable-width typeface."
+PROVIDES_subset_sc="
+	noto_serif_sc = $portVersion
+	"
+
+SUMMARY_sc_static="The Noto serif font for CJK languages (default Simplified Chinese, static)"
+DESCRIPTION_sc_static="$baseDescription
+This package supports Japanese, Korean and simple/traditional Chinese.
+Included are various weights of the Serif font."
+PROVIDES_sc_static="
+	noto_serif_cjk_sc_static = $portVersion
+	"
+CONFLICTS_sc_static="
+	noto_serif_cjk_sc
+	"
+
+PACKAGE_NAME_subset_sc_static="noto_serif_sc_static"
+SUMMARY_subset_sc_static="The Noto serif font for Simplified Chinese only (static version)"
+DESCRIPTION_subset_sc_static="$baseDescription
+This package supports Simplified Chinese.
+Included are various weights of the Serif font."
+PROVIDES_subset_sc_static="
+	noto_serif_sc_static = $portVersion
+	"
+CONFLICTS_subset_sc_static="
+	noto_serif_sc
+	"
 
 SUMMARY_tc="The Noto serif font for CJK languages (default Traditional Chinese)"
 PROVIDES_tc="
-	noto_serif_cjk_tc=$portVersion	# Traditional Chinese default
+	noto_serif_cjk_tc = $portVersion
 	"
-REQUIRES_tc=""
+
+PACKAGE_NAME_subset_tc="noto_serif_tc"
+SUMMARY_subset_tc="The Noto serif font for Traditional Chinese only"
+DESCRIPTION_subset_tc="$baseDescription
+This package supports Traditional Chinese.
+Included is the Serif font as variable-width typeface."
+PROVIDES_subset_tc="
+	noto_serif_tc = $portVersion
+	"
+
+SUMMARY_tc_static="The Noto serif font for CJK languages (default Traditional Chinese, static)"
+DESCRIPTION_tc_static="$baseDescription
+This package supports Japanese, Korean and simple/traditional Chinese.
+Included are various weights of the Serif font."
+PROVIDES_tc_static="
+	noto_serif_cjk_tc_static = $portVersion
+	"
+CONFLICTS_tc_static="
+	noto_serif_cjk_tc
+	"
+
+PACKAGE_NAME_subset_tc_static="noto_serif_tc_static"
+SUMMARY_subset_tc_static="The Noto serif font for Traditional Chinese only (static version)"
+DESCRIPTION_subset_tc_static="$baseDescription
+This package supports Traditional Chinese.
+Included are various weights of the Serif font."
+PROVIDES_subset_tc_static="
+	noto_serif_tc_static = $portVersion
+	"
+CONFLICTS_subset_tc_static="
+	noto_serif_tc
+	"
 
 SUMMARY_hk="The Noto serif font for CJK languages (default Traditional Chinese Hongkong)"
 PROVIDES_hk="
-	noto_serif_cjk_hk=$portVersion	# Traditional Chinese Hongkong default
+	noto_serif_cjk_hk = $portVersion
 	"
-REQUIRES_tc=""
 
-BUILD_REQUIRES=""
-BUILD_PREREQUIRES=""
+PACKAGE_NAME_subset_hk="noto_serif_hk"
+SUMMARY_subset_hk="The Noto serif font for Traditional Chinese Hongkong only"
+DESCRIPTION_subset_hk="$baseDescription
+This package supports Traditional Chinese Hongkong.
+Included is the Serif font as variable-width typeface."
+PROVIDES_subset_hk="
+	noto_serif_hk = $portVersion
+	"
 
-BUILD()
-{
-	true
-}
+SUMMARY_hk_static="The Noto serif font for CJK languages (default Hongkong, static version)"
+DESCRIPTION_hk_static="$baseDescription
+This package supports Japanese, Korean and simple/traditional Chinese.
+Included are various weights of the Serif font."
+PROVIDES_hk_static="
+	noto_serif_cjk_hk_static = $portVersion
+	"
+CONFLICTS_hk_static="
+	noto_serif_cjk_hk
+	"
+
+PACKAGE_NAME_subset_hk_static="noto_serif_hk_static"
+SUMMARY_subset_hk_static="The Noto serif font for Traditional Chinese Hongkong only (static version)"
+DESCRIPTION_subset_hk_static="$baseDescription
+This package supports Traditional Chinese Hongkong.
+Included are various weights of the Serif font."
+PROVIDES_subset_hk_static="
+	noto_serif_hk_static = $portVersion
+	"
+CONFLICTS_subset_hk_static="
+	noto_serif_hk
+	"
 
 INSTALL()
 {
 	FONTDIR=$fontsDir/otfonts
 	mkdir -p ${FONTDIR}
 
-	cp ../sources*/*/*/*.otf ${FONTDIR}
+	cp Variable/OTF/*.otf Variable/OTF/Subset/*.otf ${FONTDIR}
 
 	packageEntries jp \
 		${FONTDIR}/*CJKjp*.otf
 
+	packageEntries subset_jp \
+		${FONTDIR}/*JP*.otf
+
 	packageEntries kr \
 		${FONTDIR}/*CJKkr*.otf
+
+	packageEntries subset_kr \
+		${FONTDIR}/*KR*.otf
 
 	packageEntries sc \
 		${FONTDIR}/*CJKsc*.otf
 
+	packageEntries subset_sc \
+		${FONTDIR}/*SC*.otf
+
 	packageEntries tc \
 		${FONTDIR}/*CJKtc*.otf
 
+	packageEntries subset_tc \
+		${FONTDIR}/*TC*.otf
+
 	packageEntries hk \
 		${FONTDIR}/*CJKhk*.otf
+
+	packageEntries subset_hk \
+		${FONTDIR}/*HK*.otf
+
+	cp $sourceDir2/OTF/*/*.otf $sourceDir3/SubsetOTF/*/*.otf ${FONTDIR}
+
+	packageEntries jp_static \
+		${FONTDIR}/*CJKjp*.otf
+
+	packageEntries subset_jp_static \
+		${FONTDIR}/*JP*.otf
+
+	packageEntries kr_static \
+		${FONTDIR}/*CJKkr*.otf
+
+	packageEntries subset_kr_static \
+		${FONTDIR}/*KR*.otf
+
+	packageEntries sc_static \
+		${FONTDIR}/*CJKsc*.otf
+
+	packageEntries subset_sc_static \
+		${FONTDIR}/*SC*.otf
+
+	packageEntries tc_static \
+		${FONTDIR}/*CJKtc*.otf
+
+	packageEntries subset_tc_static \
+		${FONTDIR}/*TC*.otf
+
+	packageEntries hk_static \
+		${FONTDIR}/*CJKhk*.otf
+
+	packageEntries subset_hk_static \
+		${FONTDIR}/*HK*.otf
 
 	rm -rf $dataDir
 }


### PR DESCRIPTION
This is the same as #10853 for Noto Sans CJK.

I also added the region-specific subset fonts.

----

For the lilypond build, we will need some sort of compatibility, because that doesn't support variable width fonts. Should they be packaged separately?