### PR TITLE
lxml, revbump, provide dotted package version for 3.14

### DIFF
--- a/dev-python/lxml/lxml-5.3.0.recipe
+++ b/dev-python/lxml/lxml-5.3.0.recipe
@@ -62,7 +62,7 @@ for pythonVersion in ${PYTHON_VERSIONS[@]}; do
 
 	if [ "$targetArchitecture" = x86_gcc2 ]; then
 		eval "PROVIDES_${pythonPackage}+=\"
-			${portName}_$pythonPackage = $portVersion
+			${portBaseName}_$pythonPackage = $portVersion
 			\""
 	fi
 

--- a/dev-python/lxml/lxml-5.3.0.recipe
+++ b/dev-python/lxml/lxml-5.3.0.recipe
@@ -52,6 +52,11 @@ for pythonVersion in ${PYTHON_VERSIONS[@]}; do
 		eval "PROVIDES_$pythonPackage=\"
 			${portName}_python$pythonVersion = $portVersion
 			\""
+		if [ "$targetArchitecture" = x86_gcc2 ]; then
+			eval "PROVIDES_${pythonPackage}+=\"
+				${portBaseName}_python$pythonVersion = $portVersion
+				\""
+		fi
 	fi
 
 	# We need to provide the "dotless" package name too for now (to avoid having

--- a/dev-python/lxml/lxml-5.3.0.recipe
+++ b/dev-python/lxml/lxml-5.3.0.recipe
@@ -13,7 +13,7 @@ LICENSE="BSD (3-clause)
 	ElementTree
 	GNU GPL v2
 	PSF-2"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/lxml/lxml/releases/download/lxml-$portVersion/lxml-$portVersion.tar.gz"
 CHECKSUM_SHA256="4e109ca30d1edec1ac60cdbe341905dc3b8f55b16855e03a54aaf59e51ec8c6f"
 SOURCE_DIR="lxml-$portVersion"
@@ -41,17 +41,28 @@ BUILD_PREREQUIRES="
 
 PYTHON_VERSIONS=(3.10 3.14)
 
-for i in "${!PYTHON_VERSIONS[@]}"; do
-	pythonVersion=${PYTHON_VERSIONS[$i]}
+for pythonVersion in ${PYTHON_VERSIONS[@]}; do
 	pythonPackage=python${pythonVersion//.}
 
-	eval "PROVIDES_${pythonPackage}=\"
+	# Only using "dotted" name suffixes on newly introduced packages.
+	if [ $pythonVersion != 3.10 ]; then
+		# Allows using dot in sub-package names (eg: "_python3.14" vs "_python314"):
+		eval "PACKAGE_NAME_$pythonPackage=${portBaseName}_python$pythonVersion"
+
+		eval "PROVIDES_$pythonPackage=\"
+			${portName}_python$pythonVersion = $portVersion
+			\""
+	fi
+
+	# We need to provide the "dotless" package name too for now (to avoid having
+	# to change $pythonPackage in each BUILD_REQUIRES/REQUIRES of all recipes).
+	eval "PROVIDES_$pythonPackage+=\"
 		${portName}_$pythonPackage = $portVersion
 		\""
 
 	if [ "$targetArchitecture" = x86_gcc2 ]; then
 		eval "PROVIDES_${pythonPackage}+=\"
-			lxml_$pythonPackage = $portVersion
+			${portName}_$pythonPackage = $portVersion
 			\""
 	fi
 


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
