### PR TITLE
ki18n6, revbump, add python dependency in _devel

### DIFF
--- a/kde-frameworks/ki18n/ki18n6-6.29.0.recipe
+++ b/kde-frameworks/ki18n/ki18n6-6.29.0.recipe
@@ -11,7 +11,7 @@ and translation scripting."
 HOMEPAGE="https://github.com/KDE/ki18n/"
 COPYRIGHT="2010-2026 KDE Organisation"
 LICENSE="GNU LGPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://download.kde.org/stable/frameworks/${portVersion%.*}/ki18n-${portVersion}.tar.xz"
 CHECKSUM_SHA256="9037f3caa67768869f00ee257dbb35b81febe6ad600ed0bd3ffdf293c36252ba"
 SOURCE_DIR="ki18n-$portVersion"
@@ -47,6 +47,7 @@ PROVIDES_devel="
 	"
 REQUIRES_devel="
 	ki18n6$secondaryArchSuffix == $portVersion base
+	cmd:python3
 	"
 
 if $enableDocumentation; then


### PR DESCRIPTION
this is needed for _ki18n_pmap_compile_script and others

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
