### PR TITLE
librsvg, try building with only 1 job for 32bit

### DIFF
--- a/gnome-base/librsvg/librsvg-2.58.5.recipe
+++ b/gnome-base/librsvg/librsvg-2.58.5.recipe
@@ -1010,7 +1010,7 @@ BUILD()
 		--disable-static \
 		--enable-introspection=yes \
 		--enable-vala=yes
-	make $jobArgs
+	make -1
 }
 
 INSTALL()


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
