### PR TITLE
libsoup, forgot updated patchset

### DIFF
--- a/net-libs/libsoup/patches/libsoup-2.60.2.patchset
+++ b/net-libs/libsoup/patches/libsoup-2.60.2.patchset
@@ -1,11 +1,11 @@
-From 27d824c71f616df6a7c84455e8cc443896aff1d6 Mon Sep 17 00:00:00 2001
+From 2a527ed3bb4ad1adc75bd1695c54c53af78b3f45 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Wed, 25 Nov 2015 01:25:58 +0000
 Subject: Fix build
 
 
 diff --git a/libsoup/soup-auth-digest.c b/libsoup/soup-auth-digest.c
-index 1fbb639..aae87b4 100644
+index eda2a93..881a5e2 100644
 --- a/libsoup/soup-auth-digest.c
 +++ b/libsoup/soup-auth-digest.c
 @@ -9,6 +9,10 @@
@@ -20,7 +20,7 @@ index 1fbb639..aae87b4 100644
  
  #include "soup-auth-digest.h"
 diff --git a/libsoup/soup-auth-ntlm.c b/libsoup/soup-auth-ntlm.c
-index 926fd4a..bea8c70 100644
+index 723c8ca..396811d 100644
 --- a/libsoup/soup-auth-ntlm.c
 +++ b/libsoup/soup-auth-ntlm.c
 @@ -14,6 +14,10 @@
@@ -35,5 +35,29 @@ index 926fd4a..bea8c70 100644
  #include "soup.h"
  #include "soup-message-private.h"
 -- 
-2.2.2
+2.54.0
+
+
+From 1c5b532721db326932cc71b93545e79dc2179e92 Mon Sep 17 00:00:00 2001
+From: Luc Schrijvers <begasus@gmail.com>
+Date: Sat, 18 Jul 2026 16:03:08 +0200
+Subject: Build fix
+
+
+diff --git a/configure.ac b/configure.ac
+index 3449406..4394f68 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -356,8 +356,7 @@ if test "$GCC" = "yes" -a "$set_more_warnings" != "no"; then
+ 		-Werror=implicit-function-declaration \
+ 		-Werror=pointer-arith -Werror=init-self -Werror=format=2 \
+ 		-Wno-format-zero-length \
+-		-Werror=missing-include-dirs -Werror=aggregate-return \
+-		-Werror=declaration-after-statement"
++		-Werror=missing-include-dirs -Werror=aggregate-return"
+ fi
+ 
+ ##################################################
+-- 
+2.54.0
 


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
