### PR TITLE
ktextaddons_kf6, bump to version 2.1.2

### DIFF
--- a/dev-libs/ktextaddons/ktextaddons_kf6-2.1.2.recipe
+++ b/dev-libs/ktextaddons/ktextaddons_kf6-2.1.2.recipe
@@ -6,7 +6,7 @@ COPYRIGHT="2010-2026 KDE Organisation"
 LICENSE="GNU LGPL v2"
 REVISION="1"
 SOURCE_URI="https://download.kde.org/stable/ktextaddons/ktextaddons-${portVersion}.tar.xz"
-CHECKSUM_SHA256="0d7f82a976ef682f45822b221e2f15cefc0039488bc8c700a6b0e7594aaebdea"
+CHECKSUM_SHA256="f3b4448904f1656d6d7cd5a557d22fe1c50624eb32ed369f34726beff9ce0589"
 SOURCE_DIR="ktextaddons-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -14,6 +14,8 @@ SECONDARY_ARCHITECTURES="x86"
 
 libVersion="$portVersion"
 libVersionCompat="$libVersion compat >= 1"
+
+pythonVersion="3.14"
 
 PROVIDES="
 	ktextaddons_kf6$secondaryArchSuffix = $portVersion
@@ -23,6 +25,8 @@ PROVIDES="
 	lib:libtextautogenerategenericnetwork$secondaryArchSuffix = $libVersionCompat
 	lib:libtextautogenerateollama$secondaryArchSuffix = $libVersionCompat
 	lib:libKF6TextAutoGenerateText$secondaryArchSuffix = $libVersionCompat
+	lib:libKF6TextAutoGenerateTextMcpProtocolCore$secondaryArchSuffix = $libVersionCompat
+	lib:libKF6TextAutoGenerateTextMcpProtocolWidgets$secondaryArchSuffix = $libVersionCompat
 	lib:libKF6TextCustomEditor$secondaryArchSuffix = $libVersionCompat
 	lib:libKF6TextEditTextToSpeech$secondaryArchSuffix = $libVersionCompat
 	lib:libKF6TextEmoticonsCore$secondaryArchSuffix = $libVersionCompat
@@ -31,9 +35,14 @@ PROVIDES="
 	lib:libKF6TextSpeechToText$secondaryArchSuffix = $libVersionCompat
 	lib:libKF6TextTranslator$secondaryArchSuffix = $libVersionCompat
 	lib:libKF6TextUtils$secondaryArchSuffix = $libVersionCompat
+	lib:libmcpprotocolclientplugin$secondaryArchSuffix
+	lib:libmcpprotocolserverplugin$secondaryArchSuffix
+	lib:libtextautogeneratellamacpp$secondaryArchSuffix = $libVersionCompat
+	lib:libtextautogeneratelmstudio$secondaryArchSuffix = $libVersionCompat
 	lib:libtextautogenerateollamacloud$secondaryArchSuffix = $libVersionCompat
 	lib:libtextautogenerateollamacommon$secondaryArchSuffix = $libVersionCompat
 	lib:libtextautogenerateollamaonline$secondaryArchSuffix = $libVersionCompat
+	lib:libtextautogenerateplugincommon$secondaryArchSuffix = $libVersionCompat
 	lib:libtextutils_cmark_rc_copy$secondaryArchSuffix = 0.31.0 compat >= 0
 	"
 REQUIRES="
@@ -42,14 +51,11 @@ REQUIRES="
 	lib:libopenal$secondaryArchSuffix
 	# KF 6
 	lib:libKF6Archive$secondaryArchSuffix
-	lib:libKF6AuthCore$secondaryArchSuffix
 	lib:libKF6Bookmarks$secondaryArchSuffix
-	lib:libKF6Codecs$secondaryArchSuffix
 	lib:libKF6ColorScheme$secondaryArchSuffix
 	lib:libKF6Completion$secondaryArchSuffix
 	lib:libKF6ConfigCore$secondaryArchSuffix
 	lib:libKF6ConfigGui$secondaryArchSuffix
-	lib:libKF6ConfigWidgets$secondaryArchSuffix
 	lib:libKF6CoreAddons$secondaryArchSuffix
 	lib:libKF6I18n$secondaryArchSuffix
 	lib:libKF6IconThemes$secondaryArchSuffix
@@ -64,8 +70,6 @@ REQUIRES="
 	lib:libKF6SyntaxHighlighting$secondaryArchSuffix
 	lib:libKF6TextWidgets$secondaryArchSuffix
 	lib:libKF6WidgetsAddons$secondaryArchSuffix
-	lib:libKF6WindowSystem$secondaryArchSuffix
-	lib:libKF6XmlGui$secondaryArchSuffix
 	# Qt6
 	lib:libQT6Core$secondaryArchSuffix
 	lib:libQT6Gui$secondaryArchSuffix
@@ -83,6 +87,8 @@ PROVIDES_devel="
 	devel:libtextautogenerategenericnetwork$secondaryArchSuffix = $libVersionCompat
 	devel:libtextautogenerateollama$secondaryArchSuffix = $libVersionCompat
 	devel:libKF6TextAutoGenerateText$secondaryArchSuffix = $libVersionCompat
+	devel:libKF6TextAutoGenerateTextMcpProtocolCore$secondaryArchSuffix = $libVersionCompat
+	devel:libKF6TextAutoGenerateTextMcpProtocolWidgets$secondaryArchSuffix = $libVersionCompat
 	devel:libKF6TextCustomEditor$secondaryArchSuffix = $libVersionCompat
 	devel:libKF6TextEditTextToSpeech$secondaryArchSuffix = $libVersionCompat
 	devel:libKF6TextEmoticonsCore$secondaryArchSuffix = $libVersionCompat
@@ -91,9 +97,14 @@ PROVIDES_devel="
 	devel:libKF6TextSpeechToText$secondaryArchSuffix = $libVersionCompat
 	devel:libKF6TextTranslator$secondaryArchSuffix = $libVersionCompat
 	devel:libKF6TextUtils$secondaryArchSuffix = $libVersionCompat
+	devel:libmcpprotocolclientplugin$secondaryArchSuffix
+	devel:libmcpprotocolserverplugin$secondaryArchSuffix
+	devel:libtextautogeneratellamacpp$secondaryArchSuffix = $libVersionCompat
+	devel:libtextautogeneratelmstudio$secondaryArchSuffix = $libVersionCompat
 	devel:libtextautogenerateollamacloud$secondaryArchSuffix = $libVersionCompat
 	devel:libtextautogenerateollamacommon$secondaryArchSuffix = $libVersionCompat
 	devel:libtextautogenerateollamaonline$secondaryArchSuffix = $libVersionCompat
+	devel:libtextautogenerateplugincommon$secondaryArchSuffix = $libVersionCompat
 	devel:libtextutils_cmark_rc_copy$secondaryArchSuffix = 0.31.0 compat >= 0
 	"
 REQUIRES_devel="
@@ -146,7 +157,8 @@ BUILD_PREREQUIRES="
 	cmd:make
 	cmd:msgfmt$secondaryArchSuffix
 	cmd:msgmerge$secondaryArchSuffix
-	cmd:python3
+	cmd:python$pythonVersion
+	cmd:qdoc6$secondaryArchSuffix
 	"
 
 TEST_REQUIRES="
@@ -156,7 +168,7 @@ TEST_REQUIRES="
 BUILD()
 {
 # only needed for local tests
-#	python3 -m ensurepip --default-pip
+#	python$pythonVersion -m ensurepip --default-pip
 #	pip3 install --user reuse
 	cmake -B build -S . -DCMAKE_BUILD_TYPE=Release \
 		$cmakeDirArgs \
@@ -177,6 +189,8 @@ INSTALL()
 		libtextautogenerategenericnetwork \
 		libtextautogenerateollama \
 		libKF6TextAutoGenerateText \
+		libKF6TextAutoGenerateTextMcpProtocolCore \
+		libKF6TextAutoGenerateTextMcpProtocolWidgets \
 		libKF6TextCustomEditor \
 		libKF6TextEditTextToSpeech \
 		libKF6TextEmoticonsCore \
@@ -185,9 +199,14 @@ INSTALL()
 		libKF6TextSpeechToText \
 		libKF6TextTranslator \
 		libKF6TextUtils \
+		libmcpprotocolclientplugin \
+		libmcpprotocolserverplugin \
+		libtextautogeneratellamacpp \
+		libtextautogeneratelmstudio \
 		libtextautogenerateollamacloud \
 		libtextautogenerateollamacommon \
 		libtextautogenerateollamaonline \
+		libtextautogenerateplugincommon \
 		libtextutils-cmark-rc-copy
 
 	packageEntries devel \
@@ -197,7 +216,7 @@ INSTALL()
 
 TEST()
 {
-	# 97% tests passed, 5 tests failed out of 192 (1 crash, 2 not run)
+	# 99% tests passed, 3 tests failed out of 301 (1 crash)
 	export LIBRARY_PATH="$sourceDir/build/bin${LIBRARY_PATH:+:$LIBRARY_PATH}"
 	ctest --test-dir build --output-on-failure
 }


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
