### PR TITLE
scribus, revbump, cleanup and up version for libpodofo

### DIFF
--- a/app-office/scribus/scribus-1.6.6.recipe
+++ b/app-office/scribus/scribus-1.6.6.recipe
@@ -9,7 +9,7 @@ versatile PDF creation."
 HOMEPAGE="https://www.scribus.net"
 COPYRIGHT="2014-2026 Scribus Team"
 LICENSE="GNU GPL v2"
-REVISION="3"
+REVISION="4"
 SOURCE_URI="https://sourceforge.net/projects/scribus/files/scribus/$portVersion/scribus-$portVersion.tar.xz"
 CHECKSUM_SHA256="fdfe3e7cbe84b760b38d0561ed8736f9d25d4923adde6e15e03760d83be6166d"
 PATCHES="scribus-$portVersion.patchset"
@@ -26,7 +26,6 @@ REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libcairo$secondaryArchSuffix
 	lib:libcdr_0.1$secondaryArchSuffix
-	lib:libcrypto$secondaryArchSuffix
 	lib:libexecinfo$secondaryArchSuffix
 	lib:libfontconfig$secondaryArchSuffix
 	lib:libfreehand_0.1$secondaryArchSuffix
@@ -34,7 +33,6 @@ REQUIRES="
 	lib:libGraphicsMagick$secondaryArchSuffix
 	lib:libharfbuzz_icu$secondaryArchSuffix
 	lib:libhunspell_1.7$secondaryArchSuffix
-	lib:libhyphen$secondaryArchSuffix
 	lib:libicudata$secondaryArchSuffix
 	lib:libicuuc$secondaryArchSuffix
 	lib:libjpeg$secondaryArchSuffix
@@ -44,21 +42,18 @@ REQUIRES="
 	lib:libpng16$secondaryArchSuffix
 	lib:libpodofo$secondaryArchSuffix
 	lib:libpoppler$secondaryArchSuffix
-	lib:libpython3.10$secondaryArchSuffix
+	lib:libpython3.14$secondaryArchSuffix
 	lib:libQt5Core$secondaryArchSuffix
 	lib:libQt5Gui$secondaryArchSuffix
 	lib:libQt5Network$secondaryArchSuffix
 	lib:libQt5OpenGL$secondaryArchSuffix
 	lib:libQt5PrintSupport$secondaryArchSuffix
-	lib:libQt5Qml$secondaryArchSuffix
-	lib:libQt5Quick$secondaryArchSuffix
 	lib:libQt5Widgets$secondaryArchSuffix
 	lib:libQt5Xml$secondaryArchSuffix
 	lib:libqxp_0.0$secondaryArchSuffix
 	lib:librevenge_0.0${secondaryArchSuffix}
 	lib:librevenge_generators_0.0$secondaryArchSuffix
 	lib:librevenge_stream_0.0$secondaryArchSuffix
-	lib:libssl$secondaryArchSuffix
 	lib:libstdc++$secondaryArchSuffix
 	lib:libtiff$secondaryArchSuffix
 	lib:libvisio_0.1$secondaryArchSuffix
@@ -72,7 +67,6 @@ BUILD_REQUIRES="
 	devel:libboost_filesystem$secondaryArchSuffix >= 1.90.0
 	devel:libcairo$secondaryArchSuffix
 	devel:libcdr_0.1$secondaryArchSuffix
-	devel:libcrypto$secondaryArchSuffix
 	devel:libexecinfo$secondaryArchSuffix
 	devel:libfontconfig$secondaryArchSuffix
 	devel:libfreehand_0.1$secondaryArchSuffix
@@ -80,20 +74,18 @@ BUILD_REQUIRES="
 	devel:libGraphicsMagick$secondaryArchSuffix
 	devel:libharfbuzz_icu$secondaryArchSuffix
 	devel:libhunspell_1.7$secondaryArchSuffix
-	devel:libhyphen$secondaryArchSuffix
 	devel:libicuuc$secondaryArchSuffix >= 74
 	devel:libjpeg$secondaryArchSuffix
 	devel:liblcms2$secondaryArchSuffix
 	devel:libmspub_0.1$secondaryArchSuffix
 	devel:libpagemaker_0.0$secondaryArchSuffix
 	devel:libpng16$secondaryArchSuffix
-	devel:libpodofo$secondaryArchSuffix
+	devel:libpodofo$secondaryArchSuffix >= 0.10
 	devel:libpoppler$secondaryArchSuffix >= 155
-	devel:libpython3.10$secondaryArchSuffix
+	devel:libpython3.14$secondaryArchSuffix
 	devel:libQt5Core$secondaryArchSuffix
 	devel:libqxp_0.0$secondaryArchSuffix
 	devel:librevenge_0.0$secondaryArchSuffix
-	devel:libssl$secondaryArchSuffix
 	devel:libtiff$secondaryArchSuffix
 	devel:libvisio_0.1$secondaryArchSuffix
 	devel:libxml2$secondaryArchSuffix


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
