### PR TITLE
cairomm, revbump, fix for pkgconfig file

### DIFF
--- a/dev-cpp/cairomm/cairomm-1.13.1.recipe
+++ b/dev-cpp/cairomm/cairomm-1.13.1.recipe
@@ -5,7 +5,7 @@ the Standard Template Library where it makes sense."
 HOMEPAGE="https://www.cairographics.org/cairomm/"
 COPYRIGHT="2006-2016 cairomm authors"
 LICENSE="GNU LGPL v2"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://www.cairographics.org/releases/cairomm-${portVersion}.tar.gz"
 CHECKSUM_SHA256="97a78bd7de6baf8af3da1f9b39f1317f8da9f1145b7694e928fbd5521da08ef6"
 
@@ -73,7 +73,7 @@ INSTALL()
 
 	fixPkgconfig
 
-	sed -i -e 's|-I${libdir}/cairomm-$apiVersion/include||' \
+	sed -i -e 's| -I${libdir}/cairomm-'${apiVersion}'/include||' \
 		$developLibDir/pkgconfig/cairomm-$apiVersion.pc
 
 	packageEntries devel \

--- a/dev-cpp/cairomm/cairomm1.18-1.18.0.recipe
+++ b/dev-cpp/cairomm/cairomm1.18-1.18.0.recipe
@@ -5,7 +5,7 @@ the Standard Template Library where it makes sense."
 HOMEPAGE="https://www.cairographics.org/cairomm/"
 COPYRIGHT="2006-2023 cairomm authors"
 LICENSE="GNU LGPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://www.cairographics.org/releases/cairomm-$portVersion.tar.xz"
 CHECKSUM_SHA256="b81255394e3ea8e8aa887276d22afa8985fc8daef60692eb2407d23049f03cfb"
 SOURCE_DIR="cairomm-$portVersion"
@@ -98,7 +98,7 @@ INSTALL()
 
 	fixPkgconfig
 
-	sed -i -e 's|-I${libdir}/cairomm-$apiVersion/include||' \
+	sed -i -e 's| -I${libdir}/cairomm-'${apiVersion}'/include||' \
 		$developLibDir/pkgconfig/cairomm-$apiVersion.pc
 
 	packageEntries devel \


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
