### PR TITLE
libproxy, revbump, move dataDir/gir-1.0 to _devel package

### DIFF
--- a/net-libs/libproxy/libproxy-0.5.12.recipe
+++ b/net-libs/libproxy/libproxy-0.5.12.recipe
@@ -13,7 +13,7 @@ HOMEPAGE="https://github.com/libproxy/libproxy"
 COPYRIGHT="2022-2023 The Libproxy Team
 	Jan-Michael Brummer"
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/libproxy/libproxy/archive/refs/tags/$portVersion.tar.gz"
 CHECKSUM_SHA256="a1fa55991998b80a567450a9e84382421a7176a84446c95caaa8b72cf09fa86f"
 SOURCE_FILENAME="libproxy-$portVersion.tar.gz"
@@ -91,11 +91,11 @@ BUILD()
 		--datadir=$dataDir \
 		--localedir=$dataDir/locale \
 		--includedir=$includeDir \
-		-Ddocs=false \
-		-Dconfig-windows=false \
-		-Dconfig-osx=false \
-		-Dconfig-xdp=false \
-		-Dpacrunner-duktape=false
+		-D docs=false \
+		-D config-windows=false \
+		-D config-osx=false \
+		-D config-xdp=false \
+		-D pacrunner-duktape=false
 
 	ninja -C build
 }
@@ -109,7 +109,8 @@ INSTALL()
 	fixPkgconfig
 
 	packageEntries devel \
-		"$developDir"
+		$developDir \
+		$dataDir/gir-1.0
 
 	packageEntries tools \
 		$commandBinDir \


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
