### PR TITLE
libksane, revbump for dropped Qt5Script

### DIFF
--- a/kde-apps/libksane/libksane-23.08.5.recipe
+++ b/kde-apps/libksane/libksane-23.08.5.recipe
@@ -3,7 +3,7 @@ DESCRIPTION="Libksane is a KDE interface for SANE library to control flat scanne
 HOMEPAGE="https://invent.kde.org/graphics/libksane/"
 COPYRIGHT="2010-2024 KDE Organisation"
 LICENSE="GNU LGPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://download.kde.org/stable/release-service/$portVersion/src/libksane-$portVersion.tar.xz"
 CHECKSUM_SHA256="deddff992193fdd5644c4b7b5ac60be34b775e7ad1bd444ea033b0a179242f6e"
 
@@ -42,12 +42,9 @@ REQUIRES="
 	lib:libKF5WidgetsAddons$secondaryArchSuffix
 	lib:libKF5XmlGui$secondaryArchSuffix
 	lib:libKSaneCore$secondaryArchSuffix
-	lib:libQt5DBus$secondaryArchSuffix
+	lib:libQt5Core$secondaryArchSuffix
 	lib:libQt5Gui$secondaryArchSuffix
-	lib:libQt5Network$secondaryArchSuffix
-	lib:libQt5Script$secondaryArchSuffix
 	lib:libQt5Widgets$secondaryArchSuffix
-	lib:libQt5Xml$secondaryArchSuffix
 	lib:libsane$secondaryArchSuffix
 	"
 
@@ -91,6 +88,7 @@ BUILD_PREREQUIRES="
 	cmd:cmake
 	cmd:g++$secondaryArchSuffix
 	cmd:make
+	cmd:msgfmt$secondaryArchSuffix
 	cmd:python3
 	"
 


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
