### PR TITLE
telegram_desktop, revbump, fixes missing symbol on Qt6 update

### DIFF
--- a/net-im/telegram-desktop/telegram_desktop-6.1.3.recipe
+++ b/net-im/telegram-desktop/telegram_desktop-6.1.3.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="Unofficial build of the original Telegram client for Haiku."
 HOMEPAGE="https://www.telegram.org/"
 COPYRIGHT="2013-2025 Telegram"
 LICENSE="GNU GPL v3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/telegramdesktop/tdesktop/releases/download/v$portVersion/tdesktop-$portVersion-full.tar.gz"
 CHECKSUM_SHA256="1c6a531abf106d5f4b6d9179fc802f93cb8ab62630cc07e73d64688780125869"
 SOURCE_FILENAME="tdesktop-$portVersion-full.tar.gz"
@@ -137,7 +137,7 @@ else
 fi
 
 BUILD_PREREQUIRES="
-	makefile_engine	
+	makefile_engine
 	cmd:cmake
 	cmd:find
 	cmd:gawk
@@ -168,7 +168,7 @@ BUILD()
 	export GI_GIR_PATH="`finddir B_SYSTEM_DATA_DIRECTORY`"/gir-1.0
 	local DISABLE_PRECOMPILE_HEADERS="OFF"
 	local CXX_FLAGS_RELEASE="-O3"
-	
+
 	if [ $targetArchitecture == x86_gcc2 ]; then
 		sed -i -e '/-fstack-protector-all/d' cmake/options_linux.cmake
 		sed -i -e '/_GLIBCXX_ASSERTIONS/d' cmake/options_linux.cmake

--- a/net-im/telegram-desktop/telegram_desktop-6.7.6.recipe
+++ b/net-im/telegram-desktop/telegram_desktop-6.7.6.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="Unofficial build of the original Telegram client for Haiku."
 HOMEPAGE="https://www.telegram.org/"
 COPYRIGHT="2013-2026 Telegram"
 LICENSE="GNU GPL v3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/telegramdesktop/tdesktop/releases/download/v$portVersion/tdesktop-$portVersion-full.tar.gz"
 CHECKSUM_SHA256="5d3ba64c0d3e27468993d2376c68021152ea9c9e34ebadd8bee66a1e85e9d163"
 SOURCE_FILENAME="tdesktop-$portVersion-full.tar.gz"
@@ -82,10 +82,9 @@ BUILD_REQUIRES="
 	qt6_tools${secondaryArchSuffix}_devel
 	devel:libabsl_strings$secondaryArchSuffix >= 2301.0.0
 	devel:libavif$secondaryArchSuffix
-	devel:libboost_filesystem$secondaryArchSuffix >= 1.83.0
-	devel:libboost_regex$secondaryArchSuffix >= 1.83.0
-	devel:libboost_system$secondaryArchSuffix >= 1.83.0
-	devel:libboost_program_options$secondaryArchSuffix >= 1.83.0
+	devel:libboost_filesystem$secondaryArchSuffix >= 1.90.0
+	devel:libboost_regex$secondaryArchSuffix >= 1.90.0
+	devel:libboost_program_options$secondaryArchSuffix >= 1.90.0
 	devel:libbrotlienc$secondaryArchSuffix
 	devel:libcrypto$secondaryArchSuffix >= 3
 	devel:libfmt$secondaryArchSuffix
@@ -134,7 +133,7 @@ else
 fi
 
 BUILD_PREREQUIRES="
-	makefile_engine	
+	makefile_engine
 	cmd:cmake
 	cmd:find
 	cmd:gawk
@@ -157,7 +156,7 @@ BUILD()
 	export GI_GIR_PATH="`finddir B_SYSTEM_DATA_DIRECTORY`"/gir-1.0
 	local DISABLE_PRECOMPILE_HEADERS="OFF"
 	local CXX_FLAGS_RELEASE="-O3"
-	
+
 	if [ $targetArchitecture == x86_gcc2 ]; then
 		sed -i -e '/-fstack-protector-all/d' cmake/options_linux.cmake
 		sed -i -e '/_GLIBCXX_ASSERTIONS/d' cmake/options_linux.cmake
@@ -210,7 +209,8 @@ BUILD()
 		-DLIBTGVOIP_DISABLE_PULSEAUDIO=ON \
 		-DTDESKTOP_API_ID=$TELEGRAM_API_ID \
 		-DTDESKTOP_API_HASH=$TELEGRAM_API_HASH \
-		-DLZ4_INCLUDE_DIRS=/system/$relativeIncludeDir
+		-DLZ4_INCLUDE_DIRS=/system/$relativeIncludeDir \
+		-Wno-dev
 
 	# hack for info_profile_actions.cpp file (fix OOM error)
 	if [ $targetArchitecture == x86_gcc2 ]; then


### PR DESCRIPTION
tdlib and tg_owt should be build in the same cycle (references for openssl and ffmpeg8)

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
