### PR TITLE
psqlodbc, revbump for postgresql changes

### DIFF
--- a/dev-libs/psqlodbc/psqlodbc-09.03.0400.recipe
+++ b/dev-libs/psqlodbc/psqlodbc-09.03.0400.recipe
@@ -4,7 +4,7 @@ database using the ODBC API."
 HOMEPAGE="https://odbc.postgresql.org"
 COPYRIGHT="1996-2014 PostgreSQL Global Development Group"
 LICENSE="GNU LGPL v2"
-REVISION="7"
+REVISION="8"
 SOURCE_URI="https://ftp.postgresql.org/pub/odbc/versions.old/src/psqlodbc-09.03.0400.tar.gz"
 CHECKSUM_SHA256="de77dfa89dba0a159afc57b2e312ca6e9075dd92b761c7cc700c0450ba02b56b"
 PATCHES="psqlodbc-$portVersion.patchset"
@@ -34,7 +34,7 @@ REQUIRES_devel="
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libiodbc$secondaryArchSuffix
-	devel:libpq$secondaryArchSuffix < 12.0
+	devel:libpq$secondaryArchSuffix
 	devel:libssl$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
