### PR TITLE
mesa-legacy: try to support a wider range of older CPUs.

### DIFF
--- a/sys-libs/mesa/mesa-7.9.2.recipe
+++ b/sys-libs/mesa/mesa-7.9.2.recipe
@@ -6,15 +6,15 @@ providing 3D rendering to Haiku applications."
 HOMEPAGE="https://www.mesa3d.org/"
 COPYRIGHT="1999-2013 Brian Paul"
 LICENSE="MIT"
-REVISION="11"
+REVISION="12"
 SOURCE_URI="https://github.com/haiku/mesa_legacy/archive/7.9.2-9.tar.gz"
 SOURCE_DIR="mesa_legacy-7.9.2-9"
 SOURCE_FILENAME="mesa_legacy-7.9.2-9.tar.gz"
 CHECKSUM_SHA256="445c4081c761851343ae732b5f233f269f6751ff422aa0299aae009fe049c273"
 PATCHES="mesa-7.9.2.patchset"
 
-ARCHITECTURES="x86_gcc2 !x86"
-SECONDARY_ARCHITECTURES="?x86_gcc2"
+ARCHITECTURES="!all x86_gcc2"
+SECONDARY_ARCHITECTURES=""
 
 PROVIDES="
 	mesa$secondaryArchSuffix = $portVersion compat >= 7.9

--- a/sys-libs/mesa/patches/mesa-7.9.2.patchset
+++ b/sys-libs/mesa/patches/mesa-7.9.2.patchset
@@ -1,4 +1,4 @@
-From b3cfd34c382a4350625597bd5b75a1a18a05c382 Mon Sep 17 00:00:00 2001
+From 5e3b5432121d517e40281f4723a4723599cd1066 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@gmail.com>
 Date: Fri, 7 Nov 2014 09:42:21 +0100
 Subject: libGL: link against libbe
@@ -20,10 +20,10 @@ index 9d7d301..8195813 100644
  		$(GL_LIB_DEPS) $(GLAPI_LIB) $(OBJECTS) $(GLU_LIB)
  
 -- 
-2.52.0
+2.54.0
 
 
-From 856529a763dee7678467b83083da6a73eabf344b Mon Sep 17 00:00:00 2001
+From 7bce7f6b66952671f03dc0260cc424b23c2fdad7 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@gmail.com>
 Date: Tue, 31 Jan 2017 22:42:25 +0100
 Subject: Make compatible with bison 3.x.
@@ -5851,5 +5851,42 @@ index 041a49f..6a1ef0f 100644
  
  %union {
 -- 
-2.52.0
+2.54.0
+
+
+From 558d941c0b7a9301a937d74722a56ff5b1175a8d Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Fri, 24 Jul 2026 05:01:50 -0300
+Subject: Older 32-bits CPUs might not have 3DNow nor SSE.
+
+Haiku targets i586 + MMX as minimum, so lets give older CPUs a chance
+to run some GL too (even if slowly), by default.
+
+More optimized packages could be made available, if really needed,
+for those CPUs having SSE, but too old for 64 bits.
+
+Motivation for this change:
+https://github.com/haikuports/haikuports/issues/13234
+
+diff --git a/configs/haiku b/configs/haiku
+index 223f7ca..e5236ea 100644
+--- a/configs/haiku
++++ b/configs/haiku
+@@ -14,9 +14,12 @@ DEFINES = \
+ 	-DGNU_ASSEMBLER \
+ 	-DUSE_X86_ASM \
+ 	-DUSE_MMX_ASM \
+-	-DUSE_3DNOW_ASM \
+-	-DUSE_SSE_ASM \
+ 	-DPTHREADS
++# Disable these, so a wider range of 32-bits-only CPUs can be supported.
++# (Haiku's minimal config is i586 + MMX)
++#	-DUSE_3DNOW_ASM \
++#	-DUSE_SSE_ASM \
++
+ #	-DBEOS_THREADS
+  
+ MESA_ASM_SOURCES = $(X86_SOURCES)
+-- 
+2.54.0
 


### PR DESCRIPTION
Tested on 32 bits, but VM on a "modern" CPU, so... this actually needs testing on older 32-bits-only machines.

I see a slow down in GLTeapot, both with only one teapot, and when adding as many as necessary to hit a stable 60 FPS, but the difference is not *that* big here (will certainly be more impactful the slower the CPU, assuming it also had the proper 3DNow/SSE instructions before)... but the point of the change is allowing usage by older CPUs anyway, so not that much of a concern, I think.

----

@Peppersawce, whenever you can... could you try this on your eeePc and see if it helps solve your #13234 for you? (if not, I guess it might require a 32-bits version of Haiku made to build using *this* revision of the packages).

(It could be that some SDL packages might also need similar "nerfing" for 32 bits only too, or the actual lzdoom/gzdoom apps, we'll see, I guess.)