### PR TITLE
qt6_location, revbump, qt6_positioning is a dev requirement for qt6_l…

### DIFF
--- a/dev-qt/qt6-location/qt6_location-6.10.3.recipe
+++ b/dev-qt/qt6-location/qt6_location-6.10.3.recipe
@@ -7,7 +7,7 @@ COPYRIGHT="2015-2026 The Qt Company Ltd."
 LICENSE="GNU LGPL v2.1
 	GNU LGPL v3
 	GNU FDL v1"
-REVISION="2"
+REVISION="3"
 QT_MIRROR_URI="https://ftp.fau.de/qtproject/archive"
 SOURCE_URI="$QT_MIRROR_URI/qt/${portVersion%.*}/$portVersion/submodules/qtlocation-everywhere-src-$portVersion.tar.xz"
 CHECKSUM_SHA256="1d0abed99f2834a7c684d23c495c5f752611fee14726f286396cf7147376799e"
@@ -44,6 +44,7 @@ PROVIDES_devel="
 REQUIRES_devel="
 	qt6_location$secondaryArchSuffix == $portVersion base
 	devel:libQt6Core$secondaryArchSuffix == $libVersion
+	devel:libQt6Positioning$secondaryArchSuffix == $libVersion
 	"
 
 BUILD_REQUIRES="
@@ -52,7 +53,6 @@ BUILD_REQUIRES="
 	devel:libGL$secondaryArchSuffix
 	devel:libQt6Core$secondaryArchSuffix == $libVersion
 	devel:libQt6Positioning$secondaryArchSuffix == $libVersion
-	devel:libQt6PositioningQuick$secondaryArchSuffix == $libVersion
 	devel:libQt6Qml$secondaryArchSuffix == $libVersion
 	devel:libssl$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix


### PR DESCRIPTION
…ocation

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
