### PR TITLE
opencv4.13, revbump, drop python and numpy dependency from _tools pac…

### DIFF
--- a/media-libs/opencv/opencv4.13-4.13.0.recipe
+++ b/media-libs/opencv/opencv4.13-4.13.0.recipe
@@ -10,7 +10,7 @@ COPYRIGHT="2000-2020, Intel Corporation
 	2015-2016, Itseez Inc.
 	2019-2020, Xperience AI"
 LICENSE="BSD (3-clause)"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/opencv/opencv/archive/$portVersion.tar.gz"
 SOURCE_FILENAME="opencv-$portVersion.tar.gz"
 CHECKSUM_SHA256="1d40ca017ea51c533cf9fd5cbde5b5fe7ae248291ddf2af99d4c17cf8e13017d"
@@ -267,8 +267,6 @@ REQUIRES_tools="
 	haiku$secondaryArchSuffix
 	opencv4.13$secondaryArchSuffix == $portVersion base
 	opencv4.13${secondaryArchSuffix}_highgui
-	numpy${secondaryArchSuffix}_python310
-	cmd:python3
 	"
 CONFLICTS_tools="
 	opencv${secondaryArchSuffix}_tools


### PR DESCRIPTION
…kage

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
