### PR TITLE
libgpg_error, bump to version 1.61

### DIFF
--- a/dev-libs/libgpg_error/libgpg_error-1.61.recipe
+++ b/dev-libs/libgpg_error/libgpg_error-1.61.recipe
@@ -3,25 +3,32 @@ DESCRIPTION="This is a library that defines common error values for all GnuPG \
 components. Among these are GPG, GPGSM, GPGME, GPG-Agent, libgcrypt, Libksba, \
 DirMngr, Pinentry, SmartCard Daemon and more."
 HOMEPAGE="https://www.gnupg.org/related_software/libraries.en.html#lib-libgpg-error"
-COPYRIGHT="2003-2018 g10 Code GmbH"
+COPYRIGHT="2003-2026 g10 Code GmbH"
 LICENSE="GNU LGPL v2.1"
 REVISION="1"
 SOURCE_URI="https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-$portVersion.tar.bz2"
-CHECKSUM_SHA256="95b178148863f07d45df0cea67e880a79b9ef71f5d230baddc0071128516ef78"
+CHECKSUM_SHA256="7a85413f2bc354f4f8aa832b718af122e48965e9e0eb9012ee659c13c6385c93"
 SOURCE_DIR="libgpg-error-$portVersion"
 PATCHES="libgpg_error-$portVersion.patchset"
 
 ARCHITECTURES="all"
 SECONDARY_ARCHITECTURES="x86"
 
-libVersion="0.39.3"
+commandBinDir=$binDir
+commandSuffix=$secondaryArchSuffix
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+libVersion="0.42.1"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 portVersionCompat="$portVersion compat >= 1"
 
 PROVIDES="
 	libgpg_error$secondaryArchSuffix = $portVersion
-	cmd:gpg_error$secondaryArchSuffix = $portVersionCompat
-	cmd:yat2m$secondaryArchSuffix = $portVersionCompat
+	cmd:gpg_error$commandSuffix = $portVersionCompat
+	cmd:yat2m$commandSuffix = $portVersionCompat
 	lib:libgpg_error$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
@@ -30,7 +37,7 @@ REQUIRES="
 
 PROVIDES_devel="
 	libgpg_error${secondaryArchSuffix}_devel = $portVersion
-	cmd:gpgrt_config$secondaryArchSuffix = $portVersionCompat
+	cmd:gpgrt_config$commandSuffix = $portVersionCompat
 	devel:libgpg_error$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
@@ -53,7 +60,9 @@ defineDebugInfoPackage libgpg_error$secondaryArchSuffix \
 
 BUILD()
 {
-	MAKEINFO=true runConfigure ./configure
+	MAKEINFO=true runConfigure --omit-dirs binDir ./configure \
+		--bindir=$commandBinDir
+
 	make LIBS="-lnetwork"
 }
 

--- a/dev-libs/libgpg_error/patches/libgpg_error-1.61.patchset
+++ b/dev-libs/libgpg_error/patches/libgpg_error-1.61.patchset
@@ -1,4 +1,4 @@
-From 751feac44faab0c11700368fe1e85acef820e0ee Mon Sep 17 00:00:00 2001
+From b3bbfe48616a401f4e9fc52148d0af848f9c1ba3 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Tue, 5 Aug 2014 16:25:46 +0000
 Subject: haiku patch
@@ -18,17 +18,17 @@ index 188f7a4..d270f38 100644
        print "static const int err_code_from_index[] = {";
        header = 0;
 -- 
-2.48.1
+2.54.0
 
 
-From 96ef2236a03b9560484ed72b067f2414e8117526 Mon Sep 17 00:00:00 2001
+From 4d47302e6fcd8963a3fda66bf0ab468369eb3239 Mon Sep 17 00:00:00 2001
 From: fbrosson <fbrosson@localhost>
 Date: Wed, 17 Jan 2018 22:03:45 +0000
 Subject: Do not use __GNUC_PATCHLEVEL__ if it's not defined.
 
 
 diff --git a/doc/yat2m.c b/doc/yat2m.c
-index a7f072e..3f5ff5c 100644
+index ebb323c..4be6e42 100644
 --- a/doc/yat2m.c
 +++ b/doc/yat2m.c
 @@ -105,9 +105,14 @@
@@ -47,7 +47,7 @@ index a7f072e..3f5ff5c 100644
  # define MY_GCC_VERSION 0
  #endif
 diff --git a/src/gpg-error.h.in b/src/gpg-error.h.in
-index 4b4c60f..d9bcdd7 100644
+index a40f616..bd10986 100644
 --- a/src/gpg-error.h.in
 +++ b/src/gpg-error.h.in
 @@ -153,9 +153,14 @@ typedef unsigned int gpg_error_t;
@@ -66,5 +66,5 @@ index 4b4c60f..d9bcdd7 100644
  # define _GPG_ERR_GCC_VERSION 0
  #endif
 -- 
-2.48.1
+2.54.0
 


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
