### PR TITLE
"Port" CRCpp

### DIFF
--- a/dev-cpp/crcpp/crcpp-1.2.2.0.recipe
+++ b/dev-cpp/crcpp/crcpp-1.2.2.0.recipe
@@ -1,0 +1,53 @@
+SUMMARY="Easy to use and fast C++ CRC library"
+DESCRIPTION="CRC++ supports bit-by-bit and byte-by-byte calculation of full and multipart CRCs.
+The algorithms used are highly optimized and can even be configured to be branchless \
+(as always, be sure to profile your code to choose the most efficient option).
+CRC++ is a great option for embedded C++ projects with a need for efficiency.
+
+CRC++ consists of a single header file which can be included in any existing C++ application. No libraries, no boost, no mess, no fuss."
+HOMEPAGE="https://github.com/d-bahr/CRCpp"
+COPYRIGHT="2022-2026 Daniel Bahr and contributors"
+LICENSE="BSD (3-clause)"
+REVISION="1"
+SOURCE_URI="https://github.com/d-bahr/CRCpp/archive/refs/tags/release-$portVersion.tar.gz"
+CHECKSUM_SHA256="8a069757ced03644cef1afe44ff821ce1087f12f6443e9a5059d6b8272114e58"
+SOURCE_DIR="CRCpp-release-$portVersion"
+PATCHES="crcpp-$portVersion.patchset"
+
+ARCHITECTURES="any"
+
+DISABLE_SOURCE_PACKAGE="yes"
+
+PROVIDES="
+	crcpp = $portVersion
+	devel:crcpp = $portVersion
+	"
+REQUIRES="
+	haiku
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	#cmd:doxygen # Optional, for documentation (disabled by default)
+	cmd:gcc
+	cmd:make
+	cmd:pkg_config
+	"
+
+BUILD()
+{
+	cmake -Bbuild -S. $cmakeDirArgs \
+		-DCMAKE_BUILD_TYPE=Release -DBUILD_TEST=OFF
+
+	make -C build $jobArgs
+}
+
+INSTALL()
+{
+	make -C build install
+	# Fix pkgconfig
+	sed -i "s,CRCpp_INCLUDE_DIR \"\",CRCpp_INCLUDE_DIR \"$includeDir\",g" $libDir/cmake/crcpp/CRCppConfig.cmake
+}

--- a/dev-cpp/crcpp/patches/crcpp-1.2.2.0.patchset
+++ b/dev-cpp/crcpp/patches/crcpp-1.2.2.0.patchset
@@ -1,0 +1,39 @@
+From 6f5e9c27107b52132bf8a4e008b71e7895662532 Mon Sep 17 00:00:00 2001
+From: Begasus <begasus@gmail.com>
+Date: Fri, 7 Aug 2026 14:32:56 +0200
+Subject: Install dirs fix
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9e5d902..74a5684 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -32,21 +32,21 @@ configure_file(
+ configure_package_config_file(
+     cmake/CRCppConfig.cmake.in
+     "${CMAKE_CURRENT_BINARY_DIR}/CRCppConfig.cmake"
+-    INSTALL_DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/crcpp")
++    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/crcpp")
+ write_basic_package_version_file(CRCppConfigVersion.cmake
+                                  VERSION ${PACKAGE_VERSION}
+                                  COMPATIBILITY SameMajorVersion
+                                  ARCH_INDEPENDENT)
+ 
+ # Installation
+-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/inc/ DESTINATION ${CMAKE_INSTALL_INCLUDE_DIR})
++install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/inc/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ install(FILES
+           ${CMAKE_CURRENT_BINARY_DIR}/CRCpp.pc
+-        DESTINATION ${CMAKE_INSTALL_DATADIR}/pkgconfig)
++        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+ install(FILES
+ 	  ${CMAKE_CURRENT_BINARY_DIR}/CRCppConfig.cmake
+ 	  ${CMAKE_CURRENT_BINARY_DIR}/CRCppConfigVersion.cmake
+-	DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/crcpp)
++	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/crcpp)
+ 
+ # Documentation
+ if (BUILD_DOC)
+-- 
+2.54.0
+


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.

---
It's just a big header with some pkg_config files, I think it's fine as an "any" package, let me know if the folders, requires etc. are right for it.
Not present in Portage but it should be the right category.

It's used as a dependency in a port I want to update (which uses pkg_config to look for it).