### PR TITLE
(various): version of Python interpreter and packages should match.

### DIFF
--- a/app-antivirus/clamav/clamav-1.5.1.recipe
+++ b/app-antivirus/clamav/clamav-1.5.1.recipe
@@ -81,14 +81,12 @@ BUILD_REQUIRES="
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-#	pytest_python310
 	cmd:cargo$secondaryArchSuffix
 	cmd:cmake
 	cmd:dot
 	cmd:doxygen
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
-#	cmd:python3
 	"
 
 BUILD()

--- a/app-emulation/spice/spice-0.15.2.recipe
+++ b/app-emulation/spice/spice-0.15.2.recipe
@@ -17,6 +17,9 @@ SECONDARY_ARCHITECTURES="x86"
 libVersion="1.14.3"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
+pythonVersion=3.10
+pythonPackage=python${pythonVersion//.}
+
 PROVIDES="
 	spice$secondaryArchSuffix = $portVersion
 	lib:libspice_server$secondaryArchSuffix = $libVersionCompat
@@ -45,6 +48,9 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	# These are needed during build, even if we're not shipping spice's python modules.
+	pyparsing_$pythonPackage
+	six_$pythonPackage
 	devel:libglib_2.0$secondaryArchSuffix
 	devel:libjpeg$secondaryArchSuffix
 	devel:liblz4$secondaryArchSuffix
@@ -56,9 +62,6 @@ BUILD_REQUIRES="
 	devel:libX11$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	devel:spice_protocol
-	# These are needed during build, even if we're not shiping spice's python modules.
-	pyparsing_python310
-	six_python310
 	"
 BUILD_PREREQUIRES="
 	cmd:awk
@@ -69,7 +72,7 @@ BUILD_PREREQUIRES="
 	cmd:ninja
 	cmd:openssl
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:python3
+	cmd:python$pythonVersion
 	"
 
 BUILD()

--- a/app-misc/binwalk/binwalk-2.4.0.recipe
+++ b/app-misc/binwalk/binwalk-2.4.0.recipe
@@ -4,11 +4,15 @@ from binary firmware images."
 HOMEPAGE="https://github.com/ReFirmLabs/binwalk"
 COPYRIGHT="2010-2015 Craig Heffner"
 LICENSE="MIT"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/OSPG/binwalk/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="69d39f02b95c31b6dc07da0927070cadfcc5647a7e46281b6b0c7656887bfeb8"
 
 ARCHITECTURES="any"
+
+pythonVersion=3.10
+python=python$pythonVersion
+pythonPackage=python${pythonVersion//.}
 
 PROVIDES="
 	binwalk$secondaryArchSuffix = $portVersion
@@ -21,22 +25,22 @@ REQUIRES="
 
 BUILD_REQUIRES="
     haiku${secondaryArchSuffix}_devel
+	setuptools_$pythonPackage
     "
 BUILD_PREREQUIRES="
     cmd:cmake
     cmd:g++$secondaryArchSuffix
     cmd:gcc$secondaryArchSuffix
     cmd:make
-	cmd:python3
-	setuptools_python310
+	cmd:$python
     "
 
 BUILD()
 {
-	python3 setup.py build
+	$python setup.py build
 }
 
 INSTALL()
 {
-	python3 setup.py install --prefix=$prefix --root=/
+	$python setup.py install --prefix=$prefix --root=/
 }

--- a/dev-libs/caffe/caffe-1.0.recipe
+++ b/dev-libs/caffe/caffe-1.0.recipe
@@ -99,10 +99,8 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	cmd:cmake
 	cmd:gcc$secondaryArchSuffix
-#	cmd:f2py3
 	cmd:ld$secondaryArchSuffix
 	cmd:make
-#	cmd:python3
 	"
 
 BUILD()

--- a/dev-util/rizin/rizin-0.8.1.recipe
+++ b/dev-util/rizin/rizin-0.8.1.recipe
@@ -35,6 +35,9 @@ fi
 libVersion="$portVersion"
 libVersionCompat="$libVersion compat >= ${libVersion%.*}"
 
+pythonVersion=3.10
+pythonPackage=python${pythonVersion//.}
+
 PROVIDES="
 	rizin$secondaryArchSuffix = $portVersion
 	cmd:rizin$commandSuffix
@@ -139,7 +142,7 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	pyyaml_python310
+	pyyaml_$pythonPackage
 	devel:libcapstone$secondaryArchSuffix >= 5.0
 	devel:libbz2$secondaryArchSuffix
 	devel:libexecinfo$secondaryArchSuffix
@@ -164,7 +167,7 @@ BUILD_PREREQUIRES="
 	cmd:ninja
 	cmd:gcc$secondaryArchSuffix
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:python3
+	cmd:python$pythonVersion
 	cmd:tree_sitter
 	cmd:xxhsum
 	"

--- a/kde-plasma/breeze-gtk/breeze_gtk-6.6.5.recipe
+++ b/kde-plasma/breeze-gtk/breeze_gtk-6.6.5.recipe
@@ -12,6 +12,9 @@ SOURCE_DIR="breeze-gtk-$portVersion"
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="?x86"
 
+pythonVersion=3.10
+pythonPackage=python${pythonVersion//.}
+
 PROVIDES="
 	breeze_gtk$secondaryArchSuffix = $portVersion
 	"
@@ -27,17 +30,17 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	# KF6
 	extra_cmake_modules$secondaryArchSuffix
+	pycairo_$pythonPackage
 	# Plasma
 	devel:breeze6$secondaryArchSuffix == $portVersion
 	# Qt6
 	devel:libQt6Core$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-	pycairo_python310
 	cmd:cmake
 	cmd:g++$secondaryArchSuffix
 	cmd:make
-	cmd:python3
+	cmd:python$pythonVersion
 	cmd:sassc$secondaryArchSuffix
 	"
 

--- a/media-gfx/gimp/gimp-3.2.4.recipe
+++ b/media-gfx/gimp/gimp-3.2.4.recipe
@@ -40,6 +40,9 @@ fi
 libVersion="0.200.0"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
+pythonVersion=3.10
+pythonPackage=python${pythonVersion//.}
+
 PROVIDES="
 	gimp$secondaryArchSuffix = $portVersion
 	app:GIMP = $portVersion
@@ -131,11 +134,11 @@ PROVIDES_doc="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	packaging_python310
-	pycairo_python310
-	pygobject_python310
-	pygments_python310
-	setuptools_python310
+	packaging_$pythonPackage
+	pycairo_$pythonPackage
+	pygobject_$pythonPackage
+	pygments_$pythonPackage
+	setuptools_$pythonPackage
 	mypaint_brushes
 	wayland_protocols
 	devel:libappstream$secondaryArchSuffix
@@ -206,7 +209,7 @@ BUILD_PREREQUIRES="
 	cmd:ninja
 	cmd:perl
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:python3
+	cmd:python$pythonVersion
 	cmd:update_mime_database$secondaryArchSuffix
 	"
 

--- a/media-libs/graphene/graphene-1.10.8.recipe
+++ b/media-libs/graphene/graphene-1.10.8.recipe
@@ -32,6 +32,9 @@ SECONDARY_ARCHITECTURES="x86"
 libVersion="0.1000.8"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
+pythonVersion=3.10
+pythonPackage=python${pythonVersion//.}
+
 PROVIDES="
 	graphene$secondaryArchSuffix = $portVersion
 	lib:libgraphene_1.0$secondaryArchSuffix = $libVersionCompat
@@ -52,6 +55,7 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	pygments_$pythonPackage
 	devel:libgirepository_1.0$secondaryArchSuffix
 	devel:libglib_2.0$secondaryArchSuffix
 	devel:libgobject_2.0$secondaryArchSuffix
@@ -63,8 +67,7 @@ BUILD_PREREQUIRES="
 	cmd:meson
 	cmd:ninja
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:python3
-	pygments_python310
+	cmd:python$pythonVersion
 	"
 
 BUILD()

--- a/media-libs/harfbuzz/harfbuzz-14.2.0.recipe
+++ b/media-libs/harfbuzz/harfbuzz-14.2.0.recipe
@@ -38,6 +38,9 @@ fi
 libVersion="0.61420.0"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
+pythonVersion=3.10
+pythonPackage=python${pythonVersion//.}
+
 PROVIDES="
 	harfbuzz$secondaryArchSuffix = $portVersion compat >= 0.9
 	lib:libharfbuzz$secondaryArchSuffix = $libVersionCompat
@@ -96,6 +99,7 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	pygments_$pythonPackage
 	devel:libfreetype$secondaryArchSuffix
 	devel:libgirepository_1.0$secondaryArchSuffix
 	devel:libglib_2.0$secondaryArchSuffix
@@ -111,8 +115,7 @@ BUILD_PREREQUIRES="
 	cmd:meson >= 0.55.0
 	cmd:ninja
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:python3
-	pygments_python310
+	cmd:python$pythonVersion
 	"
 
 defineDebugInfoPackage harfbuzz$secondaryArchSuffix \

--- a/media-libs/libplacebo/libplacebo-7.351.0.recipe
+++ b/media-libs/libplacebo/libplacebo-7.351.0.recipe
@@ -14,6 +14,9 @@ PATCHES="libplacebo-$portVersion.patchset"
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
+pythonVersion=3.10
+pythonPackage=python${pythonVersion//.}
+
 PROVIDES="
 	libplacebo$secondaryArchSuffix = $portVersion compat >= 7
 	lib:libplacebo$secondaryArchSuffix = 351
@@ -40,7 +43,7 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	jinja2_python310
+	jinja2_$pythonPackage
 	devel:libgl$secondaryArchSuffix
 	devel:libglslang$secondaryArchSuffix
 	devel:liblcms2$secondaryArchSuffix
@@ -54,7 +57,7 @@ BUILD_PREREQUIRES="
 	cmd:meson
 	cmd:ninja
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:python3
+	cmd:python$pythonVersion
 	"
 
 BUILD()

--- a/net-fs/samba/samba4-4.20.2.recipe
+++ b/net-fs/samba/samba4-4.20.2.recipe
@@ -24,6 +24,9 @@ GLOBAL_WRITABLE_FILES="
 	settings/samba directory keep-old
 	"
 
+pythonVersion=3.10
+pythonPackage=python${pythonVersion//.}
+
 PROVIDES="
 	samba4$secondaryArchSuffix = $portVersion
 	cmd:cifsdd$secondaryArchSuffix = $portVersion
@@ -223,6 +226,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	cryptography_$pythonPackage
 	lib:libarchive$secondaryArchSuffix
 	lib:libexecinfo$secondaryArchSuffix
 	lib:libform$secondaryArchSuffix
@@ -234,12 +238,10 @@ REQUIRES="
 	lib:libpam$secondaryArchSuffix
 	lib:libpanel$secondaryArchSuffix
 	lib:libpopt$secondaryArchSuffix
-	lib:libpython3.10$secondaryArchSuffix
+	lib:libpython$pythonVersion$secondaryArchSuffix
 	lib:libreadline$secondaryArchSuffix
 	lib:libtasn1$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
-	# python
-	cryptography_python310
 	"
 CONFLICTS="
 	samba$secondaryArchSuffix
@@ -275,6 +277,7 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	markdown_$pythonPackage
 	parse_yapp
 	devel:libarchive$secondaryArchSuffix
 	devel:libcmocka$secondaryArchSuffix
@@ -311,11 +314,10 @@ BUILD_PREREQUIRES="
 	cmd:make
 	cmd:perl
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:python3
+	cmd:python$pythonVersion
 	cmd:rpcgen$secondaryArchSuffix
 	cmd:which
 	cmd:xsltproc
-	markdown_python310
 	"
 
 BUILD()
@@ -360,9 +362,6 @@ INSTALL()
 	# copy sample config file
 	cp testdata/samba3/smb.conf $settingsDir/samba
 
-	# GENERIC: all python_setuptools-based installs need this
-	export PATH="$portPackageLinksDir/cmd~python3/bin:$PATH"
-	pythonVersion=$(python3 --version 2>&1 | sed 's/Python //' | head -c4)
 	installLocation=$prefix/lib/python$pythonVersion/vendor-packages/
 
 	mkdir -p $installLocation

--- a/net-fs/samba/samba4-4.20.4.recipe
+++ b/net-fs/samba/samba4-4.20.4.recipe
@@ -24,6 +24,9 @@ GLOBAL_WRITABLE_FILES="
 	settings/samba directory keep-old
 	"
 
+pythonVersion=3.10
+pythonPackage=python${pythonVersion//.}
+
 PROVIDES="
 	samba4$secondaryArchSuffix = $portVersion
 	cmd:cifsdd$secondaryArchSuffix = $portVersion
@@ -223,6 +226,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	cryptography_$pythonPackage
 	lib:libarchive$secondaryArchSuffix
 	lib:libexecinfo$secondaryArchSuffix
 	lib:libform$secondaryArchSuffix
@@ -236,12 +240,10 @@ REQUIRES="
 	lib:libpam$secondaryArchSuffix
 	lib:libpanel$secondaryArchSuffix
 	lib:libpopt$secondaryArchSuffix
-	lib:libpython3.10$secondaryArchSuffix
+	lib:libpython$pythonVersion$secondaryArchSuffix
 	lib:libreadline$secondaryArchSuffix
 	lib:libtasn1$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
-	# python
-	cryptography_python310
 	"
 CONFLICTS="
 	samba$secondaryArchSuffix
@@ -279,6 +281,7 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 #	docbook_xml_dtd
 #	docbook_xsl_stylesheets == 1.79.2
+	markdown_$pythonPackage
 	parse_yapp
 	devel:libarchive$secondaryArchSuffix
 	devel:libcmocka$secondaryArchSuffix
@@ -320,11 +323,10 @@ BUILD_PREREQUIRES="
 	cmd:make
 	cmd:perl
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:python3
+	cmd:python$pythonVersion
 	cmd:rpcgen$secondaryArchSuffix
 	cmd:which
 	cmd:xsltproc
-	markdown_python310
 	"
 
 BUILD()
@@ -369,9 +371,6 @@ INSTALL()
 	# copy sample config file
 	cp testdata/samba3/smb.conf $settingsDir/samba
 
-	# GENERIC: all python_setuptools-based installs need this
-	export PATH="$portPackageLinksDir/cmd~python3/bin:$PATH"
-	pythonVersion=$(python3 --version 2>&1 | sed 's/Python //' | head -c4)
 	installLocation=$prefix/lib/python$pythonVersion/vendor-packages/
 
 	mkdir -p $installLocation

--- a/net-libs/libaccounts_glib/libaccounts_glib-1.27.recipe
+++ b/net-libs/libaccounts_glib/libaccounts_glib-1.27.recipe
@@ -12,7 +12,7 @@ SOURCE_DIR="libaccounts-glib-VERSION_$portVersion"
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
-pythonVersion="3.10"
+pythonVersion=3.10
 pythonPackage=python${pythonVersion//.}
 
 PROVIDES="
@@ -48,6 +48,7 @@ REQUIRES_tools="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+#	pygobject_$pythonPackage
 	devel:libcheck$secondaryArchSuffix
 	devel:libgio_2.0$secondaryArchSuffix
 	devel:libgirepository_1.0$secondaryArchSuffix
@@ -57,7 +58,6 @@ BUILD_REQUIRES="
 	devel:libxml2$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
-#	pygobject_$pythonPackage
 	cmd:cmake
 	cmd:gcc$secondaryArchSuffix
 	cmd:gtkdoc_scan

--- a/net-misc/nextcloud-client/nextcloud_client-3.13.3.recipe
+++ b/net-misc/nextcloud-client/nextcloud_client-3.13.3.recipe
@@ -27,6 +27,8 @@ libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 GLOBAL_WRITABLE_FILES="
 	settings/Nextcloud/sync-exclude.lst keep-old
 	"
+pythonVersion=3.10
+pythonPackage=python${pythonVersion//.}
 
 PROVIDES="
 	nextcloud_client$secondaryArchSuffix = $portVersion
@@ -89,6 +91,7 @@ REPLACES_doc="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	extra_cmake_modules$secondaryArchSuffix
+	sphinx_$pythonPackage
 	devel:libcmocka$secondaryArchSuffix # only needed during configure and testing
 	devel:libcrypto$secondaryArchSuffix
 	devel:libKF5Archive$secondaryArchSuffix
@@ -126,10 +129,9 @@ BUILD_PREREQUIRES="
 	cmd:ld$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:python3
+	cmd:python$pythonVersion
 	cmd:linguist$secondaryArchSuffix >= 5
 	cmd:rsvg_convert
-	sphinx_python310
 	"
 
 TEST_REQUIRES="

--- a/sys-boot/u-boot/u_boot-2024.04.recipe
+++ b/sys-boot/u-boot/u_boot-2024.04.recipe
@@ -25,6 +25,9 @@ PATCHES="u_boot-$portVersion.patchset"
 
 ARCHITECTURES="any"
 
+pythonVersion=3.10
+pythonPackage=python${pythonVersion//.}
+
 PROVIDES="
 	u_boot$secondaryArchSuffix = $portVersion
 	"
@@ -42,7 +45,7 @@ fi
 BUILD_REQUIRES="
 	haiku${hostArchSuffix}_devel
 	devel:libssl$hostArchSuffix
-	setuptools_python310
+	setuptools_$pythonPackage
 	"
 BUILD_PREREQUIRES="
 	cmd:arm_none_eabi_gcc
@@ -53,7 +56,7 @@ BUILD_PREREQUIRES="
 	cmd:flex
 	cmd:gcc$hostArchSuffix
 	cmd:make
-	cmd:python3
+	cmd:python$pythonVersion
 	cmd:swig
 	cmd:xargs
 	"


### PR DESCRIPTION
If a package requires a specific version of a package, makes little sense to also require `cmd:python3` which might be of a different version.

---

Untested, might need to rev-bump later on, as needed.

Remaining recipes that need similar changes are the llvm* ones.

I used the following command to find relevant recipes:

`grep -rsIl 'cmd:python3$' <path_to_haikuports>*/*/*.recipe | xargs grep -sI "_python310"`