### PR TITLE
gyp: depend explicitly on Python 3.10.

### DIFF
--- a/dev-build/gyp/gyp-20230301~git.recipe
+++ b/dev-build/gyp/gyp-20230301~git.recipe
@@ -4,7 +4,7 @@ DESCRIPTION="GYP is created by Google to generate native IDE project files \
 HOMEPAGE="https://gyp.gsrc.io/"
 COPYRIGHT="2009 Google Inc."
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 srcGitRev="c6d8b9f7ee355cff1531b0f369cd338a50baeb07"
 SOURCE_URI="https://github.com/chromium/gyp/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="b4be9a3baccc2d0457aa24e56d96eb703263b7ff7323ecce9177b75385fdfd88"
@@ -14,7 +14,8 @@ PATCHES="gyp-$portVersion.patchset"
 ARCHITECTURES="any"
 
 pythonVersion=3.10
-pyVer=${pythonVersion//.}
+python=python$pythonVersion
+pythonPackage=python${pythonVersion//.}
 
 PROVIDES="
 	gyp = $portVersion
@@ -22,37 +23,40 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku
-	six_python$pyVer
-	cmd:python3
+	six_$pythonPackage
+	cmd:$python
 	"
 
 BUILD_REQUIRES="
 	haiku_devel
-	setuptools_python$pyVer
+	setuptools_$pythonPackage
 	"
 BUILD_PREREQUIRES="
-	cmd:python3
+	cmd:$python
 	"
 
 PATCH()
 {
-	# Some day, python will mean python3. Not yet thou, so we patch all the things!
-	find ./ -name '*.py' -type f -print0 | xargs -0 sed -i 's|#!/usr/bin/env python|#!/bin/python3|'
-	find ./ -name '*.py' -type f -print0 | xargs -0 sed -i 's|#!/usr/bin/python|#!/bin/python3|'
-	find ./ -name '*.py' -type f -print0 | xargs -0 sed -i 's|python -c|python3 -c|'
+	# The code is always dependent on the Python version where the module gets installed,
+	# so make sure the shebangs always match with that particular version.
+	find ./ -name '*.py' -type f -print0 | xargs -0 sed -i "s|#!/usr/bin/env python|#!$python|"
+	find ./ -name '*.py' -type f -print0 | xargs -0 sed -i "s|#!/usr/bin/python|#!$python|"
+	find ./ -name '*.py' -type f -print0 | xargs -0 sed -i "s|python -c|$python -c|"
+
+	sed -i "s|#!python3|#!$python|" pylib/gyp/haiku_tool.py
 }
 
 BUILD()
 {
-	python3 setup.py build
+	$python setup.py build
 }
 
 INSTALL()
 {
-	installLocation=$prefix/lib/python$pythonVersion/vendor-packages/
+	installLocation=$prefix/lib/$python/vendor-packages/
 	export PYTHONPATH=$installLocation:$PYTHONPATH
 	mkdir -p $installLocation
 
-	python3 setup.py install \
+	$python setup.py install \
 		--prefix=$prefix
 }

--- a/dev-build/gyp/patches/gyp-20230301~git.patchset
+++ b/dev-build/gyp/patches/gyp-20230301~git.patchset
@@ -1,4 +1,4 @@
-From 5c24c71c87f14636774bc3acdba2bdcef8ad2269 Mon Sep 17 00:00:00 2001
+From 52fbf8afb7868bc72fd6cd6b5cdbb9c58e5b75d3 Mon Sep 17 00:00:00 2001
 From: Sergei Reznikov <diver@gelios.net>
 Date: Tue, 12 Sep 2017 12:46:50 +0300
 Subject: patch from Telegram team
@@ -85,10 +85,10 @@ index 8bc22be..be1aed4 100644
      # Add "sources".
      for source in spec.get('sources', []):
 -- 
-2.37.3
+2.54.0
 
 
-From d338394a6f6f73cd634d3b83de3862e367a58a62 Mon Sep 17 00:00:00 2001
+From 23621b210325623d22bfcef7a4ccb2f1084187d1 Mon Sep 17 00:00:00 2001
 From: Augustin Cavalier <waddlesplash@gmail.com>
 Date: Mon, 30 Jun 2014 14:41:57 -0400
 Subject: Make GYP work on Haiku.
@@ -172,7 +172,7 @@ index 997eec0..f19778b 100644
      'CC.target':   GetEnvironFallback(('CC_target', 'CC'), '$(CC)'),
 diff --git a/pylib/gyp/haiku_tool.py b/pylib/gyp/haiku_tool.py
 new file mode 100644
-index 0000000..44c91b4
+index 0000000..8dc1926
 --- /dev/null
 +++ b/pylib/gyp/haiku_tool.py
 @@ -0,0 +1,49 @@
@@ -226,5 +226,29 @@ index 0000000..44c91b4
 +if __name__ == '__main__':
 +  sys.exit(main(sys.argv[1:]))
 -- 
-2.37.3
+2.54.0
+
+
+From 519c39071aac39e73777aa06917f7a16a23c5146 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Fri, 17 Jul 2026 01:09:57 -0300
+Subject: Use '==' instead of 'is' in a string comparison.
+
+Python 3.14 issued this as a warning.
+
+diff --git a/pylib/gyp/input.py b/pylib/gyp/input.py
+index 4c12891..2bea334 100644
+--- a/pylib/gyp/input.py
++++ b/pylib/gyp/input.py
+@@ -1183,7 +1183,7 @@ def LoadVariablesFromVariablesDict(variables, the_dict, the_dict_key):
+       if variable_name in variables:
+         # If the variable is already set, don't set it.
+         continue
+-      if the_dict_key is 'variables' and variable_name in the_dict:
++      if the_dict_key == 'variables' and variable_name in the_dict:
+         # If the variable is set without a % in the_dict, and the_dict is a
+         # variables dict (making |variables| a varaibles sub-dict of a
+         # variables dict), use the_dict's definition.
+-- 
+2.54.0
 


### PR DESCRIPTION
The code gets installed in a path that's Python-version specific, so no point in asking for a generic "python3".

Fixed a SyntaxWarning, while at it.