### PR TITLE
libadwaita, trigger build after last failed one

### DIFF
--- a/x11-libs/libadwaita/libadwaita-1.9.1.recipe
+++ b/x11-libs/libadwaita/libadwaita-1.9.1.recipe
@@ -1,6 +1,6 @@
 SUMMARY="Building blocks for modern GNOME applications"
-DESCRIPTION="Libadwaita is a GTK 4 library that provides widgets and APIs \
-from the Adwaita design language, complementing GTK itself."
+DESCRIPTION="Libadwaita is a GTK 4 library that provides widgets and APIs from the Adwaita \
+design language, complementing GTK itself."
 HOMEPAGE="https://gitlab.gnome.org/GNOME/libadwaita"
 COPYRIGHT="GNOME Project"
 LICENSE="GNU LGPL v2.1"


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
