### PR TITLE
python: switch default "python3" to Python 3.14.

### DIFF
--- a/dev-lang/python/python3.10-3.10.20.recipe
+++ b/dev-lang/python/python3.10-3.10.20.recipe
@@ -21,7 +21,7 @@ And then you should be able to use \"pip\" or \"pip3\" normally."
 HOMEPAGE="https://www.python.org"
 LICENSE="Python"
 COPYRIGHT="1990-2025 Python Software Foundation"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://www.python.org/ftp/python/$portVersion/Python-$portVersion.tar.xz"
 CHECKSUM_SHA256="de6517421601e39a9a3bc3e1bc4c7b2f239297423ee05e282598c83ec0647505"
 SOURCE_DIR="Python-$portVersion"
@@ -50,7 +50,7 @@ GLOBAL_WRITABLE_FILES="
 
 # If this is not intended to be the "default" Python version, set to "false", so "make altinstall"
 # is used, and only version-suffixed commands are used in PROVIDES.
-installAsDefaultPython=true
+installAsDefaultPython=false
 
 # Set to "true" if we should build the "tkinter" module.
 # Disabled for now, as tkinter deadlocks on Haiku. Try again when tk drops undroidwish for xlibe.
@@ -64,7 +64,7 @@ packageTests=false
 optimizedBuild=true
 
 # Set to true to build with "-g" and create a _debuginfo package.
-buildWithDebugInfo=true
+buildWithDebugInfo=false
 
 # Run all tests by default. Set to "true" to make "hp --test" only run then known failing tests.
 runOnlyKnownFailingTests=false
@@ -106,6 +106,7 @@ BUILD_REQUIRES="
 	devel:libedit$secondaryArchSuffix
 	devel:libexpat$secondaryArchSuffix
 	devel:libffi$secondaryArchSuffix
+	devel:libintl$secondaryArchSuffix
 	devel:liblzma$secondaryArchSuffix
 	devel:libncursesw$secondaryArchSuffix
 	devel:libsqlite3$secondaryArchSuffix
@@ -127,7 +128,7 @@ BUILD_PREREQUIRES="
 if $installAsDefaultPython; then
 	PROVIDES+="
 		cmd:2to3 = $portVersion compat >= $pyShortVer
-		cmd:python3 = $portVersion compat >= $pyShortVer
+		cmd:python3 = $portVersion compat >= 3
 		cmd:pydoc3 = $portVersion compat >= $pyShortVer
 		cmd:python3_config = $portVersion compat >= $pyShortVer
 		"

--- a/dev-lang/python/python3.14-3.14.6.recipe
+++ b/dev-lang/python/python3.14-3.14.6.recipe
@@ -18,7 +18,7 @@ And then you should be able to use \"pip3.14\" normally."
 HOMEPAGE="https://www.python.org"
 LICENSE="Python"
 COPYRIGHT="1990-2025 Python Software Foundation"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://www.python.org/ftp/python/$portVersion/Python-$portVersion.tar.xz"
 CHECKSUM_SHA256="143b1dddefaec3bd2e21e3b839b34a2b7fb9842272883c576420d605e9f30c63"
 SOURCE_DIR="Python-$portVersion"
@@ -47,7 +47,7 @@ GLOBAL_WRITABLE_FILES="
 
 # If this is not intended to be the "default" Python version, set to "false", so "make altinstall"
 # is used, and only version-suffixed commands are used in PROVIDES.
-installAsDefaultPython=false
+installAsDefaultPython=true
 
 # Set to "true" if we should build the "tkinter" module.
 # Disabled for now, as tkinter deadlocks on Haiku. Try again when tk drops undroidwish for xlibe.
@@ -129,7 +129,7 @@ BUILD_PREREQUIRES="
 
 if $installAsDefaultPython; then
 	PROVIDES+="
-		cmd:python3 = $pyVersionCompat
+		cmd:python3 = $portVersion compat >= 3
 		cmd:pydoc3 = $pyVersionCompat
 		cmd:python3_config = $pyVersionCompat
 		"


### PR DESCRIPTION
Opening this in case it is decided to switch the default Python to 3.14 before Haiku releases beta6.

I have been locally using 3.14 as `/bin/python3` for a while now (months). Building Haiku and using HaikuPorter with it has been working fine.

While both 3.10 and 3.14 will co-exists beyond 3.10's EOL date (Oct 2026) until we end up migrating all the packages, having a "soon to be EOLed" default doesn't sounds too nice.

Python 3.14 has a nicer REPL, and with its EOL date set to Oct 2030... we should be set for the next 4 years :-)