### PR TITLE
Port LibADLMIDI

### DIFF
--- a/media-sound/libadlmidi/libadlmidi-1.6.1.recipe
+++ b/media-sound/libadlmidi/libadlmidi-1.6.1.recipe
@@ -1,0 +1,66 @@
+SUMMARY="A Software MIDI Synthesizer library with OPL3 emulation"
+DESCRIPTION="libADLMIDI is a free Software MIDI synthesizer library with OPL3 emulation."
+HOMEPAGE="https://github.com/Wohlstand/libADLMIDI"
+COPYRIGHT="
+	2010-2014 Joel Yliluoma
+	2015-2026 Vitaly Novichkov
+	"
+LICENSE="GNU LGPL v3"
+REVISION="1"
+SOURCE_URI="https://github.com/Wohlstand/libADLMIDI/archive/refs/tags/v$portVersion.tar.gz"
+CHECKSUM_SHA256="9f14489ce1e6d020b8b90b6cf902e31d61b2d4e82122505cec6d5d4afebcb3e1"
+SOURCE_DIR="libADLMIDI-$portVersion"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="1.6.1"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	libadlmidi$secondaryArchSuffix = $portVersion
+	lib:libADLMIDI$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	libadlmidi${secondaryArchSuffix}_devel = $portVersion
+	devel:libADLMIDI$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	haiku${secondaryArchSuffix}_devel
+	libadlmidi$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:gcc$secondaryArchSuffix
+	cmd:make
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	cmake -Bbuild -S. $cmakeDirArgs \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DlibADLMIDI_STATIC=OFF \
+		-DlibADLMIDI_SHARED=ON
+
+	make -C build $jobArgs
+}
+
+INSTALL()
+{
+	make -C build install
+
+	prepareInstalledDevelLib libADLMIDI
+
+	# devel package
+	packageEntries devel \
+		$developDir
+}

--- a/media-sound/libadlmidi/libadlmidi-1.6.1.recipe
+++ b/media-sound/libadlmidi/libadlmidi-1.6.1.recipe
@@ -14,7 +14,7 @@ SOURCE_DIR="libADLMIDI-$portVersion"
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
-libVersion="1.6.1"
+libVersion="$portVersion"
 libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 
 PROVIDES="


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.

---
Already known to be working for Haiku according to the github page. Tested and working on x86_64.