### PR TITLE
r2dec_js, add upstream patch for radare2 > 6.1.9

### DIFF
--- a/dev-util/r2dec_js/patches/393.patch
+++ b/dev-util/r2dec_js/patches/393.patch
@@ -1,0 +1,26 @@
+From 2952d33eb44c0415576161fb8ff141e842658f84 Mon Sep 17 00:00:00 2001
+From: pancake <pancake@nopcode.org>
+Date: Wed, 22 Jul 2026 18:09:40 +0200
+Subject: [PATCH] Fix build for r2-6.1.9 (r2abi >= 125)
+
+---
+ c/r2dec-plugin.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/c/r2dec-plugin.c b/c/r2dec-plugin.c
+index 20d231c7..6c11c673 100644
+--- a/c/r2dec-plugin.c
++++ b/c/r2dec-plugin.c
+@@ -142,8 +142,11 @@ static void usage(const RCore* const core) {
+ 		"pddi", "",                   "generate issue data",
+ 		NULL
+ 	};
+-
++#if R2_ABIVERSION >= 125
++	r_cons_cmd_help(core->cons, help);
++#else
+ 	r_cons_cmd_help(core->cons, help, core->print->flags & R_PRINT_FLAGS_COLOR);
++#endif
+ }
+ 
+ static void _cmd_pdd(RCore *core, const char *input) {

--- a/dev-util/r2dec_js/r2dec_js-6.1.4.recipe
+++ b/dev-util/r2dec_js/r2dec_js-6.1.4.recipe
@@ -22,6 +22,7 @@ quickjsVer="0.8.0"
 SOURCE_URI_2="https://github.com/quickjs-ng/quickjs/archive/refs/tags/v$quickjsVer.tar.gz"
 CHECKSUM_SHA256_2="7e60e1e0dcd07d25664331308a2f4aee2a88d60d85896e828d25df7c3d40204e"
 SOURCE_DIR_2="quickjs-$quickjsVer"
+PATCHES="393.patch"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
