### PR TITLE
KDE frameworks, bump to version 6.29.0, part 2

### DIFF
--- a/kde-frameworks/kauth/kauth6-6.29.0.recipe
+++ b/kde-frameworks/kauth/kauth6-6.29.0.recipe
@@ -1,22 +1,14 @@
-SUMMARY="Access to the windowing system"
-DESCRIPTION="Convenience access to certain properties and features of the \
-windowing system.
-
-KWindowSystem provides information about the windowing system and allows \
-interaction with the windowing system. It provides an high level API which \
-is windowing system independent and has platform specific implementations. \
-This API is inspired by X11 and thus not all functionality is available \
-on all windowing systems.
-
-In addition to the high level API, this framework also provides several \
-more low level classes for interaction with the X Windowing System."
-HOMEPAGE="https://invent.kde.org/frameworks/kwindowsystem"
+SUMMARY="Execute actions as privileged user"
+DESCRIPTION="KAuth provides a convenient, system-integrated way to offload actions \
+that need to be performed as a privileged user (root, for example) \
+to small (hopefully secure) helper utilities."
+HOMEPAGE="https://invent.kde.org/frameworks/kauth"
 COPYRIGHT="2010-2026 KDE Organisation"
 LICENSE="GNU LGPL v2"
 REVISION="1"
-SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/kwindowsystem-${portVersion}.tar.xz"
-CHECKSUM_SHA256="5adbdf9c82b1ecbb92bda6498ea1b8f88c08f9ec57dbff70d582e2453bf16b12"
-SOURCE_DIR="kwindowsystem-$portVersion"
+SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/kauth-${portVersion}.tar.xz"
+CHECKSUM_SHA256="40a7ec156aa1842216e1377b327efe173a737c0e6434b1dda66d2b098a307824"
+SOURCE_DIR="kauth-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -27,28 +19,32 @@ libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 enableDocumentation=true
 
 PROVIDES="
-	kwindowsystem6$secondaryArchSuffix = $portVersion
-	lib:libKF6WindowSystem$secondaryArchSuffix = $libVersionCompat
+	kauth6$secondaryArchSuffix = $portVersion
+	lib:libKF6AuthCore$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libGL$secondaryArchSuffix
+	lib:libKF6CoreAddons$secondaryArchSuffix
 	lib:libQt6Core$secondaryArchSuffix
+	lib:libQt6DBus$secondaryArchSuffix
+	lib:libQt6Gui$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
-	kwindowsystem6${secondaryArchSuffix}_devel = $portVersion
-	devel:libKF6WindowSystem$secondaryArchSuffix = $libVersionCompat
+	kauth6${secondaryArchSuffix}_devel = $portVersion
+	devel:libKF6AuthCore$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
-	kwindowsystem6$secondaryArchSuffix == $portVersion base
+	kauth6$secondaryArchSuffix == $portVersion base
+	devel:libKF6CoreAddons$secondaryArchSuffix
 	"
 
 if $enableDocumentation; then
 	ARCHITECTURES_doc="any"
 
 	PROVIDES_doc="
-		kwindowsystem6_doc = $portVersion
+		kauth6_doc = $portVersion
 		"
 fi
 
@@ -56,10 +52,8 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	extra_cmake_modules$secondaryArchSuffix >= $portVersion
 	qt6_tools${secondaryArchSuffix}_devel
+	devel:libKF6CoreAddons$secondaryArchSuffix >= $libVersion
 	devel:libQt6Core$secondaryArchSuffix
-	devel:libQt6Qml$secondaryArchSuffix
-	devel:libsqlite3$secondaryArchSuffix
-	devel:libxcb$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	kde_qdoc_common
@@ -68,6 +62,10 @@ BUILD_PREREQUIRES="
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
 	cmd:qdoc6$secondaryArchSuffix
+	"
+
+TEST_REQUIRES="
+	lib:libdbus_1$secondaryArchSuffix
 	"
 
 BUILD()
@@ -95,9 +93,9 @@ if $enableDocumentation; then
 	cmake --build build --target install_html_docs
 	cmake --build build --target install_qch_docs
 fi
+
 	prepareInstalledDevelLib \
-		libKF6WindowSystem
-	fixPkgconfig
+		libKF6AuthCore
 
 	packageEntries devel \
 		$developDir \
@@ -111,6 +109,7 @@ fi
 
 TEST()
 {
-	export LIBRARY_PATH="$sourceDir/build/bin${LIBRARY_PATH:+:$LIBRARY_PATH}"
+	# 2 tests run, second one doesn't seem to do anything (no mention in the log)
+	# killed it in the end
 	ctest --test-dir build --output-on-failure
 }

--- a/kde-frameworks/kcompletion/kcompletion6-6.29.0.recipe
+++ b/kde-frameworks/kcompletion/kcompletion6-6.29.0.recipe
@@ -15,7 +15,7 @@ COPYRIGHT="2010-2026 KDE Organisation"
 LICENSE="BSD (2-clause)"
 REVISION="1"
 SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/kcompletion-${portVersion}.tar.xz"
-CHECKSUM_SHA256="8aa9cbc36139adfa8e3b2c744cc94714afe154d21cef8a3a2d5f4d311be7cc3c"
+CHECKSUM_SHA256="b039608f79f445a6ccc383ce57bd240699e334613814374006c8a01dc6bc1250"
 SOURCE_DIR="kcompletion-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -38,7 +38,7 @@ REQUIRES="
 	lib:libKF6WidgetsAddons$secondaryArchSuffix
 	lib:libQt6Core$secondaryArchSuffix
 	lib:libQt6Gui$secondaryArchSuffix
-	lib:libQt6Xml$secondaryArchSuffix
+	lib:libQt6Widgets$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
@@ -65,10 +65,7 @@ BUILD_REQUIRES="
 	devel:libKF6ConfigCore$secondaryArchSuffix >= $libVersion
 	devel:libKF6WidgetsAddons$secondaryArchSuffix >= $libVersion
 	devel:libQt6Core$secondaryArchSuffix
-	devel:libQt6Gui$secondaryArchSuffix
 	devel:libQt6Qml$secondaryArchSuffix
-	devel:libQt6Xml$secondaryArchSuffix
-	devel:libsqlite3$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	kde_qdoc_common

--- a/kde-frameworks/kcrash/kcrash6-6.29.0.recipe
+++ b/kde-frameworks/kcrash/kcrash6-6.29.0.recipe
@@ -1,14 +1,12 @@
-SUMMARY="Execute actions as privileged user"
-DESCRIPTION="KAuth provides a convenient, system-integrated way to offload actions \
-that need to be performed as a privileged user (root, for example) \
-to small (hopefully secure) helper utilities."
-HOMEPAGE="https://invent.kde.org/frameworks/kauth"
+SUMMARY="Graceful handling of application crashes"
+DESCRIPTION="KCrash provides support for intercepting and handling application crashes."
+HOMEPAGE="https://invent.kde.org/frameworks/kcrash"
 COPYRIGHT="2010-2026 KDE Organisation"
 LICENSE="GNU LGPL v2"
 REVISION="1"
-SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/kauth-${portVersion}.tar.xz"
-CHECKSUM_SHA256="fb4d90ee46a2f6202e53cdd5af8f77069c380955e3f340881f2f36ec8312079b"
-SOURCE_DIR="kauth-$portVersion"
+SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/kcrash-${portVersion}.tar.xz"
+CHECKSUM_SHA256="decb363261fe5f6df984fa0cfa42243aca9eea352045b18ffe1b86a0bd5b1736"
+SOURCE_DIR="kcrash-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -19,8 +17,8 @@ libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 enableDocumentation=true
 
 PROVIDES="
-	kauth6$secondaryArchSuffix = $portVersion
-	lib:libKF6AuthCore$secondaryArchSuffix = $libVersionCompat
+	kcrash6$secondaryArchSuffix = $portVersion
+	lib:libKF6Crash$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -28,23 +26,21 @@ REQUIRES="
 	lib:libKF6CoreAddons$secondaryArchSuffix
 	lib:libQt6Core$secondaryArchSuffix
 	lib:libQt6Gui$secondaryArchSuffix
-	lib:libQt6Xml$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
-	kauth6${secondaryArchSuffix}_devel = $portVersion
-	devel:libKF6AuthCore$secondaryArchSuffix = $libVersionCompat
+	kcrash6${secondaryArchSuffix}_devel = $portVersion
+	devel:libKF6Crash$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
-	kauth6$secondaryArchSuffix == $portVersion base
-	devel:libKF6CoreAddons$secondaryArchSuffix
+	kcrash6$secondaryArchSuffix == $portVersion base
 	"
 
 if $enableDocumentation; then
 	ARCHITECTURES_doc="any"
 
 	PROVIDES_doc="
-		kauth6_doc = $portVersion
+		kcrash6_doc = $portVersion
 		"
 fi
 
@@ -54,7 +50,6 @@ BUILD_REQUIRES="
 	qt6_tools${secondaryArchSuffix}_devel
 	devel:libKF6CoreAddons$secondaryArchSuffix >= $libVersion
 	devel:libQt6Core$secondaryArchSuffix
-	devel:libsqlite3$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	kde_qdoc_common
@@ -66,7 +61,7 @@ BUILD_PREREQUIRES="
 	"
 
 TEST_REQUIRES="
-	lib:libdbus_1$secondaryArchSuffix
+	qthaikuplugins$secondaryArchSuffix
 	"
 
 BUILD()
@@ -96,7 +91,7 @@ if $enableDocumentation; then
 fi
 
 	prepareInstalledDevelLib \
-		libKF6AuthCore
+		libKF6Crash
 
 	packageEntries devel \
 		$developDir \
@@ -110,7 +105,7 @@ fi
 
 TEST()
 {
-	# 2 tests run, second one doesn't seem to do anything (no mention in the log)
-	# killed it in the end
+	# 67% tests passed, 1 tests failed out of 3
+	export LIBRARY_PATH=$LIBRARY_PATH:$sourceDir/build/bin
 	ctest --test-dir build --output-on-failure
 }

--- a/kde-frameworks/kdbusaddons/kdbusaddons6-6.29.0.recipe
+++ b/kde-frameworks/kdbusaddons/kdbusaddons6-6.29.0.recipe
@@ -1,14 +1,13 @@
-SUMMARY="Set of item views extending the Qt model-view framework"
-DESCRIPTION="KItemViews includes a set of views, which can be used with item \
-models. It includes views for categorizing lists and to add search filters to \
-flat and hierarchical lists."
-HOMEPAGE="https://invent.kde.org/frameworks/kitemviews"
+SUMMARY="Convenience classes for D-Bus"
+DESCRIPTION="KDBusAddons provides convenience classes on top of QtDBus, as \
+well as an API to create KDED modules."
+HOMEPAGE="https://invent.kde.org/frameworks/kdbusaddons"
 COPYRIGHT="2010-2026 KDE Organisation"
 LICENSE="GNU LGPL v2"
 REVISION="1"
-SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/kitemviews-${portVersion}.tar.xz"
-CHECKSUM_SHA256="2b474a0a0ca1d59111ab864d4f05100e0056b5204d52dfbab6776ca0fbfdd402"
-SOURCE_DIR="kitemviews-$portVersion"
+SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/kdbusaddons-${portVersion}.tar.xz"
+CHECKSUM_SHA256="a3d2de669bfad5de3f86cc8c6448a02f7567e4ad04aa6099ccfaa2df5f07e8f8"
+SOURCE_DIR="kdbusaddons-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -19,30 +18,29 @@ libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 enableDocumentation=true
 
 PROVIDES="
-	kitemviews6$secondaryArchSuffix = $portVersion
-	lib:libKF6ItemViews$secondaryArchSuffix = $libVersionCompat
+	kdbusaddons6$secondaryArchSuffix = $portVersion
+	cmd:kquitapp6$secondaryArchSuffix = $portVersion
+	lib:libKF6DBusAddons$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libGL$secondaryArchSuffix
 	lib:libQt6Core$secondaryArchSuffix
-	lib:libQt6Gui$secondaryArchSuffix
-	lib:libQt6Widgets$secondaryArchSuffix
+	lib:libQt6DBus$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
-	kitemviews6${secondaryArchSuffix}_devel = $portVersion
-	devel:libKF6ItemViews$secondaryArchSuffix = $libVersionCompat
+	kdbusaddons6${secondaryArchSuffix}_devel = $portVersion
+	devel:libKF6DBusAddons$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
-	kitemviews6$secondaryArchSuffix == $portVersion base
+	kdbusaddons6$secondaryArchSuffix == $portVersion base
 	"
 
 if $enableDocumentation; then
 	ARCHITECTURES_doc="any"
 
 	PROVIDES_doc="
-		kitemviews6_doc = $portVersion
+		kdbusaddons6_doc = $portVersion
 		"
 fi
 
@@ -51,7 +49,6 @@ BUILD_REQUIRES="
 	extra_cmake_modules$secondaryArchSuffix >= $portVersion
 	qt6_tools${secondaryArchSuffix}_devel
 	devel:libQt6Core$secondaryArchSuffix
-	devel:libsqlite3$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	kde_qdoc_common
@@ -60,10 +57,6 @@ BUILD_PREREQUIRES="
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
 	cmd:qdoc6$secondaryArchSuffix
-	"
-
-TEST_REQUIRES="
-	qthaikuplugins$secondaryArchSuffix
 	"
 
 BUILD()
@@ -93,7 +86,7 @@ if $enableDocumentation; then
 fi
 
 	prepareInstalledDevelLib \
-		libKF6ItemViews
+		libKF6DBusAddons
 
 	packageEntries devel \
 		$developDir \
@@ -107,6 +100,7 @@ fi
 
 TEST()
 {
-	export LIBRARY_PATH=$LIBRARY_PATH:$sourceDir/build/bin
+	# 0% tests passed, 2 tests failed out of 2 (needs dbus-launch, still crashes)
+	export LIBRARY_PATH="$sourceDir/build/bin${LIBRARY_PATH:+:$LIBRARY_PATH}"
 	ctest --test-dir build --output-on-failure
 }

--- a/kde-frameworks/kdoctools/kdoctools6-6.29.0.recipe
+++ b/kde-frameworks/kdoctools/kdoctools6-6.29.0.recipe
@@ -1,13 +1,12 @@
-SUMMARY="Convenience classes for D-Bus"
-DESCRIPTION="KDBusAddons provides convenience classes on top of QtDBus, as \
-well as an API to create KDED modules."
-HOMEPAGE="https://invent.kde.org/frameworks/kdbusaddons"
+SUMMARY="Create documentation from DocBook"
+DESCRIPTION="Provides tools to generate documentation in various format from DocBook files."
+HOMEPAGE="https://invent.kde.org/frameworks/kdoctools"
 COPYRIGHT="2010-2026 KDE Organisation"
 LICENSE="GNU LGPL v2"
 REVISION="1"
-SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/kdbusaddons-${portVersion}.tar.xz"
-CHECKSUM_SHA256="94ff8745ce65507986a05bffbab905bfd894936e8f53b4b6e2d9b3a96cb2d6f4"
-SOURCE_DIR="kdbusaddons-$portVersion"
+SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/kdoctools-${portVersion}.tar.xz"
+CHECKSUM_SHA256="1e1cb8bbf53e4f0482a916e1db9e202c8a8e8f4f2264dbcf98e837876ef83fae"
+SOURCE_DIR="kdoctools-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -18,49 +17,66 @@ libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 enableDocumentation=true
 
 PROVIDES="
-	kdbusaddons6$secondaryArchSuffix = $portVersion
-	cmd:kquitapp6$secondaryArchSuffix = $portVersion
-	lib:libKF6DBusAddons$secondaryArchSuffix = $libVersionCompat
+	kdoctools6$secondaryArchSuffix = $portVersion
+	cmd:checkXML6$secondaryArchSuffix = $portVersion
+	cmd:meinproc6$secondaryArchSuffix = $portVersion
+	lib:libKF6DocTools$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libGL$secondaryArchSuffix
+	lib:libexslt$secondaryArchSuffix
+	lib:libKF6Archive$secondaryArchSuffix
 	lib:libQt6Core$secondaryArchSuffix
-	lib:libQt6DBus$secondaryArchSuffix
+	lib:libxml2$secondaryArchSuffix
+	lib:libxslt$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
-	kdbusaddons6${secondaryArchSuffix}_devel = $portVersion
-	devel:libKF6DBusAddons$secondaryArchSuffix = $libVersionCompat
+	kdoctools6${secondaryArchSuffix}_devel = $portVersion
+	devel:libKF6DocTools$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
-	kdbusaddons6$secondaryArchSuffix == $portVersion base
+	kdoctools6$secondaryArchSuffix == $portVersion base
 	"
 
 if $enableDocumentation; then
 	ARCHITECTURES_doc="any"
 
 	PROVIDES_doc="
-		kdbusaddons6_doc = $portVersion
+		kdoctools6_doc = $portVersion
 		"
 fi
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
+	docbook_xml_dtd
+	docbook_xsl_stylesheets >= 1.79.2
 	extra_cmake_modules$secondaryArchSuffix >= $portVersion
 	qt6_tools${secondaryArchSuffix}_devel
+	uri
+	devel:libKF6archive$secondaryArchSuffix >= $libVersion
+#	devel:libKF6i18n$secondaryArchSuffix >= $portVersion # breaks the build
 	devel:libQt6Core$secondaryArchSuffix
-	devel:libQt6DBus$secondaryArchSuffix
-	devel:libsqlite3$secondaryArchSuffix
+	devel:libxml2$secondaryArchSuffix
+	devel:libxslt$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	kde_qdoc_common
 	cmd:cmake
 	cmd:g++$secondaryArchSuffix
 	cmd:make
+	cmd:msgfmt$secondaryArchSuffix
+	cmd:msgmerge$secondaryArchSuffix
+	cmd:perl
 	cmd:pkg_config$secondaryArchSuffix
 	cmd:qdoc6$secondaryArchSuffix
 	"
+
+PATCH()
+{
+	# Disable docs generation until libxml package is fixed
+	sed -e 's/add/#add/g' -i $sourceDir/docs/CMakeLists.txt
+}
 
 BUILD()
 {
@@ -68,6 +84,8 @@ BUILD()
 
 	cmake -B build -S . -DCMAKE_BUILD_TYPE=Release \
 		$cmakeDirArgs \
+		-DDocBookXSL_DIR=/system/data/xml/docbook/xsl-stylesheets-1.79.2 \
+		-DDocBookXML4_DTD_DIR=/system/data/xml/docbook/xml-dtd-4.5 \
 		-DCMAKE_SKIP_RPATH=YES \
 		-DBUILD_TESTING=OFF \
 		-Wno-dev
@@ -87,9 +105,8 @@ if $enableDocumentation; then
 	cmake --build build --target install_html_docs
 	cmake --build build --target install_qch_docs
 fi
-
 	prepareInstalledDevelLib \
-		libKF6DBusAddons
+		libKF6DocTools
 
 	packageEntries devel \
 		$developDir \
@@ -103,7 +120,7 @@ fi
 
 TEST()
 {
-	# 0% tests passed, 2 tests failed out of 2 (needs dbus-launch, still crashes)
+#	0% tests passed, 2 tests failed out of 2
 	export LIBRARY_PATH="$sourceDir/build/bin${LIBRARY_PATH:+:$LIBRARY_PATH}"
 	ctest --test-dir build --output-on-failure
 }

--- a/kde-frameworks/kiconthemes/kiconthemes6-6.29.0.recipe
+++ b/kde-frameworks/kiconthemes/kiconthemes6-6.29.0.recipe
@@ -16,7 +16,7 @@ COPYRIGHT="2010-2026 KDE Organisation"
 LICENSE="GNU LGPL v2"
 REVISION="1"
 SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/kiconthemes-${portVersion}.tar.xz"
-CHECKSUM_SHA256="edf83069f25f8edf759d07502a6f8302c8c064cd562651deedefe6393fefcace"
+CHECKSUM_SHA256="233de4cd2fef5b7b4ce1e317196407d25300b767614a93e160b45ac34710223d"
 SOURCE_DIR="kiconthemes-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -44,9 +44,12 @@ REQUIRES="
 	lib:libKF6WidgetsAddons$secondaryArchSuffix
 	lib:libQt6Core$secondaryArchSuffix
 	lib:libQt6Gui$secondaryArchSuffix
+	lib:libQt6Network$secondaryArchSuffix
+	lib:libQt6OpenGL$secondaryArchSuffix
+	lib:libQt6Qml$secondaryArchSuffix
+	lib:libQt6Quick$secondaryArchSuffix
 	lib:libQt6Svg$secondaryArchSuffix
 	lib:libQt6Widgets$secondaryArchSuffix
-	lib:libQt6Xml$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
@@ -77,12 +80,8 @@ BUILD_REQUIRES="
 	devel:libKF6I18n$secondaryArchSuffix >= $libVersion
 	devel:libKF6WidgetsAddons$secondaryArchSuffix >= $libVersion
 	devel:libQt6Core$secondaryArchSuffix
-	devel:libQt6Gui$secondaryArchSuffix
 	devel:libQt6Qml$secondaryArchSuffix
 	devel:libQt6Svg$secondaryArchSuffix
-	devel:libQt6Widgets$secondaryArchSuffix
-	devel:libsqlite3$secondaryArchSuffix
-	devel:libQt6Xml$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	kde_qdoc_common

--- a/kde-frameworks/kitemviews/kitemviews6-6.29.0.recipe
+++ b/kde-frameworks/kitemviews/kitemviews6-6.29.0.recipe
@@ -1,12 +1,14 @@
-SUMMARY="Graceful handling of application crashes"
-DESCRIPTION="KCrash provides support for intercepting and handling application crashes."
-HOMEPAGE="https://invent.kde.org/frameworks/kcrash"
+SUMMARY="Set of item views extending the Qt model-view framework"
+DESCRIPTION="KItemViews includes a set of views, which can be used with item \
+models. It includes views for categorizing lists and to add search filters to \
+flat and hierarchical lists."
+HOMEPAGE="https://invent.kde.org/frameworks/kitemviews"
 COPYRIGHT="2010-2026 KDE Organisation"
 LICENSE="GNU LGPL v2"
 REVISION="1"
-SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/kcrash-${portVersion}.tar.xz"
-CHECKSUM_SHA256="ddcc14c0c40e24f4c0dc04246b87d11b650e6fd8be2cb00e4f2cc2ee9e605702"
-SOURCE_DIR="kcrash-$portVersion"
+SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/kitemviews-${portVersion}.tar.xz"
+CHECKSUM_SHA256="9e6355cf1264756d3b38254181e46e3103e531f0f1613ae1c158d4f9e541576e"
+SOURCE_DIR="kitemviews-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -17,32 +19,30 @@ libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 enableDocumentation=true
 
 PROVIDES="
-	kcrash6$secondaryArchSuffix = $portVersion
-	lib:libKF6Crash$secondaryArchSuffix = $libVersionCompat
+	kitemviews6$secondaryArchSuffix = $portVersion
+	lib:libKF6ItemViews$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libGL$secondaryArchSuffix
-	lib:libKF6CoreAddons$secondaryArchSuffix
-	lib:libKF6WindowSystem$secondaryArchSuffix
 	lib:libQt6Core$secondaryArchSuffix
 	lib:libQt6Gui$secondaryArchSuffix
 	lib:libQt6Widgets$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
-	kcrash6${secondaryArchSuffix}_devel = $portVersion
-	devel:libKF6Crash$secondaryArchSuffix = $libVersionCompat
+	kitemviews6${secondaryArchSuffix}_devel = $portVersion
+	devel:libKF6ItemViews$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
-	kcrash6$secondaryArchSuffix == $portVersion base
+	kitemviews6$secondaryArchSuffix == $portVersion base
 	"
 
 if $enableDocumentation; then
 	ARCHITECTURES_doc="any"
 
 	PROVIDES_doc="
-		kcrash6_doc = $portVersion
+		kitemviews6_doc = $portVersion
 		"
 fi
 
@@ -50,12 +50,7 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	extra_cmake_modules$secondaryArchSuffix >= $portVersion
 	qt6_tools${secondaryArchSuffix}_devel
-	devel:libKF6CoreAddons$secondaryArchSuffix >= $libVersion
-	devel:libKF6WindowSystem$secondaryArchSuffix >= $libVersion
 	devel:libQt6Core$secondaryArchSuffix
-	devel:libQt6Gui$secondaryArchSuffix
-	devel:libQt6Widgets$secondaryArchSuffix
-	devel:libsqlite3$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	kde_qdoc_common
@@ -97,7 +92,7 @@ if $enableDocumentation; then
 fi
 
 	prepareInstalledDevelLib \
-		libKF6Crash
+		libKF6ItemViews
 
 	packageEntries devel \
 		$developDir \
@@ -111,7 +106,6 @@ fi
 
 TEST()
 {
-	# 67% tests passed, 1 tests failed out of 3
 	export LIBRARY_PATH=$LIBRARY_PATH:$sourceDir/build/bin
 	ctest --test-dir build --output-on-failure
 }

--- a/kde-frameworks/knotifications/knotifications6-6.29.0.recipe
+++ b/kde-frameworks/knotifications/knotifications6-6.29.0.recipe
@@ -1,15 +1,13 @@
-SUMMARY="Plugin framework for desktop services"
-DESCRIPTION="KService provides a plugin framework for handling desktop services. \
-Services can be applications or libraries. They can be bound to \
-MIME types or handled by application specific code."
-HOMEPAGE="https://invent.kde.org/frameworks/kservice"
+SUMMARY="KDE Desktop notifications"
+DESCRIPTION="KNotification is used to notify the user of an event. \
+It covers feedback and persistent events."
+HOMEPAGE="https://invent.kde.org/frameworks/knotifications"
 COPYRIGHT="2010-2026 KDE Organisation"
 LICENSE="GNU LGPL v2"
 REVISION="1"
-SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/kservice-${portVersion}.tar.xz"
-CHECKSUM_SHA256="d9151195b748361a12d7aeafd8df531d2f45b55d202d7fa5f47c3a11d59877d6"
-SOURCE_DIR="kservice-$portVersion"
-PATCHES="kservice6-$portVersion.patchset"
+SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/knotifications-${portVersion}.tar.xz"
+CHECKSUM_SHA256="883e0139fcbc692070287e47de5368c78eb91c8bdbb52fb6f8398183f6aace8f"
+SOURCE_DIR="knotifications-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -20,32 +18,32 @@ libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 enableDocumentation=true
 
 PROVIDES="
-	kservice6$secondaryArchSuffix = $portVersion
-	cmd:kbuildsycoca6$secondaryArchSuffix = $portVersion
-	lib:libKF6Service$secondaryArchSuffix = $libVersionCompat
+	knotifications6$secondaryArchSuffix = $portVersion
+	lib:libKF6Notifications$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	cmd:update_mime_database$secondaryArchSuffix
+	lib:libGL$secondaryArchSuffix
 	lib:libKF6ConfigCore$secondaryArchSuffix
-	lib:libKF6CoreAddons$secondaryArchSuffix
-	lib:libKF6I18n$secondaryArchSuffix
 	lib:libQt6Core$secondaryArchSuffix
+	lib:libQt6Gui$secondaryArchSuffix
+	lib:libQt6Network$secondaryArchSuffix
+	lib:libqt6Qml$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
-	kservice6${secondaryArchSuffix}_devel = $portVersion
-	devel:libKF6Service$secondaryArchSuffix = $libVersionCompat
+	knotifications6${secondaryArchSuffix}_devel = $portVersion
+	devel:libKF6Notifications$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
-	kservice6$secondaryArchSuffix == $portVersion base
+	knotifications6$secondaryArchSuffix == $portVersion base
 	"
 
 if $enableDocumentation; then
 	ARCHITECTURES_doc="any"
 
 	PROVIDES_doc="
-		kservice6_doc = $portVersion
+		knotifications6_doc = $portVersion
 		"
 fi
 
@@ -54,24 +52,20 @@ BUILD_REQUIRES="
 	extra_cmake_modules$secondaryArchSuffix >= $portVersion
 	qt6_tools${secondaryArchSuffix}_devel
 	devel:libKF6ConfigCore$secondaryArchSuffix >= $libVersion
-	devel:libKF6CoreAddons$secondaryArchSuffix >= $libVersion
-	devel:libKF6I18n$secondaryArchSuffix >= $libVersion
 	devel:libQt6Core$secondaryArchSuffix
-	devel:libQt6Qml$secondaryArchSuffix
-	devel:libsqlite3$secondaryArchSuffix
+	devel:libqt6Qml$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	kde_qdoc_common
-	cmd:bison$secondaryArchSuffix
 	cmd:cmake
-	cmd:flex
 	cmd:g++$secondaryArchSuffix
 	cmd:make
-	cmd:msgfmt$secondaryArchSuffix
-	cmd:msgmerge$secondaryArchSuffix
 	cmd:pkg_config$secondaryArchSuffix
-	cmd:update_mime_database$secondaryArchSuffix
 	cmd:qdoc6$secondaryArchSuffix
+	"
+
+TEST_REQUIRES="
+	qthaikuplugins
 	"
 
 BUILD()
@@ -101,7 +95,7 @@ if $enableDocumentation; then
 fi
 
 	prepareInstalledDevelLib \
-		libKF6Service
+		libKF6Notifications
 
 	packageEntries devel \
 		$developDir \
@@ -115,7 +109,9 @@ fi
 
 TEST()
 {
-	# 33% tests passed, 4 tests failed out of 6
 	export LIBRARY_PATH="$sourceDir/build/bin${LIBRARY_PATH:+:$LIBRARY_PATH}"
 	ctest --test-dir build --output-on-failure
+	# individual tests, opens windows, manual intervention needed
+	# build/bin/actiontest
+	 build/bin/notificationtester
 }

--- a/kde-frameworks/kservice/kservice6-6.29.0.recipe
+++ b/kde-frameworks/kservice/kservice6-6.29.0.recipe
@@ -1,12 +1,15 @@
-SUMMARY="Create documentation from DocBook"
-DESCRIPTION="Provides tools to generate documentation in various format from DocBook files."
-HOMEPAGE="https://invent.kde.org/frameworks/kdoctools"
+SUMMARY="Plugin framework for desktop services"
+DESCRIPTION="KService provides a plugin framework for handling desktop services. \
+Services can be applications or libraries. They can be bound to \
+MIME types or handled by application specific code."
+HOMEPAGE="https://invent.kde.org/frameworks/kservice"
 COPYRIGHT="2010-2026 KDE Organisation"
 LICENSE="GNU LGPL v2"
-REVISION="2"
-SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/kdoctools-${portVersion}.tar.xz"
-CHECKSUM_SHA256="024914031fba7a9b79982d02736b21399d9a0d09ad81323d58e17d6b2216c7b0"
-SOURCE_DIR="kdoctools-$portVersion"
+REVISION="1"
+SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/kservice-${portVersion}.tar.xz"
+CHECKSUM_SHA256="0ebde9435d0c0badecec2f96daef972de7b5600d92dddbfc1f5f81c01cfff87c"
+SOURCE_DIR="kservice-$portVersion"
+PATCHES="kservice6-$portVersion.patchset"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -17,67 +20,59 @@ libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 enableDocumentation=true
 
 PROVIDES="
-	kdoctools6$secondaryArchSuffix = $portVersion
-	cmd:checkXML6$secondaryArchSuffix = $portVersion
-	cmd:meinproc6$secondaryArchSuffix = $portVersion
-	lib:libKF6DocTools$secondaryArchSuffix = $libVersionCompat
+	kservice6$secondaryArchSuffix = $portVersion
+	cmd:kbuildsycoca6$secondaryArchSuffix = $portVersion
+	lib:libKF6Service$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libexslt$secondaryArchSuffix
-	lib:libKF6Archive$secondaryArchSuffix
+	cmd:update_mime_database$secondaryArchSuffix
+	lib:libKF6ConfigCore$secondaryArchSuffix
+	lib:libKF6CoreAddons$secondaryArchSuffix
+	lib:libKF6I18n$secondaryArchSuffix
 	lib:libQt6Core$secondaryArchSuffix
-	lib:libxml2$secondaryArchSuffix
-	lib:libxslt$secondaryArchSuffix
+	lib:libQt6Xml$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
-	kdoctools6${secondaryArchSuffix}_devel = $portVersion
-	devel:libKF6DocTools$secondaryArchSuffix = $libVersionCompat
+	kservice6${secondaryArchSuffix}_devel = $portVersion
+	devel:libKF6Service$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
-	kdoctools6$secondaryArchSuffix == $portVersion base
+	kservice6$secondaryArchSuffix == $portVersion base
+	devel:libKF6ConfigCore$secondaryArchSuffix >= $libVersion
 	"
 
 if $enableDocumentation; then
 	ARCHITECTURES_doc="any"
 
 	PROVIDES_doc="
-		kdoctools6_doc = $portVersion
+		kservice6_doc = $portVersion
 		"
 fi
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	docbook_xml_dtd
-	docbook_xsl_stylesheets >= 1.79.2
 	extra_cmake_modules$secondaryArchSuffix >= $portVersion
 	qt6_tools${secondaryArchSuffix}_devel
-	uri
-	devel:libKF6archive$secondaryArchSuffix >= $libVersion
-#	devel:libKF6i18n$secondaryArchSuffix >= $portVersion # breaks the build
+	devel:libKF6ConfigCore$secondaryArchSuffix >= $libVersion
+	devel:libKF6CoreAddons$secondaryArchSuffix >= $libVersion
+	devel:libKF6I18n$secondaryArchSuffix >= $libVersion
 	devel:libQt6Core$secondaryArchSuffix
-	devel:libsqlite3$secondaryArchSuffix
-	devel:libxml2$secondaryArchSuffix
-	devel:libxslt$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	kde_qdoc_common
+	cmd:bison$secondaryArchSuffix
 	cmd:cmake
+	cmd:flex
 	cmd:g++$secondaryArchSuffix
 	cmd:make
 	cmd:msgfmt$secondaryArchSuffix
 	cmd:msgmerge$secondaryArchSuffix
-	cmd:perl
 	cmd:pkg_config$secondaryArchSuffix
+	cmd:update_mime_database$secondaryArchSuffix
 	cmd:qdoc6$secondaryArchSuffix
 	"
-
-PATCH()
-{
-	# Disable docs generation until libxml package is fixed
-	sed -e 's/add/#add/g' -i $sourceDir/docs/CMakeLists.txt
-}
 
 BUILD()
 {
@@ -85,8 +80,6 @@ BUILD()
 
 	cmake -B build -S . -DCMAKE_BUILD_TYPE=Release \
 		$cmakeDirArgs \
-		-DDocBookXSL_DIR=/system/data/xml/docbook/xsl-stylesheets-1.79.2 \
-		-DDocBookXML4_DTD_DIR=/system/data/xml/docbook/xml-dtd-4.5 \
 		-DCMAKE_SKIP_RPATH=YES \
 		-DBUILD_TESTING=OFF \
 		-Wno-dev
@@ -106,8 +99,9 @@ if $enableDocumentation; then
 	cmake --build build --target install_html_docs
 	cmake --build build --target install_qch_docs
 fi
+
 	prepareInstalledDevelLib \
-		libKF6DocTools
+		libKF6Service
 
 	packageEntries devel \
 		$developDir \
@@ -121,7 +115,7 @@ fi
 
 TEST()
 {
-#	0% tests passed, 2 tests failed out of 2
+	# 33% tests passed, 4 tests failed out of 6
 	export LIBRARY_PATH="$sourceDir/build/bin${LIBRARY_PATH:+:$LIBRARY_PATH}"
 	ctest --test-dir build --output-on-failure
 }

--- a/kde-frameworks/kservice/patches/kservice6-6.29.0.patchset
+++ b/kde-frameworks/kservice/patches/kservice6-6.29.0.patchset
@@ -1,11 +1,11 @@
-From 83bab636c2f97c00e44ee86cdac827c91550c1c0 Mon Sep 17 00:00:00 2001
+From e0004e7cd9000229295299002eac1fefbc3f275a Mon Sep 17 00:00:00 2001
 From: Gerasim Troeglazov <3dEyes@gmail.com>
 Date: Tue, 7 Jan 2020 18:16:42 +1000
 Subject: Set path for sycoca databases
 
 
 diff --git a/src/sycoca/ksycoca.cpp b/src/sycoca/ksycoca.cpp
-index 06c5d9b..0dcb8ed 100644
+index 4499036..d20d0b8 100644
 --- a/src/sycoca/ksycoca.cpp
 +++ b/src/sycoca/ksycoca.cpp
 @@ -704,7 +704,11 @@ QString KSycoca::absoluteFilePath()
@@ -21,5 +21,5 @@ index 06c5d9b..0dcb8ed 100644
          return QFile::decodeName(ksycoca_env);
      }
 -- 
-2.52.0
+2.54.0
 

--- a/kde-frameworks/kwindowsystem/kwindowsystem6-6.29.0.recipe
+++ b/kde-frameworks/kwindowsystem/kwindowsystem6-6.29.0.recipe
@@ -1,13 +1,22 @@
-SUMMARY="KDE Desktop notifications"
-DESCRIPTION="KNotification is used to notify the user of an event. \
-It covers feedback and persistent events."
-HOMEPAGE="https://invent.kde.org/frameworks/knotifications"
+SUMMARY="Access to the windowing system"
+DESCRIPTION="Convenience access to certain properties and features of the \
+windowing system.
+
+KWindowSystem provides information about the windowing system and allows \
+interaction with the windowing system. It provides an high level API which \
+is windowing system independent and has platform specific implementations. \
+This API is inspired by X11 and thus not all functionality is available \
+on all windowing systems.
+
+In addition to the high level API, this framework also provides several \
+more low level classes for interaction with the X Windowing System."
+HOMEPAGE="https://invent.kde.org/frameworks/kwindowsystem"
 COPYRIGHT="2010-2026 KDE Organisation"
 LICENSE="GNU LGPL v2"
 REVISION="1"
-SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/knotifications-${portVersion}.tar.xz"
-CHECKSUM_SHA256="e5d3b284ccc907f190d3ab10995a0ae7fa0f505088acc69edc7adfcc6a8140d6"
-SOURCE_DIR="knotifications-$portVersion"
+SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/kwindowsystem-${portVersion}.tar.xz"
+CHECKSUM_SHA256="d2717dcf501707b14736faecf7a2d3381f09fc3e4b7a1b77fc298e4aa9f8368e"
+SOURCE_DIR="kwindowsystem-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
@@ -18,30 +27,31 @@ libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
 enableDocumentation=true
 
 PROVIDES="
-	knotifications6$secondaryArchSuffix = $portVersion
-	lib:libKF6Notifications$secondaryArchSuffix = $libVersionCompat
+	kwindowsystem6$secondaryArchSuffix = $portVersion
+	lib:libKF6WindowSystem$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
 	lib:libGL$secondaryArchSuffix
-	lib:libKF6ConfigCore$secondaryArchSuffix
 	lib:libQt6Core$secondaryArchSuffix
-	lib:libqt6Qml$secondaryArchSuffix
+	lib:libQt6Gui$secondaryArchSuffix
+	lib:libQt6Network$secondaryArchSuffix
+	lib:libQt6Qml$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
-	knotifications6${secondaryArchSuffix}_devel = $portVersion
-	devel:libKF6Notifications$secondaryArchSuffix = $libVersionCompat
+	kwindowsystem6${secondaryArchSuffix}_devel = $portVersion
+	devel:libKF6WindowSystem$secondaryArchSuffix = $libVersionCompat
 	"
 REQUIRES_devel="
-	knotifications6$secondaryArchSuffix == $portVersion base
+	kwindowsystem6$secondaryArchSuffix == $portVersion base
 	"
 
 if $enableDocumentation; then
 	ARCHITECTURES_doc="any"
 
 	PROVIDES_doc="
-		knotifications6_doc = $portVersion
+		kwindowsystem6_doc = $portVersion
 		"
 fi
 
@@ -49,10 +59,9 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	extra_cmake_modules$secondaryArchSuffix >= $portVersion
 	qt6_tools${secondaryArchSuffix}_devel
-	devel:libKF6ConfigCore$secondaryArchSuffix >= $libVersion
 	devel:libQt6Core$secondaryArchSuffix
-	devel:libqt6Qml$secondaryArchSuffix
-	devel:libsqlite3$secondaryArchSuffix
+	devel:libQt6Qml$secondaryArchSuffix
+	devel:libxcb$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
 	kde_qdoc_common
@@ -61,10 +70,6 @@ BUILD_PREREQUIRES="
 	cmd:make
 	cmd:pkg_config$secondaryArchSuffix
 	cmd:qdoc6$secondaryArchSuffix
-	"
-
-TEST_REQUIRES="
-	qthaikuplugins
 	"
 
 BUILD()
@@ -92,9 +97,9 @@ if $enableDocumentation; then
 	cmake --build build --target install_html_docs
 	cmake --build build --target install_qch_docs
 fi
-
 	prepareInstalledDevelLib \
-		libKF6Notifications
+		libKF6WindowSystem
+	fixPkgconfig
 
 	packageEntries devel \
 		$developDir \
@@ -110,7 +115,4 @@ TEST()
 {
 	export LIBRARY_PATH="$sourceDir/build/bin${LIBRARY_PATH:+:$LIBRARY_PATH}"
 	ctest --test-dir build --output-on-failure
-	# individual tests, opens windows, manual intervention needed
-	# build/bin/actiontest
-	 build/bin/notificationtester
 }


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
