### PR TITLE
libspelling, cleanup, no revbump

### DIFF
--- a/app-text/libspelling/libspelling-0.4.10.recipe
+++ b/app-text/libspelling/libspelling-0.4.10.recipe
@@ -74,7 +74,7 @@ BUILD()
 		-Ddocs=false \
 		-Dsysprof=false
 
-	(ninja -C Build || true) > "/$sourceDir/build.log" 2>&1
+	ninja -C Build $jobArgs
 }
 
 INSTALL()


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
