### PR TITLE
libcmis, revbump both versions for libxml2

### DIFF
--- a/dev-cpp/libcmis/libcmis-0.5.2.recipe
+++ b/dev-cpp/libcmis/libcmis-0.5.2.recipe
@@ -7,7 +7,7 @@ COPYRIGHT="2011-2014 Cedric Bosdonnat, SUSE
 LICENSE="GNU LGPL v2
 	GNU GPL v2
 	MPL v1.1"
-REVISION="9"
+REVISION="10"
 SOURCE_URI="https://github.com/tdf/libcmis/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="07ff0baaac717a4702ef7c9c22dddb7d55d8b639ea526a765f947f2b683ef36a"
 PATCHES="libcmis-$portVersion.patchset"
@@ -25,12 +25,8 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libboost_date_time$secondaryArchSuffix
 	lib:libboost_program_options$secondaryArchSuffix
-	lib:libcrypto$secondaryArchSuffix
 	lib:libcurl$secondaryArchSuffix
-	lib:libiconv$secondaryArchSuffix
-	lib:libssl$secondaryArchSuffix
 	lib:libxml2$secondaryArchSuffix
-	lib:libz$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
@@ -46,12 +42,8 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libboost_date_time$secondaryArchSuffix >= 1.83.0
 	devel:libboost_program_options$secondaryArchSuffix >= 1.83.0
-	devel:libcrypto$secondaryArchSuffix >= 3
 	devel:libcurl$secondaryArchSuffix
-	devel:libiconv$secondaryArchSuffix
-	devel:libssl$secondaryArchSuffix >= 3
 	devel:libxml2$secondaryArchSuffix
-	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:autoconf
@@ -66,7 +58,8 @@ BUILD()
 	autoreconf -fi
 	runConfigure ./configure --without-man --disable-tests \
 		--disable-static \
-		--disable-werror
+		--disable-werror \
+		--with-boost=$(finddir B_SYSTEM_HEADERS_DIRECTORY)/${secondaryArchSubDir}
 	make $jobArgs
 }
 

--- a/dev-cpp/libcmis/libcmis0.6-0.6.2.recipe
+++ b/dev-cpp/libcmis/libcmis0.6-0.6.2.recipe
@@ -7,7 +7,7 @@ COPYRIGHT="2011-2014 Cedric Bosdonnat, SUSE
 LICENSE="GNU LGPL v2
 	GNU GPL v2
 	MPL v1.1"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/tdf/libcmis/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="ebf7933d93b9d5d6da7b757c89c03b131abd95550864bb98d2a60536593ddeb5"
 SOURCE_DIR="libcmis-$portVersion"
@@ -25,12 +25,8 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libboost_date_time$secondaryArchSuffix
 	lib:libboost_program_options$secondaryArchSuffix
-	lib:libcrypto$secondaryArchSuffix
 	lib:libcurl$secondaryArchSuffix
-	lib:libiconv$secondaryArchSuffix
-	lib:libssl$secondaryArchSuffix
 	lib:libxml2$secondaryArchSuffix
-	lib:libz$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
@@ -46,12 +42,8 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libboost_date_time$secondaryArchSuffix >= 1.83.0
 	devel:libboost_program_options$secondaryArchSuffix >= 1.83.0
-	devel:libcrypto$secondaryArchSuffix >= 3
 	devel:libcurl$secondaryArchSuffix
-	devel:libiconv$secondaryArchSuffix
-	devel:libssl$secondaryArchSuffix >= 3
 	devel:libxml2$secondaryArchSuffix
-	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:autoconf
@@ -66,7 +58,8 @@ BUILD()
 	autoreconf -fi
 	runConfigure ./configure --without-man --disable-tests \
 		--disable-static \
-		--disable-werror
+		--disable-werror \
+		--with-boost=$(finddir B_SYSTEM_HEADERS_DIRECTORY)/${secondaryArchSubDir}
 	make $jobArgs
 }
 


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
