### PR TITLE
libgsf, bump to version 1.14.58

### DIFF
--- a/gnome-extra/libgsf/libgsf-1.14.58.recipe
+++ b/gnome-extra/libgsf/libgsf-1.14.58.recipe
@@ -4,11 +4,11 @@ dealing with different structured file formats."
 HOMEPAGE="https://github.com/GNOME/libgsf"
 COPYRIGHT="2002-2020 Jody Goldberg"
 LICENSE="GNU LGPL v2.1"
-REVISION="4"
-SOURCE_URI="https://github.com/GNOME/libgsf/archive/LIBGSF_1_14_47.tar.gz"
-CHECKSUM_SHA256="ca958db8b91113804e1c8ec772adb7cb3e44f81d404cf941330d47f3e25ccbe7"
+REVISION="1"
+SOURCE_URI="https://github.com/GNOME/libgsf/archive/LIBGSF_${portVersion//./_}.tar.gz"
+CHECKSUM_SHA256="b83a6fe67ad72cfbc28fb1eb9531e9f521fc274d75fd2c9f0fc6af0298b587e5"
 SOURCE_FILENAME="libgsf-$portVersion.tar.gz"
-SOURCE_DIR="libgsf-LIBGSF_1_14_47"
+SOURCE_DIR="libgsf-LIBGSF_${portVersion//./_}"
 PATCHES="libgsf-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -21,7 +21,7 @@ if [ "$targetArchitecture" = x86_gcc2 ]; then
 	commandBinDir=$prefix/bin
 fi
 
-libVersion="114.0.47"
+libVersion="114.0.58"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="

--- a/gnome-extra/libgsf/patches/libgsf-1.14.58.patchset
+++ b/gnome-extra/libgsf/patches/libgsf-1.14.58.patchset
@@ -1,20 +1,20 @@
-From 7170c8479657f53f95322003bc31f6b21bfe0b73 Mon Sep 17 00:00:00 2001
+From ae5cfd8cdcfe5cecab35581dac1b6e153016c78f Mon Sep 17 00:00:00 2001
 From: Luc Schrijvers <begasus@gmail.com>
 Date: Thu, 23 Jul 2026 13:10:32 +0200
 Subject: Disable warnings turning into errors
 
 
 diff --git a/configure.ac b/configure.ac
-index 3a1faf9..d2ee718 100644
+index 05fcec5..561bac8 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -202,8 +202,7 @@ if test "$GCC" = yes -a "x$set_more_warnings" != xno; then
+@@ -205,8 +205,7 @@ if test "$GCC" = yes -a "x$set_more_warnings" != xno; then
  			 -Wchar-subscripts -Wwrite-strings \
- 			 -Wdeclaration-after-statement -Wnested-externs \
+ 			 -Wnested-externs \
  			 -Wmissing-noreturn \
 -			 -Werror=missing-prototypes -Werror=nested-externs \
 -			 -Werror=implicit-function-declaration \
-+			 -Werror=missing-prototypes \
++                        -Werror=missing-prototypes \
  			 -Wmissing-declarations -Wno-pointer-sign \
  			 -Werror=format-security -Wbitwise -Wcast-to-as \
  			 -Wdefault-bitfield-sign -Wdo-while -Wparen-string \


### PR DESCRIPTION
fixes abiword

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
