### PR TITLE
flickcurl, revbump for new libxml2, cleanup

### DIFF
--- a/media-libs/flickcurl/flickcurl-1.26.recipe
+++ b/media-libs/flickcurl/flickcurl-1.26.recipe
@@ -13,7 +13,7 @@ HOMEPAGE="https://librdf.org/flickcurl/"
 COPYRIGHT="2007-2014 David Beckett
 	2007 Vanilla I. Shu"
 LICENSE="GNU LGPL v2.1"
-REVISION="9"
+REVISION="10"
 SOURCE_URI="http://download.dajobe.org/flickcurl/flickcurl-$portVersion.tar.gz"
 CHECKSUM_SHA256="ff42a36c7c1c7d368246f6bc9b7d792ed298348e5f0f5d432e49f6803562f5a3"
 PATCHES="flickcurl-$portVersion.patchset"
@@ -32,11 +32,8 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libcrypto$secondaryArchSuffix # required by libcurl
 	lib:libcurl$secondaryArchSuffix
-	lib:libssl$secondaryArchSuffix # required by libcurl
 	lib:libxml2$secondaryArchSuffix
-	lib:libz$secondaryArchSuffix # required by libcurl and libxml2
 	"
 
 PROVIDES_devel="


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
