### PR TITLE
libportal, fix for 32bit missing GTK4

### DIFF
--- a/dev-libs/libportal/libportal-0.10.0.recipe
+++ b/dev-libs/libportal/libportal-0.10.0.recipe
@@ -46,16 +46,18 @@ REQUIRES_gtk3="
 	lib:libgtk_3$secondaryArchSuffix
 	"
 
-PROVIDES_gtk4="
-	libportal${secondaryArchSuffix}_gtk4 = $portVersion compat >= 0
-	lib:libportal_gtk4$secondaryArchSuffix = $libVersionCompat
-	devel:libportal_gtk4$secondaryArchSuffix = $libVersionCompat
-	"
-REQUIRES_gtk4="
-	libportal$secondaryArchSuffix == $portVersion base
-	$REQUIRES
-	lib:libgtk_4$secondaryArchSuffix
-	"
+if [ "$targetArchitecture" != x86_gcc2 ]; then
+	PROVIDES_gtk4="
+		libportal${secondaryArchSuffix}_gtk4 = $portVersion compat >= 0
+		lib:libportal_gtk4$secondaryArchSuffix = $libVersionCompat
+		devel:libportal_gtk4$secondaryArchSuffix = $libVersionCompat
+		"
+	REQUIRES_gtk4="
+		libportal$secondaryArchSuffix == $portVersion base
+		$REQUIRES
+		lib:libgtk_4$secondaryArchSuffix
+		"
+fi
 
 PROVIDES_qt6="
 	libportal${secondaryArchSuffix}_qt6 = $portVersion compat >= 0
@@ -75,7 +77,6 @@ BUILD_REQUIRES="
 	devel:libgirepository_1.0$secondaryArchSuffix
 	devel:libglib_2.0$secondaryArchSuffix
 	devel:libgtk_3$secondaryArchSuffix
-	devel:libgtk_4$secondaryArchSuffix
 	devel:libQt6Core$secondaryArchSuffix
 	devel:libQt6Qml$secondaryArchSuffix
 #	for portal tests, missing gjs still
@@ -83,6 +84,12 @@ BUILD_REQUIRES="
 #	devel:libgstaudio_1.0$secondaryArchSuffix
 #	devel:liborc_0.4$secondaryArchSuffix
 	"
+if [ "$targetArchitecture" != x86_gcc2 ]; then
+	BUILD_REQUIRES+="
+		devel:libgtk_4$secondaryArchSuffix
+		"
+fi
+
 BUILD_PREREQUIRES="
 	cmd:cmake
 	cmd:gcc$secondaryArchSuffix
@@ -120,9 +127,12 @@ INSTALL()
 	prepareInstalledDevelLibs \
 		libportal \
 		libportal-gtk3 \
-		libportal-gtk4 \
 		libportal-qt6
 	fixPkgconfig
+if [ "$targetArchitecture" != x86_gcc2 ]; then
+		prepareInstalledDevelLibs \
+			libportal-gtk4
+fi
 
 	packageEntries gtk3 \
 		$dataDir/gir-1.0/XdpGtk3-1.0.gir \
@@ -133,14 +143,16 @@ INSTALL()
 		$developLibDir/libportal-gtk3* \
 		$developLibDir/pkgconfig/libportal-gtk3.pc
 
-	packageEntries gtk4 \
-		$dataDir/gir-1.0/XdpGtk4-1.0.gir \
-		$dataDir/vala/vapi/libportal-gtk4* \
-		$includeDir/libportal-gtk4 \
-		$libDir/libportal-gtk4* \
-		$libDir/girepository-1.0/XdpGtk4-1.0.typelib \
-		$developLibDir/libportal-gtk4* \
-		$developLibDir/pkgconfig/libportal-gtk4.pc
+if [ "$targetArchitecture" != x86_gcc2 ]; then
+		packageEntries gtk4 \
+			$dataDir/gir-1.0/XdpGtk4-1.0.gir \
+			$dataDir/vala/vapi/libportal-gtk4* \
+			$includeDir/libportal-gtk4 \
+			$libDir/libportal-gtk4* \
+			$libDir/girepository-1.0/XdpGtk4-1.0.typelib \
+			$developLibDir/libportal-gtk4* \
+			$developLibDir/pkgconfig/libportal-gtk4.pc
+fi
 
 	packageEntries qt6 \
 		$includeDir/libportal-qt6 \


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
