### PR TITLE
fastfetch: bump to 2.67.1

### DIFF
--- a/app-misc/fastfetch/fastfetch-2.67.1.recipe
+++ b/app-misc/fastfetch/fastfetch-2.67.1.recipe
@@ -9,7 +9,7 @@ COPYRIGHT="2021-2023 Linus Dierheimer
 LICENSE="MIT"
 REVISION="1"
 SOURCE_URI="https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/$portVersion.tar.gz"
-CHECKSUM_SHA256="8c4833e55b8b445a32c7cb7570007b5e10a9ee4cee74a494004ba61e88b12b26"
+CHECKSUM_SHA256="52489550d1fdeac8bde8b3442064e3bc78d28fda752a171dc46a6cd97454f237"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"


### PR DESCRIPTION
Update Fastfetch from 2.62.1 to 2.67.1.

- update source checksum
- update description to include Haiku support
- adapt CMake target/install paths for Fastfetch 2.67.1
- successfully built with HaikuPorter on x86_64
- tested Fastfetch 2.67.1 on Haiku