### PR TITLE
libaccounts_glib, revbump, cleanup, move vapi files to _devel

### DIFF
--- a/net-libs/libaccounts_glib/libaccounts_glib-1.27.recipe
+++ b/net-libs/libaccounts_glib/libaccounts_glib-1.27.recipe
@@ -4,7 +4,7 @@ applications. It is part of the accounts-sso project."
 HOMEPAGE="https://gitlab.com/accounts-sso/libaccounts-glib"
 COPYRIGHT="2024 Accounts SSO"
 LICENSE="GNU LGPL v2.1"
-REVISION="5"
+REVISION="6"
 SOURCE_URI="https://gitlab.com/accounts-sso/libaccounts-glib/-/archive/VERSION_$portVersion/libaccounts-glib-VERSION_$portVersion.tar.bz2"
 CHECKSUM_SHA256="e178c103e60ca34777afba94019a1c4571aedf9e54291b0faca71e5cad0628af"
 SOURCE_DIR="libaccounts-glib-VERSION_$portVersion"
@@ -21,11 +21,9 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libgio_2.0$secondaryArchSuffix
 	lib:libglib_2.0$secondaryArchSuffix
 	lib:libgobject_2.0$secondaryArchSuffix
 	lib:libsqlite3$secondaryArchSuffix
-	lib:libxml2$secondaryArchSuffix
 	"
 
 PROVIDES_devel="
@@ -50,10 +48,8 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 #	pygobject_$pythonPackage
 	devel:libcheck$secondaryArchSuffix
-	devel:libgio_2.0$secondaryArchSuffix
 	devel:libgirepository_1.0$secondaryArchSuffix
 	devel:libglib_2.0$secondaryArchSuffix
-	devel:libgobject_2.0$secondaryArchSuffix
 	devel:libsqlite3$secondaryArchSuffix
 	devel:libxml2$secondaryArchSuffix
 	"
@@ -97,7 +93,8 @@ INSTALL()
 
 	packageEntries devel \
 		$developDir \
-		$dataDir/gir-1.0
+		$dataDir/gir-1.0 \
+		$dataDir/vala
 
 	packageEntries tools \
 		$prefix/bin
@@ -105,7 +102,5 @@ INSTALL()
 
 TEST()
 {
-	# /bin/sh: line 1: /packages/libaccounts_glib-1.26-1/cmd~meson/bin/meson: No such file or directory
-	unset meson
 	ninja -C build test
 }


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
