### PR TITLE
cudatext, bump to version 1.234.4.2

### DIFF
--- a/app-editors/cudatext/cudatext-1.234.4.2.recipe
+++ b/app-editors/cudatext/cudatext-1.234.4.2.recipe
@@ -28,7 +28,7 @@ COPYRIGHT="2026 Alexey Torgashin"
 LICENSE="MPL v2.0"
 REVISION="1"
 SOURCE_URI="https://github.com/Begasus/CudaText-Haikuports/archive/refs/tags/$portVersion.tar.gz"
-CHECKSUM_SHA256="21b0f5860c63e76192bf54fdc8ab911d808886482e6d42dfb3b571047e685674"
+CHECKSUM_SHA256="329f89e9d0fac898d1e21c328ebafd8077960b13f69fc6fd1abfa8a4b6891f35"
 SOURCE_DIR="CudaText-Haikuports-$portVersion/files"
 ADDITIONAL_FILES="CudaText.rdef.in
 	setup-cudatext.sh


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
