### PR TITLE
kirigami_addons_kf6, bump to version 1.13.0

### DIFF
--- a/dev-libs/kirigami_addons/kirigami_addons_kf6-1.13.0.recipe
+++ b/dev-libs/kirigami_addons/kirigami_addons_kf6-1.13.0.recipe
@@ -5,7 +5,7 @@ COPYRIGHT="2010-2026 KDE Organisation"
 LICENSE="GNU LGPL v2.1"
 REVISION="1"
 SOURCE_URI="https://download.kde.org/stable/kirigami-addons/kirigami-addons-$portVersion.tar.xz"
-CHECKSUM_SHA256="c543a493ce5875f405fb1c9ff6d531060ed082cc6d710e56d46ac42d164207bb"
+CHECKSUM_SHA256="0b9e83d533fbed2ac37233fe08178e0671db4272320548b90916d7d0685aa8d4"
 SOURCE_DIR="kirigami-addons-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -29,9 +29,9 @@ REQUIRES="
 	lib:libKF6ConfigCore$secondaryArchSuffix
 	lib:libKF6CoreAddons$secondaryArchSuffix
 	lib:libKF6Crash$secondaryArchSuffix
+	lib:libKF6GuiAddons$secondaryArchSuffix
 	lib:libKF6I18n$secondaryArchSuffix
 	lib:libKF6IconThemes$secondaryArchSuffix
-	lib:libKirigami$secondaryArchSuffix
 	# Qt6
 	lib:libQt6Core$secondaryArchSuffix
 	lib:libQt6Gui$secondaryArchSuffix
@@ -77,6 +77,7 @@ BUILD_PREREQUIRES="
 	cmd:msgfmt$secondaryArchSuffix
 	cmd:msgmerge$secondaryArchSuffix
 	cmd:pkg_config$secondaryArchSuffix
+	cmd:qdoc6$secondaryArchSuffix
 	"
 
 TEST_REQUIRES="


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
