### PR TITLE
xmrig: bump to 6.26.0

### DIFF
--- a/net-misc/xmrig/xmrig-6.26.0.recipe
+++ b/net-misc/xmrig/xmrig-6.26.0.recipe
@@ -9,8 +9,8 @@ COPYRIGHT="2010 Jeff Garzik
 	2016 Jay D Dee
 	2017-2018 XMR-Stak
 	2018 Lee Clagett
-	2018-2024 SChernykh
-	2016-2024 XMRig"
+	2018-2026 SChernykh
+	2016-2026 XMRig"
 LICENSE="GNU GPL v3"
 REVISION="1"
 SOURCE_URI="https://github.com/xmrig/xmrig/archive/v$portVersion.tar.gz"

--- a/net-misc/xmrig/xmrig-6.26.0.recipe
+++ b/net-misc/xmrig/xmrig-6.26.0.recipe
@@ -13,7 +13,7 @@ COPYRIGHT="2010 Jeff Garzik
 	2016-2024 XMRig"
 LICENSE="GNU GPL v3"
 REVISION="1"
-SOURCE_URI="https://github.com/xmrig/xmrig/archive/$portVersion.tar.gz"
+SOURCE_URI="https://github.com/xmrig/xmrig/archive/v$portVersion.tar.gz"
 CHECKSUM_SHA256="5005144e78571f26586410c2b2ede2b0c72afe22f97f1708ea24cfb253c3939b"
 SOURCE_DIR="xmrig-$portVersion"
 

--- a/net-misc/xmrig/xmrig-6.26.0.recipe
+++ b/net-misc/xmrig/xmrig-6.26.0.recipe
@@ -13,10 +13,9 @@ COPYRIGHT="2010 Jeff Garzik
 	2016-2024 XMRig"
 LICENSE="GNU GPL v3"
 REVISION="1"
-srcGitRev="4cdc35f96648f8363d26526d1bfa90502833bac9"
-SOURCE_URI="https://github.com/xmrig/xmrig/archive/$srcGitRev.tar.gz"
-CHECKSUM_SHA256="b80a166521c7d447775e5c012b36ef3898388d8f8f72bf4e5fbe9769de94a60a"
-SOURCE_DIR="xmrig-$srcGitRev"
+SOURCE_URI="https://github.com/xmrig/xmrig/archive/$portVersion.tar.gz"
+CHECKSUM_SHA256="5005144e78571f26586410c2b2ede2b0c72afe22f97f1708ea24cfb253c3939b"
+SOURCE_DIR="xmrig-$portVersion"
 
 ARCHITECTURES="all !x86_gcc2"
 SECONDARY_ARCHITECTURES="x86"


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
