### PR TITLE
libxmlb, bump to version 0.3.28

### DIFF
--- a/dev-libs/libxmlb/libxmlb-0.3.28.recipe
+++ b/dev-libs/libxmlb/libxmlb-0.3.28.recipe
@@ -2,11 +2,11 @@ SUMMARY="A library to help create and query binary XML blobs"
 DESCRIPTION="libxmlb is a small helper library that is used to create and \
 query the binary XML-like blobs that are used by AppStream."
 HOMEPAGE="https://github.com/hughsie/libxmlb"
-COPYRIGHT="2018*2025 Richard Hughes"
+COPYRIGHT="2018-2025 Richard Hughes"
 LICENSE="GNU LGPL v2.1"
 REVISION="1"
 SOURCE_URI="https://github.com/hughsie/libxmlb/archive/refs/tags/$portVersion.tar.gz"
-CHECKSUM_SHA256="103684ed37a45d0aed8f95e97294ed26945b5aeebf44734f3994081eecebb11c"
+CHECKSUM_SHA256="a34f712c5c839c4c11b3093fe7ec96afa78f98c5ca8634d16108c2be6a1a9524"
 SOURCE_FILENAME="libxmlb-$portVersion.tar.gz"
 SOURCE_DIR="libxmlb-$portVersion"
 
@@ -22,9 +22,9 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	lib:libgio_2.0$secondaryArchSuffix
 	lib:libglib_2.0$secondaryArchSuffix
 	lib:libgobject_2.0$secondaryArchSuffix
-	lib:libgio_2.0$secondaryArchSuffix
 	lib:liblzma$secondaryArchSuffix
 	lib:libzstd$secondaryArchSuffix
 	"
@@ -35,9 +35,7 @@ PROVIDES_devel="
 	"
 REQUIRES_devel="
 	libxmlb$secondaryArchSuffix == $portVersion base
-	devel:libffi$secondaryArchSuffix
-	devel:libglib_2.0$secondaryArchSuffix
-	devel:libpcre2_8$secondaryArchSuffix
+	devel:libgio_2.0$secondaryArchSuffix
 	devel:liblzma$secondaryArchSuffix
 	devel:libzstd$secondaryArchSuffix
 	"
@@ -84,5 +82,6 @@ INSTALL()
 	fixPkgconfig
 
 	packageEntries devel \
-		$developDir
+		$developDir \
+		$dataDir/gir-1.0
 }


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
