### PR TITLE
Properly require 'cmd:sip_build'.

### DIFF
--- a/app-text/calibre/calibre-5.44.0.recipe
+++ b/app-text/calibre/calibre-5.44.0.recipe
@@ -187,7 +187,6 @@ BUILD_PREREQUIRES="
 	cmd:python3.10
 	cmd:pyrcc5
 	cmd:qmake >= 5
-	cmd:sip
 	cmd:unrar
 	"
 

--- a/dev-python/pyqt/pyqt5-5.15.11.recipe
+++ b/dev-python/pyqt/pyqt5-5.15.11.recipe
@@ -128,7 +128,7 @@ BUILD_PREREQUIRES="
 	cmd:gcc${secondaryArchSuffix}
 	cmd:make
 	cmd:ld${secondaryArchSuffix}
-	cmd:sip >= 6
+	cmd:sip_build
 	cmd:qmake${secondaryArchSuffix} >= 5
 	"
 

--- a/dev-python/pyqt/pyqt6-6.8.0.recipe
+++ b/dev-python/pyqt/pyqt6-6.8.0.recipe
@@ -118,7 +118,7 @@ BUILD_PREREQUIRES="
 	cmd:gcc${secondaryArchSuffix}
 	cmd:make
 	cmd:ld${secondaryArchSuffix}
-	cmd:sip >= 6
+	cmd:sip_build
 	cmd:qmake6${secondaryArchSuffix} >= 6
 	"
 

--- a/dev-python/pyqtwebengine/pyqtwebengine5-5.15.6.recipe
+++ b/dev-python/pyqtwebengine/pyqtwebengine5-5.15.6.recipe
@@ -127,7 +127,7 @@ BUILD_PREREQUIRES="
 	cmd:make
 	cmd:ld${secondaryArchSuffix}
 	cmd:sed
-	cmd:sip >= 6
+	cmd:sip_build
 	cmd:qmake${secondaryArchSuffix} >= 5
 	"
 

--- a/dev-python/python-poppler-qt5/python_poppler_qt5-21.3.0.recipe
+++ b/dev-python/python-poppler-qt5/python_poppler_qt5-21.3.0.recipe
@@ -54,7 +54,7 @@ BUILD_PREREQUIRES="
 	cmd:ld${secondaryArchSuffix}
 	cmd:pkg_config$secondaryArchSuffix
 	cmd:sed
-	cmd:sip >= 6
+	cmd:sip_build
 	cmd:qmake${secondaryArchSuffix} >= 5
 	"
 

--- a/x11-libs/qscintilla/qscintilla-2.11.6.recipe
+++ b/x11-libs/qscintilla/qscintilla-2.11.6.recipe
@@ -88,7 +88,7 @@ BUILD_PREREQUIRES="
 	cmd:make
 	cmd:python3.10
 	cmd:sed
-	cmd:sip
+	cmd:sip_build
 	"
 
 BUILD()


### PR DESCRIPTION
Revision bump should not be necessary, but this should fix most issues currently shown in the repo_consistency.txt report (well, before the libxml2 related rev-bumps, at least).