### PR TITLE
gcr, revbump, move $dataDir/gir-1.0 to _devel

### DIFF
--- a/app-crypt/gcr/gcr-3.41.1.recipe
+++ b/app-crypt/gcr/gcr-3.41.1.recipe
@@ -8,7 +8,7 @@ COPYRIGHT="2010-2022 Stefan Walter
 	2010-2021 Collabora Ltd
 	2020 Marco Trevisan"
 LICENSE="GNU LGPL v2.1"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://gitlab.gnome.org/GNOME/gcr/-/archive/$portVersion/gcr-$portVersion.tar.gz"
 CHECKSUM_SHA256="f25de5063ffe6359c79f86d70a53c2d398db4e256e2de58c2a3bd2e8111b8f11"
 PATCHES="gcr-$portVersion.patchset"
@@ -33,6 +33,8 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	cmd:gpg
+	cmd:ssh_add
 	lib:libcairo$secondaryArchSuffix
 	lib:libgcrypt$secondaryArchSuffix
 	lib:libgdk_3$secondaryArchSuffix
@@ -45,8 +47,6 @@ REQUIRES="
 	lib:libintl$secondaryArchSuffix
 	lib:libp11_kit$secondaryArchSuffix
 	lib:libpango_1.0$secondaryArchSuffix
-	cmd:gpg
-	cmd:ssh_add
 	"
 
 PROVIDES_devel="
@@ -88,7 +88,7 @@ BUILD_PREREQUIRES="
 	cmd:gtkdocize
 	cmd:ld$secondaryArchSuffix
 	cmd:meson
-	cmd:msgfmt
+	cmd:msgfmt$secondaryArchSuffix
 	cmd:pkg_config$secondaryArchSuffix
 	cmd:ssh_add
 	cmd:vapigen
@@ -142,5 +142,6 @@ INSTALL()
 
 	# devel package
 	packageEntries devel \
-		$developDir
+		$developDir \
+		$dataDir/gir-1.0
 }


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
