### PR TITLE
libfyaml, revbump, fix obsolete references in pkgconfig file

### DIFF
--- a/dev-libs/libfyaml/libfyaml-0.9.6.recipe
+++ b/dev-libs/libfyaml/libfyaml-0.9.6.recipe
@@ -7,7 +7,7 @@ operation, full document and event APIs, and the two major 1.0 alpha features:
 HOMEPAGE="https://pantoniou.github.io/libfyaml/"
 COPYRIGHT="2019 Pantelis Antoniou"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/pantoniou/libfyaml/releases/download/v$portVersion/libfyaml-$portVersion.tar.gz"
 CHECKSUM_SHA256="a59cc3331e2eb903ec36933ad52a45888041cac31e44f553a00511131242c483"
 PATCHES="libfyaml-$portVersion.patchset"
@@ -82,6 +82,8 @@ INSTALL()
 	prepareInstalledDevelLib \
 		libfyaml
 	fixPkgconfig
+
+	sed -i "s|  none required||" $developLibDir/pkgconfig/libfyaml.pc
 
 	packageEntries devel \
 		$developDir \


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
