### PR TITLE
kget, fix requirements for gpgme

### DIFF
--- a/kde-apps/kget/kget-26.08.0.recipe
+++ b/kde-apps/kget/kget-26.08.0.recipe
@@ -78,10 +78,11 @@ BUILD_REQUIRES="
 	haiku${secondaryArchSuffix}_devel
 	devel:libboost_iostreams$secondaryArchSuffix >= 1.90.0
 	devel:libboost_thread$secondaryArchSuffix >= 1.90.0
-	devel:libgpgmepp$secondaryArchSuffix
+	devel:libgpgme$secondaryArchSuffix >= 45
+	devel:libgpgmepp$secondaryArchSuffix >= 7
 	devel:libKTorrent6$secondaryArchSuffix
 	devel:libmms$secondaryArchSuffix
-	devel:libqgpgmeqt6$secondaryArchSuffix
+	devel:libqgpgmeqt6$secondaryArchSuffix >= 15.8
 	devel:libsqlite3$secondaryArchSuffix
 	# KF6
 	extra_cmake_modules$secondaryArchSuffix


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
