### PR TITLE
dbus_glib, bump to version 0.114

### DIFF
--- a/dev-libs/dbus_glib/dbus_glib-0.114.recipe
+++ b/dev-libs/dbus_glib/dbus_glib-0.114.recipe
@@ -6,7 +6,7 @@ COPYRIGHT="2003, 2004, 2005 Red Hat, Inc.
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-$portVersion.tar.gz"
-CHECKSUM_SHA256="7d550dccdfcd286e33895501829ed971eeb65c614e73aadb4a08aeef719b143a"
+CHECKSUM_SHA256="c09c5c085b2a0e391b8ee7d783a1d63fe444e96717cc1814d61b5e8fc2827a7c"
 SOURCE_DIR="dbus-glib-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -23,7 +23,7 @@ if [ "$targetArchitecture" = x86_gcc2 ]; then
 	commandBinDir=$prefix/bin
 fi
 
-libVersion="2.3.5"
+libVersion="2.3.6"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 portVersionCompat="$portVersion compat >= ${portVersion%%.*}"
 


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
