### PR TITLE
kdevelop_kf6, php and python plugin for gear26.08

### DIFF
--- a/dev-util/kdevelop_php/kdevelop_php-26.08.0.recipe
+++ b/dev-util/kdevelop_php/kdevelop_php-26.08.0.recipe
@@ -5,7 +5,7 @@ COPYRIGHT="2010-2026 KDE Organisation"
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://download.kde.org/stable/release-service/$portVersion/src/kdev-php-$portVersion.tar.xz"
-CHECKSUM_SHA256="442cddea8dd86c1190b9c705fdbedfeeac2f33d5550ad3554ebc006a458b3121"
+CHECKSUM_SHA256="4d312b811bdee7016f6273df8c355f7ed89b60aa0c88eba666a880d997b140f4"
 SOURCE_DIR="kdev-php-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -27,7 +27,6 @@ REQUIRES="
 	lib:libKDevPlatformSerialization$secondaryArchSuffix
 	lib:libKDevPlatformShell$secondaryArchSuffix
 	lib:libKDevPlatformSublime$secondaryArchSuffix
-	lib:libKDevPlatformTests$secondaryArchSuffix
 	lib:libKDevPlatformUtil$secondaryArchSuffix
 	lib:libKDevPlatformVcs$secondaryArchSuffix
 	# KF6
@@ -38,8 +37,10 @@ REQUIRES="
 	lib:libKF6CoreAddons$secondaryArchSuffix
 	lib:libKF6GuiAddons$secondaryArchSuffix
 	lib:libKF6I18n$secondaryArchSuffix
+	lib:libKF6JobWidgets$secondaryArchSuffix
 	lib:libKF6KIOCore$secondaryArchSuffix
 	lib:libKF6Parts$secondaryArchSuffix
+	lib:libKF6Service$secondaryArchSuffix
 	lib:libKF6SyntaxHighlighting$secondaryArchSuffix
 	lib:libKF6TextEditor$secondaryArchSuffix
 	lib:libKF6ThreadWeaver$secondaryArchSuffix

--- a/dev-util/kdevelop_python/kdevelop_python-26.08.0.recipe
+++ b/dev-util/kdevelop_python/kdevelop_python-26.08.0.recipe
@@ -5,7 +5,7 @@ COPYRIGHT="2010-2026 KDE Organisation"
 LICENSE="GNU GPL v2"
 REVISION="1"
 SOURCE_URI="https://download.kde.org/stable/release-service/$portVersion/src/kdev-python-$portVersion.tar.xz"
-CHECKSUM_SHA256="9e89b3019b09245289e22b06b4b81996fad1228f126f08506175763dd7fb482c"
+CHECKSUM_SHA256="9a9f82f400c2dacea7ddbb29fb791cff59bc0286360d9a85a653d79c593182d0"
 SOURCE_DIR="kdev-python-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
@@ -23,8 +23,7 @@ REQUIRES="
 	lib:libKDevPlatformInterfaces$secondaryArchSuffix
 	lib:libKDevPlatformLanguage$secondaryArchSuffix
 	lib:libKDevPlatformSerialization$secondaryArchSuffix
-	lib:libKDevPlatformTests$secondaryArchSuffix
-	lib:libpython3.10$secondaryArchSuffix
+	lib:libpython3.14$secondaryArchSuffix
 	# KF6
 	lib:libKF6ColorScheme$secondaryArchSuffix
 	lib:libKF6Completion$secondaryArchSuffix
@@ -35,6 +34,7 @@ REQUIRES="
 	lib:libKF6I18n$secondaryArchSuffix
 	lib:libKF6KIOCore$secondaryArchSuffix
 	lib:libKF6Parts$secondaryArchSuffix
+	lib:libKF6Service$secondaryArchSuffix
 	lib:libKF6SyntaxHighlighting$secondaryArchSuffix
 	lib:libKF6TextEditor$secondaryArchSuffix
 	lib:libKF6ThreadWeaver$secondaryArchSuffix


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
