### PR TITLE
tcl: drop the GCC2 version.

### DIFF
--- a/dev-lang/tcl/tcl-8.6.14.recipe
+++ b/dev-lang/tcl/tcl-8.6.14.recipe
@@ -7,13 +7,13 @@ is truly cross platform, easily deployed and highly extensible."
 HOMEPAGE="http://www.tcl.tk"
 COPYRIGHT="Regents of the University of California, Sun Microsystems, Inc., Scriptics Corporation, and other parties"
 LICENSE="TCL"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://sourceforge.net/projects/tcl/files/Tcl/$portVersion/tcl$portVersion-src.tar.gz"
 CHECKSUM_SHA256="5880225babf7954c58d4fb0f5cf6279104ce1cd6aa9b71e9a6322540e1c4de66"
 SOURCE_DIR="tcl$portVersion"
 PATCHES="tcl-$portVersion.patchset"
 
-ARCHITECTURES="all"
+ARCHITECTURES="all ?x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
 commandBinDir=$binDir


### PR DESCRIPTION
Nothing on-tree requires it, and tcllib is already marked as broken for x86_gcc2.

(along with other PRs moving recipes away from GCC2, this should allow to also drop the GCC2 version of sqlite3).

Edit: can't really drop GCC2 version of sqlite as some BeOS/Haiku apps can't be moved to modern GCC.

----

Unsure if the rev-bump is really necessary in this case.