### PR TITLE
borgbackup, trigger build on buildmaster

### DIFF
--- a/app-backup/borgbackup/borgbackup-1.4.5.recipe
+++ b/app-backup/borgbackup/borgbackup-1.4.5.recipe
@@ -1,6 +1,6 @@
 SUMMARY="Backup program with compression and authenticated encryption"
-DESCRIPTION="BorgBackup (short: Borg) is a deduplicating backup program for the \
-commandline. Optionally, it supports compression and authenticated encryption.
+DESCRIPTION="BorgBackup (short: Borg) is a deduplicating backup program for the commandline. \
+Optionally, it supports compression and authenticated encryption.
 
 The main goal of Borg is to provide an efficient and secure way to backup data. The \
 data deduplication technique used makes Borg suitable for daily backups since only \
@@ -13,7 +13,7 @@ COPYRIGHT="2015-2024 The Borg Collective
 LICENSE="BSD (3-clause)"
 REVISION="1"
 SOURCE_URI="https://files.pythonhosted.org/packages/source/b/borgbackup/borgbackup-$portVersion.tar.gz"
-CHECKSUM_SHA256="ce7aa6ec25029a2878b660d7e38f2720dc16fcf2b5c80780d4bf7494d4b29c04"
+CHECKSUM_SHA256="4f9a5fe584c504b15485841236750dea16aa7cd2ddbc4a594e9d2ce5c49c4508"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
