### PR TITLE
lxml, revbump, add python3.14 package

### DIFF
--- a/dev-python/lxml/lxml-5.3.0.recipe
+++ b/dev-python/lxml/lxml-5.3.0.recipe
@@ -13,7 +13,7 @@ LICENSE="BSD (3-clause)
 	ElementTree
 	GNU GPL v2
 	PSF-2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/lxml/lxml/releases/download/lxml-$portVersion/lxml-$portVersion.tar.gz"
 CHECKSUM_SHA256="4e109ca30d1edec1ac60cdbe341905dc3b8f55b16855e03a54aaf59e51ec8c6f"
 SOURCE_DIR="lxml-$portVersion"
@@ -39,7 +39,7 @@ BUILD_PREREQUIRES="
 	cmd:ld$secondaryArchSuffix
 	"
 
-PYTHON_VERSIONS=(3.10)
+PYTHON_VERSIONS=(3.10 3.14)
 
 for i in "${!PYTHON_VERSIONS[@]}"; do
 	pythonVersion=${PYTHON_VERSIONS[$i]}


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
