### PR TITLE
kded6, move forward in the batch, requirement for kio6

### DIFF
--- a/kde-frameworks/kded/kded6-6.28.0.recipe
+++ b/kde-frameworks/kded/kded6-6.28.0.recipe
@@ -24,7 +24,7 @@ COPYRIGHT="2010-2026 KDE Organisation"
 LICENSE="GNU LGPL v2"
 REVISION="1"
 SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/kded-${portVersion}.tar.xz"
-CHECKSUM_SHA256="030cc827c37b490a2181e120cd831b73c9a7683a87cf55d0d5b334059f78c590"
+CHECKSUM_SHA256="31ba5c920b199dd13fff634001d22c993df3d639a8df989e0a55ec1d13a8279f"
 SOURCE_DIR="kded-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -69,6 +69,7 @@ BUILD_REQUIRES="
 	devel:libKF6Service$secondaryArchSuffix >= $libVersion
 	devel:libQt6Core$secondaryArchSuffix
 	devel:libQt6Qml$secondaryArchSuffix
+	devel:libsqlite3$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:cmake
@@ -103,7 +104,7 @@ INSTALL()
 
 TEST()
 {
-	# no test cases
+	# No tests were found
 	export LIBRARY_PATH="$sourceDir/build/bin${LIBRARY_PATH:+:$LIBRARY_PATH}"
 	ctest --test-dir build --output-on-failure
 }


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
