### PR TITLE
xmlsec, bump to version 1.2.42 (libxml2 fixes)

### DIFF
--- a/dev-libs/xmlsec/xmlsec-1.2.42.recipe
+++ b/dev-libs/xmlsec/xmlsec-1.2.42.recipe
@@ -8,9 +8,9 @@ The library supports major XML security standards:
 HOMEPAGE="https://www.aleksey.com/xmlsec/"
 COPYRIGHT="2002-2021 Aleksey Sanin"
 LICENSE="MIT"
-REVISION="4"
+REVISION="1"
 SOURCE_URI="https://www.aleksey.com/xmlsec/download/older-releases/xmlsec1-$portVersion.tar.gz"
-CHECKSUM_SHA256="5f8dfbcb6d1e56bddd0b5ec2e00a3d0ca5342a9f57c24dffde5c796b2be2871c"
+CHECKSUM_SHA256="5359e3c19016ab164b505c1222ef5a2d87b34f50f85ff91d765f4aaa0df42db2"
 SOURCE_DIR="xmlsec1-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -38,7 +38,6 @@ REQUIRES="
 	lib:libltdl$secondaryArchSuffix
 	lib:libxml2$secondaryArchSuffix
 	lib:libxslt$secondaryArchSuffix
-	lib:libz$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
@@ -71,7 +70,6 @@ REQUIRES_nss="
 	lib:libsmime3$secondaryArchSuffix
 	lib:libxml2$secondaryArchSuffix
 	lib:libxslt$secondaryArchSuffix
-	lib:libz$secondaryArchSuffix
 	"
 
 PROVIDES_gcrypt="
@@ -82,10 +80,8 @@ REQUIRES_gcrypt="
 	haiku$secondaryArchSuffix
 	xmlsec$secondaryArchSuffix == $portVersion base
 	lib:libgcrypt$secondaryArchSuffix
-	lib:libgpg_error$secondaryArchSuffix
 	lib:libxml2$secondaryArchSuffix
 	lib:libxslt$secondaryArchSuffix
-	lib:libz$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
