### PR TITLE
games-board/gaiachess: bump to 4.2.6

### DIFF
--- a/games-board/gaiachess/gaiachess-4.2.6.recipe
+++ b/games-board/gaiachess/gaiachess-4.2.6.recipe
@@ -1,9 +1,9 @@
 # HaikuPorts recipe for GaiaChess, master copy — PRed to
-# github.com/haikuports/haikuports as games-board/gaiachess/gaiachess-4.2.6.recipe.
+# github.com/haikuports/haikuports as games-board/gaiachess/gaiachess-$portVersion.recipe.
 # Buildmasters build offline, which is why the network and the tablebase blob
 # arrive as sources rather than through build.rs's curl fallback. Network and
 # GaiaTB checksums verified against the published files (2026-08-29). Tarball
-# sha256 taken from github.com/jromang/gaiachess/archive/refs/tags/v4.2.6.tar.gz.
+# sha256 taken from github.com/jromang/gaiachess/archive/refs/tags/v$portVersion.tar.gz.
 
 SUMMARY="Chess engine with a pixel-art board"
 DESCRIPTION="GaiaChess is a UCI chess engine with NNUE evaluation and a built-in \
@@ -18,15 +18,16 @@ COPYRIGHT="2025-2026 Jean-Francois Romang
 LICENSE="GNU GPL v3"
 REVISION="1"
 
-SOURCE_URI="https://github.com/jromang/gaiachess/archive/refs/tags/v4.2.6.tar.gz"
+SOURCE_URI="https://github.com/jromang/gaiachess/archive/refs/tags/v$portVersion.tar.gz"
 CHECKSUM_SHA256="6edf52d6f60d11421d79492798eec797603492a5e25562144abcc593739127a8"
-SOURCE_FILENAME="gaiachess-4.2.6.tar.gz"
-SOURCE_DIR="gaiachess-4.2.6"
+SOURCE_FILENAME="gaiachess-$portVersion.tar.gz"
+SOURCE_DIR="gaiachess-$portVersion"
 
 # The NNUE network, published append-only under immutable names.
-SOURCE_URI_2="https://huggingface.co/jromanghf/gaiachess-networks/resolve/main/gaianet-t3e-1100b.bin#noarchive"
+gaianetVersion="t3e-1100b"
+SOURCE_URI_2="https://huggingface.co/jromanghf/gaiachess-networks/resolve/main/gaianet-$gaianetVersion.bin#noarchive"
 CHECKSUM_SHA256_2="09c596eee29da5e273a29318fb28877773802e8b3ff8da5896d7ff1d0733b9f6"
-SOURCE_FILENAME_2="gaianet-t3e-1100b.bin"
+SOURCE_FILENAME_2="gaianet-$gaianetVersion.bin"
 
 # The GaiaTB blob (DTM tablebases, 3+4 pieces), embedded by build.rs. Handed over
 # as a source so the build never reaches for the network itself.
@@ -536,13 +537,13 @@ BUILD()
 	# The two flat sources, exactly as build.rs will embed them. A wrong path
 	# here means dead tables at run time, so say loudly what went in.
 	echo "flat sources as embedded:"
-	sha256sum "$sourceDir2/gaianet-t3e-1100b.bin" "$sourceDir3/tb34.gtpk"
+	sha256sum "$sourceDir2/gaianet-$gaianetVersion.bin" "$sourceDir3/tb34.gtpk"
 
 	# x86-64-v2 (SSE4.2/POPCNT) is the floor the published binaries accept on
 	# every platform; AVX2 is given up for the sake of running everywhere.
 	# Fat LTO miscompiles the GaiaTB parser with Haiku's rustc (thin ICEs);
 	# see tools/pgo/build-haiku.sh.
-	MODEL="$sourceDir2/gaianet-t3e-1100b.bin" \
+	MODEL="$sourceDir2/gaianet-$gaianetVersion.bin" \
 	GAIATB_BLOB="$sourceDir3/tb34.gtpk" \
 	ZSTD_SYS_USE_PKG_CONFIG=1 \
 	CARGO_PROFILE_RELEASE_LTO=false \
@@ -580,7 +581,7 @@ TEST()
 	# Full suite (not --lib): gaiatb_sanity no longer needs the repo's Syzygy
 	# fixtures, and the remaining cross-checks are #[ignore].
 	export CARGO_HOME=$sourceDir/../cargo
-	MODEL="$sourceDir2/gaianet-t3e-1100b.bin" \
+	MODEL="$sourceDir2/gaianet-$gaianetVersion.bin" \
 	GAIATB_BLOB="$sourceDir3/tb34.gtpk" \
 	ZSTD_SYS_USE_PKG_CONFIG=1 \
 	CARGO_PROFILE_RELEASE_LTO=false \

--- a/games-board/gaiachess/gaiachess-4.2.6.recipe
+++ b/games-board/gaiachess/gaiachess-4.2.6.recipe
@@ -1,8 +1,9 @@
 # HaikuPorts recipe for GaiaChess, master copy — PRed to
-# github.com/haikuports/haikuports as games-board/gaiachess/gaiachess-4.2.5.recipe.
+# github.com/haikuports/haikuports as games-board/gaiachess/gaiachess-4.2.6.recipe.
 # Buildmasters build offline, which is why the network and the tablebase blob
-# arrive as sources rather than through build.rs's curl fallback. All three
-# checksums verified against the published files (2026-08-23).
+# arrive as sources rather than through build.rs's curl fallback. Network and
+# GaiaTB checksums verified against the published files (2026-08-29). Tarball
+# sha256 taken from github.com/jromang/gaiachess/archive/refs/tags/v4.2.6.tar.gz.
 
 SUMMARY="Chess engine with a pixel-art board"
 DESCRIPTION="GaiaChess is a UCI chess engine with NNUE evaluation and a built-in \
@@ -17,15 +18,15 @@ COPYRIGHT="2025-2026 Jean-Francois Romang
 LICENSE="GNU GPL v3"
 REVISION="1"
 
-SOURCE_URI="https://github.com/jromang/gaiachess/archive/refs/tags/v4.2.5.tar.gz"
-CHECKSUM_SHA256="cb6c184d412c358176af008bb330b5fd9bd4a38c64aa9ead11b145bd404d6bb3"
-SOURCE_FILENAME="gaiachess-4.2.5.tar.gz"
-SOURCE_DIR="gaiachess-4.2.5"
+SOURCE_URI="https://github.com/jromang/gaiachess/archive/refs/tags/v4.2.6.tar.gz"
+CHECKSUM_SHA256="6edf52d6f60d11421d79492798eec797603492a5e25562144abcc593739127a8"
+SOURCE_FILENAME="gaiachess-4.2.6.tar.gz"
+SOURCE_DIR="gaiachess-4.2.6"
 
 # The NNUE network, published append-only under immutable names.
-SOURCE_URI_2="https://huggingface.co/jromanghf/gaiachess-networks/resolve/main/gaianet-t2-1000.bin#noarchive"
-CHECKSUM_SHA256_2="9ba10e965cd20d3d3cd8e086283d29b561df0527678e9e840980447cfda6f225"
-SOURCE_FILENAME_2="gaianet-t2-1000.bin"
+SOURCE_URI_2="https://huggingface.co/jromanghf/gaiachess-networks/resolve/main/gaianet-t3e-1100b.bin#noarchive"
+CHECKSUM_SHA256_2="09c596eee29da5e273a29318fb28877773802e8b3ff8da5896d7ff1d0733b9f6"
+SOURCE_FILENAME_2="gaianet-t3e-1100b.bin"
 
 # The GaiaTB blob (DTM tablebases, 3+4 pieces), embedded by build.rs. Handed over
 # as a source so the build never reaches for the network itself.
@@ -535,13 +536,13 @@ BUILD()
 	# The two flat sources, exactly as build.rs will embed them. A wrong path
 	# here means dead tables at run time, so say loudly what went in.
 	echo "flat sources as embedded:"
-	sha256sum "$sourceDir2/gaianet-t2-1000.bin" "$sourceDir3/tb34.gtpk"
+	sha256sum "$sourceDir2/gaianet-t3e-1100b.bin" "$sourceDir3/tb34.gtpk"
 
 	# x86-64-v2 (SSE4.2/POPCNT) is the floor the published binaries accept on
 	# every platform; AVX2 is given up for the sake of running everywhere.
 	# Fat LTO miscompiles the GaiaTB parser with Haiku's rustc (thin ICEs);
 	# see tools/pgo/build-haiku.sh.
-	MODEL="$sourceDir2/gaianet-t2-1000.bin" \
+	MODEL="$sourceDir2/gaianet-t3e-1100b.bin" \
 	GAIATB_BLOB="$sourceDir3/tb34.gtpk" \
 	ZSTD_SYS_USE_PKG_CONFIG=1 \
 	CARGO_PROFILE_RELEASE_LTO=false \
@@ -574,16 +575,17 @@ INSTALL()
 TEST()
 {
 	# Same registry, flags and features as BUILD(), so the unit tests exercise
-	# the shipped configuration and cargo reuses its artifacts. Library suite
-	# only for this version: the integration cross-checks compare against
-	# reference tables kept in the repository's test data, which this source
-	# archive does not carry.
+	# the shipped configuration and cargo reuses its artifacts. Serial: the
+	# ponder liveness tests starve under a parallel cargo test on a small VM.
+	# Full suite (not --lib): gaiatb_sanity no longer needs the repo's Syzygy
+	# fixtures, and the remaining cross-checks are #[ignore].
 	export CARGO_HOME=$sourceDir/../cargo
-	MODEL="$sourceDir2/gaianet-t2-1000.bin" \
+	MODEL="$sourceDir2/gaianet-t3e-1100b.bin" \
 	GAIATB_BLOB="$sourceDir3/tb34.gtpk" \
 	ZSTD_SYS_USE_PKG_CONFIG=1 \
 	CARGO_PROFILE_RELEASE_LTO=false \
 	RUSTFLAGS="-C target-cpu=x86-64-v2" \
-		cargo test --release --frozen --lib --no-default-features \
-		--features "nnue,gui,syzygy,gaiatb,online-tb,nalimov,progress"
+		cargo test --release --frozen --no-default-features \
+		--features "nnue,gui,syzygy,gaiatb,online-tb,nalimov,progress" \
+		-- --test-threads=1
 }


### PR DESCRIPTION
Bump GaiaChess from 4.2.5 to 4.2.6.

- Default network is now `gaianet-t3e-1100b` (integrity footer). GaiaTB blob unchanged (`tb34-v3`).
- Native Haiku colour scheme is the default on this OS.
- `TEST()` is the full suite again (serial). The `--lib` restriction was only needed for the 4.2.5 tarball.

Built with `haikuporter -S` on R1/beta6 hrev59866 (x86_64). Direct-distribution `.hpkg` is also on the GitHub release: https://github.com/jromang/gaiachess/releases/tag/v4.2.6