### PR TITLE
fluidsynth3, revbump, add portaudio requirement to _devel

### DIFF
--- a/media-sound/fluidsynth/fluidsynth3-2.5.4.recipe
+++ b/media-sound/fluidsynth/fluidsynth3-2.5.4.recipe
@@ -12,7 +12,7 @@ COPYRIGHT="2017-2025 Tom Moebert
 	2007-2025 David Henningsson
 	2000-2025 Peter Hanappe"
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/FluidSynth/fluidsynth/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="72f5720328fe44e2e5c67813885f0a6b4b004d048bd2eeeb0c0064074ebff530"
 SOURCE_DIR="fluidsynth-$portVersion"
@@ -46,6 +46,7 @@ PROVIDES_devel="
 	"
 REQUIRES_devel="
 	fluidsynth3$secondaryArchSuffix == $portVersion base
+	devel:libportaudio$secondaryArchSuffix
 	devel:libreadline$secondaryArchSuffix
 	devel:libSDL3$secondaryArchSuffix
 	devel:libsndfile$secondaryArchSuffix


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
