### PR TITLE
pycairo: cleanup recipe, enable Python 3.14 package.

### DIFF
--- a/dev-python/pycairo/pycairo-1.27.0.recipe
+++ b/dev-python/pycairo/pycairo-1.27.0.recipe
@@ -4,26 +4,18 @@ and to deviate only in cases which are clearly better implemented in a more ‘P
 HOMEPAGE="https://pypi.org/project/pycairo/"
 COPYRIGHT="2023 pycairo developers"
 LICENSE="GNU LGPL v2.1"
-REVISION="2"
+REVISION="3"
 SOURCE_URI="https://github.com/pygobject/pycairo/releases/download/v$portVersion/pycairo-$portVersion.tar.gz"
 CHECKSUM_SHA256="5cb21e7a00a2afcafea7f14390235be33497a2cce53a98a19389492a60628430"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"
 
-PROVIDES="
-	pycairo$secondaryArchSuffix = $portVersion
-	"
-REQUIRES="
-	haiku$secondaryArchSuffix
-	"
-
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libcairo$secondaryArchSuffix
-	devel:libcairo_gobject$secondaryArchSuffix
-	devel:libcairo_script_interpreter$secondaryArchSuffix
 	"
+
 BUILD_PREREQUIRES="
 	cmd:gcc$secondaryArchSuffix
 	cmd:meson
@@ -31,57 +23,67 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
-PYTHON_PACKAGES=(python310)
-PYTHON_VERSIONS=(3.10)
-for i in "${!PYTHON_PACKAGES[@]}"; do
-	pythonPackage=${PYTHON_PACKAGES[i]}
-	pythonVersion=${PYTHON_VERSIONS[$i]}
+PYTHON_VERSIONS=(3.10 3.14)
 
-	eval "PROVIDES_${pythonPackage}=\"
-		${portName}_$pythonPackage = $portVersion
-		\""
-	# Also provide "non _x86" package on x86 32 bits
-	if [ "$targetArchitecture" = "x86_gcc2" ]; then
-		eval "PROVIDES_${pythonPackage}+=\"
-			pycairo_$pythonPackage = $portVersion
+for pythonVersion in ${PYTHON_VERSIONS[@]}; do
+	pythonPackage=python${pythonVersion//.}
+
+	if [ $pythonVersion != 3.10 ]; then
+		# Allows using dot in sub-package names (eg: "_python3.14" vs "_python314"):
+		eval "PACKAGE_NAME_$pythonPackage=${portBaseName}_python$pythonVersion"
+
+		# We provide both dotted and dotless suffixes to avoid having to do add conditionals
+		# in BUILD_REQUIRES/REQUIRES (of other current recipes that expect dotless names).
+		eval "PROVIDES_$pythonPackage=\"
+			${portName}_python$pythonVersion = $portVersion
 			\""
 	fi
-	eval "REQUIRES_$pythonPackage=\"
+
+	eval "PROVIDES_${pythonPackage}+=\"
+		${portName}_$pythonPackage = $portVersion
+		\""
+
+	# Also provide "non _x86" package on x86 32 bits
+	if [ "$targetArchitecture" = x86_gcc2 ]; then
+		eval "PROVIDES_${pythonPackage}+=\"
+			${portBaseName}_$pythonPackage = $portVersion
+			\""
+	fi
+
+	eval "REQUIRES_$pythonPackage+=\"
 		haiku$secondaryArchSuffix
 		cmd:python$pythonVersion
 		lib:libcairo$secondaryArchSuffix
-		lib:libcairo_gobject$secondaryArchSuffix
-		lib:libcairo_script_interpreter$secondaryArchSuffix
 		\""
+
 	BUILD_PREREQUIRES+="
 		cmd:python$pythonVersion
 		"
 done
 
+
 INSTALL()
 {
-	for i in "${!PYTHON_PACKAGES[@]}"; do
-		pythonPackage=${PYTHON_PACKAGES[i]}
-		pythonVersion=${PYTHON_VERSIONS[$i]}
-
+	for pythonVersion in ${PYTHON_VERSIONS[@]}; do
+		pythonPackage=python${pythonVersion//.}
 		python=python$pythonVersion
-		installLocation=$prefix/lib/$python/vendor-packages/
-		export PYTHONPATH=$installLocation:$PYTHONPATH
-		mkdir -p $installLocation
+
 		rm -rf build
-		meson build --buildtype=release \
+
+		meson setup build --buildtype=release \
 			--prefix=$prefix \
 			--includedir=$includeDir \
-			--libdir=$libDir \
+			--libdir=$prefix/lib \
 			--localedir=$dataDir/locale \
 			-Dpython=$python \
 			-Dtests=false
+
 		ninja -C build install
 
 		fixPkgconfig
 
 		packageEntries $pythonPackage \
 			$developDir \
-			$prefix/lib
+			$prefix/lib/$python
 	done
 }


### PR DESCRIPTION
Not a big deal, just enables 3.14 and drops the empty base package.

Real motivation[*] was to have something small that uses meson to compile, and install a python module, that I could locally test.

[*] after @Begasus mentioned some bogus `non-packaged/non-packaged` during install, while building the `apostrophe` markdown editor (that also uses meson to build, and install some python module) from Terminal.