### PR TITLE
libsdl2: disable SSE3 for x86-32 builds.

### DIFF
--- a/media-libs/libsdl2/libsdl2-2.32.10.recipe
+++ b/media-libs/libsdl2/libsdl2-2.32.10.recipe
@@ -6,7 +6,7 @@ software, emulators, and popular games."
 HOMEPAGE="https://www.libsdl.org/"
 COPYRIGHT="1997-2025 Sam Lantinga"
 LICENSE="Zlib"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://www.libsdl.org/release/SDL2-$portVersion.tar.gz"
 CHECKSUM_SHA256="5f5993c530f084535c65a6879e9b26ad441169b3e25d789d83287040a9ca5165"
 PATCHES="libsdl2-$portVersion.patchset"
@@ -51,9 +51,15 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
+	maybeDisableOptimizations=
+	if [ $targetArchitecture == x86_gcc2 ]; then
+		maybeDisableOptimizations="-DSDL_SSE3=OFF"
+	fi
+
 	cmake . -Bbuild -GNinja $cmakeDirArgs \
 		-DSDL_STATIC=OFF -DSDL_RPATH=OFF \
-		-DCMAKE_BUILD_TYPE=Release
+		-DCMAKE_BUILD_TYPE=Release \
+		$maybeDisableOptimizations
 	ninja -C build
 }
 


### PR DESCRIPTION
This should help avoid "illegal instruction" errors on older CPUs. See #13234.

The range of *32-bits only* CPUs with SSE3 is rather narrow on the Intel side (earlier Prescott Pentium 4s and Celeron Ds), and non-existent on the AMD side (where SSE3 got introduced in Athlon 64s).

So most CPUs with SSE3 support are also 64 bits capable, and should be using Haiku x86_64 instead.

----

Builds tested on both x86_64 and x86_32.

----

@Peppersawce, if this works for you (or at least improves the situation), I'll merge. Thanks!