### PR TITLE
libpeas, move dataDir/gir-1.0 to _devel package, add libpeas2 recipe

### DIFF
--- a/dev-libs/libpeas/libpeas2-2.2.1.recipe
+++ b/dev-libs/libpeas/libpeas2-2.2.1.recipe
@@ -8,65 +8,61 @@ including, but not limited to:
 *simplicity of the APIS"
 HOMEPAGE="https://wiki.gnome.org/Projects/Libpeas"
 COPYRIGHT="Steve Frécinaux
-	Ignacio Casal Quinteiro
-	"
+	Ignacio Casal Quinteiro"
 LICENSE="GNU LGPL v2.1"
-REVISION="2"
-SOURCE_URI="https://gitlab.gnome.org/GNOME/libpeas/-/archive/libpeas-$portVersion/libpeas-libpeas-$portVersion.tar.gz"
-SOURCE_DIR="libpeas-libpeas-$portVersion"
-CHECKSUM_SHA256="514b0576d9a56460915490bdb61dcb88634fdacfb2801e28dcbb9a730348858f"
+REVISION="1"
+SOURCE_URI="https://gitlab.gnome.org/GNOME/libpeas/-/archive/$portVersion/libpeas-$portVersion.tar.bz2"
+CHECKSUM_SHA256="8ffed8ccd613b1cb92bc8dc45904ef6f6d478fa280ae26a76452d8f8bb966ef7"
+SOURCE_DIR="libpeas-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
-libVersion="0.3400.0"
+libVersion="0.0200.1"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
+pythonVersion=3.10
+pythonPackage=python${pythonVersion//.}
+
 PROVIDES="
-	libpeas$secondaryArchSuffix = $portVersion compat >= 1
-	lib:libpeas_1.0$secondaryArchSuffix = $libVersionCompat
-	lib:libpeas_gtk_1.0$secondaryArchSuffix = $libVersionCompat
+	libpeas2$secondaryArchSuffix = $portVersion compat >= 1
+	lib:libpeas_2$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libgio_2.0$secondaryArchSuffix
-	lib:libgirepository_1.0$secondaryArchSuffix
 	lib:libglib_2.0$secondaryArchSuffix
 	lib:libgmodule_2.0$secondaryArchSuffix
 	lib:libgobject_2.0$secondaryArchSuffix
-	lib:libgtk_3$secondaryArchSuffix
 	lib:libintl$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
-	libpeas${secondaryArchSuffix}_devel = $portVersion compat >= 1
-	devel:libpeas_1.0$secondaryArchSuffix = $libVersionCompat
-	devel:libpeas_gtk_1.0$secondaryArchSuffix = $libVersionCompat
+	libpeas2${secondaryArchSuffix}_devel = $portVersion compat >= 1
+	devel:libpeas_2$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
-	libpeas$secondaryArchSuffix == $portVersion base
+	libpeas2$secondaryArchSuffix == $portVersion base
 	devel:libgio_2.0$secondaryArchSuffix
-	devel:libgirepository_1.0$secondaryArchSuffix
 	devel:libglib_2.0$secondaryArchSuffix
 	devel:libgmodule_2.0$secondaryArchSuffix
 	devel:libgobject_2.0$secondaryArchSuffix
-	devel:libgtk_3$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libgirepository_1.0$secondaryArchSuffix
 	devel:libglib_2.0$secondaryArchSuffix
-	devel:libgtk_3$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
+#	pygobject_$pythonPackage
 	cmd:cmake
 	cmd:gcc$secondaryArchSuffix
 	cmd:meson
 	cmd:msgfmt$secondaryArchSuffix
 	cmd:ninja
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:python3
+#	cmd:python$pythonVersion
 	cmd:valac
 	"
 
@@ -81,9 +77,11 @@ BUILD()
 		--localedir=$dataDir/locale \
 		--includedir=$includeDir \
 		--sysconfdir=$settingsDir \
-		-D demos=false \
 		-D introspection=true \
 		-D vapi=true \
+		-D gjs=false \
+		-D lua51=false \
+		-D python3=false \
 		build
 
 	ninja -C build
@@ -94,8 +92,7 @@ INSTALL()
 	ninja -C build install
 
 	prepareInstalledDevelLibs \
-		libpeas-1.0 \
-		libpeas-gtk-1.0
+		libpeas-2 #libpeas-gtk-1.0
 	fixPkgconfig
 
 	# devel package


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
