### PR TITLE
librsvg_bin, add _bin package for 32bit

### DIFF
--- a/gnome-base/librsvg/librsvg_bin-2.58.5.recipe
+++ b/gnome-base/librsvg/librsvg_bin-2.58.5.recipe
@@ -1,0 +1,109 @@
+SUMMARY="A library to render SVG files using cairo"
+DESCRIPTION="libRSVG is a a high performance SVG rendering library associated \
+with the Gnome Project."
+HOMEPAGE="https://wiki.gnome.org/Projects/LibRsvg"
+COPYRIGHT="2009-2010 Raph Levien"
+LICENSE="GNU GPL v2
+	GNU LGPL v2"
+REVISION="1"
+SOURCE_URI="https://github.com/Begasus/librsvg_haiku/archive/refs/tags/librsvg_bin-$portVersion.tar.gz"
+CHECKSUM_SHA256="5e3b9e8a1201907dbe28bf5213f3b601f1a19acae7f3c0d8bd25bea989fe8df0"
+SOURCE_DIR="librsvg_haiku-librsvg_bin-$portVersion"
+
+ADDITIONAL_FILES="update_loaders_cache.sh"
+
+ARCHITECTURES="!all"
+SECONDARY_ARCHITECTURES="x86"
+
+POST_INSTALL_SCRIPTS="
+	$relativePostInstallDir/update_loaders_cache.sh
+	"
+
+commandSuffix=$secondaryArchSuffix
+commandBinDir=$binDir
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	commandSuffix=
+	commandBinDir=$prefix/bin
+fi
+
+libVersion="2.50.0"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	librsvg_bin$secondaryArchSuffix = $portVersion
+	cmd:rsvg_convert$commandSuffix = $portVersion
+	lib:librsvg_2$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libcairo$secondaryArchSuffix
+	lib:libdav1d$secondaryArchSuffix
+	lib:libcroco_0.6$secondaryArchSuffix
+	lib:libfontconfig$secondaryArchSuffix
+	lib:libfreetype$secondaryArchSuffix
+	lib:libfribidi$secondaryArchSuffix
+	lib:libgdk_pixbuf_2.0$secondaryArchSuffix
+	lib:libgio_2.0$secondaryArchSuffix
+	lib:libglib_2.0$secondaryArchSuffix
+	lib:libharfbuzz$secondaryArchSuffix
+	lib:libintl$secondaryArchSuffix
+	lib:libpango_1.0$secondaryArchSuffix
+	lib:libpng16$secondaryArchSuffix
+	lib:libuuid$secondaryArchSuffix
+	lib:libxml2$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+CONFLICTS="
+	librsvg$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	librsvg_bin${secondaryArchSuffix}_devel = $portVersion
+	devel:librsvg_2$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	librsvg_bin$secondaryArchSuffix == $portVersion base
+	devel:libcairo$secondaryArchSuffix
+	devel:libdav1d$secondaryArchSuffix
+	devel:libffi$secondaryArchSuffix
+	devel:libfontconfig$secondaryArchSuffix
+	devel:libfreetype$secondaryArchSuffix
+	devel:libgdk_pixbuf_2.0$secondaryArchSuffix
+	devel:libglib_2.0$secondaryArchSuffix
+	devel:libgraphite2$secondaryArchSuffix
+	devel:libharfbuzz$secondaryArchSuffix
+	devel:libpcre$secondaryArchSuffix
+	devel:libpixman_1$secondaryArchSuffix
+	devel:libpng16$secondaryArchSuffix
+	devel:libxml2$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+BUILD_PREREQUIRES="
+	cmd:gzip
+	cmd:tar
+	"
+
+INSTALL()
+{
+	mkdir -p $prefix
+
+	package extract -C $prefix librsvg_x86-2.58.5-1-x86_gcc2.hpkg
+	package extract -C $prefix librsvg_x86_devel-2.58.5-1-x86_gcc2.hpkg
+
+	sed -i -e "s|librsvg_x86|librsvg_bin_x86|" $developLibDir/pkgconfig/librsvg-2.0.pc
+
+	packageEntries devel \
+		$developDir \
+		$dataDir/gir-1.0
+}
+
+TEST()
+{
+	export CARGO_HOME=$sourceDir/cargo
+	cargo test --release --frozen
+}


### PR DESCRIPTION
buildmasters keep failing, so for now use this

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
