### PR TITLE
clamav: bump to version 1.5.3

### DIFF
--- a/app-antivirus/clamav/clamav-1.5.3.recipe
+++ b/app-antivirus/clamav/clamav-1.5.3.recipe
@@ -3,13 +3,11 @@ DESCRIPTION="ClamAV is an open source antivirus engine for detecting  \
 trojans, viruses, malware & other malicious threats."
 HOMEPAGE="https://www.clamav.net"
 COPYRIGHT="2001-2007 Tomasz Kojm
-	2007-2023 Cisco Systems"
-PACKAGER="Luca D'Amico <damico.luca91@live.it>"
+	2007-2025 Cisco Systems"
 LICENSE="GNU GPL v2"
-REVISION="3"
-SOURCE_URI="https://github.com/Cisco-Talos/clamav/archive/refs/tags/clamav-$portVersion.tar.gz"
-CHECKSUM_SHA256="94cd2c7992b6ae69b09951a857777619ec14451b0ae7bb0fc914c8fb26f4d408"
-SOURCE_DIR="clamav-clamav-$portVersion"
+REVISION="1"
+SOURCE_URI="https://www.clamav.net/downloads/production/clamav-$portVersion.tar.gz"
+CHECKSUM_SHA256="89af57a45bbf13de4dc91ed7f20b435388c88428eb7dc30639a02b2f0fc2dad1"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"


### PR DESCRIPTION
Switch to the download tarball, which already contains all rust crates and allows building offline.

When submitting changes to Haikuports, please check the following:

- [X] You are not a robot.
- [ ] The modified recipe was confirmed to build on your Haiku machine.
  - rustc crashes on my machine building `tinystr` and `zerotrie` ...
- [X] The license and copyright information in modified recipes are correct.
- [X] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [X] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
