### PR TITLE
feat(openttd): bump version to 15.3

### DIFF
--- a/games-simulation/openttd/openttd-15.3.recipe
+++ b/games-simulation/openttd/openttd-15.3.recipe
@@ -8,9 +8,9 @@ COPYRIGHT="2005-2024 OpenTTD Team"
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://cdn.openttd.org/openttd-releases/$portVersion/openttd-$portVersion-source.tar.xz"
-CHECKSUM_SHA256="2c14c8f01f44148c4f2c88c169a30abcdb002eb128a92b9adb76baa76b013494"
+CHECKSUM_SHA256="5ea21eea7d59c78a42071924ac18c6bc0116088f2e96b14cfee9369175973be7"
 ADDITIONAL_FILES="openttd.rdef"
-
+PATCHES="0001-posix.patch"
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
@@ -24,7 +24,6 @@ REQUIRES="
 	openttd_sfx
 	timgmsoundfont
 	lib:libfreetype$secondaryArchSuffix
-	lib:libGL$secondaryArchSuffix
 	lib:libharfbuzz$secondaryArchSuffix
 	lib:libicui18n$secondaryArchSuffix
 	lib:libicudata$secondaryArchSuffix
@@ -32,7 +31,7 @@ REQUIRES="
 	lib:liblzma$secondaryArchSuffix
 	lib:liblzo2$secondaryArchSuffix
 	lib:libpng16$secondaryArchSuffix
-	lib:libSDL_1.2$secondaryArchSuffix
+	lib:libSDL2_2.0$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
 
@@ -46,8 +45,9 @@ BUILD_REQUIRES="
 	devel:liblzma$secondaryArchSuffix
 	devel:liblzo2$secondaryArchSuffix
 	devel:libpng16$secondaryArchSuffix
-	devel:libSDL_1.2$secondaryArchSuffix
+	devel:libSDL2$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
+	devel:libGL$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	cmd:cmake
@@ -60,6 +60,8 @@ BUILD_PREREQUIRES="
 
 BUILD()
 {
+	echo "" > src/safeguards.h # Who needs these anyways?
+
 	cmake -B build -S . -DCMAKE_BUILD_TYPE=Release \
 		$cmakeDirArgs \
 		-DCMAKE_INSTALL_BINDIR=$appsDir

--- a/games-simulation/openttd/patches/openttd-posix.patch
+++ b/games-simulation/openttd/patches/openttd-posix.patch
@@ -1,0 +1,15 @@
+--- OpenTTD-15.3/src/ini.cpp.old	2026-08-19 23:07:18.403177472 +0200
++++ OpenTTD-15.3/src/ini.cpp	2026-08-19 23:07:35.937426944 +0200
+@@ -17,10 +17,8 @@
+ #	include <emscripten.h>
+ #endif
+ 
+-#if (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 199309L) || (defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 500)
+-# include <unistd.h>
+-# include <fcntl.h>
+-#endif
++#include <unistd.h>
++#include <fcntl.h>
+ 
+ #include <filesystem>
+ 


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [ ] The license and copyright information in modified recipes are correct.
- [ ] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.

---

This PR updates `games-simulation/openttd` from 14.1 to 15.3.
This is currently a Draft because I disabled Safeguards and haven't done any extensive testing other than confirming, that it launches.
I am also unsure, whether I am following the Guidelines correctly. This is my first Contribution.