### PR TITLE
warmux, revbump for libxml2, build fixes

### DIFF
--- a/games-strategy/warmux/warmux-11.0.4~git.recipe
+++ b/games-strategy/warmux/warmux-11.0.4~git.recipe
@@ -13,7 +13,7 @@ member of each team attemps to produce a maximum of damage to his opponents."
 HOMEPAGE="https://github.com/a-team/wormux"
 COPYRIGHT="2001-2011 Warmux Team"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 srcGitRev="e0dc503460055a14a0d7fd94e66d7484264ee62b"
 SOURCE_URI="$HOMEPAGE/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="d5e66808de2e4912a64b583e3be4b8ea52cd220b8617a113507cca2c2291c6d3"
@@ -21,7 +21,7 @@ SOURCE_FILENAME="warmux-$srcGitRev.tar.gz"
 SOURCE_DIR="wormux-$srcGitRev"
 PATCHES="warmux-$portVersion.patch"
 
-ARCHITECTURES="all !x86_gcc2 ?x86"
+ARCHITECTURES="all !x86_gcc2"
 commandBinDir=$binDir
 if [ "$targetArchitecture" = x86_gcc2 ]; then
 SECONDARY_ARCHITECTURES="x86"
@@ -35,6 +35,7 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	lib:libcurl$secondaryArchSuffix
 	lib:libfribidi$secondaryArchSuffix
 	lib:libintl$secondaryArchSuffix
 	lib:libpng16$secondaryArchSuffix
@@ -49,6 +50,7 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	devel:libcurl$secondaryArchSuffix
 	devel:libintl$secondaryArchSuffix
 	devel:libfribidi$secondaryArchSuffix
 	devel:libpng16$secondaryArchSuffix
@@ -65,6 +67,7 @@ BUILD_PREREQUIRES="
 	cmd:find
 	cmd:gcc$secondaryArchSuffix
 	cmd:make
+	cmd:msgfmt$secondaryArchSuffix
 	cmd:pkg_config$secondaryArchSuffix
 	"
 


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
