### PR TITLE
Update Aika v0.0.4-1 to v0.0.4-2

### DIFF
--- a/media-sound/aika/aika-0.0.4.recipe
+++ b/media-sound/aika/aika-0.0.4.recipe
@@ -6,12 +6,12 @@ support for VGM files."
 HOMEPAGE="https://fossil.cyberia9.org/aika/"
 COPYRIGHT="2026 Remilia Scarlet"
 LICENSE="AGPL-3.0"
-REVISION="1"
+REVISION="2"
 SOURCE_URI="https://fossil.cyberia9.org/aika/uv/aika-0.0.4.tar.bz2"
 CHECKSUM_SHA256="3d7a74902e19461f8af0c4c0375f4972f57bffc36f75b64bcf02e4c175217c97"
 SOURCE_DIR="aika-$portVersion"
 
-ARCHITECTURES="all !x86_gcc2 ?ppc"
+ARCHITECTURES="all !x86 !x86_gcc2 ?ppc"
 
 PROVIDES="
 	aika = $portVersion
@@ -20,43 +20,43 @@ PROVIDES="
 
 REQUIRES="
 	haiku
-	lib:libslang
-	lib:libzmq
 	lib:libao
-	lib:libmpg123
-	lib:libwavpack
-	lib:libopus
 	lib:libiconv
-	lib:libzstd
+	lib:libmpg123
+	lib:libopus
+	lib:libslang
+	lib:libwavpack
 	lib:libxmp
 	lib:libz
+	lib:libzmq
+	lib:libzstd
 	"
 
 BUILD_REQUIRES="
 	haiku_devel
-	slang_devel
-	zeromq_devel
-	libao_devel
-	mpg123_devel
-	wavpack_devel
-	opus_devel
-	zstd_devel
-	libxmp_devel
-	libiconv_devel
-	zlib_devel
-	asciidoc
+	asciidoc$secondaryArchSuffix
+	devel:libao$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
+	devel:libxmp$secondaryArchSuffix
+	devel:libmpg123$secondaryArchSuffix
+	devel:libopus$secondaryArchSuffix
+	devel:libslang$secondaryArchSuffix
+	devel:libwavpack$secondaryArchSuffix
+	devel:libzmq$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	devel:libzstd$secondaryArchSuffix
 	"
 
 BUILD_PREREQUIRES="
+	cmd:a2x
+	cmd:fossil
 	fpc >= 3.2.0
-	cmd:rake
 	cmd:gcc
 	cmd:install
-	cmd:fossil
-	cmd:zstd
-	cmd:tar
 	cmd:nm
-	cmd:a2x
+	cmd:rake
+	cmd:tar
+	cmd:zstd
 	"
 
 PATCH()
@@ -83,15 +83,19 @@ BUILD()
 	# FPC uses different nomeclature for some platforms, so check to see if
 	# we're building on those now.  We'll use this variable to locate the
 	# RTL/FPC units that ship with FPC.
+	FPC_OPTS=""
 	case $targetArchitecture in
-x86_gcc2|x86)
-	fpcArch=i386
-	;;
-*)
-	# Assume it's the same.  If it fails, then please provide a patch
-	# ^_^
-	fpcArch=$targetArchitecture
-	;;
+	x86_64)
+		fpcArch=x86_64
+
+		# Ensure we target x86-64-v1 to favor max compatibility over performance.
+		FPC_OPTS="$FPC_OPTS -CpATHLON64 -CfSSE64 -OpATHLON64"
+		;;
+	*)
+		# Assume it's the same.  If it fails, then please provide a patch
+		# ^_^
+		fpcArch=$targetArchitecture
+		;;
 	esac
 
 	# The /system/settings/etc/fpc.conf file doesn't seem to get linked by
@@ -99,7 +103,7 @@ x86_gcc2|x86)
 	# same options as found in fpc.cfg.  The FPC_OPTS variable is handled by the
 	# Rakefile.
 	fpcVersion=$(fpc -iW)
-	FPC_OPTS="-Sgic -viwn "
+	FPC_OPTS="$FPC_OPTS -Sgic -viwn "
 	FPC_OPTS="$FPC_OPTS -Fu/boot/system/lib/fpc/$fpcVersion/units/$fpcArch-haiku "
 	FPC_OPTS="$FPC_OPTS -Fu/boot/system/lib/fpc/$fpcVersion/units/$fpcArch-haiku/*"
 	FPC_OPTS="$FPC_OPTS -Fu/boot/system/lib/fpc/$fpcVersion/units/$fpcArch-haiku/rtl"
@@ -107,8 +111,6 @@ x86_gcc2|x86)
 
 	# Again, we need to specify a USER and HOME, or Fossil will not work.
 	FPC_OPTS="$FPC_OPTS -l" USER="user" HOME=/ NO_FOSSIL_NET=1 rake release
-
-	true
 }
 
 INSTALL()

--- a/media-sound/aika/aika-0.0.4.recipe
+++ b/media-sound/aika/aika-0.0.4.recipe
@@ -11,7 +11,7 @@ SOURCE_URI="https://fossil.cyberia9.org/aika/uv/aika-0.0.4.tar.bz2"
 CHECKSUM_SHA256="3d7a74902e19461f8af0c4c0375f4972f57bffc36f75b64bcf02e4c175217c97"
 SOURCE_DIR="aika-$portVersion"
 
-ARCHITECTURES="all !x86 !x86_gcc2 ?ppc"
+ARCHITECTURES="x86_64"
 
 PROVIDES="
 	aika = $portVersion
@@ -34,17 +34,17 @@ REQUIRES="
 
 BUILD_REQUIRES="
 	haiku_devel
-	asciidoc$secondaryArchSuffix
-	devel:libao$secondaryArchSuffix
-	devel:libiconv$secondaryArchSuffix
-	devel:libxmp$secondaryArchSuffix
-	devel:libmpg123$secondaryArchSuffix
-	devel:libopus$secondaryArchSuffix
-	devel:libslang$secondaryArchSuffix
-	devel:libwavpack$secondaryArchSuffix
-	devel:libzmq$secondaryArchSuffix
-	devel:libz$secondaryArchSuffix
-	devel:libzstd$secondaryArchSuffix
+	asciidoc
+	devel:libao
+	devel:libiconv
+	devel:libmpg123
+	devel:libopus
+	devel:libslang
+	devel:libwavpack
+	devel:libxmp
+	devel:libz
+	devel:libzmq
+	devel:libzstd
 	"
 
 BUILD_PREREQUIRES="


### PR DESCRIPTION
This PR bumps the build to -2 and is mostly cosmetic: it fixes the _devel package lines, sorts the package lists, and explicitly list that 32-bit x86-64 is not supported.  I think I got everything this time XD

This also fixes an issue I discovered only a day or two after the first HaikuPorts recipe for Aika was merged: FPC defaults to targeting the CPU you are working on.  So if the machine is a Core i9-10850K (my CPU), it won't necessarily build a binary that is compatible back to x86-64-v1.  This PR fixes this by setting the `FPC_OPTS` environment variable that the Rakefile uses at build time to ensure that x86-64-v1 is targeted (which I figured would probably be you all's preferred target for x86-64 ^_^).

This behavior is [mentioned on the build instructions](https://fossil.cyberia9.org/aika/wiki?name=Building+Aika#selecting-a-cpu-and-fpu-architecture) in my repo for Aika itself as well.

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).