### PR TITLE
lxml: minor cleanup to trigger build on 32 bits (after lxml2 changes).

### DIFF
--- a/dev-python/lxml/lxml-5.3.0.recipe
+++ b/dev-python/lxml/lxml-5.3.0.recipe
@@ -89,21 +89,15 @@ done
 
 TEST_REQUIRES="
 	cmd:make
-	cmd:python3
+	cmd:python$pythonVersion
 	"
 
 INSTALL()
 {
-	for i in "${!PYTHON_VERSIONS[@]}"; do
-		pythonVersion=${PYTHON_VERSIONS[$i]}
+	for pythonVersion in ${PYTHON_VERSIONS[@]}; do
 		pythonPackage=python${pythonVersion//.}
 
 		python=python$pythonVersion
-		installLocation=$prefix/lib/$python/vendor-packages/
-		export PYTHONPATH=$installLocation
-
-		mkdir -p "$installLocation"
-		rm -rf build
 
 		$python setup.py build install \
 			--root=/ --prefix="$prefix" --without-cython
@@ -119,10 +113,10 @@ INSTALL()
 }
 
 
-# For reference, on beta4, 32 bits, with Python 3.10:
-#Ran 1965 tests in 74.267s
-#FAILED (failures=2, errors=2)
+# For reference, on beta6, 32 bits, with Python 3.14:
+#Ran 1944 tests in 45.968s
+#FAILED (failures=9, errors=7)
 TEST()
 {
-	make test3
+	make test
 }


### PR DESCRIPTION
Not doing a rev-bump, because the build for REVISION=5 failed on the x86_32 builder, but went OK on the x86_64 one.