### PR TITLE
telegram_desktop, trigger 64bit build

### DIFF
--- a/net-im/telegram-desktop/telegram_desktop-6.7.6.recipe
+++ b/net-im/telegram-desktop/telegram_desktop-6.7.6.recipe
@@ -29,10 +29,10 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libabsl_strings$secondaryArchSuffix
 	lib:libatomic$secondaryArchSuffix
-	lib:libavcodec$secondaryArchSuffix >= 62
-	lib:libavformat$secondaryArchSuffix >= 62
+	lib:libavcodec$secondaryArchSuffix
+	lib:libavformat$secondaryArchSuffix
 	lib:libavif$secondaryArchSuffix
-	lib:libavutil$secondaryArchSuffix >= 60
+	lib:libavutil$secondaryArchSuffix
 	lib:libboost_filesystem$secondaryArchSuffix
 	lib:libboost_regex$secondaryArchSuffix
 	lib:libboost_system$secondaryArchSuffix
@@ -67,8 +67,8 @@ REQUIRES="
 	lib:librnnoise$secondaryArchSuffix
 	lib:libsigc_3.0$secondaryArchSuffix
 	lib:libstdc++$secondaryArchSuffix
-	lib:libswresample$secondaryArchSuffix >= 6
-	lib:libswscale$secondaryArchSuffix >= 9
+	lib:libswresample$secondaryArchSuffix
+	lib:libswscale$secondaryArchSuffix
 	lib:libvpx$secondaryArchSuffix
 	lib:libxkbcommon$secondaryArchSuffix
 	lib:libxxhash$secondaryArchSuffix


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
