### PR TITLE
libreoffice, use external liborcus

### DIFF
--- a/app-office/libreoffice/libreoffice-6.4.7.2.recipe
+++ b/app-office/libreoffice/libreoffice-6.4.7.2.recipe
@@ -34,6 +34,9 @@ CHECKSUM_SHA256_3="5314962ca770369398599e175dc2c35c685d3fc968c9894390490c737036e
 SOURCE_DIR_3="LibreOfficeLauncher-$srcGitRevision3"
 SOURCE_FILENAME_3="LibreOfficeLauncher-$srcGitRevision3.tar.gz"
 
+SOURCE_URI_4="https://dev-www.libreoffice.org/src/liborcus-0.15.3.tar.gz#noarchive"
+CHECKSUM_SHA256_4="0dd26f3f2e611c51df9ee02d6dbf08887989eaa417b73f6877cd0d94df795fc2"
+
 PATCHES="libreoffice-${portVersion}.patchset"
 
 ADDITIONAL_FILES="
@@ -109,7 +112,6 @@ REQUIRES="
 	lib:libnssutil3$secondaryArchSuffix
 	lib:libnumbertext_1.0$secondaryArchSuffix
 	lib:libodfgen_0.1$secondaryArchSuffix
-	lib:liborcus_0.18$secondaryArchSuffix
 	lib:libpagemaker_0.0$secondaryArchSuffix
 	lib:libplc4$secondaryArchSuffix
 	lib:libplds4$secondaryArchSuffix
@@ -177,6 +179,7 @@ BUILD_REQUIRES="
 	devel:libboost_filesystem$secondaryArchSuffix >= $boostMinimumVersion
 	devel:libboost_iostreams$secondaryArchSuffix >= $boostMinimumVersion
 	devel:libboost_locale$secondaryArchSuffix >= $boostMinimumVersion
+	devel:libboost_system$secondaryArchSuffix >= $boostMinimumVersion
 	devel:libcairo$secondaryArchSuffix
 	devel:libcdr_0.1$secondaryArchSuffix
 	devel:libclucene_contribs_lib$secondaryArchSuffix
@@ -218,7 +221,6 @@ BUILD_REQUIRES="
 	devel:libnss3$secondaryArchSuffix
 	devel:libnumbertext_1.0$secondaryArchSuffix
 	devel:libodfgen_0.1$secondaryArchSuffix
-	devel:liborcus_0.18$secondaryArchSuffix
 	devel:libpagemaker_0.0$secondaryArchSuffix
 #	devel:libqrcodegen$secondaryArchSuffix
 	devel:libQt5Core$secondaryArchSuffix
@@ -286,6 +288,9 @@ BUILD()
 	rm -rf translations
 	ln -s $sourceDir2 translations
 
+	mkdir -p external/tarballs
+	cp $sourceDir4/liborcus-0.15.3.tar.gz external/tarballs
+
 	pkgconfig_libdir="`finddir B_SYSTEM_DIRECTORY`/$relativeDevelopLibDir/pkgconfig"
 	pkgconfig_datadir="`finddir B_SYSTEM_DIRECTORY`/$relativeDataDir/pkgconfig"
 	export PKG_CONFIG_LIBDIR="$pkgconfig_libdir:$pkgconfig_datadir"
@@ -301,6 +306,7 @@ BUILD()
 		--enable-sal-log \
 		\
 		--disable-ccache \
+		--disable-fetch-external \
 		--disable-firebird-sdbc \
 		--disable-pdfimport \
 		--disable-poppler \


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [ ] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
