### PR TITLE
sqlite: update to version 3.53.4.0.

### DIFF
--- a/dev-db/sqlite/sqlite-3.47.2.0.recipe
+++ b/dev-db/sqlite/sqlite-3.47.2.0.recipe
@@ -1,0 +1,90 @@
+SUMMARY="An SQL Database Engine in a C library"
+DESCRIPTION="SQLite is a software library that implements a self-contained, \
+serverless, zero-configuration, transactional SQL database engine. SQLite is \
+the most widely deployed SQL database engine in the world. The source code for \
+SQLite is in the public domain."
+HOMEPAGE="https://www.sqlite.org/"
+COPYRIGHT="Public Domain"
+LICENSE="SQLite"
+REVISION="2"
+sqliteVersion=$(echo $portVersion | sed -e 's/\.\([0-9]\>\)/0\1/g' -e 's/\.//g')
+SOURCE_URI="https://www.sqlite.org/2024/sqlite-autoconf-$sqliteVersion.tar.gz"
+CHECKSUM_SHA256="f1b2ee412c28d7472bc95ba996368d6f0cdcf00362affdadb27ed286c179540b"
+SOURCE_DIR="sqlite-autoconf-$sqliteVersion"
+
+# Leave only enabled for GCC2 compatibility.
+ARCHITECTURES="?all x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
+
+libVersion="0.8.6"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+portVersionCompat="$portVersion compat >= 3"
+
+PROVIDES="
+	sqlite$secondaryArchSuffix = $portVersionCompat
+	lib:libsqlite3$secondaryArchSuffix = $libVersionCompat
+	"
+
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	sqlite${secondaryArchSuffix}_devel = $portVersion
+	devel:libsqlite3$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	sqlite$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:aclocal
+	cmd:autoconf
+	cmd:automake
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:libtoolize$secondaryArchSuffix
+	cmd:make
+	"
+
+defineDebugInfoPackage sqlite$secondaryArchSuffix \
+	"$libDir"/libsqlite3.so.$libVersion
+
+BUILD()
+{
+	autoreconf -fi
+	export CPPFLAGS="$CPPFLAGS \
+		-DSQLITE_ENABLE_COLUMN_METADATA=1 -DSQLITE_ENABLE_UNLOCK_NOTIFY \
+		-DSQLITE_ENABLE_DBSTAT_VTAB 	-DSQLITE_SECURE_DELETE=1 \
+		-DSQLITE_ENABLE_FTS3=1 	-DSQLITE_ENABLE_FTS3_PARENTHESIS \
+		-DSQLITE_ENABLE_FTS5 -DSQLITE_ENABLE_RTREE"
+	runConfigure ./configure --disable-static
+
+	# Not using "make $jobArgs" because parallel builds are not supported.
+	make
+}
+
+INSTALL()
+{
+	make install
+
+	# remove libtool file
+	rm $libDir/libsqlite3.la
+
+	prepareInstalledDevelLib libsqlite3
+	fixPkgconfig
+
+	# devel package
+	packageEntries devel \
+		$developDir
+
+	# Remove stuff we don't need
+	# (we only want to keep/provide libsqlite3.so for compatibility purposes).
+	rm -rf $binDir
+	rm -rf $documentationDir
+}

--- a/dev-db/sqlite/sqlite-3.53.4.0.recipe
+++ b/dev-db/sqlite/sqlite-3.53.4.0.recipe
@@ -8,11 +8,11 @@ COPYRIGHT="Public Domain"
 LICENSE="SQLite"
 REVISION="1"
 sqliteVersion=$(echo $portVersion | sed -e 's/\.\([0-9]\>\)/0\1/g' -e 's/\.//g')
-SOURCE_URI="https://www.sqlite.org/2025/sqlite-autoconf-$sqliteVersion.tar.gz"
-CHECKSUM_SHA256="a3db587a1b92ee5ddac2f66b3edb41b26f9c867275782d46c3a088977d6a5b18"
+SOURCE_URI="https://www.sqlite.org/2026/sqlite-autoconf-$sqliteVersion.tar.gz"
+CHECKSUM_SHA256="0e9483900e92cd5de8fd48d16bf9200145a61f7fd5be542a5ac81d8a9516eb9c"
 SOURCE_DIR="sqlite-autoconf-$sqliteVersion"
 
-ARCHITECTURES="all"
+ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 libVersion="${portVersion%.*}"
@@ -21,17 +21,13 @@ portVersionCompat="$portVersion compat >= 3"
 
 PROVIDES="
 	sqlite$secondaryArchSuffix = $portVersionCompat
+	cmd:sqlite3 = $portVersionCompat
 	lib:libsqlite3$secondaryArchSuffix = $libVersionCompat
 	"
-if [ -z "$secondaryArchSuffix" ]; then
-PROVIDES="$PROVIDES
-	cmd:sqlite3 = $portVersionCompat
-	"
-fi
 
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libreadline$secondaryArchSuffix
+	lib:libedit$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
 
@@ -45,7 +41,7 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libreadline$secondaryArchSuffix >= 8
+	devel:libedit$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
@@ -68,11 +64,14 @@ BUILD()
 		-DSQLITE_ENABLE_FTS3_PARENTHESIS \
 		-DSQLITE_ENABLE_FTS5 \
 		-DSQLITE_ENABLE_RTREE"
+
 	./configure --prefix=$prefix \
 		--mandir=$manDir \
 		--includedir=$includeDir \
 		--libdir=$libDir \
 		--soname=legacy \
+		--with-readline-cflags="-I$includeDir -DHAVE_EDITLINE=1 -DHAVE_READLINE=0" \
+		--with-readline-ldflags="-ledit" \
 		--disable-static
 
 	# Not using "make $jobArgs" because parallel builds are not supported.
@@ -89,15 +88,4 @@ INSTALL()
 	# devel package
 	packageEntries devel \
 		$developDir
-
-	# Remove stuff we don't need in the secondary architecture base package.
-	if [ -n "$secondaryArchSuffix" ]; then
-		rm -rf $binDir
-		rm -rf $documentationDir
-	fi
-}
-
-TEST()
-{
-	make check
 }

--- a/dev-db/sqlite/sqlite-3.53.4.0.recipe
+++ b/dev-db/sqlite/sqlite-3.53.4.0.recipe
@@ -27,7 +27,7 @@ PROVIDES="
 
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libedit$secondaryArchSuffix
+	lib:libreadline$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
 
@@ -41,7 +41,7 @@ REQUIRES_devel="
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libedit$secondaryArchSuffix
+	devel:libreadline$secondaryArchSuffix >= 8
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
@@ -65,13 +65,14 @@ BUILD()
 		-DSQLITE_ENABLE_FTS5 \
 		-DSQLITE_ENABLE_RTREE"
 
+	# "--with-readline-header=$developDir" needed to fix readline
+	# detection on x86.
 	./configure --prefix=$prefix \
 		--mandir=$manDir \
 		--includedir=$includeDir \
 		--libdir=$libDir \
 		--soname=legacy \
-		--with-readline-cflags="-I$includeDir -DHAVE_EDITLINE=1 -DHAVE_READLINE=0" \
-		--with-readline-ldflags="-ledit" \
+		--with-readline-header=$developDir \
 		--disable-static
 
 	# Not using "make $jobArgs" because parallel builds are not supported.


### PR DESCRIPTION
~~- Switch back from libreadline to libedit while at it (in a hackish way, because `./configure --editline` doesn't quite works on Haiku).~~

~~Could use a better patch for it (even if only to avoid the warning about redefined 'HAVE_READLINE').~~

~~Command completion doesn't seem to work, but neither it did with the previous version.~~ Line-editing and history seem to work as before.

  Edit: command completion works, once a .db is loaded.

- Dropped TEST(), as there's no `check` make target.

- Mark as broken on x86_gcc2. Seems the last successful build there was for version 3.47.2.0.
- Restore 3.47.2.0 only for GCC2 compat.
