### PR TITLE
llvm(s): make sure python interpreter and package requirements match.

### DIFF
--- a/sys-devel/llvm/llvm22-22.1.8.recipe
+++ b/sys-devel/llvm/llvm22-22.1.8.recipe
@@ -29,7 +29,7 @@ other than the ones listed above.
 HOMEPAGE="https://www.llvm.org/"
 COPYRIGHT="2003-2026 University of Illinois at Urbana-Champaign"
 LICENSE="Apache v2 with LLVM Exception"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/llvm/llvm-project/releases/download/llvmorg-$portVersion/llvm-project-$portVersion.src.tar.xz"
 CHECKSUM_SHA256="922f1817a0df7b1489272d18134ee0087a8b068828f87ac63b9861b1a9965888"
 SOURCE_DIR="llvm-project-$portVersion.src"
@@ -39,6 +39,9 @@ ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 portVersionCompat="$portVersion compat >= ${portVersion%%.*}"
+
+pythonVersion=3.10
+pythonPackage=python${pythonVersion//.}
 
 PROVIDES="
 	llvm22$secondaryArchSuffix = $portVersionCompat
@@ -534,7 +537,7 @@ PROVIDES_clang_analysis="
 	"
 REQUIRES_clang_analysis="
 	llvm22${secondaryArchSuffix}_clang == $portVersion base
-	cmd:python3
+	cmd:python$pythonVersion
 	"
 CONFLICTS_clang_analysis="
 	llvm9${secondaryArchSuffix}_clang_analysis
@@ -578,15 +581,14 @@ REQUIRES_libs="
 	lib:libz$secondaryArchSuffix
 	"
 
-PYTHON3_VERSION="3.10"
-PROVIDES_python310="
-	llvm22${secondaryArchSuffix}_python310 = $portVersion
+eval "PROVIDES_$pythonPackage=\"
+	llvm22${secondaryArchSuffix}_$pythonPackage = $portVersion
 	cmd:lit
-	"
-REQUIRES_python310="
-	setuptools_python310
-	cmd:python$PYTHON3_VERSION
-	"
+	\""
+eval "REQUIRES_$pythonPackage=\"
+	setuptools_$pythonPackage	# is this really needed at runtime?
+	cmd:python$pythonVersion
+	\""
 
 libunwindSoVersion="1"
 libunwindLibVersion="1.0"
@@ -655,7 +657,7 @@ REQUIRES_openmp="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libz$secondaryArchSuffix
-	setuptools_python310
+	setuptools_$pythonPackage
 	"
 BUILD_PREREQUIRES="
 	cmd:cmake
@@ -667,7 +669,7 @@ BUILD_PREREQUIRES="
 	cmd:ld$secondaryArchSuffix
 	cmd:make
 	cmd:ninja
-	cmd:python$PYTHON3_VERSION
+	cmd:python$pythonVersion
 	cmd:sed
 	"
 
@@ -716,11 +718,9 @@ INSTALL()
 	cd build
 	mkdir -p $binDir $developDir $dataDir $docDir $includeDir $manDir $libDir
 
-	# GENERIC: all python_setuptools-based installs need this
-	local pythonPackageName="${portName}_python310-$portFullVersion"
-	local packageLinksDir=$(dirname $portPackageLinksDir)
-	python=$packageLinksDir/${pythonPackageName}/cmd~python$PYTHON3_VERSION/bin/python$PYTHON3_VERSION
-	pythonVersion=$($python --version 2>&1 | sed 's/Python //' | head -c3)
+	python=python$pythonVersion
+
+	# not sure these two are still needed at all now.
 	installLocation=$prefix/lib/python$pythonVersion/vendor-packages/
 	export PYTHONPATH=$installLocation:$OLDPYTHONPATH
 
@@ -900,8 +900,8 @@ INSTALL()
 		$libDir/libLTO* \
 		$libDir/libRemarks*
 
-	# python310 package
-	packageEntries python310 \
+	# python package
+	packageEntries $pythonPackage \
 		$prefix/bin/lit \
 		$prefix/lib/python*
 


### PR DESCRIPTION
Untested, but something like this is what I think should be done to all the `llvm*` recipes (similarly to #14416).

(Setting as Draft for now to gather feedback, might add the rest of llvm recipes if other team members agree with this line of changes).

----

- If we decide to switch these to 3.14, we should introduce the dotted package name instead (`_python3.14`).

- Notice that the `llvm*_python310` for all llvm versions provides `cmd:lit` without a `CONFLICTS`. Do we really need that command for each version?

- Also of note... seem that the contents of the `_python310` package is just the supporting code for such `lit` tool, and not some python bindings, or some LLVM-package one might use separately. Maybe we should just rename `llvm*_python310` to `llvm*_lit` to reflect that?

----

CC: @korli