### PR TITLE
cargo_c, trigger build for 32bit

### DIFF
--- a/dev-rust/cargo_c/cargo_c-0.10.18.recipe
+++ b/dev-rust/cargo_c/cargo_c-0.10.18.recipe
@@ -1,7 +1,6 @@
 SUMMARY="Cargo applet to build and install C-ABI compatibile dynamic and static libraries"
-DESCRIPTION="It produces and installs a correct pkg-config file, a static \
-library and a dynamic library, and a C header to be used by any C (and \
-C-compatible) software."
+DESCRIPTION="It produces and installs a correct pkg-config file, a static library and a \
+dynamic library, and a C header to be used by any C (and C-compatible) software."
 HOMEPAGE="https://github.com/lu-zero/cargo-c"
 COPYRIGHT="2019-present Luca Barbato"
 LICENSE="MIT"


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
