### PR TITLE
spidermonkey, fix patch for 32bit build

### DIFF
--- a/dev-lang/spidermonkey/patches/spidermonkey-128.13.0.patchset
+++ b/dev-lang/spidermonkey/patches/spidermonkey-128.13.0.patchset
@@ -1,4 +1,4 @@
-From 99990f179861fcf82d98a540fdd0171ad6f0a002 Mon Sep 17 00:00:00 2001
+From 07dc0c46893b3e7f7c5422500bcc81b676abc4c2 Mon Sep 17 00:00:00 2001
 From: PulkoMandy <pulkomandy@pulkomandy.tk>
 Date: Sat, 1 Aug 2026 10:53:00 +0200
 Subject: applying patch FixPython3_14.diff
@@ -34,7 +34,7 @@ index 5cb627b0e..7ef5988d2 100644
 2.54.0
 
 
-From 41e248138b924a41d816137abf3f7bd6de170507 Mon Sep 17 00:00:00 2001
+From 703ec894b5911d2821f1d23bf0a0db0fdad092a0 Mon Sep 17 00:00:00 2001
 From: PulkoMandy <pulkomandy@pulkomandy.tk>
 Date: Fri, 31 Jul 2026 18:47:26 +0200
 Subject: Let the buildsystem know about Haiku
@@ -85,7 +85,7 @@ index 25f43bb9f..887af93bd 100644
 2.54.0
 
 
-From df7646b35985a54388ecef34afd85bc8c90afbb4 Mon Sep 17 00:00:00 2001
+From e3dbce351cf2a90b21abe384756bc7eacaf928d1 Mon Sep 17 00:00:00 2001
 From: PulkoMandy <pulkomandy@pulkomandy.tk>
 Date: Sat, 1 Aug 2026 10:48:57 +0200
 Subject: Disable failing assert for Haiku
@@ -108,7 +108,7 @@ index ac5459cf1..4bc6c2f88 100644
 2.54.0
 
 
-From 6d2ef6fffb627fcb6cee3568ea4b41b87391318e Mon Sep 17 00:00:00 2001
+From 75bd0d83a2a220b9cfae0c27eaceb878147b878a Mon Sep 17 00:00:00 2001
 From: PulkoMandy <pulkomandy@pulkomandy.tk>
 Date: Sat, 1 Aug 2026 10:49:10 +0200
 Subject: Let another buildfile know about Haiku
@@ -132,7 +132,7 @@ index 0114b17f6..6fed55d0b 100755
 2.54.0
 
 
-From 0a66372859bc6080919fdf60dfadbfbf4667eded Mon Sep 17 00:00:00 2001
+From b4e8af8fe11cfc54c16cbb76eabe9372328d5800 Mon Sep 17 00:00:00 2001
 From: PulkoMandy <pulkomandy@pulkomandy.tk>
 Date: Sat, 1 Aug 2026 11:10:24 +0200
 Subject: Haiku: define macros to access registers from mcontext
@@ -173,7 +173,7 @@ index f838b7bec..7e3451d6d 100644
 2.54.0
 
 
-From adfa9667a8f2fe302305a7305b793ff05daf6f08 Mon Sep 17 00:00:00 2001
+From c1be34fb9713e2b94053a70ed5335f969106de0e Mon Sep 17 00:00:00 2001
 From: PulkoMandy <pulkomandy@pulkomandy.tk>
 Date: Sat, 1 Aug 2026 11:45:18 +0200
 Subject: There is no sys/syscalls.h in Haiku
@@ -198,31 +198,28 @@ index ba32a230e..5d93402a6 100644
 2.54.0
 
 
-From 9e333a91d165625d2ea0ebb76d9adf969272af1e Mon Sep 17 00:00:00 2001
+From 2753aee59bbae2f26c0a10d3955914ae84d167e8 Mon Sep 17 00:00:00 2001
 From: PulkoMandy <pulkomandy@pulkomandy.tk>
 Date: Sat, 1 Aug 2026 11:45:33 +0200
 Subject: Link to libnetwork and libbsd
 
 
 diff --git a/build/moz.configure/libraries.configure b/build/moz.configure/libraries.configure
-index 26ca886f6..c2e8e4c5b 100644
+index 26ca886f6..55b322b6c 100644
 --- a/build/moz.configure/libraries.configure
 +++ b/build/moz.configure/libraries.configure
-@@ -88,6 +88,14 @@ set_config(
+@@ -82,9 +82,9 @@ set_config(
+ )
+ set_config(
+     "SOCKET_LIBS",
+-    ["-lsocket"],
++    ["-lnetwork"],
+     when=check_symbol_in_lib(
+-        "socket", symbol="socket", when=building_with_gnu_compatible_cc
++        "network", symbol="socket", when=building_with_gnu_compatible_cc
      ),
  )
  
-+set_config(
-+    "SOCKET_LIBS",
-+    ["-lnetwork"],
-+    when=check_symbol_in_lib(
-+        "network", symbol="socket", when=building_with_gnu_compatible_cc
-+    ),
-+)
-+
- moz_use_pthreads = (
-     target_is_darwin
-     | check_symbol_in_libs(
 diff --git a/js/src/rust/moz.build b/js/src/rust/moz.build
 index 32f9ae9a6..ec29ff3d3 100644
 --- a/js/src/rust/moz.build

--- a/dev-lang/spidermonkey/spidermonkey-128.13.0.recipe
+++ b/dev-lang/spidermonkey/spidermonkey-128.13.0.recipe
@@ -5,7 +5,7 @@ HOMEPAGE="https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey
 COPYRIGHT="1998-1999 Netscape Communications Corporation
 2000-2026 Mozilla Fundation"
 LICENSE="NPL v1.1"
-SOURCE_URI="https://releases.wildfiregames.com/libs/mozjs-128.13.0.tar.xz"
+SOURCE_URI="https://releases.wildfiregames.com/libs/mozjs-$portVersion.tar.xz"
 SOURCE_DIR="mozjs-$portVersion"
 CHECKSUM_SHA256="6422e51b9e76586c3054127bf13f992ec2338bd2d6156dc430accfb0b5301f1d"
 REVISION="1"


### PR DESCRIPTION
having 2 SOCKET_LIBS trips configure script as it pulls -lsocket as well as -lnetwork

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
