### PR TITLE
libphonenumber, revbump, use most recent abseil_cpp

### DIFF
--- a/dev-libs/libphonenumber/libphonenumber-9.0.33.recipe
+++ b/dev-libs/libphonenumber/libphonenumber-9.0.33.recipe
@@ -5,7 +5,7 @@ the Android framework since 4.0 (Ice Cream Sandwich)."
 HOMEPAGE="https://github.com/google/libphonenumber"
 COPYRIGHT="2014 The Chromium Authors"
 LICENSE="Apache v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://github.com/google/libphonenumber/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="649e13846a7c49ca91ddfbf649e8feeafe7b04b590de4ce64cedfbf28d37b2ee"
 PATCHES="libphonenumber-$portVersion.patchset"
@@ -23,10 +23,9 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
-	lib:libabsl_base$secondaryArchSuffix # don't list all abseil libraries
+	abseil_cpp.2025$secondaryArchSuffix
 	lib:libboost_date_time$secondaryArchSuffix
 	lib:libboost_thread$secondaryArchSuffix
-	lib:libgtest$secondaryArchSuffix
 	lib:libicuuc$secondaryArchSuffix
 	lib:libicui18n$secondaryArchSuffix
 	lib:libprotobuf$secondaryArchSuffix
@@ -39,14 +38,14 @@ PROVIDES_devel="
 	"
 REQUIRES_devel="
 	libphonenumber$secondaryArchSuffix == $portVersion base
+	abseil_cpp.2025${secondaryArchSuffix}_devel
 	devel:libboost_date_time$secondaryArchSuffix
-	devel:libabsl_base$secondaryArchSuffix
 	devel:libprotobuf$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
-	devel:libabsl_base$secondaryArchSuffix >= 2301.0.0
+	abseil_cpp.2025${secondaryArchSuffix}_devel
 	devel:libboost_date_time$secondaryArchSuffix >= 1.90.0
 	devel:libboost_thread$secondaryArchSuffix >= 1.90.0
 	devel:libgtest$secondaryArchSuffix


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
