### PR TITLE
glib2, revbump, fix some python references

### DIFF
--- a/dev-libs/glib/glib2-2.88.1.recipe
+++ b/dev-libs/glib/glib2-2.88.1.recipe
@@ -20,7 +20,7 @@ COPYRIGHT="1995-1997  Peter Mattis, Spencer Kimball and Josh MacDonald
 	2008-2010 Collabora Ltd.
 	1995-2010 Several others"
 LICENSE="GNU LGPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://gitlab.gnome.org/GNOME/glib/-/archive/$portVersion/glib-$portVersion.tar.gz"
 CHECKSUM_SHA256="cfb9e5f9e321fb8fcbf743b897e18877face361341049858dcf9c9b62f4daa2d"
 SOURCE_DIR="glib-$portVersion"
@@ -166,6 +166,7 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	bash_completion
+	setuptools_$pythonPackage
 	cmd:bison$secondaryArchSuffix
 	cmd:flex
 	cmd:gcc$secondaryArchSuffix
@@ -203,6 +204,11 @@ defineDebugInfoPackage glib2$secondaryArchSuffix \
 
 PATCH()
 {
+	cd $sourceDir
+		sed -i "s|/usr/bin/env python3|/usr/bin/env python$pythonVersion|" \
+		meson.build \
+		tools/gen-visibility-macros.py
+
 	cd $sourceDir3
 	sed -i  -e "s|'gobject-introspection'|\'$pythonModuleDir\'|" \
 		tools/g-ir-tool-template.in
@@ -243,6 +249,7 @@ BUILD()
 		--datadir=$dataDir \
 		--includedir=$includeDir \
 		--libdir=$libDir \
+		-D python=python$pythonVersion \
 		-D python.bytecompile=1 \
 		-D python.install_env="prefix" \
 		-D python.platlibdir=$prefix/lib/$pythonModuleDir \

--- a/dev-libs/glib/patches/glib2-2.88.1.patchset
+++ b/dev-libs/glib/patches/glib2-2.88.1.patchset
@@ -1,4 +1,4 @@
-From e74cfc15ce4a482d2a64a79114e94662e2b7fe12 Mon Sep 17 00:00:00 2001
+From b3995e220f922bcc21dc26b1641745db4f1ad9da Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sat, 29 Jul 2017 12:13:00 +0200
 Subject: g_dbus_message_print: use B_PRIiDEV on Haiku
@@ -56,7 +56,7 @@ index bd778a3..8f9bd64 100644
 2.54.0
 
 
-From e376aa8eaa76b399ffcd2a6cd9a6d267a2e83f27 Mon Sep 17 00:00:00 2001
+From 124e89447ded160d88c5af4030e5f3fb536ae271 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sat, 29 Jul 2017 12:32:14 +0200
 Subject: glib/gutils.c: on Haiku define load_user_special_dirs()
@@ -184,7 +184,7 @@ index 02da41b..b62db12 100644
 2.54.0
 
 
-From d805a86f4368182590a95e7b28aa172d1ccfbc18 Mon Sep 17 00:00:00 2001
+From fd290bba2c50b47fbc5401d42f24aa95c64ce050 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sat, 23 Nov 2019 20:10:10 +0100
 Subject: Haiku patch for x86
@@ -220,7 +220,7 @@ index 5e4c24f..7667167 100644
 2.54.0
 
 
-From 35d2d78e01b8df01a12f24c3add608dc784721c1 Mon Sep 17 00:00:00 2001
+From 3c2dc5b406bde283287230b86f6deda1f32ad51d Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Tue, 17 Aug 2021 08:29:48 +0000
 Subject: Fix network detection
@@ -260,7 +260,7 @@ index a3e6f18..3d78217 100644
 2.54.0
 
 
-From 83f815c600ae3d1aca520a8be36ac7bc1d1c9689 Mon Sep 17 00:00:00 2001
+From 267ef7cb8804b203e12e620025c5bb631c7028c7 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Thu, 5 Jan 2023 18:31:01 +1000
 Subject: Use find_directory for xdgmime
@@ -319,7 +319,7 @@ index 66f8f39..2f1a236 100644
 2.54.0
 
 
-From d1a043c829b89e6cf4f5af39d7d33c40ef5e2274 Mon Sep 17 00:00:00 2001
+From 4370c11e5c08436d65af3e1533c8842ad8791057 Mon Sep 17 00:00:00 2001
 From: Alexander von Gluck <alex@terarocket.io>
 Date: Tue, 26 Aug 2025 10:38:29 -0500
 Subject: glib: Disable kqueue on Haiku
@@ -355,7 +355,7 @@ index bb68398..24ca607 100644
 2.54.0
 
 
-From 8469b281730e4124e21ae189b2a63c45d57082f9 Mon Sep 17 00:00:00 2001
+From 865f002691d04052cda1fb65e1aa0a1d703343be Mon Sep 17 00:00:00 2001
 From: Luc Schrijvers <begasus@gmail.com>
 Date: Mon, 13 Oct 2025 21:40:42 +0200
 Subject: Fixes for mismatching CPU_ZERO, CPU_ISSET and CPU_SET
@@ -456,7 +456,7 @@ index ba34485..2fe9952 100644
 2.54.0
 
 
-From 74a7615f9c112b4b28601e3475ffbcd2b9e04c88 Mon Sep 17 00:00:00 2001
+From 861fd2e5818efd6d8df8497f622e32da7d5f5d88 Mon Sep 17 00:00:00 2001
 From: Luc Schrijvers <begasus@gmail.com>
 Date: Thu, 5 Feb 2026 12:21:22 +0100
 Subject: disable g-ir-scanner version check
@@ -479,7 +479,7 @@ index 24ca607..a77b652 100644
 2.54.0
 
 
-From 4472915d463b68c53c95335faf397af62d754376 Mon Sep 17 00:00:00 2001
+From 242251e957a4fb02b346790046be492eb657c591 Mon Sep 17 00:00:00 2001
 From: Luc Schrijvers <begasus@gmail.com>
 Date: Sat, 16 May 2026 13:59:49 +0200
 Subject: Build fixes*
@@ -518,7 +518,7 @@ index 24a20df..e3c97aa 100644
 2.54.0
 
 
-From 4b93c26ead965d7a539fb174a070e13dc9d888e4 Mon Sep 17 00:00:00 2001
+From 9a6d20dcfb0efb7e505f41d46e469a35cbd7c131 Mon Sep 17 00:00:00 2001
 From: Luc Schrijvers <begasus@gmail.com>
 Date: Sat, 16 May 2026 15:17:25 +0200
 Subject: Fixes* for unixmounts.c
@@ -556,7 +556,7 @@ index 014c4ef..7732d76 100644
 2.54.0
 
 
-From c6ef46334b4d0e2dad680605c362dc89c89718ee Mon Sep 17 00:00:00 2001
+From 33773960d84d07c80430d1805083efc533f709a4 Mon Sep 17 00:00:00 2001
 From: Luc Schrijvers <begasus@gmail.com>
 Date: Wed, 17 Jun 2026 08:31:14 +0200
 Subject: Disable: -Werror=format=2
@@ -574,6 +574,57 @@ index a77b652..d90130e 100644
      '-Werror=init-self',
      '-Werror=missing-include-dirs',
      '-Werror=pointer-arith',
+-- 
+2.54.0
+
+
+From 455f09bc64840c9112d35c571450b598cd077d7f Mon Sep 17 00:00:00 2001
+From: Luc Schrijvers <begasus@gmail.com>
+Date: Thu, 25 Jun 2026 10:23:37 +0200
+Subject: Add search paths for user/system non-packaged directories
+
+
+diff --git a/girepository/girepository.c b/girepository/girepository.c
+index b22bad1..87ba232 100644
+--- a/girepository/girepository.c
++++ b/girepository/girepository.c
+@@ -38,6 +38,11 @@
+ #include "gitypelib-internal.h"
+ #include "girepository-private.h"
+ 
++#if defined(__HAIKU__)
++#include <FindDirectory.h>
++#include <fs_info.h>
++#endif
++
+ /**
+  * GIRepository:
+  *
+@@ -306,6 +311,24 @@ gi_repository_init (GIRepository *repository)
+       typelib_dir = g_build_filename (libdir, "girepository-1.0", NULL);
+ 
+       g_ptr_array_add (repository->typelib_search_path, g_steal_pointer (&typelib_dir));
++
++      // add search paths for user/system non-packaged directories on Haiku
++      #if defined(__HAIKU__)
++      {
++        char path[B_PATH_NAME_LENGTH + B_FILE_NAME_LENGTH];
++        dev_t volume = dev_for_path("/boot");
++          if (find_directory(B_USER_NONPACKAGED_LIB_DIRECTORY, volume, false, path, sizeof(path)) == B_OK)
++          {
++            char *haiku_user_typelib = g_build_filename (path, "girepository-1.0", NULL);
++            g_ptr_array_add (repository->typelib_search_path, g_steal_pointer (&haiku_user_typelib));
++          }
++          if (find_directory(B_SYSTEM_NONPACKAGED_LIB_DIRECTORY, volume, false, path, sizeof(path)) == B_OK)
++          {
++            char *haiku_system_typelib = g_build_filename (path, "girepository-1.0", NULL);
++            g_ptr_array_add (repository->typelib_search_path, g_steal_pointer (&haiku_system_typelib));
++          }
++      }
++      #endif
+     }
+ 
+   repository->library_paths = g_ptr_array_new_null_terminated (1, g_free, TRUE);
 -- 
 2.54.0
 


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
