### PR TITLE
libaccounts_glib, revbump, move $dataDir/gir-1.0 to _devel package

### DIFF
--- a/net-libs/libaccounts_glib/libaccounts_glib-1.27.recipe
+++ b/net-libs/libaccounts_glib/libaccounts_glib-1.27.recipe
@@ -4,7 +4,7 @@ applications. It is part of the accounts-sso project."
 HOMEPAGE="https://gitlab.com/accounts-sso/libaccounts-glib"
 COPYRIGHT="2024 Accounts SSO"
 LICENSE="GNU LGPL v2.1"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://gitlab.com/accounts-sso/libaccounts-glib/-/archive/VERSION_$portVersion/libaccounts-glib-VERSION_$portVersion.tar.bz2"
 CHECKSUM_SHA256="e178c103e60ca34777afba94019a1c4571aedf9e54291b0faca71e5cad0628af"
 SOURCE_DIR="libaccounts-glib-VERSION_$portVersion"
@@ -94,7 +94,8 @@ INSTALL()
 	fixPkgconfig
 
 	packageEntries devel \
-		$developDir
+		$developDir \
+		$dataDir/gir-1.0
 
 	packageEntries tools \
 		$prefix/bin


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
