### PR TITLE
qemu, revbump, add patch for libgcrypt and loadavg

### DIFF
--- a/app-emulation/qemu/patches/qemu-8.2.2.patchset
+++ b/app-emulation/qemu/patches/qemu-8.2.2.patchset
@@ -1,4 +1,4 @@
-From 7da58a5cb1ec6006d0601d38bf96c56a1e26dcc4 Mon Sep 17 00:00:00 2001
+From c9d8fdbd3a2f70ba5d8b1db8ba4f5d99ef224201 Mon Sep 17 00:00:00 2001
 From: Alexander von Gluck IV <kallisti5@unixzen.com>
 Date: Tue, 18 May 2021 16:49:20 -0500
 Subject: haiku: fixes and patches, rebased from qemu 3.x
@@ -39,10 +39,10 @@ index 76bab21..7c1ea84 100644
          if (ret != 0) {
              break;
 -- 
-2.37.3
+2.52.0
 
 
-From 4bd3a0ea6984801223fccbcb390c5a53be4f43b1 Mon Sep 17 00:00:00 2001
+From 77bca4352344deb458d666f67fb7390f22cf179b Mon Sep 17 00:00:00 2001
 From: David Karoly <david.karoly@outlook.com>
 Date: Fri, 8 Dec 2023 15:49:29 +0100
 Subject: Haiku: fix build
@@ -66,20 +66,20 @@ index 6c77d96..aea6184 100644
  if not get_option('stack_protector').disabled()
    stack_protector_probe = '''
 -- 
-2.37.3
+2.52.0
 
 
-From 749536fb8068626f8b20bfcb2be2f53102ff5724 Mon Sep 17 00:00:00 2001
+From 9fd29b0d039d153077aab8dfb5a371094c32214f Mon Sep 17 00:00:00 2001
 From: dalme <dalmemail@gmail.com>
 Date: Fri, 19 Jul 2024 18:23:31 +0000
 Subject: Check for NVMM support always
 
 
 diff --git a/meson.build b/meson.build
-index e450a39..7dc39be 100644
+index aea6184..db2284e 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -664,11 +664,9 @@ if get_option('hvf').allowed()
+@@ -653,11 +653,9 @@ if get_option('hvf').allowed()
      accelerators += 'CONFIG_HVF'
    endif
  endif
@@ -95,10 +95,10 @@ index e450a39..7dc39be 100644
  
  tcg_arch = host_arch
 -- 
-2.37.3
+2.52.0
 
 
-From 23473eeb520e6b4de83cf00213c089efc4a9c867 Mon Sep 17 00:00:00 2001
+From d958ce2552787beaadb4126a65fe8c9d774cbd05 Mon Sep 17 00:00:00 2001
 From: dalme <dalmemail@gmail.com>
 Date: Fri, 19 Jul 2024 19:46:42 +0000
 Subject: Don't use EPROGMISMATCH
@@ -129,4 +129,28 @@ index 7d752bc..8fcca4f 100644
  
      ret = nvmm_machine_create(&qemu_mach.mach);
 -- 
-2.37.3
+2.52.0
+
+
+From a37c2982a35102cccd3cfd21883404f597d98d50 Mon Sep 17 00:00:00 2001
+From: Luc Schrijvers <begasus@gmail.com>
+Date: Tue, 9 Jun 2026 07:47:40 +0200
+Subject: Fix detection for libgcrypt
+
+
+diff --git a/meson.build b/meson.build
+index 7dc39be..e1b083e 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1506,7 +1506,7 @@ endif
+ if not gnutls_crypto.found()
+   if (not get_option('gcrypt').auto() or have_system) and not get_option('nettle').enabled()
+     gcrypt = dependency('libgcrypt', version: '>=1.8',
+-                        method: 'config-tool',
++                        method: 'pkg-config',
+                         required: get_option('gcrypt'))
+     # Debian has removed -lgpg-error from libgcrypt-config
+     # as it "spreads unnecessary dependencies" which in
+-- 
+2.52.0
+

--- a/app-emulation/qemu/patches/qemu-8.2.2_beta6.patchset
+++ b/app-emulation/qemu/patches/qemu-8.2.2_beta6.patchset
@@ -1,0 +1,29 @@
+From 40ed3310bc9c3f02f9bffca8e6fe23fc5d992615 Mon Sep 17 00:00:00 2001
+From: Luc Schrijvers <begasus@gmail.com>
+Date: Tue, 9 Jun 2026 08:57:16 +0200
+Subject: Haiku does have loadavg
+
+Co-authored-by: Oscar Lesta <oscar.lesta@gmail.com>
+
+diff --git a/include/qemu/osdep.h b/include/qemu/osdep.h
+index d30ba73..a685945 100644
+--- a/include/qemu/osdep.h
++++ b/include/qemu/osdep.h
+@@ -174,6 +174,14 @@ extern "C" {
+ 
+ #include "qemu/typedefs.h"
+ 
++/**
++ * getloadavg is defined in Haiku
++ *
++ */
++#ifdef __HAIKU__
++#define HAVE_GETLOADAVG_FUNCTION 1
++#endif
++
+ /**
+  * Mark a function that executes in coroutine context
+  *
+-- 
+2.52.0
+

--- a/app-emulation/qemu/qemu-8.2.2.recipe
+++ b/app-emulation/qemu/qemu-8.2.2.recipe
@@ -7,7 +7,7 @@ achieves very good performance."
 HOMEPAGE="https://www.qemu.org/"
 COPYRIGHT="2003-2024 Fabrice Bellard"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://download.qemu.org/qemu-$portVersion.tar.xz"
 CHECKSUM_SHA256="847346c1b82c1a54b2c38f6edbd85549edeb17430b7d4d3da12620e2962bc4f3"
 SOURCE_DIR="qemu-$portVersion"
@@ -40,7 +40,7 @@ PROVIDES="
 	qemu$secondaryArchSuffix = $portVersion
 	cmd:elf2dmp$commandSuffix = $portVersion
 	cmd:qemu_edid$commandSuffix = $portVersion
-	cmd:qemu_keymap$commandSuffix = $portVersion
+#	cmd:qemu_keymap$commandSuffix = $portVersion
 	cmd:qemu_img$commandSuffix = $portVersion
 	cmd:qemu_io$commandSuffix = $portVersion
 	cmd:qemu_nbd$commandSuffix = $portVersion


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
