### PR TITLE
glib2, revbump, make sure typelib files end up in libDir

### DIFF
--- a/dev-libs/glib/glib2-2.88.1.recipe
+++ b/dev-libs/glib/glib2-2.88.1.recipe
@@ -20,7 +20,7 @@ COPYRIGHT="1995-1997  Peter Mattis, Spencer Kimball and Josh MacDonald
 	2008-2010 Collabora Ltd.
 	1995-2010 Several others"
 LICENSE="GNU LGPL v2"
-REVISION="7"
+REVISION="8"
 SOURCE_URI="https://gitlab.gnome.org/GNOME/glib/-/archive/$portVersion/glib-$portVersion.tar.gz"
 CHECKSUM_SHA256="cfb9e5f9e321fb8fcbf743b897e18877face361341049858dcf9c9b62f4daa2d"
 SOURCE_DIR="glib-$portVersion"
@@ -310,6 +310,10 @@ INSTALL()
 	mv $libDir/glib-2.0 $developLibDir
 
 	fixPkgconfig
+
+	# make sure typelib files end up in $libDir
+	sed -i 's,typelibdir=${libdir}/girepository-1.0,typelibdir=${prefix}/'${relativeLibDir}'/girepository-1.0,g' \
+		$developLibDir/pkgconfig/gobject-introspection-1.0.pc
 
 	# gi_devel package
 	packageEntries gi_devel \


### PR DESCRIPTION
in the pkgconfig file typelibdir points to 'develop/lib' which is wrong for packages using pkg-config, on meson packages this uses TYPELIBDIR

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
