### PR TITLE
handbrake, add missing requirement for the 32bit build

### DIFF
--- a/media-video/handbrake/handbrake-1.5.1.recipe
+++ b/media-video/handbrake/handbrake-1.5.1.recipe
@@ -71,6 +71,7 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	ffmpeg${secondaryArchSuffix}_devel
 	gcc${secondaryArchSuffix}_syslibs_devel
+	devel:libappstream_glib$secondaryArchSuffix
 	devel:libass$secondaryArchSuffix
 #	devel:libavcodec$secondaryArchSuffix >= 58
 #	devel:libavformat$secondaryArchSuffix >= 58


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
