### PR TITLE
gmime, bump to version 3.2.15

### DIFF
--- a/dev-libs/gmime/gmime-3.2.15.recipe
+++ b/dev-libs/gmime/gmime-3.2.15.recipe
@@ -13,7 +13,7 @@ COPYRIGHT="2000-2022 Jeffrey Stedfast"
 LICENSE="GNU LGPL v2.1"
 REVISION="1"
 SOURCE_URI="$HOMEPAGE/releases/download/$portVersion/gmime-$portVersion.tar.xz"
-CHECKSUM_SHA256="2e10a54d4821daf8b16c019ad5d567e0fb8e766f8ffe5fec3d4c6a37373d6406"
+CHECKSUM_SHA256="84cd2a481a27970ec39b5c95f72db026722904a2ccf3fdbd57b280cf2d02b5c4"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -88,7 +88,7 @@ INSTALL()
 
 	packageEntries devel \
 		$developDir \
-		$dataDir/gtk-doc
+		$dataDir/{gir-1.0,gtk-doc}
 }
 
 TEST()


### PR DESCRIPTION
needed for gpgme changes, required for balsa

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
