### PR TITLE
WireShare - a gnutella servent and edonkey client in Java

### DIFF
--- a/net-p2p/wireshare/wireshare-7.0.recipe
+++ b/net-p2p/wireshare/wireshare-7.0.recipe
@@ -1,0 +1,33 @@
+SUMMARY="Peer-to-peer sharing for Gnutella, BitTorrent, magnet, and eD2k"
+DESCRIPTION="WireShare is a desktop peer-to-peer client for Gnutella, BitTorrent, magnet, and eD2k links."
+HOMEPAGE="https://github.com/nmatavka/hermes-wireshare"
+COPYRIGHT="2026 Hermes"
+LICENSE="GPL v3"
+REVISION="1"
+SOURCE_URI="https://github.com/nmatavka/hermes-wireshare/releases/download/release/7.0/WireShare.jar#noarchive"
+SOURCE_FILENAME="WireShare.jar"
+CHECKSUM_SHA256="3f02fd977355c9183dffb7230b235b52e93235d5582d9cb2f338f63344d59e56"
+DISABLE_SOURCE_PACKAGE="yes"
+
+ARCHITECTURES="x86_64"
+
+PROVIDES="
+	wireshare = $portVersion
+	cmd:WireShare = $portVersion
+	"
+REQUIRES="
+	haiku
+	java:environment >= 21
+	"
+
+INSTALL()
+{
+	mkdir -p $binDir $dataDir/wireshare
+	cp $sourceDir/WireShare.jar $dataDir/wireshare/WireShare.jar
+
+	cat > $binDir/WireShare <<EOF
+#!/bin/sh
+exec java -jar $dataDir/wireshare/WireShare.jar "\$@"
+EOF
+	chmod +x $binDir/WireShare
+}


### PR DESCRIPTION
Prepared by the local WireShare Linux rollout orchestrator.

- Target: `haiku`
- Unit: `haiku`
- Submission mode: `github_pr`

(This is v7.0 of WireShare, the file sharing client that used to be called LimeWire.)