### PR TITLE
fpcupdeluxe, fix checksum for 32bit

### DIFF
--- a/sys-devel/fpcupdeluxe/fpcupdeluxe-2.4.0~j.recipe
+++ b/sys-devel/fpcupdeluxe/fpcupdeluxe-2.4.0~j.recipe
@@ -18,7 +18,7 @@ LICENSE="GNU LGPL v3
 REVISION="1"
 if [ "$targetArchitecture" = x86_gcc2 ]; then
 	SOURCE_URI="$HOMEPAGE/releases/download/v${portVersion/\~/}/fpcupdeluxe-i386-haiku-qt5.zip"
-	CHECKSUM_SHA256="c17347a6db72aaa7dd4ba8756f1d9b18ddff131cc725d14ea6a131a88be9cfb6"
+	CHECKSUM_SHA256="95b4724d0a90b4459e83c214867f925e3718f108141dbc4f541f6e759a265ffe"
 	SOURCE_DIR="fpcupdeluxe-i386-haiku-qt5"
 else
 	SOURCE_URI="$HOMEPAGE/releases/download/v${portVersion/\~/}/fpcupdeluxe-x86_64-haiku-qt6.zip"


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
