### PR TITLE
kio6, fix requirements for BUILD_REQUIRES

### DIFF
--- a/kde-frameworks/kio/kio6-6.28.0.recipe
+++ b/kde-frameworks/kio/kio6-6.28.0.recipe
@@ -94,24 +94,24 @@ BUILD_REQUIRES="
 	extra_cmake_modules$secondaryArchSuffix
 	qt6_tools${secondaryArchSuffix}_devel
 #	devel:libacl$secondaryArchSuffix
-	devel:kded6$secondaryArchSuffix
-	devel:libKF6Archive$secondaryArchSuffix
-	devel:libKF6AuthCore$secondaryArchSuffix
-	devel:libKF6Bookmarks$secondaryArchSuffix
-	devel:libKF6ColorScheme$secondaryArchSuffix
-	devel:libKF6Completion$secondaryArchSuffix
-	devel:libKF6ConfigCore$secondaryArchSuffix
-	devel:libKF6CoreAddons$secondaryArchSuffix
-	devel:libKF6Crash$secondaryArchSuffix
-	devel:libKF6GuiAddons$secondaryArchSuffix
-	devel:libKF6I18n$secondaryArchSuffix
-	devel:libKF6IconThemes$secondaryArchSuffix
-	devel:libKF6ItemViews$secondaryArchSuffix
-	devel:libKF6JobWidgets$secondaryArchSuffix
-	devel:libKF6Service$secondaryArchSuffix
-	devel:libKF6Solid$secondaryArchSuffix
-	devel:libKF6WidgetsAddons$secondaryArchSuffix
-	devel:libKF6WindowSystem$secondaryArchSuffix
+	devel:kded6$secondaryArchSuffix >= $libVersion
+	devel:libKF6Archive$secondaryArchSuffix >= $libVersion
+	devel:libKF6AuthCore$secondaryArchSuffix >= $libVersion
+	devel:libKF6Bookmarks$secondaryArchSuffix >= $libVersion
+	devel:libKF6ColorScheme$secondaryArchSuffix >= $libVersion
+	devel:libKF6Completion$secondaryArchSuffix >= $libVersion
+	devel:libKF6ConfigCore$secondaryArchSuffix >= $libVersion
+	devel:libKF6CoreAddons$secondaryArchSuffix >= $libVersion
+	devel:libKF6Crash$secondaryArchSuffix >= $libVersion
+	devel:libKF6GuiAddons$secondaryArchSuffix >= $libVersion
+	devel:libKF6I18n$secondaryArchSuffix >= $libVersion
+	devel:libKF6IconThemes$secondaryArchSuffix >= $libVersion
+	devel:libKF6ItemViews$secondaryArchSuffix >= $libVersion
+	devel:libKF6JobWidgets$secondaryArchSuffix >= $libVersion
+	devel:libKF6Service$secondaryArchSuffix >= $libVersion
+	devel:libKF6Solid$secondaryArchSuffix >= $libVersion
+	devel:libKF6WidgetsAddons$secondaryArchSuffix >= $libVersion
+	devel:libKF6WindowSystem$secondaryArchSuffix >= $libVersion
 	devel:libQt6Core$secondaryArchSuffix
 	devel:libQt6Qml$secondaryArchSuffix
 	devel:libsqlite3$secondaryArchSuffix


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
