### PR TITLE
qt_creator, revert clangVer for 32bit

### DIFF
--- a/dev-qt/qt_creator/qt_creator-20.0.0.recipe
+++ b/dev-qt/qt_creator/qt_creator-20.0.0.recipe
@@ -19,12 +19,11 @@ SECONDARY_ARCHITECTURES="x86"
 if [ "$targetArchitecture" = x86_gcc2 ]; then
 libClangVer="18"
 useClang="OFF"
-clangVer="18"
 else
 libClangVer="21.1"
 useClang="ON"
-clangVer="21"
 fi
+clangVer="21"
 
 PROVIDES="
 	qt_creator$secondaryArchSuffix = $portVersion


### PR DESCRIPTION
sinse qt6_tools clang 21 is a requirement this can be used for 32bit but still reference it for now

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
