### PR TITLE
gtksourceview, move /gir-1.0 to _devel package

### DIFF
--- a/x11-libs/gtksourceview/gtksourceview-4.8.4.recipe
+++ b/x11-libs/gtksourceview/gtksourceview-4.8.4.recipe
@@ -8,7 +8,7 @@ HOMEPAGE="https://wiki.gnome.org/Projects/GtkSourceView/"
 COPYRIGHT="Christian Hergert
 Sebastien Wilmet"
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://gitlab.gnome.org/GNOME/gtksourceview/-/archive/$portVersion/gtksourceview-$portVersion.tar.gz"
 SOURCE_DIR="gtksourceview-$portVersion"
 CHECKSUM_SHA256="db84d9818ced6311ce27df5bf7f36f83ab14646fbace026cc0b0ba0308bcfb68"
@@ -21,12 +21,12 @@ PROVIDES="
 	lib:libgtksourceview_4$secondaryArchSuffix = 0.0.0 compat >= 0
 	"
 REQUIRES="
-	haiku$secondaryArchSuffix	
+	haiku$secondaryArchSuffix
 	lib:libatk_1.0$secondaryArchSuffix
 	lib:libcairo$secondaryArchSuffix
 	lib:libfribidi$secondaryArchSuffix
+	lib:libgdk_3$secondaryArchSuffix
 	lib:libgdk_pixbuf_2.0$secondaryArchSuffix
-	lib:libgirepository_1.0$secondaryArchSuffix
 	lib:libgio_2.0$secondaryArchSuffix
 	lib:libglib_2.0$secondaryArchSuffix
 	lib:libgobject_2.0$secondaryArchSuffix
@@ -51,26 +51,20 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libatk_1.0$secondaryArchSuffix
-	devel:libcairo$secondaryArchSuffix
 	devel:libfribidi$secondaryArchSuffix
-	devel:libgdk_pixbuf_2.0$secondaryArchSuffix
 	devel:libgtk_3$secondaryArchSuffix
 	devel:libgirepository_1.0$secondaryArchSuffix
 	devel:libglib_2.0$secondaryArchSuffix
-	devel:libintl$secondaryArchSuffix
-	devel:libpango_1.0$secondaryArchSuffix
-	devel:libpangocairo_1.0$secondaryArchSuffix
 	devel:libxml2$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:find
+	cmd:cmake
 	cmd:gcc$secondaryArchSuffix
 	cmd:meson
+	cmd:msgfmt$secondaryArchSuffix
 	cmd:ninja
-	cmd:perl
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:valac
+	cmd:vapigen
 	"
 
 BUILD()
@@ -84,23 +78,25 @@ BUILD()
 		--localedir=$dataDir/locale \
 		--includedir=$includeDir \
 		--sysconfdir=$settingsDir \
-		-Dgir=true \
-		-Dvapi=true \
-		-Dgtk_doc=false \
-		-Dinstall_tests=false \
-		_build
+		-D gir=true \
+		-D vapi=true \
+		-D gtk_doc=false \
+		-D install_tests=false \
+		build
 
-	ninja -v -C _build
+	ninja -v -C build
 }
 
 INSTALL()
 {
-	ninja install -C _build
+	ninja install -C build
 
-	prepareInstalledDevelLib libgtksourceview-4
+	prepareInstalledDevelLib \
+		libgtksourceview-4
 	fixPkgconfig
 
 	# devel package
 	packageEntries devel \
-		$developDir
+		$developDir \
+		$dataDir/gir-1.0
 }

--- a/x11-libs/gtksourceview/gtksourceview5-5.20.0.recipe
+++ b/x11-libs/gtksourceview/gtksourceview5-5.20.0.recipe
@@ -8,7 +8,7 @@ HOMEPAGE="https://wiki.gnome.org/Projects/GtkSourceView/"
 COPYRIGHT="Christian Hergert
 Sebastien Wilmet"
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://gitlab.gnome.org/GNOME/gtksourceview/-/archive/$portVersion/gtksourceview-$portVersion.tar.gz"
 SOURCE_DIR="gtksourceview-$portVersion"
 CHECKSUM_SHA256="1d1c63c38e1d85438ac824ad55c2e9a03728c0b05441d6cbb8781e4bc9222a17"
@@ -30,7 +30,6 @@ REQUIRES="
 	lib:libfontconfig$secondaryArchSuffix
 	lib:libfribidi$secondaryArchSuffix
 	lib:libgdk_pixbuf_2.0$secondaryArchSuffix
-	lib:libgirepository_1.0$secondaryArchSuffix
 	lib:libgio_2.0$secondaryArchSuffix
 	lib:libglib_2.0$secondaryArchSuffix
 	lib:libgobject_2.0$secondaryArchSuffix
@@ -57,26 +56,19 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libatk_1.0$secondaryArchSuffix
-	devel:libcairo$secondaryArchSuffix
 	devel:libfribidi$secondaryArchSuffix
-	devel:libgdk_pixbuf_2.0$secondaryArchSuffix
 	devel:libgtk_4$secondaryArchSuffix
 	devel:libgirepository_1.0$secondaryArchSuffix
 	devel:libglib_2.0$secondaryArchSuffix
-	devel:libintl$secondaryArchSuffix
-	devel:libpango_1.0$secondaryArchSuffix
-	devel:libpangocairo_1.0$secondaryArchSuffix
 	devel:libxml2$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	cmd:find
 	cmd:gcc$secondaryArchSuffix
 	cmd:meson
+	cmd:msgfmt$secondaryArchSuffix
 	cmd:ninja
-	cmd:perl
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:valac
+	cmd:vapigen
 	"
 
 BUILD()
@@ -94,14 +86,14 @@ BUILD()
 		-D vapi=true \
 		-D documentation=false \
 		-D install-tests=false \
-		_build
+		build
 
-	ninja -v -C _build
+	ninja -v -C build
 }
 
 INSTALL()
 {
-	ninja install -C _build
+	ninja install -C build
 
 	rm -rf $dataDir/icons/hicolor/icon-theme.cache
 


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
