### PR TITLE
libxslt: explicitly require python3.10.

### DIFF
--- a/dev-libs/libxslt/libxslt-1.1.43.recipe
+++ b/dev-libs/libxslt/libxslt-1.1.43.recipe
@@ -8,12 +8,12 @@ in commercial applications."
 HOMEPAGE="http://www.xmlsoft.org/"
 COPYRIGHT="2001-2012 Daniel Veillard"
 LICENSE="MIT"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://download.gnome.org/sources/libxslt/1.1/libxslt-$portVersion.tar.xz"
 CHECKSUM_SHA256="5a3d6b383ca5afc235b171118e90f5ff6aa27e9fea3303065231a6d403f0183a"
 
 ARCHITECTURES="all"
-SECONDARY_ARCHITECTURES="x86_gcc2 x86"
+SECONDARY_ARCHITECTURES="x86"
 
 libVersion="$portVersion"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
@@ -78,7 +78,7 @@ BUILD_PREREQUIRES="
 	"
 if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
 	BUILD_PREREQUIRES+="
-		cmd:python3
+		cmd:python3.10
 		"
 fi
 


### PR DESCRIPTION
Should fix build after the 3.10 to 3.14 default python3 switch.

Recipe could use a bit more of a clean up, but this should do for now.

----

~Untested~, but the error in the [build log](https://build.haiku-os.org/buildmaster/master/x86_64/logviewer.html?buildruns/14766/builds/88235.log) made the issue clear enough.

Lots of the "lost" packages after the last [big re-build](https://build.haiku-os.org/buildmaster/master/x86_64/?buildrunDir=14766&viewMode=expanded) seem due to a missing libxslt, so this should hopefully help with that.

---

Edit: build tested on x86_64 now.