### PR TITLE
libksba, bump to version 1.8.0

### DIFF
--- a/dev-libs/libksba/libksba-1.8.0.recipe
+++ b/dev-libs/libksba/libksba-1.8.0.recipe
@@ -7,13 +7,13 @@ COPYRIGHT="2001-2015 g10 Code GmbH"
 LICENSE="GNU GPL v3"
 REVISION="1"
 SOURCE_URI="https://www.gnupg.org/ftp/gcrypt/libksba/libksba-$portVersion.tar.bz2"
-CHECKSUM_SHA256="bbb43f032b9164d86c781ffe42213a83bf4f2fee91455edfa4654521b8b03b6b"
+CHECKSUM_SHA256="296b9db9095749f2aa104202d7ab7fd09ad10710e00780a709c9754b1a1d9292"
 PATCHES="libksba-$portVersion.patchset"
 
 ARCHITECTURES="all"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
 
-libVersion="8.14.4"
+libVersion="8.16.0"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
@@ -47,6 +47,9 @@ BUILD_PREREQUIRES="
 	cmd:make
 	"
 
+defineDebugInfoPackage libksba$secondaryArchSuffix \
+	$libDir/libksba.so.$libVersion
+
 BUILD()
 {
 	./autogen.sh
@@ -67,8 +70,9 @@ INSTALL()
 	fi
 
 	packageEntries devel \
-		$dataDir/aclocal/ksba.m4 \
-		$developDir
+		$dataDir/aclocal \
+		$developDir \
+		$infoDir
 }
 
 TEST()

--- a/dev-libs/libksba/patches/libksba-1.8.0.patchset
+++ b/dev-libs/libksba/patches/libksba-1.8.0.patchset
@@ -1,14 +1,14 @@
-From 97f2d3a350da038fa9d11a65384a82538f0415fb Mon Sep 17 00:00:00 2001
+From 5cd5c0b87bf2c2856964f408109d53707c0eaa98 Mon Sep 17 00:00:00 2001
 From: fbrosson <fbrosson@localhost>
 Date: Wed, 17 Jan 2018 22:03:45 +0000
 Subject: Do not use __GNUC_PATCHLEVEL__ if it's not defined.
 
 
 diff --git a/src/ksba.h b/src/ksba.h
-index 955dc06..b052783 100644
+index b9c4169..ca6a7ed 100644
 --- a/src/ksba.h
 +++ b/src/ksba.h
-@@ -45,9 +45,14 @@ extern "C" {
+@@ -55,9 +55,14 @@ extern "C" {
  
  /* Check for compiler features.  */
  #ifdef __GNUC__
@@ -24,5 +24,5 @@ index 955dc06..b052783 100644
  #define _KSBA_DEPRECATED	__attribute__ ((__deprecated__))
  #endif
 -- 
-2.15.1
+2.54.0
 


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
