### PR TITLE
openmw, revbump, cleanup to trigger build

### DIFF
--- a/games-engines/openmw/openmw-0.51.0.recipe
+++ b/games-engines/openmw/openmw-0.51.0.recipe
@@ -9,7 +9,7 @@ COPYRIGHT="2008-2021 OpenMW"
 LICENSE="GNU GPL v3
 	MIT
 	Zlib"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/OpenMW/openmw/archive/refs/tags/openmw-$portVersion.tar.gz"
 SOURCE_FILENAME="openmw-$portVersion.tar.gz"
 CHECKSUM_SHA256="7a65e63a5687ff0d51f319ebd529a9e93770fed3cc5408201de4588d1140f144"
@@ -74,6 +74,7 @@ REQUIRES="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	ffmpeg8${secondaryArchSuffix}_devel
+	qt6_tools${secondaryArchSuffix}_devel
 	devel:libboost_program_options$secondaryArchSuffix >= 1.91.0
 	devel:libBulletCollision$secondaryArchSuffix
 	devel:libGL$secondaryArchSuffix
@@ -96,12 +97,9 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	cmd:cmake
 	cmd:gcc$secondaryArchSuffix
-	cmd:git
-	cmd:lrelease$secondaryArchSuffix >= 5
 	cmd:ninja
 	cmd:pkg_config$secondaryArchSuffix
 	cmd:zip
-	qt6_tools${secondaryArchSuffix}_devel
 	"
 
 PATCH()
@@ -124,13 +122,12 @@ BUILD()
 		-DOPENMW_USE_SYSTEM_RECASTNAVIGATION=ON \
 		-Wno-dev -GNinja
 
-	cd build ; ninja $jobArgs
+	ninja -C build $jobArgs
 }
 
 INSTALL()
 {
-	cd build
-	ninja install
+	ninja -C build install
 
 	#mv -f $appsDir/OpenMW/games/openmw/* $appsDir/OpenMW
 	rm -rf $appsDir/OpenMW/{applications,data,games,include,licenses,lib/pkgconfig,metainfo,pixmaps}


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
