### PR TITLE
asciidoc: bump to 10.2.1

### DIFF
--- a/app-text/asciidoc/asciidoc-10.2.1.recipe
+++ b/app-text/asciidoc/asciidoc-10.2.1.recipe
@@ -12,7 +12,7 @@ COPYRIGHT="2002-2013 Stuart Rackham
 LICENSE="GNU GPL v2"
 REVISION="3"
 SOURCE_URI="https://github.com/asciidoc/asciidoc-py3/archive/$portVersion.tar.gz"
-CHECKSUM_SHA256="684ea53c1f5b71d6d1ac6086bbc96906b1f709ecc7ab536615b0f0c9e1baa3cc"
+CHECKSUM_SHA256="8e1fb9691952cc4f13357e1ef58172e566c5f88e3c44222d4a8693585f884507"
 SOURCE_FILENAME="asciidoc-$portVersion.tar.gz"
 SOURCE_DIR="asciidoc-py-$portVersion"
 

--- a/app-text/asciidoc/asciidoc-10.2.1.recipe
+++ b/app-text/asciidoc/asciidoc-10.2.1.recipe
@@ -53,7 +53,7 @@ BUILD_PREREQUIRES="
 # TEST_REQUIRES="
 #   pytest_$pythonPackage
 #	pytest_mock_$pythonPackage
-# "                        
+# "
 
 PATCH()
 {

--- a/app-text/asciidoc/asciidoc-10.2.1.recipe
+++ b/app-text/asciidoc/asciidoc-10.2.1.recipe
@@ -18,7 +18,7 @@ SOURCE_DIR="asciidoc-py-$portVersion"
 
 ARCHITECTURES="any"
 
-pythonVersion=3.10
+pythonVersion=3.14
 pythonPackage=python${pythonVersion//.}
 
 PROVIDES="
@@ -50,10 +50,10 @@ BUILD_PREREQUIRES="
 	cmd:xmllint
 	cmd:xsltproc
 	"
-TEST_REQUIRES="
-	pytest_$pythonPackage
-	pytest_mock_$pythonPackage
-	"
+# TEST_REQUIRES="
+#   pytest_$pythonPackage
+#	pytest_mock_$pythonPackage
+# "                        
 
 PATCH()
 {

--- a/app-text/asciidoc/asciidoc-10.2.1.recipe
+++ b/app-text/asciidoc/asciidoc-10.2.1.recipe
@@ -10,7 +10,7 @@ HOMEPAGE="https://asciidoc.org/"
 COPYRIGHT="2002-2013 Stuart Rackham
 	2013-2020 AsciiDoc Contributors"
 LICENSE="GNU GPL v2"
-REVISION="3"
+REVISION="1"
 SOURCE_URI="https://github.com/asciidoc/asciidoc-py3/archive/$portVersion.tar.gz"
 CHECKSUM_SHA256="8e1fb9691952cc4f13357e1ef58172e566c5f88e3c44222d4a8693585f884507"
 SOURCE_FILENAME="asciidoc-$portVersion.tar.gz"


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
