### PR TITLE
libfyaml, new recipe, dependency for latest appstream

### DIFF
--- a/dev-libs/libfyaml/libfyaml-0.9.6.recipe
+++ b/dev-libs/libfyaml/libfyaml-0.9.6.recipe
@@ -1,0 +1,78 @@
+SUMMARY="Fully feature complete YAML parser and emitter"
+DESCRIPTION="libfyaml is a high-performance YAML 1.2 and JSON parser/emitter with zero-copy \
+operation, full document and event APIs, and the two major 1.0 alpha features:
+
+* generics: a schema-light, sum-type value model for YAML/JSON data in C
+* reflection/meta-type: typed YAML <-> C serdes driven by C type metadata"
+HOMEPAGE="https://pantoniou.github.io/libfyaml/"
+COPYRIGHT="2019 Pantelis Antoniou"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="https://github.com/pantoniou/libfyaml/releases/download/v$portVersion/libfyaml-$portVersion.tar.gz"
+CHECKSUM_SHA256="a59cc3331e2eb903ec36933ad52a45888041cac31e44f553a00511131242c483"
+PATCHES="libfyaml-$portVersion.patchset"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="$portVersion"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	libfyaml$secondaryArchSuffix = $portVersion
+	cmd:fy_tool = $portVersion
+	lib:libfyaml$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	libfyaml${secondaryArchSuffix}_devel = $portVersion
+	devel:libfyaml$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	libfyaml$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libyaml$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+defineDebugInfoPackage libfyaml$secondaryArchSuffix \
+	"$libDir"/libfyaml.so.$libVersion
+
+BUILD()
+{
+	cmake -B build -S . -DCMAKE_BUILD_TYPE=relWithDebInfo \
+		$cmakeDirArgs \
+		-DCMAKE_INSTALL_BINDIR=$prefix/bin \
+		-DBUILD_TESTING=OFF
+
+	make -C build $jobArgs
+}
+
+INSTALL()
+{
+	make -C build install
+
+	prepareInstalledDevelLib \
+		libfyaml
+	fixPkgconfig
+
+	packageEntries devel \
+		$developDir \
+		$libDir/cmake
+}
+
+TEST()
+{
+	ctest --test-dir build --output-on-failure
+}

--- a/dev-libs/libfyaml/patches/libfyaml-0.9.6.patchset
+++ b/dev-libs/libfyaml/patches/libfyaml-0.9.6.patchset
@@ -1,0 +1,22 @@
+From 9938a5b87fb14222739633ee2f254c9d605c8d91 Mon Sep 17 00:00:00 2001
+From: Luc Schrijvers <begasus@gmail.com>
+Date: Wed, 8 Jul 2026 11:58:51 +0200
+Subject: Fix for endian.h on Haiku
+
+
+diff --git a/include/libfyaml/libfyaml-endian.h b/include/libfyaml/libfyaml-endian.h
+index 0d4c69c..ab295c0 100644
+--- a/include/libfyaml/libfyaml-endian.h
++++ b/include/libfyaml/libfyaml-endian.h
+@@ -42,7 +42,7 @@
+ extern "C" {
+ #endif
+ 
+-#if defined(__linux__) || defined(__CYGWIN__) || defined(__OpenBSD__) || defined(__GNU__) || defined(__EMSCRIPTEN__)
++#if defined(__linux__) || defined(__CYGWIN__) || defined(__OpenBSD__) || defined(__GNU__) || defined(__EMSCRIPTEN__) || defined(__HAIKU__)
+ # include <endian.h>
+ #elif defined(__APPLE__)
+ # include <libkern/OSByteOrder.h>
+-- 
+2.54.0
+


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
