### PR TITLE
libksba, fix for 32bit

### DIFF
--- a/dev-libs/libksba/libksba-1.8.0.recipe
+++ b/dev-libs/libksba/libksba-1.8.0.recipe
@@ -71,8 +71,7 @@ INSTALL()
 
 	packageEntries devel \
 		$dataDir/aclocal \
-		$developDir \
-		$infoDir
+		$developDir
 }
 
 TEST()


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
