### PR TITLE
fluidlite: make buildable with cmake>=4

### DIFF
--- a/media-sound/fluidlite/fluidlite-1.0.9.recipe
+++ b/media-sound/fluidlite/fluidlite-1.0.9.recipe
@@ -64,6 +64,7 @@ BUILD()
 {
 	cmake -Bbuild -S. \
 		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
 		$cmakeDirArgs \
 		-DENABLE_SF3=YES \
 		-DSTB_VORBIS=NO


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.
