### PR TITLE
scummmvm, enable 32bit for version 2026.3.0

### DIFF
--- a/games-engines/scummvm/patches/scummvm-2026.3.0.patchset
+++ b/games-engines/scummvm/patches/scummvm-2026.3.0.patchset
@@ -1,4 +1,4 @@
-From 83036293660cb8d93da008a299ebdd653d979250 Mon Sep 17 00:00:00 2001
+From c5532b83fb39c507fd82639b7652de1bd3320a33 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sat, 25 Jan 2025 10:12:50 +0100
 Subject: Haiku patch
@@ -100,7 +100,7 @@ index cdbe5b16..bd5a2d09 100755
 2.54.0
 
 
-From ef103eb0c681eb63c06d6243c518e16aad7abdd2 Mon Sep 17 00:00:00 2001
+From 837f955074e7dfae3ac3a01b8f1cff0cf0bca4f7 Mon Sep 17 00:00:00 2001
 From: Luc Schrijvers <begasus@gmail.com>
 Date: Tue, 13 May 2025 10:40:18 +0200
 Subject: Fix conflicting int types
@@ -123,6 +123,42 @@ index c658de01..94364df3 100644
  #else
  	typedef uint32_t uint32;
  	typedef int32_t int32;
+-- 
+2.54.0
+
+
+From 957d539a1323067ec0d0f9291e5cb48df3be780c Mon Sep 17 00:00:00 2001
+From: Luc Schrijvers <begasus@gmail.com>
+Date: Fri, 26 Jun 2026 09:55:00 +0200
+Subject: Create dynamic plugins
+
+
+diff --git a/configure b/configure
+old mode 100755
+new mode 100644
+index bd5a2d09..bab4d853
+--- a/configure
++++ b/configure
+@@ -3464,6 +3464,10 @@ EOF
+ 		append_var DEFINES "-DHAIKU"
+ 		append_var DEFINES "-DSYSTEM_NOT_SUPPORTING_D_TYPE"
+ 		append_var DEFINES "-D_GNU_SOURCE"
++		if test "$_dynamic_modules" = yes ; then
++			_detection_features_static=no
++			_plugins_default=dynamic
++		fi
+ 		# Needs -lnetwork for the timidity MIDI driver
+ 		append_var LIBS "-lnetwork"
+ 		_seq_midi=no
+@@ -5177,7 +5181,7 @@ PRE_OBJS_FLAGS  := -s MAIN_MODULE=1 -s EXPORT_ALL=1
+ POST_OBJS_FLAGS :=
+ '
+ 		;;
+-	freebsd* | openbsd*)
++	freebsd* | openbsd* | haiku*)
+ 		_plugin_prefix="lib"
+ 		_plugin_suffix=".so"
+ 		append_var CXXFLAGS "-fPIC"
 -- 
 2.54.0
 

--- a/games-engines/scummvm/scummvm-2026.3.0.recipe
+++ b/games-engines/scummvm/scummvm-2026.3.0.recipe
@@ -13,9 +13,8 @@ CHECKSUM_SHA256="342f6fbdc4b228fbe17cb2f8421538c6bd743bac4dbf1009e3de330b536cfe9
 ADDITIONAL_FILES="scummvm.rdef.in"
 PATCHES="scummvm-$portVersion.patchset"
 
-# disable 32bit, OOM on buildmaster
 ARCHITECTURES="all !x86_gcc2"
-SECONDARY_ARCHITECTURES="?x86"
+SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	scummvm$secondaryArchSuffix = $portVersion
@@ -85,16 +84,19 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
+	chmod +x configure
 	libtoolize --force --copy --install
 	./configure --prefix=$prefix \
 		--bindir=$appsDir --libdir=$libDir --datarootdir=$dataDir \
 		--mandir=$manDir --docdir=$documentationDir/packages/scummvm \
-		--disable-debug --enable-release --disable-eventrecorder # \
+		--disable-debug --enable-release --disable-eventrecorder \
+		--enable-detection-dynamic --enable-plugins --default-dynamic # \
 		# --disable-all-engines
 		# can be used to compile scummvm without
 		# engines, which makes it build faster (to test), those that
 		# are still under construction can be built with --enable-all-engines
 		# for testing purposes
+
 	make $jobArgs
 }
 


### PR DESCRIPTION
plugins are build as shared objects instead of staticly linked into the main binary

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
