### PR TITLE
kwallet6, qdoc is a seperate package now

### DIFF
--- a/kde-frameworks/kwallet/kwallet6-6.25.0.recipe
+++ b/kde-frameworks/kwallet/kwallet6-6.25.0.recipe
@@ -90,6 +90,7 @@ BUILD_PREREQUIRES="
 	cmd:msgfmt$secondaryArchSuffix
 	cmd:msgmerge$secondaryArchSuffix
 	cmd:pkg_config$secondaryArchSuffix
+	cmd:qdoc6$secondaryArchSuffix
 	"
 
 TEST_REQUIRES="


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
