### PR TITLE
armagetronad, bump to version 0.2.9.3.0, fixes build for new libxml2

### DIFF
--- a/games-action/armagetronad/armagetronad-0.2.9.3.0.recipe
+++ b/games-action/armagetronad/armagetronad-0.2.9.3.0.recipe
@@ -8,9 +8,9 @@ well."
 HOMEPAGE="http://www.armagetronad.org/"
 COPYRIGHT="2007-2021 OSS Armagetronad Team"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://launchpad.net/armagetronad/0.2.9/$portVersion/+download/armagetronad-$portVersion.tbz"
-CHECKSUM_SHA256="59b6c7c01ce3f8cca5437e33f974a637529541a11aa4f52c1a5c17499e26f6a1"
+CHECKSUM_SHA256="9e0d27048ecfc963c8b07dc31177040561f221ca37e80af832b946b6e0a23fe0"
 PATCHES="armagetronad-$portVersion.patchset"
 ADDITIONAL_FILES="armagetronad.rdef.in"
 
@@ -63,6 +63,7 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	devel:libcurl$secondaryArchSuffix
 	devel:libGL$secondaryArchSuffix
 	devel:libGLU$secondaryArchSuffix
 	devel:libjpeg$secondaryArchSuffix

--- a/games-action/armagetronad/patches/armagetronad-0.2.9.3.0.patchset
+++ b/games-action/armagetronad/patches/armagetronad-0.2.9.3.0.patchset
@@ -1,11 +1,11 @@
-From d9aacb37055de77c7a1d10cc9874caec4b59d1f7 Mon Sep 17 00:00:00 2001
+From c81cc7f7df4e59b13b763e11e124226dc1cfd99e Mon Sep 17 00:00:00 2001
 From: Sergei Reznikov <diver@gelios.net>
 Date: Fri, 23 Nov 2018 15:17:26 +0300
 Subject: Add missing include
 
 
 diff --git a/src/network/nSocket.cpp b/src/network/nSocket.cpp
-index d80f908..cad1c6e 100644
+index d173a3d..39a24e0 100644
 --- a/src/network/nSocket.cpp
 +++ b/src/network/nSocket.cpp
 @@ -45,7 +45,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
@@ -18,20 +18,20 @@ index d80f908..cad1c6e 100644
  #include <arpa/inet.h> 
  #include <netinet/in_systm.h>
 -- 
-2.30.2
+2.54.0
 
 
-From ecca5b573275ae093f7ba7823d254b2dcc86d9e1 Mon Sep 17 00:00:00 2001
+From f6fad23cbce9a3f9bc26f0e4c8ce9e0eb0c2a8b4 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Tue, 19 May 2020 21:03:46 +1000
 Subject: Fix build
 
 
 diff --git a/src/network/nSocket.cpp b/src/network/nSocket.cpp
-index cad1c6e..72862c8 100644
+index 39a24e0..daa4bbc 100644
 --- a/src/network/nSocket.cpp
 +++ b/src/network/nSocket.cpp
-@@ -2155,7 +2155,7 @@ int nSocket::Write( const int8 * buf, int len, const nAddress & addr ) const
+@@ -2174,7 +2174,7 @@ int nSocket::Write( const int8 * buf, int len, const nAddress & addr ) const
  //!
  // *******************************************************************************************
  
@@ -66,20 +66,20 @@ index 5d3dbb4..0c6b3f5 100644
      nAddress const &   GetAddress( void )                  const   ;	//!< Gets the address the socket is bound to
      nSocket const &    GetAddress( nAddress & address )    const   ;	//!< Gets the address the socket is bound to
 -- 
-2.30.2
+2.54.0
 
 
-From 2505997d76d19e6a28f67a6f7c619b90d5f68e8f Mon Sep 17 00:00:00 2001
+From f64829d2a324dc26a12418e957b19949b67c8695 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Wed, 20 May 2020 08:44:37 +1000
 Subject: Fix argv[0] for launch from symlink
 
 
 diff --git a/src/tron/gArmagetron.cpp b/src/tron/gArmagetron.cpp
-index 34949f5..56c8f2a 100644
+index 800a48a..482a6d7 100644
 --- a/src/tron/gArmagetron.cpp
 +++ b/src/tron/gArmagetron.cpp
-@@ -607,7 +607,11 @@ tConfItem<tString> sn_configurationSavedInVersionConf("SAVED_IN_VERSION",sn_conf
+@@ -620,7 +620,11 @@ struct SDLSoundCleanup
  int main(int argc,char **argv){
      //std::cout << "enter\n";
      //  net_test();
@@ -93,73 +93,73 @@ index 34949f5..56c8f2a 100644
  
      //  std::cout << "Running " << argv[0] << "...\n";
 -- 
-2.30.2
+2.54.0
 
 
-From 240055e845167e96f23c2ebc6cded3700ce8cf9b Mon Sep 17 00:00:00 2001
+From b392e7dea8ea64220f18a1d24bddbfa6910e3cb3 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Mon, 27 Sep 2021 11:09:57 +1000
 Subject: SOCK_CLOEXEC and IPTOS_LOWDELAY not supported
 
 
 diff --git a/src/network/nSocket.cpp b/src/network/nSocket.cpp
-index 72862c8..46d3cd4 100644
+index daa4bbc..29a18a0 100644
 --- a/src/network/nSocket.cpp
 +++ b/src/network/nSocket.cpp
-@@ -1518,7 +1518,7 @@ int nSocket::Create( void )
-     sn_InitOSNetworking();
- 
+@@ -1522,8 +1522,10 @@ int nSocket::Create( void )
      int socktype = socktype_;
--#ifndef WIN32
-+#if !defined(WIN32) && !defined(__HAIKU__)
+ #ifndef WIN32
+ #ifndef MACOSX
++#ifndef __HAIKU__
      socktype |= SOCK_CLOEXEC;
  #endif
++#endif
+ #endif
  
-@@ -1529,7 +1529,7 @@ int nSocket::Create( void )
+     // open new socket
+@@ -1531,7 +1533,7 @@ int nSocket::Create( void )
+     if ( socket_ < 0 )
+         return -1;
  
-     // set TOS to low latency ( see manpages getsockopt(2), ip(7) and socket(7) )
-     // maybe this works for Windows, too?
 -#ifndef WIN32
 +#if !defined(WIN32) && !defined(__HAIKU__)
-     char tos = IPTOS_LOWDELAY;
- 
-     setsockopt( socket_, IPPROTO_IP, IP_TOS, &tos, sizeof(char) );
+     // set TOS to low latency ( see manpages getsockopt(2), ip(7) and socket(7) )
+     // maybe this works for Windows, too? Docs say "Do not use" :(
+     // https://learn.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
 -- 
-2.30.2
+2.54.0
 
 
-From d8dd93a242fbd76f2b08ce425ad68712c771b302 Mon Sep 17 00:00:00 2001
+From 05e86f92b9be864fba4777352791eb4e5d211ac0 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Mon, 27 Sep 2021 12:13:07 +1000
 Subject: Fix crash on exit
 
 
 diff --git a/src/tron/gArmagetron.cpp b/src/tron/gArmagetron.cpp
-index 56c8f2a..fb48580 100644
+index 482a6d7..1709380 100644
 --- a/src/tron/gArmagetron.cpp
 +++ b/src/tron/gArmagetron.cpp
-@@ -788,7 +788,7 @@ int main(int argc,char **argv){
+@@ -811,7 +811,7 @@ int main(int argc,char **argv){
                  SDL_Init(SDL_INIT_VIDEO) < 0 )            {
                  tERR_ERROR("Couldn't initialize SDL: " << SDL_GetError());
              }
--            atexit(SDL_Quit);
-+            //atexit(SDL_Quit);
+-            SDLCleanup sdlCleanup; // call SDL_Quit later
++            //SDLCleanup sdlCleanup; // call SDL_Quit later
  
              sr_glRendererInit();
  
-@@ -864,10 +864,10 @@ int main(int argc,char **argv){
+@@ -891,8 +891,9 @@ int main(int argc,char **argv){
                  //std::cout << "saved\n";
  
                  //    cleanup(grid);
 -                SDL_QuitSubSystem(SDL_INIT_VIDEO);
 +                //SDL_QuitSubSystem(SDL_INIT_VIDEO);
              }
-             se_SoundExit();
--            SDL_Quit();
 +            SDL_QuitSubSystem(SDL_INIT_AUDIO);
  #else
              sr_glOut=0;
  
 -- 
-2.30.2
+2.54.0
 


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
