### PR TITLE
vcdimager, re-enable libxml2

### DIFF
--- a/media-video/vcdimager/patches/libxml214.diff
+++ b/media-video/vcdimager/patches/libxml214.diff
@@ -1,0 +1,37 @@
+diff -Nurp vcdimager-2.0.1/frontends/xml/vcd_xml_common.c vcdimager-2.0.1-libxml214/frontends/xml/vcd_xml_common.c
+--- vcdimager-2.0.1/frontends/xml/vcd_xml_common.c	2018-01-03 21:17:37.000000000 +0100
++++ vcdimager-2.0.1-libxml214/frontends/xml/vcd_xml_common.c	2025-04-26 05:22:03.008769534 +0200
+@@ -242,17 +242,27 @@ _convert (const char in[], const char en
+ 
+   temp = size - 1;
+   if (from) {
+-    if (NULL != handler->output)
+-      ret = handler->output (out, &out_size, (const unsigned char *) in, &temp);
+-    else
++    if (!(handler->flags & 2) && NULL != handler->output.func)
++      ret = handler->output.func (handler->outputCtxt, out, &out_size, (const unsigned char *) in, &temp, 1);
++    if ((handler->flags & 2) && NULL != handler->output.legacyFunc)
++      ret = handler->output.legacyFunc (out, &out_size, (const unsigned char *) in, &temp);
++    else {
++      xmlCharEncCloseFunc(handler);
+       return strdup(in);
++    }
+   } else {
+-    if (NULL != handler->input)
+-      ret = handler->input (out, &out_size, (const unsigned char *) in, &temp);
+-    else
++    if (!(handler->flags & 2) && NULL != handler->input.func)
++      ret = handler->input.func (handler->inputCtxt, out, &out_size, (const unsigned char *) in, &temp, 1);
++    if ((handler->flags & 2) && NULL != handler->input.legacyFunc)
++      ret = handler->input.legacyFunc (out, &out_size, (const unsigned char *) in, &temp);
++    else {
++      xmlCharEncCloseFunc(handler);
+       return strdup(in);
++    }
+   }
+ 
++  xmlCharEncCloseFunc(handler);
++
+   if (ret < 0 || (temp - size + 1))
+     {
+       free (out);

--- a/media-video/vcdimager/vcdimager-2.0.1.recipe
+++ b/media-video/vcdimager/vcdimager-2.0.1.recipe
@@ -22,9 +22,11 @@ COPYRIGHT="2000-2004 Herbert Valerio Riedel
 	2004-2011 Rocky Bernstein"
 LICENSE="GNU GPL v2"
 REVISION="7"
-SOURCE_URI="https://ftpmirror.gnu.org/vcdimager/vcdimager-$portVersion.tar.gz"
+SOURCE_URI="https://ftpmirror.gnu.org/vcdimager/vcdimager-$portVersion.tar.gz
+	https://ftp.gnu.org/pub/gnu/vcdimager/vcdimager-$portVersion.tar.gz"
 CHECKSUM_SHA256="67515fefb9829d054beae40f3e840309be60cda7d68753cafdd526727758f67a"
-PATCHES="vcdimager-$portVersion.patchset"
+PATCHES="vcdimager-$portVersion.patchset
+	libxml214.diff"
 
 ARCHITECTURES="all"
 SECONDARY_ARCHITECTURES="x86_gcc2 x86"
@@ -41,6 +43,10 @@ if [ -z "$secondaryArchSuffix" ]; then
 		cmd:cdxa2mpeg = $portVersion
 		cmd:vcd_info = $portVersion
 		cmd:vcdimager = $portVersion
+		cmd:vcdxbuild = $portVersion
+		cmd:vcdxgen = $portVersion
+		cmd:vcdxminfo = $portVersion
+		cmd:vcdxrip = $portVersion
 		"
 fi
 REQUIRES="
@@ -48,6 +54,7 @@ REQUIRES="
 	lib:libcdio$secondaryArchSuffix
 	lib:libiconv$secondaryArchSuffix
 	lib:libpopt$secondaryArchSuffix
+	lib:libxml2$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
@@ -63,6 +70,7 @@ BUILD_REQUIRES="
 	devel:libcdio$secondaryArchSuffix >= 19
 	devel:libiconv$secondaryArchSuffix
 	devel:libpopt$secondaryArchSuffix
+	devel:libxml2$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:aclocal
@@ -90,7 +98,7 @@ BUILD()
 	aclocal
 	autoreconf -vfi
 
-	runConfigure ./configure --disable-static --without-xml-frontend
+	runConfigure ./configure --disable-static #--without-xml-frontend
 	make $jobArgs
 }
 


### PR DESCRIPTION
import patch from Arch Linux: https://gitlab.archlinux.org/archlinux/packaging/packages/vcdimager/-/blob/main/libxml214.diff?ref_type=heads

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
