### PR TITLE
einsteinium: move to modern GCC.

### DIFF
--- a/haiku-apps/einsteinium/einsteinium-1.4.1a.recipe
+++ b/haiku-apps/einsteinium/einsteinium-1.4.1a.recipe
@@ -6,36 +6,41 @@ provides customizable ranked lists of applications."
 HOMEPAGE="https://perelandra0x309.github.io/einsteinium"
 COPYRIGHT="2010-2017 Brian Hill"
 LICENSE="BSD (3-clause)"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://github.com/Perelandra0x309/einsteinium/archive/v${portVersion}.tar.gz"
 CHECKSUM_SHA256="cf420ac69304e48895398bec6b85401786c746418f103a291bd9209f275d96d2"
 PATCHES="einsteinium-$portVersion.patchset"
 
-ARCHITECTURES="all"
+ARCHITECTURES="all ?x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
 
 USER_SETTINGS_FILES="settings/Einsteinium directory"
 POST_INSTALL_SCRIPTS="$relativePostInstallDir/einsteinium_hpkg_postinstall.sh"
 
 PROVIDES="
-	einsteinium = $portVersion
+	einsteinium$secondaryArchSuffix = $portVersion
 	app:Einsteinium = $portVersion
 	cmd:einsteinium_daemon = $portVersion
 	cmd:einsteinium_engine = $portVersion
 	"
 REQUIRES="
-	haiku
-	lib:libsqlite3
-	lib:libxml2
+	haiku$secondaryArchSuffix
+	lib:libsqlite3$secondaryArchSuffix
+	lib:libxml2$secondaryArchSuffix
 	"
 
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	REPLACES="einsteinium"
+fi
+
 BUILD_REQUIRES="
-	haiku_devel
-	devel:libsqlite3
-	devel:libxml2
+	haiku${secondaryArchSuffix}_devel
+	devel:libsqlite3$secondaryArchSuffix
+	devel:libxml2$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	makefile_engine
-	cmd:g++
+	cmd:g++$secondaryArchSuffix
 	cmd:make
 	"
 
@@ -59,7 +64,7 @@ BUILD()
 INSTALL()
 {
 	mkdir -p $appsDir/Einsteinium/EngineSubscriberKit
-	mkdir -p $binDir
+	mkdir -p $prefix/bin
 	mkdir -p $dataDir/Einsteinium
 	mkdir -p $preferencesDir
 	mkdir -p $postInstallDir
@@ -80,7 +85,7 @@ INSTALL()
 
 	# copy executables
 	cd src
-	cp -af Engine/einsteinium_engine Daemon/einsteinium_daemon $binDir
+	cp -af Engine/einsteinium_engine Daemon/einsteinium_daemon $prefix/bin
 	cp -af Preferences/Einsteinium_Preferences $preferencesDir/Einsteinium
 	cp -af Launcher/Einsteinium $appsDir/Einsteinium/Einsteinium
 

--- a/haiku-apps/einsteinium/patches/einsteinium-1.4.1a.patchset
+++ b/haiku-apps/einsteinium/patches/einsteinium-1.4.1a.patchset
@@ -1,4 +1,4 @@
-From 6952bab0dc33a35cd283ac3a89a3fd78dee0061d Mon Sep 17 00:00:00 2001
+From 578d08fd9ee0b1efe39ffc54a8c222213eb3c055 Mon Sep 17 00:00:00 2001
 From: PulkoMandy <pulkomandy@pulkomandy.tk>
 Date: Sun, 26 Jul 2026 17:11:39 +0200
 Subject: Fix build with current compilers
@@ -34,7 +34,7 @@ index 5f95b83..83bad61 100644
 2.54.0
 
 
-From 3b8fea52d12e9acdd0738fbf18ba37a619005212 Mon Sep 17 00:00:00 2001
+From 85282d3e5547ba245b419e8b7df404b6cf172dca Mon Sep 17 00:00:00 2001
 From: PulkoMandy <pulkomandy@pulkomandy.tk>
 Date: Sun, 26 Jul 2026 17:28:32 +0200
 Subject: Missing include for atoi
@@ -53,6 +53,103 @@ index 8f321f2..2c3e8dd 100644
  
  LauncherSettingsFile::LauncherSettingsFile(BHandler *messageHandler)
  	:
+-- 
+2.54.0
+
+
+From 4c40bd26421ccf2112767a547314228426296a03 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Fri, 14 Aug 2026 19:41:50 -0300
+Subject: Fix xml2 include paths for x86.
+
+(Feels like this is something makefile_engine should do on its own).
+
+diff --git a/src/Daemon/makefile b/src/Daemon/makefile
+index 4c699d1..4173e97 100644
+--- a/src/Daemon/makefile
++++ b/src/Daemon/makefile
+@@ -16,7 +16,12 @@ LIBPATHS =
+ #	Additional paths to look for system headers. These use the form
+ #	"#include <header>". Directories that contain the files in SRCS are
+ #	NOT auto-included here.
+-SYSTEM_INCLUDE_PATHS = /boot/system/develop/headers/libxml2
++ifeq ($(shell uname -m), BePC)
++	SYSTEM_INCLUDE_PATHS = $(shell finddir B_SYSTEM_HEADERS_DIRECTORY)/x86/libxml2
++else
++	SYSTEM_INCLUDE_PATHS = $(shell finddir B_SYSTEM_HEADERS_DIRECTORY)/libxml2
++endif
++
+ 
+ #	Additional paths paths to look for local headers. These use the form
+ #	#include "header". Directories that contain the files in SRCS are
+diff --git a/src/Engine/SubscriberExample/makefile b/src/Engine/SubscriberExample/makefile
+index 37dc744..88653d8 100644
+--- a/src/Engine/SubscriberExample/makefile
++++ b/src/Engine/SubscriberExample/makefile
+@@ -16,7 +16,11 @@ LIBPATHS =
+ #	Additional paths to look for system headers. These use the form
+ #	"#include <header>". Directories that contain the files in SRCS are
+ #	NOT auto-included here.
+-SYSTEM_INCLUDE_PATHS = /boot/system/develop/headers/libxml2 /boot/common/include
++ifeq ($(shell uname -m), BePC)
++	SYSTEM_INCLUDE_PATHS = $(shell finddir B_SYSTEM_HEADERS_DIRECTORY)/x86/libxml2
++else
++	SYSTEM_INCLUDE_PATHS = $(shell finddir B_SYSTEM_HEADERS_DIRECTORY)/libxml2
++endif
+ 
+ #	Additional paths paths to look for local headers. These use the form
+ #	#include "header". Directories that contain the files in SRCS are
+diff --git a/src/Engine/makefile b/src/Engine/makefile
+index 95c6bb1..b7e5605 100644
+--- a/src/Engine/makefile
++++ b/src/Engine/makefile
+@@ -20,7 +20,11 @@ LIBPATHS =
+ #	Additional paths to look for system headers. These use the form
+ #	"#include <header>". Directories that contain the files in SRCS are
+ #	NOT auto-included here.
+-SYSTEM_INCLUDE_PATHS = /boot/system/develop/headers/libxml2 /boot/common/include
++ifeq ($(shell uname -m), BePC)
++	SYSTEM_INCLUDE_PATHS = $(shell finddir B_SYSTEM_HEADERS_DIRECTORY)/x86/libxml2
++else
++	SYSTEM_INCLUDE_PATHS = $(shell finddir B_SYSTEM_HEADERS_DIRECTORY)/libxml2
++endif
+ 
+ #	Additional paths paths to look for local headers. These use the form
+ #	#include "header". Directories that contain the files in SRCS are
+diff --git a/src/Launcher/makefile b/src/Launcher/makefile
+index 8a1b9be..2ef7fc5 100644
+--- a/src/Launcher/makefile
++++ b/src/Launcher/makefile
+@@ -35,7 +35,11 @@ LIBPATHS =
+ #	Additional paths to look for system headers. These use the form
+ #	"#include <header>". Directories that contain the files in SRCS are
+ #	NOT auto-included here.
+-SYSTEM_INCLUDE_PATHS = /boot/system/develop/headers/libxml2
++ifeq ($(shell uname -m), BePC)
++	SYSTEM_INCLUDE_PATHS = $(shell finddir B_SYSTEM_HEADERS_DIRECTORY)/x86/libxml2
++else
++	SYSTEM_INCLUDE_PATHS = $(shell finddir B_SYSTEM_HEADERS_DIRECTORY)/libxml2
++endif
+ 
+ #	Additional paths paths to look for local headers. These use the form
+ #	#include "header". Directories that contain the files in SRCS are
+diff --git a/src/Preferences/makefile b/src/Preferences/makefile
+index 47cc65a..77109b6 100644
+--- a/src/Preferences/makefile
++++ b/src/Preferences/makefile
+@@ -29,7 +29,11 @@ LIBPATHS =
+ #	Additional paths to look for system headers. These use the form
+ #	"#include <header>". Directories that contain the files in SRCS are
+ #	NOT auto-included here.
+-SYSTEM_INCLUDE_PATHS = /boot/system/develop/headers/libxml2
++ifeq ($(shell uname -m), BePC)
++	SYSTEM_INCLUDE_PATHS = $(shell finddir B_SYSTEM_HEADERS_DIRECTORY)/x86/libxml2
++else
++	SYSTEM_INCLUDE_PATHS = $(shell finddir B_SYSTEM_HEADERS_DIRECTORY)/libxml2
++endif
+ 
+ #	Additional paths paths to look for local headers. These use the form
+ #	#include "header". Directories that contain the files in SRCS are
 -- 
 2.54.0
 


### PR DESCRIPTION
Build tested on x86-32.

The post-install script showed 3 (equal) notifications, and `einsteinium_daemon` crashed with a ` (Segment violation)` on:

```
		0x759e6600	0x1895234	EDSettingsFile::EDSettingsFile(BHandler*) [clone .cold] + 0 
		0x759e6740	0x1896f11	EDSettingsFile::EDSettingsFile(BHandler*) + 0x401 
		0x759e67f0	0x18973e9	einsteinium_daemon::einsteinium_daemon() + 0x129 
		0x759e6990	0x189569b	main + 0x2b 
```

But calling `open application/x-vnd.Einsteinium_Daemon &` afterwards (as the script does) worked fine.

----

Edit: on subsequent (re)installations, I haven't seen the above anymore. No crashes, and only one notification appeared.