### PR TITLE
libkdegames_kf6, revbump, add missing requirements for _devel package

### DIFF
--- a/kde-apps/libkdegames/libkdegames_kf6-26.08.0.recipe
+++ b/kde-apps/libkdegames/libkdegames_kf6-26.08.0.recipe
@@ -4,7 +4,7 @@ are useful for other games."
 HOMEPAGE="https://invent.kde.org/games/libkdegames"
 COPYRIGHT="2010-2026 KDE Organisation"
 LICENSE="GNU GPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://download.kde.org/stable/release-service/$portVersion/src/libkdegames-$portVersion.tar.xz"
 CHECKSUM_SHA256="dfe92df0983d8344ba6544fe0071a8afe77b9af087cb4e42b2e4e9d70eed89cf"
 SOURCE_DIR="libkdegames-$portVersion"
@@ -62,6 +62,13 @@ PROVIDES_devel="
 	"
 REQUIRES_devel="
 	libkdegames_kf6$secondaryArchSuffix == $portVersion base
+	devel:libKF6Completion$secondaryArchSuffix
+	devel:libKF6ConfigCore$secondaryArchSuffix
+	devel:libKF6ConfigWidgets$secondaryArchSuffix
+	devel:libQt6Network$secondaryArchSuffix
+	devel:libQt6Qml$secondaryArchSuffix
+	devel:libQt6Widgets$secondaryArchSuffix
+	devel:libQt6Xml$secondaryArchSuffix
 	"
 
 BUILD_REQUIRES="


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
