### PR TITLE
pygobject, bump to version 3.56.3

### DIFF
--- a/dev-python/pygobject/pygobject-3.56.3.recipe
+++ b/dev-python/pygobject/pygobject-3.56.3.recipe
@@ -4,9 +4,9 @@ such as GTK, GStreamer, WebKitGTK, GLib, GIO and many more."
 HOMEPAGE="https://wiki.gnome.org/Projects/PyGObject"
 COPYRIGHT="2023 Christoph Reiter"
 LICENSE="GNU LGPL v2"
-REVISION="4"
-SOURCE_URI="https://download.gnome.org/sources/pygobject/3.44/pygobject-$portVersion.tar.xz"
-CHECKSUM_SHA256="3c6805d1321be90cc32e648215a562430e0d3d6edcda8f4c5e7a9daffcad5710"
+REVISION="1"
+SOURCE_URI="https://download.gnome.org/sources/pygobject/${portVersion%.*}/pygobject-$portVersion.tar.gz"
+CHECKSUM_SHA256="12760e4a0e3d04b6eb95e06f7a27e362c826d567ea613373a92c003b6c70d2d6"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -31,7 +31,7 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
-PYTHON_VERSIONS=(3.10)
+PYTHON_VERSIONS=(3.10 3.14)
 
 for pythonVersion in ${PYTHON_VERSIONS[@]}; do
 	pythonPackage=python${pythonVersion//.}


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
