### PR TITLE
rawtherapee, revbump for jpeg-turbo regression

### DIFF
--- a/media-gfx/rawtherapee/patches/7080.patch
+++ b/media-gfx/rawtherapee/patches/7080.patch
@@ -1,0 +1,89 @@
+From efdc5bce3b9794847093baeb040937ab55eba86e Mon Sep 17 00:00:00 2001
+From: Richard E Barber <kd6kxr@gmail.com>
+Date: Sun, 19 May 2024 04:27:10 -0700
+Subject: [PATCH 1/2] Fix linking with jpeg-turbo
+
+patch via Termux PR
+https://github.com/termux-user-repository/tur/pull/1027
+---
+ rtengine/jdatasrc.cc | 28 ++--------------------------
+ 1 file changed, 2 insertions(+), 26 deletions(-)
+
+diff --git a/rtengine/jdatasrc.cc b/rtengine/jdatasrc.cc
+index f925689..0796384 100644
+--- a/rtengine/jdatasrc.cc
++++ b/rtengine/jdatasrc.cc
+@@ -247,20 +247,6 @@ my_error_exit (j_common_ptr cinfo)
+ #endif
+ }
+ 
+-
+-#ifdef WIN32
+-#define JVERSION       "6b  27-Mar-1998"
+-#define JCOPYRIGHT_SHORT       "(C) 1998, Thomas G. Lane"
+-#define JMESSAGE(code,string)  string ,
+-
+-const char * const jpeg_std_message_table[] = {
+-#include "jerror.h"
+-  NULL
+-};
+-#else
+-extern const char * const jpeg_std_message_table[];
+-#endif
+-
+ /*
+  * Actual output of an error or trace message.
+  * Applications may override this method to send JPEG messages somewhere
+@@ -409,24 +395,14 @@ reset_error_mgr (j_common_ptr cinfo)
+ GLOBAL(struct jpeg_error_mgr *)
+ my_jpeg_std_error (struct jpeg_error_mgr * err)
+ {
++    err = jpeg_std_error(err);
+ 
++    /* override these functions */
+     err->error_exit = my_error_exit;
+     err->emit_message = emit_message;
+     err->output_message = output_message;
+     err->format_message = format_message;
+     err->reset_error_mgr = reset_error_mgr;
+ 
+-    err->trace_level = 0;     /* default = no tracing */
+-    err->num_warnings = 0;    /* no warnings emitted yet */
+-    err->msg_code = 0;        /* may be useful as a flag for "no error" */
+-
+-    /* Initialize message table pointers */
+-    err->jpeg_message_table = jpeg_std_message_table;
+-    err->last_jpeg_message = (int) JMSG_LASTMSGCODE - 1;
+-
+-    err->addon_message_table = nullptr;
+-    err->first_addon_message = 0; /* for safety */
+-    err->last_addon_message = 0;
+-
+     return err;
+ }
+
+From 7789a8574b454ebd874522a70930ae4b40726da4 Mon Sep 17 00:00:00 2001
+From: Richard E Barber <kd6kxr@gmail.com>
+Date: Sun, 19 May 2024 16:39:28 -0700
+Subject: [PATCH 2/2] removes redundant jpeg error message
+
+Co-authored-by: Lawrence37 <45837045+Lawrence37@users.noreply.github.com>
+---
+ rtengine/jdatasrc.cc | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/rtengine/jdatasrc.cc b/rtengine/jdatasrc.cc
+index a0d12657f2..96b6f83b66 100644
+--- a/rtengine/jdatasrc.cc
++++ b/rtengine/jdatasrc.cc
+@@ -399,10 +399,6 @@ my_jpeg_std_error (struct jpeg_error_mgr * err)
+ 
+     /* override these functions */
+     err->error_exit = my_error_exit;
+-    err->emit_message = emit_message;
+-    err->output_message = output_message;
+-    err->format_message = format_message;
+-    err->reset_error_mgr = reset_error_mgr;
+ 
+     return err;
+ }

--- a/media-gfx/rawtherapee/rawtherapee-5.9.recipe
+++ b/media-gfx/rawtherapee/rawtherapee-5.9.recipe
@@ -8,10 +8,11 @@ RawTherapee provides a powerful suite of tools for you to produce amazing photos
 HOMEPAGE="https://www.rawtherapee.com/"
 COPYRIGHT="2022 The RawTherapee Team"
 LICENSE="GNU GPL v3"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://www.rawtherapee.com/shared/source/rawtherapee-$portVersion.tar.xz"
 CHECKSUM_SHA256="8eaf28c428185c165ef5a28f69595dc77a1c98826065a1f51a28c86c7b0d4823"
-PATCHES="rawtherapee-$portVersion.patchset"
+PATCHES="rawtherapee-$portVersion.patchset
+	7080.patch"
 ADDITIONAL_FILES="rawtherapee.rdef.in"
 
 ARCHITECTURES="all !x86_gcc2"


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
