### PR TITLE
retroshare, trigger build on buildmasters

### DIFF
--- a/net-p2p/retroshare/retroshare-0.6.6.recipe
+++ b/net-p2p/retroshare/retroshare-0.6.6.recipe
@@ -142,9 +142,7 @@ REQUIRES="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	ffmpeg${secondaryArchSuffix}_devel
-#	devel:libavcodec$secondaryArchSuffix
-#	devel:libavformat$secondaryArchSuffix
-#	devel:libavutil$secondaryArchSuffix
+	opencv4.13${secondaryArchSuffix}_highgui_devel
 	devel:libbz2$secondaryArchSuffix
 	devel:libcrypto$secondaryArchSuffix >= 3
 	devel:libcurl$secondaryArchSuffix
@@ -152,7 +150,7 @@ BUILD_REQUIRES="
 	devel:libgpgme$secondaryArchSuffix
 	devel:libixml$secondaryArchSuffix
 	devel:libmicrohttpd$secondaryArchSuffix
-	devel:libopencv_core$secondaryArchSuffix
+	devel:libopencv_core$secondaryArchSuffix >= 4.13
 	devel:libQt5Core$secondaryArchSuffix
 	devel:libQt5Gui$secondaryArchSuffix
 	devel:libQt5Multimedia$secondaryArchSuffix
@@ -173,7 +171,7 @@ BUILD_REQUIRES="
 	"
 BUILD_PREREQUIRES="
 	cmd:awk
-	cmd:cmake
+	cmd:cmake >= 3
 	cmd:gcc$secondaryArchSuffix
 	cmd:ld$secondaryArchSuffix
 	cmd:make


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
