### PR TITLE
librsvg, make sure we are not using xcairo

### DIFF
--- a/gnome-base/librsvg/librsvg-2.58.5.recipe
+++ b/gnome-base/librsvg/librsvg-2.58.5.recipe
@@ -5,7 +5,7 @@ HOMEPAGE="https://wiki.gnome.org/Projects/LibRsvg"
 COPYRIGHT="2009-2010 Raph Levien"
 LICENSE="GNU GPL v2
 	GNU LGPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://download.gnome.org/sources/librsvg/2.58/librsvg-2.58.5.tar.xz"
 CHECKSUM_SHA256="224233a0e347d38c415f15a49f0e0885313e3ecc18f3192055f9304dd2f3a27a"
 
@@ -918,8 +918,8 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	cairo${secondaryArchSuffix}_devel
 	shared_mime_info$secondaryArchSuffix
-	devel:libcairo$secondaryArchSuffix
 	devel:libdav1d$secondaryArchSuffix
 	devel:libfontconfig$secondaryArchSuffix
 	devel:libfreetype$secondaryArchSuffix


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
