### PR TITLE
libgcrypt, bump to version 1.12.2

### DIFF
--- a/dev-libs/libgcrypt/libgcrypt-1.12.2.recipe
+++ b/dev-libs/libgcrypt/libgcrypt-1.12.2.recipe
@@ -4,15 +4,22 @@ used in GnuPG."
 HOMEPAGE="https://gnupg.org/related_software/libgcrypt/"
 COPYRIGHT="2000-2018 Free Software Foundation, Inc."
 LICENSE="GNU LGPL v3"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-$portVersion.tar.bz2"
-CHECKSUM_SHA256="09120c9867ce7f2081d6aaa1775386b98c2f2f246135761aae47d81f58685b9c"
+CHECKSUM_SHA256="7ce33c2492221a0436f96a8500215e9f3e3dcb5fd26a757cd415e7a843babd5e"
 PATCHES="libgcrypt-$portVersion.patchset"
 
-ARCHITECTURES="all"
+ARCHITECTURES="all ?x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
-libVersion="20.5.0"
+commandBinDir=$binDir
+commandSuffix=$secondaryArchSuffix
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+libVersion="20.7.2"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
@@ -26,17 +33,16 @@ REQUIRES="
 
 PROVIDES_devel="
 	libgcrypt${secondaryArchSuffix}_devel = $portVersion
-	cmd:dumpsexp$secondaryArchSuffix = $portVersion
-	cmd:hmac256$secondaryArchSuffix = $portVersion
-	cmd:libgcrypt_config$secondaryArchSuffix = $portVersion
-	cmd:mpicalc$secondaryArchSuffix = $portVersion
+	cmd:dumpsexp$commandSuffix = $portVersion
+	cmd:hmac256$commandSuffix = $portVersion
+	cmd:mpicalc$commandSuffix = $portVersion
 	devel:libgcrypt$secondaryArchSuffix = $libVersion
 	"
 REQUIRES_devel="
 	haiku$secondaryArchSuffix
 	libgcrypt$secondaryArchSuffix == $portVersion base
 	devel:libgpg_error$secondaryArchSuffix
-	lib:libgpg_error$secondaryArchSuffix
+	lib:libgpg_error$secondaryArchSuffix # for cmd:mpicalc
 	"
 
 BUILD_REQUIRES="
@@ -56,7 +62,8 @@ defineDebugInfoPackage libgcrypt$secondaryArchSuffix \
 
 BUILD()
 {
-	runConfigure ./configure \
+	runConfigure --omit-dirs binDir ./configure \
+		--bindir=$commandBinDir \
 		--disable-jent-support
 
 	make $jobArgs
@@ -67,26 +74,18 @@ INSTALL()
 	make install
 
 	#remove libtool file
-	rm -f $libDir/*.la
+	rm -f $libDir/libgcrypt.la
 
-	prepareInstalledDevelLib libgcrypt
+	prepareInstalledDevelLib \
+		libgcrypt
 	fixPkgconfig
-
-	if [ -z "$secondaryArchSuffix" ]; then
-		maybe_infoDir=$infoDir
-		maybe_manDir=$manDir
-	else
-		maybe_infoDir=
-		maybe_manDir=
-		rm -rf $documentationDir
-	fi
 
 	packageEntries devel \
 		$developDir \
 		$binDir \
 		$dataDir \
-		$maybe_infoDir \
-		$maybe_manDir
+		$infoDir \
+		$manDir
 }
 
 TEST()

--- a/dev-libs/libgcrypt/patches/libgcrypt-1.12.2.patchset
+++ b/dev-libs/libgcrypt/patches/libgcrypt-1.12.2.patchset
@@ -1,11 +1,11 @@
-From 288a82df8b678a92b28e75815932cbfee02a7a20 Mon Sep 17 00:00:00 2001
+From c55576cb64a6bc5a7f2cceae7171417edff3d430 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Tue, 5 Aug 2014 16:50:29 +0000
 Subject: haiku patch
 
 
 diff --git a/configure.ac b/configure.ac
-index 1d06ca3..25ae69a 100644
+index 4f4df34..8ab7c0d 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -854,6 +854,7 @@ fi
@@ -17,20 +17,20 @@ index 1d06ca3..25ae69a 100644
  ##################################
  #### Checks for header files. ####
 -- 
-2.48.1
+2.54.0
 
 
-From 809bab59453f74930e004c6d478990520c10c810 Mon Sep 17 00:00:00 2001
+From 272047a3e263a91a840c8b35e7a3cfeeb484c843 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Wed, 6 Aug 2014 22:08:04 +0000
 Subject: gcc2 patch
 
 
 diff --git a/src/hwf-x86.c b/src/hwf-x86.c
-index bda14d9..6ea19ff 100644
+index e2c9af0..b771b9e 100644
 --- a/src/hwf-x86.c
 +++ b/src/hwf-x86.c
-@@ -119,7 +119,7 @@ get_xgetbv(void)
+@@ -126,7 +126,7 @@ get_xgetbv(void)
    unsigned int t_eax, t_edx;
  
    asm volatile
@@ -40,20 +40,20 @@ index bda14d9..6ea19ff 100644
       : "c" (0)
      );
 -- 
-2.48.1
+2.54.0
 
 
-From 707eddf4f2f635a57b54e66302edbc6bf8ec5d4a Mon Sep 17 00:00:00 2001
+From 68efe175d1557ab9a6f50ea67371163b89caaea4 Mon Sep 17 00:00:00 2001
 From: fbrosson <fbrosson@localhost>
 Date: Wed, 17 Jan 2018 22:03:45 +0000
 Subject: Do not use __GNUC_PATCHLEVEL__ if it's not defined.
 
 
 diff --git a/src/gcrypt.h.in b/src/gcrypt.h.in
-index 9cad7a4..d9a8ba8 100644
+index 04339a4..e0c6257 100644
 --- a/src/gcrypt.h.in
 +++ b/src/gcrypt.h.in
-@@ -74,9 +74,14 @@ extern "C" {
+@@ -75,9 +75,14 @@ extern "C" {
     underscore they are subject to change without notice. */
  #ifdef __GNUC__
  
@@ -69,17 +69,17 @@ index 9cad7a4..d9a8ba8 100644
  #if _GCRY_GCC_VERSION >= 30100
  #define _GCRY_GCC_ATTR_DEPRECATED __attribute__ ((__deprecated__))
 -- 
-2.48.1
+2.54.0
 
 
-From bb8505c7e4fe33fe50ee1282e6f5138ee3ba87ff Mon Sep 17 00:00:00 2001
+From 13313d1a3e36488175edb51c5ca5e81ebda5e748 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
 Date: Tue, 6 May 2025 20:54:37 +0200
 Subject: more gcc2 fixes
 
 
 diff --git a/cipher/asm-common-i386.h b/cipher/asm-common-i386.h
-index d746ebc..9d148f7 100644
+index 346a8ff..32253ac 100644
 --- a/cipher/asm-common-i386.h
 +++ b/cipher/asm-common-i386.h
 @@ -24,7 +24,7 @@
@@ -92,10 +92,10 @@ index d746ebc..9d148f7 100644
  # define ELF(...) /*_*/
  #endif
 diff --git a/src/hwf-x86.c b/src/hwf-x86.c
-index 6ea19ff..a3d05f1 100644
+index b771b9e..43c629b 100644
 --- a/src/hwf-x86.c
 +++ b/src/hwf-x86.c
-@@ -57,7 +57,11 @@ is_cpuid_available(void)
+@@ -64,7 +64,11 @@ is_cpuid_available(void)
    /* Detect the CPUID feature by testing some undefined behaviour (16
       vs 32 bit pushf/popf). */
    asm volatile
@@ -108,7 +108,7 @@ index 6ea19ff..a3d05f1 100644
       CFI_PUSH4
       "popl %%eax\n\t"
       CFI_POP4
-@@ -79,6 +83,9 @@ is_cpuid_available(void)
+@@ -86,6 +90,9 @@ is_cpuid_available(void)
       "jz .Lno_cpuid%=\n\t"       /* Toggling did not work, thus no CPUID.  */
       "movl $1, %0\n"             /* Worked. true -> HAS_CPUID.  */
       ".Lno_cpuid%=:\n\t"
@@ -119,5 +119,5 @@ index 6ea19ff..a3d05f1 100644
       :
       : "%eax", "%ecx", "cc", "memory"
 -- 
-2.48.1
+2.54.0
 


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
