### PR TITLE
atk, revbump, move gir files to the _devel package, cleanup

### DIFF
--- a/dev-libs/atk/atk-2.38.0.recipe
+++ b/dev-libs/atk/atk-2.38.0.recipe
@@ -9,7 +9,7 @@ COPYRIGHT="2001-2003, 2006-2007 Sun Microsystems Inc.
 	2012-2018 ATK Team
 	2014 SUSE LLC."
 LICENSE="GNU LGPL v2"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://ftp.gnome.org/pub/GNOME/sources/atk/${portVersion%.*}/atk-$portVersion.tar.xz"
 CHECKSUM_SHA256="ac4de2a4ef4bd5665052952fe169657e65e895c5057dffb3c2a810f6191a0c36"
 
@@ -25,7 +25,6 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libgirepository_1.0$secondaryArchSuffix
 	lib:libglib_2.0$secondaryArchSuffix
 	lib:libgobject_2.0$secondaryArchSuffix
 	lib:libintl$secondaryArchSuffix
@@ -37,10 +36,8 @@ PROVIDES_devel="
 	"
 REQUIRES_devel="
 	atk$secondaryArchSuffix == $portVersion base
-	devel:libgirepository_1.0$secondaryArchSuffix
 	devel:libglib_2.0$secondaryArchSuffix
 	devel:libgobject_2.0$secondaryArchSuffix
-	devel:libintl$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
@@ -50,10 +47,10 @@ BUILD_REQUIRES="
 	devel:libintl$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
+	cmd:cmake
 	cmd:gcc$secondaryArchSuffix
-	cmd:libtoolize$secondaryArchSuffix
-	cmd:make
 	cmd:meson
+	cmd:msgfmt$secondaryArchSuffix
 	cmd:ninja
 	cmd:pkg_config$secondaryArchSuffix
 	"
@@ -63,14 +60,16 @@ defineDebugInfoPackage atk$secondaryArchSuffix \
 
 BUILD()
 {
-	meson  build . \
+	LDFLAGS="-lintl" meson \
 		--buildtype=debugoptimized \
 		--prefix=$prefix \
 		--libdir=$libDir \
 		--includedir=$includeDir \
 		--localedir=$dataDir/locale \
 		--datadir=$dataDir \
-		-Dintrospection=true
+		-D introspection=true \
+		build
+
 	ninja -C build $jobArgs
 }
 
@@ -78,19 +77,16 @@ INSTALL()
 {
 	ninja -C build install
 
-	prepareInstalledDevelLib libatk-1.0
+	prepareInstalledDevelLib \
+		libatk-1.0
 	fixPkgconfig
 
 	packageEntries devel \
-		$developDir
+		$developDir \
+		$dataDir/gir-1.0
 }
 
 TEST()
 {
-	cd build/tests
-	./teststateset
-	./testrelation
-	./testrole
-	./testvalue
-	./testdocument
+	meson test -C build --print-errorlogs
 }


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
