### PR TITLE
libgpg_error, revbump (real this time), fix for commandBinDir

### DIFF
--- a/dev-libs/libgpg_error/libgpg_error-1.61.recipe
+++ b/dev-libs/libgpg_error/libgpg_error-1.61.recipe
@@ -5,7 +5,7 @@ DirMngr, Pinentry, SmartCard Daemon and more."
 HOMEPAGE="https://www.gnupg.org/related_software/libraries.en.html#lib-libgpg-error"
 COPYRIGHT="2003-2026 g10 Code GmbH"
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-$portVersion.tar.bz2"
 CHECKSUM_SHA256="7a85413f2bc354f4f8aa832b718af122e48965e9e0eb9012ee659c13c6385c93"
 SOURCE_DIR="libgpg-error-$portVersion"
@@ -53,8 +53,7 @@ defineDebugInfoPackage libgpg_error$secondaryArchSuffix \
 
 BUILD()
 {
-	MAKEINFO=true runConfigure --omit-dirs binDir ./configure \
-		--bindir=$commandBinDir
+	MAKEINFO=true runConfigure ./configure
 
 	make LIBS="-lnetwork"
 }


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
