### PR TITLE
kitinerary_kf6, add missing dependency for qdoc6

### DIFF
--- a/kde-apps/kitinerary/kitinerary_kf6-26.04.0.recipe
+++ b/kde-apps/kitinerary/kitinerary_kf6-26.04.0.recipe
@@ -5,7 +5,7 @@ provides that in a machine-readable way."
 HOMEPAGE="https://invent.kde.org/pim/kitinerary"
 COPYRIGHT="2010-2026 KDE Organisation"
 LICENSE="GNU LGPL v2.1"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://download.kde.org/stable/release-service/$portVersion/src/kitinerary-$portVersion.tar.xz"
 CHECKSUM_SHA256="75a310debea448774265e312a71b5f3043d4e52d6f6f88a75aa4740bf3446f05"
 SOURCE_DIR="kitinerary-$portVersion"
@@ -104,6 +104,7 @@ BUILD_PREREQUIRES="
 	cmd:msgmerge$secondaryArchSuffix
 	cmd:osmconvert
 	cmd:pkg_config$secondaryArchSuffix
+	cmd:qdoc6$secondaryArchSuffix
 	"
 
 BUILD()


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
