### PR TITLE
0ad, trigger build on buildmaster, no extra cut needed for local MINOR

### DIFF
--- a/games-strategy/0ad/0ad-0.28.0.recipe
+++ b/games-strategy/0ad/0ad-0.28.0.recipe
@@ -113,7 +113,7 @@ INSTALL()
 	local APP_SIGNATURE="application/x-vnd.pyrogenesis-0ad"
 	local MAJOR="`echo "$portVersion" | cut -d. -f1`"
 	local MIDDLE="`echo "$portVersion" | cut -d. -f2`"
-	local MINOR="`echo "$portVersion" | cut -d. -f3 | cut -db -f1`"
+	local MINOR="`echo "$portVersion" | cut -d. -f3`"
 	local LONG_INFO="$SUMMARY"
 	sed \
 		-e "s|@APP_SIGNATURE@|$APP_SIGNATURE|" \


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
