### PR TITLE
haiku-apps/weatherpositive: new recipe

### DIFF
--- a/haiku-apps/weatherpositive/weatherpositive-1.4.1.recipe
+++ b/haiku-apps/weatherpositive/weatherpositive-1.4.1.recipe
@@ -10,7 +10,7 @@ HOMEPAGE="https://github.com/nich227/haiku-weatherpositive"
 COPYRIGHT="2026 Kevin Chen"
 LICENSE="MIT"
 REVISION="1"
-SOURCE_URI="$HOMEPAGE/archive/refs/tags/v$portVersion.tar.gz"
+SOURCE_URI="https://github.com/nich227/haiku-weatherpositive/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="1bc5c3ed607f80ca7d6536ad971a112afe085024a39d0d3db273e36426ac6a89"
 SOURCE_DIR="haiku-weatherpositive-$portVersion"
 

--- a/haiku-apps/weatherpositive/weatherpositive-1.4.1.recipe
+++ b/haiku-apps/weatherpositive/weatherpositive-1.4.1.recipe
@@ -1,0 +1,52 @@
+SUMMARY="A weather app for Haiku"
+DESCRIPTION="WeatherPositive shows the current conditions for a place you name, \
+an hourly outlook for the next day and a seven day forecast with the daily range \
+drawn as a bar, along with air quality, wind, humidity, UV index, pressure and \
+the times of sunrise and sunset. A second tab animates precipitation radar over \
+map tiles around the location.
+Weather, geocoding and air quality data come from Open-Meteo, radar imagery from \
+RainViewer, and map tiles from OpenStreetMap contributors."
+HOMEPAGE="https://github.com/nich227/haiku-weatherpositive"
+COPYRIGHT="2026 Kevin Chen"
+LICENSE="MIT"
+REVISION="1"
+SOURCE_URI="$HOMEPAGE/archive/refs/tags/v$portVersion.tar.gz"
+CHECKSUM_SHA256="1bc5c3ed607f80ca7d6536ad971a112afe085024a39d0d3db273e36426ac6a89"
+SOURCE_DIR="haiku-weatherpositive-$portVersion"
+
+ARCHITECTURES="all !x86_gcc2"
+
+USER_SETTINGS_FILES="
+	settings/WeatherPositive_settings
+	"
+
+PROVIDES="
+	weatherpositive = $portVersion
+	app:WeatherPositive = $portVersion
+	"
+REQUIRES="
+	haiku
+	cmd:python3
+	"
+
+BUILD_REQUIRES="
+	haiku_devel
+	"
+BUILD_PREREQUIRES="
+	makefile_engine
+	cmd:gcc
+	cmd:make
+	"
+
+BUILD()
+{
+	make $jobArgs
+	make bindcatalogs
+}
+
+INSTALL()
+{
+	mkdir -p $appsDir/WeatherPositive
+	cp objects*/WeatherPositive fetch.py $appsDir/WeatherPositive
+	addAppDeskbarSymlink $appsDir/WeatherPositive/WeatherPositive
+}


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.

---

New port: WeatherPositive 1.4.1, a native weather app.

Current conditions, an hourly outlook and a seven day forecast for a named
location, plus air quality, wind, humidity, UV index, pressure and sunrise and
sunset. A second tab animates precipitation radar over map tiles.

Forecast, geocoding and air quality data come from Open-Meteo, radar imagery from
RainViewer and map tiles from OpenStreetMap contributors. No API keys are
involved. The network requests are made by a small Python script that ships with
the app, hence `cmd:python3` in REQUIRES.

Built with haikuporter on x86_64, R1/beta6 hrev59866+65, and the resulting
package was installed and run. `haikuporter --lint weatherpositive` reports no
problems. `x86_gcc2` is excluded because the source is C++17.

The interface is localised into 34 languages; the catalogs are bound into the
binary with `make bindcatalogs`.

Upstream: https://github.com/nich227/haiku-weatherpositive
