### PR TITLE
gexiv2, revbump, enable vapi and move the files to _devel package

### DIFF
--- a/media-libs/gexiv2/gexiv2-0.14.6.recipe
+++ b/media-libs/gexiv2/gexiv2-0.14.6.recipe
@@ -4,7 +4,7 @@ It makes the basic features of Exiv2 available to GNOME applications."
 HOMEPAGE="https://wiki.gnome.org/Projects/gexiv2"
 COPYRIGHT="Jens Georg"
 LICENSE="GNU GPL v2"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://download.gnome.org/sources/gexiv2/${portVersion%.*}/gexiv2-$portVersion.tar.xz"
 CHECKSUM_SHA256="606c28aaae7b1f3ef5c8eabe5e7dffd7c5a1c866d25b7671fb847fe287a72b8b"
 
@@ -48,6 +48,7 @@ BUILD_PREREQUIRES="
 	cmd:meson
 	cmd:ninja
 	cmd:pkg_config$secondaryArchSuffix
+	cmd:vapigen
 	"
 
 BUILD()
@@ -64,7 +65,7 @@ BUILD()
 		--sysconfdir=$settingsDir \
 		-Dintrospection=true \
 		-Dpython3=false \
-		-Dvapi=false \
+		-Dvapi=true \
 		build
 
 	ninja -C build
@@ -81,5 +82,5 @@ INSTALL()
 	# devel package
 	packageEntries devel \
 		$developDir \
-		$dataDir/gir-1.0
+		$dataDir
 }


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
