### PR TITLE
beindexed: switch to modern GCC on 32 bits (still broken).

### DIFF
--- a/haiku-apps/beindexed/beindexed-0.2.0_alpha.recipe
+++ b/haiku-apps/beindexed/beindexed-0.2.0_alpha.recipe
@@ -7,34 +7,39 @@ Indexer, Find files with Finder.
 HOMEPAGE="https://github.com/HaikuArchives/BeIndexed"
 COPYRIGHT="2003 Mikael Eiman"
 LICENSE="BSD (3-clause)"
-REVISION="3"
+REVISION="4"
 srcGitRev="4bbd3e9709d7288ffefbc215ab41a152a24a2276"
 SOURCE_URI="https://github.com/HaikuArchives/BeIndexed/archive/$srcGitRev.tar.gz"
 CHECKSUM_SHA256="b9bb08ec87e96169708309e26ef6ee59e1c30c2f46a06c6a7427d3e8d4d65c00"
 SOURCE_DIR="BeIndexed-$srcGitRev"
 PATCHES="beindexed-$portVersion.patchset"
 
-ARCHITECTURES="all"
+ARCHITECTURES="!all ?x86_gcc2"
+SECONDARY_ARCHITECTURES="!x86"
 
 PROVIDES="
-	beindexed = $portVersion
+	beindexed$secondaryArchSuffix = $portVersion
 	app:Finder = $portVersion
 	cmd:Indexer = $portVersion
 	"
 REQUIRES="
-	haiku
-	lib:liblayout
-	lib:libsqlite3
+	haiku$secondaryArchSuffix
+	lib:liblayout$secondaryArchSuffix
+	lib:libsqlite3$secondaryArchSuffix
 	"
 
+if [ "$targetArchitecture" = x86_gcc2 ]; then
+	REPLACES="beindexed"
+fi
+
 BUILD_REQUIRES="
-	haiku_devel
-	devel:liblayout
-	devel:libsqlite3
+	haiku${secondaryArchSuffix}_devel
+	devel:liblayout$secondaryArchSuffix
+	devel:libsqlite3$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	makefile_engine
-	cmd:g++
+	cmd:g++$secondaryArchSuffix
 	cmd:make
 	cmd:xres
 	"
@@ -47,10 +52,10 @@ BUILD()
 
 INSTALL()
 {
-	mkdir -p $binDir
+	mkdir -p $prefix/bin
 	mkdir -p $appsDir
 
-	cp bin/Indexer $binDir
+	cp bin/Indexer $prefix/bin
 	cp bin/Finder $appsDir
 
 	addAppDeskbarSymlink $appsDir/Finder

--- a/haiku-apps/beindexed/patches/beindexed-0.2.0_alpha.patchset
+++ b/haiku-apps/beindexed/patches/beindexed-0.2.0_alpha.patchset
@@ -1,4 +1,4 @@
-From af255d5fe69b47e685124ff3b4f1a1c4f15395d9 Mon Sep 17 00:00:00 2001
+From 8015d15f93aa7150a080ebe47266d7c3ae23b62a Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Wed, 3 Jul 2019 21:27:54 +0200
 Subject: x86_64 patch
@@ -113,5 +113,32 @@ index 70423f6..4e131e3 100644
  	
  	return stem( strip_specials( remove_duplicates(word) ) );
 -- 
-2.21.0
+2.54.0
+
+
+From fc0ad07d39f62294f07deff65dd62e3e94792a21 Mon Sep 17 00:00:00 2001
+From: Oscar Lesta <oscar.lesta@gmail.com>
+Date: Fri, 14 Aug 2026 23:57:29 -0300
+Subject: Fix include paths for x86.
+
+
+diff --git a/src/Finder/makefile b/src/Finder/makefile
+index 78d7fc0..008b9fb 100644
+--- a/src/Finder/makefile
++++ b/src/Finder/makefile
+@@ -66,7 +66,11 @@ LIBPATHS=
+ #	additional paths to look for system headers
+ #	thes use the form: #include <header>
+ #	source file directories are NOT auto-included here
+-SYSTEM_INCLUDE_PATHS = $(shell finddir B_SYSTEM_HEADERS_DIRECTORY)/liblayout ..
++ifeq ($(shell uname -m), BePC)
++	SYSTEM_INCLUDE_PATHS = $(shell finddir B_SYSTEM_HEADERS_DIRECTORY)/x86/liblayout ..
++else
++	SYSTEM_INCLUDE_PATHS = $(shell finddir B_SYSTEM_HEADERS_DIRECTORY)/liblayout ..
++endif
+ 
+ #	additional paths to look for local headers
+ #	thes use the form: #include "header"
+-- 
+2.54.0
 


### PR DESCRIPTION
Builds, but the `Finder` app has the same startup crash as version 0.2.0_alpha-3 (currently on depot) has on both x86-64 and x86-32 (GCC2).

Throws an exception at `init_sql()` -> `SQLiteConnection::SQLiteConnection()` on `src/common/SQLConnection.cpp:38`
