### PR TITLE
libassuan3, revbump, make sure we are on par after libgpg_error changes

### DIFF
--- a/dev-libs/libassuan/libassuan3-3.0.2.recipe
+++ b/dev-libs/libassuan/libassuan3-3.0.2.recipe
@@ -7,7 +7,7 @@ COPYRIGHT="2001-2013 Free Software Foundation, Inc.
 	2001-2026 g10 Code GmbH"
 LICENSE="GNU GPL v3
 	GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://www.gnupg.org/ftp/gcrypt/libassuan/libassuan-$portVersion.tar.bz2"
 CHECKSUM_SHA256="d2931cdad266e633510f9970e1a2f346055e351bb19f9b78912475b8074c36f6"
 SOURCE_DIR="libassuan-$portVersion"


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
