### PR TITLE
liblangtag, revbump for libxml2, fix build

### DIFF
--- a/app-text/liblangtag/liblangtag-0.6.3.recipe
+++ b/app-text/liblangtag/liblangtag-0.6.3.recipe
@@ -3,13 +3,12 @@ DESCRIPTION="liblangtag is an interface library to access/deal with tags for \
 identifying languages, which is described in RFC 5646."
 HOMEPAGE="http://tagoh.bitbucket.org/liblangtag"
 COPYRIGHT="Akira Tagoh"
-LICENSE="
-	GNU LGPL v3
-	MPL v2.0
-	"
-REVISION="2"
+LICENSE="GNU LGPL v3
+	MPL v2.0"
+REVISION="3"
 SOURCE_URI="https://bitbucket.org/tagoh/liblangtag/downloads/liblangtag-$portVersion.tar.bz2"
 CHECKSUM_SHA256="1f12a20a02ec3a8d22e54dedb8b683a43c9c160bda1ba337bf1060607ae733bd"
+PATCHES="liblangtag-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -21,7 +20,6 @@ PROVIDES="
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libxml2$secondaryArchSuffix
-	lib:libz$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
@@ -38,6 +36,7 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	cmd:awk
+	cmd:cmp
 	cmd:g++$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
 	cmd:make
@@ -51,7 +50,9 @@ PATCH()
 
 BUILD()
 {
-	runConfigure ./configure --enable-introspection=no --disable-modules
+	runConfigure ./configure \
+		--enable-introspection=no \
+		--disable-modules
 	make $jobArgs
 }
 
@@ -59,9 +60,11 @@ INSTALL()
 {
 	make install
 
+	# remove libtool file
 	rm $libDir/liblangtag.la
 
-	prepareInstalledDevelLibs liblangtag
+	prepareInstalledDevelLibs \
+		liblangtag
 	fixPkgconfig
 
 	packageEntries devel $developDir

--- a/app-text/liblangtag/patches/liblangtag-0.6.3.patchset
+++ b/app-text/liblangtag/patches/liblangtag-0.6.3.patchset
@@ -1,0 +1,45 @@
+From 3fc29f0aa7afdf001e2d1c1103e885183a50e300 Mon Sep 17 00:00:00 2001
+From: Luc Schrijvers <begasus@gmail.com>
+Date: Sun, 26 Jul 2026 17:02:14 +0200
+Subject: add missing stdlib.h
+
+
+diff --git a/extensions/lt-ext-ldml-t.c b/extensions/lt-ext-ldml-t.c
+index 4b58718..c361ebe 100644
+--- a/extensions/lt-ext-ldml-t.c
++++ b/extensions/lt-ext-ldml-t.c
+@@ -25,6 +25,7 @@
+ #include "lt-tag.h"
+ #include "lt-utils.h"
+ #include "lt-xml.h"
++#include <stdlib.h>
+ 
+ 
+ typedef enum _lt_ext_ldml_t_state_t {
+diff --git a/extensions/lt-ext-ldml-u.c b/extensions/lt-ext-ldml-u.c
+index bd63ee9..880985e 100644
+--- a/extensions/lt-ext-ldml-u.c
++++ b/extensions/lt-ext-ldml-u.c
+@@ -25,6 +25,7 @@
+ #include "lt-string.h"
+ #include "lt-utils.h"
+ #include "lt-xml.h"
++#include <stdlib.h>
+ 
+ 
+ typedef enum _lt_ext_ldml_u_state_t {
+diff --git a/liblangtag/lt-tag.c b/liblangtag/lt-tag.c
+index 84f504c..d308e9a 100644
+--- a/liblangtag/lt-tag.c
++++ b/liblangtag/lt-tag.c
+@@ -33,6 +33,7 @@
+ #include "lt-xml.h"
+ #include "lt-tag.h"
+ #include "lt-tag-private.h"
++#include <stdlib.h>
+ 
+ 
+ /**
+-- 
+2.54.0
+


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
