### PR TITLE
hvif_tools(_inkscape): depend explicitly on Python 3.10.

### DIFF
--- a/media-gfx/hvif_tools/hvif_tools-2.1.5.recipe
+++ b/media-gfx/hvif_tools/hvif_tools-2.1.5.recipe
@@ -31,7 +31,7 @@ Inkscape extensions:
 HOMEPAGE="https://github.com/threedeyes/hvif-tools/"
 COPYRIGHT="2025 Gerasim Troeglazov"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/threedeyes/hvif-tools/releases/download/$portVersion/hvif-tools-$portVersion.tar.gz"
 CHECKSUM_SHA256="06e73c402b2ef10759ce40f3698cc1a67a39b93100711ac77ef18f226620f123"
 SOURCE_DIR="hvif-tools-$portVersion"
@@ -80,17 +80,20 @@ REQUIRES_devel="
 	devel:libagg$secondaryArchSuffix
 	"
 
+pythonVersion=3.10
+pythonPackage=python${pythonVersion//.}
+
 PROVIDES_inkscape="
 	hvif_tools${secondaryArchSuffix}_inkscape = $portVersion
 	"
 REQUIRES_inkscape="
 	haiku$secondaryArchSuffix
 	hvif_tools$secondaryArchSuffix == $portVersion base
-	cssselect_python310
-	lxml_python310
-	numpy_python310
-	tinycss2_python310
-	cmd:python3
+	cssselect_$pythonPackage
+	lxml_$pythonPackage
+	numpy_$pythonPackage
+	tinycss2_$pythonPackage
+	cmd:python$pythonVersion
 	"
 
 BUILD_REQUIRES="
@@ -103,6 +106,17 @@ BUILD_PREREQUIRES="
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
 	"
+
+PATCH()
+{
+	# The scripts depend on Python-version specific packages, so it is safer to use a shebang
+	# that targets that same version (instead of the generic 'python3').
+	cd inkscape
+	sed -i "s|#!/usr/bin/env python3|#!python$pythonVersion|" hvif_input.py
+	sed -i "s|#!/usr/bin/env python3|#!python$pythonVersion|" hvif_output.py
+	sed -i "s|#!/usr/bin/env python3|#!python$pythonVersion|" iom_input.py
+	sed -i "s|#!/usr/bin/env python3|#!python$pythonVersion|" iom_output.py
+}
 
 BUILD()
 {


### PR DESCRIPTION
As the plugins already depend on Python-specific versions of several modules, it is safer to make sure that the shebangs match that same version.