### PR TITLE
abaddon: bump version

### DIFF
--- a/net-im/abaddon/abaddon-0.2.4.recipe
+++ b/net-im/abaddon/abaddon-0.2.4.recipe
@@ -9,20 +9,28 @@ filter. If you should get caught in the spam filter, you can usually appeal at d
 HOMEPAGE="https://github.com/uowuo/abaddon/"
 COPYRIGHT="2025 uowuo"
 LICENSE="GNU GPL v3"
-REVISION="3"
-srcGitRev="892f73305e8afbb742bef994d5a4c22e5f58b7f6"
-SOURCE_URI="https://github.com/uowuo/abaddon/archive/$srcGitRev.tar.gz"
-CHECKSUM_SHA256="cce59ae348b8d7669cdb64ac7d23f6d9b69638ec39bfcb008aafcbac95744d99"
-SOURCE_FILENAME="abaddon-$portVersion-$srcGitRev.tar.gz"
-SOURCE_DIR="abaddon-$srcGitRev"
-SOURCE_URI_2="https://github.com/machinezone/IXWebSocket/archive/refs/tags/v11.4.6.tar.gz"
-CHECKSUM_SHA256_2="c024334f8e45980836c67008979a884d6dcc5ef067dd2eb1fa7241f4c17ddc32"
-SOURCE_DIR_2="IXWebSocket-11.4.6"
-srcGitRev_3="22fac31bdf81da68730c177c0e931c93234d2a30"
-SOURCE_URI_3="https://github.com/nayuki/QR-Code-generator/archive/$srcGitRev_3.tar.gz"
-CHECKSUM_SHA256_3="218e3e96ded7880d05f47c668aad6541a08e63303ac4d783720389087da6f4ed"
-SOURCE_FILENAME_3="QR-Code-generator-$srcGitRev.tar.gz"
-SOURCE_DIR_3="QR-Code-generator-$srcGitRev_3"
+REVISION="1"
+SOURCE_URI="https://github.com/uowuo/abaddon/archive/refs/tags/v$portVersion.tar.gz"
+CHECKSUM_SHA256="68cb3ca04eaf26dccf7d7750a65df8cf23819c9d501b25808a364b2915c360cf"
+SOURCE_FILENAME="abaddon-$portVersion.tar.gz"
+SOURCE_DIR="abaddon-$portVersion"
+srcGitRev_2="92aaa4134fa45ec39957a7c81a342401fba7feb2"
+SOURCE_URI_2="https://github.com/cisco/mlspp/archive/$srcGitRev_2.tar.gz"
+CHECKSUM_SHA256_2="251a1d19510a31c27cf8e61123efeda10ea179a6e52557378a7ca2d6a7f59a0b"
+SOURCE_FILENAME_2="mlspp-$srcGitRev_2.tar.gz"
+SOURCE_DIR_2="mlspp-$srcGitRev_2"
+SOURCE_URI_3="https://github.com/discord/libdave/archive/refs/tags/v1.1.1/cpp.tar.gz"
+CHECKSUM_SHA256_3="23827d585a2020e1bfc01f0b999d6db63de6033be38ff43b6e4e3b4067139325"
+SOURCE_FILENAME_3="libdave-1.1.1-cpp.tar.gz"
+SOURCE_DIR_3="libdave-1.1.1-cpp"
+SOURCE_URI_4="https://github.com/machinezone/IXWebSocket/archive/refs/tags/v11.4.6.tar.gz"
+CHECKSUM_SHA256_4="c024334f8e45980836c67008979a884d6dcc5ef067dd2eb1fa7241f4c17ddc32"
+SOURCE_DIR_4="IXWebSocket-11.4.6"
+srcGitRev_5="22fac31bdf81da68730c177c0e931c93234d2a30"
+SOURCE_URI_5="https://github.com/nayuki/QR-Code-generator/archive/$srcGitRev_5.tar.gz"
+CHECKSUM_SHA256_5="218e3e96ded7880d05f47c668aad6541a08e63303ac4d783720389087da6f4ed"
+SOURCE_FILENAME_5="QR-Code-generator-$srcGitRev.tar.gz"
+SOURCE_DIR_5="QR-Code-generator-$srcGitRev_5"
 
 PATCHES="abaddon-$portVersion.patchset"
 ADDITIONAL_FILES="abaddon.rdef.in"
@@ -35,7 +43,7 @@ USER_SETTINGS_FILES="
 	"
 
 PROVIDES="
-	abaddon$secondaryArchSuffix
+	abaddon$secondaryArchSuffix = $portVersion
 	app:Abaddon
 	"
 REQUIRES="
@@ -58,6 +66,7 @@ REQUIRES="
 	lib:libgtkmm_3.0$secondaryArchSuffix
 	lib:libhandy_1${secondaryArchSuffix}
 	lib:libharfbuzz$secondaryArchSuffix
+#	lib:libixwebsocket$secondaryArchSuffix
 	lib:libopus$secondaryArchSuffix
 	lib:libpango_1.0$secondaryArchSuffix
 	lib:libpangomm_1.4$secondaryArchSuffix
@@ -68,6 +77,7 @@ REQUIRES="
 	lib:libssl$secondaryArchSuffix
 	lib:libspdlog$secondaryArchSuffix
 	lib:libsqlite3$secondaryArchSuffix
+#	lib:libqrcodegencpp$secondaryArchSuffix
 	lib:libz$secondaryArchSuffix
 	"
 
@@ -91,6 +101,7 @@ BUILD_REQUIRES="
 	devel:libgtkmm_3.0$secondaryArchSuffix
 	devel:libhandy_1${secondaryArchSuffix}
 	devel:libharfbuzz$secondaryArchSuffix
+#	devel:libixwebsocket$secondaryArchSuffix
 	devel:nlohmann_json
 	devel:libopus$secondaryArchSuffix
 	devel:libpango_1.0$secondaryArchSuffix
@@ -102,6 +113,7 @@ BUILD_REQUIRES="
 	devel:libssl$secondaryArchSuffix >= 3
 	devel:libspdlog$secondaryArchSuffix
 	devel:libsqlite3$secondaryArchSuffix
+#	devel:libqrcodegen$secondaryArchSuffix
 	devel:libz$secondaryArchSuffix
 	"
 BUILD_PREREQUIRES="
@@ -111,14 +123,21 @@ BUILD_PREREQUIRES="
 	cmd:pkg_config$secondaryArchSuffix
 	"
 
+defineDebugInfoPackage abaddon$secondaryArchSuffix \
+	"$appsDir/Abaddon"
+
 BUILD() {
+	mkdir -p subprojects/mlspp/
+	mkdir -p subprojects/libdave/
 	mkdir -p subprojects/ixwebsocket/
 	mkdir -p subprojects/qrcodegen/
-	cp -r $sourceDir2/* subprojects/ixwebsocket/
-	cp -r $sourceDir3/* subprojects/qrcodegen/
+	cp -r $sourceDir2/* subprojects/mlspp/
+	cp -r $sourceDir3/* subprojects/libdave/
+	cp -r $sourceDir4/* subprojects/ixwebsocket/
+	cp -r $sourceDir5/* subprojects/qrcodegen/
 
 	cmake -Bbuild \
-		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DUSE_KEYCHAIN=0 \
 		-DUSE_PORTAUDIO=true \
 		-DENABLE_NOTIFICATION_SOUNDS=false

--- a/net-im/abaddon/patches/abaddon-0.2.4.patchset
+++ b/net-im/abaddon/patches/abaddon-0.2.4.patchset
@@ -1,14 +1,14 @@
-From c6938ce49e88383ed109ffb0b4663b9091668b43 Mon Sep 17 00:00:00 2001
+From f1d1c93e85bd62d5e2ce67fde84c321888ab75d6 Mon Sep 17 00:00:00 2001
 From: zeldakatze <mail@zeldakatze.de>
 Date: Wed, 10 Apr 2024 23:11:58 +0200
 Subject: fix build for haiku
 
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1551d0a..f476113 100644
+index 304c718..ef51bb6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -33,6 +33,10 @@ if (MINGW OR WIN32)
+@@ -34,6 +34,10 @@ if (MINGW OR WIN32)
      link_libraries(ws2_32)
  endif ()
  
@@ -19,7 +19,7 @@ index 1551d0a..f476113 100644
  if (WIN32)
      add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
      add_compile_definitions(NOMINMAX)
-@@ -70,7 +74,8 @@ if (NOT (APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
+@@ -71,7 +75,8 @@ if (NOT (APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
      target_precompile_headers(abaddon PRIVATE <gtkmm.h> src/abaddon.hpp src/util.hpp)
  endif ()
  
@@ -112,17 +112,17 @@ index e0f56c0..d81eb15 100644
  find_library(SIGC++_LIBRARY
               NAMES ${SIGC++_LIBRARY_FILE}
 -- 
-2.48.1
+2.54.0
 
 
-From a3bb805cba1bcdf7c3db1258538a11223257718f Mon Sep 17 00:00:00 2001
+From ce983d738fd3d736f92e9e36c790a9ebd907051b Mon Sep 17 00:00:00 2001
 From: zeldakatze <mail@zeldakatze.de>
 Date: Thu, 11 Apr 2024 00:16:45 +0200
 Subject: abaddon: add haiku platform code
 
 
 diff --git a/src/platform.cpp b/src/platform.cpp
-index 726655b..de75e8f 100644
+index c48f793..738b028 100644
 --- a/src/platform.cpp
 +++ b/src/platform.cpp
 @@ -224,6 +224,56 @@ std::string Platform::FindStateCacheFolder() {
@@ -183,17 +183,17 @@ index 726655b..de75e8f 100644
  #else
  std::string Platform::FindResourceFolder() {
 -- 
-2.48.1
+2.54.0
 
 
-From 014f8b78347807035b49daaae3bda14800d30672 Mon Sep 17 00:00:00 2001
-From: zeldakatze <mail@zeldakatze.de>
-Date: Thu, 7 Aug 2025 20:39:54 +0200
-Subject: add a portaudio sound interface
+From 3491acf6f0f1a0a28a738109810b1cd968690558 Mon Sep 17 00:00:00 2001
+From: zeldakatze <coffee@zeldakatze.de>
+Date: Wed, 6 Aug 2025 23:28:30 +0200
+Subject: add portaudio
 
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index be6b650..9b1a81d 100644
+index ef51bb6..dc4ddb6 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -13,6 +13,7 @@ option(USE_KEYCHAIN "Store the token in the keychain (default)" ON)
@@ -204,7 +204,7 @@ index be6b650..9b1a81d 100644
  
  find_package(nlohmann_json REQUIRED)
  find_package(CURL)
-@@ -162,7 +163,12 @@ if (ENABLE_VOICE)
+@@ -165,7 +166,11 @@ if (ENABLE_VOICE)
  
      find_package(PkgConfig)
  
@@ -214,11 +214,10 @@ index be6b650..9b1a81d 100644
 +    else ()
 +       set(USE_MINIAUDIO TRUE)
 +    endif ()
-+
      pkg_check_modules(Opus REQUIRED IMPORTED_TARGET opus)
      target_link_libraries(abaddon PkgConfig::Opus)
  
-@@ -206,7 +212,12 @@ if (ENABLE_VOICE)
+@@ -255,7 +260,11 @@ if (ENABLE_VOICE)
  endif ()
  
  if (${ENABLE_NOTIFICATION_SOUNDS})
@@ -228,11 +227,10 @@ index be6b650..9b1a81d 100644
 +    else ()
 +       set(USE_MINIAUDIO TRUE)
 +    endif ()
-+
      target_compile_definitions(abaddon PRIVATE ENABLE_NOTIFICATION_SOUNDS)
  endif ()
  
-@@ -221,6 +232,12 @@ if (USE_MINIAUDIO)
+@@ -270,6 +279,12 @@ if (USE_MINIAUDIO)
      target_compile_definitions(abaddon PRIVATE WITH_MINIAUDIO)
  endif ()
  
@@ -246,7 +244,7 @@ index be6b650..9b1a81d 100644
  foreach (COMPILER_DEF IN LISTS ABADDON_COMPILER_DEFS)
      target_compile_definitions(abaddon PRIVATE "${COMPILER_DEF}")
 diff --git a/src/audio/devices.cpp b/src/audio/devices.cpp
-index dfb7164..09fc156 100644
+index bc5bd76..3bd510c 100644
 --- a/src/audio/devices.cpp
 +++ b/src/audio/devices.cpp
 @@ -21,6 +21,75 @@ Glib::RefPtr<Gtk::ListStore> AudioDevices::GetCaptureDeviceModel() {
@@ -324,8 +322,8 @@ index dfb7164..09fc156 100644
 +#else /* USE_PORTAUDIO */
  void AudioDevices::SetDevices(ma_device_info *pPlayback, ma_uint32 playback_count, ma_device_info *pCapture, ma_uint32 capture_count) {
      m_playback->clear();
- 
-@@ -60,7 +129,39 @@ void AudioDevices::SetDevices(ma_device_info *pPlayback, ma_uint32 playback_coun
+     // reset state
+@@ -87,7 +156,39 @@ void AudioDevices::SetDevices(ma_device_info *pPlayback, ma_uint32 playback_coun
          spdlog::get("audio")->warn("No default capture device found");
      }
  }
@@ -365,7 +363,7 @@ index dfb7164..09fc156 100644
  std::optional<ma_device_id> AudioDevices::GetPlaybackDeviceIDFromModel(const Gtk::TreeModel::iterator &iter) const {
      if (iter) {
          return static_cast<ma_device_id>((*iter)[m_playback_columns.DeviceID]);
-@@ -92,6 +193,7 @@ std::optional<ma_device_id> AudioDevices::GetDefaultCapture() const {
+@@ -119,6 +220,7 @@ std::optional<ma_device_id> AudioDevices::GetDefaultCapture() const {
  
      return std::nullopt;
  }
@@ -462,6 +460,20 @@ index 531b24f..767dec1 100644
 +		#include <miniaudio.h>
 +	#endif
  #endif
+diff --git a/src/audio/manager.cpp b/src/audio/manager.cpp
+index d32c5e2..3a155fc 100644
+--- a/src/audio/manager.cpp
++++ b/src/audio/manager.cpp
+@@ -1,3 +1,4 @@
++#ifndef USE_PORTAUDIO
+ #ifdef WITH_VOICE
+ // clang-format off
+ 
+@@ -704,3 +705,4 @@ AudioManager::type_signal_opus_packet AudioManager::signal_opus_packet() {
+ }
+ 
+ #endif
++#endif /* USE_PORTAUDIO */
 diff --git a/src/audio/manager.hpp b/src/audio/manager.hpp
 index 5716fc5..a657dcc 100644
 --- a/src/audio/manager.hpp
@@ -564,30 +576,12 @@ index 5716fc5..a657dcc 100644
      std::shared_ptr<spdlog::logger> m_log;
  
  public:
-diff --git a/src/audio/manager.cpp b/src/audio/miniaudioManager.cpp
-similarity index 99%
-rename from src/audio/manager.cpp
-rename to src/audio/miniaudioManager.cpp
-index d32c5e2..3a155fc 100644
---- a/src/audio/manager.cpp
-+++ b/src/audio/miniaudioManager.cpp
-@@ -1,3 +1,4 @@
-+#ifndef USE_PORTAUDIO
- #ifdef WITH_VOICE
- // clang-format off
- 
-@@ -704,3 +705,4 @@ AudioManager::type_signal_opus_packet AudioManager::signal_opus_packet() {
- }
- 
- #endif
-+#endif /* USE_PORTAUDIO */
 diff --git a/src/audio/portaudioManager.cpp b/src/audio/portaudioManager.cpp
 new file mode 100644
-index 0000000..bcd1254
+index 0000000..fda0988
 --- /dev/null
 +++ b/src/audio/portaudioManager.cpp
-@@ -0,0 +1,601 @@
-+#ifdef WITH_VOICE
+@@ -0,0 +1,598 @@
 +#ifdef USE_PORTAUDIO
 +
 +#include "manager.hpp"
@@ -606,15 +600,14 @@ index 0000000..bcd1254
 +                           void *userData ) {
 +    AudioManager *mgr = reinterpret_cast<AudioManager *>(userData);
 +    if (mgr == nullptr) {printf("NULL\n");return paContinue;};
++    printf("PlayCallback(): %d\n", frameCount);
 +    std::lock_guard<std::mutex> _(mgr->m_mutex);
 +
-+    auto *pOutputF32 = static_cast<int16_t *>(pOutput);
++    auto *pOutputF32 = static_cast<float *>(pOutput);
 +    
-+    /* clear the output buffer */
-+    for(int i = 0; i<frameCount *  2; i++)
-+		pOutputF32[i] = 0;
-+
-+	/* write every SSRC into the output stream */
++    for(int i = 0; i<frameCount; i++)
++		pOutputF32[i] = 0.0f;
++    
 +    for (auto &[ssrc, pair] : mgr->m_sources) {
 +        double volume = 1.0;
 +        if (const auto vol_it = mgr->m_volume_ssrc.find(ssrc); vol_it != mgr->m_volume_ssrc.end()) {
@@ -622,9 +615,9 @@ index 0000000..bcd1254
 +        }
 +        auto &buf = pair.first;
 +        const size_t n = std::min(static_cast<size_t>(buf.size()), static_cast<size_t>(frameCount * 2ULL));
++        printf("Size: %d Buf%d frameCount %d\n", n, buf.size(), frameCount);
 +        for (size_t i = 0; i < n; i++) {
-+            pOutputF32[i] += (int16_t) (volume * buf[i]);
-+            //pOutputF32[i] += volume * buf[i] / 32768.F;
++            pOutputF32[i] += volume * buf[i] / 32768.F;
 +        }
 +        buf.erase(buf.begin(), buf.begin() + n);
 +    }
@@ -637,9 +630,9 @@ index 0000000..bcd1254
 +                           const PaStreamCallbackTimeInfo* timeInfo,
 +                           PaStreamCallbackFlags statusFlags,
 +                           void *userData ) {
++    printf("recordCallback() %d\n", frameCount);
 +    auto *mgr = reinterpret_cast<AudioManager *>(userData);
 +    if (mgr == nullptr) return paContinue;
-+    
 +    mgr->OnCapturedPCM(static_cast<const int16_t *>(pInput), frameCount);
 +
 +    /*
@@ -687,13 +680,13 @@ index 0000000..bcd1254
 +    Enumerate();
 +
 +	/* create the configurations for capture and playback */
-+	m_playback_config.sampleFormat = paInt16;
++	m_playback_config.sampleFormat = paFloat32;
 +	m_playback_config.channelCount = 2;
 +    m_playback_config.suggestedLatency = Pa_GetDeviceInfo( m_capture_config.device )->defaultLowInputLatency;
 +    m_playback_config.hostApiSpecificStreamInfo = NULL;
 +    m_playback_config.device = Pa_GetDefaultOutputDevice();
 +
-+    m_capture_config.sampleFormat = paInt16;
++    m_capture_config.sampleFormat = paFloat32;
 +	m_capture_config.channelCount = 2;
 +    m_capture_config.suggestedLatency = Pa_GetDeviceInfo( m_capture_config.device )->defaultLowInputLatency;
 +    m_capture_config.hostApiSpecificStreamInfo = NULL;
@@ -766,7 +759,7 @@ index 0000000..bcd1254
 +}
 +
 +void AudioManager::FeedMeOpus(uint32_t ssrc, const std::vector<uint8_t> &data) {
-+    if (!m_should_playback || Pa_IsStreamActive(pa_playback_device) != 1) return;
++    if (!m_should_playback || Pa_IsStreamActive(&pa_playback_device) != 1) return;
 +
 +    std::lock_guard<std::mutex> _(m_mutex);
 +    if (m_muted_ssrcs.find(ssrc) != m_muted_ssrcs.end()) return;
@@ -1187,15 +1180,183 @@ index 0000000..bcd1254
 +}
 +
 +#endif /* USE_PORTAUDIO */
-+#endif /* WITH_VOICE */
+diff --git a/src/discord/voiceclient.hpp b/src/discord/voiceclient.hpp
+index ac1ea7f..41abea4 100644
+--- a/src/discord/voiceclient.hpp
++++ b/src/discord/voiceclient.hpp
+@@ -33,7 +33,7 @@ enum class VoiceGatewayCloseCode : uint16_t {
+     UnknownEncryption = 4016,
+ };
+ 
+-enum class VoiceGatewayOp : int {
++enum class VoiceGatewayOp : uint32_t {
+     Identify = 0,
+     SelectProtocol = 1,
+     Ready = 2,
+@@ -74,7 +74,7 @@ struct VoiceGatewayMessage {
+ };
+ 
+ struct VoiceHelloData {
+-    int HeartbeatInterval;
++    uint32_t HeartbeatInterval;
+ 
+     friend void from_json(const nlohmann::json &j, VoiceHelloData &m);
+ };
+@@ -99,10 +99,10 @@ struct VoiceIdentifyMessage {
+ struct VoiceReadyData {
+     struct VoiceStream {
+         bool IsActive;
+-        int Quality;
++        uint32_t Quality;
+         std::string RID;
+-        int RTXSSRC;
+-        int SSRC;
++        uint32_t RTXSSRC;
++        uint32_t SSRC;
+         std::string Type;
+ 
+         friend void from_json(const nlohmann::json &j, VoiceStream &m);
 -- 
-2.48.1
+2.54.0
 
 
-From 34c05a18705deaee0583c14898de89cb2c8d5609 Mon Sep 17 00:00:00 2001
-From: zeldakatze <mail@zeldakatze.de>
-Date: Wed, 13 Aug 2025 13:50:28 +0200
-Subject: do resampling for portaudio
+From 95334b1d64890fb9cd2f43b8767ecc57e8c53c1a Mon Sep 17 00:00:00 2001
+From: zeldakatze <coffee@zeldakatze.de>
+Date: Thu, 7 Aug 2025 14:10:00 +0200
+Subject: make portaudio actually work
+
+
+diff --git a/src/audio/manager.cpp b/src/audio/miniaudioManager.cpp
+similarity index 100%
+rename from src/audio/manager.cpp
+rename to src/audio/miniaudioManager.cpp
+diff --git a/src/audio/portaudioManager.cpp b/src/audio/portaudioManager.cpp
+index fda0988..bcd1254 100644
+--- a/src/audio/portaudioManager.cpp
++++ b/src/audio/portaudioManager.cpp
+@@ -1,3 +1,4 @@
++#ifdef WITH_VOICE
+ #ifdef USE_PORTAUDIO
+ 
+ #include "manager.hpp"
+@@ -16,14 +17,15 @@ int playCallback(const void *pInput, void *pOutput,
+                            void *userData ) {
+     AudioManager *mgr = reinterpret_cast<AudioManager *>(userData);
+     if (mgr == nullptr) {printf("NULL\n");return paContinue;};
+-    printf("PlayCallback(): %d\n", frameCount);
+     std::lock_guard<std::mutex> _(mgr->m_mutex);
+ 
+-    auto *pOutputF32 = static_cast<float *>(pOutput);
+-    
+-    for(int i = 0; i<frameCount; i++)
+-		pOutputF32[i] = 0.0f;
++    auto *pOutputF32 = static_cast<int16_t *>(pOutput);
+     
++    /* clear the output buffer */
++    for(int i = 0; i<frameCount *  2; i++)
++		pOutputF32[i] = 0;
++
++	/* write every SSRC into the output stream */
+     for (auto &[ssrc, pair] : mgr->m_sources) {
+         double volume = 1.0;
+         if (const auto vol_it = mgr->m_volume_ssrc.find(ssrc); vol_it != mgr->m_volume_ssrc.end()) {
+@@ -31,9 +33,9 @@ int playCallback(const void *pInput, void *pOutput,
+         }
+         auto &buf = pair.first;
+         const size_t n = std::min(static_cast<size_t>(buf.size()), static_cast<size_t>(frameCount * 2ULL));
+-        printf("Size: %d Buf%d frameCount %d\n", n, buf.size(), frameCount);
+         for (size_t i = 0; i < n; i++) {
+-            pOutputF32[i] += volume * buf[i] / 32768.F;
++            pOutputF32[i] += (int16_t) (volume * buf[i]);
++            //pOutputF32[i] += volume * buf[i] / 32768.F;
+         }
+         buf.erase(buf.begin(), buf.begin() + n);
+     }
+@@ -46,9 +48,9 @@ int recordCallback(const void *pInput, void *pOutput,
+                            const PaStreamCallbackTimeInfo* timeInfo,
+                            PaStreamCallbackFlags statusFlags,
+                            void *userData ) {
+-    printf("recordCallback() %d\n", frameCount);
+     auto *mgr = reinterpret_cast<AudioManager *>(userData);
+     if (mgr == nullptr) return paContinue;
++    
+     mgr->OnCapturedPCM(static_cast<const int16_t *>(pInput), frameCount);
+ 
+     /*
+@@ -96,13 +98,13 @@ AudioManager::AudioManager(const Glib::ustring &backends_string)
+     Enumerate();
+ 
+ 	/* create the configurations for capture and playback */
+-	m_playback_config.sampleFormat = paFloat32;
++	m_playback_config.sampleFormat = paInt16;
+ 	m_playback_config.channelCount = 2;
+     m_playback_config.suggestedLatency = Pa_GetDeviceInfo( m_capture_config.device )->defaultLowInputLatency;
+     m_playback_config.hostApiSpecificStreamInfo = NULL;
+     m_playback_config.device = Pa_GetDefaultOutputDevice();
+ 
+-    m_capture_config.sampleFormat = paFloat32;
++    m_capture_config.sampleFormat = paInt16;
+ 	m_capture_config.channelCount = 2;
+     m_capture_config.suggestedLatency = Pa_GetDeviceInfo( m_capture_config.device )->defaultLowInputLatency;
+     m_capture_config.hostApiSpecificStreamInfo = NULL;
+@@ -175,7 +177,7 @@ void AudioManager::SetOpusBuffer(uint8_t *ptr) {
+ }
+ 
+ void AudioManager::FeedMeOpus(uint32_t ssrc, const std::vector<uint8_t> &data) {
+-    if (!m_should_playback || Pa_IsStreamActive(&pa_playback_device) != 1) return;
++    if (!m_should_playback || Pa_IsStreamActive(pa_playback_device) != 1) return;
+ 
+     std::lock_guard<std::mutex> _(m_mutex);
+     if (m_muted_ssrcs.find(ssrc) != m_muted_ssrcs.end()) return;
+@@ -596,3 +598,4 @@ AudioManager::type_signal_opus_packet AudioManager::signal_opus_packet() {
+ }
+ 
+ #endif /* USE_PORTAUDIO */
++#endif /* WITH_VOICE */
+diff --git a/src/discord/voiceclient.hpp b/src/discord/voiceclient.hpp
+index 41abea4..ac1ea7f 100644
+--- a/src/discord/voiceclient.hpp
++++ b/src/discord/voiceclient.hpp
+@@ -33,7 +33,7 @@ enum class VoiceGatewayCloseCode : uint16_t {
+     UnknownEncryption = 4016,
+ };
+ 
+-enum class VoiceGatewayOp : uint32_t {
++enum class VoiceGatewayOp : int {
+     Identify = 0,
+     SelectProtocol = 1,
+     Ready = 2,
+@@ -74,7 +74,7 @@ struct VoiceGatewayMessage {
+ };
+ 
+ struct VoiceHelloData {
+-    uint32_t HeartbeatInterval;
++    int HeartbeatInterval;
+ 
+     friend void from_json(const nlohmann::json &j, VoiceHelloData &m);
+ };
+@@ -99,10 +99,10 @@ struct VoiceIdentifyMessage {
+ struct VoiceReadyData {
+     struct VoiceStream {
+         bool IsActive;
+-        uint32_t Quality;
++        int Quality;
+         std::string RID;
+-        uint32_t RTXSSRC;
+-        uint32_t SSRC;
++        int RTXSSRC;
++        int SSRC;
+         std::string Type;
+ 
+         friend void from_json(const nlohmann::json &j, VoiceStream &m);
+-- 
+2.54.0
+
+
+From 035e26f333d3b8b4ad89104a2ce209e2a66f8032 Mon Sep 17 00:00:00 2001
+From: zeldakatze <coffee@zeldakatze.de>
+Date: Sun, 10 Aug 2025 21:50:27 +0200
+Subject: implement probably the worst resampler on earth
 
 
 diff --git a/src/audio/manager.hpp b/src/audio/manager.hpp
@@ -1218,10 +1379,10 @@ index a657dcc..2d1ae71 100644
  
  
 diff --git a/src/audio/portaudioManager.cpp b/src/audio/portaudioManager.cpp
-index bcd1254..f21f9ff 100644
+index bcd1254..56d32ed 100644
 --- a/src/audio/portaudioManager.cpp
 +++ b/src/audio/portaudioManager.cpp
-@@ -10,19 +10,39 @@
+@@ -10,19 +10,40 @@
  #include <opus.h>
  #include <cstring>
  
@@ -1230,6 +1391,7 @@ index bcd1254..f21f9ff 100644
 +static void resampleBuffer(const int16_t *input, const int inputFrames,
 +		int16_t *output, const int outputFrames) {
 +	float ratio = (float) inputFrames / (float) outputFrames;
++		inputFrames, outputFrames, ratio);
 +	for(int oi = 0; oi < outputFrames; oi++) {
 +		int ii = (int) (((float) oi) * ratio);
 +		
@@ -1264,7 +1426,7 @@ index bcd1254..f21f9ff 100644
  		pOutputF32[i] = 0;
  
  	/* write every SSRC into the output stream */
-@@ -32,7 +52,7 @@ int playCallback(const void *pInput, void *pOutput,
+@@ -32,7 +53,7 @@ int playCallback(const void *pInput, void *pOutput,
              volume = vol_it->second;
          }
          auto &buf = pair.first;
@@ -1273,7 +1435,7 @@ index bcd1254..f21f9ff 100644
          for (size_t i = 0; i < n; i++) {
              pOutputF32[i] += (int16_t) (volume * buf[i]);
              //pOutputF32[i] += volume * buf[i] / 32768.F;
-@@ -40,6 +60,9 @@ int playCallback(const void *pInput, void *pOutput,
+@@ -40,6 +61,9 @@ int playCallback(const void *pInput, void *pOutput,
          buf.erase(buf.begin(), buf.begin() + n);
      }
      
@@ -1283,7 +1445,7 @@ index bcd1254..f21f9ff 100644
      return paContinue;
  }
  
-@@ -51,7 +74,11 @@ int recordCallback(const void *pInput, void *pOutput,
+@@ -51,7 +75,11 @@ int recordCallback(const void *pInput, void *pOutput,
      auto *mgr = reinterpret_cast<AudioManager *>(userData);
      if (mgr == nullptr) return paContinue;
      
@@ -1296,7 +1458,7 @@ index bcd1254..f21f9ff 100644
  
      /*
       * You can simply increment it by 480 in UDPSocket::SendEncrypted but this is wrong
-@@ -103,22 +130,30 @@ AudioManager::AudioManager(const Glib::ustring &backends_string)
+@@ -103,22 +131,30 @@ AudioManager::AudioManager(const Glib::ustring &backends_string)
      m_playback_config.suggestedLatency = Pa_GetDeviceInfo( m_capture_config.device )->defaultLowInputLatency;
      m_playback_config.hostApiSpecificStreamInfo = NULL;
      m_playback_config.device = Pa_GetDefaultOutputDevice();
@@ -1329,7 +1491,7 @@ index bcd1254..f21f9ff 100644
  	if(pa_err != paNoError) {
  		m_ok = false;
  		spdlog::get("audio")->error("ERROR: Pa_OpenStream for playback returned %d\n", pa_err);
-@@ -140,6 +175,9 @@ AudioManager::AudioManager(const Glib::ustring &backends_string)
+@@ -140,6 +176,9 @@ AudioManager::AudioManager(const Glib::ustring &backends_string)
  AudioManager::~AudioManager() {
      Pa_Terminate();
      RemoveAllSSRCs();
@@ -1340,5 +1502,301 @@ index bcd1254..f21f9ff 100644
  #ifdef WITH_RNNOISE
      RNNoiseUninitialize();
 -- 
-2.48.1
+2.54.0
+
+
+From e8b2f4ae9cea036e04caae6a52f286151420cc00 Mon Sep 17 00:00:00 2001
+From: zeldakatze <coffee@zeldakatze.de>
+Date: Tue, 12 Aug 2025 00:20:13 +0200
+Subject: Fix typo
+
+
+diff --git a/src/audio/portaudioManager.cpp b/src/audio/portaudioManager.cpp
+index 56d32ed..f21f9ff 100644
+--- a/src/audio/portaudioManager.cpp
++++ b/src/audio/portaudioManager.cpp
+@@ -15,7 +15,6 @@
+ static void resampleBuffer(const int16_t *input, const int inputFrames,
+ 		int16_t *output, const int outputFrames) {
+ 	float ratio = (float) inputFrames / (float) outputFrames;
+-		inputFrames, outputFrames, ratio);
+ 	for(int oi = 0; oi < outputFrames; oi++) {
+ 		int ii = (int) (((float) oi) * ratio);
+ 		
+-- 
+2.54.0
+
+
+From dd0b51da7ae2371edc5c9d68d52cc73ec18600d5 Mon Sep 17 00:00:00 2001
+From: Maite Gamper <mail@zeldakatze.de>
+Date: Fri, 10 Jul 2026 23:52:53 +0200
+Subject: fix uninitialized read
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index dc4ddb6..b9040be 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -187,7 +187,7 @@ if (ENABLE_VOICE)
+     endif ()
+ 
+     find_package(MLSPP QUIET)
+-    if (NOT MLSPP_FOUND)
++    if (true)
+         message(STATUS "mlspp not found, using subproject")
+         set(DISABLE_GREASE ON CACHE BOOL "" FORCE)
+         set(TESTING OFF CACHE BOOL "" FORCE)
+diff --git a/src/audio/portaudioManager.cpp b/src/audio/portaudioManager.cpp
+index f21f9ff..0f4204c 100644
+--- a/src/audio/portaudioManager.cpp
++++ b/src/audio/portaudioManager.cpp
+@@ -127,17 +127,17 @@ AudioManager::AudioManager(const Glib::ustring &backends_string)
+ 	/* create the configurations for capture and playback */
+ 	m_playback_config.sampleFormat = paInt16;
+ 	m_playback_config.channelCount = 2;
+-    m_playback_config.suggestedLatency = Pa_GetDeviceInfo( m_capture_config.device )->defaultLowInputLatency;
+-    m_playback_config.hostApiSpecificStreamInfo = NULL;
+     m_playback_config.device = Pa_GetDefaultOutputDevice();
++    m_playback_config.suggestedLatency = Pa_GetDeviceInfo( m_playback_config.device )->defaultLowInputLatency;
++    m_playback_config.hostApiSpecificStreamInfo = NULL;
+ 	resample_playback_source_rate = Pa_GetDeviceInfo( m_playback_config.device )->defaultSampleRate;
+ 	resample_playback_framesPerBuffer = (int) (((float) resample_playback_source_rate / 48000.0) * 480.0);
+ 
+     m_capture_config.sampleFormat = paInt16;
+ 	m_capture_config.channelCount = 2;
++    m_capture_config.device = Pa_GetDefaultInputDevice();
+     m_capture_config.suggestedLatency = Pa_GetDeviceInfo( m_capture_config.device )->defaultLowInputLatency;
+     m_capture_config.hostApiSpecificStreamInfo = NULL;
+-    m_capture_config.device = Pa_GetDefaultInputDevice();
+ 	resample_capture_source_rate = Pa_GetDeviceInfo( m_capture_config.device )->defaultSampleRate;
+     resample_capture_framesPerBuffer = (int) (((float) resample_capture_source_rate / 48000.0) * 480.0);
+     
+-- 
+2.54.0
+
+
+From 8d8d659bacd2ce0f89c8eeafaf7296d78eac8295 Mon Sep 17 00:00:00 2001
+From: zeldakatze <mail@zeldakatze.de>
+Date: Sat, 11 Jul 2026 13:28:39 +0200
+Subject: clean up some patches
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b9040be..92e5326 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -36,6 +36,7 @@ if (MINGW OR WIN32)
+ endif ()
+ 
+ if (HAIKU)
++    link_libraries(be)
+     link_libraries(network)
+ endif ()
+ 
+@@ -76,7 +77,7 @@ if (NOT (APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
+     target_precompile_headers(abaddon PRIVATE <gtkmm.h> src/abaddon.hpp src/util.hpp)
+ endif ()
+ 
+-if (NOT (CMAKE_SYSTEM_NAME STREQUAL "Haiku") AND
++if (NOT HAIKU AND
+ ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.1")))
+     target_link_libraries(abaddon stdc++fs)
+ endif ()
+diff --git a/cmake/Findgtkmm.cmake b/cmake/Findgtkmm.cmake
+index 908a08c..aa92c9d 100644
+--- a/cmake/Findgtkmm.cmake
++++ b/cmake/Findgtkmm.cmake
+@@ -32,15 +32,12 @@ find_path(GTKMM_INCLUDE_DIR
+ find_path(GTKMM_CONFIG_INCLUDE_DIR
+           NAMES gtkmmconfig.h
+           HINTS ${GTKMM_LIBRARY_HINTS}
+-          PATH_SUFFIXES ${GTKMM_LIBRARY_NAME}
+-          PATH_SUFFIXES ${GTKMM_LIBRARY_NAME}/include)
++          PATH_SUFFIXES ${GTKMM_LIBRARY_NAME} ${GTKMM_LIBRARY_NAME}/include)
+ 
+ find_library(GTKMM_LIB
+              NAMES ${GTKMM_LIBRARY_NAME}
+                    gtkmm
+-             HINTS ${GTKMM_LIBRARY_HINTS}
+-             HINTS ${GTKMM_INCLUDE_DIR}
+-             PATH ${GTKMM_INCLUDE_DIR}
++             HINTS ${GTKMM_LIBRARY_HINTS} ${GTKMM_INCLUDE_DIR}
+              PATH_SUFFIXES ${GTKMM_LIBRARY_NAME}
+                            ${GTKMM_LIBRARY_NAME}/include)
+ 
+diff --git a/src/platform.cpp b/src/platform.cpp
+index 738b028..1e1f408 100644
+--- a/src/platform.cpp
++++ b/src/platform.cpp
+@@ -225,20 +225,35 @@ std::string Platform::FindStateCacheFolder() {
+ }
+ 
+ #elif __HAIKU__
++#include <Directory.h>
++#include <Entry.h>
+ #include <FindDirectory.h>
+ #include <fs_info.h>
+ 
+ std::string Platform::FindResourceFolder() {
+     static std::string found_path;
+     static bool found = false;
+-    if (found) return found_path;
++    if(found) return found_path;
+ 
++    // try the path of the packaged resource folder
+     dev_t volume = dev_for_path("/boot");
+-    char buffer[B_PATH_NAME_LENGTH+B_FILE_NAME_LENGTH];
++    char buffer[B_PATH_NAME_LENGTH+B_FILE_NAME_LENGTH] = {};
+     find_directory(B_SYSTEM_DATA_DIRECTORY, volume, false, buffer, sizeof(buffer));
+-	strcat(buffer, "/abaddon/");
+-	found_path = std::string(buffer);
+-	return found_path;
++    strcat(buffer, "/abaddon/");
++
++    // check if the directory exists
++    BEntry entry(buffer);
++    if(entry.Exists() && entry.IsDirectory()) {
++    	found = true;
++        found_path = std::string(buffer);
++        return found_path;
++    }
++
++    // otherwise, fall back to the cwd
++    spdlog::get("discord")->warn("cant find a resources folder, will try to load from cwd");
++    found_path = ".";
++    found = true;
++    return found_path;
+ }
+ 
+ std::string Platform::FindConfigFile() {
+@@ -249,16 +264,16 @@ std::string Platform::FindConfigFile() {
+     static bool found = false;
+     if (found) return found_path;
+ 
+-	dev_t volume = dev_for_path("/boot");
+-    char buffer[B_PATH_NAME_LENGTH+B_FILE_NAME_LENGTH];
+-    char cmdbuffer[B_PATH_NAME_LENGTH+B_FILE_NAME_LENGTH] = "mkdir -p ";
++    // generate the path of the config directory. If it does not exist, create it
++    dev_t volume = dev_for_path("/boot");
++    char buffer[B_PATH_NAME_LENGTH+B_FILE_NAME_LENGTH] = {};
+     find_directory(B_USER_SETTINGS_DIRECTORY, volume, false, buffer, sizeof(buffer));
+-	strcat(buffer, "/abaddon/");
+-	strcat(cmdbuffer, buffer);
+-	system(cmdbuffer);
+-	strcat(buffer, "abaddon.ini");
+-	found_path = std::string(buffer);
+-	return found_path;
++    strcat(buffer, "/abaddon/");
++    create_directory(buffer, 0777);
++
++    strcat(buffer, "abaddon.ini");
++    found_path = std::string(buffer);
++    return found_path;
+ }
+ 
+ std::string Platform::FindStateCacheFolder() {
+@@ -266,12 +281,16 @@ std::string Platform::FindStateCacheFolder() {
+     static bool found = false;
+     if (found) return found_path;
+ 
+-	dev_t volume = dev_for_path("/boot");
++    dev_t volume = dev_for_path("/boot");
+     char buffer[B_PATH_NAME_LENGTH+B_FILE_NAME_LENGTH];
+-    find_directory(B_SYSTEM_CACHE_DIRECTORY, volume, false, buffer, sizeof(buffer));
+-	strcat(buffer, "/abaddon/");
+-	found_path = std::string(buffer);
+-	return found_path;
++    find_directory(B_USER_CACHE_DIRECTORY, volume, false, buffer, sizeof(buffer));
++    strcat(buffer, "/abaddon/");
++    create_directory(buffer, 0777);
++
++
++    found_path = std::string(buffer);
++    found = true;
++    return found_path;
+ }
+ 
+ 
+-- 
+2.54.0
+
+
+From 4fe5f7c872892d2c7a7c5642246623ec1022a434 Mon Sep 17 00:00:00 2001
+From: zeldakatze <mail@zeldakatze.de>
+Date: Sat, 11 Jul 2026 15:07:18 +0200
+Subject: use system qrcodegen if it exists
+
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 92e5326..2f6261a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -65,8 +65,13 @@ target_include_directories(abaddon PUBLIC ${SQLite3_INCLUDE_DIRS})
+ target_include_directories(abaddon PUBLIC ${NLOHMANN_JSON_INCLUDE_DIRS})
+ 
+ if (ENABLE_QRCODE_LOGIN)
+-    add_library(qrcodegen subprojects/qrcodegen/cpp/qrcodegen.hpp subprojects/qrcodegen/cpp/qrcodegen.cpp)
+-    target_include_directories(qrcodegen PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/subprojects/qrcodegen/cpp")
++    find_package(qrcodegen QUIET)
++    if(NOT qrcodegen_FOUND)
++        message("qrcodegen was not found and will be included as a submodule")
++        add_library(qrcodegen subprojects/qrcodegen/cpp/qrcodegen.hpp subprojects/qrcodegen/cpp/qrcodegen.cpp)
++        target_include_directories(qrcodegen PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/subprojects/qrcodegen/cpp")
++    endif ()
++
+     target_link_libraries(abaddon qrcodegen)
+ 
+     target_include_directories(abaddon PUBLIC "subprojects/qrcodegen/cpp")
+-- 
+2.54.0
+
+
+From 7b3a4ff97ae6490a15adaa0a792ea9225c4c9e51 Mon Sep 17 00:00:00 2001
+From: Soashivito <118043209+Soashivito@users.noreply.github.com>
+Date: Wed, 9 Sep 2026 12:35:06 -0600
+Subject: [PATCH] fix READY being discarded when application_id is null (#427)
+
+* Change application_id to optional in channel.cpp
+
+discord sends "application_id": null on voice channels, but JS_O only
+checks contains(). Snowflake::from_json then falls through to
+get_to(uint64_t) on a null and throws type_error.302.
+
+* Change JS_O to JS_ON for application_id
+
+same JS_O issue as the channel's one, same optional<Snowflake> target.
+---
+ src/discord/activity.cpp | 2 +-
+ src/discord/channel.cpp  | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/discord/activity.cpp b/src/discord/activity.cpp
+index 95dda5d..bc95714 100644
+--- a/src/discord/activity.cpp
++++ b/src/discord/activity.cpp
+@@ -66,7 +66,7 @@ void from_json(const nlohmann::json &j, ActivityData &m) {
+     JS_ON("url", m.URL);
+     JS_D("created_at", m.CreatedAt);
+     JS_O("timestamps", m.Timestamps);
+-    JS_O("application_id", m.ApplicationID);
++    JS_ON("application_id", m.ApplicationID);
+     JS_ON("details", m.Details);
+     JS_ON("state", m.State);
+     JS_ON("emoji", m.Emoji);
+diff --git a/src/discord/channel.cpp b/src/discord/channel.cpp
+index 8b3ee19..06c323f 100644
+--- a/src/discord/channel.cpp
++++ b/src/discord/channel.cpp
+@@ -35,7 +35,7 @@ void from_json(const nlohmann::json &j, ChannelData &m) {
+     JS_O("recipient_ids", m.RecipientIDs);
+     JS_ON("icon", m.Icon);
+     JS_O("owner_id", m.OwnerID);
+-    JS_O("application_id", m.ApplicationID);
++    JS_ON("application_id", m.ApplicationID);
+     JS_ON("parent_id", m.ParentID);
+     JS_ON("last_pin_timestamp", m.LastPinTimestamp);
+     JS_O("thread_metadata", m.ThreadMetadata);
+-- 
+2.52.0
+
 


### PR DESCRIPTION
I tried using both the system ixwebsockets and qrcodegen. However either I've messed something up, or there is something broken with those packages.

Abaddon now uses libdave and mlspp in order to decrypt discord's voice data. Both libdave and mlspp seem to be designed to be statically linked.

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
