### PR TITLE
tuxtype2, revbump for libxml2

### DIFF
--- a/games-kids/tuxtype/tuxtype2-1.8.3.recipe
+++ b/games-kids/tuxtype/tuxtype2-1.8.3.recipe
@@ -6,7 +6,7 @@ HOMEPAGE="https://www.tux4kids.com/tuxtyping.html"
 COPYRIGHT="2000-2014 Sam Hart, Jesse D. Andrews
 	2014 David Bruce"
 LICENSE="GNU GPL v2"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://github.com/tux4kids/tuxtype/archive/refs/tags/upstream/$portVersion.tar.gz"
 CHECKSUM_SHA256="c1abea756ad8fa1e9217f9dea63e7de5fe536022c6984dc438c65d9a1afb92bb"
 SOURCE_DIR="tuxtype-upstream-$portVersion"
@@ -51,11 +51,12 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	cmd:aclocal
 	cmd:autoconf
+	cmd:autopoint
 	cmd:awk
 	cmd:bison
 	cmd:find
 	cmd:gcc$secondaryArchSuffix
-	cmd:ld$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
 	"


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
