### PR TITLE
qt_creator, don't nuke the build after configuration has ended on bui…

### DIFF
--- a/dev-qt/qt_creator/qt_creator-20.0.0.recipe
+++ b/dev-qt/qt_creator/qt_creator-20.0.0.recipe
@@ -126,7 +126,7 @@ BUILD()
 		-DBUILD_PLUGIN_CLANGFORMAT:BOOL=$useClang \
 		-DBUILD_PLUGIN_CLANGTOOLS:BOOL=$useClang \
 		-Wno-dev
-false
+
 	cmake --build build $jobArgs
 }
 


### PR DESCRIPTION
…ldmaster

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
