### PR TITLE
Port CLI11

### DIFF
--- a/dev-cpp/cli11/cli11-2.7.2.recipe
+++ b/dev-cpp/cli11/cli11-2.7.2.recipe
@@ -1,0 +1,52 @@
+SUMMARY="Command line parser for C++11"
+DESCRIPTION="CLI11 is a command line parser for C++11 and beyond that provides \
+a rich feature set with a simple and intuitive interface."
+HOMEPAGE="https://cliutils.github.io/CLI11/"
+COPYRIGHT="2017-2026 University of Cincinnati"
+LICENSE="BSD (3-clause)"
+REVISION="1"
+SOURCE_URI="https://github.com/CLIUtils/CLI11/archive/refs/tags/v$portVersion.tar.gz"
+CHECKSUM_SHA256="46eef3101da70852ec7af026e09d485ccee81813331c8c6052d39344443b83da"
+SOURCE_DIR="CLI11-$portVersion"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+DISABLE_SOURCE_PACKAGE="yes"
+
+PROVIDES="
+	cli11$secondaryArchSuffix = $portVersion
+	devel:cli11$secondaryArchSuffix = $portVersion
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libboost_system$secondaryArchSuffix >= 1.88.0
+	devel:libcatch2$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	#cmd:doxygen # Optional, for documentation
+	cmd:gcc
+	cmd:make
+	cmd:pkg_config
+	"
+
+BUILD()
+{
+	cmake -Bbuild -S. $cmakeDirArgs \
+		-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_DATADIR=$libDir \
+		-DCLI11_BUILD_TESTS=OFF -DCLI11_BUILD_EXAMPLES=OFF
+
+	make -C build $jobArgs
+}
+
+INSTALL()
+{
+	make -C build install
+	# Fix pkgconfig
+	sed -i "s,\/include,\/$relativeIncludeDir,g" $libDir/cmake/CLI11/CLI11Targets.cmake
+}


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.

---
A headers-only library like #14566 and often used with it. The recipe is also present in Portage.

Disabling x86_gcc2 as the library targets C++11 which shouldn't be available there AFAIK. Also the tests require boost and catch2, which are not available there anyway.

Building with ninja/meson is possible but that doesn't generate cmake's pkgconfig files, which I need.