### PR TITLE
libxslt: bump to version 1.1.45, switch to python 3.14, cleanup

### DIFF
--- a/dev-libs/libxslt/libxslt-1.1.45.recipe
+++ b/dev-libs/libxslt/libxslt-1.1.45.recipe
@@ -8,17 +8,21 @@ in commercial applications."
 HOMEPAGE="http://www.xmlsoft.org/"
 COPYRIGHT="2001-2012 Daniel Veillard"
 LICENSE="MIT"
-REVISION="3"
+REVISION="1"
 SOURCE_URI="https://download.gnome.org/sources/libxslt/1.1/libxslt-$portVersion.tar.xz"
-CHECKSUM_SHA256="5a3d6b383ca5afc235b171118e90f5ff6aa27e9fea3303065231a6d403f0183a"
+CHECKSUM_SHA256="9acfe68419c4d06a45c550321b3212762d92f41465062ca4ea19e632ee5d216e"
+PATCHES="libxslt-$portVersion.patchset"
 
 ARCHITECTURES="all"
 SECONDARY_ARCHITECTURES="x86"
 
 libVersion="$portVersion"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
-libexsltVersion="0.8.24"
+libexsltVersion="0.8.25"
 libexsltVersionCompat="$libexsltVersion compat >= ${libexsltVersion%%.*}"
+
+pythonVersion="3.14"
+pythonPackage="python${pythonVersion//.}"
 
 PROVIDES="
 	libxslt$secondaryArchSuffix = $portVersion
@@ -28,7 +32,6 @@ PROVIDES="
 REQUIRES="
 	haiku${secondaryArchSuffix}
 	lib:libxml2$secondaryArchSuffix
-	lib:libz$secondaryArchSuffix
 	"
 
 PROVIDES_tools="
@@ -41,12 +44,19 @@ REQUIRES_tools="
 	"
 
 if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
-	PROVIDES_python310="
-		libxslt${secondaryArchSuffix}_python310 = $portVersion
-		"
-	REQUIRES_python310="
+	eval "PACKAGE_NAME_$pythonPackage=\"libxslt${secondaryArchSuffix}_python$pythonVersion\""
+	eval "PROVIDES_$pythonPackage=\"
+		libxslt${secondaryArchSuffix}_python$pythonVersion = $portVersion
+		\""
+	if [ "$targetArchitecture" == x86_gcc2 ]; then
+		eval "PROVIDES_$pythonPackage+=\"
+			libxslt_python$pythonVersion = $portVersion
+			\""
+	fi
+	eval "REQUIRES_$pythonPackage=\"
 		libxslt$secondaryArchSuffix == $portVersion
-		"
+		libxml2${secondaryArchSuffix}_python$pythonVersion
+		\""
 fi
 
 PROVIDES_devel="
@@ -63,7 +73,6 @@ REQUIRES_devel="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libxml2$secondaryArchSuffix
-	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:aclocal
@@ -78,7 +87,14 @@ BUILD_PREREQUIRES="
 	"
 if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
 	BUILD_PREREQUIRES+="
-		cmd:python3.10
+		cmd:python$pythonVersion
+		"
+fi
+
+# Tests require libxml2_python if the python module is built.
+if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+	TEST_REQUIRES="
+		libxml2${secondaryArchSuffix}_python$pythonVersion
 		"
 fi
 
@@ -109,9 +125,9 @@ INSTALL()
 
 	rm $libDir/libexslt.la $libDir/libxslt.la
 
-if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
-	rm $prefix/lib/python3.10/vendor-packages/libxsltmod.la
-fi
+	if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+		rm $prefix/lib/python$pythonVersion/vendor-packages/libxsltmod.la
+	fi
 
 	prepareInstalledDevelLibs \
 		libxslt \
@@ -122,10 +138,10 @@ fi
 		$binDir/xsltproc \
 		$manDir/man1
 
-if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
-		packageEntries python310 \
-			$prefix/lib/python3.10
-fi
+	if [ "$effectiveTargetArchitecture" != x86_gcc2 ]; then
+		packageEntries $pythonPackage \
+			$prefix/lib/python$pythonVersion
+	fi
 
 	packageEntries devel \
 		$binDir \
@@ -138,5 +154,6 @@ fi
 
 TEST()
 {
+	export LIBRARY_PATH=$sourceDir/libxslt/.libs:$sourceDir/libexslt/.libs:$sourceDir/python/.libs:$LIBRARY_PATH
 	make check
 }

--- a/dev-libs/libxslt/patches/libxslt-1.1.45.patchset
+++ b/dev-libs/libxslt/patches/libxslt-1.1.45.patchset
@@ -1,0 +1,30 @@
+From ed0708612d8c9c9e53e47c02fc70192f8baf4435 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joachim=20Mairb=C3=B6ck?= <j.mairboeck@gmail.com>
+Date: Sat, 25 Jul 2026 16:28:03 +0200
+Subject: gcc2 build fix for tests
+
+
+diff --git a/tests/fuzz/fuzz.c b/tests/fuzz/fuzz.c
+index 5e6afe7..50aca66 100644
+--- a/tests/fuzz/fuzz.c
++++ b/tests/fuzz/fuzz.c
+@@ -125,6 +125,7 @@ xsltFuzzXPath(const char *data, size_t size) {
+     xmlNodePtr root;
+     const char *xpathExpr, *xml;
+     size_t maxAllocs, xmlSize;
++    xmlXPathCompExprPtr compExpr;
+ 
+     xmlFuzzDataInit(data, size);
+ 
+@@ -192,7 +193,7 @@ xsltFuzzXPath(const char *data, size_t size) {
+             xmlXPathEval(BAD_CAST "//node() | /*/*/namespace::*", xpctxt));
+ 
+     /* Compile and return early if the expression is invalid */
+-    xmlXPathCompExprPtr compExpr = xmlXPathCtxtCompile(xpctxt,
++    compExpr = xmlXPathCtxtCompile(xpctxt,
+             (const xmlChar *) xpathExpr);
+     if (compExpr == NULL)
+         goto error;
+-- 
+2.54.0
+


### PR DESCRIPTION
I used this (randomly) to test haikuports/haikuporter#388 and found that lib:libz (zlib) isn't actually used, so remove it accordingly.

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine: still works on all 3 x86 flavors.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
