### PR TITLE
meson, bump to version 1.11.1

### DIFF
--- a/dev-build/meson/meson-1.11.1.recipe
+++ b/dev-build/meson/meson-1.11.1.recipe
@@ -2,12 +2,13 @@ SUMMARY="A High productivity build system"
 DESCRIPTION="Meson® is a project to create the best possible next-generation \
 build system."
 HOMEPAGE="https://mesonbuild.com/"
-COPYRIGHT="2013-2025 The Meson development team"
+COPYRIGHT="2013-2026 The Meson development team"
 LICENSE="Apache v2"
 REVISION="1"
 SOURCE_URI="https://github.com/mesonbuild/meson/releases/download/$portVersion/meson-$portVersion.tar.gz"
-CHECKSUM_SHA256="8071860c1f46a75ea34801490fd1c445c9d75147a65508cd3a10366a7006cc1c"
-PATCHES="meson-$portVersion.patchset"
+CHECKSUM_SHA256="6788ae299979643f8d841bcaf64352558436cae45a0355148a3aeeccf7913866"
+PATCHES="meson-$portVersion.patchset
+	15739.patch"
 
 pythonVersion=3.10
 pythonPackage=python${pythonVersion//.}
@@ -17,10 +18,6 @@ ARCHITECTURES="any"
 PROVIDES="
 	meson = $portVersion
 	cmd:meson = $portVersion
-	cmd:mesonconf = $portVersion
-	cmd:mesonintrospect = $portVersion
-	cmd:mesontest = $portVersion
-	cmd:wraptool = $portVersion
 	"
 REQUIRES="
 	haiku
@@ -43,7 +40,7 @@ TEST_REQUIRES="
 	cmd:clang
 	cmd:g_ir_scanner
 	cmd:gcc
-	cmd:ninja >= 1.6
+	cmd:ninja
 	cmd:pkg_config
 	devel:libglib_2.0
 	"
@@ -52,7 +49,6 @@ BUILD()
 {
 	python$pythonVersion -m build --wheel --skip-dependency-check --no-isolation
 }
-
 
 INSTALL()
 {
@@ -75,5 +71,12 @@ INSTALL()
 
 TEST()
 {
+	# Total passed tests:  521
+	# Total failed tests:  18
+	# Total skipped tests: 115
+	python3 -m ensurepip --default-pip
+	pip3 install --user gpep517
+	pip3 install --user pytest
+	pip3 install --user pytest-xdist
 	MESON_PRINT_TEST_OUTPUT=1 LC_CTYPE=en_US.UTF-8 ./run_tests.py
 }

--- a/dev-build/meson/patches/15739.patch
+++ b/dev-build/meson/patches/15739.patch
@@ -1,0 +1,245 @@
+From 16a74728022d35a0be80262a5a86daeba7d3db53 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Fri, 24 Apr 2026 01:57:09 +0100
+Subject: [PATCH] mtest: support --exclude
+
+Support `--exclude name` where `name` is a full test name, optionally
+including the subproject name. Wildcards are not currently supported.
+
+Accept both `name` for the main project and `subproject:name`. We want `name`
+for convenience so users don't have to write out their project name when
+no subprojects are involved.
+
+Extended matching could be added in future, but the primary usecase for
+this is where distributions want to skip known-buggy or irrelevant tests,
+rather than developers working on their own project.
+
+The test changes are a bit noisy because needed to add a test with
+the same name in the main project and a subproject to check that --exclude
+w/ an unqualified name only affected the main parent, but adding 2 new failing
+tests required all the numbers to be adjusted.
+
+Closes: https://github.com/mesonbuild/meson/pull/11502
+Closes: https://github.com/mesonbuild/meson/issues/6999
+Signed-off-by: Sam James <sam@gentoo.org>
+---
+ docs/markdown/Unit-tests.md                   | 26 ++++++++++
+ docs/markdown/snippets/tests-exclude.md       |  6 +++
+ man/meson.1                                   |  3 ++
+ mesonbuild/mtest.py                           | 16 +++++-
+ test cases/unit/4 suite selection/meson.build |  4 ++
+ .../subprojects/subprjfail/meson.build        |  4 ++
+ unittests/allplatformstests.py                | 49 ++++++++++---------
+ 7 files changed, 83 insertions(+), 25 deletions(-)
+ create mode 100644 docs/markdown/snippets/tests-exclude.md
+
+diff --git a/docs/markdown/Unit-tests.md b/docs/markdown/Unit-tests.md
+index ab24d4b027e1..498ec4f9a18e 100644
+--- a/docs/markdown/Unit-tests.md
++++ b/docs/markdown/Unit-tests.md
+@@ -216,6 +216,32 @@ into `n` slices and execute the `ith` such slice. This allows you to distribute
+ a set of long-running tests across multiple machines to decrease the overall
+ runtime of tests.
+ 
++Since version *1.12.0*, you can pass `--exclude NAME` to skip processing
++of named tests:
++```console
++$ meson test --list
++m:basic
++m:buggy
++
++$ meson test
++...
++1/2 m:basic        OK              0.01s
++2/2 m:buggy        FAIL            0.00s ...
++
++Ok:                1
++Fail:              1
++
++$ meson test --exclude buggy
++...
++1/1 m:basic        OK              0.00s
++
++Ok:                1
++Fail:              0
++```
++
++For unqualified names (no subproject specified), `--exclude NAME` matches
++the main project.
++
+ ### Other test options
+ 
+ Sometimes you need to run the tests multiple times, which is done like this:
+diff --git a/docs/markdown/snippets/tests-exclude.md b/docs/markdown/snippets/tests-exclude.md
+new file mode 100644
+index 000000000000..daf282ef59a6
+--- /dev/null
++++ b/docs/markdown/snippets/tests-exclude.md
+@@ -0,0 +1,6 @@
++## `meson test` now accepts `--exclude`
++
++`meson test` has a new `--exclude` argument to allow skipping named
++tests. It takes a full test name and can be specified repeatedly. This
++should help distributions that need to skip tests irrelevant for them
++or known to be buggy.
+diff --git a/man/meson.1 b/man/meson.1
+index c00d90e9bfdd..b655e299d534 100644
+--- a/man/meson.1
++++ b/man/meson.1
+@@ -303,6 +303,9 @@ run tests in this suite
+ \fB\-\-no\-suite\fR
+ do not run tests in this suite
+ .TP
++\fB\-\-exclude\fR
++do not run named tests
++.TP
+ \fB\-\-no\-stdsplit\fR
+ do not split stderr and stdout in test logs
+ .TP
+diff --git a/mesonbuild/mtest.py b/mesonbuild/mtest.py
+index 18760eb51ecd..fb97f5beefc9 100644
+--- a/mesonbuild/mtest.py
++++ b/mesonbuild/mtest.py
+@@ -150,6 +150,8 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
+                         help='Only run tests belonging to the given suite.')
+     parser.add_argument('--no-suite', default=[], dest='exclude_suites', action='append', metavar='SUITE',
+                         help='Do not run tests belonging to the given suite.')
++    parser.add_argument('--exclude', default=[], dest='exclude', action='append',
++                        help='Exclude tests with the given name.')
+     parser.add_argument('--no-stdsplit', default=True, dest='split', action='store_false',
+                         help='Do not split stderr and stdout in test logs.')
+     parser.add_argument('--print-errorlogs', default=False, action='store_true',
+@@ -1970,10 +1972,18 @@ def test_in_suites(test: TestSerialisation, suites: T.List[str]) -> bool:
+                         return True
+         return False
+ 
+-    def test_suitable(self, test: TestSerialisation) -> bool:
++    def test_suitable(self, test: TestSerialisation, excluded_tests: set[str]) -> bool:
+         if TestHarness.test_in_suites(test, self.options.exclude_suites):
+             return False
+ 
++        # Accept both --exclude name and --exclude subproject:name.
++        # For the main project, we also accept 'name' without qualification
++        # for convenience.
++        if self.build_data.project_name == test.project_name and test.name in excluded_tests:
++            return False
++        if f'{test.project_name}:{test.name}' in excluded_tests:
++            return False
++
+         if self.options.include_suites:
+             # Both force inclusion (overriding add_test_setup) and exclude
+             # everything else
+@@ -2044,7 +2054,9 @@ def get_tests(self, errorfile: T.Optional[T.IO] = None) -> T.List[TestSerialisat
+             print('No tests defined.', file=errorfile)
+             return []
+ 
+-        tests = [t for t in self.tests if self.test_suitable(t)]
++        excluded_tests = set(self.options.exclude)
++        tests = [t for t in self.tests if self.test_suitable(t, excluded_tests)]
++
+         if self.options.args:
+             tests = list(self.tests_from_args(tests))
+         if self.options.slice:
+diff --git a/test cases/unit/4 suite selection/meson.build b/test cases/unit/4 suite selection/meson.build
+index ea6db923cb84..e65d16baae87 100644
+--- a/test cases/unit/4 suite selection/meson.build	
++++ b/test cases/unit/4 suite selection/meson.build	
+@@ -15,3 +15,7 @@ test('mainprj-successful_test',
+ test('mainprj-successful_test_no_suite',
+   executable('no_suite_test', 'successful_test.c'),
+   suite : [])
++
++test('buggy',
++  executable('failing_test_name_collision', 'failing_test.c'),
++  suite : 'fail')
+diff --git a/test cases/unit/4 suite selection/subprojects/subprjfail/meson.build b/test cases/unit/4 suite selection/subprojects/subprjfail/meson.build
+index e6270a8cf06c..ee6c6c2c03b4 100644
+--- a/test cases/unit/4 suite selection/subprojects/subprjfail/meson.build	
++++ b/test cases/unit/4 suite selection/subprojects/subprjfail/meson.build	
+@@ -7,3 +7,7 @@ test('subprjfail-failing_test',
+ test('subprjfail-failing_test_no_suite',
+   executable('failing_test_no_suite', 'failing_test.c'),
+   suite : [])
++
++test('buggy',
++  executable('failing_test_name_collision', 'failing_test.c'),
++  suite : 'fail')
+diff --git a/unittests/allplatformstests.py b/unittests/allplatformstests.py
+index 2769370bbfe4..4fdc9c04d6d1 100644
+--- a/unittests/allplatformstests.py
++++ b/unittests/allplatformstests.py
+@@ -906,48 +906,51 @@ def test_suite_selection(self):
+         self.init(testdir)
+         self.build()
+ 
+-        self.assertFailedTestCount(4, self.mtest_command)
++        self.assertFailedTestCount(6, self.mtest_command)
++        self.assertFailedTestCount(4, self.mtest_command + ['--exclude', 'mainprj-failing_test',
++                                                            '--exclude', 'subprjfail:subprjfail-failing_test_no_suite'])
++        self.assertFailedTestCount(5, self.mtest_command + ['--exclude', 'buggy'])
+ 
+         self.assertFailedTestCount(0, self.mtest_command + ['--suite', ':success'])
+-        self.assertFailedTestCount(3, self.mtest_command + ['--suite', ':fail'])
+-        self.assertFailedTestCount(4, self.mtest_command + ['--no-suite', ':success'])
++        self.assertFailedTestCount(5, self.mtest_command + ['--suite', ':fail'])
++        self.assertFailedTestCount(6, self.mtest_command + ['--no-suite', ':success'])
+         self.assertFailedTestCount(1, self.mtest_command + ['--no-suite', ':fail'])
+ 
+-        self.assertFailedTestCount(1, self.mtest_command + ['--suite', 'mainprj'])
++        self.assertFailedTestCount(2, self.mtest_command + ['--suite', 'mainprj'])
+         self.assertFailedTestCount(0, self.mtest_command + ['--suite', 'subprjsucc'])
+-        self.assertFailedTestCount(2, self.mtest_command + ['--suite', 'subprjfail'])
++        self.assertFailedTestCount(3, self.mtest_command + ['--suite', 'subprjfail'])
+         self.assertFailedTestCount(1, self.mtest_command + ['--suite', 'subprjmix'])
+-        self.assertFailedTestCount(3, self.mtest_command + ['--no-suite', 'mainprj'])
+-        self.assertFailedTestCount(4, self.mtest_command + ['--no-suite', 'subprjsucc'])
+-        self.assertFailedTestCount(2, self.mtest_command + ['--no-suite', 'subprjfail'])
+-        self.assertFailedTestCount(3, self.mtest_command + ['--no-suite', 'subprjmix'])
++        self.assertFailedTestCount(4, self.mtest_command + ['--no-suite', 'mainprj'])
++        self.assertFailedTestCount(6, self.mtest_command + ['--no-suite', 'subprjsucc'])
++        self.assertFailedTestCount(3, self.mtest_command + ['--no-suite', 'subprjfail'])
++        self.assertFailedTestCount(5, self.mtest_command + ['--no-suite', 'subprjmix'])
+ 
+-        self.assertFailedTestCount(1, self.mtest_command + ['--suite', 'mainprj:fail'])
++        self.assertFailedTestCount(2, self.mtest_command + ['--suite', 'mainprj:fail'])
+         self.assertFailedTestCount(0, self.mtest_command + ['--suite', 'mainprj:success'])
+-        self.assertFailedTestCount(3, self.mtest_command + ['--no-suite', 'mainprj:fail'])
+-        self.assertFailedTestCount(4, self.mtest_command + ['--no-suite', 'mainprj:success'])
++        self.assertFailedTestCount(4, self.mtest_command + ['--no-suite', 'mainprj:fail'])
++        self.assertFailedTestCount(6, self.mtest_command + ['--no-suite', 'mainprj:success'])
+ 
+-        self.assertFailedTestCount(1, self.mtest_command + ['--suite', 'subprjfail:fail'])
++        self.assertFailedTestCount(2, self.mtest_command + ['--suite', 'subprjfail:fail'])
+         self.assertFailedTestCount(0, self.mtest_command + ['--suite', 'subprjfail:success'])
+-        self.assertFailedTestCount(3, self.mtest_command + ['--no-suite', 'subprjfail:fail'])
+-        self.assertFailedTestCount(4, self.mtest_command + ['--no-suite', 'subprjfail:success'])
++        self.assertFailedTestCount(4, self.mtest_command + ['--no-suite', 'subprjfail:fail'])
++        self.assertFailedTestCount(6, self.mtest_command + ['--no-suite', 'subprjfail:success'])
+ 
+         self.assertFailedTestCount(0, self.mtest_command + ['--suite', 'subprjsucc:fail'])
+         self.assertFailedTestCount(0, self.mtest_command + ['--suite', 'subprjsucc:success'])
+-        self.assertFailedTestCount(4, self.mtest_command + ['--no-suite', 'subprjsucc:fail'])
+-        self.assertFailedTestCount(4, self.mtest_command + ['--no-suite', 'subprjsucc:success'])
++        self.assertFailedTestCount(6, self.mtest_command + ['--no-suite', 'subprjsucc:fail'])
++        self.assertFailedTestCount(6, self.mtest_command + ['--no-suite', 'subprjsucc:success'])
+ 
+         self.assertFailedTestCount(1, self.mtest_command + ['--suite', 'subprjmix:fail'])
+         self.assertFailedTestCount(0, self.mtest_command + ['--suite', 'subprjmix:success'])
+-        self.assertFailedTestCount(3, self.mtest_command + ['--no-suite', 'subprjmix:fail'])
+-        self.assertFailedTestCount(4, self.mtest_command + ['--no-suite', 'subprjmix:success'])
++        self.assertFailedTestCount(5, self.mtest_command + ['--no-suite', 'subprjmix:fail'])
++        self.assertFailedTestCount(6, self.mtest_command + ['--no-suite', 'subprjmix:success'])
+ 
+-        self.assertFailedTestCount(3, self.mtest_command + ['--suite', 'subprjfail', '--suite', 'subprjmix:fail'])
+-        self.assertFailedTestCount(4, self.mtest_command + ['--suite', 'subprjfail', '--suite', 'subprjmix', '--suite', 'mainprj'])
+-        self.assertFailedTestCount(3, self.mtest_command + ['--suite', 'subprjfail', '--suite', 'subprjmix', '--suite', 'mainprj', '--no-suite', 'subprjmix:fail'])
++        self.assertFailedTestCount(4, self.mtest_command + ['--suite', 'subprjfail', '--suite', 'subprjmix:fail'])
++        self.assertFailedTestCount(6, self.mtest_command + ['--suite', 'subprjfail', '--suite', 'subprjmix', '--suite', 'mainprj'])
++        self.assertFailedTestCount(5, self.mtest_command + ['--suite', 'subprjfail', '--suite', 'subprjmix', '--suite', 'mainprj', '--no-suite', 'subprjmix:fail'])
+         self.assertFailedTestCount(1, self.mtest_command + ['--suite', 'subprjfail', '--suite', 'subprjmix', '--suite', 'mainprj', '--no-suite', 'subprjmix:fail', 'mainprj-failing_test'])
+ 
+-        self.assertFailedTestCount(2, self.mtest_command + ['--no-suite', 'subprjfail:fail', '--no-suite', 'subprjmix:fail'])
++        self.assertFailedTestCount(3, self.mtest_command + ['--no-suite', 'subprjfail:fail', '--no-suite', 'subprjmix:fail'])
+ 
+     def test_mtest_reconfigure(self):
+         if self.backend is not Backend.ninja:

--- a/dev-build/meson/patches/meson-1.11.1.patchset
+++ b/dev-build/meson/patches/meson-1.11.1.patchset
@@ -1,14 +1,14 @@
-From faaeadf958088b0003b1f020d2a49ce84eab7c90 Mon Sep 17 00:00:00 2001
+From 0673efabe8d82a8533d50f93d8f04a470fe9b08f Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Mon, 3 Aug 2020 11:56:45 +0200
 Subject: Fix include path for boost
 
 
 diff --git a/mesonbuild/dependencies/boost.py b/mesonbuild/dependencies/boost.py
-index 1aeb451..d03387d 100644
+index 2a86c82..b0e7ee1 100644
 --- a/mesonbuild/dependencies/boost.py
 +++ b/mesonbuild/dependencies/boost.py
-@@ -538,10 +538,11 @@ class BoostDependency(SystemDependency):
+@@ -539,10 +539,11 @@ class BoostDependency(SystemDependency):
  
      def detect_inc_dirs(self, root: Path) -> T.List[BoostIncludeDir]:
          candidates: T.List[Path] = []
@@ -22,20 +22,20 @@ index 1aeb451..d03387d 100644
              for i in inc_root.iterdir():
                  if not i.is_dir() or not i.name.startswith('boost-'):
 -- 
-2.51.0
+2.54.0
 
 
-From 0f5997a2abf39d76cff1272fe1725d807747951a Mon Sep 17 00:00:00 2001
+From 8ca134d9aa237c52e5930c240a9856ac6d01a322 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 26 Nov 2021 11:39:48 +0100
 Subject: add support for gcc 2.95.3
 
 
 diff --git a/mesonbuild/compilers/detect.py b/mesonbuild/compilers/detect.py
-index db2bdf6..3a8aebd 100644
+index 15aaef8..97e1147 100644
 --- a/mesonbuild/compilers/detect.py
 +++ b/mesonbuild/compilers/detect.py
-@@ -346,7 +346,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
+@@ -349,7 +349,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
          version = search_version(out)
  
          guess_gcc_or_lcc: T.Optional[str] = None
@@ -45,7 +45,7 @@ index db2bdf6..3a8aebd 100644
          if 'e2k' in out and 'lcc' in out:
              guess_gcc_or_lcc = 'lcc'
 diff --git a/mesonbuild/compilers/mixins/gnu.py b/mesonbuild/compilers/mixins/gnu.py
-index 7e783e2..a117b10 100644
+index 776f9ed..bed1fbf 100644
 --- a/mesonbuild/compilers/mixins/gnu.py
 +++ b/mesonbuild/compilers/mixins/gnu.py
 @@ -478,7 +478,7 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
@@ -75,20 +75,20 @@ index 7e783e2..a117b10 100644
  class GnuCStds(Compiler):
  
 -- 
-2.51.0
+2.54.0
 
 
-From 4d1ee4d30985903f72678c352c266565644a9c66 Mon Sep 17 00:00:00 2001
+From 5a11f539a7756cb6097a2c67fd58b6baf452467e Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Wed, 12 Apr 2023 17:58:48 +0200
 Subject: Revert b1384b9c9f64ff909d5431176503a7dcdadd426c
 
 
 diff --git a/mesonbuild/modules/pkgconfig.py b/mesonbuild/modules/pkgconfig.py
-index 7d5bc91..e5a4b91 100644
+index 332ec33..81a9f82 100644
 --- a/mesonbuild/modules/pkgconfig.py
 +++ b/mesonbuild/modules/pkgconfig.py
-@@ -735,9 +735,6 @@ class PkgConfigModule(NewExtensionModule):
+@@ -781,9 +781,6 @@ class PkgConfigModule(NewExtensionModule):
              if m.is_freebsd():
                  pkgroot = os.path.join(_as_str(state.environment.coredata.optstore.get_value_for(OptionKey('prefix'))), 'libdata', 'pkgconfig')
                  pkgroot_name = os.path.join('{prefix}', 'libdata', 'pkgconfig')
@@ -99,10 +99,10 @@ index 7d5bc91..e5a4b91 100644
                  pkgroot = os.path.join(_as_str(state.environment.coredata.optstore.get_value_for(OptionKey('libdir'))), 'pkgconfig')
                  pkgroot_name = os.path.join('{libdir}', 'pkgconfig')
 -- 
-2.51.0
+2.54.0
 
 
-From abc06d903c2baaa653392940e53c698fa253a827 Mon Sep 17 00:00:00 2001
+From b9c5082f0fec6da31084295ecbb3bb4798f34ad1 Mon Sep 17 00:00:00 2001
 From: James Le Cuirot <chewi@gentoo.org>
 Date: Sat, 12 Aug 2023 09:56:44 +0100
 Subject: python module: Respect PATH when python is not given in machine file
@@ -113,10 +113,10 @@ if `python3` is not found in the PATH.
 https://github.com/mesonbuild/meson/pull/12116
 
 diff --git a/mesonbuild/modules/python.py b/mesonbuild/modules/python.py
-index 99602c0..450e2ec 100644
+index 881b54e..5c50e18 100644
 --- a/mesonbuild/modules/python.py
 +++ b/mesonbuild/modules/python.py
-@@ -460,7 +460,9 @@ class PythonModule(ExtensionModule):
+@@ -472,7 +472,9 @@ class PythonModule(ExtensionModule):
          build_config = self.interpreter.environment.coredata.optstore.get_value_for(OptionKey('python.build_config'))
  
          if not name_or_path:
@@ -128,30 +128,5 @@ index 99602c0..450e2ec 100644
              tmp_python = ExternalProgram.from_entry(display_name, name_or_path)
              python = PythonExternalProgram(display_name, ext_prog=tmp_python, build_config_path=build_config)
 -- 
-2.51.0
-
-
-From 731c0e058726f491919eadfe51350c4566acbbca Mon Sep 17 00:00:00 2001
-From: Oscar Lesta <oscar.lesta@gmail.com>
-Date: Thu, 4 Dec 2025 07:38:46 -0300
-Subject: Use gnu_sym() for symbol extraction.
-
-Upstreamed in https://github.com/mesonbuild/meson/pull/15352
-(merged in commit: 49b2c202b8f48451fb594e6501bb31930fa9e616)
-
-diff --git a/mesonbuild/scripts/symbolextractor.py b/mesonbuild/scripts/symbolextractor.py
-index c0aa650..3ceea4b 100644
---- a/mesonbuild/scripts/symbolextractor.py
-+++ b/mesonbuild/scripts/symbolextractor.py
-@@ -273,7 +273,7 @@ def gen_symbols(libfilename: str, impfilename: str, outfilename: str, cross_host
-             windows_syms(impfilename, outfilename)
-         else:
-             dummy_syms(outfilename)
--    elif mesonlib.is_linux() or mesonlib.is_hurd():
-+    elif mesonlib.is_linux() or mesonlib.is_hurd() or mesonlib.is_haiku():
-         gnu_syms(libfilename, outfilename)
-     elif mesonlib.is_osx():
-         osx_syms(libfilename, outfilename)
--- 
-2.51.0
+2.54.0
 


### PR DESCRIPTION
include upstream merge to enable excluding tests

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
