### PR TITLE
openscad, add missing glu_devel in BUILD_REQUIRES

### DIFF
--- a/media-gfx/openscad/openscad-2021.01.recipe
+++ b/media-gfx/openscad/openscad-2021.01.recipe
@@ -80,6 +80,7 @@ BUILD_REQUIRES="
 	devel:libfreetype$secondaryArchSuffix
 	devel:libglib_2.0$secondaryArchSuffix
 	devel:libglew$secondaryArchSuffix
+	devel:libGLU$secondaryArchSuffix
 	devel:libgmp$secondaryArchSuffix
 	devel:libharfbuzz$secondaryArchSuffix
 	devel:libmpfr$secondaryArchSuffix >= 6


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
