### PR TITLE
markdown: update to version 3.10.2.

### DIFF
--- a/dev-python/markdown/markdown-3.10.2.recipe
+++ b/dev-python/markdown/markdown-3.10.2.recipe
@@ -9,9 +9,8 @@ COPYRIGHT="2007, 2008 The Python Markdown Project
 	2004 Manfred Stienstra"
 LICENSE="BSD (3-clause)"
 REVISION="1"
-SOURCE_URI="https://files.pythonhosted.org/packages/source/M/Markdown/Markdown-$portVersion.tar.gz"
-CHECKSUM_SHA256="5ad7180c3ec16422a764568ad6409ec82460c40d1631591fa53d597033cc98bf"
-SOURCE_DIR="Markdown-$portVersion"
+SOURCE_URI="https://files.pythonhosted.org/packages/py3/${portName:0:1}/$portName/$portName-$portVersion-py3-none-any.whl#noarchive"
+CHECKSUM_SHA256="e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36"
 
 ARCHITECTURES="any"
 
@@ -48,7 +47,7 @@ for pythonVersion in ${PYTHON_VERSIONS[@]}; do
 		cmd:python$pythonVersion
 		\""
 	BUILD_REQUIRES+="
-		setuptools_$pythonPackage
+		installer_$pythonPackage
 		"
 	BUILD_PREREQUIRES+="
 		cmd:python$pythonVersion
@@ -62,14 +61,7 @@ INSTALL()
 		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
-		installLocation=$prefix/lib/$python/vendor-packages/
-		export PYTHONPATH=$installLocation:$PYTHONPATH
-
-		mkdir -p $installLocation
-		rm -rf build
-
-		$python setup.py build install \
-			--root=/ --prefix=$prefix
+		$python -m installer -p $prefix $portName-$portVersion-py3-none-any.whl
 
 		# Version suffix all the scripts
 		for f in $binDir/*; do


### PR DESCRIPTION
Should fix to solve some issues gi_docgen was having (related to markdown 3.2 requiring setuptools at runtime, for some reason).