### PR TITLE
libpeas2, revbump, move dataDir/vala to _devel package

### DIFF
--- a/dev-libs/libpeas/libpeas2-2.2.1.recipe
+++ b/dev-libs/libpeas/libpeas2-2.2.1.recipe
@@ -10,7 +10,7 @@ HOMEPAGE="https://wiki.gnome.org/Projects/Libpeas"
 COPYRIGHT="Steve Frécinaux
 	Ignacio Casal Quinteiro"
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://gitlab.gnome.org/GNOME/libpeas/-/archive/$portVersion/libpeas-$portVersion.tar.bz2"
 CHECKSUM_SHA256="8ffed8ccd613b1cb92bc8dc45904ef6f6d478fa280ae26a76452d8f8bb966ef7"
 SOURCE_DIR="libpeas-$portVersion"
@@ -98,5 +98,6 @@ INSTALL()
 	# devel package
 	packageEntries devel \
 		$developDir \
-		$dataDir/gir-1.0
+		$dataDir/gir-1.0 \
+		$dataDir/vala
 }


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
