### PR TITLE
sys-devel/avr_gcc Update to gcc 13.3

### DIFF
--- a/sys-devel/avr_gcc/avr_gcc-13.3.0.recipe
+++ b/sys-devel/avr_gcc/avr_gcc-13.3.0.recipe
@@ -6,13 +6,13 @@ HOMEPAGE="https://gcc.gnu.org"
 
 SOURCE_URI="http://ftpmirror.gnu.org/gcc/gcc-$portVersion/gcc-$portVersion.tar.xz"
 SOURCE_DIR="gcc-$portVersion"
-CHECKSUM_SHA256="61d684f0aa5e76ac6585ad8898a2427aade8979ed5e7f85492286c4dfc13ee86"
+CHECKSUM_SHA256="0845e9621c9543a13f484e94584a49ffc0129970e9914624235fc1d061a0c083"
 REVISION="2"
 LICENSE="
 	GNU GPL v2
 	GNU LGPL v2
 	"
-COPYRIGHT="1988-2023 Free Software Foundation, Inc."
+COPYRIGHT="1988-2024 Free Software Foundation, Inc."
 
 
 ARCHITECTURES="all !x86_gcc2 ?x86 ?arm"


### PR DESCRIPTION
Update sys-devel/avr_gcc from 13.1 to 13.3.
