### PR TITLE
postgresql18, revbump, fix build for 32bit

### DIFF
--- a/dev-db/postgresql/patches/postgresql18-18.4.patchset
+++ b/dev-db/postgresql/patches/postgresql18-18.4.patchset
@@ -1,4 +1,4 @@
-From 23ed4ebb19ecfd5563defe34da3e8f4116498a1b Mon Sep 17 00:00:00 2001
+From 6f6eae15ed8d9c4cea230bc30530052390df243a Mon Sep 17 00:00:00 2001
 From: Augustin Cavalier <waddlesplash@gmail.com>
 Date: Thu, 3 Oct 2019 17:36:43 +0000
 Subject: Changes to make Postgresql run on Haiku.
@@ -63,7 +63,7 @@ index 8b1b357..e93241d 100644
  ##########################################################################
  #
 diff --git a/src/Makefile.shlib b/src/Makefile.shlib
-index 3825af5..daf8eba 100644
+index 3825af5..f26aa68 100644
 --- a/src/Makefile.shlib
 +++ b/src/Makefile.shlib
 @@ -210,6 +210,17 @@ ifeq ($(PORTNAME), win32)
@@ -526,10 +526,10 @@ diff --git a/src/template/haiku b/src/template/haiku
 new file mode 100644
 index 0000000..e69de29
 -- 
-2.52.0
+2.54.0
 
 
-From d98644e9ee2b05eb0b192f5f168d650cb031bd77 Mon Sep 17 00:00:00 2001
+From afa0ffa70aaafd129fa32accb013397e1ae37d4f Mon Sep 17 00:00:00 2001
 From: begasus <begasus@gmail.com>
 Date: Mon, 26 Dec 2022 17:35:12 +0100
 Subject: adjust autoconf required version
@@ -549,10 +549,10 @@ index bc7d5e7..b6dab96 100644
  recommended.  You can remove the check from 'configure.ac' but it is then
  your responsibility whether the result works or not.])])
 -- 
-2.52.0
+2.54.0
 
 
-From e143f465fde34c76a213928a06b7c49fbf4d9f9a Mon Sep 17 00:00:00 2001
+From 50d77d9e01ab7a4eaa77ca8aa929a81f7873fbd5 Mon Sep 17 00:00:00 2001
 From: Luc Schrijvers <begasus@gmail.com>
 Date: Sun, 31 Aug 2025 08:59:11 +0200
 Subject: Disable #include <sys/shm.h>
@@ -587,10 +587,10 @@ index 6bf8ab5..c711e25 100644
  #endif
  
 -- 
-2.52.0
+2.54.0
 
 
-From ebb42800c182bd14e995a591717e4de10ad97f02 Mon Sep 17 00:00:00 2001
+From bbe7b91e5af09e2753dd058b76ae07413a790491 Mon Sep 17 00:00:00 2001
 From: Luc Schrijvers <begasus@gmail.com>
 Date: Sun, 31 Aug 2025 09:02:48 +0200
 Subject: Fix(?) for fdatasync
@@ -632,5 +632,50 @@ index 0060ea1..a1a9d13 100644
  	STOP_TIMER;
  	close(tmpfile);
 -- 
-2.52.0
+2.54.0
+
+
+From 0c47255cf7d959d1de10769d9a78f233b90eb758 Mon Sep 17 00:00:00 2001
+From: Luc Schrijvers <begasus@gmail.com>
+Date: Wed, 5 Aug 2026 14:54:58 +0200
+Subject: Build fix for 32bit
+
+
+diff --git a/src/include/c.h b/src/include/c.h
+index 1ebfa73..a15ecfe 100644
+--- a/src/include/c.h
++++ b/src/include/c.h
+@@ -58,11 +58,6 @@
+ #include "pg_config_manual.h"	/* must be after pg_config.h */
+ #include "pg_config_os.h"		/* config from include/port/PORTNAME.h */
+ 
+-#if defined(__HAIKU__)
+-// Haiku defines int (int8, int64, etc) types in SupportDefs.h
+-#include <SupportDefs.h>
+-#endif
+-
+ /* System header files that should be available everywhere in Postgres */
+ #include <inttypes.h>
+ #include <stdio.h>
+@@ -508,6 +503,10 @@ typedef void (*pg_funcptr_t) (void);
+ typedef char *Pointer;
+ 
+ /* Historical names for types in <stdint.h>. */
++#if defined(__HAIKU__)
++// Haiku defines int (int8, int64, etc) types in SupportDefs.h
++#include <SupportDefs.h>
++#else
+ typedef int8_t int8;
+ typedef int16_t int16;
+ typedef int32_t int32;
+@@ -516,6 +515,7 @@ typedef uint8_t uint8;
+ typedef uint16_t uint16;
+ typedef uint32_t uint32;
+ typedef uint64_t uint64;
++#endif
+ 
+ /*
+  * bitsN
+-- 
+2.54.0
 

--- a/dev-db/postgresql/postgresql18-18.4.recipe
+++ b/dev-db/postgresql/postgresql18-18.4.recipe
@@ -20,7 +20,7 @@ you want to build, and let PostgreSQL safely and robustly store your data."
 HOMEPAGE="https://www.postgresql.org/"
 COPYRIGHT="1996-2026 PostgreSQL Global Development Group"
 LICENSE="PostgreSQL"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://ftp.postgresql.org/pub/source/v$portVersion/postgresql-$portVersion.tar.bz2"
 CHECKSUM_SHA256="81a81ec695fb0c7901407defaa1d2f7973617154cf27ba74e3a7ab8e64436094"
 SOURCE_DIR="postgresql-$portVersion"
@@ -55,6 +55,7 @@ REQUIRES="
 	lib:libssl$secondaryArchSuffix
 	"
 REPLACES="
+	postgresql$secondaryArchSuffix
 	postgresql11$secondaryArchSuffix
 	postgresql12$secondaryArchSuffix
 	"
@@ -129,6 +130,7 @@ REQUIRES_server="
 	lib:libz$secondaryArchSuffix
 	"
 REPLACES_server="
+	postgresql${secondaryArchSuffix}_server
 	postgresql11${secondaryArchSuffix}_server
 	postgresql12${secondaryArchSuffix}_server
 	"


### PR DESCRIPTION
add replaces for postgresql(16)

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
