### PR TITLE
kirigami_app_components, new KDE library

### DIFF
--- a/dev-libs/kirigami-app-components/kirigami_app_components-1.0.2.recipe
+++ b/dev-libs/kirigami-app-components/kirigami_app_components-1.0.2.recipe
@@ -1,0 +1,100 @@
+SUMMARY="Kirigami addons and modules necessary to do a full featured KDE application"
+DESCRIPTION="Kirigami addons and modules necessary to do a full featured KDE application, such as \
+integration with configurable keyboard shortcuts and standard actions."
+HOMEPAGE="https://invent.kde.org/libraries/kirigami-app-components"
+COPYRIGHT="2010-2026 KDE Organisation"
+LICENSE="GNU GPL v2"
+REVISION="1"
+SOURCE_URI="https://download.kde.org/stable/kirigami-app-components/kirigami-app-components-$portVersion.tar.xz"
+CHECKSUM_SHA256="6bfd9e0a3a4b7d17505f0c3c0c395628165973b6f4cf1e4a7a1f3342873b44d0"
+SOURCE_DIR="kirigami-app-components-$portVersion"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="x86"
+
+libVersion="$portVersion"
+libVersionCompat="$libVersion compat >= ${libVersion%%.*}"
+
+PROVIDES="
+	kirigami_app_components$secondaryArchSuffix = $portVersion
+	lib:libKirigamiActionCollection$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	lib:libGL$secondaryArchSuffix
+	# KF6
+	lib:libKF6ConfigCore$secondaryArchSuffix
+	lib:libKF6ConfigGui$secondaryArchSuffix
+	lib:libKF6GuiAddons$secondaryArchSuffix
+	lib:libKF6I18n$secondaryArchSuffix
+	# qml modules
+	kirigami6$secondaryArchSuffix
+	# Qt6
+	lib:libQt6Core$secondaryArchSuffix
+	lib:libQt6Gui$secondaryArchSuffix
+	lib:libQt6Network$secondaryArchSuffix
+	lib:libQt6OpenGL$secondaryArchSuffix
+	lib:libQt6Qml$secondaryArchSuffix
+	lib:libQt6Quick$secondaryArchSuffix
+	lib:libQt6QuickControls2$secondaryArchSuffix
+	"
+
+PROVIDES_devel="
+	kirigami_app_components${secondaryArchSuffix}_devel = $portVersion
+	devel:libKirigamiActionCollection$secondaryArchSuffix = $libVersionCompat
+	"
+REQUIRES_devel="
+	kirigami_app_components$secondaryArchSuffix == $portVersion base
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	# KF6
+	extra_cmake_modules$secondaryArchSuffix
+	devel:libKF6ConfigCore$secondaryArchSuffix
+	devel:libKF6GuiAddons$secondaryArchSuffix
+	devel:libKF6I18n$secondaryArchSuffix
+	# qml modules
+	kirigami6${secondaryArchSuffix}_devel
+	# Qt6
+	devel:libQt6Core$secondaryArchSuffix
+	devel:libQt6Qml$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cmake
+	cmd:g++$secondaryArchSuffix
+	cmd:make
+	cmd:msgfmt$secondaryArchSuffix
+	cmd:msgmerge$secondaryArchSuffix
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+BUILD()
+{
+	cmake -B build -S . -DCMAKE_BUILD_TYPE=Release \
+		$cmakeDirArgs \
+		-DECM_DIR=/system/data/cmake/Modules/ECM/cmake \
+		-DCMAKE_SKIP_RPATH=YES \
+		-DBUILD_TESTING=OFF \
+		-Wno-dev
+
+	make -C build $jobArgs
+}
+
+INSTALL()
+{
+	make -C build install
+
+	prepareInstalledDevelLib \
+		libKirigamiActionCollection
+
+	packageEntries devel \
+		$developDir \
+		$libDir/cmake
+}
+
+TEST()
+{
+#	0% tests passed, 1 tests failed out of 1 (no error output)
+	ctest --test-dir build --output-on-failure
+}


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
