### PR TITLE
vala, bump to version 0.56.19

### DIFF
--- a/dev-lang/vala/vala-0.56.19.recipe
+++ b/dev-lang/vala/vala-0.56.19.recipe
@@ -29,7 +29,7 @@ COPYRIGHT="1995-1997 Peter Mattis, Spencer Kimball and Josh MacDonald
 LICENSE="GNU LGPL v2.1"
 REVISION="1"
 SOURCE_URI="https://download.gnome.org/sources/vala/${portVersion%.*}/vala-$portVersion.tar.xz"
-CHECKSUM_SHA256="f2affe7d40ab63db8e7b9ecc3f6bdc9c2fc7e3134c84ff2d795f482fe926a382"
+CHECKSUM_SHA256="5ad7cbbfcc0de61b403d6797c9ef60455bfbebd8e162aec33b5b0b097adfb9d5"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -67,8 +67,6 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libcdt$secondaryArchSuffix
 	lib:libcgraph$secondaryArchSuffix
-	lib:libgirepository_1.0$secondaryArchSuffix
-	lib:libgio_2.0$secondaryArchSuffix
 	lib:libglib_2.0$secondaryArchSuffix
 	lib:libgmodule_2.0$secondaryArchSuffix
 	lib:libgobject_2.0$secondaryArchSuffix
@@ -84,10 +82,7 @@ BUILD_REQUIRES="
 	devel:libcdt$secondaryArchSuffix
 	devel:libcgraph$secondaryArchSuffix
 	devel:libgirepository_1.0$secondaryArchSuffix
-	devel:libgio_2.0$secondaryArchSuffix
 	devel:libglib_2.0$secondaryArchSuffix
-	devel:libgmodule_2.0$secondaryArchSuffix
-	devel:libgobject_2.0$secondaryArchSuffix
 	devel:libgvc$secondaryArchSuffix
 	devel:libintl$secondaryArchSuffix
 	"
@@ -127,7 +122,8 @@ defineDebugInfoPackage vala$secondaryArchSuffix \
 BUILD()
 {
 	autoreconf -vfi
-	runConfigure --omit-dirs binDir ./configure --bindir="$commandBinDir"
+	runConfigure --omit-dirs binDir ./configure \
+		--bindir="$commandBinDir"
 	make $jobArgs
 }
 
@@ -137,20 +133,22 @@ INSTALL()
 
 	find "$libDir" -name '*.la' -delete
 
-	prepareInstalledDevelLibs libvala-$portVers libvaladoc-$portVers
+	prepareInstalledDevelLibs \
+		libvala-$portVers \
+		libvaladoc-$portVers
 	fixPkgconfig
 }
 
 TEST()
 {
 #============================================================================
-#Testsuite summary for vala 0.56.18
+#Testsuite summary for vala 0.56.19
 #============================================================================
-# TOTAL: 1420
-# PASS:  1395
+# TOTAL: 1425
+# PASS:  1399
 # SKIP:  0
 # XFAIL: 0
-# FAIL:  25
+# FAIL:  26
 # XPASS: 0
 # ERROR: 0
 #============================================================================


### PR DESCRIPTION
Move cmd's and vapi files to _devel package, if anything requires the libraries it shouldn't require the vala compilers or devel tools

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
