### PR TITLE
tg_owt, drop versioning for ffmpeg libraries

### DIFF
--- a/media-libs/tg_owt/tg_owt-0.0.20260409.recipe
+++ b/media-libs/tg_owt/tg_owt-0.0.20260409.recipe
@@ -37,16 +37,16 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libavcodec$secondaryArchSuffix >= 62
-	lib:libavformat$secondaryArchSuffix >= 62
-	lib:libavutil$secondaryArchSuffix >= 60
+	lib:libavcodec$secondaryArchSuffix
+	lib:libavformat$secondaryArchSuffix
+	lib:libavutil$secondaryArchSuffix
 	lib:libcrypto$secondaryArchSuffix
 	lib:libjpeg$secondaryArchSuffix
 	lib:libopenh264$secondaryArchSuffix
 	lib:libopus$secondaryArchSuffix
 	lib:libprotobuf$secondaryArchSuffix
-	lib:libswresample$secondaryArchSuffix >= 6
-	lib:libswscale$secondaryArchSuffix >= 9
+	lib:libswresample$secondaryArchSuffix
+	lib:libswscale$secondaryArchSuffix
 	lib:libvpx$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"


### PR DESCRIPTION
fixes 32bit

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
