### PR TITLE
balsa, revbump for libxml2

### DIFF
--- a/mail-client/balsa/balsa-2.6.4.recipe
+++ b/mail-client/balsa/balsa-2.6.4.recipe
@@ -21,7 +21,7 @@ Support for local mailbox formats: mbox, maildir, mh
 HOMEPAGE="https://pawsa.fedorapeople.org/balsa/"
 COPYRIGHT="1997-2018 The Balsa Developers"
 LICENSE="GNU GPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://pawsa.fedorapeople.org/balsa/balsa-$portVersion.tar.xz"
 CHECKSUM_SHA256="befa5984511db33d41f2b1ecbfc99e22a15d45d08efe5d737b5174a1a6ac8fc1"
 PATCHES="balsa-$portVersion.patchset"
@@ -104,6 +104,7 @@ BUILD_PREREQUIRES="
 	cmd:intltoolize
 	cmd:libtoolize$secondaryArchSuffix
 	cmd:make
+	cmd:msgfmt$secondaryArchSuffix
 	cmd:pkg_config$secondaryArchSuffix
 	"
 


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
