### PR TITLE
fluidsynth3, add SOURCE_URI_2 for gcem dependency

### DIFF
--- a/media-sound/fluidsynth/fluidsynth3-2.5.4.recipe
+++ b/media-sound/fluidsynth/fluidsynth3-2.5.4.recipe
@@ -15,7 +15,13 @@ LICENSE="GNU LGPL v2.1"
 REVISION="2"
 SOURCE_URI="https://github.com/FluidSynth/fluidsynth/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="72f5720328fe44e2e5c67813885f0a6b4b004d048bd2eeeb0c0064074ebff530"
+SOURCE_FILENAME="fluidsynth-$portVersion.tar.gz"
 SOURCE_DIR="fluidsynth-$portVersion"
+srcGitRev_2="012ae73c6d0a2cb09ffe86475f5c6fba3926e200"
+SOURCE_URI_2="https://github.com/kthohr/gcem/archive/$srcGitRev_2.tar.gz"
+CHECKSUM_SHA256_2="34ab0ee87a9eb26d3087fa9b49c2572ea8ee03db0c9705b83648301a3a3fc172"
+SOURCE_FILENAME_2="gcem-$srcGitRev_2.tar.gz"
+SOURCE_DIR_2="gcem-$srcGitRev_2"
 PATCHES="fluidsynth3-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -97,6 +103,8 @@ defineDebugInfoPackage fluidsynth3$secondaryArchSuffix \
 
 BUILD()
 {
+	cp -R $sourceDir2/* gcem
+
 	cmake -B build -S . -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		$cmakeDirArgs \
 		-D enable-ladspa=ON \


### PR DESCRIPTION
no need to revbump after previous buildfailure on buildmaster

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
