### PR TITLE
Disable -Werror (fix for 32bit build)

### DIFF
--- a/dev-libs/glib/glib2-2.88.1.recipe
+++ b/dev-libs/glib/glib2-2.88.1.recipe
@@ -230,6 +230,7 @@ BUILD()
 		-D tests=false \
 		-D glib_debug=disabled \
 		-D introspection=disabled \
+		-D werror=false \
 		build
 	meson compile -C build
 	meson install --no-rebuild -C build
@@ -246,6 +247,7 @@ BUILD()
 		-D python.install_env="prefix" \
 		-D python.platlibdir=$prefix/lib/$pythonModuleDir \
 		-D gir_dir_prefix=$dataDir \
+		-D werror=false \
 		build
 	meson compile -C build
 	meson install --no-rebuild -C build
@@ -264,6 +266,7 @@ BUILD()
 		-D tests=false \
 		-D glib_debug=disabled \
 		-D introspection=enabled \
+		-D werror=false \
 		build
 	PATH="$prefix/bin:$PATH" LD_LIBRARY_PATH="$prefix/lib:$LD_LIBRARY_PATH" \
 		meson compile -C build


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
