### PR TITLE
gpgme, add new version for 2.1.1

### DIFF
--- a/app-crypt/gpgme/gpgme2-2.1.1.recipe
+++ b/app-crypt/gpgme/gpgme2-2.1.1.recipe
@@ -1,0 +1,114 @@
+SUMMARY="GnuPG Made Easy is a library for making GnuPG easier to use"
+DESCRIPTION="GnuPG Made Easy (GPGME) is a library designed to make access to GnuPG \
+easier for applications. It provides a High-Level Crypto API for \
+encryption, decryption, signing, signature verification and key management. \
+Currently it uses GnuPG as its backend but the API isn't restricted to \
+this engine; in fact we have already developed a backend for CMS (S/MIME)."
+HOMEPAGE="http://www.gnupg.org/gpgme.html"
+COPYRIGHT="1998-2020 Free Software Foundation, Inc.
+	2001-2023 g10 Code GmbH"
+LICENSE="GNU GPL v2
+	GNU LGPL v2.1"
+REVISION="1"
+SOURCE_URI="https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-$portVersion.tar.bz2"
+CHECKSUM_SHA256="6d7ee12b209d7dce75468db53f72a90e1ad3d21f4c304ef2c002612a52f5333a"
+SOURCE_DIR="gpgme-$portVersion"
+PATCHES="gpgme-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+commandBinDir=$binDir
+commandSuffix=$secondaryArchSuffix
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+libVersion="45.1.1"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	gpgme2$secondaryArchSuffix = $portVersion compat >= 2.0
+	cmd:gpgme_json$commandSuffix = $portVersion compat >= 2.0
+	cmd:gpgme_tool$commandSuffix = $portVersion compat >= 2.0
+	cmd:gnupg_key_manage$commandSuffix = $portVersion compat >= 2.0
+	lib:libgpgme$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libassuan$secondaryArchSuffix
+	lib:libglib_2.0$secondaryArchSuffix
+	lib:libgpg_error$secondaryArchSuffix
+	"
+CONFLICTS="
+	gpgme$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	gpgme2${secondaryArchSuffix}_devel = $portVersion compat >= 2.0
+	devel:libgpgme$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	gpgme2$secondaryArchSuffix == $portVersion base
+	devel:libassuan$secondaryArchSuffix
+	devel:libglib_2.0$secondaryArchSuffix
+	devel:libgpg_error$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libassuan$secondaryArchSuffix >= 9
+	devel:libglib_2.0$secondaryArchSuffix
+	devel:libgpg_error$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:autoreconf
+	cmd:gcc$secondaryArchSuffix
+	cmd:gpg
+	cmd:gpgconf
+	cmd:gpg_error
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+TEST_REQUIRES="
+	cmd:which
+	"
+
+defineDebugInfoPackage gpgme2$secondaryArchSuffix \
+	"$commandBinDir"/gpgme-json \
+	"$commandBinDir"/gpgme-tool \
+	"$commandBinDir"/gnupg-key-manage \
+	$libDir/libgpgme.so.$libVersion
+
+BUILD()
+{
+	autoreconf -fi
+	runConfigure --omit-dirs binDir ./configure \
+		--bindir=$prefix/bin
+
+	make $jobArgs
+}
+
+INSTALL()
+{
+	make install
+
+	# remove libtool files
+	rm $libDir/libgpgme.la
+
+	prepareInstalledDevelLib \
+		libgpgme
+	fixPkgconfig
+
+	packageEntries devel \
+		$developDir
+}
+
+TEST()
+{
+	# 1 of 28 tests failed
+	make VERBOSE=1 check
+}

--- a/app-crypt/gpgme/patches/gpgme-2.1.1.patchset
+++ b/app-crypt/gpgme/patches/gpgme-2.1.1.patchset
@@ -1,0 +1,24 @@
+From 7337b0ef14cde0243e05a06fb8af06da915b6448 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Fran=C3=A7ois=20Revol?= <revol@free.fr>
+Date: Sun, 16 Nov 2014 14:50:17 +0100
+Subject: configure.ac: Haiku does have a thread-safe getenv
+
+Also force HAVE_PTHREAD.
+
+diff --git a/configure.ac b/configure.ac
+index ddc73c5..5eebaec 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -254,6 +254,9 @@ case "${host}" in
+     *-apple-darwin*)
+         have_macos_system=yes
+         ;;
++    *-haiku*)
++        have_thread_safe_getenv=yes
++        ;;
+ esac
+ case "${host}" in
+     *-mingw32*)
+-- 
+2.54.0
+

--- a/dev-cpp/gpgmepp/gpgmepp-2.1.0.recipe
+++ b/dev-cpp/gpgmepp/gpgmepp-2.1.0.recipe
@@ -1,0 +1,98 @@
+SUMMARY="GnuPG Made Easy is a library for making GnuPG easier to use (C++ bindings)"
+DESCRIPTION="GnuPG Made Easy (GPGME) is a library designed to make access to GnuPG \
+easier for applications. It provides a High-Level Crypto API for \
+encryption, decryption, signing, signature verification and key management. \
+Currently it uses GnuPG as its backend but the API isn't restricted to \
+this engine; in fact we have already developed a backend for CMS (S/MIME)."
+HOMEPAGE="http://www.gnupg.org/gpgme.html"
+COPYRIGHT="1998-2020 Free Software Foundation, Inc.
+	2001-2023 g10 Code GmbH"
+LICENSE="GNU GPL v2
+	GNU LGPL v2.1"
+REVISION="1"
+SOURCE_URI="https://www.gnupg.org/ftp/gcrypt/gpgmepp/gpgmepp-$portVersion.tar.xz"
+CHECKSUM_SHA256="57f804468f0204504b172c6b139cb05124b4263be7ad514932c7c4c5062a16e2"
+PATCHES="gpgmepp-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="7.1.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	gpgmepp$secondaryArchSuffix = $portVersion compat >= 2.0
+	lib:libgpgmepp$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libgpg_error$secondaryArchSuffix
+	lib:libgpgme$secondaryArchSuffix
+	"
+CONFLICTS="
+	gpgme$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	gpgmepp${secondaryArchSuffix}_devel = $portVersion compat >= 2.0
+	devel:libgpgmepp$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	gpgmepp$secondaryArchSuffix == $portVersion base
+	devel:libgpg_error$secondaryArchSuffix
+	devel:libgpgme$secondaryArchSuffix >= 45
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libgpg_error$secondaryArchSuffix
+	devel:libgpgme$secondaryArchSuffix >= 45
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:gcc$secondaryArchSuffix
+	cmd:gpg
+	cmd:gpgconf
+	cmd:gpg_error
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+defineDebugInfoPackage gpgmepp$secondaryArchSuffix \
+	$libDir/libgpgmepp.so.$libVersion
+
+BUILD()
+{
+	cmake -B build -S . -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		$cmakeDirArgs
+
+	make -C build $jobArgs
+}
+
+INSTALL()
+{
+	make -C build install
+
+	local develPackageName="${portName}_devel-$portFullVersion"
+	local packageLinksDir=$(dirname $portPackageLinksDir)
+	local assuanLinksDir="$packageLinksDir/${develPackageName}/devel~libassuan$secondaryArchSuffix/$relativeDevelopLibDir"
+
+	# fix lib path in cmake files
+	sed -i "s|$libDir|$developLibDir|" \
+		$libDir/cmake/Gpgmepp/GpgmeppConfig.cmake
+	sed -i "s|/packages/libassuan.*/lib|$assuanLinksDir|" \
+		$libDir/cmake/Gpgmepp/GpgmeppConfig.cmake
+
+	prepareInstalledDevelLib \
+		libgpgmepp
+	fixPkgconfig
+
+	packageEntries devel \
+		$developDir \
+		$libDir/cmake
+}
+
+TEST()
+{
+	ctest --test-dir build --output-on-failure
+}

--- a/dev-cpp/gpgmepp/patches/gpgmepp-2.1.0.patchset
+++ b/dev-cpp/gpgmepp/patches/gpgmepp-2.1.0.patchset
@@ -1,0 +1,31 @@
+From 77b17c91ed588a409d069439a471b81f1f9ca940 Mon Sep 17 00:00:00 2001
+From: Luc Schrijvers <begasus@gmail.com>
+Date: Tue, 7 Apr 2026 17:32:13 +0200
+Subject: Fix for INSTALL_INTERFACE:include
+
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 7be46cb..97d21b1 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -128,7 +128,7 @@ if(ENABLE_SHARED)
+ 
+     target_include_directories(Gpgmepp
+         PRIVATE ${LibGpgError_INCLUDE_DIRS}
+-        INTERFACE $<INSTALL_INTERFACE:include>
++        INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+     )
+ 
+     target_link_libraries(Gpgmepp Gpgme::Gpgme)
+@@ -144,7 +144,7 @@ if(ENABLE_STATIC)
+ 
+     target_include_directories(GpgmeppStatic
+         PRIVATE ${LibGpgError_INCLUDE_DIRS}
+-        INTERFACE $<INSTALL_INTERFACE:include>
++        INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+     )
+ 
+     target_link_libraries(GpgmeppStatic Gpgme::Gpgme)
+-- 
+2.54.0
+

--- a/dev-libs/qgpgme/patches/qgpgme-2.1.0.patchset
+++ b/dev-libs/qgpgme/patches/qgpgme-2.1.0.patchset
@@ -1,0 +1,22 @@
+From 9955ed75146d00986ad1d27209e31d57a462238c Mon Sep 17 00:00:00 2001
+From: Luc Schrijvers <begasus@gmail.com>
+Date: Tue, 7 Apr 2026 18:18:26 +0200
+Subject: Fix for INSTALL_INTERFACE:include
+
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index c9be813..fa84412 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -265,7 +265,7 @@ set_target_properties(${targetname} PROPERTIES
+     SOVERSION "${LIBQGPGME_SOVERSION}"
+ )
+ 
+-target_include_directories(${targetname} INTERFACE "$<INSTALL_INTERFACE:include/qgpgme-qt${QT_MAJOR_VERSION}>")
++target_include_directories(${targetname} INTERFACE "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/qgpgme-qt${QT_MAJOR_VERSION}>")
+ 
+ if (${QT_MAJOR_VERSION} EQUAL 6)
+     set(config_suffix Qt6)
+-- 
+2.54.0
+

--- a/dev-libs/qgpgme/qgpgme_qt5-2.1.0.recipe
+++ b/dev-libs/qgpgme/qgpgme_qt5-2.1.0.recipe
@@ -1,0 +1,90 @@
+SUMMARY="GnuPG Made Easy is a library for making GnuPG easier to use (C++ bindings)"
+DESCRIPTION="GnuPG Made Easy (GPGME) is a library designed to make access to GnuPG \
+easier for applications. It provides a High-Level Crypto API for \
+encryption, decryption, signing, signature verification and key management. \
+Currently it uses GnuPG as its backend but the API isn't restricted to \
+this engine; in fact we have already developed a backend for CMS (S/MIME)."
+HOMEPAGE="http://www.gnupg.org/gpgme.html"
+COPYRIGHT="1998-2020 Free Software Foundation, Inc.
+	2001-2023 g10 Code GmbH"
+LICENSE="GNU GPL v2
+	GNU LGPL v2.1"
+REVISION="1"
+SOURCE_URI="https://www.gnupg.org/ftp/gcrypt/qgpgme/qgpgme-$portVersion.tar.xz"
+CHECKSUM_SHA256="5b32feb3eee4a7f9402d22b7206480908dc43bb4df382917c075c512116f8f08"
+SOURCE_DIR="qgpgme-$portVersion"
+PATCHES="qgpgme-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="15.8.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	qgpgme_qt5$secondaryArchSuffix = $portVersion compat >= 2.0
+	lib:libqgpgme$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libgpg_error$secondaryArchSuffix
+	lib:libgpgme$secondaryArchSuffix
+	lib:libgpgmepp$secondaryArchSuffix
+	lib:libQt5Core$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	qgpgme_qt5${secondaryArchSuffix}_devel = $portVersion compat >= 2.0
+	devel:libqgpgme$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	qgpgme_qt5$secondaryArchSuffix == $portVersion base
+	devel:libgpgme$secondaryArchSuffix >= 45
+	devel:libgpgmepp$secondaryArchSuffix >= 7
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libgpg_error$secondaryArchSuffix
+	devel:libgpgme$secondaryArchSuffix >= 45
+	devel:libgpgmepp$secondaryArchSuffix >= 7
+	devel:libQt5Core$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:gcc$secondaryArchSuffix
+	cmd:gpg
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+defineDebugInfoPackage qgpgme_qt5$secondaryArchSuffix \
+	$libDir/libqgpgme.so.$libVersion
+
+BUILD()
+{
+	cmake -B build -S . -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		$cmakeDirArgs \
+		-DBUILD_WITH_QT6=OFF
+
+	make -C build $jobArgs
+}
+
+INSTALL()
+{
+	make -C build install
+
+	prepareInstalledDevelLib \
+		libqgpgme
+	fixPkgconfig
+
+	packageEntries devel \
+		$developDir \
+		$libDir/cmake
+}
+
+TEST()
+{
+	# 95% tests passed, 1 tests failed out of 19
+	ctest --test-dir build --output-on-failure
+}

--- a/dev-libs/qgpgme/qgpgme_qt6-2.1.0.recipe
+++ b/dev-libs/qgpgme/qgpgme_qt6-2.1.0.recipe
@@ -1,0 +1,90 @@
+SUMMARY="GnuPG Made Easy is a library for making GnuPG easier to use (C++ bindings)"
+DESCRIPTION="GnuPG Made Easy (GPGME) is a library designed to make access to GnuPG \
+easier for applications. It provides a High-Level Crypto API for \
+encryption, decryption, signing, signature verification and key management. \
+Currently it uses GnuPG as its backend but the API isn't restricted to \
+this engine; in fact we have already developed a backend for CMS (S/MIME)."
+HOMEPAGE="http://www.gnupg.org/gpgme.html"
+COPYRIGHT="1998-2020 Free Software Foundation, Inc.
+	2001-2023 g10 Code GmbH"
+LICENSE="GNU GPL v2
+	GNU LGPL v2.1"
+REVISION="1"
+SOURCE_URI="https://www.gnupg.org/ftp/gcrypt/qgpgme/qgpgme-$portVersion.tar.xz"
+CHECKSUM_SHA256="5b32feb3eee4a7f9402d22b7206480908dc43bb4df382917c075c512116f8f08"
+SOURCE_DIR="qgpgme-$portVersion"
+PATCHES="qgpgme-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="15.8.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	qgpgme_qt6$secondaryArchSuffix = $portVersion compat >= 2.0
+	lib:libqgpgmeqt6$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libgpg_error$secondaryArchSuffix
+	lib:libgpgme$secondaryArchSuffix
+	lib:libgpgmepp$secondaryArchSuffix
+	lib:libQt6Core$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	qgpgme_qt6${secondaryArchSuffix}_devel = $portVersion compat >= 2.0
+	devel:libqgpgmeqt6$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	qgpgme_qt6$secondaryArchSuffix == $portVersion base
+	devel:libgpgme$secondaryArchSuffix >= 45
+	devel:libgpgmepp$secondaryArchSuffix >= 7
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libgpg_error$secondaryArchSuffix
+	devel:libgpgme$secondaryArchSuffix >= 45
+	devel:libgpgmepp$secondaryArchSuffix >= 7
+	devel:libQt6Core$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:gcc$secondaryArchSuffix
+	cmd:gpg
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+defineDebugInfoPackage qgpgme_qt6$secondaryArchSuffix \
+	$libDir/libqgpgmeqt6.so.$libVersion
+
+BUILD()
+{
+	cmake -B build -S . -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		$cmakeDirArgs \
+		-DBUILD_WITH_QT5=OFF
+
+	make -C build $jobArgs
+}
+
+INSTALL()
+{
+	make -C build install
+
+	prepareInstalledDevelLib \
+		libqgpgmeqt6
+	fixPkgconfig
+
+	packageEntries devel \
+		$developDir \
+		$libDir/cmake
+}
+
+TEST()
+{
+	# 95% tests passed, 1 tests failed out of 19
+	ctest --test-dir build --output-on-failure
+}


### PR DESCRIPTION
Keep older version around for a while, this update will otherwise break existing ports
Subpacakges are now stanalone, like gpgmepp and qgpgme_qt5 and _qt6
following the Gentoo layout

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
