### PR TITLE
graphene, revbump, move $dataDir/gir-1.0 to _devel

### DIFF
--- a/media-libs/graphene/graphene-1.10.8.recipe
+++ b/media-libs/graphene/graphene-1.10.8.recipe
@@ -19,7 +19,7 @@ canvas implementation, which is the whole point of writing the library in the fi
 HOMEPAGE="https://ebassi.github.io/graphene/"
 COPYRIGHT="2014-2018 Emmanuele Bassi"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/ebassi/graphene/archive/refs/tags/$portVersion.tar.gz"
 CHECKSUM_SHA256="922dc109d2dc5dc56617a29bd716c79dd84db31721a8493a13a5f79109a4a4ed"
 srcGitRev_2="f0dcb2a48a4a8ef3dc1f7327bb0d4056a798c1a7"
@@ -101,5 +101,6 @@ INSTALL()
 	fixPkgconfig
 
 	packageEntries devel \
-		$developDir
+		$developDir \
+		$dataDir/gir-1.0
 }


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
