### PR TITLE
libreoffice, revbump 32bit version for new libxml2

### DIFF
--- a/app-office/libreoffice/libreoffice-6.4.7.2.recipe
+++ b/app-office/libreoffice/libreoffice-6.4.7.2.recipe
@@ -17,7 +17,7 @@ and Open Source office suite on the market:
 HOMEPAGE="https://www.libreoffice.org/"
 COPYRIGHT="2000-2020 LibreOffice contributors"
 LICENSE="MPL v2.0"
-REVISION="16"
+REVISION="17"
 
 SOURCE_URI="https://github.com/LibreOffice/core/archive/libreoffice-$portVersion.tar.gz"
 SOURCE_DIR="core-libreoffice-$portVersion"


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
