### PR TITLE
gtkmm, update gtkmm3 to 3.24.11, add gtk4mm for version 4.23.0

### DIFF
--- a/dev-cpp/gtkmm/gtkmm3-3.24.11.recipe
+++ b/dev-cpp/gtkmm/gtkmm3-3.24.11.recipe
@@ -6,9 +6,9 @@ HOMEPAGE="https://www.gtkmm.org/en/"
 COPYRIGHT="2021 The gtkmm Development Team"
 LICENSE="GNU LGPL v2.1
 	GNU GPL v2"
-REVISION="4"
+REVISION="1"
 SOURCE_URI="http://ftp.gnome.org/pub/GNOME/sources/gtkmm/${portVersion%.*}/gtkmm-$portVersion.tar.xz"
-CHECKSUM_SHA256="856333de86689f6a81c123f2db15d85db9addc438bc3574c36f15736aeae22e6"
+CHECKSUM_SHA256="19e383c82d5dd89db275e00b82864e90414d4c3fb3d100b2f996bcc2338a4cc7"
 SOURCE_DIR="gtkmm-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -93,7 +93,8 @@ INSTALL()
 	rm -rf $libDir/{gtkmm,gdkmm}-$apiVersion
 
 	prepareInstalledDevelLibs \
-		libgtkmm-$apiVersion
+		libgtkmm-$apiVersion \
+		libgdkmm-$apiVersion
 
 	fixPkgconfig
 

--- a/dev-cpp/gtkmm/gtkmm4-4.23.0.recipe
+++ b/dev-cpp/gtkmm/gtkmm4-4.23.0.recipe
@@ -1,0 +1,112 @@
+SUMMARY="C++ interface for GTK 3"
+DESCRIPTION="gtkmm is the official C++ interface for the popular GUI library \
+GTK. Highlights include typesafe callbacks, and a comprehensive set of widgets \
+that are easily extensible via inheritance."
+HOMEPAGE="https://www.gtkmm.org/en/"
+COPYRIGHT="2021 The gtkmm Development Team"
+LICENSE="GNU LGPL v2.1
+	GNU GPL v2"
+REVISION="1"
+SOURCE_URI="http://ftp.gnome.org/pub/GNOME/sources/gtkmm/${portVersion%.*}/gtkmm-$portVersion.tar.xz"
+CHECKSUM_SHA256="d3f7e7aab6e99d33fe61a609a759a9fb086aad33c0a9428ad3c1eacca2c01460"
+SOURCE_DIR="gtkmm-$portVersion"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
+
+libVersion="0.0.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+apiVersion="4.0"
+
+PROVIDES="
+	gtkmm4$secondaryArchSuffix = $portVersion
+	lib:libgtkmm_$apiVersion$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libatkmm_2.36$secondaryArchSuffix
+	lib:libcairo_gobject$secondaryArchSuffix
+	lib:libglib_2.0$secondaryArchSuffix
+	lib:libglibmm_2.68$secondaryArchSuffix
+	lib:libgraphene_1.0$secondaryArchSuffix
+	lib:libgtk_4$secondaryArchSuffix
+	lib:libgdk_pixbuf_2.0$secondaryArchSuffix
+	lib:libcairomm_1.16$secondaryArchSuffix
+	lib:libpangomm_2.48$secondaryArchSuffix
+	lib:libsigc_3.0$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	gtkmm4${secondaryArchSuffix}_devel = $portVersion
+	devel:libgtkmm_$apiVersion$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	gtkmm4$secondaryArchSuffix == $portVersion base
+	devel:libatkmm_2.36$secondaryArchSuffix
+	devel:libglib_2.0$secondaryArchSuffix
+	devel:libgdk_pixbuf_2.0$secondaryArchSuffix
+	devel:libgtk_4$secondaryArchSuffix
+	devel:libcairomm_1.16$secondaryArchSuffix
+	devel:libpangomm_2.48$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libatkmm_2.36$secondaryArchSuffix
+	devel:libglib_2.0$secondaryArchSuffix
+	devel:libgtk_4$secondaryArchSuffix
+	devel:libcairomm_1.16$secondaryArchSuffix
+	devel:libpangomm_2.48$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:gcc$secondaryArchSuffix
+	cmd:meson
+	cmd:ninja
+	cmd:pkg_config$secondaryArchSuffix
+	cmd:update_mime_database$secondaryArchSuffix
+	"
+
+defineDebugInfoPackage gtkmm4$secondaryArchSuffix \
+	"$libDir"/libgtkmm-$apiVersion.so.$libVersion
+
+BUILD()
+{
+	meson build --buildtype=debugoptimized \
+		--prefix=$prefix \
+		--bindir=$binDir \
+		--datadir=$dataDir \
+		--includedir=$includeDir \
+		--libdir=$libDir \
+		-D maintainer-mode=false \
+		-D build-demos=false
+
+	ninja $jobArgs -C build
+}
+
+INSTALL()
+{
+	ninja -C build install
+
+	rm -rf $libDir/*.la
+
+	mkdir -p $developLibDir
+	mv $libDir/gtkmm-$apiVersion/ $developLibDir
+	rm -rf $libDir/{gtkmm,gdkmm}-$apiVersion
+
+	prepareInstalledDevelLib \
+		libgtkmm-$apiVersion
+
+	fixPkgconfig
+
+	sed -i -e 's|-I${libdir}/gtkmm-$apiVersion/include||' \
+		$developLibDir/pkgconfig/gtkmm-$apiVersion.pc
+
+	packageEntries devel \
+		$developDir
+}
+
+TEST()
+{
+	meson test -C build --print-errorlogs
+}


### PR DESCRIPTION
also use Gentoo layout and use dev-cpp/gtkmm

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
