### PR TITLE
openjpeg: bump to 2.5.4

### DIFF
--- a/media-libs/openjpeg/openjpeg-2.5.4.recipe
+++ b/media-libs/openjpeg/openjpeg-2.5.4.recipe
@@ -32,7 +32,7 @@ PROVIDES="
 	cmd:opj_compress$secondaryArchSuffix = $portVersion
 	cmd:opj_decompress$secondaryArchSuffix = $portVersion
 	cmd:opj_dump$secondaryArchSuffix = $portVersion
-	lib:libopenjp2$secondaryArchSuffix = 7.5.3 compat >= 7
+	lib:libopenjp2$secondaryArchSuffix = 7.5.4 compat >= 7
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -44,7 +44,7 @@ REQUIRES="
 
 PROVIDES_devel="
 	openjpeg${secondaryArchSuffix}_devel = $portVersion
-	devel:libopenjp2$secondaryArchSuffix = 7.5.3 compat >= 7
+	devel:libopenjp2$secondaryArchSuffix = 7.5.4 compat >= 7
 	"
 REQUIRES_devel="
 	openjpeg$secondaryArchSuffix == $portVersion

--- a/media-libs/openjpeg/openjpeg-2.5.4.recipe
+++ b/media-libs/openjpeg/openjpeg-2.5.4.recipe
@@ -69,7 +69,7 @@ BUILD()
 		$cmakeDirArgs \
 		-DBUILD_SHARED_LIBS=ON \
 		-DBUILD_STATIC_LIBS=OFF \
-		-DBUILD_TESTING:BOOL=ON
+		-DBUILD_TESTING:BOOL=OFF
 	cmake --build build $jobArgs
 }
 

--- a/media-libs/openjpeg/openjpeg-2.5.4.recipe
+++ b/media-libs/openjpeg/openjpeg-2.5.4.recipe
@@ -69,7 +69,7 @@ BUILD()
 		$cmakeDirArgs \
 		-DBUILD_SHARED_LIBS=ON \
 		-DBUILD_STATIC_LIBS=OFF \
-		-DBUILD_TESTING:BOOL=OFF
+		-DBUILD_TESTING=OFF
 	cmake --build build $jobArgs
 }
 

--- a/media-libs/openjpeg/openjpeg-2.5.4.recipe
+++ b/media-libs/openjpeg/openjpeg-2.5.4.recipe
@@ -19,9 +19,9 @@ Universite catholique de Louvain (UCL), Belgium
 	2011-2012, Centre National d'Etudes Spatiales (CNES), France
 	2012, CS Systemes d'Information, France"
 LICENSE="BSD (2-clause)"
-REVISION="2"
+REVISION="1"
 SOURCE_URI="https://github.com/uclouvain/openjpeg/archive/v$portVersion.tar.gz"
-CHECKSUM_SHA256="368fe0468228e767433c9ebdea82ad9d801a3ad1e4234421f352c8b06e7aa707"
+CHECKSUM_SHA256="a695fbe19c0165f295a8531b1e4e855cd94d0875d2f88ec4b61080677e27188a"
 SOURCE_FILENAME="openjpeg-$portVersion.tar.gz"
 
 ARCHITECTURES="all !x86_gcc2"


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.

Why this should be quickly patched: the package was flagged as vulnerable on Repology. Moreover, The NVD (National Vulnerability Database) marks this package affected by [CVE-2025-54874](https://nvd.nist.gov/vuln/detail/cve-2025-54874), and version 2.5.4 is latest and also unaffected.
