### PR TITLE
Update LZDoom to 4.14.4

### DIFF
--- a/games-fps/lzdoom/lzdoom-4.14.4.recipe
+++ b/games-fps/lzdoom/lzdoom-4.14.4.recipe
@@ -20,13 +20,13 @@ The binaries can be also used via command-line with the -iwad command.
 Example: 'LZDoom -iwad /path/to/doom.wad'"
 HOMEPAGE="https://zdoom.org/"
 COPYRIGHT="
-	1998-2025 ZDoom + GZDoom, UZDoom, LZDoom teams, and contributors
+	1998-2026 ZDoom + GZDoom, UZDoom, LZDoom teams, and contributors
 	1997 id Software, Raven Software, and contributors
 	"
 LICENSE="GNU GPL v3"
 REVISION="1"
 SOURCE_URI="https://github.com/drfrag666/lzdoom/archive/l$portVersion.tar.gz"
-CHECKSUM_SHA256="dbb8dc288bba1f0b14764d76d84250bbdfdb85db25e82cbb2debd5185cb259e8"
+CHECKSUM_SHA256="46eaf896c6a8f21d80b7a6278156ad46e3a1303d2b1f144bf2351717f0720dae"
 SOURCE_DIR="lzdoom-l$portVersion"
 PATCHES="lzdoom-$portVersion.patchset"
 ADDITIONAL_FILES="lzdoom.rdef.in"
@@ -36,7 +36,7 @@ SECONDARY_ARCHITECTURES="x86"
 
 PROVIDES="
 	lzdoom$secondaryArchSuffix = $portVersion
-	app:LZDoom = $portVersion
+	cmd:lzdoom = $portVersion
 	engine:doom # Standard Doom-compatible engine
 	engine:doom_extra # Heretic, Hexen, Strife etc.
 	engine:zdoom # Can handle ZDoom-specific game data
@@ -46,10 +46,12 @@ REQUIRES="
 	lib:libbz2$secondaryArchSuffix
 	lib:libexecinfo$secondaryArchSuffix
 	lib:libgomp$secondaryArchSuffix
-	lib:libopenal$secondaryArchSuffix # Optional, required for in-game audio
 	lib:libSDL2_2.0$secondaryArchSuffix
 	lib:libvpx$secondaryArchSuffix
 	lib:libzmusic$secondaryArchSuffix
+	"
+RECOMMENDS="
+	lib:libopenal$secondaryArchSuffix # Optional, required for in-game audio
 	"
 
 BUILD_REQUIRES="
@@ -59,7 +61,7 @@ BUILD_REQUIRES="
 	devel:libGL$secondaryArchSuffix # For OpenGL renderer
 	devel:libgtk_3$secondaryArchSuffix # For GTK3 interface support
 	devel:libSDL2_2.0$secondaryArchSuffix
-	devel:libvpx$secondaryArchSuffix
+	devel:libvpx$secondaryArchSuffix >= 12
 	devel:libzmusic$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
@@ -89,6 +91,8 @@ INSTALL()
 {
 	make -C build install
 	mv $appsDir/lzdoom $appsDir/LZDoom
+	# Add lowercase /bin link
+	mkdir -p $prefix/bin && ln -s $appsDir/LZDoom $prefix/bin/lzdoom
 
 	# Remove *nixy desktop files
 	rm -r $prefix/share

--- a/games-fps/lzdoom/patches/lzdoom-4.14.4.patchset
+++ b/games-fps/lzdoom/patches/lzdoom-4.14.4.patchset
@@ -97,28 +97,3 @@ index 4ef00dc..111c05c 100644
  }
 -- 
 2.51.0
-
-
-From 460e4289ce511ce15a32598b25a4bf12cb7dd88c Mon Sep 17 00:00:00 2001
-From: Peppersawce <michaelpeppers89@yahoo.it>
-Date: Tue, 23 Dec 2025 00:52:56 +0100
-Subject: Disable assert to fix x86 build
-
-
-diff --git a/src/common/models/bonecomponents.h b/src/common/models/bonecomponents.h
-index f4f221f..826f79f 100644
---- a/src/common/models/bonecomponents.h
-+++ b/src/common/models/bonecomponents.h
-@@ -36,7 +36,9 @@ struct ModelAnim
- 	double switchOffset = 0; // when the animation was changed -- where to interpolate the switch from
- };
- 
-+#if !defined(__i386__)
- static_assert(sizeof(ModelAnim) == sizeof(double) * 6);
-+#endif
- 
- using ModelAnimFrame = std::variant<std::nullptr_t, ModelAnimFrameInterp, ModelAnimFramePrecalculatedIQM>;
- 
--- 
-2.51.0
-


### PR DESCRIPTION
Seems to be a mostly bugfix release, compiles and runs fine on 64bit, the assert that stopped compilation on 32bit and had to be patched got removed. Probably compiles fine on 32bit but testing wouldn't hurt.