### PR TITLE
yt_dlp, build fix for external yt_dlp_ejs

### DIFF
--- a/net-misc/yt_dlp/patches/yt_dlp-2026.07.04.patchset
+++ b/net-misc/yt_dlp/patches/yt_dlp-2026.07.04.patchset
@@ -1,0 +1,26 @@
+From 539ba17db31516add91df16669e87156f66cab85 Mon Sep 17 00:00:00 2001
+From: Luc Schrijvers <begasus@gmail.com>
+Date: Mon, 3 Aug 2026 09:15:45 +0200
+Subject: disable pip
+
+
+diff --git a/Makefile b/Makefile
+index d5af60e..8c35fe7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -229,9 +229,9 @@ yt-dlp-extra: current-ejs-version .ejs-$(EJS_VERSION) $(EJS_PY_FILES) $(EJS_JS_F
+ 	rm -rf zip
+ 
+ .ejs-$(EJS_VERSION):
+-	@echo Downloading yt-dlp-ejs
+-	@echo "yt-dlp-ejs==$(EJS_VERSION) --hash $(EJS_WHEEL_HASH)" > .ejs-requirements.txt
+-	$(PYTHON) -m pip download -d ./build --no-deps --require-hashes -r .ejs-requirements.txt
++#	@echo Downloading yt-dlp-ejs
++#	@echo "yt-dlp-ejs==$(EJS_VERSION) --hash $(EJS_WHEEL_HASH)" > .ejs-requirements.txt
++#	$(PYTHON) -m pip download -d ./build --no-deps --require-hashes -r .ejs-requirements.txt
+ 	unzip -o build/$(EJS_WHEEL_NAME) "yt_dlp_ejs/*"
+ 	@touch .ejs-$(EJS_VERSION)
+ 
+-- 
+2.54.0
+

--- a/net-misc/yt_dlp/yt_dlp-2026.07.04.recipe
+++ b/net-misc/yt_dlp/yt_dlp-2026.07.04.recipe
@@ -25,10 +25,13 @@ REVISION="1"
 SOURCE_URI="https://github.com/yt-dlp/yt-dlp/releases/download/$portVersion/yt-dlp.tar.gz"
 SOURCE_FILENAME="yt-dlp-$portVersion.tar.gz"
 CHECKSUM_SHA256="31c32457d1a573a341bb0929386c624fe47339a5338829e6e9c9454bdfa7397a"
-# This is needed if we need/want to avoid re-building the zimport/standalone yt-dlp:
-# SOURCE_URI_2="https://github.com/yt-dlp/yt-dlp/releases/download/$portVersion/yt-dlp#noarchive"
-# CHECKSUM_SHA256_2="aed043cabf6b352dfd5438afff595e31532538d5af7c8f4f95ced1e6f1b35c2a"
+PATCHES="yt_dlp-$portVersion.patchset"
 SOURCE_DIR="yt-dlp"
+SOURCE_URI_2="https://github.com/yt-dlp/ejs/releases/download/0.8.0/yt_dlp_ejs-0.8.0-py3-none-any.whl#noarchive"
+CHECKSUM_SHA256_2="79300e5fca7f937a1eeede11f0456862c1b41107ce1d726871e0207424f4bdb4"
+# This is needed if we need/want to avoid re-building the zimport/standalone yt-dlp:
+# SOURCE_URI_3="https://github.com/yt-dlp/yt-dlp/releases/download/$portVersion/yt-dlp#noarchive"
+# CHECKSUM_SHA256_3="aed043cabf6b352dfd5438afff595e31532538d5af7c8f4f95ced1e6f1b35c2a"
 
 ARCHITECTURES="any"
 
@@ -98,14 +101,11 @@ TEST_REQUIRES="
 	pytest_$pythonPackage
 	"
 
-PATCH()
-{
-	# not strictly required, but speeds up repeated builds a bit.
-	sed -i -e 's|-m pip |-m pip --disable-pip-version-check |' Makefile
-}
-
 BUILD()
 {
+	mkdir -p build
+	cp $sourceDir2/*.whl build
+
 	# Build the .whl we'll use to install the Python module.
 	python$pythonVersion -m build --wheel --skip-dependency-check --no-isolation
 
@@ -114,8 +114,7 @@ BUILD()
 	# contains the "ejs" code).
 
 	# Method 1: rebuild yt-dlp from release tarball code.
-	# (needs pip to download ejs code, but it *does* enforces known hashes).
-	python$pythonVersion -m ensurepip --default-pip
+	# (SOURCE_URI_2 provides the required "yt_dlp_ejs" wheel, to avoid having to rely on pip to get it)
 	make yt-dlp-extra PREFIX="$prefix" MANDIR="$manDir" SHAREDIR="$dataDir" \
 		PYTHON="python$pythonVersion" BINDIR="$binDir"
 


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
