### PR TITLE
gtkmm, revbump for pkgconfig file fix

### DIFF
--- a/dev-cpp/gtkmm/gtkmm3-3.24.11.recipe
+++ b/dev-cpp/gtkmm/gtkmm3-3.24.11.recipe
@@ -6,7 +6,7 @@ HOMEPAGE="https://www.gtkmm.org/en/"
 COPYRIGHT="2021 The gtkmm Development Team"
 LICENSE="GNU LGPL v2.1
 	GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://ftp.gnome.org/pub/GNOME/sources/gtkmm/${portVersion%.*}/gtkmm-$portVersion.tar.xz"
 CHECKSUM_SHA256="19e383c82d5dd89db275e00b82864e90414d4c3fb3d100b2f996bcc2338a4cc7"
 SOURCE_DIR="gtkmm-$portVersion"
@@ -98,9 +98,9 @@ INSTALL()
 
 	fixPkgconfig
 
-	sed -i -e 's|-I${libdir}/gtkmm-$apiVersion/include||' \
+	sed -i -e 's|-I${libdir}/gtkmm-'${apiVersion}'/include||' \
 		$developLibDir/pkgconfig/gtkmm-$apiVersion.pc
-	sed -i -e 's|-I${libdir}/gdkmm-$apiVersion/include||' \
+	sed -i -e 's|-I${libdir}/gdkmm-'${apiVersion}'/include||' \
 		$developLibDir/pkgconfig/gdkmm-$apiVersion.pc
 
 	packageEntries devel \

--- a/dev-cpp/gtkmm/gtkmm4-4.23.0.recipe
+++ b/dev-cpp/gtkmm/gtkmm4-4.23.0.recipe
@@ -6,7 +6,7 @@ HOMEPAGE="https://www.gtkmm.org/en/"
 COPYRIGHT="2021 The gtkmm Development Team"
 LICENSE="GNU LGPL v2.1
 	GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="http://ftp.gnome.org/pub/GNOME/sources/gtkmm/${portVersion%.*}/gtkmm-$portVersion.tar.xz"
 CHECKSUM_SHA256="d3f7e7aab6e99d33fe61a609a759a9fb086aad33c0a9428ad3c1eacca2c01460"
 SOURCE_DIR="gtkmm-$portVersion"
@@ -99,7 +99,7 @@ INSTALL()
 
 	fixPkgconfig
 
-	sed -i -e 's|-I${libdir}/gtkmm-$apiVersion/include||' \
+	sed -i -e 's|-I${libdir}/gtkmm-'${apiVersion}'/include||' \
 		$developLibDir/pkgconfig/gtkmm-$apiVersion.pc
 
 	packageEntries devel \


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
