### PR TITLE
tdlib, revbump for rebuild, fixes reference for openssl version

### DIFF
--- a/net-libs/tdlib/tdlib-0.0.20260409.recipe
+++ b/net-libs/tdlib/tdlib-0.0.20260409.recipe
@@ -4,7 +4,7 @@ Telegram clients. It can be easily used from almost any programming language."
 HOMEPAGE="https://github.com/tdlib/td"
 COPYRIGHT="2013-2026 Telegram"
 LICENSE="Boost v1.0"
-REVISION="1"
+REVISION="2"
 srcGitRev="a82128ab8e28bd3ff4f9fee91b7a30e0bc36ddd6"
 SOURCE_URI="https://github.com/tdlib/td/archive/$srcGitRev.tar.gz"
 SOURCE_DIR="td-$srcGitRev"
@@ -24,7 +24,6 @@ PROVIDES="
 	devel:libtdcore$secondaryArchSuffix = 0.0.0 compat >= 0
 	devel:libtddb$secondaryArchSuffix = 0.0.0 compat >= 0
 	devel:libtde2e$secondaryArchSuffix = 0.0.0 compat >= 0
-	devel:libtdjson$secondaryArchSuffix = 0.0.0 compat >= 0
 	devel:libtdjson_private$secondaryArchSuffix = 0.0.0 compat >= 0
 	devel:libtdjson_static$secondaryArchSuffix = 0.0.0 compat >= 0
 	devel:libtdmtproto$secondaryArchSuffix = 0.0.0 compat >= 0


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
