### PR TITLE
libgpg_error, revbump, fix 32bit

### DIFF
--- a/dev-libs/libgpg_error/libgpg_error-1.61.recipe
+++ b/dev-libs/libgpg_error/libgpg_error-1.61.recipe
@@ -14,21 +14,14 @@ PATCHES="libgpg_error-$portVersion.patchset"
 ARCHITECTURES="all"
 SECONDARY_ARCHITECTURES="x86"
 
-commandBinDir=$binDir
-commandSuffix=$secondaryArchSuffix
-if [ "$targetArchitecture" = x86_gcc2 ]; then
-	commandSuffix=
-	commandBinDir=$prefix/bin
-fi
-
 libVersion="0.42.1"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 portVersionCompat="$portVersion compat >= 1"
 
 PROVIDES="
 	libgpg_error$secondaryArchSuffix = $portVersion
-	cmd:gpg_error$commandSuffix = $portVersionCompat
-	cmd:yat2m$commandSuffix = $portVersionCompat
+	cmd:gpg_error$secondaryArchSuffix = $portVersionCompat
+	cmd:yat2m$secondaryArchSuffix = $portVersionCompat
 	lib:libgpg_error$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
@@ -37,7 +30,7 @@ REQUIRES="
 
 PROVIDES_devel="
 	libgpg_error${secondaryArchSuffix}_devel = $portVersion
-	cmd:gpgrt_config$commandSuffix = $portVersionCompat
+	cmd:gpgrt_config$secondaryArchSuffix = $portVersionCompat
 	devel:libgpg_error$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
