### PR TITLE
libfyaml, revbump, switch to autotools, fixes build for 32bit

### DIFF
--- a/dev-libs/libfyaml/libfyaml-0.9.6.recipe
+++ b/dev-libs/libfyaml/libfyaml-0.9.6.recipe
@@ -7,7 +7,7 @@ operation, full document and event APIs, and the two major 1.0 alpha features:
 HOMEPAGE="https://pantoniou.github.io/libfyaml/"
 COPYRIGHT="2019 Pantelis Antoniou"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/pantoniou/libfyaml/releases/download/v$portVersion/libfyaml-$portVersion.tar.gz"
 CHECKSUM_SHA256="a59cc3331e2eb903ec36933ad52a45888041cac31e44f553a00511131242c483"
 PATCHES="libfyaml-$portVersion.patchset"
@@ -15,12 +15,26 @@ PATCHES="libfyaml-$portVersion.patchset"
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
-libVersion="$portVersion"
+# On x86_gcc2 we don't want to install the commands in bin/<arch>/, but in bin/.
+commandBinDir=$binDir
+commandSuffix=$secondaryArchSuffix
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+libVersion="0.0.0"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="
 	libfyaml$secondaryArchSuffix = $portVersion
-	cmd:fy_tool = $portVersion
+	cmd:fy_compose$commandSuffix = $portVersion
+	cmd:fy_dump$commandSuffix = $portVersion
+	cmd:fy_filter$commandSuffix = $portVersion
+	cmd:fy_join$commandSuffix = $portVersion
+	cmd:fy_testsuite$commandSuffix = $portVersion
+	cmd:fy_tool$commandSuffix = $portVersion
+	cmd:fy_ypath$commandSuffix = $portVersion
 	lib:libfyaml$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
@@ -40,8 +54,10 @@ BUILD_REQUIRES="
 	devel:libyaml$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:cmake
+	cmd:aclocal
+	cmd:autoreconf
 	cmd:gcc$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
 	"
@@ -51,17 +67,17 @@ defineDebugInfoPackage libfyaml$secondaryArchSuffix \
 
 BUILD()
 {
-	cmake -B build -S . -DCMAKE_BUILD_TYPE=relWithDebInfo \
-		$cmakeDirArgs \
-		-DCMAKE_INSTALL_BINDIR=$prefix/bin \
-		-DBUILD_TESTING=OFF
+	autoreconf -fi
+	runConfigure --omit-dirs binDir ./configure \
+		--bindir=$commandBinDir \
+		--disable-static
 
-	make -C build $jobArgs
+	make $jobArgs
 }
 
 INSTALL()
 {
-	make -C build install
+	make install
 
 	prepareInstalledDevelLib \
 		libfyaml
@@ -69,7 +85,7 @@ INSTALL()
 
 	packageEntries devel \
 		$developDir \
-		$libDir/cmake
+		$manDir/man3
 }
 
 TEST()

--- a/dev-libs/libfyaml/patches/libfyaml-0.9.6.patchset
+++ b/dev-libs/libfyaml/patches/libfyaml-0.9.6.patchset
@@ -1,4 +1,4 @@
-From 9938a5b87fb14222739633ee2f254c9d605c8d91 Mon Sep 17 00:00:00 2001
+From 37dd989db87d90dbca7686554c5e9275da1cc840 Mon Sep 17 00:00:00 2001
 From: Luc Schrijvers <begasus@gmail.com>
 Date: Wed, 8 Jul 2026 11:58:51 +0200
 Subject: Fix for endian.h on Haiku
@@ -17,6 +17,42 @@ index 0d4c69c..ab295c0 100644
  # include <endian.h>
  #elif defined(__APPLE__)
  # include <libkern/OSByteOrder.h>
+-- 
+2.54.0
+
+
+From 9b32720e4c68976484d6128ef404bb6560c9202d Mon Sep 17 00:00:00 2001
+From: bbhtt <bbhtt.zn0i8@slmail.me>
+Date: Thu, 9 Jul 2026 15:15:57 +0200
+Subject: fix: Build failure on 32bit archs
+
+Reference: https://github.com/pantoniou/libfyaml/issues/270#issuecomment-4126068817
+
+diff --git a/include/libfyaml/libfyaml-vlsize.h b/include/libfyaml/libfyaml-vlsize.h
+index 6ccb7ab..acfd78d 100644
+--- a/include/libfyaml/libfyaml-vlsize.h
++++ b/include/libfyaml/libfyaml-vlsize.h
+@@ -810,13 +810,18 @@ fy_decode_size(const uint8_t *start, size_t bufsz, size_t *sizep)
+ static inline const uint8_t *
+ fy_decode_size_nocheck(const uint8_t *start, size_t *sizep)
+ {
+-	return fy_decode_size32_nocheck(start, sizep);
++	uint64_t sz;
++	const uint8_t *ret;
++
++	ret = fy_decode_size32_nocheck(start, &sz);
++	*sizep = (size_t)sz;
++	return ret;
+ }
+ 
+ static inline const uint8_t *
+ fy_skip_size(const uint8_t *start, size_t bufsz)
+ {
+-	return fy_skip_size32(start, bufsz, &sz);
++	return fy_skip_size32(start, bufsz);
+ }
+ 
+ static inline const uint8_t *
 -- 
 2.54.0
 


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
