### PR TITLE
rhash: fix invalid opcode on systems without SSE4

### DIFF
--- a/app-crypt/rhash/rhash-1.4.6.recipe
+++ b/app-crypt/rhash/rhash-1.4.6.recipe
@@ -8,7 +8,7 @@ a long-term storing or transferring."
 HOMEPAGE="https://github.com/rhash/RHash"
 COPYRIGHT="2005 Aleksey Kravchenko"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/rhash/RHash/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="9f6019cfeeae8ace7067ad22da4e4f857bb2cfa6c2deaa2258f55b2227ec937a"
 SOURCE_DIR="RHash-$portVersion"
@@ -79,7 +79,7 @@ BUILD()
 	INSTALL_INCDIR="$includeDir" \
 	./configure --prefix="$prefix" --bindir="$commandBinDir" \
 		--libdir="$libDir" --localedir="$dataDir"/locale --mandir="$manDir" \
-		--sysconfdir="$sysconfDir"
+		--sysconfdir="$sysconfDir" --disable-shani
 	make $jobArgs
 }
 


### PR DESCRIPTION
CMake ran into an invalid opcode exception on my machine,
which was caused by rhash using SSE4/SHA instructions.
This should fix that. 

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
