### PR TITLE
abiword, revbump for libxml2

### DIFF
--- a/app-office/abiword/abiword-3.0.7.recipe
+++ b/app-office/abiword/abiword-3.0.7.recipe
@@ -9,7 +9,7 @@ friends, and performs format conversions on the fly."
 HOMEPAGE="http://www.abisource.com/"
 COPYRIGHT="1998-2025 the AbiSource community"
 LICENSE="GNU GPL v2"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://gitlab.gnome.org/World/AbiWord/-/archive/release-$portVersion/AbiWord-release-$portVersion.tar.bz2"
 CHECKSUM_SHA256="19099c5cc6022efba50cebf0f081a21afdb5358256b4ea9b51c735968132f362"
 SOURCE_DIR="AbiWord-release-$portVersion"
@@ -30,7 +30,6 @@ REQUIRES="
 	lib:libatk_1.0$secondaryArchSuffix
 	lib:libcairo$secondaryArchSuffix
 	lib:libenchant_2$secondaryArchSuffix
-	lib:libexpat$secondaryArchSuffix
 	lib:libfribidi$secondaryArchSuffix
 	lib:libfreetype$secondaryArchSuffix
 	lib:libfontconfig$secondaryArchSuffix
@@ -45,7 +44,6 @@ REQUIRES="
 	lib:libgtk_3$secondaryArchSuffix
 	lib:libharfbuzz$secondaryArchSuffix
 	lib:libical$secondaryArchSuffix
-	lib:libiconv$secondaryArchSuffix
 	lib:libintl$secondaryArchSuffix
 	lib:libjpeg$secondaryArchSuffix
 	lib:libpango_1.0$secondaryArchSuffix

--- a/app-office/abiword/abiword-3.0.7.recipe
+++ b/app-office/abiword/abiword-3.0.7.recipe
@@ -9,7 +9,7 @@ friends, and performs format conversions on the fly."
 HOMEPAGE="http://www.abisource.com/"
 COPYRIGHT="1998-2025 the AbiSource community"
 LICENSE="GNU GPL v2"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://gitlab.gnome.org/World/AbiWord/-/archive/release-$portVersion/AbiWord-release-$portVersion.tar.bz2"
 CHECKSUM_SHA256="19099c5cc6022efba50cebf0f081a21afdb5358256b4ea9b51c735968132f362"
 SOURCE_DIR="AbiWord-release-$portVersion"
@@ -62,8 +62,9 @@ REQUIRES="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	gsettings_desktop_schemas$secondaryArchSuffix
-	devel:libboost_system$secondaryArchSuffix >= 1.88.0
+	devel:libboost_filesystem$secondaryArchSuffix >= 1.90.0
 	devel:libenchant_2$secondaryArchSuffix
+	devel:libdav1d$secondaryArchSuffix
 	devel:libexpat$secondaryArchSuffix
 	devel:libfribidi$secondaryArchSuffix
 	devel:libfreetype$secondaryArchSuffix


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
