### PR TITLE
kitinerary_kf6, revbump for abseil_cpp dependency from libphonenumber

### DIFF
--- a/kde-apps/kitinerary/kitinerary_kf6-26.08.0.recipe
+++ b/kde-apps/kitinerary/kitinerary_kf6-26.08.0.recipe
@@ -5,7 +5,7 @@ and provides that in a machine-readable way."
 HOMEPAGE="https://invent.kde.org/pim/kitinerary"
 COPYRIGHT="2010-2026 KDE Organisation"
 LICENSE="GNU LGPL v2.1"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://download.kde.org/stable/release-service/$portVersion/src/kitinerary-$portVersion.tar.xz"
 CHECKSUM_SHA256="b90eeba1507d99e0d911066955031854273938ff1e4f39f9cd4173f4a549515c"
 SOURCE_DIR="kitinerary-$portVersion"
@@ -24,8 +24,8 @@ PROVIDES="
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
+	abseil_cpp.2025$secondaryArchSuffix
 	cmd:osmconvert
-	lib:libabsl_base$secondaryArchSuffix # don't list all abseil libraries
 	lib:libboost_date_time$secondaryArchSuffix
 	lib:libcrypto$secondaryArchSuffix
 	lib:libGL$secondaryArchSuffix


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
