### PR TITLE
mygui, make sure to build with glew-2.2.0

### DIFF
--- a/dev-games/mygui/mygui-3.4.3.recipe
+++ b/dev-games/mygui/mygui-3.4.3.recipe
@@ -80,7 +80,7 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libfreetype$secondaryArchSuffix
 	devel:libGL$secondaryArchSuffix
-	devel:libGLEW$secondaryArchSuffix
+	devel:libGLEW$secondaryArchSuffix >= 2.2
 	devel:libSDL2_2.0$secondaryArchSuffix
 	devel:libSDL2_image_2.0$secondaryArchSuffix
 	"


### PR DESCRIPTION
build failed with 2.3.1 on 64bit buildmaster

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
