### PR TITLE
libreoffice, add liborcus to build dependency

### DIFF
--- a/app-office/libreoffice/libreoffice-6.4.7.2.recipe
+++ b/app-office/libreoffice/libreoffice-6.4.7.2.recipe
@@ -109,6 +109,7 @@ REQUIRES="
 	lib:libnssutil3$secondaryArchSuffix
 	lib:libnumbertext_1.0$secondaryArchSuffix
 	lib:libodfgen_0.1$secondaryArchSuffix
+	lib:liborcus_0.18$secondaryArchSuffix
 	lib:libpagemaker_0.0$secondaryArchSuffix
 	lib:libplc4$secondaryArchSuffix
 	lib:libplds4$secondaryArchSuffix
@@ -217,6 +218,7 @@ BUILD_REQUIRES="
 	devel:libnss3$secondaryArchSuffix
 	devel:libnumbertext_1.0$secondaryArchSuffix
 	devel:libodfgen_0.1$secondaryArchSuffix
+	devel:liborcus_0.18$secondaryArchSuffix
 	devel:libpagemaker_0.0$secondaryArchSuffix
 #	devel:libqrcodegen$secondaryArchSuffix
 	devel:libQt5Core$secondaryArchSuffix


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
