### PR TITLE
msgpack: build native Python extension

### DIFF
--- a/dev-python/msgpack/msgpack-1.0.3.recipe
+++ b/dev-python/msgpack/msgpack-1.0.3.recipe
@@ -7,16 +7,17 @@ HOMEPAGE="https://github.com/msgpack/msgpack-python/
 	https://pypi.org/project/msgpack/"
 COPYRIGHT="2007-2021 Ian Bicking and contributors"
 LICENSE="Apache v2"
-REVISION="4"
+REVISION="5"
 SOURCE_URI="https://github.com/msgpack/msgpack-python/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="576a1835a8b48d5861c883a6e10fd374065c6ae56287b221d1a4791e9529c71c"
 SOURCE_DIR="msgpack-python-$portVersion"
 
-ARCHITECTURES="any"
+ARCHITECTURES="x86_64"
 
 PROVIDES="
 	$portName = $portVersion
 	"
+
 REQUIRES="
 	haiku
 	"
@@ -38,11 +39,15 @@ for pythonVersion in ${PYTHON_VERSIONS[@]}; do
 		haiku
 		cmd:python$pythonVersion
 		\""
+
 	BUILD_REQUIRES+="
 		setuptools_$pythonPackage
+		cython_$pythonPackage
 		"
+
 	BUILD_PREREQUIRES+="
 		cmd:python$pythonVersion
+		cmd:g++
 		"
 done
 


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x ] You are not a robot.
- [x ] The modified recipe was confirmed to build on your Haiku machine.
- [ ] The license and copyright information in modified recipes are correct.
- [ ] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [ ] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.

## Description

The current msgpack recipe falls back to the pure Python implementation because
Cython and a C++ compiler are not available in the build environment.

This change adds the required build dependencies so that `msgpack._cmsgpack`
is built instead of falling back to the pure Python implementation.

Tested on Haiku x86_64 with Python 3.10.

The resulting `msgpack_python310` package was successfully built and installed.
The native `_cmsgpack.cpython-310.so` extension is loaded correctly.

This was also tested with BorgBackup 1.4.5. Before this change Borg reported:

    Using a pure-python msgpack! This will result in lower performance.

After installing the rebuilt package, Borg uses the native msgpack extension
and the warning no longer appears.