### PR TITLE
scour: depend explicitly on Python 3.10.

### DIFF
--- a/media-gfx/scour/scour-0.38.2.recipe
+++ b/media-gfx/scour/scour-0.38.2.recipe
@@ -14,15 +14,15 @@ COPYRIGHT="2013-2014 Tavendo GmbH
 	2010 Louis Simard
 	2006 Enthought, Inc."
 LICENSE="Apache v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/scour-project/scour/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="26166de53d9da3eccc52570bf8c2853e60efefd9e90e26fdfc7124fe0bd873af"
 SOURCE_FILENAME="scour-v$portVersion.tar.gz"
 
 ARCHITECTURES="any"
 
-pythonVersion="3"
-pythonPackage="python310"
+pythonVersion=3.10
+pythonPackage=python${pythonVersion//.}
 
 PROVIDES="
 	$portName = $portVersion
@@ -37,7 +37,7 @@ BUILD_REQUIRES="
 	haiku_devel
 	setuptools_$pythonPackage
 	"
-BUILD_PREREQUIRES+="
+BUILD_PREREQUIRES="
 	cmd:python$pythonVersion
 	"
 


### PR DESCRIPTION
It installs in a Pyhon-version specific path, so,
make it depend on that instead of a generic "python3".

Recipe was half-way there there anyway.