### PR TITLE
libgee, revbump, move $dataDir/gir-1.0 to _devel, cleanup

### DIFF
--- a/dev-libs/libgee/libgee-0.20.8.recipe
+++ b/dev-libs/libgee/libgee-0.20.8.recipe
@@ -4,7 +4,7 @@ interfaces and classes for commonly used data structures."
 HOMEPAGE="https://wiki.gnome.org/Projects/Libgee"
 COPYRIGHT="2007-2021 Jürg Billeter et all"
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://download.gnome.org/sources/libgee/${portVersion%.*}/libgee-$portVersion.tar.xz"
 CHECKSUM_SHA256="189815ac143d89867193b0c52b7dc31f3aa108a15f04d6b5dca2b6adfad0b0ee"
 
@@ -20,7 +20,6 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libgirepository_1.0$secondaryArchSuffix
 	lib:libglib_2.0$secondaryArchSuffix
 	lib:libgobject_2.0$secondaryArchSuffix
 	lib:libintl$secondaryArchSuffix
@@ -33,7 +32,7 @@ PROVIDES_devel="
 REQUIRES_devel="
 	libgee$secondaryArchSuffix == $portVersion base
 	devel:libglib_2.0$secondaryArchSuffix
-	devel:libpcre$secondaryArchSuffix
+	devel:libgobject_2.0$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
@@ -43,11 +42,8 @@ BUILD_REQUIRES="
 	devel:libgobject_2.0$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:awk
 	cmd:aclocal
 	cmd:autoreconf
-	cmd:cmp
-	cmd:diff
 	cmd:gcc$secondaryArchSuffix
 	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
@@ -57,22 +53,14 @@ BUILD_PREREQUIRES="
 	"
 
 defineDebugInfoPackage libgee$secondaryArchSuffix \
-	"$libDir"/libgee-0.8.so.$libVersion
-
-PATCH()
-{
-	# the patch wont break the build
-	# only applies when you enable gobject-introspection
-	sed -i \
-		-e 's|@INTROSPECTION_GIRDIR@|@datadir@/gir-1.0|g' \
-		-e 's|@INTROSPECTION_TYPELIBDIR@|@libdir@/girepository-1.0|g' \
-		gee/Makefile.am
-}
+	$libDir/libgee-0.8.so.$libVersion
 
 BUILD()
 {
 	autoreconf -vfi
-	runConfigure ./configure --enable-vala --enable-introspection
+	runConfigure ./configure \
+		--enable-vala \
+		--enable-introspection
 	make $jobArgs
 }
 
@@ -80,13 +68,20 @@ INSTALL()
 {
 	make install
 
-	# remove libtool library files
-	rm -f "$libDir"/*.la
+	# remove libtool files
+	rm -f $libDir/*.la
 
-	prepareInstalledDevelLib libgee-0.8
+	prepareInstalledDevelLib \
+		libgee-0.8
 	fixPkgconfig
 
 	# devel package
 	packageEntries devel \
-		"$developDir"
+		$developDir \
+		$dataDir/gir-1.0
+}
+
+TEST()
+{
+	make VERBOSE=1 check
 }


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
