### PR TITLE
vice, revbump, cleanup, enable REQUIRES

### DIFF
--- a/games-emulation/vice/vice-3.10.recipe
+++ b/games-emulation/vice/vice-3.10.recipe
@@ -45,7 +45,7 @@ COPYRIGHT="2005-2018 Marco van den Heuvel
     1993-1994 Jarkko Sonninen
     "
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://downloads.sourceforge.net/vice-emu/vice-$portVersion.tar.gz"
 CHECKSUM_SHA256="8e5bac18cbcb9f192380ad3ef881f8790f5b75c41d7b3da65d831985d864d6d1"
 PATCHES="vice-$portVersion.patchset"
@@ -83,16 +83,13 @@ REQUIRES="
 	lib:libFLAC$secondaryArchSuffix
 	lib:libgif$secondaryArchSuffix
 	lib:libgomp$secondaryArchSuffix
-	lib:libglib_2.0$secondaryArchSuffix
 	lib:libiconv$secondaryArchSuffix
-	lib:libjpeg$secondaryArchSuffix
-	lib:libmp3lame$secondaryArchSuffix
 	lib:libmpg123$secondaryArchSuffix
 	lib:libogg$secondaryArchSuffix
 	lib:libpng16$secondaryArchSuffix
 	lib:libSDL2_2.0$secondaryArchSuffix
-	lib:libSDL2_image$secondaryArchSuffix
 	lib:libSDL2_image_2.0$secondaryArchSuffix
+	lib:libvorbisenc$secondaryArchSuffix
 	lib:libvorbisfile$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
@@ -104,12 +101,12 @@ BUILD_REQUIRES="
 	devel:libgif$secondaryArchSuffix
 	devel:libglib_2.0$secondaryArchSuffix
 	devel:libiconv$secondaryArchSuffix
-	devel:libjpeg$secondaryArchSuffix
 	devel:libmp3lame$secondaryArchSuffix
 	devel:libmpg123$secondaryArchSuffix
+	devel:libogg$secondaryArchSuffix
 	devel:libpng16$secondaryArchSuffix
 	devel:libSDL2_2.0$secondaryArchSuffix
-	devel:libSDL2_image$secondaryArchSuffix
+	devel:libSDL2_image_2.0$secondaryArchSuffix
 	devel:libvorbisfile$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"
@@ -136,7 +133,12 @@ BUILD()
 {
 	./autogen.sh
 	runConfigure --omit-dirs sbinDir ./configure \
-		--sbindir=$commandBinDir
+		--sbindir=$commandBinDir \
+		--with-lame \
+		--with-mpg123 \
+		--with-flac \
+		--with-vorbis \
+		--with-gif
 	make $jobArgs
 }
 


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
