### PR TITLE
libktorrent_kf6, revbump add missing requirement for _devel package

### DIFF
--- a/net-libs/libktorrent/libktorrent_kf6-26.08.0.recipe
+++ b/net-libs/libktorrent/libktorrent_kf6-26.08.0.recipe
@@ -8,7 +8,7 @@ blocking lists."
 HOMEPAGE="https://github.com/KDE/libktorrent/"
 COPYRIGHT="2010-2026 KDE Organisation"
 LICENSE="GNU LGPL v2"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://download.kde.org/stable/release-service/$portVersion/src/libktorrent-$portVersion.tar.xz"
 CHECKSUM_SHA256="12308eeb1e61cdba380d10ba85b6e64ad44f3e38cc4f64e8f0f1d2694e8719be"
 SOURCE_DIR="libktorrent-$portVersion"
@@ -53,6 +53,7 @@ PROVIDES_devel="
 	"
 REQUIRES_devel="
 	libktorrent_kf6$secondaryArchSuffix == $portVersion base
+	devel:libKF6Archive$secondaryArchSuffix
 	devel:libgcrypt$secondaryArchSuffix
 	devel:libgmp$secondaryArchSuffix
 	devel:libssl$secondaryArchSuffix


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
