### PR TITLE
xmlroff, revbump for libxml2

### DIFF
--- a/app-text/xmlroff/xmlroff-0.6.3.recipe
+++ b/app-text/xmlroff/xmlroff-0.6.3.recipe
@@ -7,7 +7,7 @@ COPYRIGHT="2001-2002 Sun Microsystems
 	2007-2010 Meneith Consulting
 	2011-2012 Mentea"
 LICENSE="BSD (3-clause)"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://github.com/xmlroff/xmlroff/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="ef8386da3cd2fb12ac0d59899e3017b5ab2bebe8df23a94dbe95191724c3bc8f"
 PATCHES="xmlroff-$portVersion.patchset"


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
