### PR TITLE
qtwebkit, revbump for new libxml2

### DIFF
--- a/dev-qt/qtwebkit/qtwebkit-5.212.0~pre20200924.recipe
+++ b/dev-qt/qtwebkit/qtwebkit-5.212.0~pre20200924.recipe
@@ -9,7 +9,7 @@ HOMEPAGE="https://www.qt.io"
 COPYRIGHT="2015-2020 The Qt Company Ltd."
 LICENSE="BSD (3-clause)
 	GNU LGPL v2.1"
-REVISION="5"
+REVISION="6"
 srcGitRev="ac8ebc6c3a56064f88f5506e5e3783ab7bee2456"
 SOURCE_URI="https://github.com/qt/qtwebkit/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="405b32de1ac1921759190ef68b7dcb7620c545d0055a84ea8e1ba7b86b3d6dc4"
@@ -29,16 +29,8 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libenchant_2$secondaryArchSuffix
-	lib:libfontconfig$secondaryArchSuffix
-	lib:libfreetype$secondaryArchSuffix
-	lib:libgcrypt$secondaryArchSuffix
-	lib:libgl$secondaryArchSuffix
-	lib:libglib_2.0$secondaryArchSuffix
-	lib:libglu$secondaryArchSuffix
 	lib:libgnutls$secondaryArchSuffix
 	lib:libhyphen$secondaryArchSuffix
-	lib:libicudata$secondaryArchSuffix
 	lib:libicui18n$secondaryArchSuffix
 	lib:libicuuc$secondaryArchSuffix
 	lib:libjpeg$secondaryArchSuffix
@@ -57,7 +49,6 @@ REQUIRES="
 	lib:libQt5Widgets$secondaryArchSuffix
 	lib:libsqlite3$secondaryArchSuffix
 	lib:libstdc++$secondaryArchSuffix
-	lib:libtasn1$secondaryArchSuffix
 	lib:libwebp$secondaryArchSuffix
 	lib:libxml2$secondaryArchSuffix
 	lib:libxslt$secondaryArchSuffix
@@ -178,7 +169,8 @@ BUILD()
 		-DUSE_GSTREAMER=OFF \
 		-DUSE_LIBHYPHEN=ON \
 		-DUSE_QT_MULTIMEDIA=ON \
-		-DUSE_SYSTEM_MALLOC=ON
+		-DUSE_SYSTEM_MALLOC=ON \
+		-DCMAKE_POLICY_VERSION_MINIMUM=3.5
 	make $jobArgs
 }
 
@@ -191,9 +183,10 @@ INSTALL()
 	mv -f $libDir/qml $dataDir/Qt5
 	mv -f $prefix/mkspecs $dataDir/Qt5
 
+	prepareInstalledDevelLibs \
+		libQt5WebKit \
+		libQt5WebKitWidgets
 	fixPkgconfig
-
-	prepareInstalledDevelLibs libQt5WebKit libQt5WebKitWidgets
 
 	cd $libDir
 	for i in lib*.so.5.*;do


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
