### PR TITLE
bullet, revbump, drop requirement on python

### DIFF
--- a/sci-physics/bullet/bullet-3.17.recipe
+++ b/sci-physics/bullet/bullet-3.17.recipe
@@ -7,7 +7,7 @@ the ZLib license."
 HOMEPAGE="http://www.bulletphysics.com/"
 COPYRIGHT="2003-2020 Erwin Coumans and the Bullet Physics Library Team"
 LICENSE="Zlib"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/bulletphysics/bullet3/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="baa642c906576d4d98d041d0acb80d85dd6eff6e3c16a009b1abf1ccd2bc0a61"
 SOURCE_DIR="bullet3-$portVersion"
@@ -34,7 +34,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	cmd:python3
+#	cmd:python3
 	lib:libgl$secondaryArchSuffix
 	lib:libglew$secondaryArchSuffix
 	lib:libglu$secondaryArchSuffix
@@ -69,7 +69,7 @@ BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:python3
+#	cmd:python3
 	"
 
 defineDebugInfoPackage bullet$secondaryArchSuffix \
@@ -104,6 +104,7 @@ BUILD()
 		-DINSTALL_LIBS=ON \
 		-DLIB_SUFFIX="$secondaryArchSubDir" \
 		-DINCLUDE_INSTALL_DIR="$includeDir/bullet/" \
+		-DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
 		$cmakeDirArgs
 	make $jobArgs
 }


### PR DESCRIPTION
only required when building the python module (disabled by default)

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
