### PR TITLE
exiv2, revbump, add missing requirement for REQUIRES_devel

### DIFF
--- a/media-gfx/exiv2/exiv2-0.28.8.recipe
+++ b/media-gfx/exiv2/exiv2-0.28.8.recipe
@@ -7,7 +7,7 @@ COPYRIGHT="2004-2025 Exiv2 authors
 	2004-2013 Andreas Huggel
 	2009 Brad Schick"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/Exiv2/exiv2/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="ea51b0609f58a9afa063b60daa1539948b62247721e154f4fff0ad3aec9f9756"
 PATCHES="exiv2-$portVersion.patchset"
@@ -50,6 +50,7 @@ PROVIDES_devel="
 REQUIRES_devel="
 	exiv2$secondaryArchSuffix == $portVersion base
 	devel:libbrotlidec$secondaryArchSuffix
+	devel:libcurl$secondaryArchSuffix
 	devel:libexpat$secondaryArchSuffix
 	devel:libinih$secondaryArchSuffix
 	"


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
