### PR TITLE
spidermonkey, trigger build for cbindgen suffix

### DIFF
--- a/dev-lang/spidermonkey/spidermonkey-128.13.0.recipe
+++ b/dev-lang/spidermonkey/spidermonkey-128.13.0.recipe
@@ -44,7 +44,7 @@ BUILD_REQUIRES="
 BUILD_PREREQUIRES="
 	llvm22$secondaryArchSuffix
 	cmd:awk
-	cmd:cbindgen$secondaryArchSuffix
+	cmd:cbindgen
 	cmd:cmp
 	cmd:m4
 	cmd:make


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
