### PR TITLE
goffice, revbump for new libxml2

### DIFF
--- a/x11-libs/goffice/goffice-0.10.60.recipe
+++ b/x11-libs/goffice/goffice-0.10.60.recipe
@@ -8,7 +8,7 @@ COPYRIGHT="Jody Goldberg
 	Jean Brefort
 	Andreas J. Guelzow"
 LICENSE="GNU GPL v3"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://gitlab.gnome.org/GNOME/goffice/-/archive/GOFFICE_${portVersion//./_}/goffice-GOFFICE_${portVersion//./_}.tar.bz2"
 CHECKSUM_SHA256="241e467d74c3eabcaa6d8f61ed4a0821b947ee103a13389bb6e7603e9281a91c"
 SOURCE_DIR="goffice-GOFFICE_${portVersion//./_}"


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
