### PR TITLE
liblxi, bump to version 1.22, build for new libxml2

### DIFF
--- a/sci-electronics/liblxi/liblxi-1.22.recipe
+++ b/sci-electronics/liblxi/liblxi-1.22.recipe
@@ -8,7 +8,7 @@ SOURCE_URI="https://github.com/lxi-tools/liblxi/releases/download/v$portVersion/
 CHECKSUM_SHA256="14d46cc60f38998bccb6d6cda020048340bb9e0bc0afabbd77ff89b6bb05ccdb"
 PATCHES="liblxi-$portVersion.patchset"
 
-# See #18007
+# See https://dev.haiku-os.org/ticket/18007
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 

--- a/sci-electronics/liblxi/liblxi-1.22.recipe
+++ b/sci-electronics/liblxi/liblxi-1.22.recipe
@@ -5,10 +5,11 @@ COPYRIGHT="Martin Lund"
 LICENSE="BSD (3-clause)"
 REVISION="2"
 SOURCE_URI="https://github.com/lxi-tools/liblxi/releases/download/v$portVersion/liblxi-$portVersion.tar.xz"
-CHECKSUM_SHA256="d24b4f5d3a909672e3df7b55d6dc2b03043b013ae25cfbf35cf079ac260b5297"
+CHECKSUM_SHA256="14d46cc60f38998bccb6d6cda020048340bb9e0bc0afabbd77ff89b6bb05ccdb"
+PATCHES="liblxi-$portVersion.patchset"
 
 # See #18007
-ARCHITECTURES="!all !x86_gcc2"
+ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 libVersion="1.0.0"
@@ -20,10 +21,9 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libtirpc$secondaryArchSuffix
-	lib:libxml2$secondaryArchSuffix
 #	lib:libavahi_common$secondaryArchSuffix
 #	lib:libavahi_client$secondaryArchSuffix
+	lib:libxml2$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
@@ -36,24 +36,28 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libtirpc$secondaryArchSuffix
-	devel:libxml2$secondaryArchSuffix
 #	devel:libavahi_common$secondaryArchSuffix
 #	devel:libavahi_client$secondaryArchSuffix
+	devel:libdns_sd$secondaryArchSuffix
+	devel:libtirpc$secondaryArchSuffix
+	devel:libxml2$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:cmake
+	cmd:g++$secondaryArchSuffix
 	cmd:meson
 	cmd:ninja
-	cmd:g++$secondaryArchSuffix
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
 BUILD()
 {
-	meson build \
-		--prefix="$prefix" --libdir="$libDir" --includedir="$includeDir" \
-		--bindir="$binDir" --mandir="$manDir" --buildtype=debugoptimized
+	meson  --buildtype=release build \
+		--prefix=$prefix \
+		--bindir=$binDir \
+		--libdir=$libDir \
+		--includedir=$includeDir \
+		--mandir=$manDir
 	ninja -C build
 }
 
@@ -61,7 +65,8 @@ INSTALL()
 {
 	ninja install -C build
 
-	prepareInstalledDevelLib liblxi
+	prepareInstalledDevelLib \
+		liblxi
 	fixPkgconfig
 
 	# devel package

--- a/sci-electronics/liblxi/patches/liblxi-1.22.patchset
+++ b/sci-electronics/liblxi/patches/liblxi-1.22.patchset
@@ -1,0 +1,21 @@
+From 7b7abc417e629a4c56b112c400c1e2e9e271c6d6 Mon Sep 17 00:00:00 2001
+From: Luc Schrijvers <begasus@gmail.com>
+Date: Mon, 27 Jul 2026 14:36:48 +0200
+Subject: Silence warnings
+
+
+diff --git a/src/bonjour.c b/src/bonjour.c
+index 14276a1..7017a6a 100644
+--- a/src/bonjour.c
++++ b/src/bonjour.c
+@@ -5,6 +5,7 @@
+ #include <netdb.h>
+ #include <sys/select.h>
+ #include "lxi.h"
++#include <stdlib.h>
+ 
+ typedef struct
+ {
+-- 
+2.54.0
+


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
