### PR TITLE
qt6_tools, revbump, move qtdoc to seperate package

### DIFF
--- a/dev-qt/qt6-tools/qt6_tools-6.10.3.recipe
+++ b/dev-qt/qt6-tools/qt6_tools-6.10.3.recipe
@@ -6,7 +6,7 @@ COPYRIGHT="2015-2026 The Qt Company Ltd."
 LICENSE="GNU LGPL v2.1
 	GNU LGPL v3
 	GNU FDL v1"
-REVISION="1"
+REVISION="2"
 QT_MIRROR_URI="https://download.qt.io/official_releases"
 SOURCE_URI="$QT_MIRROR_URI/qt/${portVersion%.*}/$portVersion/submodules/qttools-everywhere-src-$portVersion.tar.xz"
 CHECKSUM_SHA256="8f00b9e3d1f80973d81cff67684972b89993183ef19924404d5b8ff0f89675b6"
@@ -32,11 +32,11 @@ PROVIDES="
 	cmd:assistant6$secondaryArchSuffix = $portVersion compat >= 6
 	cmd:designer6$secondaryArchSuffix = $portVersion compat >= 6
 	cmd:linguist6$secondaryArchSuffix = $portVersion compat >= 6
+	cmd:lrelease6$secondaryArchSuffix = $portVersion compat >= 6
 	cmd:pixeltool6$secondaryArchSuffix = $portVersion compat >= 6
 	cmd:qdbus6$secondaryArchSuffix = $portVersion compat >= 6
 	cmd:qdbusviewer6$secondaryArchSuffix = $portVersion compat >= 6
 	cmd:qdistancefieldgenerator6$secondaryArchSuffix = $portVersion compat >= 6
-	cmd:qdoc6$secondaryArchSuffix = $portVersion compat >= 6
 	cmd:qtdiag6$secondaryArchSuffix = $portVersion compat >= 6
 	cmd:qtplugininfo6$secondaryArchSuffix = $portVersion compat >= 6
 	lib:libQt6Designer$secondaryArchSuffix = $libVersionCompat
@@ -46,9 +46,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libclang$secondaryArchSuffix
 	lib:libcrypto$secondaryArchSuffix
-	lib:libLLVM$secondaryArchSuffix
 	lib:libGL$secondaryArchSuffix
 	lib:libQt6Core$secondaryArchSuffix
 	lib:libQt6Gui$secondaryArchSuffix
@@ -71,6 +69,20 @@ PROVIDES_devel="
 REQUIRES_devel="
 	qt6_tools$secondaryArchSuffix == $portVersion base
 	haiku${secondaryArchSuffix}_devel
+	"
+
+PROVIDES_qdoc="
+	qt6_tools${secondaryArchSuffix}_qdoc = $portVersion compat >= 6
+	cmd:qdoc6$secondaryArchSuffix = $portVersion compat >= 6
+	"
+REQUIRES_qdoc="
+	qt6_tools$secondaryArchSuffix == $portVersion base
+	haiku$secondaryArchSuffix
+	lib:libclang$secondaryArchSuffix
+	lib:libLLVM$secondaryArchSuffix
+	lib:libQt6Core$secondaryArchSuffix
+	lib:libQt6Network$secondaryArchSuffix
+	lib:libQt6Qml$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
@@ -157,8 +169,8 @@ INSTALL()
 		$dataDir/deskbar/menu/Applications/Qt
 
 	# install symlinks for user-facing tools
-	binFiles="linguist designer pixeltool assistant qdistancefieldgenerator qtplugininfo \
-qdoc qdbus qdbusviewer qtdiag"
+	binFiles="assistant designer linguist lrelease pixeltool qdbus qdbusviewer \
+qdistancefieldgenerator qdoc qtdiag qtplugininfo"
 	suffix="6"
 	for f in $binFiles; do
 		ln -s $libDir/Qt6/$f $binDir/$f$suffix
@@ -194,6 +206,11 @@ qdoc qdbus qdbusviewer qtdiag"
 	for i in lib*.so.6.*;do
 		ln -fs $i $(echo $i | cut -f1,2 -d.)
 	done
+
+	packageEntries qdoc \
+		$libDir/Qt6/qdoc \
+		$libDir/Qt6/lib \
+		$binDir/qdoc6
 
 	packageEntries devel \
 		$developDir \


### PR DESCRIPTION
fixes requirement on base package for LLVM21

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
