### PR TITLE
python3.13: update to version 3.13.15.

### DIFF
--- a/dev-lang/python/patches/python3.13-3.13.15.patchset
+++ b/dev-lang/python/patches/python3.13-3.13.15.patchset
@@ -1,4 +1,4 @@
-From cd3d56241e187179ddfa01bcd3860cdb2f79618c Mon Sep 17 00:00:00 2001
+From d974f8379294f0f29d65b85bb3b08a18dee5270b Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 8 Oct 2023 01:02:25 -0300
 Subject: initial Haiku patch
@@ -22,7 +22,7 @@ index 72a157e..67141ae 100644
     // See PyUnicode_DecodeFSDefaultAndSize(), PyUnicode_EncodeFSDefault(),
     // Py_DecodeLocale() and Py_EncodeLocale().
 diff --git a/Makefile.pre.in b/Makefile.pre.in
-index 8589a28..585ae52 100644
+index 2363b99..ed75b9e 100644
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
 @@ -149,7 +149,7 @@ BINDIR=		@bindir@
@@ -148,7 +148,7 @@ index 8480590..ac7b78c 100644
  #include <bluetooth/bluetooth.h>
  #include <bluetooth/rfcomm.h>
 diff --git a/configure.ac b/configure.ac
-index a016a43..243e44c 100644
+index f93a9f2..5d55ffa 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -1573,6 +1573,16 @@ if test $enable_shared = "yes"; then
@@ -176,7 +176,7 @@ index a016a43..243e44c 100644
  		CYGWIN*) LN="ln -s";;
  		*) LN=ln;;
  	esac
-@@ -3633,7 +3644,7 @@ then
+@@ -3634,7 +3645,7 @@ then
  	    LINKFORSHARED="-Wl,-E -Wl,+s";;
  #	    LINKFORSHARED="-Wl,-E -Wl,+s -Wl,+b\$(BINLIBDEST)/lib-dynload";;
  	Linux-android*) LINKFORSHARED="-pie -Xlinker -export-dynamic";;
@@ -185,7 +185,7 @@ index a016a43..243e44c 100644
  	# -u libsys_s pulls in all symbols in libsys
  	Darwin/*|iOS/*)
  		LINKFORSHARED="$extra_undefs -framework CoreFoundation"
-@@ -5967,6 +5978,7 @@ AC_CHECK_FUNC([__fpu_control],
+@@ -5975,6 +5986,7 @@ AC_CHECK_FUNC([__fpu_control],
  AC_SUBST([LIBM])
  case $ac_sys_system in
  Darwin) ;;
@@ -194,10 +194,10 @@ index a016a43..243e44c 100644
  esac
  AC_MSG_CHECKING([for --with-libm=STRING])
 -- 
-2.52.0
+2.54.0
 
 
-From 2bdf4d29599060dfea987100e0302f0c5b9eefbb Mon Sep 17 00:00:00 2001
+From c068c6e48fa58b3ab2248d7794d51623196174ba Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sun, 16 Apr 2017 10:05:42 +0200
 Subject: fix for negative errnos
@@ -217,7 +217,7 @@ index 3a8c743..f9778a6 100644
                          err_msg = ""
                          # The error must be from chdir(cwd).
 diff --git a/Modules/_posixsubprocess.c b/Modules/_posixsubprocess.c
-index eef2743..bcc94fc 100644
+index 745160e..2691acd 100644
 --- a/Modules/_posixsubprocess.c
 +++ b/Modules/_posixsubprocess.c
 @@ -847,6 +847,10 @@ error:
@@ -232,10 +232,10 @@ index eef2743..bcc94fc 100644
              *--cur = Py_hexdigits[saved_errno % 16];
              saved_errno /= 16;
 -- 
-2.52.0
+2.54.0
 
 
-From 44eb7802d73cd88bc677dfde3cd9bfd7e1391025 Mon Sep 17 00:00:00 2001
+From cf0c212e6209c657158c5e53799a423280fb383c Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 8 Oct 2023 20:06:31 -0300
 Subject: Implement CTypes's find_library for Haiku
@@ -245,7 +245,7 @@ This combines:
  - A slight variation of Adrien Destugues' fix for x86_gcc2.
 
 diff --git a/Lib/ctypes/util.py b/Lib/ctypes/util.py
-index 117bf06..6301aa2 100644
+index 43f10de..328ea89 100644
 --- a/Lib/ctypes/util.py
 +++ b/Lib/ctypes/util.py
 @@ -1,4 +1,5 @@
@@ -315,7 +315,7 @@ index 117bf06..6301aa2 100644
      else:
  
          def _findSoname_ldconfig(name):
-@@ -379,6 +434,12 @@ def test():
+@@ -378,6 +433,12 @@ def test():
              print(f"crypt\t:: {cdll.LoadLibrary(find_library('crypt'))}")
              print(f"crypto\t:: {find_library('crypto')}")
              print(f"crypto\t:: {cdll.LoadLibrary(find_library('crypto'))}")
@@ -329,10 +329,10 @@ index 117bf06..6301aa2 100644
              print(cdll.LoadLibrary("libm.so"))
              print(cdll.LoadLibrary("libcrypt.so"))
 -- 
-2.52.0
+2.54.0
 
 
-From f8541758ec53a15a2a63ff1f9c16fca19927c106 Mon Sep 17 00:00:00 2001
+From ca8ea8c825a5866403822deaa06d83cb9255c549 Mon Sep 17 00:00:00 2001
 From: Philipp Wolfer <phil@parolu.io>
 Date: Mon, 23 Sep 2019 09:14:58 +0200
 Subject: webbrowser: Support for default browsers on Haiku
@@ -356,17 +356,17 @@ index be033d7..dd484a0 100755
          # First try to use the default Windows browser
          register("windows-default", WindowsDefault)
 -- 
-2.52.0
+2.54.0
 
 
-From 86fd63fb482c0d0a1595b8f78c10d5bea63f97d4 Mon Sep 17 00:00:00 2001
+From 0e0a6ccdc16675781022ae4215135a36ef75d14e Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 4 Oct 2019 22:02:35 +0200
 Subject: since 3.8, don't reinit locks on fork.
 
 
 diff --git a/Lib/logging/__init__.py b/Lib/logging/__init__.py
-index 9005f1e..28708e2 100644
+index 6e76062..2a6c664 100644
 --- a/Lib/logging/__init__.py
 +++ b/Lib/logging/__init__.py
 @@ -253,7 +253,7 @@ def _afterFork():
@@ -379,10 +379,10 @@ index 9005f1e..28708e2 100644
          pass  # no-op when os.register_at_fork does not exist.
  else:
 -- 
-2.52.0
+2.54.0
 
 
-From 15fa44726651fa119e9fba72e74357a246e17306 Mon Sep 17 00:00:00 2001
+From 09e997ba0b0d295dc4a80480d004a9090268f24d Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Fri, 15 May 2020 15:20:57 +0200
 Subject: handle errors returned by internal_connect()
@@ -390,10 +390,10 @@ Subject: handle errors returned by internal_connect()
 upstream bug #40628 by Ryan C. Gordon
 
 diff --git a/Modules/socketmodule.c b/Modules/socketmodule.c
-index 9cdf207..e0eb5c1 100644
+index d7e36c0..19d9d47 100644
 --- a/Modules/socketmodule.c
 +++ b/Modules/socketmodule.c
-@@ -3541,7 +3541,7 @@ sock_connect(PySocketSockObject *s, PyObject *addro)
+@@ -3551,7 +3551,7 @@ sock_connect(PySocketSockObject *s, PyObject *addro)
      }
  
      res = internal_connect(s, SAS2SA(&addrbuf), addrlen, 1);
@@ -402,7 +402,7 @@ index 9cdf207..e0eb5c1 100644
          return NULL;
  
      Py_RETURN_NONE;
-@@ -3572,7 +3572,7 @@ sock_connect_ex(PySocketSockObject *s, PyObject *addro)
+@@ -3582,7 +3582,7 @@ sock_connect_ex(PySocketSockObject *s, PyObject *addro)
      }
  
      res = internal_connect(s, SAS2SA(&addrbuf), addrlen, 0);
@@ -412,17 +412,17 @@ index 9cdf207..e0eb5c1 100644
  
      return PyLong_FromLong((long) res);
 -- 
-2.52.0
+2.54.0
 
 
-From d931f51a2317b743261083bf1e53412ef41c6eb7 Mon Sep 17 00:00:00 2001
+From cd6d1a4ab1b36326e3a46769212025797f8eaabc Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Mon, 19 Oct 2020 18:03:09 +0200
 Subject: ttyname_r can use MAXPATHLEN
 
 
 diff --git a/Modules/posixmodule.c b/Modules/posixmodule.c
-index 86187cb..ac05f73 100644
+index c0dd696..06c9454 100644
 --- a/Modules/posixmodule.c
 +++ b/Modules/posixmodule.c
 @@ -3311,11 +3311,14 @@ static PyObject *
@@ -442,10 +442,10 @@ index 86187cb..ac05f73 100644
      if (buffer == NULL) {
          return PyErr_NoMemory();
 -- 
-2.52.0
+2.54.0
 
 
-From d8ac3e87ef18eef03f99e80e1c9a105aeb04eea6 Mon Sep 17 00:00:00 2001
+From 962bdff8d969f084bbe43ca0c44468a9aebe1172 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Mon, 24 Oct 2022 20:04:10 -0300
 Subject: Lib/test: require the "largefile" usage flag for I/O heavy tests.
@@ -482,10 +482,10 @@ index 41f7b70..e4830de 100644
                   'test requires %s bytes and a long time to run' % str(size))
      else:
 diff --git a/Lib/test/test_mmap.py b/Lib/test/test_mmap.py
-index 7f33db5..13a1481 100644
+index 1d91cee..f6af733 100644
 --- a/Lib/test/test_mmap.py
 +++ b/Lib/test/test_mmap.py
-@@ -1178,7 +1178,7 @@ class LargeMmapTests(unittest.TestCase):
+@@ -1179,7 +1179,7 @@ class LargeMmapTests(unittest.TestCase):
          unlink(TESTFN)
  
      def _make_test_file(self, num_zeroes, tail):
@@ -495,10 +495,10 @@ index 7f33db5..13a1481 100644
                  'test requires %s bytes and a long time to run' % str(0x180000000))
          f = open(TESTFN, 'w+b')
 -- 
-2.52.0
+2.54.0
 
 
-From 5dc26c44538f06c9549f495df937a6db24309323 Mon Sep 17 00:00:00 2001
+From 6aa17b0daaa1f75a3d8277345f609ad72776ac80 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sat, 27 Jul 2024 04:51:52 -0300
 Subject: _getuserbase(), getsitepackages(), and INSTALL_SCHEMES for Haiku.
@@ -521,11 +521,12 @@ by me, plus:
 
 * new changes to allow Python to find modules installed via 'pkgman -H'.
 * Attempt to support the "venv" install scheme (untested).
+* Fixes for venv scheme and module search paths (tested via "python -m venv").
 
 The idea was to have all _getuserbase()/INSTALL_SCHEMES related changes in "one place".
 
 diff --git a/Lib/site.py b/Lib/site.py
-index 041dca1..ff27efc 100644
+index 041dca1..c86e1e2 100644
 --- a/Lib/site.py
 +++ b/Lib/site.py
 @@ -307,6 +307,14 @@ def _getuserbase():
@@ -543,12 +544,18 @@ index 041dca1..ff27efc 100644
      return joinuser("~", ".local")
  
  
-@@ -399,7 +407,31 @@ def getsitepackages(prefixes=None):
+@@ -399,7 +407,37 @@ def getsitepackages(prefixes=None):
              abi_thread = 't'
          else:
              abi_thread = ''
 -        if os.sep == '/':
 +        if sys.platform.startswith('haiku'):
++            # This one is required for packages inside a venv:
++            path = os.path.join(prefix, 'lib',
++                                f"{implementation}{ver[0]}.{ver[1]}{abi_thread}",
++                                "site-packages")
++            sitepackages.append(path)
++
 +            # Locations under /system/
 +            sitepackages.append(os.path.join(prefix, "non-packaged", "lib",
 +                                            f"{implementation}{ver[0]}.{ver[1]}{abi_thread}",
@@ -577,7 +584,7 @@ index 041dca1..ff27efc 100644
              if sys.platlibdir != "lib":
                  libdirs.append("lib")
 diff --git a/Lib/sysconfig/__init__.py b/Lib/sysconfig/__init__.py
-index 43edebc..b09436d 100644
+index 43edebc..f07a324 100644
 --- a/Lib/sysconfig/__init__.py
 +++ b/Lib/sysconfig/__init__.py
 @@ -48,6 +48,36 @@ _INSTALL_SCHEMES = {
@@ -622,14 +629,14 @@ index 43edebc..b09436d 100644
          'data': '{base}',
          },
 +    'haiku_venv': {
-+        'stdlib': '{installed_base}/lib/python{py_version_short}{abi_thread}',
-+        'platstdlib': '{platbase}/lib/python{py_version_short}{abi_thread}',
-+        'purelib': '{base}/non-packaged/lib/python{py_version_short}{abi_thread}/site-packages',
-+        'platlib': '{platbase}/non-packaged/lib/python{py_version_short}{abi_thread}/site-packages',
-+        'include': '{installed_base}/non-packaged/develop/headers/python{py_version_short}{abiflags}',
++        'stdlib': '{installed_base}/{platlibdir}/{implementation_lower}{py_version_short}{abi_thread}',
++        'platstdlib': '{platbase}/{platlibdir}/{implementation_lower}{py_version_short}{abi_thread}',
++        'purelib': '{base}/lib/{implementation_lower}{py_version_short}{abi_thread}/site-packages',
++        'platlib': '{platbase}/{platlibdir}/{implementation_lower}{py_version_short}{abi_thread}/site-packages',
++        'include': '{installed_base}/develop/headers/python{py_version_short}{abiflags}',
 +        'platinclude': '{installed_platbase}/develop/headers/python{py_version_short}{abiflags}',
-+        'scripts': '{base}/non-packaged/bin',
-+        'data'   : '{base}/non-packaged',
++        'scripts': '{base}/bin',
++        'data'   : '{base}',
 +        },
      'nt_venv': {
          'stdlib': '{installed_base}/Lib',
@@ -711,10 +718,10 @@ index ce17206..0f19bae 100644
  
      @skip_unless_symlink
 -- 
-2.52.0
+2.54.0
 
 
-From ddb209891b7c48f0ab3885d3b46093593e3fe74d Mon Sep 17 00:00:00 2001
+From 6e5a1e9eeca3ba8325818670b2a83e88b7030c56 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Mon, 12 Feb 2024 08:39:38 -0300
 Subject: Fix location of REPL's history file.
@@ -725,10 +732,10 @@ Content-Transfer-Encoding: 8bit
 Adapted from previous patches by Jérôme Duval.
 
 diff --git a/Lib/site.py b/Lib/site.py
-index ff27efc..753420a 100644
+index c86e1e2..be62929 100644
 --- a/Lib/site.py
 +++ b/Lib/site.py
-@@ -506,8 +506,18 @@ def gethistoryfile():
+@@ -512,8 +512,18 @@ def gethistoryfile():
          history = os.environ.get("PYTHON_HISTORY")
          if history:
              return history
@@ -750,10 +757,10 @@ index ff27efc..753420a 100644
  
  def enablerlcompleter():
 -- 
-2.52.0
+2.54.0
 
 
-From 78de75aecb16fe3dda80d1be672a192af1e886cf Mon Sep 17 00:00:00 2001
+From fee72a69df0abba4f92c99c6b6aae62a0576be6e Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 8 Oct 2023 17:02:19 -0300
 Subject: Use spawn instead of fork for multiprocessing.
@@ -803,10 +810,10 @@ index 07c8a5d..75e5f6e 100644
          # on macOS since macOS 10.14 (Mojave). Use spawn by default instead.
          _default_context = DefaultContext(_concrete_contexts['spawn'])
 -- 
-2.52.0
+2.54.0
 
 
-From d26ea0ab7d3e7032e4cdd3fff7168706ad49254e Mon Sep 17 00:00:00 2001
+From ba17f72eebd6247152b11fb80644c6e3e50ae4f9 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 10 Dec 2023 19:50:22 -0300
 Subject: Miscellaneous "Lib/test/" fixes for Haiku.
@@ -817,10 +824,10 @@ Content-Transfer-Encoding: 8bit
 test_fileio.py fix from "initial Haiku patch" by Jérôme Duval.
 
 diff --git a/Lib/test/datetimetester.py b/Lib/test/datetimetester.py
-index 6749fad..788c7b0 100644
+index c0f2400..03f7377 100644
 --- a/Lib/test/datetimetester.py
 +++ b/Lib/test/datetimetester.py
-@@ -6093,6 +6093,9 @@ def pairs(iterable):
+@@ -6128,6 +6128,9 @@ def pairs(iterable):
  
  class ZoneInfo(tzinfo):
      zoneroot = '/usr/share/zoneinfo'
@@ -843,10 +850,10 @@ index fdb36ed..5411a96 100644
                          # Somehow /dev/tty appears seekable on some BSDs
                          self.assertEqual(f.seekable(), False)
 -- 
-2.52.0
+2.54.0
 
 
-From 60e3dea818b9957da6131c7aa9ef12842e6fbeff Mon Sep 17 00:00:00 2001
+From 3082dd6fe2b8dbd2fd60d1de896f48041639bc71 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Mon, 12 Feb 2024 10:50:34 -0300
 Subject: Fix build on nightlies, following the addition of kqueue.
@@ -909,10 +916,10 @@ index f69df69..6d0b426 100644
  
      /* NETDEV filter flags */
 -- 
-2.52.0
+2.54.0
 
 
-From 3475e7c9298ec5272416620037fbd4a4bf75bb52 Mon Sep 17 00:00:00 2001
+From 85f87b9cdf4b813f7bfcbf023bc00794e239f3c9 Mon Sep 17 00:00:00 2001
 From: Alexander von Gluck IV <kallisti5@unixzen.com>
 Date: Thu, 14 Mar 2024 12:54:33 -0500
 Subject: config.guess: Update to universal haiku arch guessing
@@ -939,10 +946,10 @@ index e81d3ae..366429c 100755
      SX-4:SUPER-UX:*:*)
  	GUESS=sx4-nec-superux$UNAME_RELEASE
 -- 
-2.52.0
+2.54.0
 
 
-From 5240fa711d6263211efbb511318f1e77d2cff142 Mon Sep 17 00:00:00 2001
+From 1f5e38436d154266ad6356a44dbc965c5fd712c5 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 9 Aug 2024 13:38:28 -0300
 Subject: fix test_utf8_mode.
@@ -962,10 +969,10 @@ index f668810..a55a8e4 100644
          elif sys.platform.startswith("aix"):
              c_arg = arg.decode('iso-8859-1')
 -- 
-2.52.0
+2.54.0
 
 
-From 5aeda28f21a3372ca16e77fb2dc94136aa8af22b Mon Sep 17 00:00:00 2001
+From fe2d5ad26befcb6d1aa5a80cf218ce6355471281 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 9 Aug 2024 14:35:04 -0300
 Subject: Fix test_site.
@@ -983,7 +990,7 @@ Lib/site.py changes should eventually be merged with previous commits.
 Leaving the changes here now for easier review.
 
 diff --git a/Lib/site.py b/Lib/site.py
-index 753420a..2eecc18 100644
+index be62929..ff68cbf 100644
 --- a/Lib/site.py
 +++ b/Lib/site.py
 @@ -308,12 +308,8 @@ def _getuserbase():
@@ -1001,7 +1008,7 @@ index 753420a..2eecc18 100644
  
      return joinuser("~", ".local")
  
-@@ -419,18 +415,10 @@ def getsitepackages(prefixes=None):
+@@ -425,18 +421,10 @@ def getsitepackages(prefixes=None):
              # For .hpkg installed under ~/config/ (pkgman install -H)
              # ("pip install --user" uses ~/config/non-packaged/, and gets
              # handled by the "haiku_user" install scheme.
@@ -1052,10 +1059,10 @@ index a128ab3..0b5cb08 100644
              if sys.platlibdir != "lib":
                  self.assertEqual(len(dirs), 2)
 -- 
-2.52.0
+2.54.0
 
 
-From a457506f469710ff4974b5a63163bccfbfa6d9f6 Mon Sep 17 00:00:00 2001
+From 760e93a9bbf7e57b4a274907e81d3face63b63e9 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 9 Aug 2024 15:37:13 -0300
 Subject: Fix test_sysconfig.
@@ -1095,10 +1102,10 @@ index 0f19bae..a3bd159 100644
              wanted.extend(['nt_user', 'osx_framework_user', 'posix_user', 'haiku_user'])
          self.assertEqual(get_scheme_names(), tuple(sorted(wanted)))
 -- 
-2.52.0
+2.54.0
 
 
-From d69665329aed40648259baaea293cd7f6d9d2a42 Mon Sep 17 00:00:00 2001
+From 3f0ee31d2a519e930309a2b65db8ce73ca70ae27 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sun, 29 Sep 2024 03:01:27 -0300
 Subject: Partially fix test_compileall by skipping tests that need hardlink
@@ -1106,7 +1113,7 @@ Subject: Partially fix test_compileall by skipping tests that need hardlink
 
 
 diff --git a/Lib/test/support/os_helper.py b/Lib/test/support/os_helper.py
-index 26c467a..4969750 100644
+index 3bd177b..ac2aea4 100644
 --- a/Lib/test/support/os_helper.py
 +++ b/Lib/test/support/os_helper.py
 @@ -207,6 +207,8 @@ def can_hardlink():
@@ -1119,10 +1126,10 @@ index 26c467a..4969750 100644
  
  
 diff --git a/Lib/test/test_compileall.py b/Lib/test/test_compileall.py
-index 21ecebc..632fc1c 100644
+index 2e9c37d..f2208c0 100644
 --- a/Lib/test/test_compileall.py
 +++ b/Lib/test/test_compileall.py
-@@ -947,6 +947,7 @@ class CommandLineTestsBase:
+@@ -972,6 +972,7 @@ class CommandLineTestsBase:
          # only for more than one optimization level
          self.assertRunNotOK(self.directory, "-o 1", "--hardlink-dupes")
  
@@ -1131,10 +1138,10 @@ index 21ecebc..632fc1c 100644
          # 'a = 0' code produces the same bytecode for the 3 optimization
          # levels. All three .pyc files must have the same inode (hardlinks).
 -- 
-2.52.0
+2.54.0
 
 
-From 612966863a87596432f79225f9ee5789b1ee15e0 Mon Sep 17 00:00:00 2001
+From 8be7700baa7b6cbfd9febc6f8b83b886844a19c4 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Thu, 9 May 2024 15:16:26 -0300
 Subject: Fix 3.13.0 build.
@@ -1147,10 +1154,10 @@ Previous Python versions had both the time out and the "|| true".
 Some of the test run in that PGO stage sadly still fail on Haiku.
 
 diff --git a/Makefile.pre.in b/Makefile.pre.in
-index 585ae52..ceb048d 100644
+index ed75b9e..912bf6f 100644
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
-@@ -752,7 +752,7 @@ profile-run-stamp:
+@@ -756,7 +756,7 @@ profile-run-stamp:
  	$(MAKE) profile-gen-stamp
  	# Next, run the profile task to generate the profile information.
  	@ # FIXME: can't run for a cross build
@@ -1159,7 +1166,7 @@ index 585ae52..ceb048d 100644
  	$(LLVM_PROF_MERGER)
  	# Remove profile generation binary since we are done with it.
  	$(MAKE) clean-retain-profile
-@@ -2035,7 +2035,7 @@ $(LIBRARY_OBJS) $(MODOBJS) Programs/python.o: $(PYTHON_HEADERS)
+@@ -2041,7 +2041,7 @@ $(LIBRARY_OBJS) $(MODOBJS) Programs/python.o: $(PYTHON_HEADERS)
  TESTOPTS=	$(EXTRATESTOPTS)
  TESTPYTHON=	$(RUNSHARED) $(PYTHON_FOR_BUILD) $(TESTPYTHONOPTS)
  TESTRUNNER=	$(TESTPYTHON) -m test
@@ -1182,17 +1189,17 @@ index 4d3fb65..be95e7d 100644
  
  #if !defined(__HAIKU__) && !defined(__APPLE__) && !defined(__CYGWIN__) && !defined(_AIX) && !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__sun) && !defined(__NetBSD__)
 -- 
-2.52.0
+2.54.0
 
 
-From 4d3128973c9e192451166e4324cc593bdf0b79ce Mon Sep 17 00:00:00 2001
+From 765ce25d8f88a42af1641b6458c6a3d926e50a3c Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Sat, 5 Oct 2024 07:32:17 -0300
 Subject: Avoid forcing "-g" on LTO builds, unless Py_DEBUG is defined.
 
 
 diff --git a/configure.ac b/configure.ac
-index 243e44c..24a9bb0 100644
+index 5d55ffa..b39add9 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -2069,7 +2069,9 @@ if test "$Py_LTO" = 'true' ; then
@@ -1207,17 +1214,17 @@ index 243e44c..24a9bb0 100644
  
    CFLAGS_NODIST="$CFLAGS_NODIST ${LTOCFLAGS-$LTOFLAGS}"
 -- 
-2.52.0
+2.54.0
 
 
-From 386bb810d8d5d049a83d02753cc4aef6fd77edc9 Mon Sep 17 00:00:00 2001
+From f592bd6ba76cbd79327c16beb2446038b8ae894e Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Wed, 8 Apr 2026 00:21:53 -0300
 Subject: configure.ac: add Haiku to the MACHDEP cases.
 
 
 diff --git a/configure.ac b/configure.ac
-index 24a9bb0..f8fe9f9 100644
+index b39add9..4315a24 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -330,6 +330,9 @@ then
@@ -1239,5 +1246,5 @@ index 24a9bb0..f8fe9f9 100644
      esac
  
 -- 
-2.52.0
+2.54.0
 

--- a/dev-lang/python/python3.13-3.13.15.recipe
+++ b/dev-lang/python/python3.13-3.13.15.recipe
@@ -17,10 +17,10 @@ Note: to install \"pip\" for this Python version, use the following commands:
 And then you should be able to use \"pip3.13\" normally."
 HOMEPAGE="https://www.python.org"
 LICENSE="Python"
-COPYRIGHT="1990-2025 Python Software Foundation"
+COPYRIGHT="1990-2026 Python Software Foundation"
 REVISION="1"
 SOURCE_URI="https://www.python.org/ftp/python/$portVersion/Python-$portVersion.tar.xz"
-CHECKSUM_SHA256="639e43243c620a308f968213df9e00f2f8f62332f7adbaa7a7eeb9783057c690"
+CHECKSUM_SHA256="1e66a7945a48390ee4c2a4268a0e4185884059a13c4aab6d148aa208deea4a76"
 SOURCE_DIR="Python-$portVersion"
 
 pyShortVer="${portVersion%.*}"


### PR DESCRIPTION
Includes fixes for the venv scheme.
