### PR TITLE
gnumeric, revbump for new libxml2

### DIFF
--- a/app-office/gnumeric/gnumeric-1.12.60.recipe
+++ b/app-office/gnumeric/gnumeric-1.12.60.recipe
@@ -10,7 +10,7 @@ COPYRIGHT="Morten Welinder
 	Andreas J. Guelzow
 	Jean Brefort"
 LICENSE="GNU GPL v3"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="http://ftp.gnome.org/pub/GNOME/sources/gnumeric/${portVersion%.*}/gnumeric-$portVersion.tar.xz"
 CHECKSUM_SHA256="bb02feb286062805564438534e1fea459f97cebac8a090b1a7e47ca251e07467"
 PATCHES="gnumeric-$portVersion.patchset


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
