### PR TITLE
gdk_pixbuf, revbump, require shared_mime_info

### DIFF
--- a/x11-libs/gdk-pixbuf/gdk_pixbuf-2.44.7.recipe
+++ b/x11-libs/gdk-pixbuf/gdk_pixbuf-2.44.7.recipe
@@ -9,7 +9,7 @@ GdkRGB buffers.
 HOMEPAGE="https://wiki.gnome.org/Projects/GdkPixbuf"
 COPYRIGHT="1999-2026 Gnome Project"
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://download.gnome.org/sources/gdk-pixbuf/${portVersion%.*}/gdk-pixbuf-$portVersion.tar.xz"
 CHECKSUM_SHA256="172f80e3626ec31520a970400f1a3694e04718f6c2cd2885f75250fb5a6995a4"
 SOURCE_DIR="gdk-pixbuf-$portVersion"
@@ -38,6 +38,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	shared_mime_info$secondaryArchSuffix
 	lib:libffi$secondaryArchSuffix
 	lib:libgio_2.0$secondaryArchSuffix
 	lib:libgirepository_1.0$secondaryArchSuffix
@@ -58,6 +59,7 @@ PROVIDES_devel="
 	"
 REQUIRES_devel="
 	gdk_pixbuf$secondaryArchSuffix == $portVersion base
+	shared_mime_info$secondaryArchSuffix
 	devel:libffi$secondaryArchSuffix
 	devel:libgio_2.0$secondaryArchSuffix
 	devel:libgirepository_1.0$secondaryArchSuffix
@@ -71,6 +73,7 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	shared_mime_info$secondaryArchSuffix
 	devel:libffi$secondaryArchSuffix
 	devel:libgio_2.0$secondaryArchSuffix
 	devel:libglib_2.0$secondaryArchSuffix
@@ -92,7 +95,6 @@ BUILD_PREREQUIRES="
 	cmd:msgfmt$secondaryArchSuffix
 	cmd:ninja
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:update_mime_database$secondaryArchSuffix
 	"
 
 defineDebugInfoPackage gdk_pixbuf$secondaryArchSuffix  \


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
