### PR TITLE
binutils: disabled gprof

### DIFF
--- a/sys-devel/binutils/binutils-2.46.1.recipe
+++ b/sys-devel/binutils/binutils-2.46.1.recipe
@@ -9,7 +9,7 @@ But they also include:
 - addr2line - converts addresses into filenames and line numbers.
 - ar - a utility for creating, modifying and extracting of archives.
 - c++filt - filter to demangle encoded C++ symbols.
-- gold - a linker for ELF files.
+- elfedit - Allows alteration of ELF format files.
 - nm - lists symbols from object files.
 - objcopy - copys and translates object files.
 - objdump - displays information from object files.
@@ -22,7 +22,7 @@ HOMEPAGE="https://www.gnu.org/software/binutils/"
 COPYRIGHT="1984-2026 Free Software Foundation, Inc."
 LICENSE="GNU GPL v3
 	GNU LGPL v3"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://ftpmirror.gnu.org//binutils/binutils-$portVersion.tar.xz
 	https://ftp.gnu.org/gnu/binutils/binutils-$portVersion.tar.xz"
 SOURCE_DIR="binutils-$portVersion"
@@ -39,7 +39,6 @@ PROVIDES="
 	cmd:as$secondaryArchSuffix = $portVersion compat >= $portVersion
 	cmd:c++filt$secondaryArchSuffix = $portVersion compat >= $portVersion
 	cmd:elfedit$secondaryArchSuffix = $portVersion compat >= $portVersion
-	cmd:gprof$secondaryArchSuffix = $portVersion compat >= $portVersion
 	cmd:ld$secondaryArchSuffix = $portVersion compat >= $portVersion
 	cmd:ld.bfd$secondaryArchSuffix = $portVersion compat >= $portVersion
 	cmd:nm$secondaryArchSuffix = $portVersion compat >= $portVersion
@@ -50,8 +49,6 @@ PROVIDES="
 	cmd:size$secondaryArchSuffix = $portVersion compat >= $portVersion
 	cmd:strings$secondaryArchSuffix = $portVersion compat >= $portVersion
 	cmd:strip$secondaryArchSuffix = $portVersion compat >= $portVersion
-	lib:libbfd_$binutilsVersion$secondaryArchSuffix = $portVersion compat >= $portVersion
-	lib:libopcodes_$binutilsVersion$secondaryArchSuffix = $portVersion compat >= $portVersion
 	"
 REQUIRES="
 	haiku$secondaryArchSuffix
@@ -101,7 +98,7 @@ BUILD()
 		--exec-prefix=$installDir \
 		--includedir=$includeDir/binutils \
 		--docdir=$docDir --enable-host-shared --enable-largefile=yes \
-		--disable-libtool-lock --disable-nls --enable-plugins --enable-64-bit-bfd \
+		--disable-libtool-lock --disable-nls --disable-gprof --enable-plugins --enable-64-bit-bfd \
 		--enable-ld=default --enable-targets=$binUtilsTargets \
 		--with-sysroot=/ --enable-default-execstack=no
 		# Note: The sysroot option is normally superfluous. We have to specify
@@ -134,8 +131,6 @@ INSTALL()
 	ln -sf bfd/index.html bfd.html
 	mv binutils.html binutils
 	ln -sf binutils/index.html binutils.html
-	mv gprof.html gprof
-	ln -sf gprof/index.html gprof.html
 	mv ld.html ld
 	ln -sf ld/index.html ld.html
 	rm libiberty.html


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [X] You are not a robot.
- [X] The modified recipe was confirmed to build on your Haiku machine.
- [X] The license and copyright information in modified recipes are correct.
- [X] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [X] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
