### PR TITLE
libadwaita, fix order layout, no revbump

### DIFF
--- a/x11-libs/libadwaita/libadwaita-1.9.1.recipe
+++ b/x11-libs/libadwaita/libadwaita-1.9.1.recipe
@@ -21,12 +21,6 @@ PROVIDES="
 	cmd:adwaita_1_demo
 	lib:libadwaita_$libVersion$secondaryArchSuffix = $portVersion
 	"
-
-PROVIDES_devel="
-	libadwaita${secondaryArchSuffix}_devel = $portVersion
-	devel:libadwaita_$libVersion$secondaryArchSuffix = $portVersion
-	"
-
 REQUIRES="
 	haiku$secondaryArchSuffix
 	adwaita_icon_theme
@@ -41,6 +35,10 @@ REQUIRES="
 	lib:libpango_1.0$secondaryArchSuffix
 	"
 
+PROVIDES_devel="
+	libadwaita${secondaryArchSuffix}_devel = $portVersion
+	devel:libadwaita_$libVersion$secondaryArchSuffix = $portVersion
+	"
 REQUIRES_devel="
 	libadwaita$secondaryArchSuffix == $portVersion base
 	devel:libgtk_4$secondaryArchSuffix
@@ -55,7 +53,6 @@ BUILD_REQUIRES="
 	devel:libgio_2.0$secondaryArchSuffix
 	devel:libgirepository_1.0$secondaryArchSuffix
 	"
-
 BUILD_PREREQUIRES="
 	cmd:cmake
 	cmd:gcc$secondaryArchSuffix


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
