### PR TITLE
libass: update to 0.17.5

### DIFF
--- a/media-libs/libass/libass-0.17.5.recipe
+++ b/media-libs/libass/libass-0.17.5.recipe
@@ -22,12 +22,12 @@ COPYRIGHT="2006-2022 libass contributors
 LICENSE="ISC"
 REVISION="1"
 SOURCE_URI="https://github.com/libass/libass/releases/download/$portVersion/libass-$portVersion.tar.xz"
-CHECKSUM_SHA256="78f1179b838d025e9c26e8fef33f8092f65611444ffa1bfc0cfac6a33511a05a"
+CHECKSUM_SHA256="2dca25c0e0c837ddf00b52011b3f82cac1e4ddd3ad018227806b0c2288864acc"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
-libVersion="9.4.1"
+libVersion="9.4.2"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="


### PR DESCRIPTION
Notably this update includes two security fixes:
- https://github.com/libass/libass/security/advisories/GHSA-pjjp-65r7-ppgm
- https://github.com/libass/libass/security/advisories/GHSA-5gf7-wjfm-vmvm

---

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] A pre-existing recipe was modified
- Probably not relevant for existing recipies, ig?:
    - [ ] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
    - [ ] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
