### PR TITLE
telegram_desktop, fix build for 32bit (Qt private modules not found)

### DIFF
--- a/net-im/telegram-desktop/patches/telegram_desktop-6.1.3.patchset
+++ b/net-im/telegram-desktop/patches/telegram_desktop-6.1.3.patchset
@@ -1,4 +1,4 @@
-From 9c5eb4b270664645cb2bf80ced7785f2b5114fd6 Mon Sep 17 00:00:00 2001
+From b1bdb9e2c85450424cdeb539cb92f729e3e12eab Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Tue, 30 Sep 2025 08:36:00 +1000
 Subject: Add haiku support
@@ -1334,5 +1334,11914 @@ index fdbc4b0..4aab9ea 100644
      set(protobuf_lib protobuf::libprotobuf-lite)
  elseif (WIN32)
 -- 
-2.50.1
+2.54.0
+
+
+From b8efac1b74ed2212f3bd11521a6f77ac73f5353a Mon Sep 17 00:00:00 2001
+From: Gerasim Troeglazov <3dEyes@gmail.com>
+Date: Tue, 30 Sep 2025 09:18:24 +0000
+Subject: Add PCH file
+
+
+diff --git a/pch_disable.patchset b/pch_disable.patchset
+new file mode 100644
+index 0000000..3b2ba07
+--- /dev/null
++++ b/pch_disable.patchset
+@@ -0,0 +1,11867 @@
++diff --git a/Telegram/SourceFiles/api/api_attached_stickers.cpp b/Telegram/SourceFiles/api/api_attached_stickers.cpp
++index 0f18e76..f7147e2 100644
++--- a/Telegram/SourceFiles/api/api_attached_stickers.cpp
+++++ b/Telegram/SourceFiles/api/api_attached_stickers.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_authorizations.cpp b/Telegram/SourceFiles/api/api_authorizations.cpp
++index 01caa44..cdf99fe 100644
++--- a/Telegram/SourceFiles/api/api_authorizations.cpp
+++++ b/Telegram/SourceFiles/api/api_authorizations.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_blocked_peers.cpp b/Telegram/SourceFiles/api/api_blocked_peers.cpp
++index 0a79eb7..cdab3cf 100644
++--- a/Telegram/SourceFiles/api/api_blocked_peers.cpp
+++++ b/Telegram/SourceFiles/api/api_blocked_peers.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_bot.cpp b/Telegram/SourceFiles/api/api_bot.cpp
++index 05c0d46..18cc76a 100644
++--- a/Telegram/SourceFiles/api/api_bot.cpp
+++++ b/Telegram/SourceFiles/api/api_bot.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_chat_filters.cpp b/Telegram/SourceFiles/api/api_chat_filters.cpp
++index 55bbabb..a05d002 100644
++--- a/Telegram/SourceFiles/api/api_chat_filters.cpp
+++++ b/Telegram/SourceFiles/api/api_chat_filters.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_chat_filters_remove_manager.cpp b/Telegram/SourceFiles/api/api_chat_filters_remove_manager.cpp
++index ffd3fb0..f0fc5be 100644
++--- a/Telegram/SourceFiles/api/api_chat_filters_remove_manager.cpp
+++++ b/Telegram/SourceFiles/api/api_chat_filters_remove_manager.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_chat_invite.cpp b/Telegram/SourceFiles/api/api_chat_invite.cpp
++index 415c1a8..a729d5e 100644
++--- a/Telegram/SourceFiles/api/api_chat_invite.cpp
+++++ b/Telegram/SourceFiles/api/api_chat_invite.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_chat_links.cpp b/Telegram/SourceFiles/api/api_chat_links.cpp
++index aa5be9f..b8c91c6 100644
++--- a/Telegram/SourceFiles/api/api_chat_links.cpp
+++++ b/Telegram/SourceFiles/api/api_chat_links.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_chat_participants.cpp b/Telegram/SourceFiles/api/api_chat_participants.cpp
++index 8093168..c13a7af 100644
++--- a/Telegram/SourceFiles/api/api_chat_participants.cpp
+++++ b/Telegram/SourceFiles/api/api_chat_participants.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_cloud_password.cpp b/Telegram/SourceFiles/api/api_cloud_password.cpp
++index c87b9fc..9f951fa 100644
++--- a/Telegram/SourceFiles/api/api_cloud_password.cpp
+++++ b/Telegram/SourceFiles/api/api_cloud_password.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_common.cpp b/Telegram/SourceFiles/api/api_common.cpp
++index 55017ad..b19cd81 100644
++--- a/Telegram/SourceFiles/api/api_common.cpp
+++++ b/Telegram/SourceFiles/api/api_common.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_confirm_phone.cpp b/Telegram/SourceFiles/api/api_confirm_phone.cpp
++index 7379681..104418b 100644
++--- a/Telegram/SourceFiles/api/api_confirm_phone.cpp
+++++ b/Telegram/SourceFiles/api/api_confirm_phone.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_credits.cpp b/Telegram/SourceFiles/api/api_credits.cpp
++index 0670972..889f5b2 100644
++--- a/Telegram/SourceFiles/api/api_credits.cpp
+++++ b/Telegram/SourceFiles/api/api_credits.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_credits_history_entry.cpp b/Telegram/SourceFiles/api/api_credits_history_entry.cpp
++index dbf6164..b66af31 100644
++--- a/Telegram/SourceFiles/api/api_credits_history_entry.cpp
+++++ b/Telegram/SourceFiles/api/api_credits_history_entry.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_earn.cpp b/Telegram/SourceFiles/api/api_earn.cpp
++index 3b8272f..233d82e 100644
++--- a/Telegram/SourceFiles/api/api_earn.cpp
+++++ b/Telegram/SourceFiles/api/api_earn.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_editing.cpp b/Telegram/SourceFiles/api/api_editing.cpp
++index e3ec52e..7d0ab48 100644
++--- a/Telegram/SourceFiles/api/api_editing.cpp
+++++ b/Telegram/SourceFiles/api/api_editing.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_global_privacy.cpp b/Telegram/SourceFiles/api/api_global_privacy.cpp
++index 0beb421..3728609 100644
++--- a/Telegram/SourceFiles/api/api_global_privacy.cpp
+++++ b/Telegram/SourceFiles/api/api_global_privacy.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_hash.cpp b/Telegram/SourceFiles/api/api_hash.cpp
++index 15aca8e..303a234 100644
++--- a/Telegram/SourceFiles/api/api_hash.cpp
+++++ b/Telegram/SourceFiles/api/api_hash.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_invite_links.cpp b/Telegram/SourceFiles/api/api_invite_links.cpp
++index c896561..51d34f1 100644
++--- a/Telegram/SourceFiles/api/api_invite_links.cpp
+++++ b/Telegram/SourceFiles/api/api_invite_links.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_media.cpp b/Telegram/SourceFiles/api/api_media.cpp
++index f733169..384b5a6 100644
++--- a/Telegram/SourceFiles/api/api_media.cpp
+++++ b/Telegram/SourceFiles/api/api_media.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_messages_search.cpp b/Telegram/SourceFiles/api/api_messages_search.cpp
++index fb39056..783ed5d 100644
++--- a/Telegram/SourceFiles/api/api_messages_search.cpp
+++++ b/Telegram/SourceFiles/api/api_messages_search.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_messages_search_merged.cpp b/Telegram/SourceFiles/api/api_messages_search_merged.cpp
++index 5a26e43..a808ebf 100644
++--- a/Telegram/SourceFiles/api/api_messages_search_merged.cpp
+++++ b/Telegram/SourceFiles/api/api_messages_search_merged.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_peer_colors.cpp b/Telegram/SourceFiles/api/api_peer_colors.cpp
++index 5f3fe12..a0b8ba5 100644
++--- a/Telegram/SourceFiles/api/api_peer_colors.cpp
+++++ b/Telegram/SourceFiles/api/api_peer_colors.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_peer_photo.cpp b/Telegram/SourceFiles/api/api_peer_photo.cpp
++index 9c8a470..c64a7c8 100644
++--- a/Telegram/SourceFiles/api/api_peer_photo.cpp
+++++ b/Telegram/SourceFiles/api/api_peer_photo.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_peer_search.cpp b/Telegram/SourceFiles/api/api_peer_search.cpp
++index 7893346..0885953 100644
++--- a/Telegram/SourceFiles/api/api_peer_search.cpp
+++++ b/Telegram/SourceFiles/api/api_peer_search.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_polls.cpp b/Telegram/SourceFiles/api/api_polls.cpp
++index 810d515..67f9760 100644
++--- a/Telegram/SourceFiles/api/api_polls.cpp
+++++ b/Telegram/SourceFiles/api/api_polls.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_premium.cpp b/Telegram/SourceFiles/api/api_premium.cpp
++index 545ef29..916d9cf 100644
++--- a/Telegram/SourceFiles/api/api_premium.cpp
+++++ b/Telegram/SourceFiles/api/api_premium.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_premium_option.cpp b/Telegram/SourceFiles/api/api_premium_option.cpp
++index f5f0af3..206d728 100644
++--- a/Telegram/SourceFiles/api/api_premium_option.cpp
+++++ b/Telegram/SourceFiles/api/api_premium_option.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_report.cpp b/Telegram/SourceFiles/api/api_report.cpp
++index f3b0658..d2c9192 100644
++--- a/Telegram/SourceFiles/api/api_report.cpp
+++++ b/Telegram/SourceFiles/api/api_report.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_ringtones.cpp b/Telegram/SourceFiles/api/api_ringtones.cpp
++index 307ba58..4c52d9c 100644
++--- a/Telegram/SourceFiles/api/api_ringtones.cpp
+++++ b/Telegram/SourceFiles/api/api_ringtones.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_self_destruct.cpp b/Telegram/SourceFiles/api/api_self_destruct.cpp
++index 4bc32f8..9a2bee1 100644
++--- a/Telegram/SourceFiles/api/api_self_destruct.cpp
+++++ b/Telegram/SourceFiles/api/api_self_destruct.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_send_progress.cpp b/Telegram/SourceFiles/api/api_send_progress.cpp
++index 93d2879..4110b65 100644
++--- a/Telegram/SourceFiles/api/api_send_progress.cpp
+++++ b/Telegram/SourceFiles/api/api_send_progress.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_sending.cpp b/Telegram/SourceFiles/api/api_sending.cpp
++index cbfa6a9..0577e61 100644
++--- a/Telegram/SourceFiles/api/api_sending.cpp
+++++ b/Telegram/SourceFiles/api/api_sending.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_sensitive_content.cpp b/Telegram/SourceFiles/api/api_sensitive_content.cpp
++index e1e2595..447705e 100644
++--- a/Telegram/SourceFiles/api/api_sensitive_content.cpp
+++++ b/Telegram/SourceFiles/api/api_sensitive_content.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_single_message_search.cpp b/Telegram/SourceFiles/api/api_single_message_search.cpp
++index 2597c2f..1ffaa4c 100644
++--- a/Telegram/SourceFiles/api/api_single_message_search.cpp
+++++ b/Telegram/SourceFiles/api/api_single_message_search.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_statistics.cpp b/Telegram/SourceFiles/api/api_statistics.cpp
++index 04f471e..635c617 100644
++--- a/Telegram/SourceFiles/api/api_statistics.cpp
+++++ b/Telegram/SourceFiles/api/api_statistics.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_statistics_data_deserialize.cpp b/Telegram/SourceFiles/api/api_statistics_data_deserialize.cpp
++index 9ce75af..532edfc 100644
++--- a/Telegram/SourceFiles/api/api_statistics_data_deserialize.cpp
+++++ b/Telegram/SourceFiles/api/api_statistics_data_deserialize.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_statistics_sender.cpp b/Telegram/SourceFiles/api/api_statistics_sender.cpp
++index 21d068e..4afef3e 100644
++--- a/Telegram/SourceFiles/api/api_statistics_sender.cpp
+++++ b/Telegram/SourceFiles/api/api_statistics_sender.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_suggest_post.cpp b/Telegram/SourceFiles/api/api_suggest_post.cpp
++index 05d0304..4a0b9f5 100644
++--- a/Telegram/SourceFiles/api/api_suggest_post.cpp
+++++ b/Telegram/SourceFiles/api/api_suggest_post.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_text_entities.cpp b/Telegram/SourceFiles/api/api_text_entities.cpp
++index 9f400d0..9b80ae0 100644
++--- a/Telegram/SourceFiles/api/api_text_entities.cpp
+++++ b/Telegram/SourceFiles/api/api_text_entities.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_todo_lists.cpp b/Telegram/SourceFiles/api/api_todo_lists.cpp
++index c65001f..69148ca 100644
++--- a/Telegram/SourceFiles/api/api_todo_lists.cpp
+++++ b/Telegram/SourceFiles/api/api_todo_lists.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_toggling_media.cpp b/Telegram/SourceFiles/api/api_toggling_media.cpp
++index 65d2ce3..9118064 100644
++--- a/Telegram/SourceFiles/api/api_toggling_media.cpp
+++++ b/Telegram/SourceFiles/api/api_toggling_media.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_transcribes.cpp b/Telegram/SourceFiles/api/api_transcribes.cpp
++index 17681cc..f77b386 100644
++--- a/Telegram/SourceFiles/api/api_transcribes.cpp
+++++ b/Telegram/SourceFiles/api/api_transcribes.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_unread_things.cpp b/Telegram/SourceFiles/api/api_unread_things.cpp
++index 32deab3..c4e1639 100644
++--- a/Telegram/SourceFiles/api/api_unread_things.cpp
+++++ b/Telegram/SourceFiles/api/api_unread_things.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_updates.cpp b/Telegram/SourceFiles/api/api_updates.cpp
++index 893476b..70b2b20 100644
++--- a/Telegram/SourceFiles/api/api_updates.cpp
+++++ b/Telegram/SourceFiles/api/api_updates.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_user_names.cpp b/Telegram/SourceFiles/api/api_user_names.cpp
++index fa040f1..3965fb6 100644
++--- a/Telegram/SourceFiles/api/api_user_names.cpp
+++++ b/Telegram/SourceFiles/api/api_user_names.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_user_privacy.cpp b/Telegram/SourceFiles/api/api_user_privacy.cpp
++index e07858d..dbd1505 100644
++--- a/Telegram/SourceFiles/api/api_user_privacy.cpp
+++++ b/Telegram/SourceFiles/api/api_user_privacy.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_views.cpp b/Telegram/SourceFiles/api/api_views.cpp
++index e80f56e..3835a0e 100644
++--- a/Telegram/SourceFiles/api/api_views.cpp
+++++ b/Telegram/SourceFiles/api/api_views.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_websites.cpp b/Telegram/SourceFiles/api/api_websites.cpp
++index 2ea6b2a..646b5d5 100644
++--- a/Telegram/SourceFiles/api/api_websites.cpp
+++++ b/Telegram/SourceFiles/api/api_websites.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/api/api_who_reacted.cpp b/Telegram/SourceFiles/api/api_who_reacted.cpp
++index b3070fb..d5df07f 100644
++--- a/Telegram/SourceFiles/api/api_who_reacted.cpp
+++++ b/Telegram/SourceFiles/api/api_who_reacted.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/apiwrap.cpp b/Telegram/SourceFiles/apiwrap.cpp
++index 256dbdb..8af44d9 100644
++--- a/Telegram/SourceFiles/apiwrap.cpp
+++++ b/Telegram/SourceFiles/apiwrap.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/about_box.cpp b/Telegram/SourceFiles/boxes/about_box.cpp
++index f270788..bef2dd5 100644
++--- a/Telegram/SourceFiles/boxes/about_box.cpp
+++++ b/Telegram/SourceFiles/boxes/about_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/about_sponsored_box.cpp b/Telegram/SourceFiles/boxes/about_sponsored_box.cpp
++index e4e3515..8a1f8ee 100644
++--- a/Telegram/SourceFiles/boxes/about_sponsored_box.cpp
+++++ b/Telegram/SourceFiles/boxes/about_sponsored_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/abstract_box.cpp b/Telegram/SourceFiles/boxes/abstract_box.cpp
++index 5b9f1fd..17dc925 100644
++--- a/Telegram/SourceFiles/boxes/abstract_box.cpp
+++++ b/Telegram/SourceFiles/boxes/abstract_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/add_contact_box.cpp b/Telegram/SourceFiles/boxes/add_contact_box.cpp
++index 6e9bc23..f933d6b 100644
++--- a/Telegram/SourceFiles/boxes/add_contact_box.cpp
+++++ b/Telegram/SourceFiles/boxes/add_contact_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/auto_download_box.cpp b/Telegram/SourceFiles/boxes/auto_download_box.cpp
++index 3617a9e..1ab6516 100644
++--- a/Telegram/SourceFiles/boxes/auto_download_box.cpp
+++++ b/Telegram/SourceFiles/boxes/auto_download_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/auto_lock_box.cpp b/Telegram/SourceFiles/boxes/auto_lock_box.cpp
++index cc7cdb4..e405681 100644
++--- a/Telegram/SourceFiles/boxes/auto_lock_box.cpp
+++++ b/Telegram/SourceFiles/boxes/auto_lock_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/background_box.cpp b/Telegram/SourceFiles/boxes/background_box.cpp
++index 8723572..6c85aa8 100644
++--- a/Telegram/SourceFiles/boxes/background_box.cpp
+++++ b/Telegram/SourceFiles/boxes/background_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/background_preview_box.cpp b/Telegram/SourceFiles/boxes/background_preview_box.cpp
++index 24d4fd1..0f9b223 100644
++--- a/Telegram/SourceFiles/boxes/background_preview_box.cpp
+++++ b/Telegram/SourceFiles/boxes/background_preview_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/choose_filter_box.cpp b/Telegram/SourceFiles/boxes/choose_filter_box.cpp
++index 4cd5562..5389b2d 100644
++--- a/Telegram/SourceFiles/boxes/choose_filter_box.cpp
+++++ b/Telegram/SourceFiles/boxes/choose_filter_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/connection_box.cpp b/Telegram/SourceFiles/boxes/connection_box.cpp
++index 898c049..9df888b 100644
++--- a/Telegram/SourceFiles/boxes/connection_box.cpp
+++++ b/Telegram/SourceFiles/boxes/connection_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/create_poll_box.cpp b/Telegram/SourceFiles/boxes/create_poll_box.cpp
++index 290da2d..9f9607c 100644
++--- a/Telegram/SourceFiles/boxes/create_poll_box.cpp
+++++ b/Telegram/SourceFiles/boxes/create_poll_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/delete_messages_box.cpp b/Telegram/SourceFiles/boxes/delete_messages_box.cpp
++index 9a04827..884203b 100644
++--- a/Telegram/SourceFiles/boxes/delete_messages_box.cpp
+++++ b/Telegram/SourceFiles/boxes/delete_messages_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/dictionaries_manager.cpp b/Telegram/SourceFiles/boxes/dictionaries_manager.cpp
++index 8881449..f2a14fa 100644
++--- a/Telegram/SourceFiles/boxes/dictionaries_manager.cpp
+++++ b/Telegram/SourceFiles/boxes/dictionaries_manager.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/download_path_box.cpp b/Telegram/SourceFiles/boxes/download_path_box.cpp
++index a5e15f3..537174b 100644
++--- a/Telegram/SourceFiles/boxes/download_path_box.cpp
+++++ b/Telegram/SourceFiles/boxes/download_path_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/edit_caption_box.cpp b/Telegram/SourceFiles/boxes/edit_caption_box.cpp
++index 3e48724..0e4b107 100644
++--- a/Telegram/SourceFiles/boxes/edit_caption_box.cpp
+++++ b/Telegram/SourceFiles/boxes/edit_caption_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/edit_privacy_box.cpp b/Telegram/SourceFiles/boxes/edit_privacy_box.cpp
++index 411f4b1..a8570f5 100644
++--- a/Telegram/SourceFiles/boxes/edit_privacy_box.cpp
+++++ b/Telegram/SourceFiles/boxes/edit_privacy_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/edit_todo_list_box.cpp b/Telegram/SourceFiles/boxes/edit_todo_list_box.cpp
++index 2f1add5..7acd44f 100644
++--- a/Telegram/SourceFiles/boxes/edit_todo_list_box.cpp
+++++ b/Telegram/SourceFiles/boxes/edit_todo_list_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/filters/edit_filter_box.cpp b/Telegram/SourceFiles/boxes/filters/edit_filter_box.cpp
++index 7584c9f..8851a0f 100644
++--- a/Telegram/SourceFiles/boxes/filters/edit_filter_box.cpp
+++++ b/Telegram/SourceFiles/boxes/filters/edit_filter_box.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/filters/edit_filter_chats_list.cpp b/Telegram/SourceFiles/boxes/filters/edit_filter_chats_list.cpp
++index a200bce..1b70650 100644
++--- a/Telegram/SourceFiles/boxes/filters/edit_filter_chats_list.cpp
+++++ b/Telegram/SourceFiles/boxes/filters/edit_filter_chats_list.cpp
++@@ -1,3 +1,6 @@
+++#include "stdafx.h"
+++#include "stdafx.h"
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/filters/edit_filter_chats_preview.cpp b/Telegram/SourceFiles/boxes/filters/edit_filter_chats_preview.cpp
++index 1938665..a2f1a5e 100644
++--- a/Telegram/SourceFiles/boxes/filters/edit_filter_chats_preview.cpp
+++++ b/Telegram/SourceFiles/boxes/filters/edit_filter_chats_preview.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/filters/edit_filter_links.cpp b/Telegram/SourceFiles/boxes/filters/edit_filter_links.cpp
++index d420be8..de7a847 100644
++--- a/Telegram/SourceFiles/boxes/filters/edit_filter_links.cpp
+++++ b/Telegram/SourceFiles/boxes/filters/edit_filter_links.cpp
++@@ -1,3 +1,6 @@
+++#include "stdafx.h"
+++#include "stdafx.h"
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/gift_credits_box.cpp b/Telegram/SourceFiles/boxes/gift_credits_box.cpp
++index da7aef0..74c0e8b 100644
++--- a/Telegram/SourceFiles/boxes/gift_credits_box.cpp
+++++ b/Telegram/SourceFiles/boxes/gift_credits_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/gift_premium_box.cpp b/Telegram/SourceFiles/boxes/gift_premium_box.cpp
++index 9d674b9..711708d 100644
++--- a/Telegram/SourceFiles/boxes/gift_premium_box.cpp
+++++ b/Telegram/SourceFiles/boxes/gift_premium_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/language_box.cpp b/Telegram/SourceFiles/boxes/language_box.cpp
++index b8a9173..0e21638 100644
++--- a/Telegram/SourceFiles/boxes/language_box.cpp
+++++ b/Telegram/SourceFiles/boxes/language_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/local_storage_box.cpp b/Telegram/SourceFiles/boxes/local_storage_box.cpp
++index ade6a4e..6b49a61 100644
++--- a/Telegram/SourceFiles/boxes/local_storage_box.cpp
+++++ b/Telegram/SourceFiles/boxes/local_storage_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/max_invite_box.cpp b/Telegram/SourceFiles/boxes/max_invite_box.cpp
++index 3159285..df79fbd 100644
++--- a/Telegram/SourceFiles/boxes/max_invite_box.cpp
+++++ b/Telegram/SourceFiles/boxes/max_invite_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/moderate_messages_box.cpp b/Telegram/SourceFiles/boxes/moderate_messages_box.cpp
++index 1b493ec..ba877ee 100644
++--- a/Telegram/SourceFiles/boxes/moderate_messages_box.cpp
+++++ b/Telegram/SourceFiles/boxes/moderate_messages_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/passcode_box.cpp b/Telegram/SourceFiles/boxes/passcode_box.cpp
++index a235dc2..7dc8e52 100644
++--- a/Telegram/SourceFiles/boxes/passcode_box.cpp
+++++ b/Telegram/SourceFiles/boxes/passcode_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peer_list_box.cpp b/Telegram/SourceFiles/boxes/peer_list_box.cpp
++index 657c647..ff33d88 100644
++--- a/Telegram/SourceFiles/boxes/peer_list_box.cpp
+++++ b/Telegram/SourceFiles/boxes/peer_list_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peer_list_controllers.cpp b/Telegram/SourceFiles/boxes/peer_list_controllers.cpp
++index 0f0a8e0..2577e56 100644
++--- a/Telegram/SourceFiles/boxes/peer_list_controllers.cpp
+++++ b/Telegram/SourceFiles/boxes/peer_list_controllers.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peer_list_widgets.cpp b/Telegram/SourceFiles/boxes/peer_list_widgets.cpp
++index dfa729e..ea5e5a4 100644
++--- a/Telegram/SourceFiles/boxes/peer_list_widgets.cpp
+++++ b/Telegram/SourceFiles/boxes/peer_list_widgets.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peer_lists_box.cpp b/Telegram/SourceFiles/boxes/peer_lists_box.cpp
++index 9929840..b725431 100644
++--- a/Telegram/SourceFiles/boxes/peer_lists_box.cpp
+++++ b/Telegram/SourceFiles/boxes/peer_lists_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/add_bot_to_chat_box.cpp b/Telegram/SourceFiles/boxes/peers/add_bot_to_chat_box.cpp
++index e3cf2a2..80dce9d 100644
++--- a/Telegram/SourceFiles/boxes/peers/add_bot_to_chat_box.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/add_bot_to_chat_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp b/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
++index a5f2ec3..e33434f 100644
++--- a/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/add_participants_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/choose_peer_box.cpp b/Telegram/SourceFiles/boxes/peers/choose_peer_box.cpp
++index ca10840..26acf96 100644
++--- a/Telegram/SourceFiles/boxes/peers/choose_peer_box.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/choose_peer_box.cpp
++@@ -1,3 +1,6 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/edit_contact_box.cpp b/Telegram/SourceFiles/boxes/peers/edit_contact_box.cpp
++index cc378e6..5032002 100644
++--- a/Telegram/SourceFiles/boxes/peers/edit_contact_box.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/edit_contact_box.cpp
++@@ -1,3 +1,6 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/edit_discussion_link_box.cpp b/Telegram/SourceFiles/boxes/peers/edit_discussion_link_box.cpp
++index 7b9779e..30f5bc5 100644
++--- a/Telegram/SourceFiles/boxes/peers/edit_discussion_link_box.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/edit_discussion_link_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/edit_forum_topic_box.cpp b/Telegram/SourceFiles/boxes/peers/edit_forum_topic_box.cpp
++index e651ae7..1c63ac7 100644
++--- a/Telegram/SourceFiles/boxes/peers/edit_forum_topic_box.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/edit_forum_topic_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/edit_members_visible.cpp b/Telegram/SourceFiles/boxes/peers/edit_members_visible.cpp
++index 216a043..f1cae82 100644
++--- a/Telegram/SourceFiles/boxes/peers/edit_members_visible.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/edit_members_visible.cpp
++@@ -1,3 +1,6 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/edit_participant_box.cpp b/Telegram/SourceFiles/boxes/peers/edit_participant_box.cpp
++index 84c47cd..19981af 100644
++--- a/Telegram/SourceFiles/boxes/peers/edit_participant_box.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/edit_participant_box.cpp
++@@ -1,3 +1,6 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/edit_participants_box.cpp b/Telegram/SourceFiles/boxes/peers/edit_participants_box.cpp
++index 15a5f1a..0da9c0d 100644
++--- a/Telegram/SourceFiles/boxes/peers/edit_participants_box.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/edit_participants_box.cpp
++@@ -1,3 +1,6 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/edit_peer_color_box.cpp b/Telegram/SourceFiles/boxes/peers/edit_peer_color_box.cpp
++index a13b197..28d8647 100644
++--- a/Telegram/SourceFiles/boxes/peers/edit_peer_color_box.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/edit_peer_color_box.cpp
++@@ -1,3 +1,6 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/edit_peer_history_visibility_box.cpp b/Telegram/SourceFiles/boxes/peers/edit_peer_history_visibility_box.cpp
++index 8883ad0..e41cb21 100644
++--- a/Telegram/SourceFiles/boxes/peers/edit_peer_history_visibility_box.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/edit_peer_history_visibility_box.cpp
++@@ -1,3 +1,5 @@
+++#include "base/base_pch.h"
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/edit_peer_info_box.cpp b/Telegram/SourceFiles/boxes/peers/edit_peer_info_box.cpp
++index 201705a..4c81ba1 100644
++--- a/Telegram/SourceFiles/boxes/peers/edit_peer_info_box.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/edit_peer_info_box.cpp
++@@ -1,3 +1,6 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/edit_peer_invite_link.cpp b/Telegram/SourceFiles/boxes/peers/edit_peer_invite_link.cpp
++index 3058d4c..64f8bc5 100644
++--- a/Telegram/SourceFiles/boxes/peers/edit_peer_invite_link.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/edit_peer_invite_link.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/edit_peer_invite_links.cpp b/Telegram/SourceFiles/boxes/peers/edit_peer_invite_links.cpp
++index e3f3870..5369cf7 100644
++--- a/Telegram/SourceFiles/boxes/peers/edit_peer_invite_links.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/edit_peer_invite_links.cpp
++@@ -1,3 +1,6 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/edit_peer_permissions_box.cpp b/Telegram/SourceFiles/boxes/peers/edit_peer_permissions_box.cpp
++index 46cfe1c..c4e275c 100644
++--- a/Telegram/SourceFiles/boxes/peers/edit_peer_permissions_box.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/edit_peer_permissions_box.cpp
++@@ -1,3 +1,6 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/edit_peer_reactions.cpp b/Telegram/SourceFiles/boxes/peers/edit_peer_reactions.cpp
++index fdc3161..b822226 100644
++--- a/Telegram/SourceFiles/boxes/peers/edit_peer_reactions.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/edit_peer_reactions.cpp
++@@ -1,3 +1,6 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/edit_peer_requests_box.cpp b/Telegram/SourceFiles/boxes/peers/edit_peer_requests_box.cpp
++index 26310db..21f93cb 100644
++--- a/Telegram/SourceFiles/boxes/peers/edit_peer_requests_box.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/edit_peer_requests_box.cpp
++@@ -1,3 +1,6 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/edit_peer_type_box.cpp b/Telegram/SourceFiles/boxes/peers/edit_peer_type_box.cpp
++index 2b3665a..e77290a 100644
++--- a/Telegram/SourceFiles/boxes/peers/edit_peer_type_box.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/edit_peer_type_box.cpp
++@@ -1,3 +1,6 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/edit_peer_usernames_list.cpp b/Telegram/SourceFiles/boxes/peers/edit_peer_usernames_list.cpp
++index 7fcea45..09a83eb 100644
++--- a/Telegram/SourceFiles/boxes/peers/edit_peer_usernames_list.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/edit_peer_usernames_list.cpp
++@@ -1,3 +1,6 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/peer_short_info_box.cpp b/Telegram/SourceFiles/boxes/peers/peer_short_info_box.cpp
++index 12fab35..32315de 100644
++--- a/Telegram/SourceFiles/boxes/peers/peer_short_info_box.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/peer_short_info_box.cpp
++@@ -1,3 +1,6 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/prepare_short_info_box.cpp b/Telegram/SourceFiles/boxes/peers/prepare_short_info_box.cpp
++index 4e17073..75febf7 100644
++--- a/Telegram/SourceFiles/boxes/peers/prepare_short_info_box.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/prepare_short_info_box.cpp
++@@ -1,3 +1,6 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/replace_boost_box.cpp b/Telegram/SourceFiles/boxes/peers/replace_boost_box.cpp
++index f76b4cc..8bb744b 100644
++--- a/Telegram/SourceFiles/boxes/peers/replace_boost_box.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/replace_boost_box.cpp
++@@ -1,3 +1,6 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/toggle_topics_box.cpp b/Telegram/SourceFiles/boxes/peers/toggle_topics_box.cpp
++index 4d6d545..b8cc4ea 100644
++--- a/Telegram/SourceFiles/boxes/peers/toggle_topics_box.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/toggle_topics_box.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/peers/verify_peers_box.cpp b/Telegram/SourceFiles/boxes/peers/verify_peers_box.cpp
++index f3e71b6..e6541c6 100644
++--- a/Telegram/SourceFiles/boxes/peers/verify_peers_box.cpp
+++++ b/Telegram/SourceFiles/boxes/peers/verify_peers_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/phone_banned_box.cpp b/Telegram/SourceFiles/boxes/phone_banned_box.cpp
++index c1e9fb5..fae05da 100644
++--- a/Telegram/SourceFiles/boxes/phone_banned_box.cpp
+++++ b/Telegram/SourceFiles/boxes/phone_banned_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/pin_messages_box.cpp b/Telegram/SourceFiles/boxes/pin_messages_box.cpp
++index 9f0a84f..503195c 100644
++--- a/Telegram/SourceFiles/boxes/pin_messages_box.cpp
+++++ b/Telegram/SourceFiles/boxes/pin_messages_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/premium_limits_box.cpp b/Telegram/SourceFiles/boxes/premium_limits_box.cpp
++index f88a525..74337cd 100644
++--- a/Telegram/SourceFiles/boxes/premium_limits_box.cpp
+++++ b/Telegram/SourceFiles/boxes/premium_limits_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/premium_preview_box.cpp b/Telegram/SourceFiles/boxes/premium_preview_box.cpp
++index 53fa77a..19f7be1 100644
++--- a/Telegram/SourceFiles/boxes/premium_preview_box.cpp
+++++ b/Telegram/SourceFiles/boxes/premium_preview_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/reactions_settings_box.cpp b/Telegram/SourceFiles/boxes/reactions_settings_box.cpp
++index 8a71e39..4f0d906 100644
++--- a/Telegram/SourceFiles/boxes/reactions_settings_box.cpp
+++++ b/Telegram/SourceFiles/boxes/reactions_settings_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/report_messages_box.cpp b/Telegram/SourceFiles/boxes/report_messages_box.cpp
++index 25e548f..cc4bf88 100644
++--- a/Telegram/SourceFiles/boxes/report_messages_box.cpp
+++++ b/Telegram/SourceFiles/boxes/report_messages_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/ringtones_box.cpp b/Telegram/SourceFiles/boxes/ringtones_box.cpp
++index ef945ba..3049565 100644
++--- a/Telegram/SourceFiles/boxes/ringtones_box.cpp
+++++ b/Telegram/SourceFiles/boxes/ringtones_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/self_destruction_box.cpp b/Telegram/SourceFiles/boxes/self_destruction_box.cpp
++index e9946c9..d556f3e 100644
++--- a/Telegram/SourceFiles/boxes/self_destruction_box.cpp
+++++ b/Telegram/SourceFiles/boxes/self_destruction_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/send_credits_box.cpp b/Telegram/SourceFiles/boxes/send_credits_box.cpp
++index 8cfcdc1..1a6aba9 100644
++--- a/Telegram/SourceFiles/boxes/send_credits_box.cpp
+++++ b/Telegram/SourceFiles/boxes/send_credits_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/send_files_box.cpp b/Telegram/SourceFiles/boxes/send_files_box.cpp
++index 37ecd0a..28f55db 100644
++--- a/Telegram/SourceFiles/boxes/send_files_box.cpp
+++++ b/Telegram/SourceFiles/boxes/send_files_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/send_gif_with_caption_box.cpp b/Telegram/SourceFiles/boxes/send_gif_with_caption_box.cpp
++index 7deadbe..648494f 100644
++--- a/Telegram/SourceFiles/boxes/send_gif_with_caption_box.cpp
+++++ b/Telegram/SourceFiles/boxes/send_gif_with_caption_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/share_box.cpp b/Telegram/SourceFiles/boxes/share_box.cpp
++index 4c6eb01..ede7bce 100644
++--- a/Telegram/SourceFiles/boxes/share_box.cpp
+++++ b/Telegram/SourceFiles/boxes/share_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/star_gift_box.cpp b/Telegram/SourceFiles/boxes/star_gift_box.cpp
++index 0a89d2b..3095eb3 100644
++--- a/Telegram/SourceFiles/boxes/star_gift_box.cpp
+++++ b/Telegram/SourceFiles/boxes/star_gift_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/sticker_set_box.cpp b/Telegram/SourceFiles/boxes/sticker_set_box.cpp
++index f9f1e84..1d12736 100644
++--- a/Telegram/SourceFiles/boxes/sticker_set_box.cpp
+++++ b/Telegram/SourceFiles/boxes/sticker_set_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/stickers_box.cpp b/Telegram/SourceFiles/boxes/stickers_box.cpp
++index 65d3c40..20236e0 100644
++--- a/Telegram/SourceFiles/boxes/stickers_box.cpp
+++++ b/Telegram/SourceFiles/boxes/stickers_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/transfer_gift_box.cpp b/Telegram/SourceFiles/boxes/transfer_gift_box.cpp
++index 6ee2a49..8930567 100644
++--- a/Telegram/SourceFiles/boxes/transfer_gift_box.cpp
+++++ b/Telegram/SourceFiles/boxes/transfer_gift_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/translate_box.cpp b/Telegram/SourceFiles/boxes/translate_box.cpp
++index e805793..6b7163b 100644
++--- a/Telegram/SourceFiles/boxes/translate_box.cpp
+++++ b/Telegram/SourceFiles/boxes/translate_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/url_auth_box.cpp b/Telegram/SourceFiles/boxes/url_auth_box.cpp
++index 3047bbb..a3a7131 100644
++--- a/Telegram/SourceFiles/boxes/url_auth_box.cpp
+++++ b/Telegram/SourceFiles/boxes/url_auth_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/boxes/username_box.cpp b/Telegram/SourceFiles/boxes/username_box.cpp
++index 24635f9..ff93737 100644
++--- a/Telegram/SourceFiles/boxes/username_box.cpp
+++++ b/Telegram/SourceFiles/boxes/username_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/calls_box_controller.cpp b/Telegram/SourceFiles/calls/calls_box_controller.cpp
++index 794291d..3f4b7fc 100644
++--- a/Telegram/SourceFiles/calls/calls_box_controller.cpp
+++++ b/Telegram/SourceFiles/calls/calls_box_controller.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/calls_call.cpp b/Telegram/SourceFiles/calls/calls_call.cpp
++index 8e862fd..71a76f5 100644
++--- a/Telegram/SourceFiles/calls/calls_call.cpp
+++++ b/Telegram/SourceFiles/calls/calls_call.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/calls_controller.cpp b/Telegram/SourceFiles/calls/calls_controller.cpp
++index 9b82a8e..d488411 100644
++--- a/Telegram/SourceFiles/calls/calls_controller.cpp
+++++ b/Telegram/SourceFiles/calls/calls_controller.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/calls_controller_webrtc.cpp b/Telegram/SourceFiles/calls/calls_controller_webrtc.cpp
++index 6df83c2..648a25a 100644
++--- a/Telegram/SourceFiles/calls/calls_controller_webrtc.cpp
+++++ b/Telegram/SourceFiles/calls/calls_controller_webrtc.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/calls_emoji_fingerprint.cpp b/Telegram/SourceFiles/calls/calls_emoji_fingerprint.cpp
++index 7432c4a..8c0afdf 100644
++--- a/Telegram/SourceFiles/calls/calls_emoji_fingerprint.cpp
+++++ b/Telegram/SourceFiles/calls/calls_emoji_fingerprint.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/calls_instance.cpp b/Telegram/SourceFiles/calls/calls_instance.cpp
++index a04db8b..624750e 100644
++--- a/Telegram/SourceFiles/calls/calls_instance.cpp
+++++ b/Telegram/SourceFiles/calls/calls_instance.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/calls_panel.cpp b/Telegram/SourceFiles/calls/calls_panel.cpp
++index dbc9da8..da07f21 100644
++--- a/Telegram/SourceFiles/calls/calls_panel.cpp
+++++ b/Telegram/SourceFiles/calls/calls_panel.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/calls_signal_bars.cpp b/Telegram/SourceFiles/calls/calls_signal_bars.cpp
++index 9d2f3c8..9e5e518 100644
++--- a/Telegram/SourceFiles/calls/calls_signal_bars.cpp
+++++ b/Telegram/SourceFiles/calls/calls_signal_bars.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/calls_top_bar.cpp b/Telegram/SourceFiles/calls/calls_top_bar.cpp
++index 9715382..c156566 100644
++--- a/Telegram/SourceFiles/calls/calls_top_bar.cpp
+++++ b/Telegram/SourceFiles/calls/calls_top_bar.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/calls_userpic.cpp b/Telegram/SourceFiles/calls/calls_userpic.cpp
++index a57b6ff..6f64d91 100644
++--- a/Telegram/SourceFiles/calls/calls_userpic.cpp
+++++ b/Telegram/SourceFiles/calls/calls_userpic.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/calls_video_bubble.cpp b/Telegram/SourceFiles/calls/calls_video_bubble.cpp
++index b6866e9..783a1e7 100644
++--- a/Telegram/SourceFiles/calls/calls_video_bubble.cpp
+++++ b/Telegram/SourceFiles/calls/calls_video_bubble.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/calls_video_incoming.cpp b/Telegram/SourceFiles/calls/calls_video_incoming.cpp
++index e1a52eb..dabdfcb 100644
++--- a/Telegram/SourceFiles/calls/calls_video_incoming.cpp
+++++ b/Telegram/SourceFiles/calls/calls_video_incoming.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/calls_window.cpp b/Telegram/SourceFiles/calls/calls_window.cpp
++index 16b754d..b99149d 100644
++--- a/Telegram/SourceFiles/calls/calls_window.cpp
+++++ b/Telegram/SourceFiles/calls/calls_window.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/group/calls_choose_join_as.cpp b/Telegram/SourceFiles/calls/group/calls_choose_join_as.cpp
++index 137417a..165a3b9 100644
++--- a/Telegram/SourceFiles/calls/group/calls_choose_join_as.cpp
+++++ b/Telegram/SourceFiles/calls/group/calls_choose_join_as.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/group/calls_cover_item.cpp b/Telegram/SourceFiles/calls/group/calls_cover_item.cpp
++index dc77bbe..5bbd797 100644
++--- a/Telegram/SourceFiles/calls/group/calls_cover_item.cpp
+++++ b/Telegram/SourceFiles/calls/group/calls_cover_item.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/group/calls_group_call.cpp b/Telegram/SourceFiles/calls/group/calls_group_call.cpp
++index 96b2f7a..2aac40e 100644
++--- a/Telegram/SourceFiles/calls/group/calls_group_call.cpp
+++++ b/Telegram/SourceFiles/calls/group/calls_group_call.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/group/calls_group_common.cpp b/Telegram/SourceFiles/calls/group/calls_group_common.cpp
++index eabcca6..1a17ed4 100644
++--- a/Telegram/SourceFiles/calls/group/calls_group_common.cpp
+++++ b/Telegram/SourceFiles/calls/group/calls_group_common.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/group/calls_group_invite_controller.cpp b/Telegram/SourceFiles/calls/group/calls_group_invite_controller.cpp
++index 46fa70f..5f4dae6 100644
++--- a/Telegram/SourceFiles/calls/group/calls_group_invite_controller.cpp
+++++ b/Telegram/SourceFiles/calls/group/calls_group_invite_controller.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/group/calls_group_members.cpp b/Telegram/SourceFiles/calls/group/calls_group_members.cpp
++index 67a82cc..18978fa 100644
++--- a/Telegram/SourceFiles/calls/group/calls_group_members.cpp
+++++ b/Telegram/SourceFiles/calls/group/calls_group_members.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/group/calls_group_members_row.cpp b/Telegram/SourceFiles/calls/group/calls_group_members_row.cpp
++index 3f213d6..96babef 100644
++--- a/Telegram/SourceFiles/calls/group/calls_group_members_row.cpp
+++++ b/Telegram/SourceFiles/calls/group/calls_group_members_row.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/group/calls_group_menu.cpp b/Telegram/SourceFiles/calls/group/calls_group_menu.cpp
++index cea1794..a9b3f9a 100644
++--- a/Telegram/SourceFiles/calls/group/calls_group_menu.cpp
+++++ b/Telegram/SourceFiles/calls/group/calls_group_menu.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/group/calls_group_panel.cpp b/Telegram/SourceFiles/calls/group/calls_group_panel.cpp
++index ce9c69b..230b133 100644
++--- a/Telegram/SourceFiles/calls/group/calls_group_panel.cpp
+++++ b/Telegram/SourceFiles/calls/group/calls_group_panel.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/group/calls_group_rtmp.cpp b/Telegram/SourceFiles/calls/group/calls_group_rtmp.cpp
++index 9c35ed5..7514117 100644
++--- a/Telegram/SourceFiles/calls/group/calls_group_rtmp.cpp
+++++ b/Telegram/SourceFiles/calls/group/calls_group_rtmp.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/group/calls_group_settings.cpp b/Telegram/SourceFiles/calls/group/calls_group_settings.cpp
++index cb70c06..3bd1af3 100644
++--- a/Telegram/SourceFiles/calls/group/calls_group_settings.cpp
+++++ b/Telegram/SourceFiles/calls/group/calls_group_settings.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/group/calls_group_toasts.cpp b/Telegram/SourceFiles/calls/group/calls_group_toasts.cpp
++index 584a30b..a583253 100644
++--- a/Telegram/SourceFiles/calls/group/calls_group_toasts.cpp
+++++ b/Telegram/SourceFiles/calls/group/calls_group_toasts.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/group/calls_group_viewport.cpp b/Telegram/SourceFiles/calls/group/calls_group_viewport.cpp
++index dc89026..99f2ee5 100644
++--- a/Telegram/SourceFiles/calls/group/calls_group_viewport.cpp
+++++ b/Telegram/SourceFiles/calls/group/calls_group_viewport.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/group/calls_group_viewport_opengl.cpp b/Telegram/SourceFiles/calls/group/calls_group_viewport_opengl.cpp
++index 9af2a36..9dcce0a 100644
++--- a/Telegram/SourceFiles/calls/group/calls_group_viewport_opengl.cpp
+++++ b/Telegram/SourceFiles/calls/group/calls_group_viewport_opengl.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/group/calls_group_viewport_raster.cpp b/Telegram/SourceFiles/calls/group/calls_group_viewport_raster.cpp
++index e8aa42a..7cce98e 100644
++--- a/Telegram/SourceFiles/calls/group/calls_group_viewport_raster.cpp
+++++ b/Telegram/SourceFiles/calls/group/calls_group_viewport_raster.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/group/calls_group_viewport_tile.cpp b/Telegram/SourceFiles/calls/group/calls_group_viewport_tile.cpp
++index 1b31a20..60e788a 100644
++--- a/Telegram/SourceFiles/calls/group/calls_group_viewport_tile.cpp
+++++ b/Telegram/SourceFiles/calls/group/calls_group_viewport_tile.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/group/calls_volume_item.cpp b/Telegram/SourceFiles/calls/group/calls_volume_item.cpp
++index 69529b9..410258c 100644
++--- a/Telegram/SourceFiles/calls/group/calls_volume_item.cpp
+++++ b/Telegram/SourceFiles/calls/group/calls_volume_item.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/group/ui/calls_group_recording_box.cpp b/Telegram/SourceFiles/calls/group/ui/calls_group_recording_box.cpp
++index 8f26959..f69a724 100644
++--- a/Telegram/SourceFiles/calls/group/ui/calls_group_recording_box.cpp
+++++ b/Telegram/SourceFiles/calls/group/ui/calls_group_recording_box.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/group/ui/calls_group_scheduled_labels.cpp b/Telegram/SourceFiles/calls/group/ui/calls_group_scheduled_labels.cpp
++index 708cf3c..e685f00 100644
++--- a/Telegram/SourceFiles/calls/group/ui/calls_group_scheduled_labels.cpp
+++++ b/Telegram/SourceFiles/calls/group/ui/calls_group_scheduled_labels.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/group/ui/desktop_capture_choose_source.cpp b/Telegram/SourceFiles/calls/group/ui/desktop_capture_choose_source.cpp
++index 4071239..2a956ed 100644
++--- a/Telegram/SourceFiles/calls/group/ui/desktop_capture_choose_source.cpp
+++++ b/Telegram/SourceFiles/calls/group/ui/desktop_capture_choose_source.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/calls/ui/calls_device_menu.cpp b/Telegram/SourceFiles/calls/ui/calls_device_menu.cpp
++index 1db1941..20fc026 100644
++--- a/Telegram/SourceFiles/calls/ui/calls_device_menu.cpp
+++++ b/Telegram/SourceFiles/calls/ui/calls_device_menu.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/bot_command.cpp b/Telegram/SourceFiles/chat_helpers/bot_command.cpp
++index e827426..eeea454 100644
++--- a/Telegram/SourceFiles/chat_helpers/bot_command.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/bot_command.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/bot_keyboard.cpp b/Telegram/SourceFiles/chat_helpers/bot_keyboard.cpp
++index e3ddd4d..65d8ee9 100644
++--- a/Telegram/SourceFiles/chat_helpers/bot_keyboard.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/bot_keyboard.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/compose/compose_show.cpp b/Telegram/SourceFiles/chat_helpers/compose/compose_show.cpp
++index 192937b..4e88143 100644
++--- a/Telegram/SourceFiles/chat_helpers/compose/compose_show.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/compose/compose_show.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/emoji_interactions.cpp b/Telegram/SourceFiles/chat_helpers/emoji_interactions.cpp
++index 9f7fe7b..e2b2563 100644
++--- a/Telegram/SourceFiles/chat_helpers/emoji_interactions.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/emoji_interactions.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/emoji_keywords.cpp b/Telegram/SourceFiles/chat_helpers/emoji_keywords.cpp
++index 500de20..843da83 100644
++--- a/Telegram/SourceFiles/chat_helpers/emoji_keywords.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/emoji_keywords.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/emoji_list_widget.cpp b/Telegram/SourceFiles/chat_helpers/emoji_list_widget.cpp
++index ec9df7d..5c168eb 100644
++--- a/Telegram/SourceFiles/chat_helpers/emoji_list_widget.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/emoji_list_widget.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/emoji_sets_manager.cpp b/Telegram/SourceFiles/chat_helpers/emoji_sets_manager.cpp
++index 38b54e3..31e9233 100644
++--- a/Telegram/SourceFiles/chat_helpers/emoji_sets_manager.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/emoji_sets_manager.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/emoji_suggestions_widget.cpp b/Telegram/SourceFiles/chat_helpers/emoji_suggestions_widget.cpp
++index b0a1cd5..c34e288 100644
++--- a/Telegram/SourceFiles/chat_helpers/emoji_suggestions_widget.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/emoji_suggestions_widget.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/field_autocomplete.cpp b/Telegram/SourceFiles/chat_helpers/field_autocomplete.cpp
++index 209dab9..7ffebfc 100644
++--- a/Telegram/SourceFiles/chat_helpers/field_autocomplete.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/field_autocomplete.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/field_characters_count_manager.cpp b/Telegram/SourceFiles/chat_helpers/field_characters_count_manager.cpp
++index 87d1f61..9f10459 100644
++--- a/Telegram/SourceFiles/chat_helpers/field_characters_count_manager.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/field_characters_count_manager.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/gifs_list_widget.cpp b/Telegram/SourceFiles/chat_helpers/gifs_list_widget.cpp
++index ba0a303..60cf0d8 100644
++--- a/Telegram/SourceFiles/chat_helpers/gifs_list_widget.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/gifs_list_widget.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/message_field.cpp b/Telegram/SourceFiles/chat_helpers/message_field.cpp
++index 6fdf722..bb64a38 100644
++--- a/Telegram/SourceFiles/chat_helpers/message_field.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/message_field.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/share_message_phrase_factory.cpp b/Telegram/SourceFiles/chat_helpers/share_message_phrase_factory.cpp
++index 3d08fb9..b06a250 100644
++--- a/Telegram/SourceFiles/chat_helpers/share_message_phrase_factory.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/share_message_phrase_factory.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/spellchecker_common.cpp b/Telegram/SourceFiles/chat_helpers/spellchecker_common.cpp
++index 42b980f..f7b2fa5 100644
++--- a/Telegram/SourceFiles/chat_helpers/spellchecker_common.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/spellchecker_common.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/stickers_dice_pack.cpp b/Telegram/SourceFiles/chat_helpers/stickers_dice_pack.cpp
++index 8941f35..bbf5fe7 100644
++--- a/Telegram/SourceFiles/chat_helpers/stickers_dice_pack.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/stickers_dice_pack.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/stickers_emoji_image_loader.cpp b/Telegram/SourceFiles/chat_helpers/stickers_emoji_image_loader.cpp
++index b5f0b20..01e7cc5 100644
++--- a/Telegram/SourceFiles/chat_helpers/stickers_emoji_image_loader.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/stickers_emoji_image_loader.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/stickers_emoji_pack.cpp b/Telegram/SourceFiles/chat_helpers/stickers_emoji_pack.cpp
++index af07736..b9ef19c 100644
++--- a/Telegram/SourceFiles/chat_helpers/stickers_emoji_pack.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/stickers_emoji_pack.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/stickers_gift_box_pack.cpp b/Telegram/SourceFiles/chat_helpers/stickers_gift_box_pack.cpp
++index 9d9f0fd..38e99a8 100644
++--- a/Telegram/SourceFiles/chat_helpers/stickers_gift_box_pack.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/stickers_gift_box_pack.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/stickers_list_footer.cpp b/Telegram/SourceFiles/chat_helpers/stickers_list_footer.cpp
++index 6ea61e0..4cee4b2 100644
++--- a/Telegram/SourceFiles/chat_helpers/stickers_list_footer.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/stickers_list_footer.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/stickers_list_widget.cpp b/Telegram/SourceFiles/chat_helpers/stickers_list_widget.cpp
++index ecf2056..98fbd9b 100644
++--- a/Telegram/SourceFiles/chat_helpers/stickers_list_widget.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/stickers_list_widget.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/stickers_lottie.cpp b/Telegram/SourceFiles/chat_helpers/stickers_lottie.cpp
++index 04ceda9..d2e72f0 100644
++--- a/Telegram/SourceFiles/chat_helpers/stickers_lottie.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/stickers_lottie.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/tabbed_panel.cpp b/Telegram/SourceFiles/chat_helpers/tabbed_panel.cpp
++index a3d8ba3..2e57076 100644
++--- a/Telegram/SourceFiles/chat_helpers/tabbed_panel.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/tabbed_panel.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/tabbed_section.cpp b/Telegram/SourceFiles/chat_helpers/tabbed_section.cpp
++index 7efa340..63c3bbc 100644
++--- a/Telegram/SourceFiles/chat_helpers/tabbed_section.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/tabbed_section.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/tabbed_selector.cpp b/Telegram/SourceFiles/chat_helpers/tabbed_selector.cpp
++index 68437e4..0987a80 100644
++--- a/Telegram/SourceFiles/chat_helpers/tabbed_selector.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/tabbed_selector.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/chat_helpers/ttl_media_layer_widget.cpp b/Telegram/SourceFiles/chat_helpers/ttl_media_layer_widget.cpp
++index 65940c6..f8fea20 100644
++--- a/Telegram/SourceFiles/chat_helpers/ttl_media_layer_widget.cpp
+++++ b/Telegram/SourceFiles/chat_helpers/ttl_media_layer_widget.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/application.cpp b/Telegram/SourceFiles/core/application.cpp
++index 933e248..2197659 100644
++--- a/Telegram/SourceFiles/core/application.cpp
+++++ b/Telegram/SourceFiles/core/application.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/bank_card_click_handler.cpp b/Telegram/SourceFiles/core/bank_card_click_handler.cpp
++index 1bcca7f..a744d8e 100644
++--- a/Telegram/SourceFiles/core/bank_card_click_handler.cpp
+++++ b/Telegram/SourceFiles/core/bank_card_click_handler.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/base_integration.cpp b/Telegram/SourceFiles/core/base_integration.cpp
++index 4e794a1..b7fa545 100644
++--- a/Telegram/SourceFiles/core/base_integration.cpp
+++++ b/Telegram/SourceFiles/core/base_integration.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/changelogs.cpp b/Telegram/SourceFiles/core/changelogs.cpp
++index ddb5b8a..adffd67 100644
++--- a/Telegram/SourceFiles/core/changelogs.cpp
+++++ b/Telegram/SourceFiles/core/changelogs.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/click_handler_types.cpp b/Telegram/SourceFiles/core/click_handler_types.cpp
++index 824f781..0f5d00b 100644
++--- a/Telegram/SourceFiles/core/click_handler_types.cpp
+++++ b/Telegram/SourceFiles/core/click_handler_types.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/core_cloud_password.cpp b/Telegram/SourceFiles/core/core_cloud_password.cpp
++index 95e1782..1725532 100644
++--- a/Telegram/SourceFiles/core/core_cloud_password.cpp
+++++ b/Telegram/SourceFiles/core/core_cloud_password.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/core_settings.cpp b/Telegram/SourceFiles/core/core_settings.cpp
++index aaf7bae..8351bd3 100644
++--- a/Telegram/SourceFiles/core/core_settings.cpp
+++++ b/Telegram/SourceFiles/core/core_settings.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/core_settings_proxy.cpp b/Telegram/SourceFiles/core/core_settings_proxy.cpp
++index 1807aa2..cbf9248 100644
++--- a/Telegram/SourceFiles/core/core_settings_proxy.cpp
+++++ b/Telegram/SourceFiles/core/core_settings_proxy.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/crash_report_window.cpp b/Telegram/SourceFiles/core/crash_report_window.cpp
++index b73c12a..d7b33f0 100644
++--- a/Telegram/SourceFiles/core/crash_report_window.cpp
+++++ b/Telegram/SourceFiles/core/crash_report_window.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/crash_reports.cpp b/Telegram/SourceFiles/core/crash_reports.cpp
++index 1e38d72..2d17546 100644
++--- a/Telegram/SourceFiles/core/crash_reports.cpp
+++++ b/Telegram/SourceFiles/core/crash_reports.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/current_geo_location.cpp b/Telegram/SourceFiles/core/current_geo_location.cpp
++index 2ec4a9c..620026b 100644
++--- a/Telegram/SourceFiles/core/current_geo_location.cpp
+++++ b/Telegram/SourceFiles/core/current_geo_location.cpp
++@@ -1,3 +1,5 @@
+++#include "base/base_pch.h"
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/file_location.cpp b/Telegram/SourceFiles/core/file_location.cpp
++index 8d2eef4..7be22a9 100644
++--- a/Telegram/SourceFiles/core/file_location.cpp
+++++ b/Telegram/SourceFiles/core/file_location.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/file_utilities.cpp b/Telegram/SourceFiles/core/file_utilities.cpp
++index da963a1..9517e44 100644
++--- a/Telegram/SourceFiles/core/file_utilities.cpp
+++++ b/Telegram/SourceFiles/core/file_utilities.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/launcher.cpp b/Telegram/SourceFiles/core/launcher.cpp
++index e844acf..79fbbf7 100644
++--- a/Telegram/SourceFiles/core/launcher.cpp
+++++ b/Telegram/SourceFiles/core/launcher.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/local_url_handlers.cpp b/Telegram/SourceFiles/core/local_url_handlers.cpp
++index 7e313da..03b4aa2 100644
++--- a/Telegram/SourceFiles/core/local_url_handlers.cpp
+++++ b/Telegram/SourceFiles/core/local_url_handlers.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/mime_type.cpp b/Telegram/SourceFiles/core/mime_type.cpp
++index b770195..abbbcde 100644
++--- a/Telegram/SourceFiles/core/mime_type.cpp
+++++ b/Telegram/SourceFiles/core/mime_type.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/phone_click_handler.cpp b/Telegram/SourceFiles/core/phone_click_handler.cpp
++index 167aec1..87cfa98 100644
++--- a/Telegram/SourceFiles/core/phone_click_handler.cpp
+++++ b/Telegram/SourceFiles/core/phone_click_handler.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/sandbox.cpp b/Telegram/SourceFiles/core/sandbox.cpp
++index 0e0b448..818526e 100644
++--- a/Telegram/SourceFiles/core/sandbox.cpp
+++++ b/Telegram/SourceFiles/core/sandbox.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/shortcuts.cpp b/Telegram/SourceFiles/core/shortcuts.cpp
++index fe12804..52bc0c5 100644
++--- a/Telegram/SourceFiles/core/shortcuts.cpp
+++++ b/Telegram/SourceFiles/core/shortcuts.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/ui_integration.cpp b/Telegram/SourceFiles/core/ui_integration.cpp
++index c918904..6d4927d 100644
++--- a/Telegram/SourceFiles/core/ui_integration.cpp
+++++ b/Telegram/SourceFiles/core/ui_integration.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/update_checker.cpp b/Telegram/SourceFiles/core/update_checker.cpp
++index 777dde8..c95e161 100644
++--- a/Telegram/SourceFiles/core/update_checker.cpp
+++++ b/Telegram/SourceFiles/core/update_checker.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/core/utils.cpp b/Telegram/SourceFiles/core/utils.cpp
++index caeb3a1..ca3df46 100644
++--- a/Telegram/SourceFiles/core/utils.cpp
+++++ b/Telegram/SourceFiles/core/utils.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/countries/countries_instance.cpp b/Telegram/SourceFiles/countries/countries_instance.cpp
++index d9ef7c3..a96ac4c 100644
++--- a/Telegram/SourceFiles/countries/countries_instance.cpp
+++++ b/Telegram/SourceFiles/countries/countries_instance.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/countries/countries_manager.cpp b/Telegram/SourceFiles/countries/countries_manager.cpp
++index 5b8c30c..ec9fa95 100644
++--- a/Telegram/SourceFiles/countries/countries_manager.cpp
+++++ b/Telegram/SourceFiles/countries/countries_manager.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/business/data_business_chatbots.cpp b/Telegram/SourceFiles/data/business/data_business_chatbots.cpp
++index 126b704..cd1086a 100644
++--- a/Telegram/SourceFiles/data/business/data_business_chatbots.cpp
+++++ b/Telegram/SourceFiles/data/business/data_business_chatbots.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/business/data_business_common.cpp b/Telegram/SourceFiles/data/business/data_business_common.cpp
++index dc6619f..9876942 100644
++--- a/Telegram/SourceFiles/data/business/data_business_common.cpp
+++++ b/Telegram/SourceFiles/data/business/data_business_common.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/business/data_business_info.cpp b/Telegram/SourceFiles/data/business/data_business_info.cpp
++index d9bb6ec..a75de79 100644
++--- a/Telegram/SourceFiles/data/business/data_business_info.cpp
+++++ b/Telegram/SourceFiles/data/business/data_business_info.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/business/data_shortcut_messages.cpp b/Telegram/SourceFiles/data/business/data_shortcut_messages.cpp
++index e3701b1..739deb5 100644
++--- a/Telegram/SourceFiles/data/business/data_shortcut_messages.cpp
+++++ b/Telegram/SourceFiles/data/business/data_shortcut_messages.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/components/credits.cpp b/Telegram/SourceFiles/data/components/credits.cpp
++index 0bca688..46c8a13 100644
++--- a/Telegram/SourceFiles/data/components/credits.cpp
+++++ b/Telegram/SourceFiles/data/components/credits.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/components/factchecks.cpp b/Telegram/SourceFiles/data/components/factchecks.cpp
++index 7725192..92f2419 100644
++--- a/Telegram/SourceFiles/data/components/factchecks.cpp
+++++ b/Telegram/SourceFiles/data/components/factchecks.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/components/location_pickers.cpp b/Telegram/SourceFiles/data/components/location_pickers.cpp
++index 7f15a30..be751e0 100644
++--- a/Telegram/SourceFiles/data/components/location_pickers.cpp
+++++ b/Telegram/SourceFiles/data/components/location_pickers.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/components/promo_suggestions.cpp b/Telegram/SourceFiles/data/components/promo_suggestions.cpp
++index 33c0b86..a8585ca 100644
++--- a/Telegram/SourceFiles/data/components/promo_suggestions.cpp
+++++ b/Telegram/SourceFiles/data/components/promo_suggestions.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/components/recent_peers.cpp b/Telegram/SourceFiles/data/components/recent_peers.cpp
++index 2185fd1..fcab656 100644
++--- a/Telegram/SourceFiles/data/components/recent_peers.cpp
+++++ b/Telegram/SourceFiles/data/components/recent_peers.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/components/recent_shared_media_gifts.cpp b/Telegram/SourceFiles/data/components/recent_shared_media_gifts.cpp
++index 3d2442b..a0e1c02 100644
++--- a/Telegram/SourceFiles/data/components/recent_shared_media_gifts.cpp
+++++ b/Telegram/SourceFiles/data/components/recent_shared_media_gifts.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/components/scheduled_messages.cpp b/Telegram/SourceFiles/data/components/scheduled_messages.cpp
++index 493a3cc..82bef1c 100644
++--- a/Telegram/SourceFiles/data/components/scheduled_messages.cpp
+++++ b/Telegram/SourceFiles/data/components/scheduled_messages.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/components/sponsored_messages.cpp b/Telegram/SourceFiles/data/components/sponsored_messages.cpp
++index b907f1d..af61806 100644
++--- a/Telegram/SourceFiles/data/components/sponsored_messages.cpp
+++++ b/Telegram/SourceFiles/data/components/sponsored_messages.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/components/top_peers.cpp b/Telegram/SourceFiles/data/components/top_peers.cpp
++index 4fac09a..051680e 100644
++--- a/Telegram/SourceFiles/data/components/top_peers.cpp
+++++ b/Telegram/SourceFiles/data/components/top_peers.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_abstract_structure.cpp b/Telegram/SourceFiles/data/data_abstract_structure.cpp
++index aa02c91..cde7f74 100644
++--- a/Telegram/SourceFiles/data/data_abstract_structure.cpp
+++++ b/Telegram/SourceFiles/data/data_abstract_structure.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_audio_msg_id.cpp b/Telegram/SourceFiles/data/data_audio_msg_id.cpp
++index d8365be..dc8a83b 100644
++--- a/Telegram/SourceFiles/data/data_audio_msg_id.cpp
+++++ b/Telegram/SourceFiles/data/data_audio_msg_id.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_audio_msg_id.h b/Telegram/SourceFiles/data/data_audio_msg_id.h
++index 2951587..e67c37e 100644
++--- a/Telegram/SourceFiles/data/data_audio_msg_id.h
+++++ b/Telegram/SourceFiles/data/data_audio_msg_id.h
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_auto_download.cpp b/Telegram/SourceFiles/data/data_auto_download.cpp
++index c0ea850..d14b545 100644
++--- a/Telegram/SourceFiles/data/data_auto_download.cpp
+++++ b/Telegram/SourceFiles/data/data_auto_download.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_auto_download.h b/Telegram/SourceFiles/data/data_auto_download.h
++index a327545..722864f 100644
++--- a/Telegram/SourceFiles/data/data_auto_download.h
+++++ b/Telegram/SourceFiles/data/data_auto_download.h
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_birthday.cpp b/Telegram/SourceFiles/data/data_birthday.cpp
++index 34a2b07..a36b0b1 100644
++--- a/Telegram/SourceFiles/data/data_birthday.cpp
+++++ b/Telegram/SourceFiles/data/data_birthday.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_bot_app.cpp b/Telegram/SourceFiles/data/data_bot_app.cpp
++index ff9705c..ffdc956 100644
++--- a/Telegram/SourceFiles/data/data_bot_app.cpp
+++++ b/Telegram/SourceFiles/data/data_bot_app.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_changes.cpp b/Telegram/SourceFiles/data/data_changes.cpp
++index 5356d48..07ab625 100644
++--- a/Telegram/SourceFiles/data/data_changes.cpp
+++++ b/Telegram/SourceFiles/data/data_changes.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_channel.cpp b/Telegram/SourceFiles/data/data_channel.cpp
++index 0832138..25d83d3 100644
++--- a/Telegram/SourceFiles/data/data_channel.cpp
+++++ b/Telegram/SourceFiles/data/data_channel.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_channel_admins.cpp b/Telegram/SourceFiles/data/data_channel_admins.cpp
++index e7ac8ce..2270787 100644
++--- a/Telegram/SourceFiles/data/data_channel_admins.cpp
+++++ b/Telegram/SourceFiles/data/data_channel_admins.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_chat.cpp b/Telegram/SourceFiles/data/data_chat.cpp
++index 288e080..be54abf 100644
++--- a/Telegram/SourceFiles/data/data_chat.cpp
+++++ b/Telegram/SourceFiles/data/data_chat.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_chat_filters.cpp b/Telegram/SourceFiles/data/data_chat_filters.cpp
++index a2c5f48..7234509 100644
++--- a/Telegram/SourceFiles/data/data_chat_filters.cpp
+++++ b/Telegram/SourceFiles/data/data_chat_filters.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_chat_participant_status.cpp b/Telegram/SourceFiles/data/data_chat_participant_status.cpp
++index 33315b6..7334958 100644
++--- a/Telegram/SourceFiles/data/data_chat_participant_status.cpp
+++++ b/Telegram/SourceFiles/data/data_chat_participant_status.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_cloud_file.cpp b/Telegram/SourceFiles/data/data_cloud_file.cpp
++index 7b3e738..fa91e98 100644
++--- a/Telegram/SourceFiles/data/data_cloud_file.cpp
+++++ b/Telegram/SourceFiles/data/data_cloud_file.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_cloud_themes.cpp b/Telegram/SourceFiles/data/data_cloud_themes.cpp
++index 1a8fce9..3c67ec1 100644
++--- a/Telegram/SourceFiles/data/data_cloud_themes.cpp
+++++ b/Telegram/SourceFiles/data/data_cloud_themes.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_document.cpp b/Telegram/SourceFiles/data/data_document.cpp
++index 937ebd8..f3ebe55 100644
++--- a/Telegram/SourceFiles/data/data_document.cpp
+++++ b/Telegram/SourceFiles/data/data_document.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_document.h b/Telegram/SourceFiles/data/data_document.h
++index b0918a3..f7e47d0 100644
++--- a/Telegram/SourceFiles/data/data_document.h
+++++ b/Telegram/SourceFiles/data/data_document.h
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_document_media.cpp b/Telegram/SourceFiles/data/data_document_media.cpp
++index e610303..5bd9434 100644
++--- a/Telegram/SourceFiles/data/data_document_media.cpp
+++++ b/Telegram/SourceFiles/data/data_document_media.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_document_resolver.cpp b/Telegram/SourceFiles/data/data_document_resolver.cpp
++index 248daec..cf16128 100644
++--- a/Telegram/SourceFiles/data/data_document_resolver.cpp
+++++ b/Telegram/SourceFiles/data/data_document_resolver.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_download_manager.cpp b/Telegram/SourceFiles/data/data_download_manager.cpp
++index 79db0ac..e0cf5a8 100644
++--- a/Telegram/SourceFiles/data/data_download_manager.cpp
+++++ b/Telegram/SourceFiles/data/data_download_manager.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_drafts.cpp b/Telegram/SourceFiles/data/data_drafts.cpp
++index 9aae0e8..a436699 100644
++--- a/Telegram/SourceFiles/data/data_drafts.cpp
+++++ b/Telegram/SourceFiles/data/data_drafts.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_emoji_statuses.cpp b/Telegram/SourceFiles/data/data_emoji_statuses.cpp
++index 73c1598..6a7cc87 100644
++--- a/Telegram/SourceFiles/data/data_emoji_statuses.cpp
+++++ b/Telegram/SourceFiles/data/data_emoji_statuses.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_file_click_handler.cpp b/Telegram/SourceFiles/data/data_file_click_handler.cpp
++index e42397d..a9f931d 100644
++--- a/Telegram/SourceFiles/data/data_file_click_handler.cpp
+++++ b/Telegram/SourceFiles/data/data_file_click_handler.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_file_origin.cpp b/Telegram/SourceFiles/data/data_file_origin.cpp
++index a543c60..cf7de0b 100644
++--- a/Telegram/SourceFiles/data/data_file_origin.cpp
+++++ b/Telegram/SourceFiles/data/data_file_origin.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_folder.cpp b/Telegram/SourceFiles/data/data_folder.cpp
++index e6599a5..bb1c7a6 100644
++--- a/Telegram/SourceFiles/data/data_folder.cpp
+++++ b/Telegram/SourceFiles/data/data_folder.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_forum.cpp b/Telegram/SourceFiles/data/data_forum.cpp
++index 4fa805b..c682e2b 100644
++--- a/Telegram/SourceFiles/data/data_forum.cpp
+++++ b/Telegram/SourceFiles/data/data_forum.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_forum_icons.cpp b/Telegram/SourceFiles/data/data_forum_icons.cpp
++index c47c8e6..7a4a77e 100644
++--- a/Telegram/SourceFiles/data/data_forum_icons.cpp
+++++ b/Telegram/SourceFiles/data/data_forum_icons.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_forum_topic.cpp b/Telegram/SourceFiles/data/data_forum_topic.cpp
++index a8d0591..b16ad3f 100644
++--- a/Telegram/SourceFiles/data/data_forum_topic.cpp
+++++ b/Telegram/SourceFiles/data/data_forum_topic.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_game.cpp b/Telegram/SourceFiles/data/data_game.cpp
++index 6861e69..4fdf633 100644
++--- a/Telegram/SourceFiles/data/data_game.cpp
+++++ b/Telegram/SourceFiles/data/data_game.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_group_call.cpp b/Telegram/SourceFiles/data/data_group_call.cpp
++index f17e64a..76ca864 100644
++--- a/Telegram/SourceFiles/data/data_group_call.cpp
+++++ b/Telegram/SourceFiles/data/data_group_call.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_groups.cpp b/Telegram/SourceFiles/data/data_groups.cpp
++index 7af7050..4e20f4f 100644
++--- a/Telegram/SourceFiles/data/data_groups.cpp
+++++ b/Telegram/SourceFiles/data/data_groups.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_histories.cpp b/Telegram/SourceFiles/data/data_histories.cpp
++index 047f1ba..49b59b0 100644
++--- a/Telegram/SourceFiles/data/data_histories.cpp
+++++ b/Telegram/SourceFiles/data/data_histories.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_history_messages.cpp b/Telegram/SourceFiles/data/data_history_messages.cpp
++index 6711059..938a409 100644
++--- a/Telegram/SourceFiles/data/data_history_messages.cpp
+++++ b/Telegram/SourceFiles/data/data_history_messages.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++@@ -217,4 +219,4 @@ rpl::producer<MessagesSlice> HistoryMessagesViewer(
++ 	});
++ }
++ 
++-} // namespace Data
++\ No newline at end of file
+++} // namespace Data
++diff --git a/Telegram/SourceFiles/data/data_location.cpp b/Telegram/SourceFiles/data/data_location.cpp
++index 457bb64..121fe1f 100644
++--- a/Telegram/SourceFiles/data/data_location.cpp
+++++ b/Telegram/SourceFiles/data/data_location.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_media_preload.cpp b/Telegram/SourceFiles/data/data_media_preload.cpp
++index 8fb9380..b93a75d 100644
++--- a/Telegram/SourceFiles/data/data_media_preload.cpp
+++++ b/Telegram/SourceFiles/data/data_media_preload.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_media_rotation.cpp b/Telegram/SourceFiles/data/data_media_rotation.cpp
++index eaa0a12..3ca4760 100644
++--- a/Telegram/SourceFiles/data/data_media_rotation.cpp
+++++ b/Telegram/SourceFiles/data/data_media_rotation.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_media_types.cpp b/Telegram/SourceFiles/data/data_media_types.cpp
++index 6f1001b..970d0da 100644
++--- a/Telegram/SourceFiles/data/data_media_types.cpp
+++++ b/Telegram/SourceFiles/data/data_media_types.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_message_reaction_id.cpp b/Telegram/SourceFiles/data/data_message_reaction_id.cpp
++index b4a34a7..b0a35f7 100644
++--- a/Telegram/SourceFiles/data/data_message_reaction_id.cpp
+++++ b/Telegram/SourceFiles/data/data_message_reaction_id.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_message_reactions.cpp b/Telegram/SourceFiles/data/data_message_reactions.cpp
++index a909a2c..b558d63 100644
++--- a/Telegram/SourceFiles/data/data_message_reactions.cpp
+++++ b/Telegram/SourceFiles/data/data_message_reactions.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_messages.cpp b/Telegram/SourceFiles/data/data_messages.cpp
++index fabee6f..7395b01 100644
++--- a/Telegram/SourceFiles/data/data_messages.cpp
+++++ b/Telegram/SourceFiles/data/data_messages.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_peer.cpp b/Telegram/SourceFiles/data/data_peer.cpp
++index 036d828..8fb5a76 100644
++--- a/Telegram/SourceFiles/data/data_peer.cpp
+++++ b/Telegram/SourceFiles/data/data_peer.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_peer_bot_command.cpp b/Telegram/SourceFiles/data/data_peer_bot_command.cpp
++index 9aef254..064f161 100644
++--- a/Telegram/SourceFiles/data/data_peer_bot_command.cpp
+++++ b/Telegram/SourceFiles/data/data_peer_bot_command.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_peer_bot_commands.cpp b/Telegram/SourceFiles/data/data_peer_bot_commands.cpp
++index 2487dc7..651cad5 100644
++--- a/Telegram/SourceFiles/data/data_peer_bot_commands.cpp
+++++ b/Telegram/SourceFiles/data/data_peer_bot_commands.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_peer_id.cpp b/Telegram/SourceFiles/data/data_peer_id.cpp
++index b6a7723..3c5792d 100644
++--- a/Telegram/SourceFiles/data/data_peer_id.cpp
+++++ b/Telegram/SourceFiles/data/data_peer_id.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_peer_values.cpp b/Telegram/SourceFiles/data/data_peer_values.cpp
++index 77fdb04..d7a0537 100644
++--- a/Telegram/SourceFiles/data/data_peer_values.cpp
+++++ b/Telegram/SourceFiles/data/data_peer_values.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_photo.cpp b/Telegram/SourceFiles/data/data_photo.cpp
++index 0a2d37f..be18b20 100644
++--- a/Telegram/SourceFiles/data/data_photo.cpp
+++++ b/Telegram/SourceFiles/data/data_photo.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_photo_media.cpp b/Telegram/SourceFiles/data/data_photo_media.cpp
++index 06a52ed..93c24c6 100644
++--- a/Telegram/SourceFiles/data/data_photo_media.cpp
+++++ b/Telegram/SourceFiles/data/data_photo_media.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_poll.cpp b/Telegram/SourceFiles/data/data_poll.cpp
++index 658f7c2..d2c71e1 100644
++--- a/Telegram/SourceFiles/data/data_poll.cpp
+++++ b/Telegram/SourceFiles/data/data_poll.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_premium_limits.cpp b/Telegram/SourceFiles/data/data_premium_limits.cpp
++index f83d392..d13a32e 100644
++--- a/Telegram/SourceFiles/data/data_premium_limits.cpp
+++++ b/Telegram/SourceFiles/data/data_premium_limits.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_pts_waiter.cpp b/Telegram/SourceFiles/data/data_pts_waiter.cpp
++index 316ef0a..547ed9f 100644
++--- a/Telegram/SourceFiles/data/data_pts_waiter.cpp
+++++ b/Telegram/SourceFiles/data/data_pts_waiter.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_replies_list.cpp b/Telegram/SourceFiles/data/data_replies_list.cpp
++index f334c47..bffc0dd 100644
++--- a/Telegram/SourceFiles/data/data_replies_list.cpp
+++++ b/Telegram/SourceFiles/data/data_replies_list.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_reply_preview.cpp b/Telegram/SourceFiles/data/data_reply_preview.cpp
++index e31f30f..fbd87a0 100644
++--- a/Telegram/SourceFiles/data/data_reply_preview.cpp
+++++ b/Telegram/SourceFiles/data/data_reply_preview.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_saved_messages.cpp b/Telegram/SourceFiles/data/data_saved_messages.cpp
++index 48db91d..18a7265 100644
++--- a/Telegram/SourceFiles/data/data_saved_messages.cpp
+++++ b/Telegram/SourceFiles/data/data_saved_messages.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_saved_music.cpp b/Telegram/SourceFiles/data/data_saved_music.cpp
++index 0d0e9d3..9142b5c 100644
++--- a/Telegram/SourceFiles/data/data_saved_music.cpp
+++++ b/Telegram/SourceFiles/data/data_saved_music.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_saved_sublist.cpp b/Telegram/SourceFiles/data/data_saved_sublist.cpp
++index 7eab828..80c78c1 100644
++--- a/Telegram/SourceFiles/data/data_saved_sublist.cpp
+++++ b/Telegram/SourceFiles/data/data_saved_sublist.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_search_controller.cpp b/Telegram/SourceFiles/data/data_search_controller.cpp
++index 6b43192..887401d 100644
++--- a/Telegram/SourceFiles/data/data_search_controller.cpp
+++++ b/Telegram/SourceFiles/data/data_search_controller.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_send_action.cpp b/Telegram/SourceFiles/data/data_send_action.cpp
++index ea8f92b..4a549a4 100644
++--- a/Telegram/SourceFiles/data/data_send_action.cpp
+++++ b/Telegram/SourceFiles/data/data_send_action.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_session.cpp b/Telegram/SourceFiles/data/data_session.cpp
++index c2dce9a..730e397 100644
++--- a/Telegram/SourceFiles/data/data_session.cpp
+++++ b/Telegram/SourceFiles/data/data_session.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_shared_media.cpp b/Telegram/SourceFiles/data/data_shared_media.cpp
++index 3ee5f54..d8fdc60 100644
++--- a/Telegram/SourceFiles/data/data_shared_media.cpp
+++++ b/Telegram/SourceFiles/data/data_shared_media.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_sparse_ids.cpp b/Telegram/SourceFiles/data/data_sparse_ids.cpp
++index 787c014..d2cdebf 100644
++--- a/Telegram/SourceFiles/data/data_sparse_ids.cpp
+++++ b/Telegram/SourceFiles/data/data_sparse_ids.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_star_gift.cpp b/Telegram/SourceFiles/data/data_star_gift.cpp
++index 998c799..037afbc 100644
++--- a/Telegram/SourceFiles/data/data_star_gift.cpp
+++++ b/Telegram/SourceFiles/data/data_star_gift.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_statistics_chart.cpp b/Telegram/SourceFiles/data/data_statistics_chart.cpp
++index 5faf7bd..6173b8f 100644
++--- a/Telegram/SourceFiles/data/data_statistics_chart.cpp
+++++ b/Telegram/SourceFiles/data/data_statistics_chart.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_stories.cpp b/Telegram/SourceFiles/data/data_stories.cpp
++index 5d7c335..ad733c3 100644
++--- a/Telegram/SourceFiles/data/data_stories.cpp
+++++ b/Telegram/SourceFiles/data/data_stories.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_stories_ids.cpp b/Telegram/SourceFiles/data/data_stories_ids.cpp
++index 130cb5e..446ae10 100644
++--- a/Telegram/SourceFiles/data/data_stories_ids.cpp
+++++ b/Telegram/SourceFiles/data/data_stories_ids.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_story.cpp b/Telegram/SourceFiles/data/data_story.cpp
++index 1c92eca..2565fbf 100644
++--- a/Telegram/SourceFiles/data/data_story.cpp
+++++ b/Telegram/SourceFiles/data/data_story.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_streaming.cpp b/Telegram/SourceFiles/data/data_streaming.cpp
++index 658c838..7b1a87c 100644
++--- a/Telegram/SourceFiles/data/data_streaming.cpp
+++++ b/Telegram/SourceFiles/data/data_streaming.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_thread.cpp b/Telegram/SourceFiles/data/data_thread.cpp
++index 47a8f22..aa0c004 100644
++--- a/Telegram/SourceFiles/data/data_thread.cpp
+++++ b/Telegram/SourceFiles/data/data_thread.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_todo_list.cpp b/Telegram/SourceFiles/data/data_todo_list.cpp
++index 8400eb2..106ba2c 100644
++--- a/Telegram/SourceFiles/data/data_todo_list.cpp
+++++ b/Telegram/SourceFiles/data/data_todo_list.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_types.cpp b/Telegram/SourceFiles/data/data_types.cpp
++index 8fed3ec..abe6e5b 100644
++--- a/Telegram/SourceFiles/data/data_types.cpp
+++++ b/Telegram/SourceFiles/data/data_types.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_unread_value.cpp b/Telegram/SourceFiles/data/data_unread_value.cpp
++index c374dc0..4978dca 100644
++--- a/Telegram/SourceFiles/data/data_unread_value.cpp
+++++ b/Telegram/SourceFiles/data/data_unread_value.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_user.cpp b/Telegram/SourceFiles/data/data_user.cpp
++index 638aa1f..420a189 100644
++--- a/Telegram/SourceFiles/data/data_user.cpp
+++++ b/Telegram/SourceFiles/data/data_user.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_user_names.cpp b/Telegram/SourceFiles/data/data_user_names.cpp
++index c2edd6b..822a3eb 100644
++--- a/Telegram/SourceFiles/data/data_user_names.cpp
+++++ b/Telegram/SourceFiles/data/data_user_names.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_user_photos.cpp b/Telegram/SourceFiles/data/data_user_photos.cpp
++index 6271f9b..ea064ae 100644
++--- a/Telegram/SourceFiles/data/data_user_photos.cpp
+++++ b/Telegram/SourceFiles/data/data_user_photos.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_wall_paper.cpp b/Telegram/SourceFiles/data/data_wall_paper.cpp
++index 0234bdb..900f91a 100644
++--- a/Telegram/SourceFiles/data/data_wall_paper.cpp
+++++ b/Telegram/SourceFiles/data/data_wall_paper.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/data_web_page.cpp b/Telegram/SourceFiles/data/data_web_page.cpp
++index 9c63bb1..91f0d5a 100644
++--- a/Telegram/SourceFiles/data/data_web_page.cpp
+++++ b/Telegram/SourceFiles/data/data_web_page.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/notify/data_notify_settings.cpp b/Telegram/SourceFiles/data/notify/data_notify_settings.cpp
++index beb4769..bfc91ef 100644
++--- a/Telegram/SourceFiles/data/notify/data_notify_settings.cpp
+++++ b/Telegram/SourceFiles/data/notify/data_notify_settings.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/notify/data_peer_notify_settings.cpp b/Telegram/SourceFiles/data/notify/data_peer_notify_settings.cpp
++index 48d198d..1ce8565 100644
++--- a/Telegram/SourceFiles/data/notify/data_peer_notify_settings.cpp
+++++ b/Telegram/SourceFiles/data/notify/data_peer_notify_settings.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/notify/data_peer_notify_volume.cpp b/Telegram/SourceFiles/data/notify/data_peer_notify_volume.cpp
++index 90ce085..be51740 100644
++--- a/Telegram/SourceFiles/data/notify/data_peer_notify_volume.cpp
+++++ b/Telegram/SourceFiles/data/notify/data_peer_notify_volume.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/raw/raw_countries_bounds.cpp b/Telegram/SourceFiles/data/raw/raw_countries_bounds.cpp
++index d4e3831..c167a5b 100644
++--- a/Telegram/SourceFiles/data/raw/raw_countries_bounds.cpp
+++++ b/Telegram/SourceFiles/data/raw/raw_countries_bounds.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/stickers/data_custom_emoji.cpp b/Telegram/SourceFiles/data/stickers/data_custom_emoji.cpp
++index a923f44..3c6cbea 100644
++--- a/Telegram/SourceFiles/data/stickers/data_custom_emoji.cpp
+++++ b/Telegram/SourceFiles/data/stickers/data_custom_emoji.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/stickers/data_stickers.cpp b/Telegram/SourceFiles/data/stickers/data_stickers.cpp
++index 19c8e96..2cab7a7 100644
++--- a/Telegram/SourceFiles/data/stickers/data_stickers.cpp
+++++ b/Telegram/SourceFiles/data/stickers/data_stickers.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/data/stickers/data_stickers_set.cpp b/Telegram/SourceFiles/data/stickers/data_stickers_set.cpp
++index 75d9840..807e1de 100644
++--- a/Telegram/SourceFiles/data/stickers/data_stickers_set.cpp
+++++ b/Telegram/SourceFiles/data/stickers/data_stickers_set.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/dialogs_entry.cpp b/Telegram/SourceFiles/dialogs/dialogs_entry.cpp
++index 9298a8d..7bae88a 100644
++--- a/Telegram/SourceFiles/dialogs/dialogs_entry.cpp
+++++ b/Telegram/SourceFiles/dialogs/dialogs_entry.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/dialogs_indexed_list.cpp b/Telegram/SourceFiles/dialogs/dialogs_indexed_list.cpp
++index 2254346..8d96bed 100644
++--- a/Telegram/SourceFiles/dialogs/dialogs_indexed_list.cpp
+++++ b/Telegram/SourceFiles/dialogs/dialogs_indexed_list.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp b/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
++index 43cc854..5be9d1f 100644
++--- a/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
+++++ b/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/dialogs_key.cpp b/Telegram/SourceFiles/dialogs/dialogs_key.cpp
++index db5df96..adedf11 100644
++--- a/Telegram/SourceFiles/dialogs/dialogs_key.cpp
+++++ b/Telegram/SourceFiles/dialogs/dialogs_key.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/dialogs_list.cpp b/Telegram/SourceFiles/dialogs/dialogs_list.cpp
++index e3c8044..367d090 100644
++--- a/Telegram/SourceFiles/dialogs/dialogs_list.cpp
+++++ b/Telegram/SourceFiles/dialogs/dialogs_list.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/dialogs_main_list.cpp b/Telegram/SourceFiles/dialogs/dialogs_main_list.cpp
++index c38d844..170fbd8 100644
++--- a/Telegram/SourceFiles/dialogs/dialogs_main_list.cpp
+++++ b/Telegram/SourceFiles/dialogs/dialogs_main_list.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/dialogs_pinned_list.cpp b/Telegram/SourceFiles/dialogs/dialogs_pinned_list.cpp
++index cac85b3..a4e10da 100644
++--- a/Telegram/SourceFiles/dialogs/dialogs_pinned_list.cpp
+++++ b/Telegram/SourceFiles/dialogs/dialogs_pinned_list.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/dialogs_quick_action.cpp b/Telegram/SourceFiles/dialogs/dialogs_quick_action.cpp
++index a796b47..4c408f5 100644
++--- a/Telegram/SourceFiles/dialogs/dialogs_quick_action.cpp
+++++ b/Telegram/SourceFiles/dialogs/dialogs_quick_action.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/dialogs_row.cpp b/Telegram/SourceFiles/dialogs/dialogs_row.cpp
++index 1082a20..b3294cc 100644
++--- a/Telegram/SourceFiles/dialogs/dialogs_row.cpp
+++++ b/Telegram/SourceFiles/dialogs/dialogs_row.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.cpp b/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.cpp
++index b81e79f..989d6f6 100644
++--- a/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.cpp
+++++ b/Telegram/SourceFiles/dialogs/dialogs_search_from_controllers.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/dialogs_search_posts.cpp b/Telegram/SourceFiles/dialogs/dialogs_search_posts.cpp
++index 626c961..3db99f3 100644
++--- a/Telegram/SourceFiles/dialogs/dialogs_search_posts.cpp
+++++ b/Telegram/SourceFiles/dialogs/dialogs_search_posts.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/dialogs_search_tags.cpp b/Telegram/SourceFiles/dialogs/dialogs_search_tags.cpp
++index 6127281..de086b2 100644
++--- a/Telegram/SourceFiles/dialogs/dialogs_search_tags.cpp
+++++ b/Telegram/SourceFiles/dialogs/dialogs_search_tags.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/dialogs_top_bar_suggestion.cpp b/Telegram/SourceFiles/dialogs/dialogs_top_bar_suggestion.cpp
++index 8d25e70..6fe741b 100644
++--- a/Telegram/SourceFiles/dialogs/dialogs_top_bar_suggestion.cpp
+++++ b/Telegram/SourceFiles/dialogs/dialogs_top_bar_suggestion.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
++index d559c17..f8207f9 100644
++--- a/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
+++++ b/Telegram/SourceFiles/dialogs/dialogs_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/ui/chat_search_empty.cpp b/Telegram/SourceFiles/dialogs/ui/chat_search_empty.cpp
++index 028452e..1b09946 100644
++--- a/Telegram/SourceFiles/dialogs/ui/chat_search_empty.cpp
+++++ b/Telegram/SourceFiles/dialogs/ui/chat_search_empty.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/ui/chat_search_in.cpp b/Telegram/SourceFiles/dialogs/ui/chat_search_in.cpp
++index 42e8c33..8b1a5ee 100644
++--- a/Telegram/SourceFiles/dialogs/ui/chat_search_in.cpp
+++++ b/Telegram/SourceFiles/dialogs/ui/chat_search_in.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/ui/dialogs_layout.cpp b/Telegram/SourceFiles/dialogs/ui/dialogs_layout.cpp
++index b4b0c9e..c2286a0 100644
++--- a/Telegram/SourceFiles/dialogs/ui/dialogs_layout.cpp
+++++ b/Telegram/SourceFiles/dialogs/ui/dialogs_layout.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/ui/dialogs_message_view.cpp b/Telegram/SourceFiles/dialogs/ui/dialogs_message_view.cpp
++index 448160e..6bfb4d7 100644
++--- a/Telegram/SourceFiles/dialogs/ui/dialogs_message_view.cpp
+++++ b/Telegram/SourceFiles/dialogs/ui/dialogs_message_view.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/ui/dialogs_stories_content.cpp b/Telegram/SourceFiles/dialogs/ui/dialogs_stories_content.cpp
++index 3de988b..b5e59a1 100644
++--- a/Telegram/SourceFiles/dialogs/ui/dialogs_stories_content.cpp
+++++ b/Telegram/SourceFiles/dialogs/ui/dialogs_stories_content.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/ui/dialogs_stories_list.cpp b/Telegram/SourceFiles/dialogs/ui/dialogs_stories_list.cpp
++index bfe6325..7b72ee2 100644
++--- a/Telegram/SourceFiles/dialogs/ui/dialogs_stories_list.cpp
+++++ b/Telegram/SourceFiles/dialogs/ui/dialogs_stories_list.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/ui/dialogs_suggestions.cpp b/Telegram/SourceFiles/dialogs/ui/dialogs_suggestions.cpp
++index 33954d2..57efa86 100644
++--- a/Telegram/SourceFiles/dialogs/ui/dialogs_suggestions.cpp
+++++ b/Telegram/SourceFiles/dialogs/ui/dialogs_suggestions.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/ui/dialogs_top_bar_suggestion_content.cpp b/Telegram/SourceFiles/dialogs/ui/dialogs_top_bar_suggestion_content.cpp
++index 6e53d71..73b064d 100644
++--- a/Telegram/SourceFiles/dialogs/ui/dialogs_top_bar_suggestion_content.cpp
+++++ b/Telegram/SourceFiles/dialogs/ui/dialogs_top_bar_suggestion_content.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/ui/dialogs_topics_view.cpp b/Telegram/SourceFiles/dialogs/ui/dialogs_topics_view.cpp
++index 9286e40..62f0450 100644
++--- a/Telegram/SourceFiles/dialogs/ui/dialogs_topics_view.cpp
+++++ b/Telegram/SourceFiles/dialogs/ui/dialogs_topics_view.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/ui/dialogs_video_userpic.cpp b/Telegram/SourceFiles/dialogs/ui/dialogs_video_userpic.cpp
++index 9f970a3..10db1d9 100644
++--- a/Telegram/SourceFiles/dialogs/ui/dialogs_video_userpic.cpp
+++++ b/Telegram/SourceFiles/dialogs/ui/dialogs_video_userpic.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/ui/posts_search_intro.cpp b/Telegram/SourceFiles/dialogs/ui/posts_search_intro.cpp
++index 87bda8f..210aa60 100644
++--- a/Telegram/SourceFiles/dialogs/ui/posts_search_intro.cpp
+++++ b/Telegram/SourceFiles/dialogs/ui/posts_search_intro.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/dialogs/ui/top_peers_strip.cpp b/Telegram/SourceFiles/dialogs/ui/top_peers_strip.cpp
++index 67cafb9..227bcd3 100644
++--- a/Telegram/SourceFiles/dialogs/ui/top_peers_strip.cpp
+++++ b/Telegram/SourceFiles/dialogs/ui/top_peers_strip.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/editor/color_picker.cpp b/Telegram/SourceFiles/editor/color_picker.cpp
++index a07e021..1f7440f 100644
++--- a/Telegram/SourceFiles/editor/color_picker.cpp
+++++ b/Telegram/SourceFiles/editor/color_picker.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/editor/controllers/stickers_panel_controller.cpp b/Telegram/SourceFiles/editor/controllers/stickers_panel_controller.cpp
++index 2c0482c..fd4ba24 100644
++--- a/Telegram/SourceFiles/editor/controllers/stickers_panel_controller.cpp
+++++ b/Telegram/SourceFiles/editor/controllers/stickers_panel_controller.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/editor/controllers/undo_controller.cpp b/Telegram/SourceFiles/editor/controllers/undo_controller.cpp
++index 0d65794..7f2375a 100644
++--- a/Telegram/SourceFiles/editor/controllers/undo_controller.cpp
+++++ b/Telegram/SourceFiles/editor/controllers/undo_controller.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/editor/editor_crop.cpp b/Telegram/SourceFiles/editor/editor_crop.cpp
++index b528881..1cef1ac 100644
++--- a/Telegram/SourceFiles/editor/editor_crop.cpp
+++++ b/Telegram/SourceFiles/editor/editor_crop.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/editor/editor_layer_widget.cpp b/Telegram/SourceFiles/editor/editor_layer_widget.cpp
++index fc2096f..9499b22 100644
++--- a/Telegram/SourceFiles/editor/editor_layer_widget.cpp
+++++ b/Telegram/SourceFiles/editor/editor_layer_widget.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/editor/editor_paint.cpp b/Telegram/SourceFiles/editor/editor_paint.cpp
++index 5f858ae..b3a70b7 100644
++--- a/Telegram/SourceFiles/editor/editor_paint.cpp
+++++ b/Telegram/SourceFiles/editor/editor_paint.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/editor/photo_editor.cpp b/Telegram/SourceFiles/editor/photo_editor.cpp
++index 0ec6de9..baf373b 100644
++--- a/Telegram/SourceFiles/editor/photo_editor.cpp
+++++ b/Telegram/SourceFiles/editor/photo_editor.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/editor/photo_editor_common.cpp b/Telegram/SourceFiles/editor/photo_editor_common.cpp
++index 4fd72ac..b679f94 100644
++--- a/Telegram/SourceFiles/editor/photo_editor_common.cpp
+++++ b/Telegram/SourceFiles/editor/photo_editor_common.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/editor/photo_editor_content.cpp b/Telegram/SourceFiles/editor/photo_editor_content.cpp
++index 1a379b9..f1d702d 100644
++--- a/Telegram/SourceFiles/editor/photo_editor_content.cpp
+++++ b/Telegram/SourceFiles/editor/photo_editor_content.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/editor/photo_editor_controls.cpp b/Telegram/SourceFiles/editor/photo_editor_controls.cpp
++index 72a4338..43e1ff6 100644
++--- a/Telegram/SourceFiles/editor/photo_editor_controls.cpp
+++++ b/Telegram/SourceFiles/editor/photo_editor_controls.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/editor/photo_editor_layer_widget.cpp b/Telegram/SourceFiles/editor/photo_editor_layer_widget.cpp
++index 257e47e..34711d7 100644
++--- a/Telegram/SourceFiles/editor/photo_editor_layer_widget.cpp
+++++ b/Telegram/SourceFiles/editor/photo_editor_layer_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/editor/scene/scene.cpp b/Telegram/SourceFiles/editor/scene/scene.cpp
++index 0ebb29c..4643403 100644
++--- a/Telegram/SourceFiles/editor/scene/scene.cpp
+++++ b/Telegram/SourceFiles/editor/scene/scene.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/editor/scene/scene_item_base.cpp b/Telegram/SourceFiles/editor/scene/scene_item_base.cpp
++index 8c69702..0b0c8c4 100644
++--- a/Telegram/SourceFiles/editor/scene/scene_item_base.cpp
+++++ b/Telegram/SourceFiles/editor/scene/scene_item_base.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/editor/scene/scene_item_canvas.cpp b/Telegram/SourceFiles/editor/scene/scene_item_canvas.cpp
++index 21b7266..3ce60f8 100644
++--- a/Telegram/SourceFiles/editor/scene/scene_item_canvas.cpp
+++++ b/Telegram/SourceFiles/editor/scene/scene_item_canvas.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/editor/scene/scene_item_image.cpp b/Telegram/SourceFiles/editor/scene/scene_item_image.cpp
++index 1a93923..20cffe4 100644
++--- a/Telegram/SourceFiles/editor/scene/scene_item_image.cpp
+++++ b/Telegram/SourceFiles/editor/scene/scene_item_image.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/editor/scene/scene_item_line.cpp b/Telegram/SourceFiles/editor/scene/scene_item_line.cpp
++index 0b68b39..58db402 100644
++--- a/Telegram/SourceFiles/editor/scene/scene_item_line.cpp
+++++ b/Telegram/SourceFiles/editor/scene/scene_item_line.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/editor/scene/scene_item_sticker.cpp b/Telegram/SourceFiles/editor/scene/scene_item_sticker.cpp
++index 2cf42d1..c021627 100644
++--- a/Telegram/SourceFiles/editor/scene/scene_item_sticker.cpp
+++++ b/Telegram/SourceFiles/editor/scene/scene_item_sticker.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/export/data/export_data_types.cpp b/Telegram/SourceFiles/export/data/export_data_types.cpp
++index bd16f6d..d2808c6 100644
++--- a/Telegram/SourceFiles/export/data/export_data_types.cpp
+++++ b/Telegram/SourceFiles/export/data/export_data_types.cpp
++@@ -1,3 +1,4 @@
+++#include "export/export_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/export/export_api_wrap.cpp b/Telegram/SourceFiles/export/export_api_wrap.cpp
++index e378d90..46225e3 100644
++--- a/Telegram/SourceFiles/export/export_api_wrap.cpp
+++++ b/Telegram/SourceFiles/export/export_api_wrap.cpp
++@@ -1,3 +1,4 @@
+++#include "export/export_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/export/export_controller.cpp b/Telegram/SourceFiles/export/export_controller.cpp
++index a6e12d2..c2ea550 100644
++--- a/Telegram/SourceFiles/export/export_controller.cpp
+++++ b/Telegram/SourceFiles/export/export_controller.cpp
++@@ -1,3 +1,4 @@
+++#include "export/export_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/export/export_manager.cpp b/Telegram/SourceFiles/export/export_manager.cpp
++index 7277ade..740ce29 100644
++--- a/Telegram/SourceFiles/export/export_manager.cpp
+++++ b/Telegram/SourceFiles/export/export_manager.cpp
++@@ -1,3 +1,5 @@
+++#include "export/export_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/export/export_settings.cpp b/Telegram/SourceFiles/export/export_settings.cpp
++index 58f2ab5..1059430 100644
++--- a/Telegram/SourceFiles/export/export_settings.cpp
+++++ b/Telegram/SourceFiles/export/export_settings.cpp
++@@ -1,3 +1,4 @@
+++#include "export/export_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/export/output/export_output_abstract.cpp b/Telegram/SourceFiles/export/output/export_output_abstract.cpp
++index cadd6db..e942982 100644
++--- a/Telegram/SourceFiles/export/output/export_output_abstract.cpp
+++++ b/Telegram/SourceFiles/export/output/export_output_abstract.cpp
++@@ -1,3 +1,4 @@
+++#include "export/export_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/export/output/export_output_file.cpp b/Telegram/SourceFiles/export/output/export_output_file.cpp
++index 8b33039..78269c7 100644
++--- a/Telegram/SourceFiles/export/output/export_output_file.cpp
+++++ b/Telegram/SourceFiles/export/output/export_output_file.cpp
++@@ -1,3 +1,4 @@
+++#include "export/export_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/export/output/export_output_html.cpp b/Telegram/SourceFiles/export/output/export_output_html.cpp
++index 11b0e49..35d8900 100644
++--- a/Telegram/SourceFiles/export/output/export_output_html.cpp
+++++ b/Telegram/SourceFiles/export/output/export_output_html.cpp
++@@ -1,3 +1,4 @@
+++#include "export/export_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/export/output/export_output_html_and_json.cpp b/Telegram/SourceFiles/export/output/export_output_html_and_json.cpp
++index 9220147..dc7e681 100644
++--- a/Telegram/SourceFiles/export/output/export_output_html_and_json.cpp
+++++ b/Telegram/SourceFiles/export/output/export_output_html_and_json.cpp
++@@ -1,3 +1,4 @@
+++#include "export/export_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/export/output/export_output_json.cpp b/Telegram/SourceFiles/export/output/export_output_json.cpp
++index b591bfb..f70e26d 100644
++--- a/Telegram/SourceFiles/export/output/export_output_json.cpp
+++++ b/Telegram/SourceFiles/export/output/export_output_json.cpp
++@@ -1,3 +1,4 @@
+++#include "export/export_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/export/output/export_output_stats.cpp b/Telegram/SourceFiles/export/output/export_output_stats.cpp
++index 30275ac..fedb250 100644
++--- a/Telegram/SourceFiles/export/output/export_output_stats.cpp
+++++ b/Telegram/SourceFiles/export/output/export_output_stats.cpp
++@@ -1,3 +1,4 @@
+++#include "export/export_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/export/view/export_view_content.cpp b/Telegram/SourceFiles/export/view/export_view_content.cpp
++index 9813321..a37217d 100644
++--- a/Telegram/SourceFiles/export/view/export_view_content.cpp
+++++ b/Telegram/SourceFiles/export/view/export_view_content.cpp
++@@ -1,3 +1,4 @@
+++#include "export/export_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/export/view/export_view_panel_controller.cpp b/Telegram/SourceFiles/export/view/export_view_panel_controller.cpp
++index d65be8f..91cc520 100644
++--- a/Telegram/SourceFiles/export/view/export_view_panel_controller.cpp
+++++ b/Telegram/SourceFiles/export/view/export_view_panel_controller.cpp
++@@ -1,3 +1,5 @@
+++#include "export/export_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/export/view/export_view_progress.cpp b/Telegram/SourceFiles/export/view/export_view_progress.cpp
++index c7d28c7..011fc99 100644
++--- a/Telegram/SourceFiles/export/view/export_view_progress.cpp
+++++ b/Telegram/SourceFiles/export/view/export_view_progress.cpp
++@@ -1,3 +1,5 @@
+++#include "export/export_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/export/view/export_view_settings.cpp b/Telegram/SourceFiles/export/view/export_view_settings.cpp
++index e610471..f516947 100644
++--- a/Telegram/SourceFiles/export/view/export_view_settings.cpp
+++++ b/Telegram/SourceFiles/export/view/export_view_settings.cpp
++@@ -1,3 +1,5 @@
+++#include "export/export_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/export/view/export_view_top_bar.cpp b/Telegram/SourceFiles/export/view/export_view_top_bar.cpp
++index add2539..75cdf54 100644
++--- a/Telegram/SourceFiles/export/view/export_view_top_bar.cpp
+++++ b/Telegram/SourceFiles/export/view/export_view_top_bar.cpp
++@@ -1,3 +1,5 @@
+++#include "export/export_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/admin_log/history_admin_log_filter.cpp b/Telegram/SourceFiles/history/admin_log/history_admin_log_filter.cpp
++index fc78769..3baa8fd 100644
++--- a/Telegram/SourceFiles/history/admin_log/history_admin_log_filter.cpp
+++++ b/Telegram/SourceFiles/history/admin_log/history_admin_log_filter.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/admin_log/history_admin_log_inner.cpp b/Telegram/SourceFiles/history/admin_log/history_admin_log_inner.cpp
++index 6c956ac..9277548 100644
++--- a/Telegram/SourceFiles/history/admin_log/history_admin_log_inner.cpp
+++++ b/Telegram/SourceFiles/history/admin_log/history_admin_log_inner.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/admin_log/history_admin_log_item.cpp b/Telegram/SourceFiles/history/admin_log/history_admin_log_item.cpp
++index 618af25..f5cd32f 100644
++--- a/Telegram/SourceFiles/history/admin_log/history_admin_log_item.cpp
+++++ b/Telegram/SourceFiles/history/admin_log/history_admin_log_item.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/admin_log/history_admin_log_section.cpp b/Telegram/SourceFiles/history/admin_log/history_admin_log_section.cpp
++index b8f2177..8bc684d 100644
++--- a/Telegram/SourceFiles/history/admin_log/history_admin_log_section.cpp
+++++ b/Telegram/SourceFiles/history/admin_log/history_admin_log_section.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/history.cpp b/Telegram/SourceFiles/history/history.cpp
++index be7089d..13c60c1 100644
++--- a/Telegram/SourceFiles/history/history.cpp
+++++ b/Telegram/SourceFiles/history/history.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/history_drag_area.cpp b/Telegram/SourceFiles/history/history_drag_area.cpp
++index 4f99ec7..b8cae5e 100644
++--- a/Telegram/SourceFiles/history/history_drag_area.cpp
+++++ b/Telegram/SourceFiles/history/history_drag_area.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/history_inner_widget.cpp b/Telegram/SourceFiles/history/history_inner_widget.cpp
++index 2a938e5..8620d86 100644
++--- a/Telegram/SourceFiles/history/history_inner_widget.cpp
+++++ b/Telegram/SourceFiles/history/history_inner_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/history_item.cpp b/Telegram/SourceFiles/history/history_item.cpp
++index 47b8410..284bf41 100644
++--- a/Telegram/SourceFiles/history/history_item.cpp
+++++ b/Telegram/SourceFiles/history/history_item.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/history_item_components.cpp b/Telegram/SourceFiles/history/history_item_components.cpp
++index 184a368..d232812 100644
++--- a/Telegram/SourceFiles/history/history_item_components.cpp
+++++ b/Telegram/SourceFiles/history/history_item_components.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/history_item_edition.cpp b/Telegram/SourceFiles/history/history_item_edition.cpp
++index 968a429..4fed16e 100644
++--- a/Telegram/SourceFiles/history/history_item_edition.cpp
+++++ b/Telegram/SourceFiles/history/history_item_edition.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/history_item_helpers.cpp b/Telegram/SourceFiles/history/history_item_helpers.cpp
++index 762419f..5be72cb 100644
++--- a/Telegram/SourceFiles/history/history_item_helpers.cpp
+++++ b/Telegram/SourceFiles/history/history_item_helpers.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/history_item_reply_markup.cpp b/Telegram/SourceFiles/history/history_item_reply_markup.cpp
++index 8ca15fe..a2248f8 100644
++--- a/Telegram/SourceFiles/history/history_item_reply_markup.cpp
+++++ b/Telegram/SourceFiles/history/history_item_reply_markup.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/history_item_text.cpp b/Telegram/SourceFiles/history/history_item_text.cpp
++index ba35168..ffbde0a 100644
++--- a/Telegram/SourceFiles/history/history_item_text.cpp
+++++ b/Telegram/SourceFiles/history/history_item_text.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/history_location_manager.cpp b/Telegram/SourceFiles/history/history_location_manager.cpp
++index 7810460..c7f4431 100644
++--- a/Telegram/SourceFiles/history/history_location_manager.cpp
+++++ b/Telegram/SourceFiles/history/history_location_manager.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/history_translation.cpp b/Telegram/SourceFiles/history/history_translation.cpp
++index be4febe..13e1bc2 100644
++--- a/Telegram/SourceFiles/history/history_translation.cpp
+++++ b/Telegram/SourceFiles/history/history_translation.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/history_unread_things.cpp b/Telegram/SourceFiles/history/history_unread_things.cpp
++index 1ba1678..ab9f1da 100644
++--- a/Telegram/SourceFiles/history/history_unread_things.cpp
+++++ b/Telegram/SourceFiles/history/history_unread_things.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/history_view_highlight_manager.cpp b/Telegram/SourceFiles/history/history_view_highlight_manager.cpp
++index 5ff3f71..d127b56 100644
++--- a/Telegram/SourceFiles/history/history_view_highlight_manager.cpp
+++++ b/Telegram/SourceFiles/history/history_view_highlight_manager.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/history_view_swipe_back_session.cpp b/Telegram/SourceFiles/history/history_view_swipe_back_session.cpp
++index b757a0a..edfed32 100644
++--- a/Telegram/SourceFiles/history/history_view_swipe_back_session.cpp
+++++ b/Telegram/SourceFiles/history/history_view_swipe_back_session.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/history_view_top_toast.cpp b/Telegram/SourceFiles/history/history_view_top_toast.cpp
++index a68061b..81ca5a6 100644
++--- a/Telegram/SourceFiles/history/history_view_top_toast.cpp
+++++ b/Telegram/SourceFiles/history/history_view_top_toast.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/history_widget.cpp b/Telegram/SourceFiles/history/history_widget.cpp
++index 1fa75f6..544f3af 100644
++--- a/Telegram/SourceFiles/history/history_widget.cpp
+++++ b/Telegram/SourceFiles/history/history_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/controls/history_view_characters_limit.cpp b/Telegram/SourceFiles/history/view/controls/history_view_characters_limit.cpp
++index c3f2736..b1b720e 100644
++--- a/Telegram/SourceFiles/history/view/controls/history_view_characters_limit.cpp
+++++ b/Telegram/SourceFiles/history/view/controls/history_view_characters_limit.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/controls/history_view_compose_controls.cpp b/Telegram/SourceFiles/history/view/controls/history_view_compose_controls.cpp
++index b820f57..1b8714c 100644
++--- a/Telegram/SourceFiles/history/view/controls/history_view_compose_controls.cpp
+++++ b/Telegram/SourceFiles/history/view/controls/history_view_compose_controls.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/controls/history_view_compose_media_edit_manager.cpp b/Telegram/SourceFiles/history/view/controls/history_view_compose_media_edit_manager.cpp
++index 45ababe..53e5d28 100644
++--- a/Telegram/SourceFiles/history/view/controls/history_view_compose_media_edit_manager.cpp
+++++ b/Telegram/SourceFiles/history/view/controls/history_view_compose_media_edit_manager.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/controls/history_view_compose_search.cpp b/Telegram/SourceFiles/history/view/controls/history_view_compose_search.cpp
++index 22d3ecb..0de97a2 100644
++--- a/Telegram/SourceFiles/history/view/controls/history_view_compose_search.cpp
+++++ b/Telegram/SourceFiles/history/view/controls/history_view_compose_search.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/controls/history_view_draft_options.cpp b/Telegram/SourceFiles/history/view/controls/history_view_draft_options.cpp
++index 417548f..310b0e8 100644
++--- a/Telegram/SourceFiles/history/view/controls/history_view_draft_options.cpp
+++++ b/Telegram/SourceFiles/history/view/controls/history_view_draft_options.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/controls/history_view_forward_panel.cpp b/Telegram/SourceFiles/history/view/controls/history_view_forward_panel.cpp
++index 5d01148..9e70698 100644
++--- a/Telegram/SourceFiles/history/view/controls/history_view_forward_panel.cpp
+++++ b/Telegram/SourceFiles/history/view/controls/history_view_forward_panel.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/controls/history_view_suggest_options.cpp b/Telegram/SourceFiles/history/view/controls/history_view_suggest_options.cpp
++index 618d1b2..d89cdef 100644
++--- a/Telegram/SourceFiles/history/view/controls/history_view_suggest_options.cpp
+++++ b/Telegram/SourceFiles/history/view/controls/history_view_suggest_options.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/controls/history_view_ttl_button.cpp b/Telegram/SourceFiles/history/view/controls/history_view_ttl_button.cpp
++index f7e15f5..e306656 100644
++--- a/Telegram/SourceFiles/history/view/controls/history_view_ttl_button.cpp
+++++ b/Telegram/SourceFiles/history/view/controls/history_view_ttl_button.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/controls/history_view_voice_record_bar.cpp b/Telegram/SourceFiles/history/view/controls/history_view_voice_record_bar.cpp
++index f7f3e7c..5705ed9 100644
++--- a/Telegram/SourceFiles/history/view/controls/history_view_voice_record_bar.cpp
+++++ b/Telegram/SourceFiles/history/view/controls/history_view_voice_record_bar.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/controls/history_view_voice_record_button.cpp b/Telegram/SourceFiles/history/view/controls/history_view_voice_record_button.cpp
++index b32fa2d..57b7e55 100644
++--- a/Telegram/SourceFiles/history/view/controls/history_view_voice_record_button.cpp
+++++ b/Telegram/SourceFiles/history/view/controls/history_view_voice_record_button.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/controls/history_view_webpage_processor.cpp b/Telegram/SourceFiles/history/view/controls/history_view_webpage_processor.cpp
++index 379ffb9..10f4dc9 100644
++--- a/Telegram/SourceFiles/history/view/controls/history_view_webpage_processor.cpp
+++++ b/Telegram/SourceFiles/history/view/controls/history_view_webpage_processor.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_about_view.cpp b/Telegram/SourceFiles/history/view/history_view_about_view.cpp
++index e09fc42..c2276a1 100644
++--- a/Telegram/SourceFiles/history/view/history_view_about_view.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_about_view.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_bottom_info.cpp b/Telegram/SourceFiles/history/view/history_view_bottom_info.cpp
++index 4d735d3..018a4dc 100644
++--- a/Telegram/SourceFiles/history/view/history_view_bottom_info.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_bottom_info.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_chat_preview.cpp b/Telegram/SourceFiles/history/view/history_view_chat_preview.cpp
++index 353a9ac..78c271f 100644
++--- a/Telegram/SourceFiles/history/view/history_view_chat_preview.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_chat_preview.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_chat_section.cpp b/Telegram/SourceFiles/history/view/history_view_chat_section.cpp
++index 5fecbc4..c12f7d4 100644
++--- a/Telegram/SourceFiles/history/view/history_view_chat_section.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_chat_section.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_contact_status.cpp b/Telegram/SourceFiles/history/view/history_view_contact_status.cpp
++index b0a48e1..eea2f30 100644
++--- a/Telegram/SourceFiles/history/view/history_view_contact_status.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_contact_status.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_context_menu.cpp b/Telegram/SourceFiles/history/view/history_view_context_menu.cpp
++index 476e8b5..1195cb4 100644
++--- a/Telegram/SourceFiles/history/view/history_view_context_menu.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_context_menu.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_corner_buttons.cpp b/Telegram/SourceFiles/history/view/history_view_corner_buttons.cpp
++index 37885d8..5e2ed89 100644
++--- a/Telegram/SourceFiles/history/view/history_view_corner_buttons.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_corner_buttons.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_cursor_state.cpp b/Telegram/SourceFiles/history/view/history_view_cursor_state.cpp
++index 56ca495..24d3581 100644
++--- a/Telegram/SourceFiles/history/view/history_view_cursor_state.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_cursor_state.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_element.cpp b/Telegram/SourceFiles/history/view/history_view_element.cpp
++index 8a1a260..45caa7d 100644
++--- a/Telegram/SourceFiles/history/view/history_view_element.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_element.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_emoji_interactions.cpp b/Telegram/SourceFiles/history/view/history_view_emoji_interactions.cpp
++index fed0bdd..8469b60 100644
++--- a/Telegram/SourceFiles/history/view/history_view_emoji_interactions.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_emoji_interactions.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_empty_list_bubble.cpp b/Telegram/SourceFiles/history/view/history_view_empty_list_bubble.cpp
++index 0b47a01..4050c44 100644
++--- a/Telegram/SourceFiles/history/view/history_view_empty_list_bubble.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_empty_list_bubble.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_fake_items.cpp b/Telegram/SourceFiles/history/view/history_view_fake_items.cpp
++index 49a310a..ccebf82 100644
++--- a/Telegram/SourceFiles/history/view/history_view_fake_items.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_fake_items.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_group_call_bar.cpp b/Telegram/SourceFiles/history/view/history_view_group_call_bar.cpp
++index 68d952d..624b813 100644
++--- a/Telegram/SourceFiles/history/view/history_view_group_call_bar.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_group_call_bar.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_group_members_widget.cpp b/Telegram/SourceFiles/history/view/history_view_group_members_widget.cpp
++index 63b090d..2d6d531 100644
++--- a/Telegram/SourceFiles/history/view/history_view_group_members_widget.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_group_members_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_list_widget.cpp b/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
++index f2ff933..61a5d04 100644
++--- a/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_list_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_message.cpp b/Telegram/SourceFiles/history/view/history_view_message.cpp
++index 1a82ad8..38f94ac 100644
++--- a/Telegram/SourceFiles/history/view/history_view_message.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_message.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_paid_reaction_toast.cpp b/Telegram/SourceFiles/history/view/history_view_paid_reaction_toast.cpp
++index 2fd7945..1cf3fe2 100644
++--- a/Telegram/SourceFiles/history/view/history_view_paid_reaction_toast.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_paid_reaction_toast.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_pinned_bar.cpp b/Telegram/SourceFiles/history/view/history_view_pinned_bar.cpp
++index 97b7164..8714d8e 100644
++--- a/Telegram/SourceFiles/history/view/history_view_pinned_bar.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_pinned_bar.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_pinned_section.cpp b/Telegram/SourceFiles/history/view/history_view_pinned_section.cpp
++index 3330001..437a804 100644
++--- a/Telegram/SourceFiles/history/view/history_view_pinned_section.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_pinned_section.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_pinned_tracker.cpp b/Telegram/SourceFiles/history/view/history_view_pinned_tracker.cpp
++index fcc7226..1aece33 100644
++--- a/Telegram/SourceFiles/history/view/history_view_pinned_tracker.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_pinned_tracker.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_quick_action.cpp b/Telegram/SourceFiles/history/view/history_view_quick_action.cpp
++index 40222da..df2ed17 100644
++--- a/Telegram/SourceFiles/history/view/history_view_quick_action.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_quick_action.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_reply.cpp b/Telegram/SourceFiles/history/view/history_view_reply.cpp
++index fc18f3d..46a71d7 100644
++--- a/Telegram/SourceFiles/history/view/history_view_reply.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_reply.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_requests_bar.cpp b/Telegram/SourceFiles/history/view/history_view_requests_bar.cpp
++index d0ddb48..a8783c7 100644
++--- a/Telegram/SourceFiles/history/view/history_view_requests_bar.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_requests_bar.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_schedule_box.cpp b/Telegram/SourceFiles/history/view/history_view_schedule_box.cpp
++index 1dc8a8b..dcc4178 100644
++--- a/Telegram/SourceFiles/history/view/history_view_schedule_box.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_schedule_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_scheduled_section.cpp b/Telegram/SourceFiles/history/view/history_view_scheduled_section.cpp
++index 27c8d2f..20fdcfa 100644
++--- a/Telegram/SourceFiles/history/view/history_view_scheduled_section.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_scheduled_section.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_send_action.cpp b/Telegram/SourceFiles/history/view/history_view_send_action.cpp
++index 460941e..b9a074a 100644
++--- a/Telegram/SourceFiles/history/view/history_view_send_action.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_send_action.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_service_message.cpp b/Telegram/SourceFiles/history/view/history_view_service_message.cpp
++index 5c96ee4..cca9692 100644
++--- a/Telegram/SourceFiles/history/view/history_view_service_message.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_service_message.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_sponsored_click_handler.cpp b/Telegram/SourceFiles/history/view/history_view_sponsored_click_handler.cpp
++index 6fe3414..e47bb88 100644
++--- a/Telegram/SourceFiles/history/view/history_view_sponsored_click_handler.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_sponsored_click_handler.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_sticker_toast.cpp b/Telegram/SourceFiles/history/view/history_view_sticker_toast.cpp
++index b352398..08d1537 100644
++--- a/Telegram/SourceFiles/history/view/history_view_sticker_toast.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_sticker_toast.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_subsection_tabs.cpp b/Telegram/SourceFiles/history/view/history_view_subsection_tabs.cpp
++index 51ebf3b..ce75f21 100644
++--- a/Telegram/SourceFiles/history/view/history_view_subsection_tabs.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_subsection_tabs.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_text_helper.cpp b/Telegram/SourceFiles/history/view/history_view_text_helper.cpp
++index fbe97ed..5a68290 100644
++--- a/Telegram/SourceFiles/history/view/history_view_text_helper.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_text_helper.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_top_bar_widget.cpp b/Telegram/SourceFiles/history/view/history_view_top_bar_widget.cpp
++index 9ff9720..cc7dd36 100644
++--- a/Telegram/SourceFiles/history/view/history_view_top_bar_widget.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_top_bar_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_transcribe_button.cpp b/Telegram/SourceFiles/history/view/history_view_transcribe_button.cpp
++index 1688b8f..2a57adb 100644
++--- a/Telegram/SourceFiles/history/view/history_view_transcribe_button.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_transcribe_button.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_translate_bar.cpp b/Telegram/SourceFiles/history/view/history_view_translate_bar.cpp
++index c263c5f..e778fab 100644
++--- a/Telegram/SourceFiles/history/view/history_view_translate_bar.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_translate_bar.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_translate_tracker.cpp b/Telegram/SourceFiles/history/view/history_view_translate_tracker.cpp
++index d16eee6..f28142f 100644
++--- a/Telegram/SourceFiles/history/view/history_view_translate_tracker.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_translate_tracker.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_view_button.cpp b/Telegram/SourceFiles/history/view/history_view_view_button.cpp
++index 5f981bd..a7cfd2b 100644
++--- a/Telegram/SourceFiles/history/view/history_view_view_button.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_view_button.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/history_view_webpage_preview.cpp b/Telegram/SourceFiles/history/view/history_view_webpage_preview.cpp
++index 0d71e75..2e2e4df 100644
++--- a/Telegram/SourceFiles/history/view/history_view_webpage_preview.cpp
+++++ b/Telegram/SourceFiles/history/view/history_view_webpage_preview.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_call.cpp b/Telegram/SourceFiles/history/view/media/history_view_call.cpp
++index 6cfd8c9..3040cbb 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_call.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_call.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_contact.cpp b/Telegram/SourceFiles/history/view/media/history_view_contact.cpp
++index fa01e99..288e695 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_contact.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_contact.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_custom_emoji.cpp b/Telegram/SourceFiles/history/view/media/history_view_custom_emoji.cpp
++index 94de0a3..c6005c9 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_custom_emoji.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_custom_emoji.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_dice.cpp b/Telegram/SourceFiles/history/view/media/history_view_dice.cpp
++index 0ce2500..93a7384 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_dice.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_dice.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_document.cpp b/Telegram/SourceFiles/history/view/media/history_view_document.cpp
++index 445d414..24d44f1 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_document.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_document.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_file.cpp b/Telegram/SourceFiles/history/view/media/history_view_file.cpp
++index 00f3c5e..9e3c75b 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_file.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_file.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_game.cpp b/Telegram/SourceFiles/history/view/media/history_view_game.cpp
++index cd3950b..4db994e 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_game.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_game.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_gif.cpp b/Telegram/SourceFiles/history/view/media/history_view_gif.cpp
++index 9e45c23..e833783 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_gif.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_gif.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_giveaway.cpp b/Telegram/SourceFiles/history/view/media/history_view_giveaway.cpp
++index 93aa428..fea3a07 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_giveaway.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_giveaway.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_invoice.cpp b/Telegram/SourceFiles/history/view/media/history_view_invoice.cpp
++index eba510c..117de5a 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_invoice.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_invoice.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_large_emoji.cpp b/Telegram/SourceFiles/history/view/media/history_view_large_emoji.cpp
++index 0f77af1..36f675f 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_large_emoji.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_large_emoji.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_location.cpp b/Telegram/SourceFiles/history/view/media/history_view_location.cpp
++index 5b8b18e..ae01a5e 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_location.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_location.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_media.cpp b/Telegram/SourceFiles/history/view/media/history_view_media.cpp
++index ae837b3..e6bdde1 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_media.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_media.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_media_common.cpp b/Telegram/SourceFiles/history/view/media/history_view_media_common.cpp
++index 8a9cec6..fbbda7a 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_media_common.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_media_common.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_media_generic.cpp b/Telegram/SourceFiles/history/view/media/history_view_media_generic.cpp
++index 198cd99..87975dd 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_media_generic.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_media_generic.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_media_grouped.cpp b/Telegram/SourceFiles/history/view/media/history_view_media_grouped.cpp
++index 413fd75..8a0c233 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_media_grouped.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_media_grouped.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_media_spoiler.cpp b/Telegram/SourceFiles/history/view/media/history_view_media_spoiler.cpp
++index cdf0ff3..202ab3c 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_media_spoiler.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_media_spoiler.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_media_unwrapped.cpp b/Telegram/SourceFiles/history/view/media/history_view_media_unwrapped.cpp
++index 8f8b15e..77017de 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_media_unwrapped.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_media_unwrapped.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_photo.cpp b/Telegram/SourceFiles/history/view/media/history_view_photo.cpp
++index 3e56d77..d21d0be 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_photo.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_photo.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_poll.cpp b/Telegram/SourceFiles/history/view/media/history_view_poll.cpp
++index bc9386a..7c3307a 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_poll.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_poll.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_premium_gift.cpp b/Telegram/SourceFiles/history/view/media/history_view_premium_gift.cpp
++index 68ac6ee..7b5bb0d 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_premium_gift.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_premium_gift.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_save_document_action.cpp b/Telegram/SourceFiles/history/view/media/history_view_save_document_action.cpp
++index 7e9e41c..237e2a2 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_save_document_action.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_save_document_action.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_service_box.cpp b/Telegram/SourceFiles/history/view/media/history_view_service_box.cpp
++index 4e5e11d..4450843 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_service_box.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_service_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_similar_channels.cpp b/Telegram/SourceFiles/history/view/media/history_view_similar_channels.cpp
++index 93b99c4..9b300e8 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_similar_channels.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_similar_channels.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_slot_machine.cpp b/Telegram/SourceFiles/history/view/media/history_view_slot_machine.cpp
++index 307a18c..d4e67eb 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_slot_machine.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_slot_machine.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_sticker.cpp b/Telegram/SourceFiles/history/view/media/history_view_sticker.cpp
++index c5472fe..95e75e1 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_sticker.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_sticker.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_sticker_player.cpp b/Telegram/SourceFiles/history/view/media/history_view_sticker_player.cpp
++index da95870..0379cd9 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_sticker_player.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_sticker_player.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_story_mention.cpp b/Telegram/SourceFiles/history/view/media/history_view_story_mention.cpp
++index 7356e7b..69cf32c 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_story_mention.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_story_mention.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_suggest_decision.cpp b/Telegram/SourceFiles/history/view/media/history_view_suggest_decision.cpp
++index 3b7f24b..c7e7a2a 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_suggest_decision.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_suggest_decision.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_theme_document.cpp b/Telegram/SourceFiles/history/view/media/history_view_theme_document.cpp
++index 84add9c..ec21cc4 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_theme_document.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_theme_document.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_todo_list.cpp b/Telegram/SourceFiles/history/view/media/history_view_todo_list.cpp
++index e468a46..32699b1 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_todo_list.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_todo_list.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_unique_gift.cpp b/Telegram/SourceFiles/history/view/media/history_view_unique_gift.cpp
++index 350b784..a3d506a 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_unique_gift.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_unique_gift.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_userpic_suggestion.cpp b/Telegram/SourceFiles/history/view/media/history_view_userpic_suggestion.cpp
++index 6e5252a..98fcef4 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_userpic_suggestion.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_userpic_suggestion.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/media/history_view_web_page.cpp b/Telegram/SourceFiles/history/view/media/history_view_web_page.cpp
++index f25d133..662cc1d 100644
++--- a/Telegram/SourceFiles/history/view/media/history_view_web_page.cpp
+++++ b/Telegram/SourceFiles/history/view/media/history_view_web_page.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/reactions/history_view_reactions.cpp b/Telegram/SourceFiles/history/view/reactions/history_view_reactions.cpp
++index 8a18852..5683b3e 100644
++--- a/Telegram/SourceFiles/history/view/reactions/history_view_reactions.cpp
+++++ b/Telegram/SourceFiles/history/view/reactions/history_view_reactions.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/reactions/history_view_reactions_button.cpp b/Telegram/SourceFiles/history/view/reactions/history_view_reactions_button.cpp
++index 9f2759f..f35df95 100644
++--- a/Telegram/SourceFiles/history/view/reactions/history_view_reactions_button.cpp
+++++ b/Telegram/SourceFiles/history/view/reactions/history_view_reactions_button.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/reactions/history_view_reactions_list.cpp b/Telegram/SourceFiles/history/view/reactions/history_view_reactions_list.cpp
++index 90c6d52..272fd67 100644
++--- a/Telegram/SourceFiles/history/view/reactions/history_view_reactions_list.cpp
+++++ b/Telegram/SourceFiles/history/view/reactions/history_view_reactions_list.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/reactions/history_view_reactions_selector.cpp b/Telegram/SourceFiles/history/view/reactions/history_view_reactions_selector.cpp
++index 38970fb..9bdd87a 100644
++--- a/Telegram/SourceFiles/history/view/reactions/history_view_reactions_selector.cpp
+++++ b/Telegram/SourceFiles/history/view/reactions/history_view_reactions_selector.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/reactions/history_view_reactions_strip.cpp b/Telegram/SourceFiles/history/view/reactions/history_view_reactions_strip.cpp
++index 08524c1..bd4d11d 100644
++--- a/Telegram/SourceFiles/history/view/reactions/history_view_reactions_strip.cpp
+++++ b/Telegram/SourceFiles/history/view/reactions/history_view_reactions_strip.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/history/view/reactions/history_view_reactions_tabs.cpp b/Telegram/SourceFiles/history/view/reactions/history_view_reactions_tabs.cpp
++index df06ba4..b443351 100644
++--- a/Telegram/SourceFiles/history/view/reactions/history_view_reactions_tabs.cpp
+++++ b/Telegram/SourceFiles/history/view/reactions/history_view_reactions_tabs.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/bot/earn/info_bot_earn_list.cpp b/Telegram/SourceFiles/info/bot/earn/info_bot_earn_list.cpp
++index 8974765..37f860b 100644
++--- a/Telegram/SourceFiles/info/bot/earn/info_bot_earn_list.cpp
+++++ b/Telegram/SourceFiles/info/bot/earn/info_bot_earn_list.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/bot/earn/info_bot_earn_widget.cpp b/Telegram/SourceFiles/info/bot/earn/info_bot_earn_widget.cpp
++index 123c8e3..cb68bfe 100644
++--- a/Telegram/SourceFiles/info/bot/earn/info_bot_earn_widget.cpp
+++++ b/Telegram/SourceFiles/info/bot/earn/info_bot_earn_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/bot/starref/info_bot_starref_common.cpp b/Telegram/SourceFiles/info/bot/starref/info_bot_starref_common.cpp
++index b134eaf..434c26c 100644
++--- a/Telegram/SourceFiles/info/bot/starref/info_bot_starref_common.cpp
+++++ b/Telegram/SourceFiles/info/bot/starref/info_bot_starref_common.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/bot/starref/info_bot_starref_join_widget.cpp b/Telegram/SourceFiles/info/bot/starref/info_bot_starref_join_widget.cpp
++index 0343af5..c9dac8e 100644
++--- a/Telegram/SourceFiles/info/bot/starref/info_bot_starref_join_widget.cpp
+++++ b/Telegram/SourceFiles/info/bot/starref/info_bot_starref_join_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/bot/starref/info_bot_starref_setup_widget.cpp b/Telegram/SourceFiles/info/bot/starref/info_bot_starref_setup_widget.cpp
++index 46183eb..a060c84 100644
++--- a/Telegram/SourceFiles/info/bot/starref/info_bot_starref_setup_widget.cpp
+++++ b/Telegram/SourceFiles/info/bot/starref/info_bot_starref_setup_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/channel_statistics/boosts/create_giveaway_box.cpp b/Telegram/SourceFiles/info/channel_statistics/boosts/create_giveaway_box.cpp
++index 6be47fd..840618c 100644
++--- a/Telegram/SourceFiles/info/channel_statistics/boosts/create_giveaway_box.cpp
+++++ b/Telegram/SourceFiles/info/channel_statistics/boosts/create_giveaway_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/channel_statistics/boosts/giveaway/boost_badge.cpp b/Telegram/SourceFiles/info/channel_statistics/boosts/giveaway/boost_badge.cpp
++index aea01c5..831c3fc 100644
++--- a/Telegram/SourceFiles/info/channel_statistics/boosts/giveaway/boost_badge.cpp
+++++ b/Telegram/SourceFiles/info/channel_statistics/boosts/giveaway/boost_badge.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/channel_statistics/boosts/giveaway/giveaway_list_controllers.cpp b/Telegram/SourceFiles/info/channel_statistics/boosts/giveaway/giveaway_list_controllers.cpp
++index 22c3680..009f46e 100644
++--- a/Telegram/SourceFiles/info/channel_statistics/boosts/giveaway/giveaway_list_controllers.cpp
+++++ b/Telegram/SourceFiles/info/channel_statistics/boosts/giveaway/giveaway_list_controllers.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/channel_statistics/boosts/giveaway/giveaway_type_row.cpp b/Telegram/SourceFiles/info/channel_statistics/boosts/giveaway/giveaway_type_row.cpp
++index 60c1814..7f82ca2 100644
++--- a/Telegram/SourceFiles/info/channel_statistics/boosts/giveaway/giveaway_type_row.cpp
+++++ b/Telegram/SourceFiles/info/channel_statistics/boosts/giveaway/giveaway_type_row.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/channel_statistics/boosts/giveaway/select_countries_box.cpp b/Telegram/SourceFiles/info/channel_statistics/boosts/giveaway/select_countries_box.cpp
++index d9cb866..4b496cd 100644
++--- a/Telegram/SourceFiles/info/channel_statistics/boosts/giveaway/select_countries_box.cpp
+++++ b/Telegram/SourceFiles/info/channel_statistics/boosts/giveaway/select_countries_box.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/channel_statistics/boosts/info_boosts_inner_widget.cpp b/Telegram/SourceFiles/info/channel_statistics/boosts/info_boosts_inner_widget.cpp
++index de6862e..ab43ae9 100644
++--- a/Telegram/SourceFiles/info/channel_statistics/boosts/info_boosts_inner_widget.cpp
+++++ b/Telegram/SourceFiles/info/channel_statistics/boosts/info_boosts_inner_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/channel_statistics/boosts/info_boosts_widget.cpp b/Telegram/SourceFiles/info/channel_statistics/boosts/info_boosts_widget.cpp
++index 447897d..f9f8e75 100644
++--- a/Telegram/SourceFiles/info/channel_statistics/boosts/info_boosts_widget.cpp
+++++ b/Telegram/SourceFiles/info/channel_statistics/boosts/info_boosts_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/channel_statistics/earn/earn_format.cpp b/Telegram/SourceFiles/info/channel_statistics/earn/earn_format.cpp
++index 69ece36..0596843 100644
++--- a/Telegram/SourceFiles/info/channel_statistics/earn/earn_format.cpp
+++++ b/Telegram/SourceFiles/info/channel_statistics/earn/earn_format.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/channel_statistics/earn/earn_icons.cpp b/Telegram/SourceFiles/info/channel_statistics/earn/earn_icons.cpp
++index a398532..a25cca4 100644
++--- a/Telegram/SourceFiles/info/channel_statistics/earn/earn_icons.cpp
+++++ b/Telegram/SourceFiles/info/channel_statistics/earn/earn_icons.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/channel_statistics/earn/info_channel_earn_list.cpp b/Telegram/SourceFiles/info/channel_statistics/earn/info_channel_earn_list.cpp
++index cbc8376..ce86f33 100644
++--- a/Telegram/SourceFiles/info/channel_statistics/earn/info_channel_earn_list.cpp
+++++ b/Telegram/SourceFiles/info/channel_statistics/earn/info_channel_earn_list.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/channel_statistics/earn/info_channel_earn_widget.cpp b/Telegram/SourceFiles/info/channel_statistics/earn/info_channel_earn_widget.cpp
++index 99424a1..db28a77 100644
++--- a/Telegram/SourceFiles/info/channel_statistics/earn/info_channel_earn_widget.cpp
+++++ b/Telegram/SourceFiles/info/channel_statistics/earn/info_channel_earn_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/common_groups/info_common_groups_inner_widget.cpp b/Telegram/SourceFiles/info/common_groups/info_common_groups_inner_widget.cpp
++index cd5fe0b..b168d88 100644
++--- a/Telegram/SourceFiles/info/common_groups/info_common_groups_inner_widget.cpp
+++++ b/Telegram/SourceFiles/info/common_groups/info_common_groups_inner_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/common_groups/info_common_groups_widget.cpp b/Telegram/SourceFiles/info/common_groups/info_common_groups_widget.cpp
++index 46ad5a3..5af5d34 100644
++--- a/Telegram/SourceFiles/info/common_groups/info_common_groups_widget.cpp
+++++ b/Telegram/SourceFiles/info/common_groups/info_common_groups_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/downloads/info_downloads_inner_widget.cpp b/Telegram/SourceFiles/info/downloads/info_downloads_inner_widget.cpp
++index 411dfaf..47e09af 100644
++--- a/Telegram/SourceFiles/info/downloads/info_downloads_inner_widget.cpp
+++++ b/Telegram/SourceFiles/info/downloads/info_downloads_inner_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/downloads/info_downloads_provider.cpp b/Telegram/SourceFiles/info/downloads/info_downloads_provider.cpp
++index b9a8149..18d9b37 100644
++--- a/Telegram/SourceFiles/info/downloads/info_downloads_provider.cpp
+++++ b/Telegram/SourceFiles/info/downloads/info_downloads_provider.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/downloads/info_downloads_widget.cpp b/Telegram/SourceFiles/info/downloads/info_downloads_widget.cpp
++index 92f7e19..3619aea 100644
++--- a/Telegram/SourceFiles/info/downloads/info_downloads_widget.cpp
+++++ b/Telegram/SourceFiles/info/downloads/info_downloads_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/global_media/info_global_media_inner_widget.cpp b/Telegram/SourceFiles/info/global_media/info_global_media_inner_widget.cpp
++index f3e0cad..01e36bd 100644
++--- a/Telegram/SourceFiles/info/global_media/info_global_media_inner_widget.cpp
+++++ b/Telegram/SourceFiles/info/global_media/info_global_media_inner_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++@@ -148,4 +150,4 @@ rpl::producer<Ui::ScrollToRequest> InnerWidget::scrollToRequests() const {
++ 	return _scrollToRequests.events();
++ }
++ 
++-} // namespace Info::GlobalMedia
++\ No newline at end of file
+++} // namespace Info::GlobalMedia
++diff --git a/Telegram/SourceFiles/info/global_media/info_global_media_provider.cpp b/Telegram/SourceFiles/info/global_media/info_global_media_provider.cpp
++index 9f73f58..74bf625 100644
++--- a/Telegram/SourceFiles/info/global_media/info_global_media_provider.cpp
+++++ b/Telegram/SourceFiles/info/global_media/info_global_media_provider.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/global_media/info_global_media_widget.cpp b/Telegram/SourceFiles/info/global_media/info_global_media_widget.cpp
++index 69787fb..9f14eb1 100644
++--- a/Telegram/SourceFiles/info/global_media/info_global_media_widget.cpp
+++++ b/Telegram/SourceFiles/info/global_media/info_global_media_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++@@ -141,4 +143,4 @@ std::shared_ptr<Info::Memento> Make(
++ 			std::make_shared<Memento>(self, type)));
++ }
++ 
++-} // namespace Info::GlobalMedia
++\ No newline at end of file
+++} // namespace Info::GlobalMedia
++diff --git a/Telegram/SourceFiles/info/info_content_widget.cpp b/Telegram/SourceFiles/info/info_content_widget.cpp
++index 075bd6a..c08327f 100644
++--- a/Telegram/SourceFiles/info/info_content_widget.cpp
+++++ b/Telegram/SourceFiles/info/info_content_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/info_controller.cpp b/Telegram/SourceFiles/info/info_controller.cpp
++index 42f8972..a479488 100644
++--- a/Telegram/SourceFiles/info/info_controller.cpp
+++++ b/Telegram/SourceFiles/info/info_controller.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/info_layer_widget.cpp b/Telegram/SourceFiles/info/info_layer_widget.cpp
++index 3404cf9..3780f60 100644
++--- a/Telegram/SourceFiles/info/info_layer_widget.cpp
+++++ b/Telegram/SourceFiles/info/info_layer_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/info_memento.cpp b/Telegram/SourceFiles/info/info_memento.cpp
++index 48d8835..d25bbab 100644
++--- a/Telegram/SourceFiles/info/info_memento.cpp
+++++ b/Telegram/SourceFiles/info/info_memento.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/info_section_widget.cpp b/Telegram/SourceFiles/info/info_section_widget.cpp
++index 0a7b7da..5701c2c 100644
++--- a/Telegram/SourceFiles/info/info_section_widget.cpp
+++++ b/Telegram/SourceFiles/info/info_section_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/info_top_bar.cpp b/Telegram/SourceFiles/info/info_top_bar.cpp
++index af7006b..e2b3cb9 100644
++--- a/Telegram/SourceFiles/info/info_top_bar.cpp
+++++ b/Telegram/SourceFiles/info/info_top_bar.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/info_wrap_widget.cpp b/Telegram/SourceFiles/info/info_wrap_widget.cpp
++index ae59c84..b3662a1 100644
++--- a/Telegram/SourceFiles/info/info_wrap_widget.cpp
+++++ b/Telegram/SourceFiles/info/info_wrap_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/media/info_media_buttons.cpp b/Telegram/SourceFiles/info/media/info_media_buttons.cpp
++index fda15a1..a3e1c5c 100644
++--- a/Telegram/SourceFiles/info/media/info_media_buttons.cpp
+++++ b/Telegram/SourceFiles/info/media/info_media_buttons.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/media/info_media_common.cpp b/Telegram/SourceFiles/info/media/info_media_common.cpp
++index 47f3e80..6ca2ce5 100644
++--- a/Telegram/SourceFiles/info/media/info_media_common.cpp
+++++ b/Telegram/SourceFiles/info/media/info_media_common.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/media/info_media_empty_widget.cpp b/Telegram/SourceFiles/info/media/info_media_empty_widget.cpp
++index 07f07af..4b1ac61 100644
++--- a/Telegram/SourceFiles/info/media/info_media_empty_widget.cpp
+++++ b/Telegram/SourceFiles/info/media/info_media_empty_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/media/info_media_inner_widget.cpp b/Telegram/SourceFiles/info/media/info_media_inner_widget.cpp
++index faccefc..6c1a13c 100644
++--- a/Telegram/SourceFiles/info/media/info_media_inner_widget.cpp
+++++ b/Telegram/SourceFiles/info/media/info_media_inner_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/media/info_media_list_section.cpp b/Telegram/SourceFiles/info/media/info_media_list_section.cpp
++index ba207ff..a493129 100644
++--- a/Telegram/SourceFiles/info/media/info_media_list_section.cpp
+++++ b/Telegram/SourceFiles/info/media/info_media_list_section.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/media/info_media_list_widget.cpp b/Telegram/SourceFiles/info/media/info_media_list_widget.cpp
++index 3fe4f34..3df4722 100644
++--- a/Telegram/SourceFiles/info/media/info_media_list_widget.cpp
+++++ b/Telegram/SourceFiles/info/media/info_media_list_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/media/info_media_provider.cpp b/Telegram/SourceFiles/info/media/info_media_provider.cpp
++index 14553f7..88d29da 100644
++--- a/Telegram/SourceFiles/info/media/info_media_provider.cpp
+++++ b/Telegram/SourceFiles/info/media/info_media_provider.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/media/info_media_widget.cpp b/Telegram/SourceFiles/info/media/info_media_widget.cpp
++index 58d9e8e..d5482c3 100644
++--- a/Telegram/SourceFiles/info/media/info_media_widget.cpp
+++++ b/Telegram/SourceFiles/info/media/info_media_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/members/info_members_widget.cpp b/Telegram/SourceFiles/info/members/info_members_widget.cpp
++index 07609a4..f722d00 100644
++--- a/Telegram/SourceFiles/info/members/info_members_widget.cpp
+++++ b/Telegram/SourceFiles/info/members/info_members_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/peer_gifts/info_peer_gifts_collections.cpp b/Telegram/SourceFiles/info/peer_gifts/info_peer_gifts_collections.cpp
++index a237403..6305ae8 100644
++--- a/Telegram/SourceFiles/info/peer_gifts/info_peer_gifts_collections.cpp
+++++ b/Telegram/SourceFiles/info/peer_gifts/info_peer_gifts_collections.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/peer_gifts/info_peer_gifts_common.cpp b/Telegram/SourceFiles/info/peer_gifts/info_peer_gifts_common.cpp
++index 940f1c2..fa34110 100644
++--- a/Telegram/SourceFiles/info/peer_gifts/info_peer_gifts_common.cpp
+++++ b/Telegram/SourceFiles/info/peer_gifts/info_peer_gifts_common.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/peer_gifts/info_peer_gifts_widget.cpp b/Telegram/SourceFiles/info/peer_gifts/info_peer_gifts_widget.cpp
++index d3a649b..23e930e 100644
++--- a/Telegram/SourceFiles/info/peer_gifts/info_peer_gifts_widget.cpp
+++++ b/Telegram/SourceFiles/info/peer_gifts/info_peer_gifts_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/polls/info_polls_results_inner_widget.cpp b/Telegram/SourceFiles/info/polls/info_polls_results_inner_widget.cpp
++index 24afb84..a52c58d 100644
++--- a/Telegram/SourceFiles/info/polls/info_polls_results_inner_widget.cpp
+++++ b/Telegram/SourceFiles/info/polls/info_polls_results_inner_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/polls/info_polls_results_widget.cpp b/Telegram/SourceFiles/info/polls/info_polls_results_widget.cpp
++index 056eb35..11a8d67 100644
++--- a/Telegram/SourceFiles/info/polls/info_polls_results_widget.cpp
+++++ b/Telegram/SourceFiles/info/polls/info_polls_results_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/profile/info_profile_actions.cpp b/Telegram/SourceFiles/info/profile/info_profile_actions.cpp
++index c035c09..ccbcd56 100644
++--- a/Telegram/SourceFiles/info/profile/info_profile_actions.cpp
+++++ b/Telegram/SourceFiles/info/profile/info_profile_actions.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/profile/info_profile_badge.cpp b/Telegram/SourceFiles/info/profile/info_profile_badge.cpp
++index 8cdfa8c..815c167 100644
++--- a/Telegram/SourceFiles/info/profile/info_profile_badge.cpp
+++++ b/Telegram/SourceFiles/info/profile/info_profile_badge.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/profile/info_profile_cover.cpp b/Telegram/SourceFiles/info/profile/info_profile_cover.cpp
++index 96b0b33..53ec7c5 100644
++--- a/Telegram/SourceFiles/info/profile/info_profile_cover.cpp
+++++ b/Telegram/SourceFiles/info/profile/info_profile_cover.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/profile/info_profile_emoji_status_panel.cpp b/Telegram/SourceFiles/info/profile/info_profile_emoji_status_panel.cpp
++index de39c8e..7137a33 100644
++--- a/Telegram/SourceFiles/info/profile/info_profile_emoji_status_panel.cpp
+++++ b/Telegram/SourceFiles/info/profile/info_profile_emoji_status_panel.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/profile/info_profile_icon.cpp b/Telegram/SourceFiles/info/profile/info_profile_icon.cpp
++index 174b144..e53a401 100644
++--- a/Telegram/SourceFiles/info/profile/info_profile_icon.cpp
+++++ b/Telegram/SourceFiles/info/profile/info_profile_icon.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/profile/info_profile_inner_widget.cpp b/Telegram/SourceFiles/info/profile/info_profile_inner_widget.cpp
++index b4c27bc..bff3813 100644
++--- a/Telegram/SourceFiles/info/profile/info_profile_inner_widget.cpp
+++++ b/Telegram/SourceFiles/info/profile/info_profile_inner_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/profile/info_profile_members.cpp b/Telegram/SourceFiles/info/profile/info_profile_members.cpp
++index 0574dd6..3593902 100644
++--- a/Telegram/SourceFiles/info/profile/info_profile_members.cpp
+++++ b/Telegram/SourceFiles/info/profile/info_profile_members.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/profile/info_profile_members_controllers.cpp b/Telegram/SourceFiles/info/profile/info_profile_members_controllers.cpp
++index 619a520..488f021 100644
++--- a/Telegram/SourceFiles/info/profile/info_profile_members_controllers.cpp
+++++ b/Telegram/SourceFiles/info/profile/info_profile_members_controllers.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/profile/info_profile_music_button.cpp b/Telegram/SourceFiles/info/profile/info_profile_music_button.cpp
++index 3a9433f..ba9722c 100644
++--- a/Telegram/SourceFiles/info/profile/info_profile_music_button.cpp
+++++ b/Telegram/SourceFiles/info/profile/info_profile_music_button.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/profile/info_profile_phone_menu.cpp b/Telegram/SourceFiles/info/profile/info_profile_phone_menu.cpp
++index 85fde82..69fafaf 100644
++--- a/Telegram/SourceFiles/info/profile/info_profile_phone_menu.cpp
+++++ b/Telegram/SourceFiles/info/profile/info_profile_phone_menu.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/profile/info_profile_text.cpp b/Telegram/SourceFiles/info/profile/info_profile_text.cpp
++index bfca3d0..fb68340 100644
++--- a/Telegram/SourceFiles/info/profile/info_profile_text.cpp
+++++ b/Telegram/SourceFiles/info/profile/info_profile_text.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/profile/info_profile_values.cpp b/Telegram/SourceFiles/info/profile/info_profile_values.cpp
++index ac25b6c..2b3edef 100644
++--- a/Telegram/SourceFiles/info/profile/info_profile_values.cpp
+++++ b/Telegram/SourceFiles/info/profile/info_profile_values.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/profile/info_profile_widget.cpp b/Telegram/SourceFiles/info/profile/info_profile_widget.cpp
++index a11face..55f8cdf 100644
++--- a/Telegram/SourceFiles/info/profile/info_profile_widget.cpp
+++++ b/Telegram/SourceFiles/info/profile/info_profile_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/reactions_list/info_reactions_list_widget.cpp b/Telegram/SourceFiles/info/reactions_list/info_reactions_list_widget.cpp
++index 9b0f4ad..5e03f0a 100644
++--- a/Telegram/SourceFiles/info/reactions_list/info_reactions_list_widget.cpp
+++++ b/Telegram/SourceFiles/info/reactions_list/info_reactions_list_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/requests_list/info_requests_list_widget.cpp b/Telegram/SourceFiles/info/requests_list/info_requests_list_widget.cpp
++index b006dbb..66babe4 100644
++--- a/Telegram/SourceFiles/info/requests_list/info_requests_list_widget.cpp
+++++ b/Telegram/SourceFiles/info/requests_list/info_requests_list_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/saved/info_saved_music_provider.cpp b/Telegram/SourceFiles/info/saved/info_saved_music_provider.cpp
++index 605a58e..225619e 100644
++--- a/Telegram/SourceFiles/info/saved/info_saved_music_provider.cpp
+++++ b/Telegram/SourceFiles/info/saved/info_saved_music_provider.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/saved/info_saved_music_widget.cpp b/Telegram/SourceFiles/info/saved/info_saved_music_widget.cpp
++index 208b6ec..3fa9ddf 100644
++--- a/Telegram/SourceFiles/info/saved/info_saved_music_widget.cpp
+++++ b/Telegram/SourceFiles/info/saved/info_saved_music_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/saved/info_saved_sublists_widget.cpp b/Telegram/SourceFiles/info/saved/info_saved_sublists_widget.cpp
++index 298ef5f..79ddc5d 100644
++--- a/Telegram/SourceFiles/info/saved/info_saved_sublists_widget.cpp
+++++ b/Telegram/SourceFiles/info/saved/info_saved_sublists_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/settings/info_settings_widget.cpp b/Telegram/SourceFiles/info/settings/info_settings_widget.cpp
++index 90b4523..b3398cc 100644
++--- a/Telegram/SourceFiles/info/settings/info_settings_widget.cpp
+++++ b/Telegram/SourceFiles/info/settings/info_settings_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/similar_peers/info_similar_peers_widget.cpp b/Telegram/SourceFiles/info/similar_peers/info_similar_peers_widget.cpp
++index 003166f..d92fc16 100644
++--- a/Telegram/SourceFiles/info/similar_peers/info_similar_peers_widget.cpp
+++++ b/Telegram/SourceFiles/info/similar_peers/info_similar_peers_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/statistics/info_statistics_inner_widget.cpp b/Telegram/SourceFiles/info/statistics/info_statistics_inner_widget.cpp
++index 2c44348..e7b5fea 100644
++--- a/Telegram/SourceFiles/info/statistics/info_statistics_inner_widget.cpp
+++++ b/Telegram/SourceFiles/info/statistics/info_statistics_inner_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/statistics/info_statistics_list_controllers.cpp b/Telegram/SourceFiles/info/statistics/info_statistics_list_controllers.cpp
++index a486a54..d702153 100644
++--- a/Telegram/SourceFiles/info/statistics/info_statistics_list_controllers.cpp
+++++ b/Telegram/SourceFiles/info/statistics/info_statistics_list_controllers.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/statistics/info_statistics_recent_message.cpp b/Telegram/SourceFiles/info/statistics/info_statistics_recent_message.cpp
++index 1a5da3a..42815c2 100644
++--- a/Telegram/SourceFiles/info/statistics/info_statistics_recent_message.cpp
+++++ b/Telegram/SourceFiles/info/statistics/info_statistics_recent_message.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/statistics/info_statistics_widget.cpp b/Telegram/SourceFiles/info/statistics/info_statistics_widget.cpp
++index 087d3dd..7f3684f 100644
++--- a/Telegram/SourceFiles/info/statistics/info_statistics_widget.cpp
+++++ b/Telegram/SourceFiles/info/statistics/info_statistics_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/stories/info_stories_albums.cpp b/Telegram/SourceFiles/info/stories/info_stories_albums.cpp
++index b8751c8..57afb8a 100644
++--- a/Telegram/SourceFiles/info/stories/info_stories_albums.cpp
+++++ b/Telegram/SourceFiles/info/stories/info_stories_albums.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/stories/info_stories_inner_widget.cpp b/Telegram/SourceFiles/info/stories/info_stories_inner_widget.cpp
++index 8dc057a..2e64e1b 100644
++--- a/Telegram/SourceFiles/info/stories/info_stories_inner_widget.cpp
+++++ b/Telegram/SourceFiles/info/stories/info_stories_inner_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/stories/info_stories_provider.cpp b/Telegram/SourceFiles/info/stories/info_stories_provider.cpp
++index e0e07fd..7d691e2 100644
++--- a/Telegram/SourceFiles/info/stories/info_stories_provider.cpp
+++++ b/Telegram/SourceFiles/info/stories/info_stories_provider.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/stories/info_stories_widget.cpp b/Telegram/SourceFiles/info/stories/info_stories_widget.cpp
++index 203d83c..1e54617 100644
++--- a/Telegram/SourceFiles/info/stories/info_stories_widget.cpp
+++++ b/Telegram/SourceFiles/info/stories/info_stories_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/userpic/info_userpic_bubble_wrap.cpp b/Telegram/SourceFiles/info/userpic/info_userpic_bubble_wrap.cpp
++index afeb858..106c40d 100644
++--- a/Telegram/SourceFiles/info/userpic/info_userpic_bubble_wrap.cpp
+++++ b/Telegram/SourceFiles/info/userpic/info_userpic_bubble_wrap.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/userpic/info_userpic_color_circle_button.cpp b/Telegram/SourceFiles/info/userpic/info_userpic_color_circle_button.cpp
++index 97ce58a..2b0147a 100644
++--- a/Telegram/SourceFiles/info/userpic/info_userpic_color_circle_button.cpp
+++++ b/Telegram/SourceFiles/info/userpic/info_userpic_color_circle_button.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/userpic/info_userpic_colors_editor.cpp b/Telegram/SourceFiles/info/userpic/info_userpic_colors_editor.cpp
++index cb7846d..eec1725 100644
++--- a/Telegram/SourceFiles/info/userpic/info_userpic_colors_editor.cpp
+++++ b/Telegram/SourceFiles/info/userpic/info_userpic_colors_editor.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder.cpp b/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder.cpp
++index 24fc13e..7d0b810 100644
++--- a/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder.cpp
+++++ b/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder_common.cpp b/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder_common.cpp
++index a440f59..13c7b0d 100644
++--- a/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder_common.cpp
+++++ b/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder_common.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder_layer.cpp b/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder_layer.cpp
++index c251c7b..3a6594e 100644
++--- a/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder_layer.cpp
+++++ b/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder_layer.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder_menu_item.cpp b/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder_menu_item.cpp
++index 64be531..d9a3bc8 100644
++--- a/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder_menu_item.cpp
+++++ b/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder_menu_item.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder_preview.cpp b/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder_preview.cpp
++index 8ee2975..1f6ba4a 100644
++--- a/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder_preview.cpp
+++++ b/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder_preview.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder_widget.cpp b/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder_widget.cpp
++index 2bed5f5..af49af2 100644
++--- a/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder_widget.cpp
+++++ b/Telegram/SourceFiles/info/userpic/info_userpic_emoji_builder_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/inline_bots/bot_attach_web_view.cpp b/Telegram/SourceFiles/inline_bots/bot_attach_web_view.cpp
++index 18744b0..2061168 100644
++--- a/Telegram/SourceFiles/inline_bots/bot_attach_web_view.cpp
+++++ b/Telegram/SourceFiles/inline_bots/bot_attach_web_view.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/inline_bots/inline_bot_confirm_prepared.cpp b/Telegram/SourceFiles/inline_bots/inline_bot_confirm_prepared.cpp
++index 4b4b434..c49fcaf 100644
++--- a/Telegram/SourceFiles/inline_bots/inline_bot_confirm_prepared.cpp
+++++ b/Telegram/SourceFiles/inline_bots/inline_bot_confirm_prepared.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/inline_bots/inline_bot_downloads.cpp b/Telegram/SourceFiles/inline_bots/inline_bot_downloads.cpp
++index d1c82d5..3502830 100644
++--- a/Telegram/SourceFiles/inline_bots/inline_bot_downloads.cpp
+++++ b/Telegram/SourceFiles/inline_bots/inline_bot_downloads.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/inline_bots/inline_bot_layout_internal.cpp b/Telegram/SourceFiles/inline_bots/inline_bot_layout_internal.cpp
++index 3778522..a2b9fb6 100644
++--- a/Telegram/SourceFiles/inline_bots/inline_bot_layout_internal.cpp
+++++ b/Telegram/SourceFiles/inline_bots/inline_bot_layout_internal.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/inline_bots/inline_bot_layout_item.cpp b/Telegram/SourceFiles/inline_bots/inline_bot_layout_item.cpp
++index 89b0e41..2e1f727 100644
++--- a/Telegram/SourceFiles/inline_bots/inline_bot_layout_item.cpp
+++++ b/Telegram/SourceFiles/inline_bots/inline_bot_layout_item.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/inline_bots/inline_bot_result.cpp b/Telegram/SourceFiles/inline_bots/inline_bot_result.cpp
++index b79c168..d4b8b9e 100644
++--- a/Telegram/SourceFiles/inline_bots/inline_bot_result.cpp
+++++ b/Telegram/SourceFiles/inline_bots/inline_bot_result.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/inline_bots/inline_bot_send_data.cpp b/Telegram/SourceFiles/inline_bots/inline_bot_send_data.cpp
++index e4ac798..9748ea1 100644
++--- a/Telegram/SourceFiles/inline_bots/inline_bot_send_data.cpp
+++++ b/Telegram/SourceFiles/inline_bots/inline_bot_send_data.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/inline_bots/inline_bot_storage.cpp b/Telegram/SourceFiles/inline_bots/inline_bot_storage.cpp
++index 2e6a858..3bb3ade 100644
++--- a/Telegram/SourceFiles/inline_bots/inline_bot_storage.cpp
+++++ b/Telegram/SourceFiles/inline_bots/inline_bot_storage.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/inline_bots/inline_results_inner.cpp b/Telegram/SourceFiles/inline_bots/inline_results_inner.cpp
++index 41ee7f4..09e6ce6 100644
++--- a/Telegram/SourceFiles/inline_bots/inline_results_inner.cpp
+++++ b/Telegram/SourceFiles/inline_bots/inline_results_inner.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/inline_bots/inline_results_widget.cpp b/Telegram/SourceFiles/inline_bots/inline_results_widget.cpp
++index c5cf41c..2ac2500 100644
++--- a/Telegram/SourceFiles/inline_bots/inline_results_widget.cpp
+++++ b/Telegram/SourceFiles/inline_bots/inline_results_widget.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/intro/intro_code.cpp b/Telegram/SourceFiles/intro/intro_code.cpp
++index e41810e..5f4d321 100644
++--- a/Telegram/SourceFiles/intro/intro_code.cpp
+++++ b/Telegram/SourceFiles/intro/intro_code.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/intro/intro_code_input.cpp b/Telegram/SourceFiles/intro/intro_code_input.cpp
++index 476d7ec..abb986c 100644
++--- a/Telegram/SourceFiles/intro/intro_code_input.cpp
+++++ b/Telegram/SourceFiles/intro/intro_code_input.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/intro/intro_email.cpp b/Telegram/SourceFiles/intro/intro_email.cpp
++index b80077b..127a1de 100644
++--- a/Telegram/SourceFiles/intro/intro_email.cpp
+++++ b/Telegram/SourceFiles/intro/intro_email.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/intro/intro_password_check.cpp b/Telegram/SourceFiles/intro/intro_password_check.cpp
++index 748e304..6f58aca 100644
++--- a/Telegram/SourceFiles/intro/intro_password_check.cpp
+++++ b/Telegram/SourceFiles/intro/intro_password_check.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/intro/intro_phone.cpp b/Telegram/SourceFiles/intro/intro_phone.cpp
++index 21299c4..cc5243a 100644
++--- a/Telegram/SourceFiles/intro/intro_phone.cpp
+++++ b/Telegram/SourceFiles/intro/intro_phone.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/intro/intro_qr.cpp b/Telegram/SourceFiles/intro/intro_qr.cpp
++index a76f753..11d5029 100644
++--- a/Telegram/SourceFiles/intro/intro_qr.cpp
+++++ b/Telegram/SourceFiles/intro/intro_qr.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/intro/intro_signup.cpp b/Telegram/SourceFiles/intro/intro_signup.cpp
++index 32831ea..ae036c5 100644
++--- a/Telegram/SourceFiles/intro/intro_signup.cpp
+++++ b/Telegram/SourceFiles/intro/intro_signup.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/intro/intro_start.cpp b/Telegram/SourceFiles/intro/intro_start.cpp
++index d4ebdec..93f501e 100644
++--- a/Telegram/SourceFiles/intro/intro_start.cpp
+++++ b/Telegram/SourceFiles/intro/intro_start.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/intro/intro_step.cpp b/Telegram/SourceFiles/intro/intro_step.cpp
++index 977f0bd..62ead72 100644
++--- a/Telegram/SourceFiles/intro/intro_step.cpp
+++++ b/Telegram/SourceFiles/intro/intro_step.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/intro/intro_widget.cpp b/Telegram/SourceFiles/intro/intro_widget.cpp
++index 296991f..12c0c8b 100644
++--- a/Telegram/SourceFiles/intro/intro_widget.cpp
+++++ b/Telegram/SourceFiles/intro/intro_widget.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/iv/iv_controller.cpp b/Telegram/SourceFiles/iv/iv_controller.cpp
++index f58cc14..b4a8331 100644
++--- a/Telegram/SourceFiles/iv/iv_controller.cpp
+++++ b/Telegram/SourceFiles/iv/iv_controller.cpp
++@@ -1,3 +1,5 @@
+++#include "mtproto/mtproto_pch.h"
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/iv/iv_data.cpp b/Telegram/SourceFiles/iv/iv_data.cpp
++index 8d424c9..354670f 100644
++--- a/Telegram/SourceFiles/iv/iv_data.cpp
+++++ b/Telegram/SourceFiles/iv/iv_data.cpp
++@@ -1,3 +1,5 @@
+++#include "mtproto/mtproto_pch.h"
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/iv/iv_delegate_impl.cpp b/Telegram/SourceFiles/iv/iv_delegate_impl.cpp
++index e97de87..dc0e7b6 100644
++--- a/Telegram/SourceFiles/iv/iv_delegate_impl.cpp
+++++ b/Telegram/SourceFiles/iv/iv_delegate_impl.cpp
++@@ -1,3 +1,6 @@
+++#include "mtproto/mtproto_pch.h"
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/iv/iv_instance.cpp b/Telegram/SourceFiles/iv/iv_instance.cpp
++index dec3f36..939b996 100644
++--- a/Telegram/SourceFiles/iv/iv_instance.cpp
+++++ b/Telegram/SourceFiles/iv/iv_instance.cpp
++@@ -1,3 +1,6 @@
+++#include "mtproto/mtproto_pch.h"
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/iv/iv_prepare.cpp b/Telegram/SourceFiles/iv/iv_prepare.cpp
++index 6fc891a..597a2dd 100644
++--- a/Telegram/SourceFiles/iv/iv_prepare.cpp
+++++ b/Telegram/SourceFiles/iv/iv_prepare.cpp
++@@ -1,3 +1,5 @@
+++#include "mtproto/mtproto_pch.h"
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/lang/lang_cloud_manager.cpp b/Telegram/SourceFiles/lang/lang_cloud_manager.cpp
++index 5bbe85c..e57245f 100644
++--- a/Telegram/SourceFiles/lang/lang_cloud_manager.cpp
+++++ b/Telegram/SourceFiles/lang/lang_cloud_manager.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "lang/lang_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/lang/lang_file_parser.cpp b/Telegram/SourceFiles/lang/lang_file_parser.cpp
++index 5dac61a..b343331 100644
++--- a/Telegram/SourceFiles/lang/lang_file_parser.cpp
+++++ b/Telegram/SourceFiles/lang/lang_file_parser.cpp
++@@ -1,3 +1,4 @@
+++#include "lang/lang_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/lang/lang_instance.cpp b/Telegram/SourceFiles/lang/lang_instance.cpp
++index eadb265..7b8ce8b 100644
++--- a/Telegram/SourceFiles/lang/lang_instance.cpp
+++++ b/Telegram/SourceFiles/lang/lang_instance.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "lang/lang_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/lang/lang_keys.cpp b/Telegram/SourceFiles/lang/lang_keys.cpp
++index aa65ed8..a08fa46 100644
++--- a/Telegram/SourceFiles/lang/lang_keys.cpp
+++++ b/Telegram/SourceFiles/lang/lang_keys.cpp
++@@ -1,3 +1,4 @@
+++#include "lang/lang_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/lang/lang_numbers_animation.cpp b/Telegram/SourceFiles/lang/lang_numbers_animation.cpp
++index fdeb96a..f1e948c 100644
++--- a/Telegram/SourceFiles/lang/lang_numbers_animation.cpp
+++++ b/Telegram/SourceFiles/lang/lang_numbers_animation.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "lang/lang_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/lang/lang_tag.cpp b/Telegram/SourceFiles/lang/lang_tag.cpp
++index d05d917..f7363d6 100644
++--- a/Telegram/SourceFiles/lang/lang_tag.cpp
+++++ b/Telegram/SourceFiles/lang/lang_tag.cpp
++@@ -1,3 +1,4 @@
+++#include "lang/lang_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/lang/lang_tag.h b/Telegram/SourceFiles/lang/lang_tag.h
++index 74088d9..454b938 100644
++--- a/Telegram/SourceFiles/lang/lang_tag.h
+++++ b/Telegram/SourceFiles/lang/lang_tag.h
++@@ -1,3 +1,4 @@
+++#include "lang/lang_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/lang/lang_text_entity.cpp b/Telegram/SourceFiles/lang/lang_text_entity.cpp
++index 5bdc1bd..a584a39 100644
++--- a/Telegram/SourceFiles/lang/lang_text_entity.cpp
+++++ b/Telegram/SourceFiles/lang/lang_text_entity.cpp
++@@ -1,3 +1,4 @@
+++#include "lang/lang_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/lang/lang_translator.cpp b/Telegram/SourceFiles/lang/lang_translator.cpp
++index eeb1251..d1747f8 100644
++--- a/Telegram/SourceFiles/lang/lang_translator.cpp
+++++ b/Telegram/SourceFiles/lang/lang_translator.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "lang/lang_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/layout/abstract_layout_item.cpp b/Telegram/SourceFiles/layout/abstract_layout_item.cpp
++index d83f0a7..1691cad 100644
++--- a/Telegram/SourceFiles/layout/abstract_layout_item.cpp
+++++ b/Telegram/SourceFiles/layout/abstract_layout_item.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/layout/layout_document_generic_preview.cpp b/Telegram/SourceFiles/layout/layout_document_generic_preview.cpp
++index a0a9285..6fb5843 100644
++--- a/Telegram/SourceFiles/layout/layout_document_generic_preview.cpp
+++++ b/Telegram/SourceFiles/layout/layout_document_generic_preview.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/layout/layout_item_base.cpp b/Telegram/SourceFiles/layout/layout_item_base.cpp
++index 77f2d8e..88576e3 100644
++--- a/Telegram/SourceFiles/layout/layout_item_base.cpp
+++++ b/Telegram/SourceFiles/layout/layout_item_base.cpp
++@@ -1,3 +1,5 @@
+++#include "stdafx.h"
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/layout/layout_mosaic.cpp b/Telegram/SourceFiles/layout/layout_mosaic.cpp
++index 645f290..f832a21 100644
++--- a/Telegram/SourceFiles/layout/layout_mosaic.cpp
+++++ b/Telegram/SourceFiles/layout/layout_mosaic.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/layout/layout_position.cpp b/Telegram/SourceFiles/layout/layout_position.cpp
++index 2631e2c..7cb95cb 100644
++--- a/Telegram/SourceFiles/layout/layout_position.cpp
+++++ b/Telegram/SourceFiles/layout/layout_position.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/layout/layout_selection.cpp b/Telegram/SourceFiles/layout/layout_selection.cpp
++index 32f48b2..bd0e2d0 100644
++--- a/Telegram/SourceFiles/layout/layout_selection.cpp
+++++ b/Telegram/SourceFiles/layout/layout_selection.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/logs.cpp b/Telegram/SourceFiles/logs.cpp
++index 382d65a..2fa47df 100644
++--- a/Telegram/SourceFiles/logs.cpp
+++++ b/Telegram/SourceFiles/logs.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/main.cpp b/Telegram/SourceFiles/main.cpp
++index d3d938c..53e90d3 100644
++--- a/Telegram/SourceFiles/main.cpp
+++++ b/Telegram/SourceFiles/main.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/main/main_account.cpp b/Telegram/SourceFiles/main/main_account.cpp
++index 5a2f894..a164c64 100644
++--- a/Telegram/SourceFiles/main/main_account.cpp
+++++ b/Telegram/SourceFiles/main/main_account.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/main/main_app_config.cpp b/Telegram/SourceFiles/main/main_app_config.cpp
++index 844c68d..1bd4302 100644
++--- a/Telegram/SourceFiles/main/main_app_config.cpp
+++++ b/Telegram/SourceFiles/main/main_app_config.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/main/main_app_config_values.cpp b/Telegram/SourceFiles/main/main_app_config_values.cpp
++index bd2b1f0..41e7fcd 100644
++--- a/Telegram/SourceFiles/main/main_app_config_values.cpp
+++++ b/Telegram/SourceFiles/main/main_app_config_values.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/main/main_domain.cpp b/Telegram/SourceFiles/main/main_domain.cpp
++index 714f7e2..649cc0c 100644
++--- a/Telegram/SourceFiles/main/main_domain.cpp
+++++ b/Telegram/SourceFiles/main/main_domain.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/main/main_session.cpp b/Telegram/SourceFiles/main/main_session.cpp
++index 4b90f06..39e751b 100644
++--- a/Telegram/SourceFiles/main/main_session.cpp
+++++ b/Telegram/SourceFiles/main/main_session.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/main/main_session_settings.cpp b/Telegram/SourceFiles/main/main_session_settings.cpp
++index 543bb26..9833d54 100644
++--- a/Telegram/SourceFiles/main/main_session_settings.cpp
+++++ b/Telegram/SourceFiles/main/main_session_settings.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/main/session/send_as_peers.cpp b/Telegram/SourceFiles/main/session/send_as_peers.cpp
++index e8bdaf0..61b4ee2 100644
++--- a/Telegram/SourceFiles/main/session/send_as_peers.cpp
+++++ b/Telegram/SourceFiles/main/session/send_as_peers.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/main/session/session_show.cpp b/Telegram/SourceFiles/main/session/session_show.cpp
++index 1f740d4..cf944e6 100644
++--- a/Telegram/SourceFiles/main/session/session_show.cpp
+++++ b/Telegram/SourceFiles/main/session/session_show.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mainwidget.cpp b/Telegram/SourceFiles/mainwidget.cpp
++index 42f3494..9dca32b 100644
++--- a/Telegram/SourceFiles/mainwidget.cpp
+++++ b/Telegram/SourceFiles/mainwidget.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mainwindow.cpp b/Telegram/SourceFiles/mainwindow.cpp
++index 773c4fb..08f661e 100644
++--- a/Telegram/SourceFiles/mainwindow.cpp
+++++ b/Telegram/SourceFiles/mainwindow.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/audio/media_audio.cpp b/Telegram/SourceFiles/media/audio/media_audio.cpp
++index 86fe5ce..cfaffc8 100644
++--- a/Telegram/SourceFiles/media/audio/media_audio.cpp
+++++ b/Telegram/SourceFiles/media/audio/media_audio.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/audio/media_audio.h b/Telegram/SourceFiles/media/audio/media_audio.h
++index dd1f43f..fa3deea 100644
++--- a/Telegram/SourceFiles/media/audio/media_audio.h
+++++ b/Telegram/SourceFiles/media/audio/media_audio.h
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/audio/media_audio_capture.cpp b/Telegram/SourceFiles/media/audio/media_audio_capture.cpp
++index d46f878..2889b4a 100644
++--- a/Telegram/SourceFiles/media/audio/media_audio_capture.cpp
+++++ b/Telegram/SourceFiles/media/audio/media_audio_capture.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/audio/media_audio_ffmpeg_loader.cpp b/Telegram/SourceFiles/media/audio/media_audio_ffmpeg_loader.cpp
++index bdfe863..df8c634 100644
++--- a/Telegram/SourceFiles/media/audio/media_audio_ffmpeg_loader.cpp
+++++ b/Telegram/SourceFiles/media/audio/media_audio_ffmpeg_loader.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/audio/media_audio_loader.cpp b/Telegram/SourceFiles/media/audio/media_audio_loader.cpp
++index 7451de9..0b72fda 100644
++--- a/Telegram/SourceFiles/media/audio/media_audio_loader.cpp
+++++ b/Telegram/SourceFiles/media/audio/media_audio_loader.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/audio/media_audio_loaders.cpp b/Telegram/SourceFiles/media/audio/media_audio_loaders.cpp
++index 5cff816..015ce34 100644
++--- a/Telegram/SourceFiles/media/audio/media_audio_loaders.cpp
+++++ b/Telegram/SourceFiles/media/audio/media_audio_loaders.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/audio/media_audio_local_cache.cpp b/Telegram/SourceFiles/media/audio/media_audio_local_cache.cpp
++index 7d9f994..47561e6 100644
++--- a/Telegram/SourceFiles/media/audio/media_audio_local_cache.cpp
+++++ b/Telegram/SourceFiles/media/audio/media_audio_local_cache.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/audio/media_audio_track.cpp b/Telegram/SourceFiles/media/audio/media_audio_track.cpp
++index 4cef903..45ff8ec 100644
++--- a/Telegram/SourceFiles/media/audio/media_audio_track.cpp
+++++ b/Telegram/SourceFiles/media/audio/media_audio_track.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/audio/media_child_ffmpeg_loader.cpp b/Telegram/SourceFiles/media/audio/media_child_ffmpeg_loader.cpp
++index 96efc7c..30d5e59 100644
++--- a/Telegram/SourceFiles/media/audio/media_child_ffmpeg_loader.cpp
+++++ b/Telegram/SourceFiles/media/audio/media_child_ffmpeg_loader.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/clip/media_clip_check_streaming.cpp b/Telegram/SourceFiles/media/clip/media_clip_check_streaming.cpp
++index e60eed1..c134118 100644
++--- a/Telegram/SourceFiles/media/clip/media_clip_check_streaming.cpp
+++++ b/Telegram/SourceFiles/media/clip/media_clip_check_streaming.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/clip/media_clip_ffmpeg.cpp b/Telegram/SourceFiles/media/clip/media_clip_ffmpeg.cpp
++index 1188f02..dd03351 100644
++--- a/Telegram/SourceFiles/media/clip/media_clip_ffmpeg.cpp
+++++ b/Telegram/SourceFiles/media/clip/media_clip_ffmpeg.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/clip/media_clip_implementation.cpp b/Telegram/SourceFiles/media/clip/media_clip_implementation.cpp
++index e9b1f25..e5a412d 100644
++--- a/Telegram/SourceFiles/media/clip/media_clip_implementation.cpp
+++++ b/Telegram/SourceFiles/media/clip/media_clip_implementation.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/clip/media_clip_reader.cpp b/Telegram/SourceFiles/media/clip/media_clip_reader.cpp
++index ee74872..7e5f689 100644
++--- a/Telegram/SourceFiles/media/clip/media_clip_reader.cpp
+++++ b/Telegram/SourceFiles/media/clip/media_clip_reader.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/player/media_player_button.cpp b/Telegram/SourceFiles/media/player/media_player_button.cpp
++index 2fc6b88..01b5339 100644
++--- a/Telegram/SourceFiles/media/player/media_player_button.cpp
+++++ b/Telegram/SourceFiles/media/player/media_player_button.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/player/media_player_dropdown.cpp b/Telegram/SourceFiles/media/player/media_player_dropdown.cpp
++index 27a29d7..7e9fc51 100644
++--- a/Telegram/SourceFiles/media/player/media_player_dropdown.cpp
+++++ b/Telegram/SourceFiles/media/player/media_player_dropdown.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/player/media_player_float.cpp b/Telegram/SourceFiles/media/player/media_player_float.cpp
++index 755eef4..e50fc7e 100644
++--- a/Telegram/SourceFiles/media/player/media_player_float.cpp
+++++ b/Telegram/SourceFiles/media/player/media_player_float.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/player/media_player_instance.cpp b/Telegram/SourceFiles/media/player/media_player_instance.cpp
++index 51e30ce..4b31ed2 100644
++--- a/Telegram/SourceFiles/media/player/media_player_instance.cpp
+++++ b/Telegram/SourceFiles/media/player/media_player_instance.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/player/media_player_panel.cpp b/Telegram/SourceFiles/media/player/media_player_panel.cpp
++index 73c9556..c1b5de7 100644
++--- a/Telegram/SourceFiles/media/player/media_player_panel.cpp
+++++ b/Telegram/SourceFiles/media/player/media_player_panel.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/player/media_player_volume_controller.cpp b/Telegram/SourceFiles/media/player/media_player_volume_controller.cpp
++index c8e4af7..6cbe56d 100644
++--- a/Telegram/SourceFiles/media/player/media_player_volume_controller.cpp
+++++ b/Telegram/SourceFiles/media/player/media_player_volume_controller.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/player/media_player_widget.cpp b/Telegram/SourceFiles/media/player/media_player_widget.cpp
++index 89d85a5..5895304 100644
++--- a/Telegram/SourceFiles/media/player/media_player_widget.cpp
+++++ b/Telegram/SourceFiles/media/player/media_player_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/stories/media_stories_caption_full_view.cpp b/Telegram/SourceFiles/media/stories/media_stories_caption_full_view.cpp
++index 218add3..f635ba9 100644
++--- a/Telegram/SourceFiles/media/stories/media_stories_caption_full_view.cpp
+++++ b/Telegram/SourceFiles/media/stories/media_stories_caption_full_view.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/stories/media_stories_controller.cpp b/Telegram/SourceFiles/media/stories/media_stories_controller.cpp
++index 2b473eb..5a4586e 100644
++--- a/Telegram/SourceFiles/media/stories/media_stories_controller.cpp
+++++ b/Telegram/SourceFiles/media/stories/media_stories_controller.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/stories/media_stories_delegate.cpp b/Telegram/SourceFiles/media/stories/media_stories_delegate.cpp
++index 721d980..6b258b4 100644
++--- a/Telegram/SourceFiles/media/stories/media_stories_delegate.cpp
+++++ b/Telegram/SourceFiles/media/stories/media_stories_delegate.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/stories/media_stories_header.cpp b/Telegram/SourceFiles/media/stories/media_stories_header.cpp
++index b2cf0c3..6fb8e9e 100644
++--- a/Telegram/SourceFiles/media/stories/media_stories_header.cpp
+++++ b/Telegram/SourceFiles/media/stories/media_stories_header.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/stories/media_stories_reactions.cpp b/Telegram/SourceFiles/media/stories/media_stories_reactions.cpp
++index e65443b..84f5a4a 100644
++--- a/Telegram/SourceFiles/media/stories/media_stories_reactions.cpp
+++++ b/Telegram/SourceFiles/media/stories/media_stories_reactions.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/stories/media_stories_recent_views.cpp b/Telegram/SourceFiles/media/stories/media_stories_recent_views.cpp
++index 6645637..72c43b1 100644
++--- a/Telegram/SourceFiles/media/stories/media_stories_recent_views.cpp
+++++ b/Telegram/SourceFiles/media/stories/media_stories_recent_views.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/stories/media_stories_reply.cpp b/Telegram/SourceFiles/media/stories/media_stories_reply.cpp
++index 715ee52..e1757fa 100644
++--- a/Telegram/SourceFiles/media/stories/media_stories_reply.cpp
+++++ b/Telegram/SourceFiles/media/stories/media_stories_reply.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/stories/media_stories_repost_view.cpp b/Telegram/SourceFiles/media/stories/media_stories_repost_view.cpp
++index 423738d..bca6ea3 100644
++--- a/Telegram/SourceFiles/media/stories/media_stories_repost_view.cpp
+++++ b/Telegram/SourceFiles/media/stories/media_stories_repost_view.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/stories/media_stories_share.cpp b/Telegram/SourceFiles/media/stories/media_stories_share.cpp
++index 7419a67..6fbf5b3 100644
++--- a/Telegram/SourceFiles/media/stories/media_stories_share.cpp
+++++ b/Telegram/SourceFiles/media/stories/media_stories_share.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/stories/media_stories_sibling.cpp b/Telegram/SourceFiles/media/stories/media_stories_sibling.cpp
++index 6e4947e..dcac017 100644
++--- a/Telegram/SourceFiles/media/stories/media_stories_sibling.cpp
+++++ b/Telegram/SourceFiles/media/stories/media_stories_sibling.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/stories/media_stories_slider.cpp b/Telegram/SourceFiles/media/stories/media_stories_slider.cpp
++index 53f39c1..0b52788 100644
++--- a/Telegram/SourceFiles/media/stories/media_stories_slider.cpp
+++++ b/Telegram/SourceFiles/media/stories/media_stories_slider.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/stories/media_stories_stealth.cpp b/Telegram/SourceFiles/media/stories/media_stories_stealth.cpp
++index 0f6dc35..ed9999a 100644
++--- a/Telegram/SourceFiles/media/stories/media_stories_stealth.cpp
+++++ b/Telegram/SourceFiles/media/stories/media_stories_stealth.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/stories/media_stories_view.cpp b/Telegram/SourceFiles/media/stories/media_stories_view.cpp
++index 73bd57e..d6fbfbf 100644
++--- a/Telegram/SourceFiles/media/stories/media_stories_view.cpp
+++++ b/Telegram/SourceFiles/media/stories/media_stories_view.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/streaming/media_streaming_audio_track.cpp b/Telegram/SourceFiles/media/streaming/media_streaming_audio_track.cpp
++index ff18b67..2e34571 100644
++--- a/Telegram/SourceFiles/media/streaming/media_streaming_audio_track.cpp
+++++ b/Telegram/SourceFiles/media/streaming/media_streaming_audio_track.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/streaming/media_streaming_document.cpp b/Telegram/SourceFiles/media/streaming/media_streaming_document.cpp
++index 5ba5ff5..42dfcce 100644
++--- a/Telegram/SourceFiles/media/streaming/media_streaming_document.cpp
+++++ b/Telegram/SourceFiles/media/streaming/media_streaming_document.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/streaming/media_streaming_file.cpp b/Telegram/SourceFiles/media/streaming/media_streaming_file.cpp
++index 9e5ee84..d7039fd 100644
++--- a/Telegram/SourceFiles/media/streaming/media_streaming_file.cpp
+++++ b/Telegram/SourceFiles/media/streaming/media_streaming_file.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/streaming/media_streaming_instance.cpp b/Telegram/SourceFiles/media/streaming/media_streaming_instance.cpp
++index 4d4149c..a8b3630 100644
++--- a/Telegram/SourceFiles/media/streaming/media_streaming_instance.cpp
+++++ b/Telegram/SourceFiles/media/streaming/media_streaming_instance.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/streaming/media_streaming_loader.cpp b/Telegram/SourceFiles/media/streaming/media_streaming_loader.cpp
++index e507efe..bcfa45d 100644
++--- a/Telegram/SourceFiles/media/streaming/media_streaming_loader.cpp
+++++ b/Telegram/SourceFiles/media/streaming/media_streaming_loader.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/streaming/media_streaming_loader_local.cpp b/Telegram/SourceFiles/media/streaming/media_streaming_loader_local.cpp
++index 868296d..81dcafb 100644
++--- a/Telegram/SourceFiles/media/streaming/media_streaming_loader_local.cpp
+++++ b/Telegram/SourceFiles/media/streaming/media_streaming_loader_local.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/streaming/media_streaming_loader_mtproto.cpp b/Telegram/SourceFiles/media/streaming/media_streaming_loader_mtproto.cpp
++index d6f869c..49988bb 100644
++--- a/Telegram/SourceFiles/media/streaming/media_streaming_loader_mtproto.cpp
+++++ b/Telegram/SourceFiles/media/streaming/media_streaming_loader_mtproto.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/streaming/media_streaming_player.cpp b/Telegram/SourceFiles/media/streaming/media_streaming_player.cpp
++index 0005d17..17fbee4 100644
++--- a/Telegram/SourceFiles/media/streaming/media_streaming_player.cpp
+++++ b/Telegram/SourceFiles/media/streaming/media_streaming_player.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/streaming/media_streaming_reader.cpp b/Telegram/SourceFiles/media/streaming/media_streaming_reader.cpp
++index 807492b..4a91355 100644
++--- a/Telegram/SourceFiles/media/streaming/media_streaming_reader.cpp
+++++ b/Telegram/SourceFiles/media/streaming/media_streaming_reader.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/streaming/media_streaming_round_preview.cpp b/Telegram/SourceFiles/media/streaming/media_streaming_round_preview.cpp
++index 56beb61..a0079fa 100644
++--- a/Telegram/SourceFiles/media/streaming/media_streaming_round_preview.cpp
+++++ b/Telegram/SourceFiles/media/streaming/media_streaming_round_preview.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/streaming/media_streaming_utility.cpp b/Telegram/SourceFiles/media/streaming/media_streaming_utility.cpp
++index fdfbe20..3c23652 100644
++--- a/Telegram/SourceFiles/media/streaming/media_streaming_utility.cpp
+++++ b/Telegram/SourceFiles/media/streaming/media_streaming_utility.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/streaming/media_streaming_video_track.cpp b/Telegram/SourceFiles/media/streaming/media_streaming_video_track.cpp
++index b951812..8e9d02c 100644
++--- a/Telegram/SourceFiles/media/streaming/media_streaming_video_track.cpp
+++++ b/Telegram/SourceFiles/media/streaming/media_streaming_video_track.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/system_media_controls_manager.cpp b/Telegram/SourceFiles/media/system_media_controls_manager.cpp
++index 91f016a..f97a6f7 100644
++--- a/Telegram/SourceFiles/media/system_media_controls_manager.cpp
+++++ b/Telegram/SourceFiles/media/system_media_controls_manager.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/view/media_view_group_thumbs.cpp b/Telegram/SourceFiles/media/view/media_view_group_thumbs.cpp
++index c03c20c..85e4110 100644
++--- a/Telegram/SourceFiles/media/view/media_view_group_thumbs.cpp
+++++ b/Telegram/SourceFiles/media/view/media_view_group_thumbs.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/view/media_view_open_common.cpp b/Telegram/SourceFiles/media/view/media_view_open_common.cpp
++index 346a87e..777f252 100644
++--- a/Telegram/SourceFiles/media/view/media_view_open_common.cpp
+++++ b/Telegram/SourceFiles/media/view/media_view_open_common.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/view/media_view_overlay_opengl.cpp b/Telegram/SourceFiles/media/view/media_view_overlay_opengl.cpp
++index 99be555..773d650 100644
++--- a/Telegram/SourceFiles/media/view/media_view_overlay_opengl.cpp
+++++ b/Telegram/SourceFiles/media/view/media_view_overlay_opengl.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/view/media_view_overlay_raster.cpp b/Telegram/SourceFiles/media/view/media_view_overlay_raster.cpp
++index 2867a36..679f8bf 100644
++--- a/Telegram/SourceFiles/media/view/media_view_overlay_raster.cpp
+++++ b/Telegram/SourceFiles/media/view/media_view_overlay_raster.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
++index 5ff6a06..bcc881b 100644
++--- a/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
+++++ b/Telegram/SourceFiles/media/view/media_view_overlay_widget.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/view/media_view_pip.cpp b/Telegram/SourceFiles/media/view/media_view_pip.cpp
++index 42600db..e50f408 100644
++--- a/Telegram/SourceFiles/media/view/media_view_pip.cpp
+++++ b/Telegram/SourceFiles/media/view/media_view_pip.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/view/media_view_pip_opengl.cpp b/Telegram/SourceFiles/media/view/media_view_pip_opengl.cpp
++index f4be398..a804ce5 100644
++--- a/Telegram/SourceFiles/media/view/media_view_pip_opengl.cpp
+++++ b/Telegram/SourceFiles/media/view/media_view_pip_opengl.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/view/media_view_pip_raster.cpp b/Telegram/SourceFiles/media/view/media_view_pip_raster.cpp
++index 4698309..000f5d4 100644
++--- a/Telegram/SourceFiles/media/view/media_view_pip_raster.cpp
+++++ b/Telegram/SourceFiles/media/view/media_view_pip_raster.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/view/media_view_playback_controls.cpp b/Telegram/SourceFiles/media/view/media_view_playback_controls.cpp
++index 5ecb20d..efff4ab 100644
++--- a/Telegram/SourceFiles/media/view/media_view_playback_controls.cpp
+++++ b/Telegram/SourceFiles/media/view/media_view_playback_controls.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/view/media_view_playback_progress.cpp b/Telegram/SourceFiles/media/view/media_view_playback_progress.cpp
++index 745c437..0a6a57e 100644
++--- a/Telegram/SourceFiles/media/view/media_view_playback_progress.cpp
+++++ b/Telegram/SourceFiles/media/view/media_view_playback_progress.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/media/view/media_view_playback_sponsored.cpp b/Telegram/SourceFiles/media/view/media_view_playback_sponsored.cpp
++index 895b4c7..165c667 100644
++--- a/Telegram/SourceFiles/media/view/media_view_playback_sponsored.cpp
+++++ b/Telegram/SourceFiles/media/view/media_view_playback_sponsored.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/menu/gift_resale_filter.cpp b/Telegram/SourceFiles/menu/gift_resale_filter.cpp
++index 35cad8a..7c49390 100644
++--- a/Telegram/SourceFiles/menu/gift_resale_filter.cpp
+++++ b/Telegram/SourceFiles/menu/gift_resale_filter.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/menu/menu_antispam_validator.cpp b/Telegram/SourceFiles/menu/menu_antispam_validator.cpp
++index 16c183a..bd0082c 100644
++--- a/Telegram/SourceFiles/menu/menu_antispam_validator.cpp
+++++ b/Telegram/SourceFiles/menu/menu_antispam_validator.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/menu/menu_check_item.cpp b/Telegram/SourceFiles/menu/menu_check_item.cpp
++index f76e5d3..e69c606 100644
++--- a/Telegram/SourceFiles/menu/menu_check_item.cpp
+++++ b/Telegram/SourceFiles/menu/menu_check_item.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/menu/menu_item_download_files.cpp b/Telegram/SourceFiles/menu/menu_item_download_files.cpp
++index 540f2eb..1fd283a 100644
++--- a/Telegram/SourceFiles/menu/menu_item_download_files.cpp
+++++ b/Telegram/SourceFiles/menu/menu_item_download_files.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/menu/menu_item_rate_transcribe.cpp b/Telegram/SourceFiles/menu/menu_item_rate_transcribe.cpp
++index 75567c7..e42c2a8 100644
++--- a/Telegram/SourceFiles/menu/menu_item_rate_transcribe.cpp
+++++ b/Telegram/SourceFiles/menu/menu_item_rate_transcribe.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/menu/menu_item_rate_transcribe_session.cpp b/Telegram/SourceFiles/menu/menu_item_rate_transcribe_session.cpp
++index 95ce62c..087a004 100644
++--- a/Telegram/SourceFiles/menu/menu_item_rate_transcribe_session.cpp
+++++ b/Telegram/SourceFiles/menu/menu_item_rate_transcribe_session.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/menu/menu_mute.cpp b/Telegram/SourceFiles/menu/menu_mute.cpp
++index caf5964..e1b5f1d 100644
++--- a/Telegram/SourceFiles/menu/menu_mute.cpp
+++++ b/Telegram/SourceFiles/menu/menu_mute.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/menu/menu_send.cpp b/Telegram/SourceFiles/menu/menu_send.cpp
++index 86518f7..5c710d0 100644
++--- a/Telegram/SourceFiles/menu/menu_send.cpp
+++++ b/Telegram/SourceFiles/menu/menu_send.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/menu/menu_sponsored.cpp b/Telegram/SourceFiles/menu/menu_sponsored.cpp
++index f3637a5..d38ae66 100644
++--- a/Telegram/SourceFiles/menu/menu_sponsored.cpp
+++++ b/Telegram/SourceFiles/menu/menu_sponsored.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/menu/menu_ttl.cpp b/Telegram/SourceFiles/menu/menu_ttl.cpp
++index f77294a..ae52494 100644
++--- a/Telegram/SourceFiles/menu/menu_ttl.cpp
+++++ b/Telegram/SourceFiles/menu/menu_ttl.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/menu/menu_ttl_validator.cpp b/Telegram/SourceFiles/menu/menu_ttl_validator.cpp
++index ba5ad14..3a89bd1 100644
++--- a/Telegram/SourceFiles/menu/menu_ttl_validator.cpp
+++++ b/Telegram/SourceFiles/menu/menu_ttl_validator.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/config_loader.cpp b/Telegram/SourceFiles/mtproto/config_loader.cpp
++index 5d07404..4fe180d 100644
++--- a/Telegram/SourceFiles/mtproto/config_loader.cpp
+++++ b/Telegram/SourceFiles/mtproto/config_loader.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/connection_abstract.cpp b/Telegram/SourceFiles/mtproto/connection_abstract.cpp
++index a932363..135af6c 100644
++--- a/Telegram/SourceFiles/mtproto/connection_abstract.cpp
+++++ b/Telegram/SourceFiles/mtproto/connection_abstract.cpp
++@@ -1,3 +1,5 @@
+++#include "mtproto/mtproto_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/connection_http.cpp b/Telegram/SourceFiles/mtproto/connection_http.cpp
++index baaad90..3272c44 100644
++--- a/Telegram/SourceFiles/mtproto/connection_http.cpp
+++++ b/Telegram/SourceFiles/mtproto/connection_http.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/connection_resolving.cpp b/Telegram/SourceFiles/mtproto/connection_resolving.cpp
++index 571e14e..6d55be0 100644
++--- a/Telegram/SourceFiles/mtproto/connection_resolving.cpp
+++++ b/Telegram/SourceFiles/mtproto/connection_resolving.cpp
++@@ -1,3 +1,5 @@
+++#include "mtproto/mtproto_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/connection_tcp.cpp b/Telegram/SourceFiles/mtproto/connection_tcp.cpp
++index 26dff1d..5723c5e 100644
++--- a/Telegram/SourceFiles/mtproto/connection_tcp.cpp
+++++ b/Telegram/SourceFiles/mtproto/connection_tcp.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/dedicated_file_loader.cpp b/Telegram/SourceFiles/mtproto/dedicated_file_loader.cpp
++index 72e69e4..a18f7b2 100644
++--- a/Telegram/SourceFiles/mtproto/dedicated_file_loader.cpp
+++++ b/Telegram/SourceFiles/mtproto/dedicated_file_loader.cpp
++@@ -1,3 +1,5 @@
+++#include "mtproto/mtproto_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/details/mtproto_abstract_socket.cpp b/Telegram/SourceFiles/mtproto/details/mtproto_abstract_socket.cpp
++index 6530333..33a70e9 100644
++--- a/Telegram/SourceFiles/mtproto/details/mtproto_abstract_socket.cpp
+++++ b/Telegram/SourceFiles/mtproto/details/mtproto_abstract_socket.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/details/mtproto_bound_key_creator.cpp b/Telegram/SourceFiles/mtproto/details/mtproto_bound_key_creator.cpp
++index 7938c7a..c2a1432 100644
++--- a/Telegram/SourceFiles/mtproto/details/mtproto_bound_key_creator.cpp
+++++ b/Telegram/SourceFiles/mtproto/details/mtproto_bound_key_creator.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/details/mtproto_dc_key_binder.cpp b/Telegram/SourceFiles/mtproto/details/mtproto_dc_key_binder.cpp
++index 740ca28..949d2f1 100644
++--- a/Telegram/SourceFiles/mtproto/details/mtproto_dc_key_binder.cpp
+++++ b/Telegram/SourceFiles/mtproto/details/mtproto_dc_key_binder.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/details/mtproto_dc_key_creator.cpp b/Telegram/SourceFiles/mtproto/details/mtproto_dc_key_creator.cpp
++index badec9e..516fc84 100644
++--- a/Telegram/SourceFiles/mtproto/details/mtproto_dc_key_creator.cpp
+++++ b/Telegram/SourceFiles/mtproto/details/mtproto_dc_key_creator.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/details/mtproto_dcenter.cpp b/Telegram/SourceFiles/mtproto/details/mtproto_dcenter.cpp
++index a98e24b..0a35b71 100644
++--- a/Telegram/SourceFiles/mtproto/details/mtproto_dcenter.cpp
+++++ b/Telegram/SourceFiles/mtproto/details/mtproto_dcenter.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/details/mtproto_domain_resolver.cpp b/Telegram/SourceFiles/mtproto/details/mtproto_domain_resolver.cpp
++index bd8dddb..cdd41f6 100644
++--- a/Telegram/SourceFiles/mtproto/details/mtproto_domain_resolver.cpp
+++++ b/Telegram/SourceFiles/mtproto/details/mtproto_domain_resolver.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/details/mtproto_dump_to_text.cpp b/Telegram/SourceFiles/mtproto/details/mtproto_dump_to_text.cpp
++index a6250bb..6bcdf97 100644
++--- a/Telegram/SourceFiles/mtproto/details/mtproto_dump_to_text.cpp
+++++ b/Telegram/SourceFiles/mtproto/details/mtproto_dump_to_text.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/details/mtproto_received_ids_manager.cpp b/Telegram/SourceFiles/mtproto/details/mtproto_received_ids_manager.cpp
++index 20bade0..da26c28 100644
++--- a/Telegram/SourceFiles/mtproto/details/mtproto_received_ids_manager.cpp
+++++ b/Telegram/SourceFiles/mtproto/details/mtproto_received_ids_manager.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/details/mtproto_rsa_public_key.cpp b/Telegram/SourceFiles/mtproto/details/mtproto_rsa_public_key.cpp
++index 312c8b1..4e91cf9 100644
++--- a/Telegram/SourceFiles/mtproto/details/mtproto_rsa_public_key.cpp
+++++ b/Telegram/SourceFiles/mtproto/details/mtproto_rsa_public_key.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/details/mtproto_serialized_request.cpp b/Telegram/SourceFiles/mtproto/details/mtproto_serialized_request.cpp
++index f4ff131..3b32e9e 100644
++--- a/Telegram/SourceFiles/mtproto/details/mtproto_serialized_request.cpp
+++++ b/Telegram/SourceFiles/mtproto/details/mtproto_serialized_request.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/details/mtproto_tcp_socket.cpp b/Telegram/SourceFiles/mtproto/details/mtproto_tcp_socket.cpp
++index 76a59c1..72ecd44 100644
++--- a/Telegram/SourceFiles/mtproto/details/mtproto_tcp_socket.cpp
+++++ b/Telegram/SourceFiles/mtproto/details/mtproto_tcp_socket.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/details/mtproto_tls_socket.cpp b/Telegram/SourceFiles/mtproto/details/mtproto_tls_socket.cpp
++index 36aa875..ff18eb2 100644
++--- a/Telegram/SourceFiles/mtproto/details/mtproto_tls_socket.cpp
+++++ b/Telegram/SourceFiles/mtproto/details/mtproto_tls_socket.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/facade.cpp b/Telegram/SourceFiles/mtproto/facade.cpp
++index 2ff96d0..57737c0 100644
++--- a/Telegram/SourceFiles/mtproto/facade.cpp
+++++ b/Telegram/SourceFiles/mtproto/facade.cpp
++@@ -1,3 +1,5 @@
+++#include "mtproto/mtproto_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/mtp_instance.cpp b/Telegram/SourceFiles/mtproto/mtp_instance.cpp
++index 1890c44..19e6948 100644
++--- a/Telegram/SourceFiles/mtproto/mtp_instance.cpp
+++++ b/Telegram/SourceFiles/mtproto/mtp_instance.cpp
++@@ -1,3 +1,5 @@
+++#include "mtproto/mtproto_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/mtproto_auth_key.cpp b/Telegram/SourceFiles/mtproto/mtproto_auth_key.cpp
++index c84d19a..e5bc010 100644
++--- a/Telegram/SourceFiles/mtproto/mtproto_auth_key.cpp
+++++ b/Telegram/SourceFiles/mtproto/mtproto_auth_key.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/mtproto_concurrent_sender.cpp b/Telegram/SourceFiles/mtproto/mtproto_concurrent_sender.cpp
++index 89ad7d9..d9ce1db 100644
++--- a/Telegram/SourceFiles/mtproto/mtproto_concurrent_sender.cpp
+++++ b/Telegram/SourceFiles/mtproto/mtproto_concurrent_sender.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/mtproto_config.cpp b/Telegram/SourceFiles/mtproto/mtproto_config.cpp
++index e8fc605..6771481 100644
++--- a/Telegram/SourceFiles/mtproto/mtproto_config.cpp
+++++ b/Telegram/SourceFiles/mtproto/mtproto_config.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/mtproto_dc_options.cpp b/Telegram/SourceFiles/mtproto/mtproto_dc_options.cpp
++index 048845a..df5038d 100644
++--- a/Telegram/SourceFiles/mtproto/mtproto_dc_options.cpp
+++++ b/Telegram/SourceFiles/mtproto/mtproto_dc_options.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/mtproto_dh_utils.cpp b/Telegram/SourceFiles/mtproto/mtproto_dh_utils.cpp
++index db9c054..c9ac9bf 100644
++--- a/Telegram/SourceFiles/mtproto/mtproto_dh_utils.cpp
+++++ b/Telegram/SourceFiles/mtproto/mtproto_dh_utils.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/mtproto_proxy_data.cpp b/Telegram/SourceFiles/mtproto/mtproto_proxy_data.cpp
++index e6d06a5..4461220 100644
++--- a/Telegram/SourceFiles/mtproto/mtproto_proxy_data.cpp
+++++ b/Telegram/SourceFiles/mtproto/mtproto_proxy_data.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/mtproto_response.cpp b/Telegram/SourceFiles/mtproto/mtproto_response.cpp
++index 7729044..33e583f 100644
++--- a/Telegram/SourceFiles/mtproto/mtproto_response.cpp
+++++ b/Telegram/SourceFiles/mtproto/mtproto_response.cpp
++@@ -1,3 +1,4 @@
+++#include "mtproto/mtproto_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/session.cpp b/Telegram/SourceFiles/mtproto/session.cpp
++index 842541e..aafd711 100644
++--- a/Telegram/SourceFiles/mtproto/session.cpp
+++++ b/Telegram/SourceFiles/mtproto/session.cpp
++@@ -1,8 +1,10 @@
+++#include "mtproto/mtproto_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++ 
++-For license and copyright information please follow this link:
+++For license and copyright information please follow this loink:
++ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
++ */
++ #include "mtproto/session.h"
++diff --git a/Telegram/SourceFiles/mtproto/session_private.cpp b/Telegram/SourceFiles/mtproto/session_private.cpp
++index 4458537..70cc3a2 100644
++--- a/Telegram/SourceFiles/mtproto/session_private.cpp
+++++ b/Telegram/SourceFiles/mtproto/session_private.cpp
++@@ -1,3 +1,5 @@
+++#include "mtproto/mtproto_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/mtproto/special_config_request.cpp b/Telegram/SourceFiles/mtproto/special_config_request.cpp
++index 9736518..de1be4e 100644
++--- a/Telegram/SourceFiles/mtproto/special_config_request.cpp
+++++ b/Telegram/SourceFiles/mtproto/special_config_request.cpp
++@@ -1,3 +1,5 @@
+++#include "mtproto/mtproto_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/overview/overview_layout.cpp b/Telegram/SourceFiles/overview/overview_layout.cpp
++index 7f73fdd..4ab7af2 100644
++--- a/Telegram/SourceFiles/overview/overview_layout.cpp
+++++ b/Telegram/SourceFiles/overview/overview_layout.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/passport/passport_edit_identity_box.cpp b/Telegram/SourceFiles/passport/passport_edit_identity_box.cpp
++index 68285b9..9e7d075 100644
++--- a/Telegram/SourceFiles/passport/passport_edit_identity_box.cpp
+++++ b/Telegram/SourceFiles/passport/passport_edit_identity_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/passport/passport_encryption.cpp b/Telegram/SourceFiles/passport/passport_encryption.cpp
++index c5c6e2a..f2c40c2 100644
++--- a/Telegram/SourceFiles/passport/passport_encryption.cpp
+++++ b/Telegram/SourceFiles/passport/passport_encryption.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/passport/passport_form_controller.cpp b/Telegram/SourceFiles/passport/passport_form_controller.cpp
++index a82cecf..7958f8b 100644
++--- a/Telegram/SourceFiles/passport/passport_form_controller.cpp
+++++ b/Telegram/SourceFiles/passport/passport_form_controller.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/passport/passport_form_row.cpp b/Telegram/SourceFiles/passport/passport_form_row.cpp
++index e07e2ae..e50c9ec 100644
++--- a/Telegram/SourceFiles/passport/passport_form_row.cpp
+++++ b/Telegram/SourceFiles/passport/passport_form_row.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/passport/passport_form_view_controller.cpp b/Telegram/SourceFiles/passport/passport_form_view_controller.cpp
++index cd038ac..2d66420 100644
++--- a/Telegram/SourceFiles/passport/passport_form_view_controller.cpp
+++++ b/Telegram/SourceFiles/passport/passport_form_view_controller.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/passport/passport_panel.cpp b/Telegram/SourceFiles/passport/passport_panel.cpp
++index 8db7c18..1765b9e 100644
++--- a/Telegram/SourceFiles/passport/passport_panel.cpp
+++++ b/Telegram/SourceFiles/passport/passport_panel.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/passport/passport_panel_controller.cpp b/Telegram/SourceFiles/passport/passport_panel_controller.cpp
++index 1abfa68..3b12ad8 100644
++--- a/Telegram/SourceFiles/passport/passport_panel_controller.cpp
+++++ b/Telegram/SourceFiles/passport/passport_panel_controller.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/passport/passport_panel_edit_contact.cpp b/Telegram/SourceFiles/passport/passport_panel_edit_contact.cpp
++index 9e1d108..8886d0e 100644
++--- a/Telegram/SourceFiles/passport/passport_panel_edit_contact.cpp
+++++ b/Telegram/SourceFiles/passport/passport_panel_edit_contact.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/passport/passport_panel_edit_document.cpp b/Telegram/SourceFiles/passport/passport_panel_edit_document.cpp
++index 723e37f..814aca6 100644
++--- a/Telegram/SourceFiles/passport/passport_panel_edit_document.cpp
+++++ b/Telegram/SourceFiles/passport/passport_panel_edit_document.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/passport/passport_panel_edit_scans.cpp b/Telegram/SourceFiles/passport/passport_panel_edit_scans.cpp
++index 35d5bd8..aa41106 100644
++--- a/Telegram/SourceFiles/passport/passport_panel_edit_scans.cpp
+++++ b/Telegram/SourceFiles/passport/passport_panel_edit_scans.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/passport/passport_panel_form.cpp b/Telegram/SourceFiles/passport/passport_panel_form.cpp
++index 07a673c..3e07d37 100644
++--- a/Telegram/SourceFiles/passport/passport_panel_form.cpp
+++++ b/Telegram/SourceFiles/passport/passport_panel_form.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/passport/passport_panel_password.cpp b/Telegram/SourceFiles/passport/passport_panel_password.cpp
++index 15163dc..d1cfba3 100644
++--- a/Telegram/SourceFiles/passport/passport_panel_password.cpp
+++++ b/Telegram/SourceFiles/passport/passport_panel_password.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/passport/ui/passport_details_row.cpp b/Telegram/SourceFiles/passport/ui/passport_details_row.cpp
++index 0fa946f..3e5914b 100644
++--- a/Telegram/SourceFiles/passport/ui/passport_details_row.cpp
+++++ b/Telegram/SourceFiles/passport/ui/passport_details_row.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/passport/ui/passport_form_row.cpp b/Telegram/SourceFiles/passport/ui/passport_form_row.cpp
++index ca76b40..3ed97f5 100644
++--- a/Telegram/SourceFiles/passport/ui/passport_form_row.cpp
+++++ b/Telegram/SourceFiles/passport/ui/passport_form_row.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/payments_checkout_process.cpp b/Telegram/SourceFiles/payments/payments_checkout_process.cpp
++index d271616..cc31333 100644
++--- a/Telegram/SourceFiles/payments/payments_checkout_process.cpp
+++++ b/Telegram/SourceFiles/payments/payments_checkout_process.cpp
++@@ -1,3 +1,5 @@
+++#include "stripe/stripe_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/payments_form.cpp b/Telegram/SourceFiles/payments/payments_form.cpp
++index ff00532..2e47e2e 100644
++--- a/Telegram/SourceFiles/payments/payments_form.cpp
+++++ b/Telegram/SourceFiles/payments/payments_form.cpp
++@@ -1,3 +1,5 @@
+++#include "stripe/stripe_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/payments_non_panel_process.cpp b/Telegram/SourceFiles/payments/payments_non_panel_process.cpp
++index 09b3bc1..2893558 100644
++--- a/Telegram/SourceFiles/payments/payments_non_panel_process.cpp
+++++ b/Telegram/SourceFiles/payments/payments_non_panel_process.cpp
++@@ -1,3 +1,5 @@
+++#include "stripe/stripe_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/payments_reaction_process.cpp b/Telegram/SourceFiles/payments/payments_reaction_process.cpp
++index 81f9aed..ee83d0a 100644
++--- a/Telegram/SourceFiles/payments/payments_reaction_process.cpp
+++++ b/Telegram/SourceFiles/payments/payments_reaction_process.cpp
++@@ -1,3 +1,5 @@
+++#include "stripe/stripe_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/smartglocal/smartglocal_api_client.cpp b/Telegram/SourceFiles/payments/smartglocal/smartglocal_api_client.cpp
++index 690438c..f554e8b 100644
++--- a/Telegram/SourceFiles/payments/smartglocal/smartglocal_api_client.cpp
+++++ b/Telegram/SourceFiles/payments/smartglocal/smartglocal_api_client.cpp
++@@ -1,3 +1,4 @@
+++#include "stripe/stripe_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/smartglocal/smartglocal_card.cpp b/Telegram/SourceFiles/payments/smartglocal/smartglocal_card.cpp
++index a08b098..38afa21 100644
++--- a/Telegram/SourceFiles/payments/smartglocal/smartglocal_card.cpp
+++++ b/Telegram/SourceFiles/payments/smartglocal/smartglocal_card.cpp
++@@ -1,3 +1,4 @@
+++#include "stripe/stripe_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/smartglocal/smartglocal_error.cpp b/Telegram/SourceFiles/payments/smartglocal/smartglocal_error.cpp
++index cc764a0..dc25f6f 100644
++--- a/Telegram/SourceFiles/payments/smartglocal/smartglocal_error.cpp
+++++ b/Telegram/SourceFiles/payments/smartglocal/smartglocal_error.cpp
++@@ -1,3 +1,4 @@
+++#include "stripe/stripe_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/smartglocal/smartglocal_token.cpp b/Telegram/SourceFiles/payments/smartglocal/smartglocal_token.cpp
++index ee8725c..bfe000b 100644
++--- a/Telegram/SourceFiles/payments/smartglocal/smartglocal_token.cpp
+++++ b/Telegram/SourceFiles/payments/smartglocal/smartglocal_token.cpp
++@@ -1,3 +1,4 @@
+++#include "stripe/stripe_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/stripe/stripe_api_client.cpp b/Telegram/SourceFiles/payments/stripe/stripe_api_client.cpp
++index 853dc14..d983b87 100644
++--- a/Telegram/SourceFiles/payments/stripe/stripe_api_client.cpp
+++++ b/Telegram/SourceFiles/payments/stripe/stripe_api_client.cpp
++@@ -1,3 +1,4 @@
+++#include "stripe/stripe_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/stripe/stripe_card.cpp b/Telegram/SourceFiles/payments/stripe/stripe_card.cpp
++index ca2c864..bb0c509 100644
++--- a/Telegram/SourceFiles/payments/stripe/stripe_card.cpp
+++++ b/Telegram/SourceFiles/payments/stripe/stripe_card.cpp
++@@ -1,3 +1,4 @@
+++#include "stripe/stripe_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/stripe/stripe_card_params.cpp b/Telegram/SourceFiles/payments/stripe/stripe_card_params.cpp
++index 81b72c4..203a806 100644
++--- a/Telegram/SourceFiles/payments/stripe/stripe_card_params.cpp
+++++ b/Telegram/SourceFiles/payments/stripe/stripe_card_params.cpp
++@@ -1,3 +1,4 @@
+++#include "stripe/stripe_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/stripe/stripe_card_validator.cpp b/Telegram/SourceFiles/payments/stripe/stripe_card_validator.cpp
++index 599a392..4cd2d77 100644
++--- a/Telegram/SourceFiles/payments/stripe/stripe_card_validator.cpp
+++++ b/Telegram/SourceFiles/payments/stripe/stripe_card_validator.cpp
++@@ -1,3 +1,4 @@
+++#include "stripe/stripe_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/stripe/stripe_decode.cpp b/Telegram/SourceFiles/payments/stripe/stripe_decode.cpp
++index acd2dac..2fb8be0 100644
++--- a/Telegram/SourceFiles/payments/stripe/stripe_decode.cpp
+++++ b/Telegram/SourceFiles/payments/stripe/stripe_decode.cpp
++@@ -1,3 +1,4 @@
+++#include "stripe/stripe_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/stripe/stripe_error.cpp b/Telegram/SourceFiles/payments/stripe/stripe_error.cpp
++index c5be7e0..68d9e5c 100644
++--- a/Telegram/SourceFiles/payments/stripe/stripe_error.cpp
+++++ b/Telegram/SourceFiles/payments/stripe/stripe_error.cpp
++@@ -1,3 +1,4 @@
+++#include "stripe/stripe_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/stripe/stripe_form_encoder.cpp b/Telegram/SourceFiles/payments/stripe/stripe_form_encoder.cpp
++index 2f8f61f..6bde930 100644
++--- a/Telegram/SourceFiles/payments/stripe/stripe_form_encoder.cpp
+++++ b/Telegram/SourceFiles/payments/stripe/stripe_form_encoder.cpp
++@@ -1,3 +1,4 @@
+++#include "stripe/stripe_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/stripe/stripe_token.cpp b/Telegram/SourceFiles/payments/stripe/stripe_token.cpp
++index d91e48b..d4ebabf 100644
++--- a/Telegram/SourceFiles/payments/stripe/stripe_token.cpp
+++++ b/Telegram/SourceFiles/payments/stripe/stripe_token.cpp
++@@ -1,3 +1,4 @@
+++#include "stripe/stripe_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/ui/payments_edit_card.cpp b/Telegram/SourceFiles/payments/ui/payments_edit_card.cpp
++index ec18ef6..16eb19d 100644
++--- a/Telegram/SourceFiles/payments/ui/payments_edit_card.cpp
+++++ b/Telegram/SourceFiles/payments/ui/payments_edit_card.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stripe/stripe_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/ui/payments_edit_information.cpp b/Telegram/SourceFiles/payments/ui/payments_edit_information.cpp
++index ab96a8a..f307746 100644
++--- a/Telegram/SourceFiles/payments/ui/payments_edit_information.cpp
+++++ b/Telegram/SourceFiles/payments/ui/payments_edit_information.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stripe/stripe_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/ui/payments_field.cpp b/Telegram/SourceFiles/payments/ui/payments_field.cpp
++index e5fbcb3..ed5a21e 100644
++--- a/Telegram/SourceFiles/payments/ui/payments_field.cpp
+++++ b/Telegram/SourceFiles/payments/ui/payments_field.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stripe/stripe_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/ui/payments_form_summary.cpp b/Telegram/SourceFiles/payments/ui/payments_form_summary.cpp
++index cd7d8a8..6219f4e 100644
++--- a/Telegram/SourceFiles/payments/ui/payments_form_summary.cpp
+++++ b/Telegram/SourceFiles/payments/ui/payments_form_summary.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stripe/stripe_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/ui/payments_panel.cpp b/Telegram/SourceFiles/payments/ui/payments_panel.cpp
++index 6e7f049..8306a6d 100644
++--- a/Telegram/SourceFiles/payments/ui/payments_panel.cpp
+++++ b/Telegram/SourceFiles/payments/ui/payments_panel.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stripe/stripe_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/payments/ui/payments_reaction_box.cpp b/Telegram/SourceFiles/payments/ui/payments_reaction_box.cpp
++index 639cd1c..3aeabaa 100644
++--- a/Telegram/SourceFiles/payments/ui/payments_reaction_box.cpp
+++++ b/Telegram/SourceFiles/payments/ui/payments_reaction_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stripe/stripe_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/platform/linux/current_geo_location_linux.cpp b/Telegram/SourceFiles/platform/linux/current_geo_location_linux.cpp
++index 9c528ef..9aaa7de 100644
++--- a/Telegram/SourceFiles/platform/linux/current_geo_location_linux.cpp
+++++ b/Telegram/SourceFiles/platform/linux/current_geo_location_linux.cpp
++@@ -1,3 +1,5 @@
+++#include "base/base_pch.h"
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/platform/linux/file_utilities_linux.cpp b/Telegram/SourceFiles/platform/linux/file_utilities_linux.cpp
++index 331db8a..53a0d5e 100644
++--- a/Telegram/SourceFiles/platform/linux/file_utilities_linux.cpp
+++++ b/Telegram/SourceFiles/platform/linux/file_utilities_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/platform/linux/integration_linux.cpp b/Telegram/SourceFiles/platform/linux/integration_linux.cpp
++index 1d927db..ca501aa 100644
++--- a/Telegram/SourceFiles/platform/linux/integration_linux.cpp
+++++ b/Telegram/SourceFiles/platform/linux/integration_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/platform/linux/launcher_linux.cpp b/Telegram/SourceFiles/platform/linux/launcher_linux.cpp
++index 3c853c7..8c25471 100644
++--- a/Telegram/SourceFiles/platform/linux/launcher_linux.cpp
+++++ b/Telegram/SourceFiles/platform/linux/launcher_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
++index 43cd9c7..aec27bc 100644
++--- a/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
+++++ b/Telegram/SourceFiles/platform/linux/main_window_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/platform/linux/notifications_manager_haiku.cpp b/Telegram/SourceFiles/platform/linux/notifications_manager_haiku.cpp
++index 055b95d..6173b7d 100644
++--- a/Telegram/SourceFiles/platform/linux/notifications_manager_haiku.cpp
+++++ b/Telegram/SourceFiles/platform/linux/notifications_manager_haiku.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /* 
++ This file is part of Telegram Desktop for Haiku,
++ 
++diff --git a/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp b/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
++index f2f9b02..3b5cb25 100644
++--- a/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
+++++ b/Telegram/SourceFiles/platform/linux/notifications_manager_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ 
++ /*
++ This file is part of Telegram Desktop,
++diff --git a/Telegram/SourceFiles/platform/linux/specific_linux.cpp b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
++index 5490098..5faf6f1 100644
++--- a/Telegram/SourceFiles/platform/linux/specific_linux.cpp
+++++ b/Telegram/SourceFiles/platform/linux/specific_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/platform/linux/tray_linux.cpp b/Telegram/SourceFiles/platform/linux/tray_linux.cpp
++index 7db6ab8..e91c0d1 100644
++--- a/Telegram/SourceFiles/platform/linux/tray_linux.cpp
+++++ b/Telegram/SourceFiles/platform/linux/tray_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/platform/platform_integration.cpp b/Telegram/SourceFiles/platform/platform_integration.cpp
++index d2f832e..35fe449 100644
++--- a/Telegram/SourceFiles/platform/platform_integration.cpp
+++++ b/Telegram/SourceFiles/platform/platform_integration.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/platform/platform_overlay_widget.cpp b/Telegram/SourceFiles/platform/platform_overlay_widget.cpp
++index 3e07e8b..4730d42 100644
++--- a/Telegram/SourceFiles/platform/platform_overlay_widget.cpp
+++++ b/Telegram/SourceFiles/platform/platform_overlay_widget.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/profile/profile_back_button.cpp b/Telegram/SourceFiles/profile/profile_back_button.cpp
++index 15b2f28..874960c 100644
++--- a/Telegram/SourceFiles/profile/profile_back_button.cpp
+++++ b/Telegram/SourceFiles/profile/profile_back_button.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/profile/profile_block_widget.cpp b/Telegram/SourceFiles/profile/profile_block_widget.cpp
++index f029e26..618da35 100644
++--- a/Telegram/SourceFiles/profile/profile_block_widget.cpp
+++++ b/Telegram/SourceFiles/profile/profile_block_widget.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/profile/profile_cover_drop_area.cpp b/Telegram/SourceFiles/profile/profile_cover_drop_area.cpp
++index 4f68613..327a60b 100644
++--- a/Telegram/SourceFiles/profile/profile_cover_drop_area.cpp
+++++ b/Telegram/SourceFiles/profile/profile_cover_drop_area.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings.cpp b/Telegram/SourceFiles/settings.cpp
++index 4e2f6e8..7eb0bb6 100644
++--- a/Telegram/SourceFiles/settings.cpp
+++++ b/Telegram/SourceFiles/settings.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/business/settings_away_message.cpp b/Telegram/SourceFiles/settings/business/settings_away_message.cpp
++index 181582f..5ba1965 100644
++--- a/Telegram/SourceFiles/settings/business/settings_away_message.cpp
+++++ b/Telegram/SourceFiles/settings/business/settings_away_message.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/business/settings_chat_intro.cpp b/Telegram/SourceFiles/settings/business/settings_chat_intro.cpp
++index 98cffdc..219f24c 100644
++--- a/Telegram/SourceFiles/settings/business/settings_chat_intro.cpp
+++++ b/Telegram/SourceFiles/settings/business/settings_chat_intro.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/business/settings_chat_links.cpp b/Telegram/SourceFiles/settings/business/settings_chat_links.cpp
++index 44025db..9c3ab79 100644
++--- a/Telegram/SourceFiles/settings/business/settings_chat_links.cpp
+++++ b/Telegram/SourceFiles/settings/business/settings_chat_links.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/business/settings_chatbots.cpp b/Telegram/SourceFiles/settings/business/settings_chatbots.cpp
++index d6cdf4b..52b30b5 100644
++--- a/Telegram/SourceFiles/settings/business/settings_chatbots.cpp
+++++ b/Telegram/SourceFiles/settings/business/settings_chatbots.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/business/settings_greeting.cpp b/Telegram/SourceFiles/settings/business/settings_greeting.cpp
++index a65d694..ba0ebea 100644
++--- a/Telegram/SourceFiles/settings/business/settings_greeting.cpp
+++++ b/Telegram/SourceFiles/settings/business/settings_greeting.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/business/settings_location.cpp b/Telegram/SourceFiles/settings/business/settings_location.cpp
++index 6b659d0..de58fff 100644
++--- a/Telegram/SourceFiles/settings/business/settings_location.cpp
+++++ b/Telegram/SourceFiles/settings/business/settings_location.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/business/settings_quick_replies.cpp b/Telegram/SourceFiles/settings/business/settings_quick_replies.cpp
++index 9c4bcf1..a59a144 100644
++--- a/Telegram/SourceFiles/settings/business/settings_quick_replies.cpp
+++++ b/Telegram/SourceFiles/settings/business/settings_quick_replies.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/business/settings_recipients_helper.cpp b/Telegram/SourceFiles/settings/business/settings_recipients_helper.cpp
++index e80a0cf..9a5173c 100644
++--- a/Telegram/SourceFiles/settings/business/settings_recipients_helper.cpp
+++++ b/Telegram/SourceFiles/settings/business/settings_recipients_helper.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/business/settings_shortcut_messages.cpp b/Telegram/SourceFiles/settings/business/settings_shortcut_messages.cpp
++index eb3dc49..907b19f 100644
++--- a/Telegram/SourceFiles/settings/business/settings_shortcut_messages.cpp
+++++ b/Telegram/SourceFiles/settings/business/settings_shortcut_messages.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/business/settings_working_hours.cpp b/Telegram/SourceFiles/settings/business/settings_working_hours.cpp
++index 00e4c29..2e8f7a6 100644
++--- a/Telegram/SourceFiles/settings/business/settings_working_hours.cpp
+++++ b/Telegram/SourceFiles/settings/business/settings_working_hours.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_common.cpp b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_common.cpp
++index 87e0a2a..f8b85fe 100644
++--- a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_common.cpp
+++++ b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_common.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_email.cpp b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_email.cpp
++index ab1a0fb..582e3d7 100644
++--- a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_email.cpp
+++++ b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_email.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_email_confirm.cpp b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_email_confirm.cpp
++index e9e5e79..7caad58 100644
++--- a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_email_confirm.cpp
+++++ b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_email_confirm.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_hint.cpp b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_hint.cpp
++index b505ffa..048a849 100644
++--- a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_hint.cpp
+++++ b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_hint.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_input.cpp b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_input.cpp
++index 2986c05..1b9c014 100644
++--- a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_input.cpp
+++++ b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_input.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_login_email.cpp b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_login_email.cpp
++index eccada0..19a1050 100644
++--- a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_login_email.cpp
+++++ b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_login_email.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_login_email_confirm.cpp b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_login_email_confirm.cpp
++index e3213f9..2f379dd 100644
++--- a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_login_email_confirm.cpp
+++++ b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_login_email_confirm.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_manage.cpp b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_manage.cpp
++index 1c6c484..2ef0caa 100644
++--- a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_manage.cpp
+++++ b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_manage.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_start.cpp b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_start.cpp
++index e882a34..b3049df 100644
++--- a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_start.cpp
+++++ b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_start.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_step.cpp b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_step.cpp
++index b9bf6ba..0bdb428 100644
++--- a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_step.cpp
+++++ b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_step.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_validate_icon.cpp b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_validate_icon.cpp
++index d8441c5..375a5bf 100644
++--- a/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_validate_icon.cpp
+++++ b/Telegram/SourceFiles/settings/cloud_password/settings_cloud_password_validate_icon.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_active_sessions.cpp b/Telegram/SourceFiles/settings/settings_active_sessions.cpp
++index c358456..cf4db8c 100644
++--- a/Telegram/SourceFiles/settings/settings_active_sessions.cpp
+++++ b/Telegram/SourceFiles/settings/settings_active_sessions.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_advanced.cpp b/Telegram/SourceFiles/settings/settings_advanced.cpp
++index c541f71..71381f2 100644
++--- a/Telegram/SourceFiles/settings/settings_advanced.cpp
+++++ b/Telegram/SourceFiles/settings/settings_advanced.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_blocked_peers.cpp b/Telegram/SourceFiles/settings/settings_blocked_peers.cpp
++index 3ba6000..ed28dcb 100644
++--- a/Telegram/SourceFiles/settings/settings_blocked_peers.cpp
+++++ b/Telegram/SourceFiles/settings/settings_blocked_peers.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_business.cpp b/Telegram/SourceFiles/settings/settings_business.cpp
++index 384a11f..9fb4c8c 100644
++--- a/Telegram/SourceFiles/settings/settings_business.cpp
+++++ b/Telegram/SourceFiles/settings/settings_business.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_calls.cpp b/Telegram/SourceFiles/settings/settings_calls.cpp
++index d80f394..d2cf3f1 100644
++--- a/Telegram/SourceFiles/settings/settings_calls.cpp
+++++ b/Telegram/SourceFiles/settings/settings_calls.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_chat.cpp b/Telegram/SourceFiles/settings/settings_chat.cpp
++index d375700..3c1519e 100644
++--- a/Telegram/SourceFiles/settings/settings_chat.cpp
+++++ b/Telegram/SourceFiles/settings/settings_chat.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_codes.cpp b/Telegram/SourceFiles/settings/settings_codes.cpp
++index 3ac0239..c644ecf 100644
++--- a/Telegram/SourceFiles/settings/settings_codes.cpp
+++++ b/Telegram/SourceFiles/settings/settings_codes.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_common.cpp b/Telegram/SourceFiles/settings/settings_common.cpp
++index 67ab82a..304ff31 100644
++--- a/Telegram/SourceFiles/settings/settings_common.cpp
+++++ b/Telegram/SourceFiles/settings/settings_common.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_common_session.cpp b/Telegram/SourceFiles/settings/settings_common_session.cpp
++index d72c74d..845e889 100644
++--- a/Telegram/SourceFiles/settings/settings_common_session.cpp
+++++ b/Telegram/SourceFiles/settings/settings_common_session.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_credits.cpp b/Telegram/SourceFiles/settings/settings_credits.cpp
++index 2fd4e11..4d15851 100644
++--- a/Telegram/SourceFiles/settings/settings_credits.cpp
+++++ b/Telegram/SourceFiles/settings/settings_credits.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_credits_graphics.cpp b/Telegram/SourceFiles/settings/settings_credits_graphics.cpp
++index 85f29f0..0c24c2c 100644
++--- a/Telegram/SourceFiles/settings/settings_credits_graphics.cpp
+++++ b/Telegram/SourceFiles/settings/settings_credits_graphics.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_experimental.cpp b/Telegram/SourceFiles/settings/settings_experimental.cpp
++index 7b04129..45cc60e 100644
++--- a/Telegram/SourceFiles/settings/settings_experimental.cpp
+++++ b/Telegram/SourceFiles/settings/settings_experimental.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_folders.cpp b/Telegram/SourceFiles/settings/settings_folders.cpp
++index c8ac855..2e37a5e 100644
++--- a/Telegram/SourceFiles/settings/settings_folders.cpp
+++++ b/Telegram/SourceFiles/settings/settings_folders.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_global_ttl.cpp b/Telegram/SourceFiles/settings/settings_global_ttl.cpp
++index 0e5d338..3302cd8 100644
++--- a/Telegram/SourceFiles/settings/settings_global_ttl.cpp
+++++ b/Telegram/SourceFiles/settings/settings_global_ttl.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_information.cpp b/Telegram/SourceFiles/settings/settings_information.cpp
++index 898673b..93963ff 100644
++--- a/Telegram/SourceFiles/settings/settings_information.cpp
+++++ b/Telegram/SourceFiles/settings/settings_information.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_intro.cpp b/Telegram/SourceFiles/settings/settings_intro.cpp
++index 6ddb33f..865882a 100644
++--- a/Telegram/SourceFiles/settings/settings_intro.cpp
+++++ b/Telegram/SourceFiles/settings/settings_intro.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_local_passcode.cpp b/Telegram/SourceFiles/settings/settings_local_passcode.cpp
++index 3bab6d2..5c08a07 100644
++--- a/Telegram/SourceFiles/settings/settings_local_passcode.cpp
+++++ b/Telegram/SourceFiles/settings/settings_local_passcode.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_main.cpp b/Telegram/SourceFiles/settings/settings_main.cpp
++index 0320235..fae185e 100644
++--- a/Telegram/SourceFiles/settings/settings_main.cpp
+++++ b/Telegram/SourceFiles/settings/settings_main.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_notifications.cpp b/Telegram/SourceFiles/settings/settings_notifications.cpp
++index e0ca4c1..b003ff1 100644
++--- a/Telegram/SourceFiles/settings/settings_notifications.cpp
+++++ b/Telegram/SourceFiles/settings/settings_notifications.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_notifications_type.cpp b/Telegram/SourceFiles/settings/settings_notifications_type.cpp
++index 4f3f9e9..193c374 100644
++--- a/Telegram/SourceFiles/settings/settings_notifications_type.cpp
+++++ b/Telegram/SourceFiles/settings/settings_notifications_type.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_power_saving.cpp b/Telegram/SourceFiles/settings/settings_power_saving.cpp
++index 6c4e776..7b59064 100644
++--- a/Telegram/SourceFiles/settings/settings_power_saving.cpp
+++++ b/Telegram/SourceFiles/settings/settings_power_saving.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_premium.cpp b/Telegram/SourceFiles/settings/settings_premium.cpp
++index c1f8f49..242c05a 100644
++--- a/Telegram/SourceFiles/settings/settings_premium.cpp
+++++ b/Telegram/SourceFiles/settings/settings_premium.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_privacy_controllers.cpp b/Telegram/SourceFiles/settings/settings_privacy_controllers.cpp
++index 5ce93e0..26f04a1 100644
++--- a/Telegram/SourceFiles/settings/settings_privacy_controllers.cpp
+++++ b/Telegram/SourceFiles/settings/settings_privacy_controllers.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_privacy_security.cpp b/Telegram/SourceFiles/settings/settings_privacy_security.cpp
++index 57e794d..9aa847a 100644
++--- a/Telegram/SourceFiles/settings/settings_privacy_security.cpp
+++++ b/Telegram/SourceFiles/settings/settings_privacy_security.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_scale_preview.cpp b/Telegram/SourceFiles/settings/settings_scale_preview.cpp
++index d42007a..97d7173 100644
++--- a/Telegram/SourceFiles/settings/settings_scale_preview.cpp
+++++ b/Telegram/SourceFiles/settings/settings_scale_preview.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_shortcuts.cpp b/Telegram/SourceFiles/settings/settings_shortcuts.cpp
++index d65f96b..3bc4f26 100644
++--- a/Telegram/SourceFiles/settings/settings_shortcuts.cpp
+++++ b/Telegram/SourceFiles/settings/settings_shortcuts.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/settings/settings_websites.cpp b/Telegram/SourceFiles/settings/settings_websites.cpp
++index f772945..ffb9751 100644
++--- a/Telegram/SourceFiles/settings/settings_websites.cpp
+++++ b/Telegram/SourceFiles/settings/settings_websites.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/statistics/chart_lines_filter_controller.cpp b/Telegram/SourceFiles/statistics/chart_lines_filter_controller.cpp
++index 40c3b61..64e6989 100644
++--- a/Telegram/SourceFiles/statistics/chart_lines_filter_controller.cpp
+++++ b/Telegram/SourceFiles/statistics/chart_lines_filter_controller.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/statistics/chart_rulers_data.cpp b/Telegram/SourceFiles/statistics/chart_rulers_data.cpp
++index c559a23..83a5749 100644
++--- a/Telegram/SourceFiles/statistics/chart_rulers_data.cpp
+++++ b/Telegram/SourceFiles/statistics/chart_rulers_data.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/statistics/chart_widget.cpp b/Telegram/SourceFiles/statistics/chart_widget.cpp
++index 7123b18..bf2da63 100644
++--- a/Telegram/SourceFiles/statistics/chart_widget.cpp
+++++ b/Telegram/SourceFiles/statistics/chart_widget.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/statistics/segment_tree.cpp b/Telegram/SourceFiles/statistics/segment_tree.cpp
++index 51c2082..fc20559 100644
++--- a/Telegram/SourceFiles/statistics/segment_tree.cpp
+++++ b/Telegram/SourceFiles/statistics/segment_tree.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/statistics/statistics_data_deserialize.cpp b/Telegram/SourceFiles/statistics/statistics_data_deserialize.cpp
++index 10a77ad..a8fa471 100644
++--- a/Telegram/SourceFiles/statistics/statistics_data_deserialize.cpp
+++++ b/Telegram/SourceFiles/statistics/statistics_data_deserialize.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/statistics/statistics_format_values.cpp b/Telegram/SourceFiles/statistics/statistics_format_values.cpp
++index da20e1a..b43ea6b 100644
++--- a/Telegram/SourceFiles/statistics/statistics_format_values.cpp
+++++ b/Telegram/SourceFiles/statistics/statistics_format_values.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/statistics/statistics_graphics.cpp b/Telegram/SourceFiles/statistics/statistics_graphics.cpp
++index 167082a..785da62 100644
++--- a/Telegram/SourceFiles/statistics/statistics_graphics.cpp
+++++ b/Telegram/SourceFiles/statistics/statistics_graphics.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/statistics/view/abstract_chart_view.cpp b/Telegram/SourceFiles/statistics/view/abstract_chart_view.cpp
++index 4b5f292..f297afa 100644
++--- a/Telegram/SourceFiles/statistics/view/abstract_chart_view.cpp
+++++ b/Telegram/SourceFiles/statistics/view/abstract_chart_view.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/statistics/view/bar_chart_view.cpp b/Telegram/SourceFiles/statistics/view/bar_chart_view.cpp
++index f796e02..91031ad 100644
++--- a/Telegram/SourceFiles/statistics/view/bar_chart_view.cpp
+++++ b/Telegram/SourceFiles/statistics/view/bar_chart_view.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/statistics/view/chart_rulers_view.cpp b/Telegram/SourceFiles/statistics/view/chart_rulers_view.cpp
++index 9034ed1..dbf6b5e 100644
++--- a/Telegram/SourceFiles/statistics/view/chart_rulers_view.cpp
+++++ b/Telegram/SourceFiles/statistics/view/chart_rulers_view.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/statistics/view/chart_view_factory.cpp b/Telegram/SourceFiles/statistics/view/chart_view_factory.cpp
++index 789369d..a399d80 100644
++--- a/Telegram/SourceFiles/statistics/view/chart_view_factory.cpp
+++++ b/Telegram/SourceFiles/statistics/view/chart_view_factory.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/statistics/view/linear_chart_view.cpp b/Telegram/SourceFiles/statistics/view/linear_chart_view.cpp
++index a13067a..e021072 100644
++--- a/Telegram/SourceFiles/statistics/view/linear_chart_view.cpp
+++++ b/Telegram/SourceFiles/statistics/view/linear_chart_view.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/statistics/view/stack_chart_common.cpp b/Telegram/SourceFiles/statistics/view/stack_chart_common.cpp
++index 82a1143..d0240f3 100644
++--- a/Telegram/SourceFiles/statistics/view/stack_chart_common.cpp
+++++ b/Telegram/SourceFiles/statistics/view/stack_chart_common.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/statistics/view/stack_linear_chart_common.cpp b/Telegram/SourceFiles/statistics/view/stack_linear_chart_common.cpp
++index 50b8628..028e7f3 100644
++--- a/Telegram/SourceFiles/statistics/view/stack_linear_chart_common.cpp
+++++ b/Telegram/SourceFiles/statistics/view/stack_linear_chart_common.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/statistics/view/stack_linear_chart_view.cpp b/Telegram/SourceFiles/statistics/view/stack_linear_chart_view.cpp
++index a4e4a7c..a20f7f1 100644
++--- a/Telegram/SourceFiles/statistics/view/stack_linear_chart_view.cpp
+++++ b/Telegram/SourceFiles/statistics/view/stack_linear_chart_view.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/statistics/widgets/chart_header_widget.cpp b/Telegram/SourceFiles/statistics/widgets/chart_header_widget.cpp
++index b8754ce..5a8f9dd 100644
++--- a/Telegram/SourceFiles/statistics/widgets/chart_header_widget.cpp
+++++ b/Telegram/SourceFiles/statistics/widgets/chart_header_widget.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/statistics/widgets/chart_lines_filter_widget.cpp b/Telegram/SourceFiles/statistics/widgets/chart_lines_filter_widget.cpp
++index a6dfa45..bf56d7d 100644
++--- a/Telegram/SourceFiles/statistics/widgets/chart_lines_filter_widget.cpp
+++++ b/Telegram/SourceFiles/statistics/widgets/chart_lines_filter_widget.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/statistics/widgets/point_details_widget.cpp b/Telegram/SourceFiles/statistics/widgets/point_details_widget.cpp
++index b5e7daa..4a1a5d8 100644
++--- a/Telegram/SourceFiles/statistics/widgets/point_details_widget.cpp
+++++ b/Telegram/SourceFiles/statistics/widgets/point_details_widget.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/details/storage_file_utilities.cpp b/Telegram/SourceFiles/storage/details/storage_file_utilities.cpp
++index b433848..cd4f464 100644
++--- a/Telegram/SourceFiles/storage/details/storage_file_utilities.cpp
+++++ b/Telegram/SourceFiles/storage/details/storage_file_utilities.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/details/storage_settings_scheme.cpp b/Telegram/SourceFiles/storage/details/storage_settings_scheme.cpp
++index ebef828..abbab87 100644
++--- a/Telegram/SourceFiles/storage/details/storage_settings_scheme.cpp
+++++ b/Telegram/SourceFiles/storage/details/storage_settings_scheme.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/download_manager_mtproto.cpp b/Telegram/SourceFiles/storage/download_manager_mtproto.cpp
++index b74eb77..ad6befe 100644
++--- a/Telegram/SourceFiles/storage/download_manager_mtproto.cpp
+++++ b/Telegram/SourceFiles/storage/download_manager_mtproto.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/file_download.cpp b/Telegram/SourceFiles/storage/file_download.cpp
++index 3cd4222..7a3bb15 100644
++--- a/Telegram/SourceFiles/storage/file_download.cpp
+++++ b/Telegram/SourceFiles/storage/file_download.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/file_download_mtproto.cpp b/Telegram/SourceFiles/storage/file_download_mtproto.cpp
++index 18c4ca3..37c85d7 100644
++--- a/Telegram/SourceFiles/storage/file_download_mtproto.cpp
+++++ b/Telegram/SourceFiles/storage/file_download_mtproto.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/file_download_web.cpp b/Telegram/SourceFiles/storage/file_download_web.cpp
++index ddac1f8..f549634 100644
++--- a/Telegram/SourceFiles/storage/file_download_web.cpp
+++++ b/Telegram/SourceFiles/storage/file_download_web.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/file_upload.cpp b/Telegram/SourceFiles/storage/file_upload.cpp
++index 39be04d..59d87f0 100644
++--- a/Telegram/SourceFiles/storage/file_upload.cpp
+++++ b/Telegram/SourceFiles/storage/file_upload.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/localimageloader.cpp b/Telegram/SourceFiles/storage/localimageloader.cpp
++index 8603cd7..dae06c2 100644
++--- a/Telegram/SourceFiles/storage/localimageloader.cpp
+++++ b/Telegram/SourceFiles/storage/localimageloader.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/localstorage.cpp b/Telegram/SourceFiles/storage/localstorage.cpp
++index 2958024..f7c7737 100644
++--- a/Telegram/SourceFiles/storage/localstorage.cpp
+++++ b/Telegram/SourceFiles/storage/localstorage.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/serialize_common.cpp b/Telegram/SourceFiles/storage/serialize_common.cpp
++index 3267ee1..8484601 100644
++--- a/Telegram/SourceFiles/storage/serialize_common.cpp
+++++ b/Telegram/SourceFiles/storage/serialize_common.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/serialize_document.cpp b/Telegram/SourceFiles/storage/serialize_document.cpp
++index 89b335c..3960312 100644
++--- a/Telegram/SourceFiles/storage/serialize_document.cpp
+++++ b/Telegram/SourceFiles/storage/serialize_document.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/serialize_peer.cpp b/Telegram/SourceFiles/storage/serialize_peer.cpp
++index 96e9dae..fcd1493 100644
++--- a/Telegram/SourceFiles/storage/serialize_peer.cpp
+++++ b/Telegram/SourceFiles/storage/serialize_peer.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/storage_account.cpp b/Telegram/SourceFiles/storage/storage_account.cpp
++index e39e6ba..9006c11 100644
++--- a/Telegram/SourceFiles/storage/storage_account.cpp
+++++ b/Telegram/SourceFiles/storage/storage_account.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/storage_cloud_blob.cpp b/Telegram/SourceFiles/storage/storage_cloud_blob.cpp
++index d3c4546..48fec1a 100644
++--- a/Telegram/SourceFiles/storage/storage_cloud_blob.cpp
+++++ b/Telegram/SourceFiles/storage/storage_cloud_blob.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/storage_domain.cpp b/Telegram/SourceFiles/storage/storage_domain.cpp
++index c46594f..f46119b 100644
++--- a/Telegram/SourceFiles/storage/storage_domain.cpp
+++++ b/Telegram/SourceFiles/storage/storage_domain.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/storage_facade.cpp b/Telegram/SourceFiles/storage/storage_facade.cpp
++index dfd4429..e30ac28 100644
++--- a/Telegram/SourceFiles/storage/storage_facade.cpp
+++++ b/Telegram/SourceFiles/storage/storage_facade.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/storage_file_lock_posix.cpp b/Telegram/SourceFiles/storage/storage_file_lock_posix.cpp
++index c198e4c..d6aa515 100644
++--- a/Telegram/SourceFiles/storage/storage_file_lock_posix.cpp
+++++ b/Telegram/SourceFiles/storage/storage_file_lock_posix.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/storage_file_lock_win.cpp b/Telegram/SourceFiles/storage/storage_file_lock_win.cpp
++index 84ada93..5c6632a 100644
++--- a/Telegram/SourceFiles/storage/storage_file_lock_win.cpp
+++++ b/Telegram/SourceFiles/storage/storage_file_lock_win.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/storage_media_prepare.cpp b/Telegram/SourceFiles/storage/storage_media_prepare.cpp
++index 588d901..41b42d9 100644
++--- a/Telegram/SourceFiles/storage/storage_media_prepare.cpp
+++++ b/Telegram/SourceFiles/storage/storage_media_prepare.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/storage_shared_media.cpp b/Telegram/SourceFiles/storage/storage_shared_media.cpp
++index 89ce8f6..3889cbf 100644
++--- a/Telegram/SourceFiles/storage/storage_shared_media.cpp
+++++ b/Telegram/SourceFiles/storage/storage_shared_media.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/storage_sparse_ids_list.cpp b/Telegram/SourceFiles/storage/storage_sparse_ids_list.cpp
++index 33ea5ec..ef49ac4 100644
++--- a/Telegram/SourceFiles/storage/storage_sparse_ids_list.cpp
+++++ b/Telegram/SourceFiles/storage/storage_sparse_ids_list.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/storage_user_photos.cpp b/Telegram/SourceFiles/storage/storage_user_photos.cpp
++index 5ecb6bc..c31a3fd 100644
++--- a/Telegram/SourceFiles/storage/storage_user_photos.cpp
+++++ b/Telegram/SourceFiles/storage/storage_user_photos.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/storage/streamed_file_downloader.cpp b/Telegram/SourceFiles/storage/streamed_file_downloader.cpp
++index 990e0fd..f03be3c 100644
++--- a/Telegram/SourceFiles/storage/streamed_file_downloader.cpp
+++++ b/Telegram/SourceFiles/storage/streamed_file_downloader.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/support/support_autocomplete.cpp b/Telegram/SourceFiles/support/support_autocomplete.cpp
++index 8122a47..0ff7645 100644
++--- a/Telegram/SourceFiles/support/support_autocomplete.cpp
+++++ b/Telegram/SourceFiles/support/support_autocomplete.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/support/support_common.cpp b/Telegram/SourceFiles/support/support_common.cpp
++index 797d735..b5fdc79 100644
++--- a/Telegram/SourceFiles/support/support_common.cpp
+++++ b/Telegram/SourceFiles/support/support_common.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/support/support_helper.cpp b/Telegram/SourceFiles/support/support_helper.cpp
++index 1119d19..1a0f724 100644
++--- a/Telegram/SourceFiles/support/support_helper.cpp
+++++ b/Telegram/SourceFiles/support/support_helper.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/support/support_preload.cpp b/Telegram/SourceFiles/support/support_preload.cpp
++index 046bc91..04587f2 100644
++--- a/Telegram/SourceFiles/support/support_preload.cpp
+++++ b/Telegram/SourceFiles/support/support_preload.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/support/support_templates.cpp b/Telegram/SourceFiles/support/support_templates.cpp
++index cb1515e..f682c5d 100644
++--- a/Telegram/SourceFiles/support/support_templates.cpp
+++++ b/Telegram/SourceFiles/support/support_templates.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/tde2e/tde2e_integration.cpp b/Telegram/SourceFiles/tde2e/tde2e_integration.cpp
++index 3f63917..03a150d 100644
++--- a/Telegram/SourceFiles/tde2e/tde2e_integration.cpp
+++++ b/Telegram/SourceFiles/tde2e/tde2e_integration.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/tray.cpp b/Telegram/SourceFiles/tray.cpp
++index 235bf06..98e5c43 100644
++--- a/Telegram/SourceFiles/tray.cpp
+++++ b/Telegram/SourceFiles/tray.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/boxes/auto_delete_settings.cpp b/Telegram/SourceFiles/ui/boxes/auto_delete_settings.cpp
++index 33be631..7ea2182 100644
++--- a/Telegram/SourceFiles/ui/boxes/auto_delete_settings.cpp
+++++ b/Telegram/SourceFiles/ui/boxes/auto_delete_settings.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/boxes/boost_box.cpp b/Telegram/SourceFiles/ui/boxes/boost_box.cpp
++index 6dab099..916bcbc 100644
++--- a/Telegram/SourceFiles/ui/boxes/boost_box.cpp
+++++ b/Telegram/SourceFiles/ui/boxes/boost_box.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/boxes/calendar_box.cpp b/Telegram/SourceFiles/ui/boxes/calendar_box.cpp
++index f8e91fb..ff08681 100644
++--- a/Telegram/SourceFiles/ui/boxes/calendar_box.cpp
+++++ b/Telegram/SourceFiles/ui/boxes/calendar_box.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/boxes/choose_date_time.cpp b/Telegram/SourceFiles/ui/boxes/choose_date_time.cpp
++index 0dfc516..00e3cbd 100644
++--- a/Telegram/SourceFiles/ui/boxes/choose_date_time.cpp
+++++ b/Telegram/SourceFiles/ui/boxes/choose_date_time.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp b/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp
++index a891c42..ab14ee1 100644
++--- a/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp
+++++ b/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/boxes/choose_language_box.cpp b/Telegram/SourceFiles/ui/boxes/choose_language_box.cpp
++index ef7604f..8292c87 100644
++--- a/Telegram/SourceFiles/ui/boxes/choose_language_box.cpp
+++++ b/Telegram/SourceFiles/ui/boxes/choose_language_box.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/boxes/choose_time.cpp b/Telegram/SourceFiles/ui/boxes/choose_time.cpp
++index ba2bdba..e768380 100644
++--- a/Telegram/SourceFiles/ui/boxes/choose_time.cpp
+++++ b/Telegram/SourceFiles/ui/boxes/choose_time.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/boxes/collectible_info_box.cpp b/Telegram/SourceFiles/ui/boxes/collectible_info_box.cpp
++index f9c24ef..129147c 100644
++--- a/Telegram/SourceFiles/ui/boxes/collectible_info_box.cpp
+++++ b/Telegram/SourceFiles/ui/boxes/collectible_info_box.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/boxes/confirm_box.cpp b/Telegram/SourceFiles/ui/boxes/confirm_box.cpp
++index 6d9f25c..383c4d0 100644
++--- a/Telegram/SourceFiles/ui/boxes/confirm_box.cpp
+++++ b/Telegram/SourceFiles/ui/boxes/confirm_box.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/boxes/confirm_phone_box.cpp b/Telegram/SourceFiles/ui/boxes/confirm_phone_box.cpp
++index e69cd3e..b8692c1 100644
++--- a/Telegram/SourceFiles/ui/boxes/confirm_phone_box.cpp
+++++ b/Telegram/SourceFiles/ui/boxes/confirm_phone_box.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/boxes/country_select_box.cpp b/Telegram/SourceFiles/ui/boxes/country_select_box.cpp
++index bb7cc70..a5be366 100644
++--- a/Telegram/SourceFiles/ui/boxes/country_select_box.cpp
+++++ b/Telegram/SourceFiles/ui/boxes/country_select_box.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/boxes/edit_birthday_box.cpp b/Telegram/SourceFiles/ui/boxes/edit_birthday_box.cpp
++index e217bb1..f46a7c7 100644
++--- a/Telegram/SourceFiles/ui/boxes/edit_birthday_box.cpp
+++++ b/Telegram/SourceFiles/ui/boxes/edit_birthday_box.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/boxes/edit_factcheck_box.cpp b/Telegram/SourceFiles/ui/boxes/edit_factcheck_box.cpp
++index 2c371da..99f443b 100644
++--- a/Telegram/SourceFiles/ui/boxes/edit_factcheck_box.cpp
+++++ b/Telegram/SourceFiles/ui/boxes/edit_factcheck_box.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/boxes/edit_invite_link.cpp b/Telegram/SourceFiles/ui/boxes/edit_invite_link.cpp
++index 4b0bf0c..c1974ab 100644
++--- a/Telegram/SourceFiles/ui/boxes/edit_invite_link.cpp
+++++ b/Telegram/SourceFiles/ui/boxes/edit_invite_link.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/boxes/edit_invite_link_session.cpp b/Telegram/SourceFiles/ui/boxes/edit_invite_link_session.cpp
++index 2f09147..8bbc3c4 100644
++--- a/Telegram/SourceFiles/ui/boxes/edit_invite_link_session.cpp
+++++ b/Telegram/SourceFiles/ui/boxes/edit_invite_link_session.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/boxes/peer_qr_box.cpp b/Telegram/SourceFiles/ui/boxes/peer_qr_box.cpp
++index 37f3913..ce5a787 100644
++--- a/Telegram/SourceFiles/ui/boxes/peer_qr_box.cpp
+++++ b/Telegram/SourceFiles/ui/boxes/peer_qr_box.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/boxes/rate_call_box.cpp b/Telegram/SourceFiles/ui/boxes/rate_call_box.cpp
++index d56889f..95c6295 100644
++--- a/Telegram/SourceFiles/ui/boxes/rate_call_box.cpp
+++++ b/Telegram/SourceFiles/ui/boxes/rate_call_box.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/boxes/report_box_graphics.cpp b/Telegram/SourceFiles/ui/boxes/report_box_graphics.cpp
++index 483e61c..d7c41b3 100644
++--- a/Telegram/SourceFiles/ui/boxes/report_box_graphics.cpp
+++++ b/Telegram/SourceFiles/ui/boxes/report_box_graphics.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/boxes/show_or_premium_box.cpp b/Telegram/SourceFiles/ui/boxes/show_or_premium_box.cpp
++index f99b9ff..06dfdea 100644
++--- a/Telegram/SourceFiles/ui/boxes/show_or_premium_box.cpp
+++++ b/Telegram/SourceFiles/ui/boxes/show_or_premium_box.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/boxes/single_choice_box.cpp b/Telegram/SourceFiles/ui/boxes/single_choice_box.cpp
++index 10303d6..c3b78e2 100644
++--- a/Telegram/SourceFiles/ui/boxes/single_choice_box.cpp
+++++ b/Telegram/SourceFiles/ui/boxes/single_choice_box.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/boxes/time_picker_box.cpp b/Telegram/SourceFiles/ui/boxes/time_picker_box.cpp
++index 0cf0d51..ff53959 100644
++--- a/Telegram/SourceFiles/ui/boxes/time_picker_box.cpp
+++++ b/Telegram/SourceFiles/ui/boxes/time_picker_box.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/cached_round_corners.cpp b/Telegram/SourceFiles/ui/cached_round_corners.cpp
++index 4aba838..84ba334 100644
++--- a/Telegram/SourceFiles/ui/cached_round_corners.cpp
+++++ b/Telegram/SourceFiles/ui/cached_round_corners.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/attach/attach_abstract_single_file_preview.cpp b/Telegram/SourceFiles/ui/chat/attach/attach_abstract_single_file_preview.cpp
++index 78148f8..ddc3358 100644
++--- a/Telegram/SourceFiles/ui/chat/attach/attach_abstract_single_file_preview.cpp
+++++ b/Telegram/SourceFiles/ui/chat/attach/attach_abstract_single_file_preview.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/attach/attach_abstract_single_media_preview.cpp b/Telegram/SourceFiles/ui/chat/attach/attach_abstract_single_media_preview.cpp
++index 0d57e74..0b49b4c 100644
++--- a/Telegram/SourceFiles/ui/chat/attach/attach_abstract_single_media_preview.cpp
+++++ b/Telegram/SourceFiles/ui/chat/attach/attach_abstract_single_media_preview.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/attach/attach_album_preview.cpp b/Telegram/SourceFiles/ui/chat/attach/attach_album_preview.cpp
++index 2843141..446de73 100644
++--- a/Telegram/SourceFiles/ui/chat/attach/attach_album_preview.cpp
+++++ b/Telegram/SourceFiles/ui/chat/attach/attach_album_preview.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/attach/attach_album_thumbnail.cpp b/Telegram/SourceFiles/ui/chat/attach/attach_album_thumbnail.cpp
++index 562ae2d..38b475a 100644
++--- a/Telegram/SourceFiles/ui/chat/attach/attach_album_thumbnail.cpp
+++++ b/Telegram/SourceFiles/ui/chat/attach/attach_album_thumbnail.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/attach/attach_bot_downloads.cpp b/Telegram/SourceFiles/ui/chat/attach/attach_bot_downloads.cpp
++index 5f6fe43..58aedbd 100644
++--- a/Telegram/SourceFiles/ui/chat/attach/attach_bot_downloads.cpp
+++++ b/Telegram/SourceFiles/ui/chat/attach/attach_bot_downloads.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/attach/attach_bot_webview.cpp b/Telegram/SourceFiles/ui/chat/attach/attach_bot_webview.cpp
++index 5bc6481..c4d458f 100644
++--- a/Telegram/SourceFiles/ui/chat/attach/attach_bot_webview.cpp
+++++ b/Telegram/SourceFiles/ui/chat/attach/attach_bot_webview.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/attach/attach_controls.cpp b/Telegram/SourceFiles/ui/chat/attach/attach_controls.cpp
++index 775218a..048e78b 100644
++--- a/Telegram/SourceFiles/ui/chat/attach/attach_controls.cpp
+++++ b/Telegram/SourceFiles/ui/chat/attach/attach_controls.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/attach/attach_extensions.cpp b/Telegram/SourceFiles/ui/chat/attach/attach_extensions.cpp
++index d88b31c..8d9ba75 100644
++--- a/Telegram/SourceFiles/ui/chat/attach/attach_extensions.cpp
+++++ b/Telegram/SourceFiles/ui/chat/attach/attach_extensions.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/attach/attach_item_single_file_preview.cpp b/Telegram/SourceFiles/ui/chat/attach/attach_item_single_file_preview.cpp
++index 1c235c9..231c78f 100644
++--- a/Telegram/SourceFiles/ui/chat/attach/attach_item_single_file_preview.cpp
+++++ b/Telegram/SourceFiles/ui/chat/attach/attach_item_single_file_preview.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/attach/attach_item_single_media_preview.cpp b/Telegram/SourceFiles/ui/chat/attach/attach_item_single_media_preview.cpp
++index 02f3c92..7dd39cc 100644
++--- a/Telegram/SourceFiles/ui/chat/attach/attach_item_single_media_preview.cpp
+++++ b/Telegram/SourceFiles/ui/chat/attach/attach_item_single_media_preview.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/attach/attach_prepare.cpp b/Telegram/SourceFiles/ui/chat/attach/attach_prepare.cpp
++index fb96860..4ca9e28 100644
++--- a/Telegram/SourceFiles/ui/chat/attach/attach_prepare.cpp
+++++ b/Telegram/SourceFiles/ui/chat/attach/attach_prepare.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/attach/attach_send_files_way.cpp b/Telegram/SourceFiles/ui/chat/attach/attach_send_files_way.cpp
++index 13f2f08..79c76bb 100644
++--- a/Telegram/SourceFiles/ui/chat/attach/attach_send_files_way.cpp
+++++ b/Telegram/SourceFiles/ui/chat/attach/attach_send_files_way.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/attach/attach_single_file_preview.cpp b/Telegram/SourceFiles/ui/chat/attach/attach_single_file_preview.cpp
++index 344b30d..0cc182b 100644
++--- a/Telegram/SourceFiles/ui/chat/attach/attach_single_file_preview.cpp
+++++ b/Telegram/SourceFiles/ui/chat/attach/attach_single_file_preview.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/attach/attach_single_media_preview.cpp b/Telegram/SourceFiles/ui/chat/attach/attach_single_media_preview.cpp
++index 7f039e3..2440036 100644
++--- a/Telegram/SourceFiles/ui/chat/attach/attach_single_media_preview.cpp
+++++ b/Telegram/SourceFiles/ui/chat/attach/attach_single_media_preview.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/chat_style.cpp b/Telegram/SourceFiles/ui/chat/chat_style.cpp
++index 7929c9c..ed28b95 100644
++--- a/Telegram/SourceFiles/ui/chat/chat_style.cpp
+++++ b/Telegram/SourceFiles/ui/chat/chat_style.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/chat_style_radius.cpp b/Telegram/SourceFiles/ui/chat/chat_style_radius.cpp
++index 0d54394..e722593 100644
++--- a/Telegram/SourceFiles/ui/chat/chat_style_radius.cpp
+++++ b/Telegram/SourceFiles/ui/chat/chat_style_radius.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/chat_theme.cpp b/Telegram/SourceFiles/ui/chat/chat_theme.cpp
++index 0d1424d..a9c3016 100644
++--- a/Telegram/SourceFiles/ui/chat/chat_theme.cpp
+++++ b/Telegram/SourceFiles/ui/chat/chat_theme.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/chats_filter_tag.cpp b/Telegram/SourceFiles/ui/chat/chats_filter_tag.cpp
++index 020ffa4..db508f9 100644
++--- a/Telegram/SourceFiles/ui/chat/chats_filter_tag.cpp
+++++ b/Telegram/SourceFiles/ui/chat/chats_filter_tag.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/choose_send_as.cpp b/Telegram/SourceFiles/ui/chat/choose_send_as.cpp
++index be0fa56..689684a 100644
++--- a/Telegram/SourceFiles/ui/chat/choose_send_as.cpp
+++++ b/Telegram/SourceFiles/ui/chat/choose_send_as.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/choose_theme_controller.cpp b/Telegram/SourceFiles/ui/chat/choose_theme_controller.cpp
++index ee929cf..4b67675 100644
++--- a/Telegram/SourceFiles/ui/chat/choose_theme_controller.cpp
+++++ b/Telegram/SourceFiles/ui/chat/choose_theme_controller.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/continuous_scroll.cpp b/Telegram/SourceFiles/ui/chat/continuous_scroll.cpp
++index dbaf551..95f0617 100644
++--- a/Telegram/SourceFiles/ui/chat/continuous_scroll.cpp
+++++ b/Telegram/SourceFiles/ui/chat/continuous_scroll.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/forward_options_box.cpp b/Telegram/SourceFiles/ui/chat/forward_options_box.cpp
++index 0f3ed64..1edbd56 100644
++--- a/Telegram/SourceFiles/ui/chat/forward_options_box.cpp
+++++ b/Telegram/SourceFiles/ui/chat/forward_options_box.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/group_call_bar.cpp b/Telegram/SourceFiles/ui/chat/group_call_bar.cpp
++index 239028b..ef3183d 100644
++--- a/Telegram/SourceFiles/ui/chat/group_call_bar.cpp
+++++ b/Telegram/SourceFiles/ui/chat/group_call_bar.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/group_call_userpics.cpp b/Telegram/SourceFiles/ui/chat/group_call_userpics.cpp
++index f415151..7de5692 100644
++--- a/Telegram/SourceFiles/ui/chat/group_call_userpics.cpp
+++++ b/Telegram/SourceFiles/ui/chat/group_call_userpics.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/message_bar.cpp b/Telegram/SourceFiles/ui/chat/message_bar.cpp
++index 7699445..f58d9b2 100644
++--- a/Telegram/SourceFiles/ui/chat/message_bar.cpp
+++++ b/Telegram/SourceFiles/ui/chat/message_bar.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/message_bubble.cpp b/Telegram/SourceFiles/ui/chat/message_bubble.cpp
++index 8d398e5..b692181 100644
++--- a/Telegram/SourceFiles/ui/chat/message_bubble.cpp
+++++ b/Telegram/SourceFiles/ui/chat/message_bubble.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/more_chats_bar.cpp b/Telegram/SourceFiles/ui/chat/more_chats_bar.cpp
++index d78a606..f6e8a37 100644
++--- a/Telegram/SourceFiles/ui/chat/more_chats_bar.cpp
+++++ b/Telegram/SourceFiles/ui/chat/more_chats_bar.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/pinned_bar.cpp b/Telegram/SourceFiles/ui/chat/pinned_bar.cpp
++index eb2cf01..84fc37a 100644
++--- a/Telegram/SourceFiles/ui/chat/pinned_bar.cpp
+++++ b/Telegram/SourceFiles/ui/chat/pinned_bar.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/requests_bar.cpp b/Telegram/SourceFiles/ui/chat/requests_bar.cpp
++index c8841f5..d4d23d3 100644
++--- a/Telegram/SourceFiles/ui/chat/requests_bar.cpp
+++++ b/Telegram/SourceFiles/ui/chat/requests_bar.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/chat/sponsored_message_bar.cpp b/Telegram/SourceFiles/ui/chat/sponsored_message_bar.cpp
++index 4cd3ca1..764db1a 100644
++--- a/Telegram/SourceFiles/ui/chat/sponsored_message_bar.cpp
+++++ b/Telegram/SourceFiles/ui/chat/sponsored_message_bar.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/color_contrast.cpp b/Telegram/SourceFiles/ui/color_contrast.cpp
++index ea3f9d0..3d68ce1 100644
++--- a/Telegram/SourceFiles/ui/color_contrast.cpp
+++++ b/Telegram/SourceFiles/ui/color_contrast.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/color_int_conversion.cpp b/Telegram/SourceFiles/ui/color_int_conversion.cpp
++index b5df1c1..3456949 100644
++--- a/Telegram/SourceFiles/ui/color_int_conversion.cpp
+++++ b/Telegram/SourceFiles/ui/color_int_conversion.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/button_labels.cpp b/Telegram/SourceFiles/ui/controls/button_labels.cpp
++index 8a3f978..44cc9f5 100644
++--- a/Telegram/SourceFiles/ui/controls/button_labels.cpp
+++++ b/Telegram/SourceFiles/ui/controls/button_labels.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/call_mute_button.cpp b/Telegram/SourceFiles/ui/controls/call_mute_button.cpp
++index 34f2650..f43887d 100644
++--- a/Telegram/SourceFiles/ui/controls/call_mute_button.cpp
+++++ b/Telegram/SourceFiles/ui/controls/call_mute_button.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/chat_service_checkbox.cpp b/Telegram/SourceFiles/ui/controls/chat_service_checkbox.cpp
++index b8e80c5..3f8d591 100644
++--- a/Telegram/SourceFiles/ui/controls/chat_service_checkbox.cpp
+++++ b/Telegram/SourceFiles/ui/controls/chat_service_checkbox.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/delete_message_context_action.cpp b/Telegram/SourceFiles/ui/controls/delete_message_context_action.cpp
++index 2c4bca9..e61d8ce 100644
++--- a/Telegram/SourceFiles/ui/controls/delete_message_context_action.cpp
+++++ b/Telegram/SourceFiles/ui/controls/delete_message_context_action.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/download_bar.cpp b/Telegram/SourceFiles/ui/controls/download_bar.cpp
++index 3b3db11..ef487c6 100644
++--- a/Telegram/SourceFiles/ui/controls/download_bar.cpp
+++++ b/Telegram/SourceFiles/ui/controls/download_bar.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/emoji_button.cpp b/Telegram/SourceFiles/ui/controls/emoji_button.cpp
++index b2656f5..ae9a330 100644
++--- a/Telegram/SourceFiles/ui/controls/emoji_button.cpp
+++++ b/Telegram/SourceFiles/ui/controls/emoji_button.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/emoji_button_factory.cpp b/Telegram/SourceFiles/ui/controls/emoji_button_factory.cpp
++index a62c244..877e00a 100644
++--- a/Telegram/SourceFiles/ui/controls/emoji_button_factory.cpp
+++++ b/Telegram/SourceFiles/ui/controls/emoji_button_factory.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/filter_link_header.cpp b/Telegram/SourceFiles/ui/controls/filter_link_header.cpp
++index e6a02ef..3368a0b 100644
++--- a/Telegram/SourceFiles/ui/controls/filter_link_header.cpp
+++++ b/Telegram/SourceFiles/ui/controls/filter_link_header.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/invite_link_buttons.cpp b/Telegram/SourceFiles/ui/controls/invite_link_buttons.cpp
++index ac13cab..1ca100b 100644
++--- a/Telegram/SourceFiles/ui/controls/invite_link_buttons.cpp
+++++ b/Telegram/SourceFiles/ui/controls/invite_link_buttons.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/invite_link_label.cpp b/Telegram/SourceFiles/ui/controls/invite_link_label.cpp
++index 80d58be..9719075 100644
++--- a/Telegram/SourceFiles/ui/controls/invite_link_label.cpp
+++++ b/Telegram/SourceFiles/ui/controls/invite_link_label.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/jump_down_button.cpp b/Telegram/SourceFiles/ui/controls/jump_down_button.cpp
++index aded3fc..1916ccf 100644
++--- a/Telegram/SourceFiles/ui/controls/jump_down_button.cpp
+++++ b/Telegram/SourceFiles/ui/controls/jump_down_button.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/location_picker.cpp b/Telegram/SourceFiles/ui/controls/location_picker.cpp
++index 1ce6823..2379acf 100644
++--- a/Telegram/SourceFiles/ui/controls/location_picker.cpp
+++++ b/Telegram/SourceFiles/ui/controls/location_picker.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/peer_list_dummy.cpp b/Telegram/SourceFiles/ui/controls/peer_list_dummy.cpp
++index 6146afd..6fccdf6 100644
++--- a/Telegram/SourceFiles/ui/controls/peer_list_dummy.cpp
+++++ b/Telegram/SourceFiles/ui/controls/peer_list_dummy.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/round_video_recorder.cpp b/Telegram/SourceFiles/ui/controls/round_video_recorder.cpp
++index 36a03c6..72a8f4f 100644
++--- a/Telegram/SourceFiles/ui/controls/round_video_recorder.cpp
+++++ b/Telegram/SourceFiles/ui/controls/round_video_recorder.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/send_as_button.cpp b/Telegram/SourceFiles/ui/controls/send_as_button.cpp
++index 2ffbe77..c713ff3 100644
++--- a/Telegram/SourceFiles/ui/controls/send_as_button.cpp
+++++ b/Telegram/SourceFiles/ui/controls/send_as_button.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/send_button.cpp b/Telegram/SourceFiles/ui/controls/send_button.cpp
++index b02bf1c..8b971b9 100644
++--- a/Telegram/SourceFiles/ui/controls/send_button.cpp
+++++ b/Telegram/SourceFiles/ui/controls/send_button.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/silent_toggle.cpp b/Telegram/SourceFiles/ui/controls/silent_toggle.cpp
++index 5fb1f46..6e7827b 100644
++--- a/Telegram/SourceFiles/ui/controls/silent_toggle.cpp
+++++ b/Telegram/SourceFiles/ui/controls/silent_toggle.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/stars_rating.cpp b/Telegram/SourceFiles/ui/controls/stars_rating.cpp
++index 16a211a..8ab0903 100644
++--- a/Telegram/SourceFiles/ui/controls/stars_rating.cpp
+++++ b/Telegram/SourceFiles/ui/controls/stars_rating.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/sub_tabs.cpp b/Telegram/SourceFiles/ui/controls/sub_tabs.cpp
++index e5c6e61..dc520b6 100644
++--- a/Telegram/SourceFiles/ui/controls/sub_tabs.cpp
+++++ b/Telegram/SourceFiles/ui/controls/sub_tabs.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/subsection_tabs_slider.cpp b/Telegram/SourceFiles/ui/controls/subsection_tabs_slider.cpp
++index 42b0830..ece4878 100644
++--- a/Telegram/SourceFiles/ui/controls/subsection_tabs_slider.cpp
+++++ b/Telegram/SourceFiles/ui/controls/subsection_tabs_slider.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/swipe_handler.cpp b/Telegram/SourceFiles/ui/controls/swipe_handler.cpp
++index b39afc3..0423cd0 100644
++--- a/Telegram/SourceFiles/ui/controls/swipe_handler.cpp
+++++ b/Telegram/SourceFiles/ui/controls/swipe_handler.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/tabbed_search.cpp b/Telegram/SourceFiles/ui/controls/tabbed_search.cpp
++index ea9f1e7..6942995 100644
++--- a/Telegram/SourceFiles/ui/controls/tabbed_search.cpp
+++++ b/Telegram/SourceFiles/ui/controls/tabbed_search.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/ton_common.cpp b/Telegram/SourceFiles/ui/controls/ton_common.cpp
++index 4f66b4b..9722434 100644
++--- a/Telegram/SourceFiles/ui/controls/ton_common.cpp
+++++ b/Telegram/SourceFiles/ui/controls/ton_common.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/userpic_button.cpp b/Telegram/SourceFiles/ui/controls/userpic_button.cpp
++index ad0402e..f461509 100644
++--- a/Telegram/SourceFiles/ui/controls/userpic_button.cpp
+++++ b/Telegram/SourceFiles/ui/controls/userpic_button.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h" 
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/who_reacted_context_action.cpp b/Telegram/SourceFiles/ui/controls/who_reacted_context_action.cpp
++index 3fe2363..4e0d97b 100644
++--- a/Telegram/SourceFiles/ui/controls/who_reacted_context_action.cpp
+++++ b/Telegram/SourceFiles/ui/controls/who_reacted_context_action.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/window_outdated_bar.cpp b/Telegram/SourceFiles/ui/controls/window_outdated_bar.cpp
++index 69c38d0..bba6d9d 100644
++--- a/Telegram/SourceFiles/ui/controls/window_outdated_bar.cpp
+++++ b/Telegram/SourceFiles/ui/controls/window_outdated_bar.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/controls/window_outdated_bar_dummy.cpp b/Telegram/SourceFiles/ui/controls/window_outdated_bar_dummy.cpp
++index a584271..a1a83fa 100644
++--- a/Telegram/SourceFiles/ui/controls/window_outdated_bar_dummy.cpp
+++++ b/Telegram/SourceFiles/ui/controls/window_outdated_bar_dummy.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/countryinput.cpp b/Telegram/SourceFiles/ui/countryinput.cpp
++index 3cb78ae..119d0ee 100644
++--- a/Telegram/SourceFiles/ui/countryinput.cpp
+++++ b/Telegram/SourceFiles/ui/countryinput.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/dynamic_thumbnails.cpp b/Telegram/SourceFiles/ui/dynamic_thumbnails.cpp
++index 32f1647..02d56e6 100644
++--- a/Telegram/SourceFiles/ui/dynamic_thumbnails.cpp
+++++ b/Telegram/SourceFiles/ui/dynamic_thumbnails.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/effects/credits_graphics.cpp b/Telegram/SourceFiles/ui/effects/credits_graphics.cpp
++index 6766684..228820f 100644
++--- a/Telegram/SourceFiles/ui/effects/credits_graphics.cpp
+++++ b/Telegram/SourceFiles/ui/effects/credits_graphics.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/effects/emoji_fly_animation.cpp b/Telegram/SourceFiles/ui/effects/emoji_fly_animation.cpp
++index 0552994..ddce3d2 100644
++--- a/Telegram/SourceFiles/ui/effects/emoji_fly_animation.cpp
+++++ b/Telegram/SourceFiles/ui/effects/emoji_fly_animation.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/effects/fireworks_animation.cpp b/Telegram/SourceFiles/ui/effects/fireworks_animation.cpp
++index f9eb099..db9596a 100644
++--- a/Telegram/SourceFiles/ui/effects/fireworks_animation.cpp
+++++ b/Telegram/SourceFiles/ui/effects/fireworks_animation.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/effects/glare.cpp b/Telegram/SourceFiles/ui/effects/glare.cpp
++index e326982..b7f019b 100644
++--- a/Telegram/SourceFiles/ui/effects/glare.cpp
+++++ b/Telegram/SourceFiles/ui/effects/glare.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/effects/loading_element.cpp b/Telegram/SourceFiles/ui/effects/loading_element.cpp
++index bb31210..43084af 100644
++--- a/Telegram/SourceFiles/ui/effects/loading_element.cpp
+++++ b/Telegram/SourceFiles/ui/effects/loading_element.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/effects/message_sending_animation_controller.cpp b/Telegram/SourceFiles/ui/effects/message_sending_animation_controller.cpp
++index 552f464..3d36a79 100644
++--- a/Telegram/SourceFiles/ui/effects/message_sending_animation_controller.cpp
+++++ b/Telegram/SourceFiles/ui/effects/message_sending_animation_controller.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/effects/outline_segments.cpp b/Telegram/SourceFiles/ui/effects/outline_segments.cpp
++index 6dc330c..94e9749 100644
++--- a/Telegram/SourceFiles/ui/effects/outline_segments.cpp
+++++ b/Telegram/SourceFiles/ui/effects/outline_segments.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/effects/premium_bubble.cpp b/Telegram/SourceFiles/ui/effects/premium_bubble.cpp
++index beb3ff3..a9d021b 100644
++--- a/Telegram/SourceFiles/ui/effects/premium_bubble.cpp
+++++ b/Telegram/SourceFiles/ui/effects/premium_bubble.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/effects/premium_graphics.cpp b/Telegram/SourceFiles/ui/effects/premium_graphics.cpp
++index 32c3a9e..c7935b4 100644
++--- a/Telegram/SourceFiles/ui/effects/premium_graphics.cpp
+++++ b/Telegram/SourceFiles/ui/effects/premium_graphics.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/effects/premium_stars.cpp b/Telegram/SourceFiles/ui/effects/premium_stars.cpp
++index 7323500..19a8c84 100644
++--- a/Telegram/SourceFiles/ui/effects/premium_stars.cpp
+++++ b/Telegram/SourceFiles/ui/effects/premium_stars.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/effects/premium_stars_colored.cpp b/Telegram/SourceFiles/ui/effects/premium_stars_colored.cpp
++index 017e1b1..a50ffef 100644
++--- a/Telegram/SourceFiles/ui/effects/premium_stars_colored.cpp
+++++ b/Telegram/SourceFiles/ui/effects/premium_stars_colored.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/effects/premium_top_bar.cpp b/Telegram/SourceFiles/ui/effects/premium_top_bar.cpp
++index 9cfb5e3..2c226a7 100644
++--- a/Telegram/SourceFiles/ui/effects/premium_top_bar.cpp
+++++ b/Telegram/SourceFiles/ui/effects/premium_top_bar.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/effects/reaction_fly_animation.cpp b/Telegram/SourceFiles/ui/effects/reaction_fly_animation.cpp
++index 239a1e5..071b8b8 100644
++--- a/Telegram/SourceFiles/ui/effects/reaction_fly_animation.cpp
+++++ b/Telegram/SourceFiles/ui/effects/reaction_fly_animation.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/effects/round_checkbox.cpp b/Telegram/SourceFiles/ui/effects/round_checkbox.cpp
++index f74ecd0..2f1ce93 100644
++--- a/Telegram/SourceFiles/ui/effects/round_checkbox.cpp
+++++ b/Telegram/SourceFiles/ui/effects/round_checkbox.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/effects/scroll_content_shadow.cpp b/Telegram/SourceFiles/ui/effects/scroll_content_shadow.cpp
++index 392caf2..25d2dc5 100644
++--- a/Telegram/SourceFiles/ui/effects/scroll_content_shadow.cpp
+++++ b/Telegram/SourceFiles/ui/effects/scroll_content_shadow.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/effects/send_action_animations.cpp b/Telegram/SourceFiles/ui/effects/send_action_animations.cpp
++index 3cee433..9132d22 100644
++--- a/Telegram/SourceFiles/ui/effects/send_action_animations.cpp
+++++ b/Telegram/SourceFiles/ui/effects/send_action_animations.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/effects/shake_animation.cpp b/Telegram/SourceFiles/ui/effects/shake_animation.cpp
++index 38fbd6f..b77ff28 100644
++--- a/Telegram/SourceFiles/ui/effects/shake_animation.cpp
+++++ b/Telegram/SourceFiles/ui/effects/shake_animation.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/effects/snowflakes.cpp b/Telegram/SourceFiles/ui/effects/snowflakes.cpp
++index 504c912..1e7bae0 100644
++--- a/Telegram/SourceFiles/ui/effects/snowflakes.cpp
+++++ b/Telegram/SourceFiles/ui/effects/snowflakes.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/effects/toggle_arrow.cpp b/Telegram/SourceFiles/ui/effects/toggle_arrow.cpp
++index 1c8779a..c94093f 100644
++--- a/Telegram/SourceFiles/ui/effects/toggle_arrow.cpp
+++++ b/Telegram/SourceFiles/ui/effects/toggle_arrow.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/empty_userpic.cpp b/Telegram/SourceFiles/ui/empty_userpic.cpp
++index e731062..38609f4 100644
++--- a/Telegram/SourceFiles/ui/empty_userpic.cpp
+++++ b/Telegram/SourceFiles/ui/empty_userpic.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/filter_icon_panel.cpp b/Telegram/SourceFiles/ui/filter_icon_panel.cpp
++index de82ad7..48d0640 100644
++--- a/Telegram/SourceFiles/ui/filter_icon_panel.cpp
+++++ b/Telegram/SourceFiles/ui/filter_icon_panel.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/filter_icons.cpp b/Telegram/SourceFiles/ui/filter_icons.cpp
++index 01a982d..511d363 100644
++--- a/Telegram/SourceFiles/ui/filter_icons.cpp
+++++ b/Telegram/SourceFiles/ui/filter_icons.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/grouped_layout.cpp b/Telegram/SourceFiles/ui/grouped_layout.cpp
++index 004d772..64f81f8 100644
++--- a/Telegram/SourceFiles/ui/grouped_layout.cpp
+++++ b/Telegram/SourceFiles/ui/grouped_layout.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/image/image.cpp b/Telegram/SourceFiles/ui/image/image.cpp
++index 1ef41f6..6c6f1c7 100644
++--- a/Telegram/SourceFiles/ui/image/image.cpp
+++++ b/Telegram/SourceFiles/ui/image/image.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/image/image_location.cpp b/Telegram/SourceFiles/ui/image/image_location.cpp
++index 1484a98..983ac08 100644
++--- a/Telegram/SourceFiles/ui/image/image_location.cpp
+++++ b/Telegram/SourceFiles/ui/image/image_location.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/image/image_location_factory.cpp b/Telegram/SourceFiles/ui/image/image_location_factory.cpp
++index cda2cad..b92f413 100644
++--- a/Telegram/SourceFiles/ui/image/image_location_factory.cpp
+++++ b/Telegram/SourceFiles/ui/image/image_location_factory.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/image/image_source.cpp b/Telegram/SourceFiles/ui/image/image_source.cpp
++index 94a8ab1..846fc41 100644
++--- a/Telegram/SourceFiles/ui/image/image_source.cpp
+++++ b/Telegram/SourceFiles/ui/image/image_source.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/item_text_options.cpp b/Telegram/SourceFiles/ui/item_text_options.cpp
++index 57ccc44..331b6cc 100644
++--- a/Telegram/SourceFiles/ui/item_text_options.cpp
+++++ b/Telegram/SourceFiles/ui/item_text_options.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/new_badges.cpp b/Telegram/SourceFiles/ui/new_badges.cpp
++index 0532181..9fa93f3 100644
++--- a/Telegram/SourceFiles/ui/new_badges.cpp
+++++ b/Telegram/SourceFiles/ui/new_badges.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/power_saving.cpp b/Telegram/SourceFiles/ui/power_saving.cpp
++index a401aca..558c985 100644
++--- a/Telegram/SourceFiles/ui/power_saving.cpp
+++++ b/Telegram/SourceFiles/ui/power_saving.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/search_field_controller.cpp b/Telegram/SourceFiles/ui/search_field_controller.cpp
++index b1d3ae5..8d342f1 100644
++--- a/Telegram/SourceFiles/ui/search_field_controller.cpp
+++++ b/Telegram/SourceFiles/ui/search_field_controller.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/text/format_song_document_name.cpp b/Telegram/SourceFiles/ui/text/format_song_document_name.cpp
++index 82d2a99..3ee72ee 100644
++--- a/Telegram/SourceFiles/ui/text/format_song_document_name.cpp
+++++ b/Telegram/SourceFiles/ui/text/format_song_document_name.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/text/format_song_name.cpp b/Telegram/SourceFiles/ui/text/format_song_name.cpp
++index c3f161d..de42879 100644
++--- a/Telegram/SourceFiles/ui/text/format_song_name.cpp
+++++ b/Telegram/SourceFiles/ui/text/format_song_name.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/text/format_values.cpp b/Telegram/SourceFiles/ui/text/format_values.cpp
++index d25e571..a613db7 100644
++--- a/Telegram/SourceFiles/ui/text/format_values.cpp
+++++ b/Telegram/SourceFiles/ui/text/format_values.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/text/text_lottie_custom_emoji.cpp b/Telegram/SourceFiles/ui/text/text_lottie_custom_emoji.cpp
++index e78a264..2856404 100644
++--- a/Telegram/SourceFiles/ui/text/text_lottie_custom_emoji.cpp
+++++ b/Telegram/SourceFiles/ui/text/text_lottie_custom_emoji.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++@@ -119,4 +120,4 @@ MarkedContext LottieEmojiContext(Lottie::IconDescriptor descriptor) {
++ 	return { .customEmojiFactory = std::move(customEmojiFactory) };
++ }
++ 
++-} // namespace Ui::Text
++\ No newline at end of file
+++} // namespace Ui::Text
++diff --git a/Telegram/SourceFiles/ui/text/text_options.cpp b/Telegram/SourceFiles/ui/text/text_options.cpp
++index eeeb28e..2486052 100644
++--- a/Telegram/SourceFiles/ui/text/text_options.cpp
+++++ b/Telegram/SourceFiles/ui/text/text_options.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/unread_badge.cpp b/Telegram/SourceFiles/ui/unread_badge.cpp
++index 88f6d37..68e71bc 100644
++--- a/Telegram/SourceFiles/ui/unread_badge.cpp
+++++ b/Telegram/SourceFiles/ui/unread_badge.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/unread_badge_paint.cpp b/Telegram/SourceFiles/ui/unread_badge_paint.cpp
++index d6b150a..18eee03 100644
++--- a/Telegram/SourceFiles/ui/unread_badge_paint.cpp
+++++ b/Telegram/SourceFiles/ui/unread_badge_paint.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/userpic_view.cpp b/Telegram/SourceFiles/ui/userpic_view.cpp
++index ff5f336..c0cbcf9 100644
++--- a/Telegram/SourceFiles/ui/userpic_view.cpp
+++++ b/Telegram/SourceFiles/ui/userpic_view.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/vertical_list.cpp b/Telegram/SourceFiles/ui/vertical_list.cpp
++index 6666077..37227fe 100644
++--- a/Telegram/SourceFiles/ui/vertical_list.cpp
+++++ b/Telegram/SourceFiles/ui/vertical_list.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/webview_helpers.cpp b/Telegram/SourceFiles/ui/webview_helpers.cpp
++index e68f19e..b978138 100644
++--- a/Telegram/SourceFiles/ui/webview_helpers.cpp
+++++ b/Telegram/SourceFiles/ui/webview_helpers.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_slider.cpp b/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_slider.cpp
++index beafcc4..512ca55 100644
++--- a/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_slider.cpp
+++++ b/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_slider.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_slider_reorder.cpp b/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_slider_reorder.cpp
++index 21d0e96..f973cf3 100644
++--- a/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_slider_reorder.cpp
+++++ b/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_slider_reorder.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_strip.cpp b/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_strip.cpp
++index 96a6668..e6351f0 100644
++--- a/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_strip.cpp
+++++ b/Telegram/SourceFiles/ui/widgets/chat_filters_tabs_strip.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/widgets/color_editor.cpp b/Telegram/SourceFiles/ui/widgets/color_editor.cpp
++index 06ca4d3..6d4705c 100644
++--- a/Telegram/SourceFiles/ui/widgets/color_editor.cpp
+++++ b/Telegram/SourceFiles/ui/widgets/color_editor.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/widgets/continuous_sliders.cpp b/Telegram/SourceFiles/ui/widgets/continuous_sliders.cpp
++index d400c12..b20a155 100644
++--- a/Telegram/SourceFiles/ui/widgets/continuous_sliders.cpp
+++++ b/Telegram/SourceFiles/ui/widgets/continuous_sliders.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/widgets/discrete_sliders.cpp b/Telegram/SourceFiles/ui/widgets/discrete_sliders.cpp
++index 3c80be1..46ae0af 100644
++--- a/Telegram/SourceFiles/ui/widgets/discrete_sliders.cpp
+++++ b/Telegram/SourceFiles/ui/widgets/discrete_sliders.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/widgets/expandable_peer_list.cpp b/Telegram/SourceFiles/ui/widgets/expandable_peer_list.cpp
++index a033a17..8319d55 100644
++--- a/Telegram/SourceFiles/ui/widgets/expandable_peer_list.cpp
+++++ b/Telegram/SourceFiles/ui/widgets/expandable_peer_list.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/widgets/fields/special_fields.cpp b/Telegram/SourceFiles/ui/widgets/fields/special_fields.cpp
++index b4afeb5..03d7c3d 100644
++--- a/Telegram/SourceFiles/ui/widgets/fields/special_fields.cpp
+++++ b/Telegram/SourceFiles/ui/widgets/fields/special_fields.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/widgets/fields/time_part_input_with_placeholder.cpp b/Telegram/SourceFiles/ui/widgets/fields/time_part_input_with_placeholder.cpp
++index c38241c..8bbfa51 100644
++--- a/Telegram/SourceFiles/ui/widgets/fields/time_part_input_with_placeholder.cpp
+++++ b/Telegram/SourceFiles/ui/widgets/fields/time_part_input_with_placeholder.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/widgets/gradient_round_button.cpp b/Telegram/SourceFiles/ui/widgets/gradient_round_button.cpp
++index f108d16..46ae11c 100644
++--- a/Telegram/SourceFiles/ui/widgets/gradient_round_button.cpp
+++++ b/Telegram/SourceFiles/ui/widgets/gradient_round_button.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/widgets/level_meter.cpp b/Telegram/SourceFiles/ui/widgets/level_meter.cpp
++index 7a94b8c..7b93f5e 100644
++--- a/Telegram/SourceFiles/ui/widgets/level_meter.cpp
+++++ b/Telegram/SourceFiles/ui/widgets/level_meter.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/widgets/multi_select.cpp b/Telegram/SourceFiles/ui/widgets/multi_select.cpp
++index 30435a0..9359f17 100644
++--- a/Telegram/SourceFiles/ui/widgets/multi_select.cpp
+++++ b/Telegram/SourceFiles/ui/widgets/multi_select.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/widgets/participants_check_view.cpp b/Telegram/SourceFiles/ui/widgets/participants_check_view.cpp
++index 0a8aad5..aec5c00 100644
++--- a/Telegram/SourceFiles/ui/widgets/participants_check_view.cpp
+++++ b/Telegram/SourceFiles/ui/widgets/participants_check_view.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/widgets/peer_bubble.cpp b/Telegram/SourceFiles/ui/widgets/peer_bubble.cpp
++index 73a7b1b..9c220d6 100644
++--- a/Telegram/SourceFiles/ui/widgets/peer_bubble.cpp
+++++ b/Telegram/SourceFiles/ui/widgets/peer_bubble.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/widgets/sent_code_field.cpp b/Telegram/SourceFiles/ui/widgets/sent_code_field.cpp
++index f5ba4b8..53f7293 100644
++--- a/Telegram/SourceFiles/ui/widgets/sent_code_field.cpp
+++++ b/Telegram/SourceFiles/ui/widgets/sent_code_field.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/ui/widgets/vertical_drum_picker.cpp b/Telegram/SourceFiles/ui/widgets/vertical_drum_picker.cpp
++index a414b56..5224bab 100644
++--- a/Telegram/SourceFiles/ui/widgets/vertical_drum_picker.cpp
+++++ b/Telegram/SourceFiles/ui/widgets/vertical_drum_picker.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/main_window.cpp b/Telegram/SourceFiles/window/main_window.cpp
++index 4ff5bb6..7a8f970 100644
++--- a/Telegram/SourceFiles/window/main_window.cpp
+++++ b/Telegram/SourceFiles/window/main_window.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/notifications_manager.cpp b/Telegram/SourceFiles/window/notifications_manager.cpp
++index 3ef6a40..0879bb4 100644
++--- a/Telegram/SourceFiles/window/notifications_manager.cpp
+++++ b/Telegram/SourceFiles/window/notifications_manager.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/notifications_manager_default.cpp b/Telegram/SourceFiles/window/notifications_manager_default.cpp
++index 441f97e..abe0bb4 100644
++--- a/Telegram/SourceFiles/window/notifications_manager_default.cpp
+++++ b/Telegram/SourceFiles/window/notifications_manager_default.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/notifications_utilities.cpp b/Telegram/SourceFiles/window/notifications_utilities.cpp
++index e2ef49f..6879381 100644
++--- a/Telegram/SourceFiles/window/notifications_utilities.cpp
+++++ b/Telegram/SourceFiles/window/notifications_utilities.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/section_widget.cpp b/Telegram/SourceFiles/window/section_widget.cpp
++index 36fd532..bd597ee 100644
++--- a/Telegram/SourceFiles/window/section_widget.cpp
+++++ b/Telegram/SourceFiles/window/section_widget.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/themes/window_theme.cpp b/Telegram/SourceFiles/window/themes/window_theme.cpp
++index a6827b0..837c5a9 100644
++--- a/Telegram/SourceFiles/window/themes/window_theme.cpp
+++++ b/Telegram/SourceFiles/window/themes/window_theme.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/themes/window_theme_editor.cpp b/Telegram/SourceFiles/window/themes/window_theme_editor.cpp
++index deba489..a1b2e7a 100644
++--- a/Telegram/SourceFiles/window/themes/window_theme_editor.cpp
+++++ b/Telegram/SourceFiles/window/themes/window_theme_editor.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/themes/window_theme_editor_block.cpp b/Telegram/SourceFiles/window/themes/window_theme_editor_block.cpp
++index cd5b5d8..8465496 100644
++--- a/Telegram/SourceFiles/window/themes/window_theme_editor_block.cpp
+++++ b/Telegram/SourceFiles/window/themes/window_theme_editor_block.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/themes/window_theme_editor_box.cpp b/Telegram/SourceFiles/window/themes/window_theme_editor_box.cpp
++index c430b3e..e11a36d 100644
++--- a/Telegram/SourceFiles/window/themes/window_theme_editor_box.cpp
+++++ b/Telegram/SourceFiles/window/themes/window_theme_editor_box.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/themes/window_theme_preview.cpp b/Telegram/SourceFiles/window/themes/window_theme_preview.cpp
++index 9b05d2f..d3eac50 100644
++--- a/Telegram/SourceFiles/window/themes/window_theme_preview.cpp
+++++ b/Telegram/SourceFiles/window/themes/window_theme_preview.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/themes/window_theme_warning.cpp b/Telegram/SourceFiles/window/themes/window_theme_warning.cpp
++index bb53332..b64fed5 100644
++--- a/Telegram/SourceFiles/window/themes/window_theme_warning.cpp
+++++ b/Telegram/SourceFiles/window/themes/window_theme_warning.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/themes/window_themes_cloud_list.cpp b/Telegram/SourceFiles/window/themes/window_themes_cloud_list.cpp
++index 0971a1a..c61d85a 100644
++--- a/Telegram/SourceFiles/window/themes/window_themes_cloud_list.cpp
+++++ b/Telegram/SourceFiles/window/themes/window_themes_cloud_list.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/themes/window_themes_embedded.cpp b/Telegram/SourceFiles/window/themes/window_themes_embedded.cpp
++index 5415346..928f553 100644
++--- a/Telegram/SourceFiles/window/themes/window_themes_embedded.cpp
+++++ b/Telegram/SourceFiles/window/themes/window_themes_embedded.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/themes/window_themes_generate_name.cpp b/Telegram/SourceFiles/window/themes/window_themes_generate_name.cpp
++index 81c0e09..6103147 100644
++--- a/Telegram/SourceFiles/window/themes/window_themes_generate_name.cpp
+++++ b/Telegram/SourceFiles/window/themes/window_themes_generate_name.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/window_adaptive.cpp b/Telegram/SourceFiles/window/window_adaptive.cpp
++index 784164d..687b784 100644
++--- a/Telegram/SourceFiles/window/window_adaptive.cpp
+++++ b/Telegram/SourceFiles/window/window_adaptive.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/window_chat_preview.cpp b/Telegram/SourceFiles/window/window_chat_preview.cpp
++index 68498ec..0823ff4 100644
++--- a/Telegram/SourceFiles/window/window_chat_preview.cpp
+++++ b/Telegram/SourceFiles/window/window_chat_preview.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++@@ -139,4 +140,4 @@ void ChatPreviewManager::cancelScheduled() {
++ 	_timer.cancel();
++ }
++ 
++-} // namespace Window
++\ No newline at end of file
+++} // namespace Window
++diff --git a/Telegram/SourceFiles/window/window_chat_switch_process.cpp b/Telegram/SourceFiles/window/window_chat_switch_process.cpp
++index cbbab00..0e483dc 100644
++--- a/Telegram/SourceFiles/window/window_chat_switch_process.cpp
+++++ b/Telegram/SourceFiles/window/window_chat_switch_process.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/window_connecting_widget.cpp b/Telegram/SourceFiles/window/window_connecting_widget.cpp
++index 9940287..f17efa5 100644
++--- a/Telegram/SourceFiles/window/window_connecting_widget.cpp
+++++ b/Telegram/SourceFiles/window/window_connecting_widget.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/window_controller.cpp b/Telegram/SourceFiles/window/window_controller.cpp
++index 52d0cc0..e387402 100644
++--- a/Telegram/SourceFiles/window/window_controller.cpp
+++++ b/Telegram/SourceFiles/window/window_controller.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/window_filters_menu.cpp b/Telegram/SourceFiles/window/window_filters_menu.cpp
++index b23efa3..ac0c5b2 100644
++--- a/Telegram/SourceFiles/window/window_filters_menu.cpp
+++++ b/Telegram/SourceFiles/window/window_filters_menu.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/window_history_hider.cpp b/Telegram/SourceFiles/window/window_history_hider.cpp
++index 134bd45..6151d1e 100644
++--- a/Telegram/SourceFiles/window/window_history_hider.cpp
+++++ b/Telegram/SourceFiles/window/window_history_hider.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/window_lock_widgets.cpp b/Telegram/SourceFiles/window/window_lock_widgets.cpp
++index 3e2f6cb..5c4de6d 100644
++--- a/Telegram/SourceFiles/window/window_lock_widgets.cpp
+++++ b/Telegram/SourceFiles/window/window_lock_widgets.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/window_main_menu.cpp b/Telegram/SourceFiles/window/window_main_menu.cpp
++index 9c52ca4..07cb23b 100644
++--- a/Telegram/SourceFiles/window/window_main_menu.cpp
+++++ b/Telegram/SourceFiles/window/window_main_menu.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/window_main_menu_helpers.cpp b/Telegram/SourceFiles/window/window_main_menu_helpers.cpp
++index 0a05a33..6ef698a 100644
++--- a/Telegram/SourceFiles/window/window_main_menu_helpers.cpp
+++++ b/Telegram/SourceFiles/window/window_main_menu_helpers.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/window_media_preview.cpp b/Telegram/SourceFiles/window/window_media_preview.cpp
++index edbaab9..6ded3de 100644
++--- a/Telegram/SourceFiles/window/window_media_preview.cpp
+++++ b/Telegram/SourceFiles/window/window_media_preview.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/window_peer_menu.cpp b/Telegram/SourceFiles/window/window_peer_menu.cpp
++index dab3191..16f52e4 100644
++--- a/Telegram/SourceFiles/window/window_peer_menu.cpp
+++++ b/Telegram/SourceFiles/window/window_peer_menu.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/window_separate_id.cpp b/Telegram/SourceFiles/window/window_separate_id.cpp
++index f6ed915..371761c 100644
++--- a/Telegram/SourceFiles/window/window_separate_id.cpp
+++++ b/Telegram/SourceFiles/window/window_separate_id.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/window_session_controller.cpp b/Telegram/SourceFiles/window/window_session_controller.cpp
++index 06b11a7..62877e4 100644
++--- a/Telegram/SourceFiles/window/window_session_controller.cpp
+++++ b/Telegram/SourceFiles/window/window_session_controller.cpp
++@@ -1,3 +1,4 @@
+++#include "stdafx.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/SourceFiles/window/window_slide_animation.cpp b/Telegram/SourceFiles/window/window_slide_animation.cpp
++index fced2ba..3968961 100644
++--- a/Telegram/SourceFiles/window/window_slide_animation.cpp
+++++ b/Telegram/SourceFiles/window/window_slide_animation.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ /*
++ This file is part of Telegram Desktop,
++ the official desktop application for the Telegram messaging service.
++diff --git a/Telegram/lib_base/base/algorithm.cpp b/Telegram/lib_base/base/algorithm.cpp
++index fbc0bdf..d7534a6 100644
++--- a/Telegram/lib_base/base/algorithm.cpp
+++++ b/Telegram/lib_base/base/algorithm.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/algorithm_tests.cpp b/Telegram/lib_base/base/algorithm_tests.cpp
++index 9dd2c49..8ba3c82 100644
++--- a/Telegram/lib_base/base/algorithm_tests.cpp
+++++ b/Telegram/lib_base/base/algorithm_tests.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/assertion.cpp b/Telegram/lib_base/base/assertion.cpp
++index f79cadb..81a9bf0 100644
++--- a/Telegram/lib_base/base/assertion.cpp
+++++ b/Telegram/lib_base/base/assertion.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/base_file_utilities.cpp b/Telegram/lib_base/base/base_file_utilities.cpp
++index c0f3c66..20ad8f2 100644
++--- a/Telegram/lib_base/base/base_file_utilities.cpp
+++++ b/Telegram/lib_base/base/base_file_utilities.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/battery_saving.cpp b/Telegram/lib_base/base/battery_saving.cpp
++index 59de3b1..6a3b2fb 100644
++--- a/Telegram/lib_base/base/battery_saving.cpp
+++++ b/Telegram/lib_base/base/battery_saving.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/bytes.cpp b/Telegram/lib_base/base/bytes.cpp
++index 9668115..912dad9 100644
++--- a/Telegram/lib_base/base/bytes.cpp
+++++ b/Telegram/lib_base/base/bytes.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/call_delayed.cpp b/Telegram/lib_base/base/call_delayed.cpp
++index 93d975d..a01bf2f 100644
++--- a/Telegram/lib_base/base/call_delayed.cpp
+++++ b/Telegram/lib_base/base/call_delayed.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/concurrent_timer.cpp b/Telegram/lib_base/base/concurrent_timer.cpp
++index ed48b36..84ac65b 100644
++--- a/Telegram/lib_base/base/concurrent_timer.cpp
+++++ b/Telegram/lib_base/base/concurrent_timer.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/crash_report_header.cpp b/Telegram/lib_base/base/crash_report_header.cpp
++index f1718f7..9c3776f 100644
++--- a/Telegram/lib_base/base/crash_report_header.cpp
+++++ b/Telegram/lib_base/base/crash_report_header.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/crash_report_writer.cpp b/Telegram/lib_base/base/crash_report_writer.cpp
++index b298e8d..e5821d5 100644
++--- a/Telegram/lib_base/base/crash_report_writer.cpp
+++++ b/Telegram/lib_base/base/crash_report_writer.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/crc32hash.cpp b/Telegram/lib_base/base/crc32hash.cpp
++index 3384fea..714c8a5 100644
++--- a/Telegram/lib_base/base/crc32hash.cpp
+++++ b/Telegram/lib_base/base/crc32hash.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/debug_log.cpp b/Telegram/lib_base/base/debug_log.cpp
++index 661ae1b..3626563 100644
++--- a/Telegram/lib_base/base/debug_log.cpp
+++++ b/Telegram/lib_base/base/debug_log.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/event_filter.cpp b/Telegram/lib_base/base/event_filter.cpp
++index 0700c66..3265531 100644
++--- a/Telegram/lib_base/base/event_filter.cpp
+++++ b/Telegram/lib_base/base/event_filter.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/file_lock_posix.cpp b/Telegram/lib_base/base/file_lock_posix.cpp
++index c6efcd5..458a9b1 100644
++--- a/Telegram/lib_base/base/file_lock_posix.cpp
+++++ b/Telegram/lib_base/base/file_lock_posix.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/file_lock_win.cpp b/Telegram/lib_base/base/file_lock_win.cpp
++index 132ff47..96e8b5f 100644
++--- a/Telegram/lib_base/base/file_lock_win.cpp
+++++ b/Telegram/lib_base/base/file_lock_win.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/flags_tests.cpp b/Telegram/lib_base/base/flags_tests.cpp
++index 317969c..e4e9024 100644
++--- a/Telegram/lib_base/base/flags_tests.cpp
+++++ b/Telegram/lib_base/base/flags_tests.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/flat_map_tests.cpp b/Telegram/lib_base/base/flat_map_tests.cpp
++index cf11b62..7412443 100644
++--- a/Telegram/lib_base/base/flat_map_tests.cpp
+++++ b/Telegram/lib_base/base/flat_map_tests.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/flat_set_tests.cpp b/Telegram/lib_base/base/flat_set_tests.cpp
++index 3ed1584..7da17be 100644
++--- a/Telegram/lib_base/base/flat_set_tests.cpp
+++++ b/Telegram/lib_base/base/flat_set_tests.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/global_shortcuts_generic.cpp b/Telegram/lib_base/base/global_shortcuts_generic.cpp
++index b8ffaef..8b8f49b 100644
++--- a/Telegram/lib_base/base/global_shortcuts_generic.cpp
+++++ b/Telegram/lib_base/base/global_shortcuts_generic.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/integration.cpp b/Telegram/lib_base/base/integration.cpp
++index 9233281..6b71d52 100644
++--- a/Telegram/lib_base/base/integration.cpp
+++++ b/Telegram/lib_base/base/integration.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/last_user_input.cpp b/Telegram/lib_base/base/last_user_input.cpp
++index d3b35f8..e33e3d3 100644
++--- a/Telegram/lib_base/base/last_user_input.cpp
+++++ b/Telegram/lib_base/base/last_user_input.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/network_reachability.cpp b/Telegram/lib_base/base/network_reachability.cpp
++index f17c48b..1d11662 100644
++--- a/Telegram/lib_base/base/network_reachability.cpp
+++++ b/Telegram/lib_base/base/network_reachability.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/options.cpp b/Telegram/lib_base/base/options.cpp
++index 7e57652..77576bb 100644
++--- a/Telegram/lib_base/base/options.cpp
+++++ b/Telegram/lib_base/base/options.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/parse_helper.cpp b/Telegram/lib_base/base/parse_helper.cpp
++index b82c182..4915fc7 100644
++--- a/Telegram/lib_base/base/parse_helper.cpp
+++++ b/Telegram/lib_base/base/parse_helper.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/base_platform_file_utilities.cpp b/Telegram/lib_base/base/platform/base_platform_file_utilities.cpp
++index 38d444e..1a81037 100644
++--- a/Telegram/lib_base/base/platform/base_platform_file_utilities.cpp
+++++ b/Telegram/lib_base/base/platform/base_platform_file_utilities.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/base_platform_info.cpp b/Telegram/lib_base/base/platform/base_platform_info.cpp
++index da0f4d0..d0421c4 100644
++--- a/Telegram/lib_base/base/platform/base_platform_info.cpp
+++++ b/Telegram/lib_base/base/platform/base_platform_info.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/linux/base_battery_saving_linux.cpp b/Telegram/lib_base/base/platform/linux/base_battery_saving_linux.cpp
++index b9c1e8c..cdd86b0 100644
++--- a/Telegram/lib_base/base/platform/linux/base_battery_saving_linux.cpp
+++++ b/Telegram/lib_base/base/platform/linux/base_battery_saving_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/linux/base_file_utilities_linux.cpp b/Telegram/lib_base/base/platform/linux/base_file_utilities_linux.cpp
++index b49c8c0..4de1ea7 100644
++--- a/Telegram/lib_base/base/platform/linux/base_file_utilities_linux.cpp
+++++ b/Telegram/lib_base/base/platform/linux/base_file_utilities_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/linux/base_global_shortcuts_linux.cpp b/Telegram/lib_base/base/platform/linux/base_global_shortcuts_linux.cpp
++index 2247daf..6541fde 100644
++--- a/Telegram/lib_base/base/platform/linux/base_global_shortcuts_linux.cpp
+++++ b/Telegram/lib_base/base/platform/linux/base_global_shortcuts_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/linux/base_haptic_linux.cpp b/Telegram/lib_base/base/platform/linux/base_haptic_linux.cpp
++index 2b24705..6adc8fb 100644
++--- a/Telegram/lib_base/base/platform/linux/base_haptic_linux.cpp
+++++ b/Telegram/lib_base/base/platform/linux/base_haptic_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/linux/base_info_linux.cpp b/Telegram/lib_base/base/platform/linux/base_info_linux.cpp
++index b1b2d98..0fe2ae6 100644
++--- a/Telegram/lib_base/base/platform/linux/base_info_linux.cpp
+++++ b/Telegram/lib_base/base/platform/linux/base_info_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/linux/base_last_input_linux.cpp b/Telegram/lib_base/base/platform/linux/base_last_input_linux.cpp
++index 9bd332a..e89948c 100644
++--- a/Telegram/lib_base/base/platform/linux/base_last_input_linux.cpp
+++++ b/Telegram/lib_base/base/platform/linux/base_last_input_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/linux/base_layout_switch_linux.cpp b/Telegram/lib_base/base/platform/linux/base_layout_switch_linux.cpp
++index c99c410..472d2e3 100644
++--- a/Telegram/lib_base/base/platform/linux/base_layout_switch_linux.cpp
+++++ b/Telegram/lib_base/base/platform/linux/base_layout_switch_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/linux/base_linux_allocation_tracer.cpp b/Telegram/lib_base/base/platform/linux/base_linux_allocation_tracer.cpp
++index 62fc24a..1d7b0fd 100644
++--- a/Telegram/lib_base/base/platform/linux/base_linux_allocation_tracer.cpp
+++++ b/Telegram/lib_base/base/platform/linux/base_linux_allocation_tracer.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/linux/base_linux_dbus_utilities.cpp b/Telegram/lib_base/base/platform/linux/base_linux_dbus_utilities.cpp
++index ef0c8d5..bc89b56 100644
++--- a/Telegram/lib_base/base/platform/linux/base_linux_dbus_utilities.cpp
+++++ b/Telegram/lib_base/base/platform/linux/base_linux_dbus_utilities.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/linux/base_linux_library.cpp b/Telegram/lib_base/base/platform/linux/base_linux_library.cpp
++index 1b4eb75..523bd95 100644
++--- a/Telegram/lib_base/base/platform/linux/base_linux_library.cpp
+++++ b/Telegram/lib_base/base/platform/linux/base_linux_library.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/linux/base_linux_xcb_utilities.cpp b/Telegram/lib_base/base/platform/linux/base_linux_xcb_utilities.cpp
++index 37f4623..6c32ffe 100644
++--- a/Telegram/lib_base/base/platform/linux/base_linux_xcb_utilities.cpp
+++++ b/Telegram/lib_base/base/platform/linux/base_linux_xcb_utilities.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/linux/base_linux_xdg_activation_token.cpp b/Telegram/lib_base/base/platform/linux/base_linux_xdg_activation_token.cpp
++index 31e8d15..f1c479e 100644
++--- a/Telegram/lib_base/base/platform/linux/base_linux_xdg_activation_token.cpp
+++++ b/Telegram/lib_base/base/platform/linux/base_linux_xdg_activation_token.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/linux/base_linux_xdp_utilities.cpp b/Telegram/lib_base/base/platform/linux/base_linux_xdp_utilities.cpp
++index c0dd69f..82346fd 100644
++--- a/Telegram/lib_base/base/platform/linux/base_linux_xdp_utilities.cpp
+++++ b/Telegram/lib_base/base/platform/linux/base_linux_xdp_utilities.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/linux/base_linux_xsettings.cpp b/Telegram/lib_base/base/platform/linux/base_linux_xsettings.cpp
++index 50519a0..bbee24f 100644
++--- a/Telegram/lib_base/base/platform/linux/base_linux_xsettings.cpp
+++++ b/Telegram/lib_base/base/platform/linux/base_linux_xsettings.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/linux/base_network_reachability_linux.cpp b/Telegram/lib_base/base/platform/linux/base_network_reachability_linux.cpp
++index 145b02e..2e91765 100644
++--- a/Telegram/lib_base/base/platform/linux/base_network_reachability_linux.cpp
+++++ b/Telegram/lib_base/base/platform/linux/base_network_reachability_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/linux/base_power_save_blocker_linux.cpp b/Telegram/lib_base/base/platform/linux/base_power_save_blocker_linux.cpp
++index 5d4a40b..2884ed2 100644
++--- a/Telegram/lib_base/base/platform/linux/base_power_save_blocker_linux.cpp
+++++ b/Telegram/lib_base/base/platform/linux/base_power_save_blocker_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/linux/base_process_linux.cpp b/Telegram/lib_base/base/platform/linux/base_process_linux.cpp
++index 6ae721b..549cf82 100644
++--- a/Telegram/lib_base/base/platform/linux/base_process_linux.cpp
+++++ b/Telegram/lib_base/base/platform/linux/base_process_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/linux/base_system_media_controls_linux.cpp b/Telegram/lib_base/base/platform/linux/base_system_media_controls_linux.cpp
++index b3f0bbd..9972ad9 100644
++--- a/Telegram/lib_base/base/platform/linux/base_system_media_controls_linux.cpp
+++++ b/Telegram/lib_base/base/platform/linux/base_system_media_controls_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/linux/base_system_unlock_linux.cpp b/Telegram/lib_base/base/platform/linux/base_system_unlock_linux.cpp
++index e72d450..f9cb2e0 100644
++--- a/Telegram/lib_base/base/platform/linux/base_system_unlock_linux.cpp
+++++ b/Telegram/lib_base/base/platform/linux/base_system_unlock_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/linux/base_url_scheme_linux.cpp b/Telegram/lib_base/base/platform/linux/base_url_scheme_linux.cpp
++index de188ac..6fb3be1 100644
++--- a/Telegram/lib_base/base/platform/linux/base_url_scheme_linux.cpp
+++++ b/Telegram/lib_base/base/platform/linux/base_url_scheme_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/win/base_battery_saving_win.cpp b/Telegram/lib_base/base/platform/win/base_battery_saving_win.cpp
++index 173cc54..c707be5 100644
++--- a/Telegram/lib_base/base/platform/win/base_battery_saving_win.cpp
+++++ b/Telegram/lib_base/base/platform/win/base_battery_saving_win.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/win/base_file_utilities_win.cpp b/Telegram/lib_base/base/platform/win/base_file_utilities_win.cpp
++index e71dbf5..07a6b76 100644
++--- a/Telegram/lib_base/base/platform/win/base_file_utilities_win.cpp
+++++ b/Telegram/lib_base/base/platform/win/base_file_utilities_win.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/win/base_global_shortcuts_win.cpp b/Telegram/lib_base/base/platform/win/base_global_shortcuts_win.cpp
++index f29a1bd..66e8216 100644
++--- a/Telegram/lib_base/base/platform/win/base_global_shortcuts_win.cpp
+++++ b/Telegram/lib_base/base/platform/win/base_global_shortcuts_win.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/win/base_info_win.cpp b/Telegram/lib_base/base/platform/win/base_info_win.cpp
++index 331b3ba..ee3d347 100644
++--- a/Telegram/lib_base/base/platform/win/base_info_win.cpp
+++++ b/Telegram/lib_base/base/platform/win/base_info_win.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/win/base_last_input_win.cpp b/Telegram/lib_base/base/platform/win/base_last_input_win.cpp
++index a9bfd85..58404d9 100644
++--- a/Telegram/lib_base/base/platform/win/base_last_input_win.cpp
+++++ b/Telegram/lib_base/base/platform/win/base_last_input_win.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/win/base_layout_switch_win.cpp b/Telegram/lib_base/base/platform/win/base_layout_switch_win.cpp
++index 4c39290..e8780db 100644
++--- a/Telegram/lib_base/base/platform/win/base_layout_switch_win.cpp
+++++ b/Telegram/lib_base/base/platform/win/base_layout_switch_win.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/win/base_network_reachability_win.cpp b/Telegram/lib_base/base/platform/win/base_network_reachability_win.cpp
++index 7e87601..126d8b2 100644
++--- a/Telegram/lib_base/base/platform/win/base_network_reachability_win.cpp
+++++ b/Telegram/lib_base/base/platform/win/base_network_reachability_win.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/win/base_power_save_blocker_win.cpp b/Telegram/lib_base/base/platform/win/base_power_save_blocker_win.cpp
++index 7c79fee..36fbf4f 100644
++--- a/Telegram/lib_base/base/platform/win/base_power_save_blocker_win.cpp
+++++ b/Telegram/lib_base/base/platform/win/base_power_save_blocker_win.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/win/base_process_win.cpp b/Telegram/lib_base/base/platform/win/base_process_win.cpp
++index 6ac364e..85301f3 100644
++--- a/Telegram/lib_base/base/platform/win/base_process_win.cpp
+++++ b/Telegram/lib_base/base/platform/win/base_process_win.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/win/base_system_media_controls_win.cpp b/Telegram/lib_base/base/platform/win/base_system_media_controls_win.cpp
++index 168287f..38d40b6 100644
++--- a/Telegram/lib_base/base/platform/win/base_system_media_controls_win.cpp
+++++ b/Telegram/lib_base/base/platform/win/base_system_media_controls_win.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/win/base_url_scheme_win.cpp b/Telegram/lib_base/base/platform/win/base_url_scheme_win.cpp
++index 5e094e2..00e5327 100644
++--- a/Telegram/lib_base/base/platform/win/base_url_scheme_win.cpp
+++++ b/Telegram/lib_base/base/platform/win/base_url_scheme_win.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/win/base_windows_safe_library.cpp b/Telegram/lib_base/base/platform/win/base_windows_safe_library.cpp
++index 6272ddf..4b8e442 100644
++--- a/Telegram/lib_base/base/platform/win/base_windows_safe_library.cpp
+++++ b/Telegram/lib_base/base/platform/win/base_windows_safe_library.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/win/base_windows_winrt.cpp b/Telegram/lib_base/base/platform/win/base_windows_winrt.cpp
++index 076a853..a40944b 100644
++--- a/Telegram/lib_base/base/platform/win/base_windows_winrt.cpp
+++++ b/Telegram/lib_base/base/platform/win/base_windows_winrt.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/platform/win/base_windows_wrl.cpp b/Telegram/lib_base/base/platform/win/base_windows_wrl.cpp
++index 38e08c0..52c4114 100644
++--- a/Telegram/lib_base/base/platform/win/base_windows_wrl.cpp
+++++ b/Telegram/lib_base/base/platform/win/base_windows_wrl.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/power_save_blocker.cpp b/Telegram/lib_base/base/power_save_blocker.cpp
++index 93decb2..ea9bede 100644
++--- a/Telegram/lib_base/base/power_save_blocker.cpp
+++++ b/Telegram/lib_base/base/power_save_blocker.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/qt/qt_tab_key.cpp b/Telegram/lib_base/base/qt/qt_tab_key.cpp
++index 52a0aa9..17c2a9c 100644
++--- a/Telegram/lib_base/base/qt/qt_tab_key.cpp
+++++ b/Telegram/lib_base/base/qt/qt_tab_key.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/qthelp_url.cpp b/Telegram/lib_base/base/qthelp_url.cpp
++index eed4439..c71d700 100644
++--- a/Telegram/lib_base/base/qthelp_url.cpp
+++++ b/Telegram/lib_base/base/qthelp_url.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/random.cpp b/Telegram/lib_base/base/random.cpp
++index c32f8a3..1138857 100644
++--- a/Telegram/lib_base/base/random.cpp
+++++ b/Telegram/lib_base/base/random.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/runtime_composer.cpp b/Telegram/lib_base/base/runtime_composer.cpp
++index f765c28..41ae014 100644
++--- a/Telegram/lib_base/base/runtime_composer.cpp
+++++ b/Telegram/lib_base/base/runtime_composer.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/single_instance.cpp b/Telegram/lib_base/base/single_instance.cpp
++index b8af943..95dee8f 100644
++--- a/Telegram/lib_base/base/single_instance.cpp
+++++ b/Telegram/lib_base/base/single_instance.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/tests_main.cpp b/Telegram/lib_base/base/tests_main.cpp
++index f7c38a4..50e03f6 100644
++--- a/Telegram/lib_base/base/tests_main.cpp
+++++ b/Telegram/lib_base/base/tests_main.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/timer.cpp b/Telegram/lib_base/base/timer.cpp
++index 73211de..35f4251 100644
++--- a/Telegram/lib_base/base/timer.cpp
+++++ b/Telegram/lib_base/base/timer.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_base/base/unixtime.cpp b/Telegram/lib_base/base/unixtime.cpp
++index b39b788..6fb5606 100644
++--- a/Telegram/lib_base/base/unixtime.cpp
+++++ b/Telegram/lib_base/base/unixtime.cpp
++@@ -1,3 +1,4 @@
+++#include "base/base_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_spellcheck/spellcheck/platform/linux/language_linux.cpp b/Telegram/lib_spellcheck/spellcheck/platform/linux/language_linux.cpp
++index a691889..6b266ef 100644
++--- a/Telegram/lib_spellcheck/spellcheck/platform/linux/language_linux.cpp
+++++ b/Telegram/lib_spellcheck/spellcheck/platform/linux/language_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "spellcheck/spellcheck_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_spellcheck/spellcheck/platform/linux/linux_enchant.cpp b/Telegram/lib_spellcheck/spellcheck/platform/linux/linux_enchant.cpp
++index 8d25ee0..1d2fe23 100644
++--- a/Telegram/lib_spellcheck/spellcheck/platform/linux/linux_enchant.cpp
+++++ b/Telegram/lib_spellcheck/spellcheck/platform/linux/linux_enchant.cpp
++@@ -1,3 +1,4 @@
+++#include "spellcheck/spellcheck_pch.h"
++ /* enchant
++  * Copyright (C) 2003 Dom Lachowicz
++  *
++diff --git a/Telegram/lib_spellcheck/spellcheck/platform/linux/spellcheck_linux.cpp b/Telegram/lib_spellcheck/spellcheck/platform/linux/spellcheck_linux.cpp
++index 3e839c7..86e975c 100644
++--- a/Telegram/lib_spellcheck/spellcheck/platform/linux/spellcheck_linux.cpp
+++++ b/Telegram/lib_spellcheck/spellcheck/platform/linux/spellcheck_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "spellcheck/spellcheck_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_spellcheck/spellcheck/platform/win/language_win.cpp b/Telegram/lib_spellcheck/spellcheck/platform/win/language_win.cpp
++index 847aaa2..effb47d 100644
++--- a/Telegram/lib_spellcheck/spellcheck/platform/win/language_win.cpp
+++++ b/Telegram/lib_spellcheck/spellcheck/platform/win/language_win.cpp
++@@ -1,3 +1,4 @@
+++#include "spellcheck/spellcheck_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_spellcheck/spellcheck/platform/win/spellcheck_win.cpp b/Telegram/lib_spellcheck/spellcheck/platform/win/spellcheck_win.cpp
++index 431effd..3166ff3 100644
++--- a/Telegram/lib_spellcheck/spellcheck/platform/win/spellcheck_win.cpp
+++++ b/Telegram/lib_spellcheck/spellcheck/platform/win/spellcheck_win.cpp
++@@ -1,3 +1,4 @@
+++#include "spellcheck/spellcheck_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_spellcheck/spellcheck/spellcheck_highlight_syntax.cpp b/Telegram/lib_spellcheck/spellcheck/spellcheck_highlight_syntax.cpp
++index f2a556b..0471fb8 100644
++--- a/Telegram/lib_spellcheck/spellcheck/spellcheck_highlight_syntax.cpp
+++++ b/Telegram/lib_spellcheck/spellcheck/spellcheck_highlight_syntax.cpp
++@@ -1,3 +1,4 @@
+++#include "spellcheck/spellcheck_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_spellcheck/spellcheck/spellcheck_utils.cpp b/Telegram/lib_spellcheck/spellcheck/spellcheck_utils.cpp
++index efeb6da..57a8f6a 100644
++--- a/Telegram/lib_spellcheck/spellcheck/spellcheck_utils.cpp
+++++ b/Telegram/lib_spellcheck/spellcheck/spellcheck_utils.cpp
++@@ -1,3 +1,4 @@
+++#include "spellcheck/spellcheck_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_spellcheck/spellcheck/spellcheck_value.cpp b/Telegram/lib_spellcheck/spellcheck/spellcheck_value.cpp
++index 5d25149..892db16 100644
++--- a/Telegram/lib_spellcheck/spellcheck/spellcheck_value.cpp
+++++ b/Telegram/lib_spellcheck/spellcheck/spellcheck_value.cpp
++@@ -1,3 +1,4 @@
+++#include "spellcheck/spellcheck_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_spellcheck/spellcheck/spelling_highlighter.cpp b/Telegram/lib_spellcheck/spellcheck/spelling_highlighter.cpp
++index b117d4d..d477499 100644
++--- a/Telegram/lib_spellcheck/spellcheck/spelling_highlighter.cpp
+++++ b/Telegram/lib_spellcheck/spellcheck/spelling_highlighter.cpp
++@@ -1,3 +1,4 @@
+++#include "spellcheck/spellcheck_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_spellcheck/spellcheck/spelling_highlighter_helper.cpp b/Telegram/lib_spellcheck/spellcheck/spelling_highlighter_helper.cpp
++index 4730bc8..7f2612e 100644
++--- a/Telegram/lib_spellcheck/spellcheck/spelling_highlighter_helper.cpp
+++++ b/Telegram/lib_spellcheck/spellcheck/spelling_highlighter_helper.cpp
++@@ -1,3 +1,4 @@
+++#include "spellcheck/spellcheck_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_spellcheck/spellcheck/third_party/hunspell_controller.cpp b/Telegram/lib_spellcheck/spellcheck/third_party/hunspell_controller.cpp
++index 97a5bcd..4b85fc5 100644
++--- a/Telegram/lib_spellcheck/spellcheck/third_party/hunspell_controller.cpp
+++++ b/Telegram/lib_spellcheck/spellcheck/third_party/hunspell_controller.cpp
++@@ -1,3 +1,4 @@
+++#include "spellcheck/spellcheck_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_spellcheck/spellcheck/third_party/language_cld3.cpp b/Telegram/lib_spellcheck/spellcheck/third_party/language_cld3.cpp
++index 514f3a7..1f465de 100644
++--- a/Telegram/lib_spellcheck/spellcheck/third_party/language_cld3.cpp
+++++ b/Telegram/lib_spellcheck/spellcheck/third_party/language_cld3.cpp
++@@ -1,3 +1,4 @@
+++#include "spellcheck/spellcheck_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_spellcheck/spellcheck/third_party/spellcheck_hunspell.cpp b/Telegram/lib_spellcheck/spellcheck/third_party/spellcheck_hunspell.cpp
++index 895f74e..09c54a6 100644
++--- a/Telegram/lib_spellcheck/spellcheck/third_party/spellcheck_hunspell.cpp
+++++ b/Telegram/lib_spellcheck/spellcheck/third_party/spellcheck_hunspell.cpp
++@@ -1,3 +1,4 @@
+++#include "spellcheck/spellcheck_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_storage/storage/cache/storage_cache_binlog_reader.cpp b/Telegram/lib_storage/storage/cache/storage_cache_binlog_reader.cpp
++index 1586b7c..a48dabb 100644
++--- a/Telegram/lib_storage/storage/cache/storage_cache_binlog_reader.cpp
+++++ b/Telegram/lib_storage/storage/cache/storage_cache_binlog_reader.cpp
++@@ -1,3 +1,4 @@
+++#include "storage/storage_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_storage/storage/cache/storage_cache_cleaner.cpp b/Telegram/lib_storage/storage/cache/storage_cache_cleaner.cpp
++index ae6b8a6..0cb16ea 100644
++--- a/Telegram/lib_storage/storage/cache/storage_cache_cleaner.cpp
+++++ b/Telegram/lib_storage/storage/cache/storage_cache_cleaner.cpp
++@@ -1,3 +1,4 @@
+++#include "storage/storage_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_storage/storage/cache/storage_cache_compactor.cpp b/Telegram/lib_storage/storage/cache/storage_cache_compactor.cpp
++index 57b2c23..b5711b9 100644
++--- a/Telegram/lib_storage/storage/cache/storage_cache_compactor.cpp
+++++ b/Telegram/lib_storage/storage/cache/storage_cache_compactor.cpp
++@@ -1,3 +1,4 @@
+++#include "storage/storage_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_storage/storage/cache/storage_cache_database.cpp b/Telegram/lib_storage/storage/cache/storage_cache_database.cpp
++index 894b3cd..8bf1f5a 100644
++--- a/Telegram/lib_storage/storage/cache/storage_cache_database.cpp
+++++ b/Telegram/lib_storage/storage/cache/storage_cache_database.cpp
++@@ -1,3 +1,4 @@
+++#include "storage/storage_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_storage/storage/cache/storage_cache_database_object.cpp b/Telegram/lib_storage/storage/cache/storage_cache_database_object.cpp
++index ff9db28..6115b70 100644
++--- a/Telegram/lib_storage/storage/cache/storage_cache_database_object.cpp
+++++ b/Telegram/lib_storage/storage/cache/storage_cache_database_object.cpp
++@@ -1,3 +1,4 @@
+++#include "storage/storage_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_storage/storage/cache/storage_cache_types.cpp b/Telegram/lib_storage/storage/cache/storage_cache_types.cpp
++index 5ec225c..c163984 100644
++--- a/Telegram/lib_storage/storage/cache/storage_cache_types.cpp
+++++ b/Telegram/lib_storage/storage/cache/storage_cache_types.cpp
++@@ -1,3 +1,4 @@
+++#include "storage/storage_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_storage/storage/cache/storage_encrypted_file_tests.cpp b/Telegram/lib_storage/storage/cache/storage_encrypted_file_tests.cpp
++index 86c7d63..acf7041 100644
++--- a/Telegram/lib_storage/storage/cache/storage_encrypted_file_tests.cpp
+++++ b/Telegram/lib_storage/storage/cache/storage_encrypted_file_tests.cpp
++@@ -1,3 +1,5 @@
+++#include "ui/ui_pch.h"
+++#include "storage/storage_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_storage/storage/storage_clear_legacy.cpp b/Telegram/lib_storage/storage/storage_clear_legacy.cpp
++index 255fd3e..68dbc9c 100644
++--- a/Telegram/lib_storage/storage/storage_clear_legacy.cpp
+++++ b/Telegram/lib_storage/storage/storage_clear_legacy.cpp
++@@ -1,3 +1,4 @@
+++#include "storage/storage_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_storage/storage/storage_clear_legacy_posix.cpp b/Telegram/lib_storage/storage/storage_clear_legacy_posix.cpp
++index 6b4b1d1..e293386 100644
++--- a/Telegram/lib_storage/storage/storage_clear_legacy_posix.cpp
+++++ b/Telegram/lib_storage/storage/storage_clear_legacy_posix.cpp
++@@ -1,3 +1,4 @@
+++#include "storage/storage_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_storage/storage/storage_clear_legacy_win.cpp b/Telegram/lib_storage/storage/storage_clear_legacy_win.cpp
++index 8309afc..8e9a32b 100644
++--- a/Telegram/lib_storage/storage/storage_clear_legacy_win.cpp
+++++ b/Telegram/lib_storage/storage/storage_clear_legacy_win.cpp
++@@ -1,3 +1,4 @@
+++#include "storage/storage_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_storage/storage/storage_databases.cpp b/Telegram/lib_storage/storage/storage_databases.cpp
++index 6fd0809..8929af8 100644
++--- a/Telegram/lib_storage/storage/storage_databases.cpp
+++++ b/Telegram/lib_storage/storage/storage_databases.cpp
++@@ -1,3 +1,4 @@
+++#include "storage/storage_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_storage/storage/storage_encrypted_file.cpp b/Telegram/lib_storage/storage/storage_encrypted_file.cpp
++index ca62baa..e12a255 100644
++--- a/Telegram/lib_storage/storage/storage_encrypted_file.cpp
+++++ b/Telegram/lib_storage/storage/storage_encrypted_file.cpp
++@@ -1,3 +1,4 @@
+++#include "storage/storage_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_storage/storage/storage_encryption.cpp b/Telegram/lib_storage/storage/storage_encryption.cpp
++index c4c14ef..1b487a8 100644
++--- a/Telegram/lib_storage/storage/storage_encryption.cpp
+++++ b/Telegram/lib_storage/storage/storage_encryption.cpp
++@@ -1,3 +1,4 @@
+++#include "storage/storage_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/emoji_suggestions/emoji_suggestions.h b/Telegram/lib_ui/emoji_suggestions/emoji_suggestions.h
++index 1725a2a..2ad5ab5 100644
++--- a/Telegram/lib_ui/emoji_suggestions/emoji_suggestions.h
+++++ b/Telegram/lib_ui/emoji_suggestions/emoji_suggestions.h
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/abstract_button.cpp b/Telegram/lib_ui/ui/abstract_button.cpp
++index 2407461..6735a6a 100644
++--- a/Telegram/lib_ui/ui/abstract_button.cpp
+++++ b/Telegram/lib_ui/ui/abstract_button.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/animated_icon.cpp b/Telegram/lib_ui/ui/animated_icon.cpp
++index d0e7699..4c7559b 100644
++--- a/Telegram/lib_ui/ui/animated_icon.cpp
+++++ b/Telegram/lib_ui/ui/animated_icon.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/basic_click_handlers.cpp b/Telegram/lib_ui/ui/basic_click_handlers.cpp
++index e5c455e..21abca6 100644
++--- a/Telegram/lib_ui/ui/basic_click_handlers.cpp
+++++ b/Telegram/lib_ui/ui/basic_click_handlers.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/cached_special_layer_shadow_corners.cpp b/Telegram/lib_ui/ui/cached_special_layer_shadow_corners.cpp
++index 0d98360..3b9f062 100644
++--- a/Telegram/lib_ui/ui/cached_special_layer_shadow_corners.cpp
+++++ b/Telegram/lib_ui/ui/cached_special_layer_shadow_corners.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/click_handler.cpp b/Telegram/lib_ui/ui/click_handler.cpp
++index 3631c54..9248fef 100644
++--- a/Telegram/lib_ui/ui/click_handler.cpp
+++++ b/Telegram/lib_ui/ui/click_handler.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/delayed_activation.cpp b/Telegram/lib_ui/ui/delayed_activation.cpp
++index 963d5ae..c68a10f 100644
++--- a/Telegram/lib_ui/ui/delayed_activation.cpp
+++++ b/Telegram/lib_ui/ui/delayed_activation.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/dpr/dpr_icon.cpp b/Telegram/lib_ui/ui/dpr/dpr_icon.cpp
++index 6515cd3..7ff9490 100644
++--- a/Telegram/lib_ui/ui/dpr/dpr_icon.cpp
+++++ b/Telegram/lib_ui/ui/dpr/dpr_icon.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/dragging_scroll_manager.cpp b/Telegram/lib_ui/ui/dragging_scroll_manager.cpp
++index 011b291..34ad3a0 100644
++--- a/Telegram/lib_ui/ui/dragging_scroll_manager.cpp
+++++ b/Telegram/lib_ui/ui/dragging_scroll_manager.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/effects/animation_value.cpp b/Telegram/lib_ui/ui/effects/animation_value.cpp
++index c83c418..bb4661e 100644
++--- a/Telegram/lib_ui/ui/effects/animation_value.cpp
+++++ b/Telegram/lib_ui/ui/effects/animation_value.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/effects/animations.cpp b/Telegram/lib_ui/ui/effects/animations.cpp
++index 3fb737a..8acf7ba 100644
++--- a/Telegram/lib_ui/ui/effects/animations.cpp
+++++ b/Telegram/lib_ui/ui/effects/animations.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/effects/cross_animation.cpp b/Telegram/lib_ui/ui/effects/cross_animation.cpp
++index e847ab3..13c5237 100644
++--- a/Telegram/lib_ui/ui/effects/cross_animation.cpp
+++++ b/Telegram/lib_ui/ui/effects/cross_animation.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/effects/cross_line.cpp b/Telegram/lib_ui/ui/effects/cross_line.cpp
++index aeffdef..3c10db4 100644
++--- a/Telegram/lib_ui/ui/effects/cross_line.cpp
+++++ b/Telegram/lib_ui/ui/effects/cross_line.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/effects/fade_animation.cpp b/Telegram/lib_ui/ui/effects/fade_animation.cpp
++index 7fef1d7..63749d5 100644
++--- a/Telegram/lib_ui/ui/effects/fade_animation.cpp
+++++ b/Telegram/lib_ui/ui/effects/fade_animation.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/effects/frame_generator.cpp b/Telegram/lib_ui/ui/effects/frame_generator.cpp
++index a50b443..8929a8a 100644
++--- a/Telegram/lib_ui/ui/effects/frame_generator.cpp
+++++ b/Telegram/lib_ui/ui/effects/frame_generator.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/effects/gradient.cpp b/Telegram/lib_ui/ui/effects/gradient.cpp
++index f65ae06..9b0a991 100644
++--- a/Telegram/lib_ui/ui/effects/gradient.cpp
+++++ b/Telegram/lib_ui/ui/effects/gradient.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/effects/numbers_animation.cpp b/Telegram/lib_ui/ui/effects/numbers_animation.cpp
++index 6eb4ad8..ab7fd09 100644
++--- a/Telegram/lib_ui/ui/effects/numbers_animation.cpp
+++++ b/Telegram/lib_ui/ui/effects/numbers_animation.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/effects/panel_animation.cpp b/Telegram/lib_ui/ui/effects/panel_animation.cpp
++index 51144b5..46db429 100644
++--- a/Telegram/lib_ui/ui/effects/panel_animation.cpp
+++++ b/Telegram/lib_ui/ui/effects/panel_animation.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/effects/path_shift_gradient.cpp b/Telegram/lib_ui/ui/effects/path_shift_gradient.cpp
++index b8037b1..d3f01ac 100644
++--- a/Telegram/lib_ui/ui/effects/path_shift_gradient.cpp
+++++ b/Telegram/lib_ui/ui/effects/path_shift_gradient.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/effects/radial_animation.cpp b/Telegram/lib_ui/ui/effects/radial_animation.cpp
++index a3efc15..6828e9a 100644
++--- a/Telegram/lib_ui/ui/effects/radial_animation.cpp
+++++ b/Telegram/lib_ui/ui/effects/radial_animation.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/effects/ripple_animation.cpp b/Telegram/lib_ui/ui/effects/ripple_animation.cpp
++index 6c5e335..29f1a28 100644
++--- a/Telegram/lib_ui/ui/effects/ripple_animation.cpp
+++++ b/Telegram/lib_ui/ui/effects/ripple_animation.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/effects/round_area_with_shadow.cpp b/Telegram/lib_ui/ui/effects/round_area_with_shadow.cpp
++index f1bf71a..2e50061 100644
++--- a/Telegram/lib_ui/ui/effects/round_area_with_shadow.cpp
+++++ b/Telegram/lib_ui/ui/effects/round_area_with_shadow.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/effects/show_animation.cpp b/Telegram/lib_ui/ui/effects/show_animation.cpp
++index b7330b7..aab050d 100644
++--- a/Telegram/lib_ui/ui/effects/show_animation.cpp
+++++ b/Telegram/lib_ui/ui/effects/show_animation.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/effects/slide_animation.cpp b/Telegram/lib_ui/ui/effects/slide_animation.cpp
++index 06ad3ed..3669220 100644
++--- a/Telegram/lib_ui/ui/effects/slide_animation.cpp
+++++ b/Telegram/lib_ui/ui/effects/slide_animation.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/effects/spoiler_mess.cpp b/Telegram/lib_ui/ui/effects/spoiler_mess.cpp
++index d4413de..0e0d907 100644
++--- a/Telegram/lib_ui/ui/effects/spoiler_mess.cpp
+++++ b/Telegram/lib_ui/ui/effects/spoiler_mess.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/emoji_config.cpp b/Telegram/lib_ui/ui/emoji_config.cpp
++index d720b0d..2370ab3 100644
++--- a/Telegram/lib_ui/ui/emoji_config.cpp
+++++ b/Telegram/lib_ui/ui/emoji_config.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/gl/gl_detection.cpp b/Telegram/lib_ui/ui/gl/gl_detection.cpp
++index e574b18..eeba5e0 100644
++--- a/Telegram/lib_ui/ui/gl/gl_detection.cpp
+++++ b/Telegram/lib_ui/ui/gl/gl_detection.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/gl/gl_image.cpp b/Telegram/lib_ui/ui/gl/gl_image.cpp
++index cb04fdd..7baec05 100644
++--- a/Telegram/lib_ui/ui/gl/gl_image.cpp
+++++ b/Telegram/lib_ui/ui/gl/gl_image.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/gl/gl_math.cpp b/Telegram/lib_ui/ui/gl/gl_math.cpp
++index 92da4cc..01ac737 100644
++--- a/Telegram/lib_ui/ui/gl/gl_math.cpp
+++++ b/Telegram/lib_ui/ui/gl/gl_math.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/gl/gl_primitives.cpp b/Telegram/lib_ui/ui/gl/gl_primitives.cpp
++index 9b8b785..e03618e 100644
++--- a/Telegram/lib_ui/ui/gl/gl_primitives.cpp
+++++ b/Telegram/lib_ui/ui/gl/gl_primitives.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/gl/gl_shader.cpp b/Telegram/lib_ui/ui/gl/gl_shader.cpp
++index f306bbe..a82a898 100644
++--- a/Telegram/lib_ui/ui/gl/gl_shader.cpp
+++++ b/Telegram/lib_ui/ui/gl/gl_shader.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/gl/gl_surface.cpp b/Telegram/lib_ui/ui/gl/gl_surface.cpp
++index 7945510..cbfb9a1 100644
++--- a/Telegram/lib_ui/ui/gl/gl_surface.cpp
+++++ b/Telegram/lib_ui/ui/gl/gl_surface.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/gl/gl_window.cpp b/Telegram/lib_ui/ui/gl/gl_window.cpp
++index da0a2bc..30dfa66 100644
++--- a/Telegram/lib_ui/ui/gl/gl_window.cpp
+++++ b/Telegram/lib_ui/ui/gl/gl_window.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/image/image_prepare.cpp b/Telegram/lib_ui/ui/image/image_prepare.cpp
++index 325f5c9..5680eac 100644
++--- a/Telegram/lib_ui/ui/image/image_prepare.cpp
+++++ b/Telegram/lib_ui/ui/image/image_prepare.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/inactive_press.cpp b/Telegram/lib_ui/ui/inactive_press.cpp
++index b30bf05..3ea28c8 100644
++--- a/Telegram/lib_ui/ui/inactive_press.cpp
+++++ b/Telegram/lib_ui/ui/inactive_press.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/integration.cpp b/Telegram/lib_ui/ui/integration.cpp
++index 431a9bb..e7f4e8f 100644
++--- a/Telegram/lib_ui/ui/integration.cpp
+++++ b/Telegram/lib_ui/ui/integration.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/layers/box_content.cpp b/Telegram/lib_ui/ui/layers/box_content.cpp
++index b7d36d8..5a39bf9 100644
++--- a/Telegram/lib_ui/ui/layers/box_content.cpp
+++++ b/Telegram/lib_ui/ui/layers/box_content.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/layers/box_layer_widget.cpp b/Telegram/lib_ui/ui/layers/box_layer_widget.cpp
++index e315715..89f8215 100644
++--- a/Telegram/lib_ui/ui/layers/box_layer_widget.cpp
+++++ b/Telegram/lib_ui/ui/layers/box_layer_widget.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/layers/generic_box.cpp b/Telegram/lib_ui/ui/layers/generic_box.cpp
++index bfcc7aa..c64e64d 100644
++--- a/Telegram/lib_ui/ui/layers/generic_box.cpp
+++++ b/Telegram/lib_ui/ui/layers/generic_box.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/layers/layer_manager.cpp b/Telegram/lib_ui/ui/layers/layer_manager.cpp
++index cad285f..3f54577 100644
++--- a/Telegram/lib_ui/ui/layers/layer_manager.cpp
+++++ b/Telegram/lib_ui/ui/layers/layer_manager.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/layers/layer_widget.cpp b/Telegram/lib_ui/ui/layers/layer_widget.cpp
++index 86df951..76516e9 100644
++--- a/Telegram/lib_ui/ui/layers/layer_widget.cpp
+++++ b/Telegram/lib_ui/ui/layers/layer_widget.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/layers/show.cpp b/Telegram/lib_ui/ui/layers/show.cpp
++index f28c64b..8ec0f89 100644
++--- a/Telegram/lib_ui/ui/layers/show.cpp
+++++ b/Telegram/lib_ui/ui/layers/show.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/main_queue_processor.cpp b/Telegram/lib_ui/ui/main_queue_processor.cpp
++index 76e36a9..7d8c8ed 100644
++--- a/Telegram/lib_ui/ui/main_queue_processor.cpp
+++++ b/Telegram/lib_ui/ui/main_queue_processor.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/paint/arcs.cpp b/Telegram/lib_ui/ui/paint/arcs.cpp
++index 2f346e4..ed8efdd 100644
++--- a/Telegram/lib_ui/ui/paint/arcs.cpp
+++++ b/Telegram/lib_ui/ui/paint/arcs.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/paint/blob.cpp b/Telegram/lib_ui/ui/paint/blob.cpp
++index 5722659..d421048 100644
++--- a/Telegram/lib_ui/ui/paint/blob.cpp
+++++ b/Telegram/lib_ui/ui/paint/blob.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/paint/blobs.cpp b/Telegram/lib_ui/ui/paint/blobs.cpp
++index 00e2cb8..be15cbf 100644
++--- a/Telegram/lib_ui/ui/paint/blobs.cpp
+++++ b/Telegram/lib_ui/ui/paint/blobs.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/paint/blobs_linear.cpp b/Telegram/lib_ui/ui/paint/blobs_linear.cpp
++index 4d274f2..f5e52a1 100644
++--- a/Telegram/lib_ui/ui/paint/blobs_linear.cpp
+++++ b/Telegram/lib_ui/ui/paint/blobs_linear.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/ph.cpp b/Telegram/lib_ui/ui/ph.cpp
++index 620db93..03a686c 100644
++--- a/Telegram/lib_ui/ui/ph.cpp
+++++ b/Telegram/lib_ui/ui/ph.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/platform/linux/ui_utility_linux.cpp b/Telegram/lib_ui/ui/platform/linux/ui_utility_linux.cpp
++index 02ada1f..430778a 100644
++--- a/Telegram/lib_ui/ui/platform/linux/ui_utility_linux.cpp
+++++ b/Telegram/lib_ui/ui/platform/linux/ui_utility_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/platform/linux/ui_window_linux.cpp b/Telegram/lib_ui/ui/platform/linux/ui_window_linux.cpp
++index dd1a463..305e285 100644
++--- a/Telegram/lib_ui/ui/platform/linux/ui_window_linux.cpp
+++++ b/Telegram/lib_ui/ui/platform/linux/ui_window_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/platform/linux/ui_window_title_linux.cpp b/Telegram/lib_ui/ui/platform/linux/ui_window_title_linux.cpp
++index d257590..26de4ef 100644
++--- a/Telegram/lib_ui/ui/platform/linux/ui_window_title_linux.cpp
+++++ b/Telegram/lib_ui/ui/platform/linux/ui_window_title_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/platform/ui_platform_window.cpp b/Telegram/lib_ui/ui/platform/ui_platform_window.cpp
++index 5e4fc87..432b51b 100644
++--- a/Telegram/lib_ui/ui/platform/ui_platform_window.cpp
+++++ b/Telegram/lib_ui/ui/platform/ui_platform_window.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/platform/ui_platform_window_title.cpp b/Telegram/lib_ui/ui/platform/ui_platform_window_title.cpp
++index 93d9831..0d67e05 100644
++--- a/Telegram/lib_ui/ui/platform/ui_platform_window_title.cpp
+++++ b/Telegram/lib_ui/ui/platform/ui_platform_window_title.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/platform/win/ui_utility_win.cpp b/Telegram/lib_ui/ui/platform/win/ui_utility_win.cpp
++index e72744f..084c617 100644
++--- a/Telegram/lib_ui/ui/platform/win/ui_utility_win.cpp
+++++ b/Telegram/lib_ui/ui/platform/win/ui_utility_win.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/platform/win/ui_window_shadow_win.cpp b/Telegram/lib_ui/ui/platform/win/ui_window_shadow_win.cpp
++index eed9bb9..6c05f73 100644
++--- a/Telegram/lib_ui/ui/platform/win/ui_window_shadow_win.cpp
+++++ b/Telegram/lib_ui/ui/platform/win/ui_window_shadow_win.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/platform/win/ui_window_title_win.cpp b/Telegram/lib_ui/ui/platform/win/ui_window_title_win.cpp
++index 9971ac5..1b073f4 100644
++--- a/Telegram/lib_ui/ui/platform/win/ui_window_title_win.cpp
+++++ b/Telegram/lib_ui/ui/platform/win/ui_window_title_win.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/platform/win/ui_window_win.cpp b/Telegram/lib_ui/ui/platform/win/ui_window_win.cpp
++index e4cb1d7..ea39c9d 100644
++--- a/Telegram/lib_ui/ui/platform/win/ui_window_win.cpp
+++++ b/Telegram/lib_ui/ui/platform/win/ui_window_win.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/platform/win/ui_windows_direct_manipulation.cpp b/Telegram/lib_ui/ui/platform/win/ui_windows_direct_manipulation.cpp
++index dbdbec5..0d58c60 100644
++--- a/Telegram/lib_ui/ui/platform/win/ui_windows_direct_manipulation.cpp
+++++ b/Telegram/lib_ui/ui/platform/win/ui_windows_direct_manipulation.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/round_rect.cpp b/Telegram/lib_ui/ui/round_rect.cpp
++index d539462..81d540e 100644
++--- a/Telegram/lib_ui/ui/round_rect.cpp
+++++ b/Telegram/lib_ui/ui/round_rect.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/rp_widget.cpp b/Telegram/lib_ui/ui/rp_widget.cpp
++index 37135f9..f78417d 100644
++--- a/Telegram/lib_ui/ui/rp_widget.cpp
+++++ b/Telegram/lib_ui/ui/rp_widget.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/style/style_core.cpp b/Telegram/lib_ui/ui/style/style_core.cpp
++index e589944..da59c94 100644
++--- a/Telegram/lib_ui/ui/style/style_core.cpp
+++++ b/Telegram/lib_ui/ui/style/style_core.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/style/style_core_color.cpp b/Telegram/lib_ui/ui/style/style_core_color.cpp
++index 3325cfd..f0923c1 100644
++--- a/Telegram/lib_ui/ui/style/style_core_color.cpp
+++++ b/Telegram/lib_ui/ui/style/style_core_color.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/style/style_core_direction.cpp b/Telegram/lib_ui/ui/style/style_core_direction.cpp
++index a276df1..23b73dc 100644
++--- a/Telegram/lib_ui/ui/style/style_core_direction.cpp
+++++ b/Telegram/lib_ui/ui/style/style_core_direction.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/style/style_core_font.cpp b/Telegram/lib_ui/ui/style/style_core_font.cpp
++index e4a95f4..41751f2 100644
++--- a/Telegram/lib_ui/ui/style/style_core_font.cpp
+++++ b/Telegram/lib_ui/ui/style/style_core_font.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/style/style_core_icon.cpp b/Telegram/lib_ui/ui/style/style_core_icon.cpp
++index 1781256..bd3f419 100644
++--- a/Telegram/lib_ui/ui/style/style_core_icon.cpp
+++++ b/Telegram/lib_ui/ui/style/style_core_icon.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/style/style_core_palette.cpp b/Telegram/lib_ui/ui/style/style_core_palette.cpp
++index bad3e65..9600496 100644
++--- a/Telegram/lib_ui/ui/style/style_core_palette.cpp
+++++ b/Telegram/lib_ui/ui/style/style_core_palette.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/style/style_core_scale.cpp b/Telegram/lib_ui/ui/style/style_core_scale.cpp
++index b6be737..5fd378c 100644
++--- a/Telegram/lib_ui/ui/style/style_core_scale.cpp
+++++ b/Telegram/lib_ui/ui/style/style_core_scale.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/style/style_core_scale.h b/Telegram/lib_ui/ui/style/style_core_scale.h
++index 23ea43b..9642786 100644
++--- a/Telegram/lib_ui/ui/style/style_core_scale.h
+++++ b/Telegram/lib_ui/ui/style/style_core_scale.h
++@@ -6,6 +6,7 @@
++ //
++ #pragma once
++ 
+++#include "base/basic_types.h"
++ #include "base/algorithm.h"
++ #include "base/assertion.h"
++ 
++diff --git a/Telegram/lib_ui/ui/style/style_core_types.cpp b/Telegram/lib_ui/ui/style/style_core_types.cpp
++index a39a1d8..5fd0714 100644
++--- a/Telegram/lib_ui/ui/style/style_core_types.cpp
+++++ b/Telegram/lib_ui/ui/style/style_core_types.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/style/style_palette_colorizer.cpp b/Telegram/lib_ui/ui/style/style_palette_colorizer.cpp
++index 491d8cd..2122f20 100644
++--- a/Telegram/lib_ui/ui/style/style_palette_colorizer.cpp
+++++ b/Telegram/lib_ui/ui/style/style_palette_colorizer.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/text/custom_emoji_helper.cpp b/Telegram/lib_ui/ui/text/custom_emoji_helper.cpp
++index a7a6844..84b922c 100644
++--- a/Telegram/lib_ui/ui/text/custom_emoji_helper.cpp
+++++ b/Telegram/lib_ui/ui/text/custom_emoji_helper.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/text/custom_emoji_instance.cpp b/Telegram/lib_ui/ui/text/custom_emoji_instance.cpp
++index 3148a07..4fcf221 100644
++--- a/Telegram/lib_ui/ui/text/custom_emoji_instance.cpp
+++++ b/Telegram/lib_ui/ui/text/custom_emoji_instance.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/text/custom_emoji_text_badge.cpp b/Telegram/lib_ui/ui/text/custom_emoji_text_badge.cpp
++index 2f8b452..6e0be45 100644
++--- a/Telegram/lib_ui/ui/text/custom_emoji_text_badge.cpp
+++++ b/Telegram/lib_ui/ui/text/custom_emoji_text_badge.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++@@ -47,4 +48,4 @@ namespace Ui::Text {
++ 	}, .margin = margin };
++ }
++ 
++-}
++\ No newline at end of file
+++}
++diff --git a/Telegram/lib_ui/ui/text/text.cpp b/Telegram/lib_ui/ui/text/text.cpp
++index 76120cd..3ed9747 100644
++--- a/Telegram/lib_ui/ui/text/text.cpp
+++++ b/Telegram/lib_ui/ui/text/text.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/text/text_block.cpp b/Telegram/lib_ui/ui/text/text_block.cpp
++index f33f0bd..b05b081 100644
++--- a/Telegram/lib_ui/ui/text/text_block.cpp
+++++ b/Telegram/lib_ui/ui/text/text_block.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/text/text_block_parser.cpp b/Telegram/lib_ui/ui/text/text_block_parser.cpp
++index 75b15a0..6206ece 100644
++--- a/Telegram/lib_ui/ui/text/text_block_parser.cpp
+++++ b/Telegram/lib_ui/ui/text/text_block_parser.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/text/text_custom_emoji.cpp b/Telegram/lib_ui/ui/text/text_custom_emoji.cpp
++index 4535b82..16e3a64 100644
++--- a/Telegram/lib_ui/ui/text/text_custom_emoji.cpp
+++++ b/Telegram/lib_ui/ui/text/text_custom_emoji.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/text/text_entity.cpp b/Telegram/lib_ui/ui/text/text_entity.cpp
++index 810f576..be6c6fc 100644
++--- a/Telegram/lib_ui/ui/text/text_entity.cpp
+++++ b/Telegram/lib_ui/ui/text/text_entity.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/text/text_extended_data.cpp b/Telegram/lib_ui/ui/text/text_extended_data.cpp
++index 5bffdca..d648cb1 100644
++--- a/Telegram/lib_ui/ui/text/text_extended_data.cpp
+++++ b/Telegram/lib_ui/ui/text/text_extended_data.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/text/text_renderer.cpp b/Telegram/lib_ui/ui/text/text_renderer.cpp
++index 12ce001..7767c69 100644
++--- a/Telegram/lib_ui/ui/text/text_renderer.cpp
+++++ b/Telegram/lib_ui/ui/text/text_renderer.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/text/text_stack_engine.cpp b/Telegram/lib_ui/ui/text/text_stack_engine.cpp
++index 339745c..c7bdecc 100644
++--- a/Telegram/lib_ui/ui/text/text_stack_engine.cpp
+++++ b/Telegram/lib_ui/ui/text/text_stack_engine.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/text/text_utilities.cpp b/Telegram/lib_ui/ui/text/text_utilities.cpp
++index e4093be..c350c16 100644
++--- a/Telegram/lib_ui/ui/text/text_utilities.cpp
+++++ b/Telegram/lib_ui/ui/text/text_utilities.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/text/text_variant.cpp b/Telegram/lib_ui/ui/text/text_variant.cpp
++index 5a71950..89308d1 100644
++--- a/Telegram/lib_ui/ui/text/text_variant.cpp
+++++ b/Telegram/lib_ui/ui/text/text_variant.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/text/text_word_parser.cpp b/Telegram/lib_ui/ui/text/text_word_parser.cpp
++index 6561e79..a2e9ad1 100644
++--- a/Telegram/lib_ui/ui/text/text_word_parser.cpp
+++++ b/Telegram/lib_ui/ui/text/text_word_parser.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/toast/toast.cpp b/Telegram/lib_ui/ui/toast/toast.cpp
++index 4865c1d..47f56af 100644
++--- a/Telegram/lib_ui/ui/toast/toast.cpp
+++++ b/Telegram/lib_ui/ui/toast/toast.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/toast/toast_manager.cpp b/Telegram/lib_ui/ui/toast/toast_manager.cpp
++index 11302ab..102cc9d 100644
++--- a/Telegram/lib_ui/ui/toast/toast_manager.cpp
+++++ b/Telegram/lib_ui/ui/toast/toast_manager.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/toast/toast_widget.cpp b/Telegram/lib_ui/ui/toast/toast_widget.cpp
++index 4a2284b..c57b3dc 100644
++--- a/Telegram/lib_ui/ui/toast/toast_widget.cpp
+++++ b/Telegram/lib_ui/ui/toast/toast_widget.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/ui_utility.cpp b/Telegram/lib_ui/ui/ui_utility.cpp
++index ea43678..dbf248e 100644
++--- a/Telegram/lib_ui/ui/ui_utility.cpp
+++++ b/Telegram/lib_ui/ui/ui_utility.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/box_content_divider.cpp b/Telegram/lib_ui/ui/widgets/box_content_divider.cpp
++index 0e4469b..78e952b 100644
++--- a/Telegram/lib_ui/ui/widgets/box_content_divider.cpp
+++++ b/Telegram/lib_ui/ui/widgets/box_content_divider.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/buttons.cpp b/Telegram/lib_ui/ui/widgets/buttons.cpp
++index b05f76c..a422bd1 100644
++--- a/Telegram/lib_ui/ui/widgets/buttons.cpp
+++++ b/Telegram/lib_ui/ui/widgets/buttons.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/call_button.cpp b/Telegram/lib_ui/ui/widgets/call_button.cpp
++index 834b726..9413d10 100644
++--- a/Telegram/lib_ui/ui/widgets/call_button.cpp
+++++ b/Telegram/lib_ui/ui/widgets/call_button.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/checkbox.cpp b/Telegram/lib_ui/ui/widgets/checkbox.cpp
++index 1451765..5dcde79 100644
++--- a/Telegram/lib_ui/ui/widgets/checkbox.cpp
+++++ b/Telegram/lib_ui/ui/widgets/checkbox.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/dropdown_menu.cpp b/Telegram/lib_ui/ui/widgets/dropdown_menu.cpp
++index 070c43f..8894ded 100644
++--- a/Telegram/lib_ui/ui/widgets/dropdown_menu.cpp
+++++ b/Telegram/lib_ui/ui/widgets/dropdown_menu.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/elastic_scroll.cpp b/Telegram/lib_ui/ui/widgets/elastic_scroll.cpp
++index 7940b83..94e99ed 100644
++--- a/Telegram/lib_ui/ui/widgets/elastic_scroll.cpp
+++++ b/Telegram/lib_ui/ui/widgets/elastic_scroll.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/fields/custom_field_object.cpp b/Telegram/lib_ui/ui/widgets/fields/custom_field_object.cpp
++index 67e2893..f520d1c 100644
++--- a/Telegram/lib_ui/ui/widgets/fields/custom_field_object.cpp
+++++ b/Telegram/lib_ui/ui/widgets/fields/custom_field_object.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/fields/input_field.cpp b/Telegram/lib_ui/ui/widgets/fields/input_field.cpp
++index 8c02f90..f3cf91b 100644
++--- a/Telegram/lib_ui/ui/widgets/fields/input_field.cpp
+++++ b/Telegram/lib_ui/ui/widgets/fields/input_field.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/fields/masked_input_field.cpp b/Telegram/lib_ui/ui/widgets/fields/masked_input_field.cpp
++index 353a9b5..4448202 100644
++--- a/Telegram/lib_ui/ui/widgets/fields/masked_input_field.cpp
+++++ b/Telegram/lib_ui/ui/widgets/fields/masked_input_field.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/fields/masked_input_field.h b/Telegram/lib_ui/ui/widgets/fields/masked_input_field.h
++index 1b09430..27c4578 100644
++--- a/Telegram/lib_ui/ui/widgets/fields/masked_input_field.h
+++++ b/Telegram/lib_ui/ui/widgets/fields/masked_input_field.h
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/fields/number_input.cpp b/Telegram/lib_ui/ui/widgets/fields/number_input.cpp
++index ceb5a6f..76c4eb2 100644
++--- a/Telegram/lib_ui/ui/widgets/fields/number_input.cpp
+++++ b/Telegram/lib_ui/ui/widgets/fields/number_input.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/fields/password_input.cpp b/Telegram/lib_ui/ui/widgets/fields/password_input.cpp
++index b0cbd70..50d1fe0 100644
++--- a/Telegram/lib_ui/ui/widgets/fields/password_input.cpp
+++++ b/Telegram/lib_ui/ui/widgets/fields/password_input.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/fields/time_part_input.cpp b/Telegram/lib_ui/ui/widgets/fields/time_part_input.cpp
++index 95bc1d0..98a35b4 100644
++--- a/Telegram/lib_ui/ui/widgets/fields/time_part_input.cpp
+++++ b/Telegram/lib_ui/ui/widgets/fields/time_part_input.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/icon_button_with_text.cpp b/Telegram/lib_ui/ui/widgets/icon_button_with_text.cpp
++index 0ff2159..3e5175a 100644
++--- a/Telegram/lib_ui/ui/widgets/icon_button_with_text.cpp
+++++ b/Telegram/lib_ui/ui/widgets/icon_button_with_text.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/inner_dropdown.cpp b/Telegram/lib_ui/ui/widgets/inner_dropdown.cpp
++index de75876..2d17053 100644
++--- a/Telegram/lib_ui/ui/widgets/inner_dropdown.cpp
+++++ b/Telegram/lib_ui/ui/widgets/inner_dropdown.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/labels.cpp b/Telegram/lib_ui/ui/widgets/labels.cpp
++index 407cf0e..82bf059 100644
++--- a/Telegram/lib_ui/ui/widgets/labels.cpp
+++++ b/Telegram/lib_ui/ui/widgets/labels.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/menu/menu.cpp b/Telegram/lib_ui/ui/widgets/menu/menu.cpp
++index c4bb831..85bc8ab 100644
++--- a/Telegram/lib_ui/ui/widgets/menu/menu.cpp
+++++ b/Telegram/lib_ui/ui/widgets/menu/menu.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/menu/menu_action.cpp b/Telegram/lib_ui/ui/widgets/menu/menu_action.cpp
++index e6a2ae3..4ff26ca 100644
++--- a/Telegram/lib_ui/ui/widgets/menu/menu_action.cpp
+++++ b/Telegram/lib_ui/ui/widgets/menu/menu_action.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/menu/menu_add_action_callback.cpp b/Telegram/lib_ui/ui/widgets/menu/menu_add_action_callback.cpp
++index feb6702..c335cb4 100644
++--- a/Telegram/lib_ui/ui/widgets/menu/menu_add_action_callback.cpp
+++++ b/Telegram/lib_ui/ui/widgets/menu/menu_add_action_callback.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/menu/menu_add_action_callback_factory.cpp b/Telegram/lib_ui/ui/widgets/menu/menu_add_action_callback_factory.cpp
++index 47069c5..1adc224 100644
++--- a/Telegram/lib_ui/ui/widgets/menu/menu_add_action_callback_factory.cpp
+++++ b/Telegram/lib_ui/ui/widgets/menu/menu_add_action_callback_factory.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/menu/menu_common.cpp b/Telegram/lib_ui/ui/widgets/menu/menu_common.cpp
++index badc14c..a55cfd1 100644
++--- a/Telegram/lib_ui/ui/widgets/menu/menu_common.cpp
+++++ b/Telegram/lib_ui/ui/widgets/menu/menu_common.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/menu/menu_item_base.cpp b/Telegram/lib_ui/ui/widgets/menu/menu_item_base.cpp
++index ab9b2d9..a636514 100644
++--- a/Telegram/lib_ui/ui/widgets/menu/menu_item_base.cpp
+++++ b/Telegram/lib_ui/ui/widgets/menu/menu_item_base.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/menu/menu_multiline_action.cpp b/Telegram/lib_ui/ui/widgets/menu/menu_multiline_action.cpp
++index 4e89422..f5852ec 100644
++--- a/Telegram/lib_ui/ui/widgets/menu/menu_multiline_action.cpp
+++++ b/Telegram/lib_ui/ui/widgets/menu/menu_multiline_action.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/menu/menu_separator.cpp b/Telegram/lib_ui/ui/widgets/menu/menu_separator.cpp
++index f6d37ae..eaaf162 100644
++--- a/Telegram/lib_ui/ui/widgets/menu/menu_separator.cpp
+++++ b/Telegram/lib_ui/ui/widgets/menu/menu_separator.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/menu/menu_toggle.cpp b/Telegram/lib_ui/ui/widgets/menu/menu_toggle.cpp
++index 93071ea..6347c2e 100644
++--- a/Telegram/lib_ui/ui/widgets/menu/menu_toggle.cpp
+++++ b/Telegram/lib_ui/ui/widgets/menu/menu_toggle.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/popup_menu.cpp b/Telegram/lib_ui/ui/widgets/popup_menu.cpp
++index 4992351..9066d11 100644
++--- a/Telegram/lib_ui/ui/widgets/popup_menu.cpp
+++++ b/Telegram/lib_ui/ui/widgets/popup_menu.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/rp_window.cpp b/Telegram/lib_ui/ui/widgets/rp_window.cpp
++index 74d95e1..91a157e 100644
++--- a/Telegram/lib_ui/ui/widgets/rp_window.cpp
+++++ b/Telegram/lib_ui/ui/widgets/rp_window.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/scroll_area.cpp b/Telegram/lib_ui/ui/widgets/scroll_area.cpp
++index 3a1f904..ec94805 100644
++--- a/Telegram/lib_ui/ui/widgets/scroll_area.cpp
+++++ b/Telegram/lib_ui/ui/widgets/scroll_area.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/separate_panel.cpp b/Telegram/lib_ui/ui/widgets/separate_panel.cpp
++index 80cdd75..6cfc1f5 100644
++--- a/Telegram/lib_ui/ui/widgets/separate_panel.cpp
+++++ b/Telegram/lib_ui/ui/widgets/separate_panel.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/shadow.cpp b/Telegram/lib_ui/ui/widgets/shadow.cpp
++index 216941d..a65b8bb 100644
++--- a/Telegram/lib_ui/ui/widgets/shadow.cpp
+++++ b/Telegram/lib_ui/ui/widgets/shadow.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/side_bar_button.cpp b/Telegram/lib_ui/ui/widgets/side_bar_button.cpp
++index d9975ee..3f796f2 100644
++--- a/Telegram/lib_ui/ui/widgets/side_bar_button.cpp
+++++ b/Telegram/lib_ui/ui/widgets/side_bar_button.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/time_input.cpp b/Telegram/lib_ui/ui/widgets/time_input.cpp
++index b6a0238..9143ffe 100644
++--- a/Telegram/lib_ui/ui/widgets/time_input.cpp
+++++ b/Telegram/lib_ui/ui/widgets/time_input.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/widgets/tooltip.cpp b/Telegram/lib_ui/ui/widgets/tooltip.cpp
++index 66d9143..bbfb2ad 100644
++--- a/Telegram/lib_ui/ui/widgets/tooltip.cpp
+++++ b/Telegram/lib_ui/ui/widgets/tooltip.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/wrap/fade_wrap.cpp b/Telegram/lib_ui/ui/wrap/fade_wrap.cpp
++index 92da08d..515ec24 100644
++--- a/Telegram/lib_ui/ui/wrap/fade_wrap.cpp
+++++ b/Telegram/lib_ui/ui/wrap/fade_wrap.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/wrap/follow_slide_wrap.cpp b/Telegram/lib_ui/ui/wrap/follow_slide_wrap.cpp
++index ae9fd6f..3c58ea4 100644
++--- a/Telegram/lib_ui/ui/wrap/follow_slide_wrap.cpp
+++++ b/Telegram/lib_ui/ui/wrap/follow_slide_wrap.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/wrap/padding_wrap.cpp b/Telegram/lib_ui/ui/wrap/padding_wrap.cpp
++index 26727c7..9531f16 100644
++--- a/Telegram/lib_ui/ui/wrap/padding_wrap.cpp
+++++ b/Telegram/lib_ui/ui/wrap/padding_wrap.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/wrap/slide_wrap.cpp b/Telegram/lib_ui/ui/wrap/slide_wrap.cpp
++index 19d1bb9..c39005b 100644
++--- a/Telegram/lib_ui/ui/wrap/slide_wrap.cpp
+++++ b/Telegram/lib_ui/ui/wrap/slide_wrap.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/wrap/table_layout.cpp b/Telegram/lib_ui/ui/wrap/table_layout.cpp
++index 539c577..c124ed3 100644
++--- a/Telegram/lib_ui/ui/wrap/table_layout.cpp
+++++ b/Telegram/lib_ui/ui/wrap/table_layout.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/wrap/vertical_layout.cpp b/Telegram/lib_ui/ui/wrap/vertical_layout.cpp
++index f14f2af..d34a988 100644
++--- a/Telegram/lib_ui/ui/wrap/vertical_layout.cpp
+++++ b/Telegram/lib_ui/ui/wrap/vertical_layout.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_ui/ui/wrap/vertical_layout_reorder.cpp b/Telegram/lib_ui/ui/wrap/vertical_layout_reorder.cpp
++index b882ef6..42dcaff 100644
++--- a/Telegram/lib_ui/ui/wrap/vertical_layout_reorder.cpp
+++++ b/Telegram/lib_ui/ui/wrap/vertical_layout_reorder.cpp
++@@ -1,3 +1,4 @@
+++#include "ui/ui_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_webrtc/webrtc/details/webrtc_environment_openal.cpp b/Telegram/lib_webrtc/webrtc/details/webrtc_environment_openal.cpp
++index e96fb4a..b66d65f 100644
++--- a/Telegram/lib_webrtc/webrtc/details/webrtc_environment_openal.cpp
+++++ b/Telegram/lib_webrtc/webrtc/details/webrtc_environment_openal.cpp
++@@ -1,3 +1,4 @@
+++#include "webrtc/webrtc_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_webrtc/webrtc/details/webrtc_environment_video_capture.cpp b/Telegram/lib_webrtc/webrtc/details/webrtc_environment_video_capture.cpp
++index 0b38efc..25fe6ac 100644
++--- a/Telegram/lib_webrtc/webrtc/details/webrtc_environment_video_capture.cpp
+++++ b/Telegram/lib_webrtc/webrtc/details/webrtc_environment_video_capture.cpp
++@@ -1,3 +1,4 @@
+++#include "webrtc/webrtc_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_webrtc/webrtc/details/webrtc_openal_adm.cpp b/Telegram/lib_webrtc/webrtc/details/webrtc_openal_adm.cpp
++index 733f6b5..c2f4bc7 100644
++--- a/Telegram/lib_webrtc/webrtc/details/webrtc_openal_adm.cpp
+++++ b/Telegram/lib_webrtc/webrtc/details/webrtc_openal_adm.cpp
++@@ -1,3 +1,4 @@
+++#include "webrtc/webrtc_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_webrtc/webrtc/platform/linux/webrtc_environment_linux.cpp b/Telegram/lib_webrtc/webrtc/platform/linux/webrtc_environment_linux.cpp
++index e89717c..289801a 100644
++--- a/Telegram/lib_webrtc/webrtc/platform/linux/webrtc_environment_linux.cpp
+++++ b/Telegram/lib_webrtc/webrtc/platform/linux/webrtc_environment_linux.cpp
++@@ -1,3 +1,4 @@
+++#include "webrtc/webrtc_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_webrtc/webrtc/webrtc_audio_input_tester.cpp b/Telegram/lib_webrtc/webrtc/webrtc_audio_input_tester.cpp
++index 22fb3d6..c9a0f4a 100644
++--- a/Telegram/lib_webrtc/webrtc/webrtc_audio_input_tester.cpp
+++++ b/Telegram/lib_webrtc/webrtc/webrtc_audio_input_tester.cpp
++@@ -1,3 +1,4 @@
+++#include "webrtc/webrtc_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_webrtc/webrtc/webrtc_create_adm.cpp b/Telegram/lib_webrtc/webrtc/webrtc_create_adm.cpp
++index c53652b..210d2fc 100644
++--- a/Telegram/lib_webrtc/webrtc/webrtc_create_adm.cpp
+++++ b/Telegram/lib_webrtc/webrtc/webrtc_create_adm.cpp
++@@ -1,3 +1,4 @@
+++#include "webrtc/webrtc_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_webrtc/webrtc/webrtc_device_resolver.cpp b/Telegram/lib_webrtc/webrtc/webrtc_device_resolver.cpp
++index 2e43bf7..ec4d549 100644
++--- a/Telegram/lib_webrtc/webrtc/webrtc_device_resolver.cpp
+++++ b/Telegram/lib_webrtc/webrtc/webrtc_device_resolver.cpp
++@@ -1,3 +1,4 @@
+++#include "webrtc/webrtc_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_webrtc/webrtc/webrtc_environment.cpp b/Telegram/lib_webrtc/webrtc/webrtc_environment.cpp
++index a1cd3d9..5d6fbab 100644
++--- a/Telegram/lib_webrtc/webrtc/webrtc_environment.cpp
+++++ b/Telegram/lib_webrtc/webrtc/webrtc_environment.cpp
++@@ -1,3 +1,4 @@
+++#include "webrtc/webrtc_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
++diff --git a/Telegram/lib_webrtc/webrtc/webrtc_video_track.cpp b/Telegram/lib_webrtc/webrtc/webrtc_video_track.cpp
++index 2bac8b1..d4dc8a1 100644
++--- a/Telegram/lib_webrtc/webrtc/webrtc_video_track.cpp
+++++ b/Telegram/lib_webrtc/webrtc/webrtc_video_track.cpp
++@@ -1,3 +1,4 @@
+++#include "webrtc/webrtc_pch.h"
++ // This file is part of Desktop App Toolkit,
++ // a set of libraries for developing nice desktop applications.
++ //
+-- 
+2.54.0
+
+
+From 3ee40b8620ad70039ba0eab1c174bd6aee34c7eb Mon Sep 17 00:00:00 2001
+From: Luc Schrijvers <begasus@gmail.com>
+Date: Sun, 21 Jun 2026 13:04:18 +0200
+Subject: Fix for: find_package(Qt6 REQUIRED COMPONENTS CorePrivate GuiPrivate
+ WidgetsPrivate)
+
+
+diff --git a/cmake/external/qt/package.cmake b/cmake/external/qt/package.cmake
+index 4500e16..577e071 100644
+--- a/cmake/external/qt/package.cmake
++++ b/cmake/external/qt/package.cmake
+@@ -69,6 +69,10 @@ endif()
+ find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Gui Widgets Network Svg REQUIRED)
+ find_package(Qt${QT_VERSION_MAJOR} OPTIONAL_COMPONENTS Quick QuickWidgets QUIET)
+ 
++if(Qt6Gui_VERSION VERSION_GREATER_EQUAL "6.10.0")
++    find_package(Qt6 REQUIRED COMPONENTS CorePrivate GuiPrivate WidgetsPrivate)
++endif()
++
+ if (QT_VERSION_MAJOR GREATER_EQUAL 6)
+     find_package(Qt${QT_VERSION_MAJOR} COMPONENTS OpenGL OpenGLWidgets REQUIRED)
+ endif()
+-- 
+2.54.0
 

--- a/net-im/telegram-desktop/telegram_desktop-6.1.3.recipe
+++ b/net-im/telegram-desktop/telegram_desktop-6.1.3.recipe
@@ -13,16 +13,14 @@ CHECKSUM_SHA256_2="20b09948cf58362abe4de20b8e709d5041477fb798350fd1a02cde6aad121
 srcGitRev_3="2b383fe05f8ae78ac99470b9a2b9ea22b3ee5a92"
 SOURCE_URI_3="https://salsa.debian.org/debian/telegram-desktop/-/raw/$srcGitRev_3/debian/rules#noarchive"
 CHECKSUM_SHA256_3="613e7e357518739e1f7d035337f37c344b248283fd4d916ddc95df73c2ff84ad"
-
-PATCHES="
-	telegram_desktop-$portVersion.patchset
-	pch_disable-$portVersion.patchset
-	"
-
+PATCHES="telegram_desktop-$portVersion.patchset
+	pch_disable-$portVersion.patchset"
 ADDITIONAL_FILES="telegram_desktop.rdef.in"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
+
+boostMinimumVersion="1.90.0"
 
 PROVIDES="
 	telegram_desktop$secondaryArchSuffix = $portVersion
@@ -85,10 +83,9 @@ BUILD_REQUIRES="
 	qt6_tools${secondaryArchSuffix}_devel
 	devel:libabsl_strings$secondaryArchSuffix >= 2301.0.0
 	devel:libavif$secondaryArchSuffix
-	devel:libboost_filesystem$secondaryArchSuffix >= 1.83.0
-	devel:libboost_regex$secondaryArchSuffix >= 1.83.0
-	devel:libboost_system$secondaryArchSuffix >= 1.83.0
-	devel:libboost_program_options$secondaryArchSuffix >= 1.83.0
+	devel:libboost_filesystem$secondaryArchSuffix >= $boostMinimumVersion
+	devel:libboost_regex$secondaryArchSuffix >= $boostMinimumVersion
+	devel:libboost_program_options$secondaryArchSuffix >= $boostMinimumVersion
 	devel:libbrotlienc$secondaryArchSuffix
 	devel:libcrypto$secondaryArchSuffix >= 3
 	devel:libfmt$secondaryArchSuffix
@@ -132,7 +129,7 @@ if [ $targetArchitecture == x86_gcc2 ]; then
 	"
 else
 	BUILD_REQUIRES+="
-		ffmpeg6${secondaryArchSuffix}_devel
+		ffmpeg8${secondaryArchSuffix}_devel
 	"
 fi
 
@@ -164,6 +161,7 @@ PATCH()
 
 BUILD()
 {
+	rm -rf build
 	export DISABLE_ASLR=1
 	export GI_GIR_PATH="`finddir B_SYSTEM_DATA_DIRECTORY`"/gir-1.0
 	local DISABLE_PRECOMPILE_HEADERS="OFF"
@@ -221,7 +219,8 @@ BUILD()
 		-DLIBTGVOIP_DISABLE_PULSEAUDIO=ON \
 		-DTDESKTOP_API_ID=$TELEGRAM_API_ID \
 		-DTDESKTOP_API_HASH=$TELEGRAM_API_HASH \
-		-DLZ4_INCLUDE_DIRS=/system/$relativeIncludeDir
+		-DLZ4_INCLUDE_DIRS=/system/$relativeIncludeDir \
+		-Wno-dev
 
 	# hack for info_profile_actions.cpp file (fix OOM error)
 	if [ $targetArchitecture == x86_gcc2 ]; then


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
