### PR TITLE
CLISP 2.49.95+, no PostgreSQL

### DIFF
--- a/dev-lisp/clisp/clisp-2.49.95~git.recipe
+++ b/dev-lisp/clisp/clisp-2.49.95~git.recipe
@@ -15,7 +15,7 @@ COPYRIGHT="1992-1993 Bruno Haible, Michael Stoll
 	2001-2018 Sam Steingold, Bruno Haible
 	"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 srcGitRev="9ff8aedb796fbf7c47e594bfc2357b69c8e64dc9"
 SOURCE_URI="https://gitlab.com/gnu-clisp/clisp/-/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="4dec02817e45c9f4a05fd31ef725728bc8da07c4c4c5b647dfb190c1d41439ce"
@@ -89,14 +89,14 @@ REQUIRES_pcre="
 	lib:libpcre$secondaryArchSuffix
 	"
 
-DESCRIPTION_postgresql="${desc_base} postgresql module for clisp."
-PROVIDES_postgresql="
-	clisp_postgresql$secondaryArchSuffix = $portVersion
-	"
-REQUIRES_postgresql="
-	$requires_base
-	lib:libpq$secondaryArchSuffix
-	"
+#DESCRIPTION_postgresql="${desc_base} postgresql module for clisp."
+#PROVIDES_postgresql="
+#	clisp_postgresql$secondaryArchSuffix = $portVersion
+#	"
+#REQUIRES_postgresql="
+#	$requires_base
+#	lib:libpq$secondaryArchSuffix
+#	"
 
 DESCRIPTION_zlib="${desc_base} zlib module for clisp."
 PROVIDES_zlib="
@@ -118,7 +118,7 @@ BUILD_REQUIRES="
 	devel:libncurses$secondaryArchSuffix
 #	devel:libpari$secondaryArchSuffix
 	devel:libpcre$secondaryArchSuffix
-	devel:libpq$secondaryArchSuffix < 12.0
+#	devel:libpq$secondaryArchSuffix < 12.0
 	devel:libreadline$secondaryArchSuffix >= 8
 	devel:libsigsegv$secondaryArchSuffix
 	devel:libsvm$secondaryArchSuffix
@@ -164,7 +164,8 @@ INSTALL()
 		make install-modules MODULES="$module"
 	done
 	# TODO Add pari
-	for module in berkeley-db gdbm libsvm pcre postgresql zlib; do
+	# TODO Reconsider removed postgresql
+	for module in berkeley-db gdbm libsvm pcre zlib; do
 		pack=$(echo $module | sed 's/-/_/')
 		new_prefix=$(getPackagePrefix $pack)
 		sed -i "s|=[[:space:]]$last_prefix|= $new_prefix|g" Makefile


### PR DESCRIPTION
The manual compilation according to this recipe works. The recipe itself *fails* on my machine for some reason.

The only difference is removal (commented out) reference to PostgreSQL module package and any reference to its libraries.

When submitting changes to Haikuports, please check the following:

- [X] You are not a robot.
- [] The modified recipe was confirmed to build on your Haiku machine.
- [X] The license and copyright information in modified recipes are correct.
- [X] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [X] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
