### PR TITLE
SBCL 2.6.5

### DIFF
--- a/dev-lisp/sbcl/sbcl-2.6.5.recipe
+++ b/dev-lisp/sbcl/sbcl-2.6.5.recipe
@@ -9,7 +9,7 @@ COPYRIGHT="2002 Gerd Moellmann"
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="https://github.com/sbcl/sbcl/archive/refs/tags/sbcl-$portVersion.zip"
-CHECKSUM_SHA256="52bc5544ece89eb3b135c9903ebcffc3d23b6cc8adcd3a3b4621b963243cf542"
+CHECKSUM_SHA256="72019bd22b10c2b7383924b4860f62f9b29faa4a65bcadb925d19c04c37bd974"
 SOURCE_DIR="sbcl-sbcl-$portVersion"
 
 ARCHITECTURES="x86_64"


### PR DESCRIPTION
This is the first SBCL version with enabled threads on Haiku built with SBCL with enables threads.

When submitting changes to Haikuports, please check the following:

- [X] You are not a robot.
- [X] The modified recipe was confirmed to build on your Haiku machine.
- [X] The license and copyright information in modified recipes are correct.
- [X] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [X] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
