### PR TITLE
cd: fix up recipe so it builds on beta6.

### DIFF
--- a/x11-libs/cd/cd-5.12.recipe
+++ b/x11-libs/cd/cd-5.12.recipe
@@ -8,7 +8,7 @@ surface, such as Image, Clipboard, Metafile, PS, and so on."
 HOMEPAGE="http://www.tecgraf.puc-rio.br/cd/"
 COPYRIGHT="1994-2019 Tecgraf, PUC-Rio."
 LICENSE="MIT"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://sourceforge.net/projects/canvasdraw/files/$portVersion/Docs%20and%20Sources/cd-${portVersion}_Sources.zip" # They have a tar.gz but the permissions are broken inside it (will create unreadable files)
 CHECKSUM_SHA256="288fe4decd2100b2d5fad8ba4081837b492c2ce380e86dcfcd5a4c9ee1458e60"
 SOURCE_DIR="cd"
@@ -40,7 +40,6 @@ REQUIRES="
 	lib:libGLU$secondaryArchSuffix
 	lib:libim$secondaryArchSuffix
 	lib:libpng16$secondaryArchSuffix
-	lib:libxml2$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
 
@@ -65,14 +64,11 @@ REQUIRES_devel="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libfontconfig$secondaryArchSuffix
-	devel:libfreetype$secondaryArchSuffix
 	devel:libftgl$secondaryArchSuffix
 	devel:libgl$secondaryArchSuffix
 	devel:libglu$secondaryArchSuffix
-	devel:libiconv$secondaryArchSuffix
 	devel:libim$secondaryArchSuffix
 	devel:liblua$secondaryArchSuffix
-	devel:libxml2$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
@@ -85,9 +81,7 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
-	cd src
-	make LINK_FREETYPE=Yes LINK_ZLIB=Yes
-	cd ..
+	make -C src LINK_FREETYPE=Yes LINK_ZLIB=Yes
 }
 
 INSTALL()
@@ -96,9 +90,11 @@ INSTALL()
 	mkdir -p $libDir
 	mkdir -p $includeDir
 
-	cp lib/Haiku11/Lua51/* $libDir
-	rm -rf lib/Haiku11/Lua51
-	cp -r lib/Haiku11/* $libDir
+	tmpDir=$(uname -s)
+
+	cp lib/$tmpDir/Lua51/* $libDir
+	rm -rf lib/$tmpDir/Lua51
+	cp -r lib/$tmpDir/* $libDir
 	rm -f $libDir/*.a
 
 	cp include/* $includeDir
@@ -112,24 +108,26 @@ INSTALL()
 
 TEST()
 {
+	tmpDir=$(uname -s)
+
 	export PKG_CONFIG_PATH=`finddir B_SYSTEM_DEVELOP_DIRECTORY`/lib$secondaryArchSubDir/pkgconfig
 
 	# Make sure the tests can link against the built libs
-	mkdir -p bin/Haiku11
-	ln -sf ../../lib/Haiku11 bin/Haiku11/lib
+	mkdir -p bin/$tmpDir
+	ln -sf ../../lib/$tmpDir bin/$tmpDir/lib
 
 	cd test
 
 	make -f ../tecmake.mak MF=metafile
-	../bin/Haiku11/metafile
+	../bin/$tmpDir/metafile
 
 	# needs IUP
 	#make -f ../tecmake.mak MF=screencapture
-	#../bin/Haiku11/screencapture
+	#../bin/$tmpDir/screencapture
 
 	# needs IUP
 	#pushd cdtest
 	#make -f ../../tecmake.mak
 	#popd
-	#../bin/Haiku11/cdtest
+	#../bin/$tmpDir/cdtest
 }

--- a/x11-libs/cd/patches/cd-5.12.patchset
+++ b/x11-libs/cd/patches/cd-5.12.patchset
@@ -1,4 +1,4 @@
-From 0b0590688b815e88cb019d4b807519f689024534 Mon Sep 17 00:00:00 2001
+From c1e709f67670b138acc10a5f1d7bc69100c33c7f Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Thu, 21 Feb 2019 16:46:08 +0100
 Subject: gcc2 fixes
@@ -24,10 +24,10 @@ index 80d38f1..b5b5759 100644
      return 0;
    close(fd);
 -- 
-2.19.1
+2.54.0
 
 
-From b7443a55907fdd203c44938dcdc98c31de2c7ba0 Mon Sep 17 00:00:00 2001
+From e1ac75af6efd07314d56feea5a562bdf0ced5f73 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Thu, 21 Feb 2019 16:49:26 +0100
 Subject: Do not link xrender on Haiku
@@ -78,16 +78,15 @@ index ee08381..f8a62e4 100644
  endif
  
 -- 
-2.19.1
+2.54.0
 
 
-From 8c677268d4272342681450c25996093d70acf1d0 Mon Sep 17 00:00:00 2001
+From 21b9300bbc2f64459fc6aa2c72068f29552c28ee Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Thu, 21 Feb 2019 16:51:58 +0100
 Subject: Use iconv on Haiku
 
 The fallback is glib, which we prefer to avoid.
-
 
 diff --git a/src/config.mak b/src/config.mak
 index f382141..7a29b8b 100644
@@ -102,10 +101,10 @@ index f382141..7a29b8b 100644
      LIBS += fontconfig
    else
 -- 
-2.19.1
+2.54.0
 
 
-From 696f47e419a7a92e528bbe2f2367773fcca0038f Mon Sep 17 00:00:00 2001
+From f33752c8fb5895b4adc46b9125646b26a036bfde Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@pulkomandy.tk>
 Date: Thu, 21 Feb 2019 16:56:04 +0100
 Subject: Adjust search paths for Haiku
@@ -153,5 +152,78 @@ index 524b7ec..a599c3d 100644
  
    LUA_BIN ?= $(LUA)/bin/$(TEC_UNAME)
 -- 
-2.19.1
+2.54.0
+
+
+From f7fe86226655c833743e475cc4a5a6621b23f350 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Mon, 27 Jul 2026 04:34:30 -0300
+Subject: Quick and dirty attempt at fixing the build.
+
+Error was:
+
+error: invalid application of 'sizeof' to incomplete type 'FILE'
+
+diff --git a/src/pdflib/pdflib/p_document.c b/src/pdflib/pdflib/p_document.c
+index 5e5e0f7..7f43004 100644
+--- a/src/pdflib/pdflib/p_document.c
++++ b/src/pdflib/pdflib/p_document.c
+@@ -1411,7 +1411,8 @@ pdf__begin_document(PDF *p, const char *filename, int len, const char *optlist)
+ #endif
+ 
+         doc->fp = fp;
+-        doc->len = sizeof(FILE);
++        //doc->len = sizeof(FILE); // this is pretty invalid code.
++        doc->len = 0; // let's hope for the best...
+     }
+     else if (filename && (*filename || len > 0))
+     {
+-- 
+2.54.0
+
+
+From 8c42d754c1d1a71307001d9bf6c87ff44460ffc1 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Mon, 27 Jul 2026 05:03:40 -0300
+Subject: Tweak things a bit so TEC_UNAME becomes shorter.
+
+Before changes in Haiku's uname, this was giving "Haiku11",
+before *this* change, it was giving:
+
+"HaikuR1~beta6+developmentR1~beta6+development"
+
+As that variable is used for the name of directories during the build,
+let's use something less crazy :-D
+
+diff --git a/tec_uname b/tec_uname
+index 2d2b6a9..adbff79 100644
+--- a/tec_uname
++++ b/tec_uname
+@@ -16,6 +16,11 @@ ComputeTecUname()
+   TEC_SYSARCH=`uname -m`
+ 
+   # Fixes
++  if [ $TEC_SYSNAME == Haiku ]; then
++    TEC_SYSVERSION=`uname -r | cut -d~ -f1`
++    TEC_SYSMINOR=
++  fi
++
+   if [ $TEC_SYSNAME == SunOS ]; then
+     TEC_SYSARCH=`uname -p`
+   fi
+diff --git a/tecmake.mak b/tecmake.mak
+index a599c3d..315dcce 100644
+--- a/tecmake.mak
++++ b/tecmake.mak
+@@ -28,6 +28,8 @@ ifndef TEC_UNAME
+   # Fixes
+   ifeq ($(TEC_SYSNAME), Haiku)
+     TEC_SYSARCH:=$(shell uname -p)
++    TEC_SYSVERSION:=$(uname -r | cut -d~ -f1)
++    TEC_SYSMINOR:=
+   endif
+   ifeq ($(TEC_SYSNAME), SunOS)
+     TEC_SYSARCH:=$(shell uname -p)
+-- 
+2.54.0
 


### PR DESCRIPTION
Dropped spurious libxml2 dependency (and a couple more at build time).

.patchset includes a questionable "fix", to questionable code that the compiler wasn't buying anymore.

Better patches welcomed. For now, this will do. Inpact will be low, as seemingly nothing on depot actually requires anything that this package provides.