### PR TITLE
webkit_gtk4, revbump for typelib changes in glib2

### DIFF
--- a/net-libs/webkit-gtk/webkit_gtk4-2.52.5.recipe
+++ b/net-libs/webkit-gtk/webkit_gtk4-2.52.5.recipe
@@ -11,7 +11,7 @@ HOMEPAGE="https://www.webkitgtk.org/"
 COPYRIGHT="2009‒2026 The WebKitGTK Team"
 LICENSE="GNU LGPL v2
 	BSD (2-clause)"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://www.webkitgtk.org/releases/webkitgtk-$portVersion.tar.xz"
 CHECKSUM_SHA256="8a531a9abd2215936e8a8a914c077b586c0228b31d652f205286a8ec90f3364b"
 SOURCE_DIR="webkitgtk-$portVersion"


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
