### PR TITLE
libdazzle, revbump, move gir-1.0 to _devel package

### DIFF
--- a/dev-libs/libdazzle/libdazzle-3.44.0.recipe
+++ b/dev-libs/libdazzle/libdazzle-3.44.0.recipe
@@ -6,10 +6,9 @@ COPYRIGHT="Christian Hergert
 	Emmanuele Bassi
 	Garrett Regier
 	Georges Basile Stavracas Neto
-	Sébastien Lafargue
-	"
+	Sébastien Lafargue"
 LICENSE="GNU GPL v3"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://gitlab.gnome.org/GNOME/libdazzle/-/archive/$portVersion/libdazzle-$portVersion.tar.gz"
 CHECKSUM_SHA256="279e519bb4f50ea9581ca060df5da1c9f4346c331cc94b31209435d0172340e1"
 SOURCE_DIR="libdazzle-$portVersion"
@@ -17,10 +16,14 @@ SOURCE_DIR="libdazzle-$portVersion"
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
+# FIXME: libVersion is actually 0, on next epiphany update this should be fixed
+libVersion="1.0"
+libVersionCompat="$libVersion compat >= ${libVersion%.*}"
+
 PROVIDES="
 	libdazzle$secondaryArchSuffix = $portVersion compat >= 3
-	lib:libdazzle_1.0$secondaryArchSuffix = 1.0 compat >= 1
-	cmd:dazzle_list_counters$secondaryArchSuffix
+	cmd:dazzle_list_counters
+	lib:libdazzle_1.0$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -28,7 +31,6 @@ REQUIRES="
 	lib:libgdk_3$secondaryArchSuffix
 	lib:libgdk_pixbuf_2.0$secondaryArchSuffix
 	lib:libgio_2.0$secondaryArchSuffix
-	lib:libgirepository_1.0$secondaryArchSuffix
 	lib:libglib_2.0$secondaryArchSuffix
 	lib:libgobject_2.0$secondaryArchSuffix
 	lib:libgtk_3$secondaryArchSuffix
@@ -38,46 +40,43 @@ REQUIRES="
 
 PROVIDES_devel="
 	libdazzle${secondaryArchSuffix}_devel = $portVersion
-	devel:libdazzle_1.0${secondaryArchSuffix} = 1.0 compat >= 1
+	devel:libdazzle_1.0${secondaryArchSuffix} = $libVersionCompat
 	"
 REQUIRES_devel="
 	libdazzle${secondaryArchSuffix} == $portVersion base
-	devel:libgirepository_1.0$secondaryArchSuffix
-	devel:libgdk_pixbuf_2.0$secondaryArchSuffix
-	devel:libglib_2.0$secondaryArchSuffix
 	devel:libgtk_3$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libgirepository_1.0$secondaryArchSuffix
-	devel:libglib_2.0$secondaryArchSuffix
-	devel:libgdk_pixbuf_2.0$secondaryArchSuffix
+	devel:libgio_2.0$secondaryArchSuffix
 	devel:libgtk_3$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:cmake
-	cmd:find
 	cmd:gcc$secondaryArchSuffix
-	cmd:gtkdocize
-	cmd:ld$secondaryArchSuffix
 	cmd:meson
+	cmd:msgfmt$secondaryArchSuffix
 	cmd:pkg_config$secondaryArchSuffix
 	cmd:vapigen
 	"
 
+defineDebugInfoPackage libdazzle$secondaryArchSuffix \
+	$prefix/bin/dazzle-list-counters \
+	$libDir/libdazzle-1.0.so.0
+
 BUILD()
 {
 	meson build \
-		--buildtype=release \
-		--prefix="$prefix" \
-		--libdir="$libDir" \
-		--includedir="$includeDir" \
-		--bindir="$binDir" \
-		--libexecdir="$binDir" \
-		--datadir="$dataDir" \
-		--localedir="$dataDir/locale" \
-		-Dwith_introspection=true
+		--buildtype=debugoptimized \
+		--prefix=$prefix \
+		--bindir=$prefix/bin \
+		--datadir=$dataDir \
+		--includedir=$includeDir \
+		--libdir=$libDir \
+		--localedir=$dataDir/locale \
+		-D with_introspection=true
 
 	ninja -C build
 }
@@ -86,10 +85,17 @@ INSTALL()
 {
 	ninja install -C build
 
-	prepareInstalledDevelLibs libdazzle-1.0
-
+	prepareInstalledDevelLib \
+		libdazzle-1.0
 	fixPkgconfig
 
 	packageEntries devel \
-		$developDir
+		$developDir \
+		$dataDir/gir-1.0
+}
+
+TEST()
+{
+	# 1 test fails out of 29
+	meson test -C build --print-errorlogs --exclude libdazzle:test-recursive-monitor
 }

--- a/www-client/epiphany/epiphany-43.1.recipe
+++ b/www-client/epiphany/epiphany-43.1.recipe
@@ -18,6 +18,7 @@ ADDITIONAL_FILES="
 	icons.zip
 	"
 
+# FIXME: check libVersion for libdazzle
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 


### PR DESCRIPTION
add note for libVersion here and in epiphany recipe

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
