### PR TITLE
opensubdiv: neither of these require python at runtime.

### DIFF
--- a/media-libs/opensubdiv/opensubdiv-3.7.0.recipe
+++ b/media-libs/opensubdiv/opensubdiv-3.7.0.recipe
@@ -7,7 +7,7 @@ surface matches Pixar's Renderman to numerical precision."
 HOMEPAGE="https://graphics.pixar.com/opensubdiv/"
 COPYRIGHT="2013-2020 Pixar"
 LICENSE="Apache v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/PixarAnimationStudios/OpenSubdiv/archive/v${portVersion//\./_}.tar.gz"
 CHECKSUM_SHA256="f843eb49daf20264007d807cbc64516a1fed9cdb1149aaf84ff47691d97491f9"
 SOURCE_FILENAME="opensubdiv-v$portVersion.tar.gz"
@@ -26,7 +26,6 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	cmd:python3
 	lib:libGl$secondaryArchSuffix
 	lib:libglew$secondaryArchSuffix
 	lib:libGLU$secondaryArchSuffix

--- a/media-libs/opensubdiv/opensubdiv3.5-3.5.0.recipe
+++ b/media-libs/opensubdiv/opensubdiv3.5-3.5.0.recipe
@@ -19,7 +19,7 @@ SECONDARY_ARCHITECTURES="x86"
 libVersion="$portVersion"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
-tbbVersion="2"
+tbbVersion="3"
 
 PROVIDES="
 	opensubdiv3.5$secondaryArchSuffix = $portVersion
@@ -28,7 +28,6 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	cmd:python3
 	lib:libGl$secondaryArchSuffix
 	lib:libglew$secondaryArchSuffix
 	lib:libGLU$secondaryArchSuffix


### PR DESCRIPTION
Python is only really required if building the documentation.
(which is optional, and seemingly not done at the moment).