### PR TITLE
Package akku for chez on Haiku

### DIFF
--- a/dev-scheme/chez_akku/additional-files/setup-akku.sh
+++ b/dev-scheme/chez_akku/additional-files/setup-akku.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+dataDir="$(finddir B_SYSTEM_DATA_DIRECTORY)/akku"
+installDataDir="$(finddir B_USER_NONPACKAGED_DATA_DIRECTORY)"
+
+mkdir -p $installDataDir
+cp -rf "${dataDir}" "${installDataDir}"
+

--- a/dev-scheme/chez_akku/chez_akku-1.1.0.recipe
+++ b/dev-scheme/chez_akku/chez_akku-1.1.0.recipe
@@ -1,6 +1,6 @@
 SUMMARY="Akku.scm package manager for Scheme (Chez version)"
 DESCRIPTION="Akku.scm is a language package manager for Scheme.
-It grabs hold of code and shakes it vigorously until it behaves properly. 
+It grabs hold of code and shakes it vigorously until it behaves properly.
 
     One command to install everything needed for your project.
     Separately declare your dependencies and locked versions.
@@ -63,6 +63,3 @@ EOF
         --program "${libdir}/bin/akku.sps" 2>/dev/null
     cp "${libdir}/akku.chezscheme" "${binDir}/akku"
 }
-
-
-

--- a/dev-scheme/chez_akku/chez_akku-1.1.0.recipe
+++ b/dev-scheme/chez_akku/chez_akku-1.1.0.recipe
@@ -13,13 +13,14 @@ COPYRIGHT="2017-2023 Gwen Weinholt"
 LICENSE="GNU GPL v3"
 REVISION="1"
 SOURCE_URI="https://gitlab.com/-/project/6808260/uploads/9d23bb6ec47dd2d7ee41802115cd7d80/akku-1.1.0.src.tar.xz"
-SOURCE_DIR="akku-$portVersion.src"
 CHECKSUM_SHA256="658ed20bd3f8681232e2d539b08e5084bc90a8b4ea4697782eff03f65abd4ad2"
+SOURCE_DIR="akku-$portVersion.src"
 PATCHES="0001-add-haiku-compatibility-via-libroot.so.patch"
 
 ADDITIONAL_FILES="setup-akku.sh"
 
 ARCHITECTURES="x86_64"
+
 POST_INSTALL_SCRIPTS="$relativePostInstallDir/setup-akku.sh"
 
 PROVIDES="
@@ -33,13 +34,10 @@ REQUIRES="
 BUILD_REQUIRES="
 	chez
 	"
-BUILD_PREREQUIRES="
-	make
-	"
+
 
 INSTALL()
 {
-    PREFIX=$prefix
     libdir=$libDir/akku
     mkdir -p "$binDir" "$libdir " "$dataDir" "$postInstallDir"
 
@@ -49,7 +47,7 @@ INSTALL()
 
     
     cp -a share/* "${dataDir}"
-    cp -a lib "${PREFIX}"
+    cp -a lib "${prefix}"
     cat > "${libdir}/akku.chezscheme" <<EOF
 #!/bin/sh
 export CHEZSCHEMELIBDIRS="${libdir}/lib"
@@ -60,7 +58,7 @@ EOF
     chmod 0755 "${libdir}/akku.chezscheme"
     export CHEZSCHEMELIBDIRS="${libdir}/lib"
     unset CHEZSCHEMELIBEXTS
-    /bin/scheme \
+    PREFIX=${prefix} /bin/scheme \
         --compile-imported-libraries \
         --program "${libdir}/bin/akku.sps" 2>/dev/null
     cp "${libdir}/akku.chezscheme" "${binDir}/akku"

--- a/dev-scheme/chez_akku/chez_akku-1.1.0.recipe
+++ b/dev-scheme/chez_akku/chez_akku-1.1.0.recipe
@@ -2,11 +2,11 @@ SUMMARY="Akku.scm package manager for Scheme (Chez version)"
 DESCRIPTION="Akku.scm is a language package manager for Scheme.
 It grabs hold of code and shakes it vigorously until it behaves properly.
 
-    One command to install everything needed for your project.
-    Separately declare your dependencies and locked versions.
-    Automatically convert R7RS libraries for use in R6RS projects.
-    Audited build scripts for use with FFI libraries.
-    Mirror of R7RS libraries from Snow.
+- One command to install everything needed for your project.
+- Separately declare your dependencies and locked versions.
+- Automatically convert R7RS libraries for use in R6RS projects.
+- Audited build scripts for use with FFI libraries.
+- Mirror of R7RS libraries from Snow.
 "
 HOMEPAGE="https://akkuscm.org/"
 COPYRIGHT="2017-2023 Gwen Weinholt"

--- a/dev-scheme/chez_akku/chez_akku-1.1.0.recipe
+++ b/dev-scheme/chez_akku/chez_akku-1.1.0.recipe
@@ -41,11 +41,9 @@ INSTALL()
     libdir=$libDir/akku
     mkdir -p "$binDir" "$libdir " "$dataDir" "$postInstallDir"
 
-    
     cp -f $portDir/additional-files/setup-akku.sh $postInstallDir
     chmod -v a+rx $postInstallDir/setup-akku.sh
 
-    
     cp -a share/* "${dataDir}"
     cp -a lib "${prefix}"
     cat > "${libdir}/akku.chezscheme" <<EOF

--- a/dev-scheme/chez_akku/chez_akku-1.1.0.recipe
+++ b/dev-scheme/chez_akku/chez_akku-1.1.0.recipe
@@ -1,0 +1,70 @@
+SUMMARY="Akku.scm package manager for Scheme (Chez version)"
+DESCRIPTION="Akku.scm is a language package manager for Scheme.
+It grabs hold of code and shakes it vigorously until it behaves properly. 
+
+    One command to install everything needed for your project.
+    Separately declare your dependencies and locked versions.
+    Automatically convert R7RS libraries for use in R6RS projects.
+    Audited build scripts for use with FFI libraries.
+    Mirror of R7RS libraries from Snow.
+"
+HOMEPAGE="https://akkuscm.org/"
+COPYRIGHT="2017-2023 Gwen Weinholt"
+LICENSE="GNU GPL v3"
+REVISION="1"
+SOURCE_URI="https://gitlab.com/-/project/6808260/uploads/9d23bb6ec47dd2d7ee41802115cd7d80/akku-1.1.0.src.tar.xz"
+SOURCE_DIR="akku-$portVersion.src"
+CHECKSUM_SHA256="658ed20bd3f8681232e2d539b08e5084bc90a8b4ea4697782eff03f65abd4ad2"
+PATCHES="0001-add-haiku-compatibility-via-libroot.so.patch"
+
+ADDITIONAL_FILES="setup-akku.sh"
+
+ARCHITECTURES="x86_64"
+POST_INSTALL_SCRIPTS="$relativePostInstallDir/setup-akku.sh"
+
+PROVIDES="
+ 	chez_akku = $portVersion
+ 	cmd:akku = $portVersion
+ 	"
+REQUIRES="
+ 	haiku
+	chez
+	"
+BUILD_REQUIRES="
+	chez
+	"
+BUILD_PREREQUIRES="
+	make
+	"
+
+INSTALL()
+{
+    PREFIX=$prefix
+    libdir=$libDir/akku
+    mkdir -p "$binDir" "$libdir " "$dataDir" "$postInstallDir"
+
+    
+    cp -f $portDir/additional-files/setup-akku.sh $postInstallDir
+    chmod -v a+rx $postInstallDir/setup-akku.sh
+
+    
+    cp -a share/* "${dataDir}"
+    cp -a lib "${PREFIX}"
+    cat > "${libdir}/akku.chezscheme" <<EOF
+#!/bin/sh
+export CHEZSCHEMELIBDIRS="${libdir}/lib"
+unset CHEZSCHEMELIBEXTS
+exec /bin/scheme --program "${libdir}/bin/akku.sps" "\$@"
+EOF
+
+    chmod 0755 "${libdir}/akku.chezscheme"
+    export CHEZSCHEMELIBDIRS="${libdir}/lib"
+    unset CHEZSCHEMELIBEXTS
+    /bin/scheme \
+        --compile-imported-libraries \
+        --program "${libdir}/bin/akku.sps" 2>/dev/null
+    cp "${libdir}/akku.chezscheme" "${binDir}/akku"
+}
+
+
+

--- a/dev-scheme/chez_akku/chez_akku-1.1.0.recipe
+++ b/dev-scheme/chez_akku/chez_akku-1.1.0.recipe
@@ -12,7 +12,7 @@ HOMEPAGE="https://akkuscm.org/"
 COPYRIGHT="2017-2023 Gwen Weinholt"
 LICENSE="GNU GPL v3"
 REVISION="1"
-SOURCE_URI="https://gitlab.com/-/project/6808260/uploads/9d23bb6ec47dd2d7ee41802115cd7d80/akku-1.1.0.src.tar.xz"
+SOURCE_URI="https://gitlab.com/-/project/6808260/uploads/9d23bb6ec47dd2d7ee41802115cd7d80/akku-$portVersion.src.tar.xz"
 CHECKSUM_SHA256="658ed20bd3f8681232e2d539b08e5084bc90a8b4ea4697782eff03f65abd4ad2"
 SOURCE_DIR="akku-$portVersion.src"
 PATCHES="0001-add-haiku-compatibility-via-libroot.so.patch"
@@ -31,10 +31,10 @@ REQUIRES="
  	haiku
 	chez
 	"
+
 BUILD_REQUIRES="
 	chez
 	"
-
 
 INSTALL()
 {

--- a/dev-scheme/chez_akku/patches/0001-add-haiku-compatibility-via-libroot.so.patch
+++ b/dev-scheme/chez_akku/patches/0001-add-haiku-compatibility-via-libroot.so.patch
@@ -32,7 +32,7 @@ index bf89aaf..1891fb7 100644
            ((string-suffix? "s2" mt) 'sunos)
            ((string-suffix? "qnx" mt) 'qnx)
            ((string-suffix? "nt" mt) 'cygwin)
-+	  ((string-suffix? "hk" mt) 'haiku)
++         ((string-suffix? "hk" mt) 'haiku)
            (else 'unknown))))
  
  (case (os-name)

--- a/dev-scheme/chez_akku/patches/0001-add-haiku-compatibility-via-libroot.so.patch
+++ b/dev-scheme/chez_akku/patches/0001-add-haiku-compatibility-via-libroot.so.patch
@@ -1,0 +1,100 @@
+From 2eb7ea51675cc4bc3b4f8a19bd7cea98dfbf45ef Mon Sep 17 00:00:00 2001
+From: Yourself <geoffrey@teale.de>
+Date: Sun, 31 May 2026 11:58:24 +0200
+Subject: [PATCH] add haiku compatibility via libroot.so
+
+---
+ lib/akku/lib/akku-r7rs/compat.chezscheme.sls               | 1 +
+ lib/akku/lib/akku/private/compat.chezscheme.sls            | 2 ++
+ lib/akku/lib/pffi/bv-pointer.chezscheme.sls                | 1 +
+ lib/akku/lib/spells/filesys/compat.chezscheme.sls          | 1 +
+ lib/akku/lib/spells/process/compat.chezscheme.sls          | 1 +
+ .../lib/srfi/:98/os-environment-variables.chezscheme.sls   | 7 +++++++
+ 6 files changed, 13 insertions(+)
+
+diff --git a/lib/akku/lib/akku-r7rs/compat.chezscheme.sls b/lib/akku/lib/akku-r7rs/compat.chezscheme.sls
+index 34708a4..f6fbca5 100644
+--- a/lib/akku/lib/akku-r7rs/compat.chezscheme.sls
++++ b/lib/akku/lib/akku-r7rs/compat.chezscheme.sls
+@@ -40,6 +40,7 @@
+        ((ta6nt a6nt) '(x86-64 windows))
+        ((tarm32le arm32le) '(arm posix gnu-linux))
+        ((tppc32le ppc32le) '(ppc posix gnu-linux))
++       ((ta6hk a6hk) '(x86-64 haiku))
+        (else '()))
+      (case (native-endianness)
+        ((big) '(big-endian))
+diff --git a/lib/akku/lib/akku/private/compat.chezscheme.sls b/lib/akku/lib/akku/private/compat.chezscheme.sls
+index bf89aaf..1891fb7 100644
+--- a/lib/akku/lib/akku/private/compat.chezscheme.sls
++++ b/lib/akku/lib/akku/private/compat.chezscheme.sls
+@@ -83,6 +83,7 @@
+           ((string-suffix? "s2" mt) 'sunos)
+           ((string-suffix? "qnx" mt) 'qnx)
+           ((string-suffix? "nt" mt) 'cygwin)
++	  ((string-suffix? "hk" mt) 'haiku)
+           (else 'unknown))))
+ 
+ (case (os-name)
+@@ -90,4 +91,5 @@
+   ((freebsd) (load-shared-object "libc.so.7"))
+   ((darwin) (load-shared-object "libc.dylib"))
+   ((cygwin) (load-shared-object "crtdll.dll"))
++  ((haiku) (load-shared-object "libroot.so"))
+   (else (load-shared-object "libc.so"))))
+diff --git a/lib/akku/lib/pffi/bv-pointer.chezscheme.sls b/lib/akku/lib/pffi/bv-pointer.chezscheme.sls
+index 04a74c1..1a88726 100644
+--- a/lib/akku/lib/pffi/bv-pointer.chezscheme.sls
++++ b/lib/akku/lib/pffi/bv-pointer.chezscheme.sls
+@@ -40,6 +40,7 @@
+     ((ta6le a6le i3le ti3le arm32le ppc32le) (load-shared-object "libc.so.6"))
+     ((i3osx ti3osx a6osx ta6osx) (load-shared-object "libc.dylib"))
+     ((ta6nt a6nt i3nt ti3nt) (load-shared-object "msvcrt.dll"))
++    ((ta6hk a6hk) (load-shared-object "libroot.so"))
+     (else (load-shared-object "libc.so"))))
+ 
+ (define f (foreign-procedure "memmove" (u8* u8* size_t) uptr))
+diff --git a/lib/akku/lib/spells/filesys/compat.chezscheme.sls b/lib/akku/lib/spells/filesys/compat.chezscheme.sls
+index 8ade573..7b4bdb2 100644
+--- a/lib/akku/lib/spells/filesys/compat.chezscheme.sls
++++ b/lib/akku/lib/spells/filesys/compat.chezscheme.sls
+@@ -66,6 +66,7 @@
+       ((i3le ti3le a6le ta6le arm32le ppc32le) (cs:load-shared-object "libc.so.6"))
+       ((i3osx ti3osx a6osx ta6osx) (cs:load-shared-object "libc.dylib"))
+       ((i3nt ti3nt a3nt ta3nt) (cs:load-shared-object "crtdll.dll"))
++      ((ta6hk a6hk) (cs:load-shared-object "libroot.so"))
+       (else (cs:load-shared-object "libc.so"))))
+ 
+   (define ->fn ->namestring)
+diff --git a/lib/akku/lib/spells/process/compat.chezscheme.sls b/lib/akku/lib/spells/process/compat.chezscheme.sls
+index eb4cee5..8c586b1 100644
+--- a/lib/akku/lib/spells/process/compat.chezscheme.sls
++++ b/lib/akku/lib/spells/process/compat.chezscheme.sls
+@@ -40,6 +40,7 @@
+       ((i3le ti3le a6le ta6le arm32le ppc32le) (load-shared-object "libc.so.6"))
+       ((i3osx ti3osx a6osx ta6osx) (load-shared-object "libc.dylib"))
+       ((i3nt ti3nt a3nt ta3nt) (load-shared-object "crtdll.dll"))
++      ((ta6hk a6hk) (load-shared-object "libroot.so"))
+       (else (load-shared-object "libc.so"))))
+ 
+   (define-record-type process
+diff --git a/lib/akku/lib/srfi/:98/os-environment-variables.chezscheme.sls b/lib/akku/lib/srfi/:98/os-environment-variables.chezscheme.sls
+index 0196a64..d174f09 100644
+--- a/lib/akku/lib/srfi/:98/os-environment-variables.chezscheme.sls
++++ b/lib/akku/lib/srfi/:98/os-environment-variables.chezscheme.sls
+@@ -124,5 +124,12 @@
+            (if (= ptr-to-ptr 0)
+                0
+                (foreign-ref 'void* ptr-to-ptr 0))))]
++      [(ta6hk a6hk)
++       (load-shared-object "libroot.so")
++       (lambda ()
++         (let ([ptr-to-ptr (foreign-entry "environ")])
++           (if (= ptr-to-ptr 0)
++               0
++               (foreign-ref 'void* ptr-to-ptr 0))))]
+       [else (error 'get-environment-variables
+                    "currently unsupoorted on ~s" (machine-type))])))
+-- 
+2.52.0
+


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [ ] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.

This PR provides the [akku](https://akkuscm.org) dependency manager for Chez scheme.  You could think of this as analogous to npm or yarn.  In particular, it not only provides dependency management, but also the primary way to make the Chez scheme compiler comply to the current [R7RS](https://r7rs.org/) standard for Scheme (Chez is natively R6RS). 

I tried to write a `TEST()` for this package, but I seem to absolutely fail to understand how I can invoke the `akku` binary within that test.  However, I have tested this myself and I'm using it locally without error.  Such a test would essentially do the following in a temporary directory (in case you want to test manually, or suggest a way to do this):

```bash
set -x
TMPDIR=$(mktemp -d)
cd $TMPDIR
akku update
akku install akku-r7rs
./akku/env
mkdir ./bin
cat > ./bin/test.ss <<EOF
(import (scheme base)
	(scheme write))

(display "yes\n")
EOF
chmod +x ./bin/test.ss
akku install
test.ss
exit
cd - 
rm -rf $TMPDIR
```

This package is limited to x86_64 because Chez itself is only support on that architecture (in Haiku, anyway).