### PR TITLE
qt_creator, keep 19.0.2 alive for 32bit, disable this for 20.0.0

### DIFF
--- a/dev-qt/qt_creator/patches/qt_creator-19.0.2.patchset
+++ b/dev-qt/qt_creator/patches/qt_creator-19.0.2.patchset
@@ -1,0 +1,475 @@
+From 15b057757514eccfd81123a3abd89504670239b8 Mon Sep 17 00:00:00 2001
+From: Niels Sascha Reedijk <niels.reedijk@gmail.com>
+Date: Fri, 29 Sep 2023 16:03:27 +0000
+Subject: Port 6.0.3 changes to 11.0.03
+
+
+diff --git a/src/libs/3rdparty/libptyqt/unixptyprocess.cpp b/src/libs/3rdparty/libptyqt/unixptyprocess.cpp
+index a20e24e..63db32e 100644
+--- a/src/libs/3rdparty/libptyqt/unixptyprocess.cpp
++++ b/src/libs/3rdparty/libptyqt/unixptyprocess.cpp
+@@ -117,7 +117,10 @@ bool UnixPtyProcess::startProcess(const QString &shellPath,
+         return false;
+     }
+ 
+-    ttmode.c_iflag = ICRNL | IXON | IXANY | IMAXBEL | BRKINT;
++    ttmode.c_iflag = ICRNL | IXON | IXANY | BRKINT;
++#if !defined(Q_OS_HAIKU)
++    ttmode.c_iflag |= IMAXBEL;
++#endif
+ #if defined(IUTF8)
+     ttmode.c_iflag |= IUTF8;
+ #endif
+@@ -130,16 +133,22 @@ bool UnixPtyProcess::startProcess(const QString &shellPath,
+     ttmode.c_cc[VEOL] = -1;
+     ttmode.c_cc[VEOL2] = -1;
+     ttmode.c_cc[VERASE] = 0x7f;
++#if !defined(Q_OS_HAIKU)
+     ttmode.c_cc[VWERASE] = 23;
++#endif
+     ttmode.c_cc[VKILL] = 21;
++#if !defined(Q_OS_HAIKU)
+     ttmode.c_cc[VREPRINT] = 18;
++#endif
+     ttmode.c_cc[VINTR] = 3;
+     ttmode.c_cc[VQUIT] = 0x1c;
+     ttmode.c_cc[VSUSP] = 26;
+     ttmode.c_cc[VSTART] = 17;
+     ttmode.c_cc[VSTOP] = 19;
++#if !defined(Q_OS_HAIKU)
+     ttmode.c_cc[VLNEXT] = 22;
+     ttmode.c_cc[VDISCARD] = 15;
++#endif
+     ttmode.c_cc[VMIN] = 1;
+     ttmode.c_cc[VTIME] = 0;
+ 
+@@ -322,7 +331,7 @@ void ShellProcess::configChildProcess()
+     ioctl(m_handleSlave, TIOCSCTTY, 0);
+     tcsetpgrp(m_handleSlave, sid);
+ 
+-#if !defined(Q_OS_ANDROID) && !defined(Q_OS_FREEBSD)
++#if !defined(Q_OS_ANDROID) && !defined(Q_OS_FREEBSD) && !defined(Q_OS_HAIKU)
+     // on Android imposible to put record to the 'utmp' file
+     struct utmpx utmpxInfo;
+     memset(&utmpxInfo, 0, sizeof(utmpxInfo));
+diff --git a/src/libs/3rdparty/sqlite/config.h b/src/libs/3rdparty/sqlite/config.h
+index f229d85..6c7f863 100644
+--- a/src/libs/3rdparty/sqlite/config.h
++++ b/src/libs/3rdparty/sqlite/config.h
+@@ -35,6 +35,11 @@
+ #define HAVE_UTIME 1
+ #endif
+ 
++#ifdef __HAIKU__
++#define _DEFAULT_SOURCE 1
++#define _BSD_SOURCE 1
++#endif
++
+ #if (_XOPEN_SOURCE >= 500) && !(_POSIX_C_SOURCE >= 200809L) || _DEFAULT_SOURCE || _BSD_SOURCE
+ #define HAVE_USLEEP 1
+ #endif
+diff --git a/src/libs/3rdparty/sqlite/sqlite3.c b/src/libs/3rdparty/sqlite/sqlite3.c
+index 49a4256..25ba12d 100644
+--- a/src/libs/3rdparty/sqlite/sqlite3.c
++++ b/src/libs/3rdparty/sqlite/sqlite3.c
+@@ -42511,7 +42511,7 @@ static int full_fsync(int fd, int fullSync, int dataOnly){
+   */
+   if( rc ) rc = fsync(fd);
+ 
+-#elif defined(__APPLE__)
++#elif defined(__APPLE__) || defined(__HAIKU__)
+   /* fdatasync() on HFS+ doesn't yet flush the file size if it changed correctly
+   ** so currently we default to the macro that redefines fdatasync to fsync
+   */
+diff --git a/src/libs/utils/qtcassert.cpp b/src/libs/utils/qtcassert.cpp
+index c139eb3..37b810e 100644
+--- a/src/libs/utils/qtcassert.cpp
++++ b/src/libs/utils/qtcassert.cpp
+@@ -29,7 +29,7 @@ void dumpBacktrace(int maxdepth)
+     const int ArraySize = 1000;
+     if (maxdepth < 0 || maxdepth > ArraySize)
+         maxdepth = ArraySize;
+-#if defined(Q_OS_UNIX)
++#if defined(Q_OS_UNIX) && !defined(Q_OS_HAIKU)
+     void *bt[ArraySize] = {nullptr};
+     int size = backtrace(bt, maxdepth);
+     char **lines = backtrace_symbols(bt, size);
+diff --git a/src/libs/utils/savefile.cpp b/src/libs/utils/savefile.cpp
+index d1b4347..c336ee4 100644
+--- a/src/libs/utils/savefile.cpp
++++ b/src/libs/utils/savefile.cpp
+@@ -113,7 +113,7 @@ bool SaveFile::commit()
+     }
+ #ifdef Q_OS_WIN
+     FlushFileBuffers(reinterpret_cast<HANDLE>(_get_osfhandle(handle())));
+-#elif _POSIX_SYNCHRONIZED_IO > 0
++#elif _POSIX_SYNCHRONIZED_IO > 0 && !defined(Q_OS_HAIKU)
+     fdatasync(handle());
+ #else
+     fsync(handle());
+diff --git a/src/plugins/coreplugin/manhattanstyle.cpp b/src/plugins/coreplugin/manhattanstyle.cpp
+index 6c9d38d..033d31a 100644
+--- a/src/plugins/coreplugin/manhattanstyle.cpp
++++ b/src/plugins/coreplugin/manhattanstyle.cpp
+@@ -227,16 +227,20 @@ int ManhattanStyle::pixelMetric(PixelMetric metric, const QStyleOption *option,
+     case PM_DockWidgetSeparatorExtent:
+         retval = 1;
+         break;
++#if !defined(Q_OS_HAIKU)
+     case PM_MenuPanelWidth:
+     case PM_MenuBarHMargin:
+     case PM_MenuBarVMargin:
++#endif
+     case PM_ToolBarFrameWidth:
+         if (panelWidget(widget))
+             retval = 1;
+         break;
+     case PM_ButtonShiftVertical:
+     case PM_ButtonShiftHorizontal:
++#if !defined(Q_OS_HAIKU)
+     case PM_MenuBarPanelWidth:
++#endif
+     case PM_ToolBarItemMargin:
+     case PM_ToolBarItemSpacing:
+         if (panelWidget(widget))
+@@ -949,6 +953,7 @@ void ManhattanStyle::drawControl(
+     }
+ 
+     switch (element) {
++#if !defined(Q_OS_HAIKU)
+     case CE_MenuItem:
+         painter->save();
+         if (const auto mbi = qstyleoption_cast<const QStyleOptionMenuItem *>(option)) {
+@@ -967,6 +972,7 @@ void ManhattanStyle::drawControl(
+         }
+         painter->restore();
+         break;
++#endif
+ 
+     case CE_MenuBarItem:
+         painter->save();
+@@ -1109,6 +1115,7 @@ void ManhattanStyle::drawControl(
+         }
+         break;
+ 
++#if !defined(Q_OS_HAIKU)
+     case CE_MenuBarEmptyArea: {
+             if (creatorTheme()->flag(Theme::FlatMenuBar))
+                 painter->fillRect(option->rect, StyleHelper::baseColor());
+@@ -1122,6 +1129,7 @@ void ManhattanStyle::drawControl(
+             painter->restore();
+         }
+         break;
++#endif
+ 
+     case CE_ToolBar:
+         {
+diff --git a/src/plugins/projectexplorer/abi.cpp b/src/plugins/projectexplorer/abi.cpp
+index 96b6688..21acd13 100644
+--- a/src/plugins/projectexplorer/abi.cpp
++++ b/src/plugins/projectexplorer/abi.cpp
+@@ -1167,6 +1167,10 @@ Abi Abi::hostAbi()
+     subos = WindowsMSysFlavor;
+ #endif
+     format = PEFormat;
++#elif defined (Q_OS_HAIKU)
++    os = UnknownOS;
++    subos = GenericFlavor;
++    format = UnknownFormat;
+ #elif defined (Q_OS_LINUX)
+     os = LinuxOS;
+     subos = GenericFlavor;
+diff --git a/src/plugins/qmldesigner/libs/designercore/CMakeLists.txt b/src/plugins/qmldesigner/libs/designercore/CMakeLists.txt
+index 243b78e..b55a119 100644
+--- a/src/plugins/qmldesigner/libs/designercore/CMakeLists.txt
++++ b/src/plugins/qmldesigner/libs/designercore/CMakeLists.txt
+@@ -67,7 +67,7 @@ extend_qtc_library(QmlDesignerCore
+   PUBLIC_DEFINES QDS_BUILD_QMLPARSER
+ )
+ extend_qtc_library(QmlDesignerCore
+-  CONDITION UNIX AND NOT APPLE
++  CONDITION UNIX AND NOT APPLE AND NOT HAIKU
+   PUBLIC_DEPENDS rt
+ )
+ 
+diff --git a/src/shared/qbs/src/lib/corelib/tools/processutils.cpp b/src/shared/qbs/src/lib/corelib/tools/processutils.cpp
+index 52963e7..749b312 100644
+--- a/src/shared/qbs/src/lib/corelib/tools/processutils.cpp
++++ b/src/shared/qbs/src/lib/corelib/tools/processutils.cpp
+@@ -56,6 +56,8 @@
+ #   include <sys/sysctl.h>
+ # if !defined(Q_OS_NETBSD)
+ #   include <sys/user.h>
++#elif defined(Q_OS_HAIKU)
++// Do nothing
+ # endif
+ #else
+ #   error Missing implementation of processNameByPid for this platform.
+diff --git a/src/tools/process_stub/main.cpp b/src/tools/process_stub/main.cpp
+index af2e73e..bb010cd 100644
+--- a/src/tools/process_stub/main.cpp
++++ b/src/tools/process_stub/main.cpp
+@@ -50,7 +50,7 @@ std::optional<QStringList> environmentVariables;
+ QProcess inferiorProcess;
+ int inferiorId{0};
+ 
+-#ifdef Q_OS_DARWIN
++#if defined(Q_OS_DARWIN) || defined(Q_OS_HAIKU)
+ // A memory mapped helper to retrieve the pid of the inferior process in debugMode
+ static int *shared_child_pid = nullptr;
+ #endif
+@@ -255,7 +255,7 @@ void onInferiorStarted()
+ #ifdef Q_OS_WIN
+     sendThreadId(win_process_information->dwThreadId);
+     sendPid(inferiorId);
+-#elif defined(Q_OS_DARWIN)
++#elif defined(Q_OS_DARWIN) || defined(Q_OS_HAIKU)
+     // In debug mode we use the poll timer to send the pid.
+     if (!debugMode)
+         sendPid(inferiorId);
+@@ -285,7 +285,7 @@ void setupUnixInferior()
+ #ifdef Q_OS_UNIX
+     if (debugMode) {
+         qCInfo(log) << "Debug mode enabled";
+-#ifdef Q_OS_DARWIN
++#if defined(Q_OS_DARWIN) || defined(Q_OS_HAIKU)
+         // We are using raise(SIGSTOP) to stop the child process, macOS does not support ptrace(...)
+         inferiorProcess.setChildProcessModifier([] {
+             // Let the parent know our pid ...
+diff --git a/src/tools/qmlpuppet/CMakeLists.txt b/src/tools/qmlpuppet/CMakeLists.txt
+index b5435f7..59e36e4 100644
+--- a/src/tools/qmlpuppet/CMakeLists.txt
++++ b/src/tools/qmlpuppet/CMakeLists.txt
+@@ -82,7 +82,7 @@ extend_qtc_executable(qmlpuppet
+ )
+ 
+ extend_qtc_executable(qmlpuppet
+-  CONDITION UNIX AND (NOT APPLE)
++  CONDITION UNIX AND (NOT APPLE) AND (NOT HAIKU)
+   DEPENDS rt
+ )
+ 
+-- 
+2.52.0
+
+
+From f97218edf949a25210adb7941170bdb8433605d4 Mon Sep 17 00:00:00 2001
+From: Gerasim Troeglazov <3dEyes@gmail.com>
+Date: Mon, 15 Apr 2024 21:42:18 +1000
+Subject: nanotrace: haiku support
+
+
+diff --git a/src/libs/nanotrace/nanotracehr.cpp b/src/libs/nanotrace/nanotracehr.cpp
+index ffe58e0..f0e4c46 100644
+--- a/src/libs/nanotrace/nanotracehr.cpp
++++ b/src/libs/nanotrace/nanotracehr.cpp
+@@ -18,6 +18,10 @@
+ #  include <pthread.h>
+ #endif
+ 
++#ifdef Q_OS_HAIKU
++#  include <OS.h>
++#endif
++
+ namespace NanotraceHR {
+ 
+ namespace {
+@@ -100,7 +104,11 @@ std::string getThreadName()
+ {
+     std::array<char, 200> buffer;
+     buffer[0] = 0;
+-#ifdef Q_OS_UNIX
++#ifdef Q_OS_HAIKU
++    status_t res = rename_thread(find_thread(NULL), buffer.data());
++    if (res != B_OK)
++        return {};
++#elif defined(Q_OS_UNIX)
+     auto rc = pthread_getname_np(pthread_self(), buffer.data(), buffer.size());
+     if (rc != 0)
+         return {};
+-- 
+2.52.0
+
+
+From d51cd22c89973166be6e2e2282b43e5ce0b606c7 Mon Sep 17 00:00:00 2001
+From: Gerasim Troeglazov <3dEyes@gmail.com>
+Date: Tue, 20 Aug 2024 22:53:45 +1000
+Subject: Implement ProcessInfo for Haiku
+
+
+diff --git a/src/libs/utils/processinfo.cpp b/src/libs/utils/processinfo.cpp
+index 8f0eceb..5a2b645 100644
+--- a/src/libs/utils/processinfo.cpp
++++ b/src/libs/utils/processinfo.cpp
+@@ -22,6 +22,10 @@
+ #include <psapi.h>
+ #include <tlhelp32.h>
+ #endif
++#if defined(Q_OS_HAIKU)
++#include <OS.h>
++#include <kernel/image.h>
++#endif
+ 
+ namespace Utils {
+ 
+@@ -238,6 +242,35 @@ static Result<QList<ProcessInfo>> processInfoListUnix(const FilePath &deviceRoot
+ }
+ 
+ Result<QList<ProcessInfo>> ProcessInfo::processInfoList(const FilePath &deviceRoot)
++#if defined(Q_OS_HAIKU)
++{
++    if (deviceRoot.needsDevice())
++        return processInfoListUnix(deviceRoot);
++
++    QList<ProcessInfo> processes;
++
++    team_info teamInfo;
++    int32 teamCookie = 0;
++
++    while (get_next_team_info(&teamCookie, &teamInfo) >= B_OK) {
++        int32 imageCookie = 0;
++        image_info imageInfo;
++        while (get_next_image_info(teamInfo.team, &imageCookie, &imageInfo) == B_OK) {
++            if (imageInfo.type != B_APP_IMAGE && imageInfo.type != B_SYSTEM_IMAGE)
++                continue;
++            break;
++        }
++
++        ProcessInfo deviceProcess;
++        deviceProcess.processId = teamInfo.team;
++        deviceProcess.executable = QString::fromUtf8(imageInfo.name);
++        deviceProcess.commandLine = QString::fromUtf8(teamInfo.args);
++        processes.append(deviceProcess);
++    }
++
++    return processes;
++}
++#else
+ {
+     if (deviceRoot.osType() != OsType::OsTypeWindows)
+         return processInfoListUnix(deviceRoot);
+@@ -271,5 +304,6 @@ Result<QList<ProcessInfo>> ProcessInfo::processInfoList(const FilePath &deviceRo
+ 
+     return {};
+ }
++#endif
+ 
+ } // namespace Utils
+-- 
+2.52.0
+
+
+From df2e4c7005c0cbe0782764bd69daf67ff73a7b8e Mon Sep 17 00:00:00 2001
+From: Gerasim Troeglazov <3dEyes@gmail.com>
+Date: Thu, 5 Sep 2024 17:25:10 +1000
+Subject: Add Haiku provider for AppStatisticsMonitor plugin
+
+
+diff --git a/src/plugins/appstatisticsmonitor/idataprovider.cpp b/src/plugins/appstatisticsmonitor/idataprovider.cpp
+index 1f6d985..1e0c573 100644
+--- a/src/plugins/appstatisticsmonitor/idataprovider.cpp
++++ b/src/plugins/appstatisticsmonitor/idataprovider.cpp
+@@ -31,6 +31,11 @@
+ #include <mach/mach_time.h>
+ #endif
+ 
++#ifdef Q_OS_HAIKU
++#include <OS.h>
++#include <kernel/image.h>
++#endif
++
+ using namespace Utils;
+ 
+ namespace AppStatisticsMonitor::Internal {
+@@ -329,6 +334,59 @@ private:
+ };
+ #endif
+ 
++// ------------------------- HaikuDataProvider --------------------------------
++
++#ifdef Q_OS_HAIKU
++class HaikuDataProvider : public IDataProvider
++{
++public:
++    HaikuDataProvider(qint64 pid, QObject *parent = nullptr)
++        : IDataProvider(pid, parent)
++    {}
++
++    double getCpuConsumption()
++    {
++        system_info	sysInfo;
++        get_system_info(&sysInfo);
++
++        team_usage_info usageInfo;
++        status_t status = get_team_usage_info(m_pid, B_TEAM_USAGE_SELF, &usageInfo);
++        if (status != B_OK)
++            return 0.0;
++
++        const double currentTotalCpuTime = (double)usageInfo.user_time + (double)usageInfo.kernel_time;
++        const double cpuUsageDelta = currentTotalCpuTime - m_prevCpuUsage;
++        const auto elapsedTime = std::chrono::steady_clock::now() - m_prevTime;
++        const double elapsedTimeMks = std::chrono::duration_cast<std::chrono::milliseconds>(elapsedTime).count() * 1000.0;
++
++        m_prevCpuUsage = currentTotalCpuTime;
++        m_prevTime = std::chrono::steady_clock::now();
++
++        return (cpuUsageDelta / (elapsedTimeMks * sysInfo.cpu_count)) * 100.0;
++    }
++
++    double getMemoryConsumption()
++    {
++        system_info	sysinfo;
++        get_system_info(&sysinfo);
++        int64 physicalMemory = (int64)sysinfo.max_pages * B_PAGE_SIZE;
++
++        area_info area;
++        ssize_t cookie = 0;
++        int64 teamMemory = 0;
++
++        while (get_next_area_info(m_pid, &cookie, &area) == B_OK)
++            teamMemory += area.ram_size;
++
++        return static_cast<double>(teamMemory) / static_cast<double>(physicalMemory) * 100.0;
++    }
++private:
++    std::chrono::steady_clock::time_point m_prevTime = std::chrono::steady_clock::now();
++    double m_prevCpuUsage = 0;
++    int cpuCount = 1;
++};
++#endif
++
+ // ------------------------- NullDataProvider --------------------------------
+ 
+ class NullDataProvider : public IDataProvider
+@@ -355,6 +413,8 @@ IDataProvider *createDataProvider(qint64 pid)
+     return new WindowsDataProvider(pid);
+ #elif defined(Q_OS_MACOS)
+     return new MacDataProvider(pid);
++#elif defined(Q_OS_HAIKU)
++    return new HaikuDataProvider(pid);
+ #elif defined(Q_OS_LINUX)
+     return new LinuxDataProvider(pid);
+ #else
+-- 
+2.52.0
+
+
+From 2fe6f98d522f610ece2a8adca8644a3dba264e34 Mon Sep 17 00:00:00 2001
+From: Luc Schrijvers <begasus@gmail.com>
+Date: Thu, 19 Jun 2025 14:31:35 +0200
+Subject: Fix binary reference in launcher script
+
+
+diff --git a/bin/qtcreator.sh b/bin/qtcreator.sh
+index 86826f1..244dc7a 100755
+--- a/bin/qtcreator.sh
++++ b/bin/qtcreator.sh
+@@ -42,4 +42,4 @@ fi
+ _ORIGINAL_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
+ LD_LIBRARY_PATH=$libdir:$libdir/qtcreator$qtlibpath${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+ export LD_LIBRARY_PATH
+-exec "$bindir/qtcreator" -user-library-path "$_ORIGINAL_LD_LIBRARY_PATH" ${1+"$@"}
++exec "$bindir/Qt Creator" -user-library-path "$_ORIGINAL_LD_LIBRARY_PATH" ${1+"$@"}
+-- 
+2.52.0
+

--- a/dev-qt/qt_creator/qt_creator-19.0.2.recipe
+++ b/dev-qt/qt_creator/qt_creator-19.0.2.recipe
@@ -8,13 +8,14 @@ COPYRIGHT="2026 The Qt Company Ltd"
 LICENSE="GNU GPL v3"
 REVISION="1"
 SOURCE_URI="https://download.qt.io/official_releases/qtcreator/${portVersion%.*}/$portVersion/qt-creator-opensource-src-$portVersion.tar.xz"
-CHECKSUM_SHA256="76e094ac8ae56e8611bc2dae07e972652860b2ae9d59baff49768523a4cff289"
+CHECKSUM_SHA256="5c3c38ce88b03882d1fb40ce6ef54a7ff6bf2b87602f80dabea169bffb519cc3"
 SOURCE_DIR="qt-creator-opensource-src-$portVersion"
-PATCHES="qt_creator-$portVersion.patchset"
+PATCHES="qt_creator-$portVersion.patchset
+	int128.diff"
 ADDITIONAL_FILES="qt_creator.rdef.in"
 
-ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="?x86"
+ARCHITECTURES="ALL !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 if [ "$targetArchitecture" = x86_gcc2 ]; then
 libClangVer="18"
@@ -32,11 +33,8 @@ PROVIDES="
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libarchive$secondaryArchSuffix
-	lib:libclang$secondaryArchSuffix
-	lib:libclang_cpp$secondaryArchSuffix
 	lib:libexecinfo$secondaryArchSuffix
 	lib:libGL$secondaryArchSuffix
-	lib:libLLVM$secondaryArchSuffix
 	lib:libsecret_1$secondaryArchSuffix
 	lib:libsqlite3$secondaryArchSuffix
 	lib:libyaml_cpp$secondaryArchSuffix
@@ -63,15 +61,20 @@ REQUIRES="
 	lib:libQt6Widgets$secondaryArchSuffix
 	lib:libQt6Xml$secondaryArchSuffix
 	"
+if [ "$targetArchitecture" = !x86_gcc2 ]; then
+REQUIRES+="
+	lib:libclang$secondaryArchSuffix
+	lib:libclang_cpp$secondaryArchSuffix
+	lib:libLLVM$secondaryArchSuffix
+	"
+fi
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libarchive$secondaryArchSuffix
-	devel:libclang$secondaryArchSuffix >= $clangVer
-	devel:libclang_cpp$secondaryArchSuffix >= $clangVer
 	devel:libexecinfo$secondaryArchSuffix
 	devel:libGL$secondaryArchSuffix
-	devel:libLLVM_$clangVer$secondaryArchSuffix
+	devel:libomp$secondaryArchSuffix
 	devel:libsecret_1$secondaryArchSuffix
 	devel:libsqlite3$secondaryArchSuffix
 	devel:libyaml_cpp$secondaryArchSuffix >= 0.8
@@ -99,14 +102,10 @@ BUILD_REQUIRES="
 	devel:libQt6Widgets$secondaryArchSuffix
 	devel:libQt6Xml$secondaryArchSuffix
 	"
-if [ "$clangVer" == 21 ]; then
-BUILD_REQUIRES+="
-	devel:libomp$secondaryArchSuffix
-	"
-fi
 BUILD_PREREQUIRES="
 	cmd:cmake
 	cmd:g++$secondaryArchSuffix
+	cmd:llvm_config >= $clangVer
 	cmd:ninja
 	cmd:perl
 	cmd:pkg_config$secondaryArchSuffix
@@ -134,14 +133,16 @@ INSTALL()
 {
 	cmake --install build --prefix $appsDir/QtCreator
 
+if [ "$targetArchitecture" != x86_gcc2 ]; then
 	# Create symlink to libclang
 	ln -s /system/$relativeDevelopLibDir/libclang.so.$libClangVer $appsDir/QtCreator/lib/qtcreator/
 	ln -s /system/$relativeDevelopLibDir/libclang.so.$libClangVer $appsDir/QtCreator/libexec/qtcreator/
+fi
 
 	local APP_SIGNATURE="application/x-vnd.qt6-qtcreator"
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
 	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
-	local MINOR="`echo "$portVersion" | cut -d. -f3 | cut -d~ -f1`"
+	local MINOR="`echo "$portVersion" | cut -d. -f3`"
 	local LONG_INFO="$SUMMARY"
 	sed \
 		-e "s|@APP_SIGNATURE@|$APP_SIGNATURE|" \


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
