### PR TITLE
boost, revbump 1.90.0 and 1.91.0 for link_map

### DIFF
--- a/dev-libs/boost/boost1.90-1.90.0.recipe
+++ b/dev-libs/boost/boost1.90-1.90.0.recipe
@@ -6,7 +6,7 @@ expressions, and unit testing. It contains over eighty individual libraries."
 HOMEPAGE="https://www.boost.org/"
 SOURCE_URI="https://archives.boost.io/release/$portVersion/source/boost_${portVersion//./_}.tar.bz2"
 CHECKSUM_SHA256="49551aff3b22cbc5c5a9ed3dbc92f0e23ea50a0f7325b0d198b705e8ee3fc305"
-REVISION="2"
+REVISION="3"
 LICENSE="Boost v1.0"
 COPYRIGHT="1993-2002 Christopher Seiwald and Perforce Software, Inc.
 	1998-2018 Beman Dawes
@@ -235,6 +235,11 @@ INSTALL()
 		echo "Replacing LIBDIR in $i";
 		sed -i "s%\${_BOOST_LIBDIR}%$prefix/$relativeDevelopLibDir%g" $i;
 	done;
+
+	# static libraries missed the above filter
+	prepareInstalledDevelLibs \
+		libboost_exception \
+		libboost_test_exec_monitor
 
 	packageEntries doc \
 		$developDocDir

--- a/dev-libs/boost/boost1.91-1.91.0.recipe
+++ b/dev-libs/boost/boost1.91-1.91.0.recipe
@@ -6,7 +6,7 @@ expressions, and unit testing. It contains over eighty individual libraries."
 HOMEPAGE="https://www.boost.org/"
 SOURCE_URI="https://archives.boost.io/release/$portVersion/source/boost_${portVersion//./_}.tar.bz2"
 CHECKSUM_SHA256="de5e6b0e4913395c6bdfa90537febd9028ea4c0735d2cdb0cd9b45d5f51264f5"
-REVISION="1"
+REVISION="2"
 LICENSE="Boost v1.0"
 COPYRIGHT="1993-2002 Christopher Seiwald and Perforce Software, Inc.
 	1998-2018 Beman Dawes

--- a/dev-libs/boost/patches/boost1.90-1.90.0.patchset
+++ b/dev-libs/boost/patches/boost1.90-1.90.0.patchset
@@ -1,11 +1,11 @@
-From 0fd4eaceb0dba6c882823eeea88f5978a08b2970 Mon Sep 17 00:00:00 2001
+From 231214c840ff6ab914780fa19238b573a07ca547 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@gmail.com>
 Date: Sat, 6 Aug 2016 22:27:19 +0200
 Subject: Import changes from 1.55.0: buildtools
 
 
 diff --git a/tools/build/src/engine/jam.h b/tools/build/src/engine/jam.h
-index fb6e5da..f78bbe7 100644
+index fb6e5dabb..f78bbe705 100644
 --- a/tools/build/src/engine/jam.h
 +++ b/tools/build/src/engine/jam.h
 @@ -161,6 +161,11 @@
@@ -21,17 +21,17 @@ index fb6e5da..f78bbe7 100644
  #define OSMINOR "OS=BSDI"
  #define OS_BSDI
 -- 
-2.51.0
+2.54.0
 
 
-From 7cc1b2eb3ed55037e7b099a0979d3d42da89e79c Mon Sep 17 00:00:00 2001
+From a4fc2d7053e6cbda6777b10784b8f4f306379b34 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@gmail.com>
 Date: Sat, 6 Aug 2016 22:27:41 +0200
 Subject: Import changes from 1.55.0: sourcecode
 
 
 diff --git a/boost/thread/detail/platform.hpp b/boost/thread/detail/platform.hpp
-index 172a601..c706e40 100644
+index 172a601a0..c706e408e 100644
 --- a/boost/thread/detail/platform.hpp
 +++ b/boost/thread/detail/platform.hpp
 @@ -34,7 +34,7 @@
@@ -44,17 +44,17 @@ index 172a601..c706e40 100644
  #elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__)
  #  define BOOST_THREAD_MACOS
 -- 
-2.51.0
+2.54.0
 
 
-From cc676f73db63241cf6e3c37379e043f3897a746a Mon Sep 17 00:00:00 2001
+From 4954156ae9c6419c31ee760ca7b48258b4543338 Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sat, 14 Oct 2017 11:47:09 +0200
 Subject: Haiku needs bsd and _BSD_SOURCE.
 
 
 diff --git a/tools/build/src/engine/build.sh b/tools/build/src/engine/build.sh
-index 65a366a..1b0c014 100755
+index 65a366aa0..1b0c01436 100755
 --- a/tools/build/src/engine/build.sh
 +++ b/tools/build/src/engine/build.sh
 @@ -316,6 +316,22 @@ case "${B2_TOOLSET}" in
@@ -81,17 +81,17 @@ index 65a366a..1b0c014 100755
  
      intel-*)
 -- 
-2.51.0
+2.54.0
 
 
-From 79a33b50a20f37f589a4904df6d383cf7aef537f Mon Sep 17 00:00:00 2001
+From 3bf82f7a1854ef81374689e876514b4e57ad6250 Mon Sep 17 00:00:00 2001
 From: Begasus <begasus@gmail.com>
 Date: Fri, 25 Aug 2023 10:15:17 +0200
 Subject: Add auto_index binary to tools
 
 
 diff --git a/tools/Jamfile.v2 b/tools/Jamfile.v2
-index e1391c7..a580eb1 100644
+index e1391c768..a580eb1aa 100644
 --- a/tools/Jamfile.v2
 +++ b/tools/Jamfile.v2
 @@ -18,6 +18,7 @@ project
@@ -103,17 +103,17 @@ index e1391c7..a580eb1 100644
      inspect/build//inspect
      quickbook//quickbook
 -- 
-2.51.0
+2.54.0
 
 
-From 62f687589bef14530e794eeed96b5498902ae0f4 Mon Sep 17 00:00:00 2001
+From 9ca52605d6e4f669cc52c373ab298d5ddf16f5de Mon Sep 17 00:00:00 2001
 From: Begasus <begasus@gmail.com>
 Date: Sun, 27 Aug 2023 19:13:24 +0200
 Subject: Fix missing functions to build libboost_locale
 
 
 diff --git a/boost/config/platform/haiku.hpp b/boost/config/platform/haiku.hpp
-index 04244c5..e22ac4f 100644
+index 04244c567..e22ac4f0c 100644
 --- a/boost/config/platform/haiku.hpp
 +++ b/boost/config/platform/haiku.hpp
 @@ -16,11 +16,6 @@
@@ -129,17 +129,17 @@ index 04244c5..e22ac4f 100644
  // thread API's not auto detected:
  //
 -- 
-2.51.0
+2.54.0
 
 
-From d8fb33d96633e943dbe31c13c191d77112e568b7 Mon Sep 17 00:00:00 2001
+From 0a92959d6a4aed541fa32ab20dfa311b4f1586ba Mon Sep 17 00:00:00 2001
 From: Begasus <begasus@gmail.com>
 Date: Mon, 28 Aug 2023 18:08:06 +0200
 Subject: Fix building the tests
 
 
 diff --git a/libs/predef/test/build.jam b/libs/predef/test/build.jam
-index d67d932..6406018 100644
+index d67d93253..64060182b 100644
 --- a/libs/predef/test/build.jam
 +++ b/libs/predef/test/build.jam
 @@ -12,7 +12,7 @@ project
@@ -152,17 +152,17 @@ index d67d932..6406018 100644
  
  using testing ;
 -- 
-2.51.0
+2.54.0
 
 
-From 19493386d8f7ca4bf9adf33481f8b35a29e72e5f Mon Sep 17 00:00:00 2001
+From 6b8b0b8460c5cc4ac67a6425cd55797c078d0d3c Mon Sep 17 00:00:00 2001
 From: PulkoMandy <pulkomandy@pulkomandy.tk>
 Date: Fri, 13 Jan 2023 21:26:43 +0100
 Subject: Haiku currently doesn't have cfsetspeed
 
 
 diff --git a/boost/asio/impl/serial_port_base.ipp b/boost/asio/impl/serial_port_base.ipp
-index e6a275d..7866eec 100644
+index e6a275de7..7866eec05 100644
 --- a/boost/asio/impl/serial_port_base.ipp
 +++ b/boost/asio/impl/serial_port_base.ipp
 @@ -114,7 +114,8 @@ BOOST_ASIO_SYNC_OP_VOID serial_port_base::baud_rate::store(
@@ -176,17 +176,17 @@ index e6a275d..7866eec 100644
  # else
    ::cfsetispeed(&storage, baud);
 -- 
-2.51.0
+2.54.0
 
 
-From 1d5d30221298951b386a06a8613fb7382b832768 Mon Sep 17 00:00:00 2001
+From fdabd84e2d17876567ee7caf637bf7ca2f31c671 Mon Sep 17 00:00:00 2001
 From: Schrijvers Luc <begasus@gmail.com>
 Date: Sat, 6 Jul 2024 17:27:48 +0200
 Subject: build fix for sourcetrail
 
 
 diff --git a/boost/process/v1/detail/posix/is_running.hpp b/boost/process/v1/detail/posix/is_running.hpp
-index 133ad9c..89e1f30 100644
+index 133ad9c06..89e1f305f 100644
 --- a/boost/process/v1/detail/posix/is_running.hpp
 +++ b/boost/process/v1/detail/posix/is_running.hpp
 @@ -17,10 +17,12 @@ namespace boost { namespace process { BOOST_PROCESS_V1_INLINE namespace v1 { nam
@@ -203,7 +203,7 @@ index 133ad9c..89e1f30 100644
  inline bool is_running(int code)
  {
 diff --git a/boost/process/v2/exit_code.hpp b/boost/process/v2/exit_code.hpp
-index 24e51fa..2836d9d 100644
+index 24e51fa67..2836d9d95 100644
 --- a/boost/process/v2/exit_code.hpp
 +++ b/boost/process/v2/exit_code.hpp
 @@ -73,10 +73,12 @@ typedef int native_exit_code_type;
@@ -231,17 +231,17 @@ index 24e51fa..2836d9d 100644
 \ No newline at end of file
 +#endif //BOOST_PROCESS_V2_EXIT_CODE_HPP
 -- 
-2.51.0
+2.54.0
 
 
-From 5aeb246b1b2b08fcf36eb5126345046de61d9595 Mon Sep 17 00:00:00 2001
+From c32f6cfbf95bf00417044a8874e78adc2a1590f8 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 20 Dec 2024 22:32:12 -0300
 Subject: Fix build issue related to dirent->d_name[].
 
 
 diff --git a/libs/filesystem/src/directory.cpp b/libs/filesystem/src/directory.cpp
-index 8ea0a59..d5250ec 100644
+index 8ea0a59d6..d5250ec29 100644
 --- a/libs/filesystem/src/directory.cpp
 +++ b/libs/filesystem/src/directory.cpp
 @@ -310,8 +310,13 @@ inline std::size_t get_path_max()
@@ -271,17 +271,17 @@ index 8ea0a59..d5250ec 100644
      }
  #endif // defined(BOOST_FILESYSTEM_USE_READDIR_R)
 -- 
-2.51.0
+2.54.0
 
 
-From cad861806c4c72707ac57f6f0cb004a57f5d7138 Mon Sep 17 00:00:00 2001
+From 7f3abc6d359ea2b929c3e41721c1d9fbe18b212f Mon Sep 17 00:00:00 2001
 From: Luc Schrijvers <begasus@gmail.com>
 Date: Fri, 4 Apr 2025 11:14:17 +0200
 Subject: No wordexpr.h on Haiku
 
 
 diff --git a/libs/process/src/shell.cpp b/libs/process/src/shell.cpp
-index bf4bbfd..d7315d0 100644
+index bf4bbfd83..d7315d002 100644
 --- a/libs/process/src/shell.cpp
 +++ b/libs/process/src/shell.cpp
 @@ -19,7 +19,7 @@
@@ -312,17 +312,17 @@ index bf4bbfd..d7315d0 100644
  void shell::parse_()
  {
 -- 
-2.51.0
+2.54.0
 
 
-From 558aeda7399581e45f5545ba8dfd9c6d7986df56 Mon Sep 17 00:00:00 2001
+From 2075cbfbd4b0bf9daa8fed2cd99fdb36e25b359b Mon Sep 17 00:00:00 2001
 From: Luc Schrijvers <begasus@gmail.com>
 Date: Fri, 4 Apr 2025 12:20:08 +0200
 Subject: Fixes for boost_process
 
 
 diff --git a/libs/process/src/ext/cmd.cpp b/libs/process/src/ext/cmd.cpp
-index 463e9ed..7ecf9e7 100644
+index 463e9ed3e..7ecf9e7d3 100644
 --- a/libs/process/src/ext/cmd.cpp
 +++ b/libs/process/src/ext/cmd.cpp
 @@ -31,7 +31,7 @@
@@ -344,5 +344,37 @@ index 463e9ed..7ecf9e7 100644
  shell cmd(boost::process::v2::pid_type pid, error_code & ec)
  {
 -- 
-2.51.0
+2.54.0
+
+
+From 195e97e6ef9e1cfd4bbd3fc42e05ce65a2449a73 Mon Sep 17 00:00:00 2001
+From: Luc Schrijvers <begasus@gmail.com>
+Date: Sun, 23 Aug 2026 17:34:47 +0200
+Subject: Add fix for link_map like BOOST_OS_QNX does
+
+
+diff --git a/boost/dll/detail/posix/path_from_handle.hpp b/boost/dll/detail/posix/path_from_handle.hpp
+index 0ad881683..39c012292 100644
+--- a/boost/dll/detail/posix/path_from_handle.hpp
++++ b/boost/dll/detail/posix/path_from_handle.hpp
+@@ -119,14 +119,14 @@ extern "C" unsigned long long GetLastError();
+ 
+ namespace boost { namespace dll { namespace detail {
+ 
+-#if BOOST_OS_QNX
+-    // Android and QNX miss struct link_map. QNX misses ElfW macro, so avoiding it.
++#if BOOST_OS_QNX || BOOST_OS_HAIKU
++    // Android, QNX and Haiku miss struct link_map. QNX misses ElfW macro, so avoiding it.
+     struct link_map {
+         void *l_addr;   // Base address shared object is loaded at
+         char *l_name;   // Absolute file name object was found in
+         // ...          // Ignoring remaning parts of the structure
+     };
+-#endif // #if BOOST_OS_QNX
++#endif // #if BOOST_OS_QNX || BOOST_OS_HAIKU
+ 
+     inline boost::dll::fs::path path_from_handle(void* handle, std::error_code &ec) {
+         // RTLD_DI_LINKMAP (RTLD_DI_ORIGIN returns only folder and is not suitable for this case)
+-- 
+2.54.0
 

--- a/dev-libs/boost/patches/boost1.91-1.91.0.patchset
+++ b/dev-libs/boost/patches/boost1.91-1.91.0.patchset
@@ -1,11 +1,11 @@
-From b070cc172aa97daf5d67b888ca2b894e453b2dcf Mon Sep 17 00:00:00 2001
+From 6d8c271fef49a3a6ae7acdf6736678d07617dc84 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@gmail.com>
 Date: Sat, 6 Aug 2016 22:27:19 +0200
 Subject: Import changes from 1.55.0: buildtools
 
 
 diff --git a/tools/build/src/engine/jam.h b/tools/build/src/engine/jam.h
-index fb6e5da..f78bbe7 100644
+index fb6e5dabb..f78bbe705 100644
 --- a/tools/build/src/engine/jam.h
 +++ b/tools/build/src/engine/jam.h
 @@ -161,6 +161,11 @@
@@ -21,17 +21,17 @@ index fb6e5da..f78bbe7 100644
  #define OSMINOR "OS=BSDI"
  #define OS_BSDI
 -- 
-2.52.0
+2.54.0
 
 
-From 2a60e6e4c9a4e4b762151c6c840bf0ad3d37ac55 Mon Sep 17 00:00:00 2001
+From bfebe89480cec14321c18fc3e51351d5f49427c2 Mon Sep 17 00:00:00 2001
 From: Adrien Destugues <pulkomandy@gmail.com>
 Date: Sat, 6 Aug 2016 22:27:41 +0200
 Subject: Import changes from 1.55.0: sourcecode
 
 
 diff --git a/boost/thread/detail/platform.hpp b/boost/thread/detail/platform.hpp
-index 172a601..c706e40 100644
+index 172a601a0..c706e408e 100644
 --- a/boost/thread/detail/platform.hpp
 +++ b/boost/thread/detail/platform.hpp
 @@ -34,7 +34,7 @@
@@ -44,17 +44,17 @@ index 172a601..c706e40 100644
  #elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__)
  #  define BOOST_THREAD_MACOS
 -- 
-2.52.0
+2.54.0
 
 
-From 6874e06d95e4959f609603bd9603aa70979dceb9 Mon Sep 17 00:00:00 2001
+From 4ff9013ae95a4a27744cfe4033c7cb66b30dc2aa Mon Sep 17 00:00:00 2001
 From: Jerome Duval <jerome.duval@gmail.com>
 Date: Sat, 14 Oct 2017 11:47:09 +0200
 Subject: Haiku needs bsd and _BSD_SOURCE.
 
 
 diff --git a/tools/build/src/engine/build.sh b/tools/build/src/engine/build.sh
-index 1938704..c5f5f2d 100755
+index 1938704a2..c5f5f2d45 100755
 --- a/tools/build/src/engine/build.sh
 +++ b/tools/build/src/engine/build.sh
 @@ -316,6 +316,22 @@ case "${B2_TOOLSET}" in
@@ -81,17 +81,17 @@ index 1938704..c5f5f2d 100755
  
      intel-*)
 -- 
-2.52.0
+2.54.0
 
 
-From 079dc947caa91bbdefb42a6fe94f4e44fae681eb Mon Sep 17 00:00:00 2001
+From 027fcc81b06a8fd00b9f0ba02ff90201b2e45423 Mon Sep 17 00:00:00 2001
 From: Begasus <begasus@gmail.com>
 Date: Fri, 25 Aug 2023 10:15:17 +0200
 Subject: Add auto_index binary to tools
 
 
 diff --git a/tools/Jamfile.v2 b/tools/Jamfile.v2
-index e1391c7..a580eb1 100644
+index e1391c768..a580eb1aa 100644
 --- a/tools/Jamfile.v2
 +++ b/tools/Jamfile.v2
 @@ -18,6 +18,7 @@ project
@@ -103,17 +103,17 @@ index e1391c7..a580eb1 100644
      inspect/build//inspect
      quickbook//quickbook
 -- 
-2.52.0
+2.54.0
 
 
-From 852a7fc0ada406eb1d3fe20e933adf97d6a8d7f7 Mon Sep 17 00:00:00 2001
+From 1f91982b5fa3a6fd84a28eb582bc5f6b4c5e3a45 Mon Sep 17 00:00:00 2001
 From: Begasus <begasus@gmail.com>
 Date: Sun, 27 Aug 2023 19:13:24 +0200
 Subject: Fix missing functions to build libboost_locale
 
 
 diff --git a/boost/config/platform/haiku.hpp b/boost/config/platform/haiku.hpp
-index 04244c5..e22ac4f 100644
+index 04244c567..e22ac4f0c 100644
 --- a/boost/config/platform/haiku.hpp
 +++ b/boost/config/platform/haiku.hpp
 @@ -16,11 +16,6 @@
@@ -129,17 +129,17 @@ index 04244c5..e22ac4f 100644
  // thread API's not auto detected:
  //
 -- 
-2.52.0
+2.54.0
 
 
-From d97f48ca4918762047fe3c6121891fcb4adba75f Mon Sep 17 00:00:00 2001
+From bd3ce8168e57cd6527a67bea5b229ca7d8d649fb Mon Sep 17 00:00:00 2001
 From: Begasus <begasus@gmail.com>
 Date: Mon, 28 Aug 2023 18:08:06 +0200
 Subject: Fix building the tests
 
 
 diff --git a/libs/predef/test/build.jam b/libs/predef/test/build.jam
-index d67d932..6406018 100644
+index d67d93253..64060182b 100644
 --- a/libs/predef/test/build.jam
 +++ b/libs/predef/test/build.jam
 @@ -12,7 +12,7 @@ project
@@ -152,17 +152,17 @@ index d67d932..6406018 100644
  
  using testing ;
 -- 
-2.52.0
+2.54.0
 
 
-From 2b829cec6f4ced6e2f03dd1b86be3568f4ea4dee Mon Sep 17 00:00:00 2001
+From aa6c5738d7920fc803183e44a85e29ea80c33c3f Mon Sep 17 00:00:00 2001
 From: PulkoMandy <pulkomandy@pulkomandy.tk>
 Date: Fri, 13 Jan 2023 21:26:43 +0100
 Subject: Haiku currently doesn't have cfsetspeed
 
 
 diff --git a/boost/asio/impl/serial_port_base.ipp b/boost/asio/impl/serial_port_base.ipp
-index d3e9afa..6be7300 100644
+index d3e9afaeb..6be73008c 100644
 --- a/boost/asio/impl/serial_port_base.ipp
 +++ b/boost/asio/impl/serial_port_base.ipp
 @@ -115,7 +115,8 @@ BOOST_ASIO_SYNC_OP_VOID serial_port_base::baud_rate::store(
@@ -176,17 +176,17 @@ index d3e9afa..6be7300 100644
  # else
    ::cfsetispeed(&storage, baud);
 -- 
-2.52.0
+2.54.0
 
 
-From bfd21763244c6bd5b431c861f6f5d9d4590d9dae Mon Sep 17 00:00:00 2001
+From f9ba5dc28db247403c049a3b0546124d00ed52dc Mon Sep 17 00:00:00 2001
 From: Schrijvers Luc <begasus@gmail.com>
 Date: Sat, 6 Jul 2024 17:27:48 +0200
 Subject: build fix for sourcetrail
 
 
 diff --git a/boost/process/v1/detail/posix/is_running.hpp b/boost/process/v1/detail/posix/is_running.hpp
-index 133ad9c..89e1f30 100644
+index 133ad9c06..89e1f305f 100644
 --- a/boost/process/v1/detail/posix/is_running.hpp
 +++ b/boost/process/v1/detail/posix/is_running.hpp
 @@ -17,10 +17,12 @@ namespace boost { namespace process { BOOST_PROCESS_V1_INLINE namespace v1 { nam
@@ -203,7 +203,7 @@ index 133ad9c..89e1f30 100644
  inline bool is_running(int code)
  {
 diff --git a/boost/process/v2/exit_code.hpp b/boost/process/v2/exit_code.hpp
-index 24e51fa..2836d9d 100644
+index 24e51fa67..2836d9d95 100644
 --- a/boost/process/v2/exit_code.hpp
 +++ b/boost/process/v2/exit_code.hpp
 @@ -73,10 +73,12 @@ typedef int native_exit_code_type;
@@ -231,17 +231,17 @@ index 24e51fa..2836d9d 100644
 \ No newline at end of file
 +#endif //BOOST_PROCESS_V2_EXIT_CODE_HPP
 -- 
-2.52.0
+2.54.0
 
 
-From f72275651de557b1285ad9378a5d73b95f565b90 Mon Sep 17 00:00:00 2001
+From 3ffddd07e0f8be91fd45b6377264263678237184 Mon Sep 17 00:00:00 2001
 From: Oscar Lesta <oscar.lesta@gmail.com>
 Date: Fri, 20 Dec 2024 22:32:12 -0300
 Subject: Fix build issue related to dirent->d_name[].
 
 
 diff --git a/libs/filesystem/src/directory.cpp b/libs/filesystem/src/directory.cpp
-index 8c4d0a8..e168621 100644
+index 8c4d0a8c9..e1686214a 100644
 --- a/libs/filesystem/src/directory.cpp
 +++ b/libs/filesystem/src/directory.cpp
 @@ -310,8 +310,13 @@ inline std::size_t get_path_max()
@@ -271,17 +271,17 @@ index 8c4d0a8..e168621 100644
      }
  #endif // defined(BOOST_FILESYSTEM_USE_READDIR_R)
 -- 
-2.52.0
+2.54.0
 
 
-From f3f193ef5e47ccce1312c5b3b77fb275e0f68900 Mon Sep 17 00:00:00 2001
+From 60145ac946f68ca530d3ee62ec83a75e029f9e6c Mon Sep 17 00:00:00 2001
 From: Luc Schrijvers <begasus@gmail.com>
 Date: Fri, 4 Apr 2025 11:14:17 +0200
 Subject: No wordexpr.h on Haiku
 
 
 diff --git a/libs/process/src/shell.cpp b/libs/process/src/shell.cpp
-index bf4bbfd..d7315d0 100644
+index bf4bbfd83..d7315d002 100644
 --- a/libs/process/src/shell.cpp
 +++ b/libs/process/src/shell.cpp
 @@ -19,7 +19,7 @@
@@ -312,17 +312,17 @@ index bf4bbfd..d7315d0 100644
  void shell::parse_()
  {
 -- 
-2.52.0
+2.54.0
 
 
-From 63d9cea6f084b61d301937073985ed4d1e7d48e5 Mon Sep 17 00:00:00 2001
+From fa06defa71e183310bfac178e2adf63d4920f8f5 Mon Sep 17 00:00:00 2001
 From: Luc Schrijvers <begasus@gmail.com>
 Date: Fri, 4 Apr 2025 12:20:08 +0200
 Subject: Fixes for boost_process
 
 
 diff --git a/libs/process/src/ext/cmd.cpp b/libs/process/src/ext/cmd.cpp
-index 463e9ed..7ecf9e7 100644
+index 463e9ed3e..7ecf9e7d3 100644
 --- a/libs/process/src/ext/cmd.cpp
 +++ b/libs/process/src/ext/cmd.cpp
 @@ -31,7 +31,7 @@
@@ -344,5 +344,37 @@ index 463e9ed..7ecf9e7 100644
  shell cmd(boost::process::v2::pid_type pid, error_code & ec)
  {
 -- 
-2.52.0
+2.54.0
+
+
+From fecda769fdad29f646047a954c0a7cbfbf3304da Mon Sep 17 00:00:00 2001
+From: Luc Schrijvers <begasus@gmail.com>
+Date: Sun, 23 Aug 2026 17:37:38 +0200
+Subject: Add fix for link_map like BOOST_OS_QNX does
+
+
+diff --git a/boost/dll/detail/posix/path_from_handle.hpp b/boost/dll/detail/posix/path_from_handle.hpp
+index d34413c80..27d93c749 100644
+--- a/boost/dll/detail/posix/path_from_handle.hpp
++++ b/boost/dll/detail/posix/path_from_handle.hpp
+@@ -119,14 +119,14 @@ extern "C" unsigned long long GetLastError();
+ 
+ namespace boost { namespace dll { namespace detail {
+ 
+-#if BOOST_OS_QNX
+-    // Android and QNX miss struct link_map. QNX misses ElfW macro, so avoiding it.
++#if BOOST_OS_QNX || BOOST_OS_HAIKU
++    // Android, QNX and Haiku miss struct link_map. QNX misses ElfW macro, so avoiding it.
+     struct link_map {
+         void *l_addr;   // Base address shared object is loaded at
+         char *l_name;   // Absolute file name object was found in
+         // ...          // Ignoring remaning parts of the structure
+     };
+-#endif // #if BOOST_OS_QNX
++#endif // #if BOOST_OS_QNX || BOOST_OS_HAIKU
+ 
+     inline boost::dll::fs::path path_from_handle(void* handle, std::error_code &ec) {
+         // RTLD_DI_LINKMAP (RTLD_DI_ORIGIN returns only folder and is not suitable for this case)
+-- 
+2.54.0
 


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
