### PR TITLE
hemera: add 1.0-1

### DIFF
--- a/mail-client/hemera/hemera-1.0.recipe
+++ b/mail-client/hemera/hemera-1.0.recipe
@@ -1,0 +1,31 @@
+SUMMARY="Hemera mail client"
+DESCRIPTION="Hemera is a Haiku-native mail client shell packaged by HERMES."
+HOMEPAGE="https://github.com/nmatavka/hermes-hemera"
+COPYRIGHT="2026 HERMES"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://github.com/nmatavka/hermes-hemera/releases/download/v1.0/hemera-v1.0-source.tar.gz"
+CHECKSUM_SHA256="426c1ccaad33b52c09455e07370fce26437b3832c27cb868211ce1e1827cb9f5"
+ARCHITECTURES="?x86_64"
+
+PROVIDES="
+	hemera = $portVersion
+	app:Hemera = $portVersion
+	cmd:Hemera = $portVersion
+"
+REQUIRES="
+	haiku
+"
+
+BUILD()
+{
+	cmake -S . -B build -DHERMES_BUILD_HAIKU_SHELL=ON
+	cmake --build build --target Hemera
+}
+
+INSTALL()
+{
+	mkdir -p $appsDir/Hemera/icons
+	cp build/src/hermes_port/haiku/Hemera $appsDir/Hemera/
+	cp -R src/hermes_port/haiku/assets/icons/toolbar $appsDir/Hemera/icons/
+}

--- a/mail-client/hemera/hemera-1.0.recipe
+++ b/mail-client/hemera/hemera-1.0.recipe
@@ -8,11 +8,6 @@ SOURCE_URI="https://github.com/nmatavka/hermes-hemera/releases/download/v1.0/hem
 CHECKSUM_SHA256="426c1ccaad33b52c09455e07370fce26437b3832c27cb868211ce1e1827cb9f5"
 ARCHITECTURES="?x86_64"
 
-PROVIDES="
-	hemera = $portVersion
-	app:Hemera = $portVersion
-	cmd:Hemera = $portVersion
-"
 REQUIRES="
 	haiku
 "

--- a/mail-client/hemera/hemera-1.0.recipe
+++ b/mail-client/hemera/hemera-1.0.recipe
@@ -12,6 +12,11 @@ REQUIRES="
 	haiku
 "
 
+PROVIDES="
+	hemera = $portVersion
+	app:Hemera = $portVersion
+"
+
 BUILD()
 {
 	cmake -S . -B build -DHERMES_BUILD_HAIKU_SHELL=ON


### PR DESCRIPTION
## Summary

- add Hemera 1.0-1
- source asset: https://github.com/nmatavka/hermes-hemera/releases/download/v1.0/hemera-v1.0-source.tar.gz
- generated from Hemera tag `v1.0`

## Validation

- Hemera rollout tool prepared the recipe and source tarball
- local Haiku preflight runs only when the rollout host is Haiku
- follow-up build/check results are tracked through this PR
