### PR TITLE
extra_cmake_modules, bump to version 6.29.0

### DIFF
--- a/kde-frameworks/extra-cmake-modules/extra_cmake_modules-6.29.0.recipe
+++ b/kde-frameworks/extra-cmake-modules/extra_cmake_modules-6.29.0.recipe
@@ -9,7 +9,7 @@ COPYRIGHT="2010-2026 KDE Organisation"
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/extra-cmake-modules-$portVersion.tar.xz"
-CHECKSUM_SHA256="a32e24b267e8528d0253bc8df18bdc00e676560a43b796533e1b1406f4eef4db"
+CHECKSUM_SHA256="aaf2542edd5c5af9ea56a46468892d38a7978af65f0f3518379fa8ce66cad2b8"
 SOURCE_DIR="extra-cmake-modules-$portVersion"
 PATCHES="extra_cmake_modules-$portVersion.patchset"
 

--- a/kde-frameworks/extra-cmake-modules/patches/extra_cmake_modules-6.29.0.patchset
+++ b/kde-frameworks/extra-cmake-modules/patches/extra_cmake_modules-6.29.0.patchset
@@ -1,4 +1,4 @@
-From 752f3259dae7bca2c3e5cd8e6719a2e25eb9a204 Mon Sep 17 00:00:00 2001
+From 244b1d2d2bb30422a7726406e85b79dd6ad4f29d Mon Sep 17 00:00:00 2001
 From: Sergei Reznikov <diver@gelios.net>
 Date: Mon, 16 Dec 2019 16:01:30 +0300
 Subject: don't default to using debug build type on Haiku...
@@ -22,7 +22,7 @@ index 8267507..60b35d5 100644
 2.54.0
 
 
-From bf95b1d21360ad05841603126b2025b87f222db9 Mon Sep 17 00:00:00 2001
+From 11d24055758d1f71a1dbaa16be42a9d94c81c615 Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Sun, 8 May 2022 21:16:49 +1000
 Subject: Add Haiku platform check
@@ -47,7 +47,7 @@ index 9d38ad8..95340a0 100644
 2.54.0
 
 
-From 4439ff6af3ee8e86b900fd3379b76b18a0eeddce Mon Sep 17 00:00:00 2001
+From 314a633f92a307d3067bef2938e21ab4ed94e9ba Mon Sep 17 00:00:00 2001
 From: Schrijvers Luc <begasus@gmail.com>
 Date: Wed, 28 Feb 2024 11:48:23 +0100
 Subject: demote_unsupported_platform_error_to_a_warning
@@ -70,7 +70,7 @@ index 95340a0..3ffa400 100644
 2.54.0
 
 
-From 78e6fa492a92afc113d11d6018233b01534abb4e Mon Sep 17 00:00:00 2001
+From 387c212bdd7a1d203f19b5170faa179cf9a6f0d4 Mon Sep 17 00:00:00 2001
 From: Luc Schrijvers <begasus@gmail.com>
 Date: Tue, 20 May 2025 16:21:06 +0200
 Subject: Fix hardcoded paths, we don't use /usr/*
@@ -124,7 +124,7 @@ index 3cb4c4a..9561539 100644
 2.54.0
 
 
-From a8ead7ff58f6af146e4e8e5f89563e9664895e93 Mon Sep 17 00:00:00 2001
+From 63c0065c17891f166ec57fa911f9513f07801f12 Mon Sep 17 00:00:00 2001
 From: Luc Schrijvers <begasus@gmail.com>
 Date: Thu, 16 Oct 2025 14:39:36 +0200
 Subject: Set QTPLUGINDIR,QMLDIR and QCHDIR for Haiku
@@ -324,7 +324,7 @@ index 30726b7..2bc4f47 100644
 2.54.0
 
 
-From 8a3b9b3996f60494675bc79d92f7e0214525e4bb Mon Sep 17 00:00:00 2001
+From 50092f9ea1ea1241d0fb0670398fb12ee28ab526 Mon Sep 17 00:00:00 2001
 From: Luc Schrijvers <begasus@gmail.com>
 Date: Fri, 12 Jun 2026 11:38:58 +0200
 Subject: Fix install path for QTMETATYPESDIR


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
