### PR TITLE
llvm: build on non-Intel architectures

### DIFF
--- a/sys-devel/llvm/patches/llvm-12.0.1.patchset
+++ b/sys-devel/llvm/patches/llvm-12.0.1.patchset
@@ -177,3 +177,31 @@ index f6d882d..e2a3343 100644
 -- 
 2.30.0
 
+From 743bf463a73c06afadc4be8a570e06955fb03d1f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Przemys=C5=82aw=20Buczkowski?= <prem@prem.moe>
+Date: Tue, 8 Sep 2026 23:59:15 +0900
+Subject: config.guess: recognize non-Intel Haiku
+
+Port the wildcard Haiku entry from upstream GNU config, so the host
+triple is guessed on any Haiku architecture (arm64, riscv64, powerpc).
+---
+ cmake/config.guess | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/cmake/config.guess b/cmake/config.guess
+index 60d3f58..1ad1fa6 100644
+--- a/cmake/config.guess
++++ b/cmake/config.guess
+@@ -1229,6 +1229,9 @@ EOF
+     x86_64:Haiku:*:*) # Haiku running on x86_64.
+ 	echo x86_64-unknown-haiku
+ 	exit ;;
++    *:Haiku:*:*)	# Haiku
++	echo ${UNAME_MACHINE}-unknown-haiku
++	exit ;;
+     SX-4:SUPER-UX:*:*)
+ 	echo sx4-nec-superux${UNAME_RELEASE}
+ 	exit ;;
+-- 
+2.55.0
+

--- a/sys-devel/llvm/patches/llvm16-16.0.6.patchset
+++ b/sys-devel/llvm/patches/llvm16-16.0.6.patchset
@@ -1108,3 +1108,31 @@ index 231f514..d883c03 100644
 -- 
 2.42.0
 
+From 2ba7cbe742acaa9ea368c73a07a893144afaad03 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Przemys=C5=82aw=20Buczkowski?= <prem@prem.moe>
+Date: Tue, 8 Sep 2026 23:59:13 +0900
+Subject: config.guess: recognize non-Intel Haiku
+
+Port the wildcard Haiku entry from upstream GNU config, so the host
+triple is guessed on any Haiku architecture (arm64, riscv64, powerpc).
+---
+ llvm/cmake/config.guess | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/llvm/cmake/config.guess b/llvm/cmake/config.guess
+index 71abbf9..bcc29ad 100644
+--- a/llvm/cmake/config.guess
++++ b/llvm/cmake/config.guess
+@@ -1253,6 +1253,9 @@ EOF
+     x86_64:Haiku:*:*) # Haiku running on x86_64.
+ 	echo x86_64-unknown-haiku
+ 	exit ;;
++    *:Haiku:*:*)	# Haiku
++	echo ${UNAME_MACHINE}-unknown-haiku
++	exit ;;
+     SX-4:SUPER-UX:*:*)
+ 	echo sx4-nec-superux${UNAME_RELEASE}
+ 	exit ;;
+-- 
+2.55.0
+

--- a/sys-devel/llvm/patches/llvm17-17.0.6.patchset
+++ b/sys-devel/llvm/patches/llvm17-17.0.6.patchset
@@ -1266,3 +1266,31 @@ index c2059c7..31541a4 100644
 -- 
 2.43.2
 
+From f17596cea301c19efcd64e18b5821547853b38b0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Przemys=C5=82aw=20Buczkowski?= <prem@prem.moe>
+Date: Tue, 8 Sep 2026 23:59:14 +0900
+Subject: config.guess: recognize non-Intel Haiku
+
+Port the wildcard Haiku entry from upstream GNU config, so the host
+triple is guessed on any Haiku architecture (arm64, riscv64, powerpc).
+---
+ llvm/cmake/config.guess | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/llvm/cmake/config.guess b/llvm/cmake/config.guess
+index 71abbf9..bcc29ad 100644
+--- a/llvm/cmake/config.guess
++++ b/llvm/cmake/config.guess
+@@ -1253,6 +1253,9 @@ EOF
+     x86_64:Haiku:*:*) # Haiku running on x86_64.
+ 	echo x86_64-unknown-haiku
+ 	exit ;;
++    *:Haiku:*:*)	# Haiku
++	echo ${UNAME_MACHINE}-unknown-haiku
++	exit ;;
+     SX-4:SUPER-UX:*:*)
+ 	echo sx4-nec-superux${UNAME_RELEASE}
+ 	exit ;;
+-- 
+2.55.0
+

--- a/sys-devel/llvm/patches/llvm18-18.1.7.patchset
+++ b/sys-devel/llvm/patches/llvm18-18.1.7.patchset
@@ -768,3 +768,31 @@ index 3b9e9ee..94b2efd 100644
 -- 
 2.48.1
 
+From dcb552d1cd07f2c4689533d9f161030ecf53c4f7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Przemys=C5=82aw=20Buczkowski?= <prem@prem.moe>
+Date: Tue, 8 Sep 2026 23:59:12 +0900
+Subject: config.guess: recognize non-Intel Haiku
+
+Port the wildcard Haiku entry from upstream GNU config, so the host
+triple is guessed on any Haiku architecture (arm64, riscv64, powerpc).
+---
+ llvm/cmake/config.guess | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/llvm/cmake/config.guess b/llvm/cmake/config.guess
+index f489623..6a45709 100644
+--- a/llvm/cmake/config.guess
++++ b/llvm/cmake/config.guess
+@@ -1256,6 +1256,9 @@ EOF
+     x86_64:Haiku:*:*) # Haiku running on x86_64.
+ 	echo x86_64-unknown-haiku
+ 	exit ;;
++    *:Haiku:*:*)	# Haiku
++	echo ${UNAME_MACHINE}-unknown-haiku
++	exit ;;
+     SX-4:SUPER-UX:*:*)
+ 	echo sx4-nec-superux${UNAME_RELEASE}
+ 	exit ;;
+-- 
+2.55.0
+

--- a/sys-devel/llvm/patches/llvm19-19.1.7.patchset
+++ b/sys-devel/llvm/patches/llvm19-19.1.7.patchset
@@ -757,3 +757,31 @@ index 8fc9b49..1fd2cf8 100644
 -- 
 2.48.1
 
+From 6f4820af59af2a0e05c3e80626937daf5a05cca7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Przemys=C5=82aw=20Buczkowski?= <prem@prem.moe>
+Date: Tue, 8 Sep 2026 23:59:12 +0900
+Subject: config.guess: recognize non-Intel Haiku
+
+Port the wildcard Haiku entry from upstream GNU config, so the host
+triple is guessed on any Haiku architecture (arm64, riscv64, powerpc).
+---
+ llvm/cmake/config.guess | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/llvm/cmake/config.guess b/llvm/cmake/config.guess
+index 96cc554..9ed8ac5 100644
+--- a/llvm/cmake/config.guess
++++ b/llvm/cmake/config.guess
+@@ -1256,6 +1256,9 @@ EOF
+     x86_64:Haiku:*:*) # Haiku running on x86_64.
+ 	echo x86_64-unknown-haiku
+ 	exit ;;
++    *:Haiku:*:*)	# Haiku
++	echo ${UNAME_MACHINE}-unknown-haiku
++	exit ;;
+     SX-4:SUPER-UX:*:*)
+ 	echo sx4-nec-superux${UNAME_RELEASE}
+ 	exit ;;
+-- 
+2.55.0
+

--- a/sys-devel/llvm/patches/llvm20-20.1.8.patchset
+++ b/sys-devel/llvm/patches/llvm20-20.1.8.patchset
@@ -2577,3 +2577,31 @@ index 4e659cd..1f48b0e 100644
 -- 
 2.48.1
 
+From 88a34619dc25418091b90bdb6bfef7d6a91a6cd0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Przemys=C5=82aw=20Buczkowski?= <prem@prem.moe>
+Date: Tue, 8 Sep 2026 23:59:14 +0900
+Subject: config.guess: recognize non-Intel Haiku
+
+Port the wildcard Haiku entry from upstream GNU config, so the host
+triple is guessed on any Haiku architecture (arm64, riscv64, powerpc).
+---
+ llvm/cmake/config.guess | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/llvm/cmake/config.guess b/llvm/cmake/config.guess
+index 96cc554..9ed8ac5 100644
+--- a/llvm/cmake/config.guess
++++ b/llvm/cmake/config.guess
+@@ -1256,6 +1256,9 @@ EOF
+     x86_64:Haiku:*:*) # Haiku running on x86_64.
+ 	echo x86_64-unknown-haiku
+ 	exit ;;
++    *:Haiku:*:*)	# Haiku
++	echo ${UNAME_MACHINE}-unknown-haiku
++	exit ;;
+     SX-4:SUPER-UX:*:*)
+ 	echo sx4-nec-superux${UNAME_RELEASE}
+ 	exit ;;
+-- 
+2.55.0
+

--- a/sys-devel/llvm/patches/llvm21-21.1.8.patchset
+++ b/sys-devel/llvm/patches/llvm21-21.1.8.patchset
@@ -386,3 +386,31 @@ index 9a1afd3..d77110f 100644
 -- 
 2.48.1
 
+From 543192e3d2762b1bedbe5fcca51233b2dc66ddf9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Przemys=C5=82aw=20Buczkowski?= <prem@prem.moe>
+Date: Tue, 8 Sep 2026 23:59:12 +0900
+Subject: config.guess: recognize non-Intel Haiku
+
+Port the wildcard Haiku entry from upstream GNU config, so the host
+triple is guessed on any Haiku architecture (arm64, riscv64, powerpc).
+---
+ llvm/cmake/config.guess | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/llvm/cmake/config.guess b/llvm/cmake/config.guess
+index 96cc554..9ed8ac5 100644
+--- a/llvm/cmake/config.guess
++++ b/llvm/cmake/config.guess
+@@ -1256,6 +1256,9 @@ EOF
+     x86_64:Haiku:*:*) # Haiku running on x86_64.
+ 	echo x86_64-unknown-haiku
+ 	exit ;;
++    *:Haiku:*:*)	# Haiku
++	echo ${UNAME_MACHINE}-unknown-haiku
++	exit ;;
+     SX-4:SUPER-UX:*:*)
+ 	echo sx4-nec-superux${UNAME_RELEASE}
+ 	exit ;;
+-- 
+2.55.0
+

--- a/sys-devel/llvm/patches/llvm22-22.1.8.patchset
+++ b/sys-devel/llvm/patches/llvm22-22.1.8.patchset
@@ -395,3 +395,31 @@ index 975798a..de1827e 100644
 -- 
 2.45.2
 
+From 958cdff057765a7c2a3209dffe43a070b4064df3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Przemys=C5=82aw=20Buczkowski?= <prem@prem.moe>
+Date: Tue, 8 Sep 2026 23:59:13 +0900
+Subject: config.guess: recognize non-Intel Haiku
+
+Port the wildcard Haiku entry from upstream GNU config, so the host
+triple is guessed on any Haiku architecture (arm64, riscv64, powerpc).
+---
+ llvm/cmake/config.guess | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/llvm/cmake/config.guess b/llvm/cmake/config.guess
+index 2c22d6d..d9a013e 100644
+--- a/llvm/cmake/config.guess
++++ b/llvm/cmake/config.guess
+@@ -1259,6 +1259,9 @@ EOF
+     x86_64:Haiku:*:*) # Haiku running on x86_64.
+ 	echo x86_64-unknown-haiku
+ 	exit ;;
++    *:Haiku:*:*)	# Haiku
++	echo ${UNAME_MACHINE}-unknown-haiku
++	exit ;;
+     SX-4:SUPER-UX:*:*)
+ 	echo sx4-nec-superux${UNAME_RELEASE}
+ 	exit ;;
+-- 
+2.55.0
+

--- a/sys-devel/llvm/patches/llvm23-23.1.0.patchset
+++ b/sys-devel/llvm/patches/llvm23-23.1.0.patchset
@@ -363,3 +363,31 @@ index ee270d70a..4e96ffa7c 100644
 -- 
 2.54.0
 
+From e6005db0380fc0d5beea29a266434aa4bc0c6232 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Przemys=C5=82aw=20Buczkowski?= <prem@prem.moe>
+Date: Tue, 8 Sep 2026 23:59:13 +0900
+Subject: config.guess: recognize non-Intel Haiku
+
+Port the wildcard Haiku entry from upstream GNU config, so the host
+triple is guessed on any Haiku architecture (arm64, riscv64, powerpc).
+---
+ llvm/cmake/config.guess | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/llvm/cmake/config.guess b/llvm/cmake/config.guess
+index 2c22d6d..d9a013e 100644
+--- a/llvm/cmake/config.guess
++++ b/llvm/cmake/config.guess
+@@ -1259,6 +1259,9 @@ EOF
+     x86_64:Haiku:*:*) # Haiku running on x86_64.
+ 	echo x86_64-unknown-haiku
+ 	exit ;;
++    *:Haiku:*:*)	# Haiku
++	echo ${UNAME_MACHINE}-unknown-haiku
++	exit ;;
+     SX-4:SUPER-UX:*:*)
+ 	echo sx4-nec-superux${UNAME_RELEASE}
+ 	exit ;;
+-- 
+2.55.0
+


### PR DESCRIPTION
config.guess used by LLVM is an antique version that supports only x86 and x86_64.
Now it's patched to use auto-detection, as GNU config.guess has since been updated to.

Confirmed to build on arm64, should be upstreamed once these arches are less experimental :)

When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
