### PR TITLE
openjdk25: add recipe

### DIFF
--- a/dev-lang/openjdk/openjdk25-25.0.4.1.recipe
+++ b/dev-lang/openjdk/openjdk25-25.0.4.1.recipe
@@ -1,0 +1,268 @@
+SUMMARY="An open-source implementation of the Java Platform, SE"
+DESCRIPTION="OpenJDK (Open Java Development Kit) is a free and open source \
+implementation of the Java Platform, Standard Edition (Java SE). It is the \
+result of an effort Sun Microsystems began in 2006.
+
+The implementation is licensed under the GNU General Public License (GNU GPL) \
+with a linking exception. Were it not for the GPL linking exception, components \
+that linked to the Java class library would be subject to the terms of the GPL \
+license. OpenJDK is the official Java SE 24 reference implementation."
+HOMEPAGE="https://openjdk.java.net/"
+COPYRIGHT="2007-2026 Oracle and/or its affiliates."
+LICENSE="GNU GPL v2"
+REVISION="1"
+jdkBuild="jdk-${portVersion%.*}+${portVersion##*.}"
+srcGitRev="9b56a7e76a77910d8e9ea71d301877df53beb9ba"
+SOURCE_URI="https://github.com/ElectrodeYT/jdk25u/archive/$srcGitRev.tar.gz"
+CHECKSUM_SHA256="3b6babaf9cb6afd4edde90fc2b5607740ca9704768dbe7804f98d2fb9b851963"
+SOURCE_FILENAME="jdk25u-$jdkBuild-$srcGitRev.tar.gz"
+SOURCE_DIR="jdk25u-$srcGitRev"
+SOURCE_URI_2="https://builds.shipilev.net/jtreg/jtreg-8.3%2B1.zip"
+CHECKSUM_SHA256_2="98bdf089dbe5bb837ffb853dd4e4d2b09d91955022aa8bf3be055589ec1ce2a3"
+SOURCE_DIR_2="jtreg"
+ADDITIONAL_FILES="
+	elf.h
+	"
+
+ARCHITECTURES="all !x86_gcc2"
+SECONDARY_ARCHITECTURES="?x86"
+
+DISABLE_SOURCE_PACKAGE="yes"
+	# at least as long as Ant and a complete SDK image are part of the "sources" package
+
+PROVIDES="
+	openjdk25$secondaryArchSuffix = $portVersion compat >= 25
+	java:environment = 25
+	"
+REQUIRES="
+	haiku$secondaryArchSuffix
+	openjdk25${secondaryArchSuffix}_jre == $portVersion
+	"
+
+PROVIDES_default="
+	openjdk25${secondaryArchSuffix}_default = $portVersion
+	cmd:jar = $portVersion compat >= 25
+	cmd:jarsigner = $portVersion compat >= 25
+	cmd:java = $portVersion compat >= 25
+	cmd:javac = $portVersion compat >= 25
+	cmd:javadoc = $portVersion compat >= 25
+	cmd:javah = $portVersion compat >= 25
+	cmd:javap = $portVersion compat >= 25
+	cmd:jcmd = $portVersion compat >= 25
+	cmd:jconsole = $portVersion compat >= 25
+	cmd:jdb = $portVersion compat >= 25
+	cmd:jinfo = $portVersion compat >= 25
+	cmd:jmap = $portVersion compat >= 25
+	cmd:jps = $portVersion compat >= 25
+	cmd:jstack = $portVersion compat >= 25
+	cmd:jstat = $portVersion compat >= 25
+	cmd:jstatd = $portVersion compat >= 25
+	cmd:keytool = $portVersion compat >= 25
+	cmd:rmiregistry = $portVersion compat >= 25
+	cmd:serialver = $portVersion compat >= 25
+	"
+REQUIRES_default="
+	openjdk25$secondaryArchSuffix == $portVersion
+	"
+CONFLICTS_default="
+	openjdk8${secondaryArchSuffix}_default
+	openjdk9${secondaryArchSuffix}_default
+	openjdk10${secondaryArchSuffix}_default
+	openjdk11${secondaryArchSuffix}_default
+	openjdk12${secondaryArchSuffix}_default
+	openjdk13${secondaryArchSuffix}_default
+	openjdk14${secondaryArchSuffix}_default
+	openjdk15${secondaryArchSuffix}_default
+	openjdk16${secondaryArchSuffix}_default
+	openjdk17${secondaryArchSuffix}_default
+	openjdk18${secondaryArchSuffix}_default
+	openjdk19${secondaryArchSuffix}_default
+	openjdk20${secondaryArchSuffix}_default
+	openjdk21${secondaryArchSuffix}_default
+	openjdk22${secondaryArchSuffix}_default
+	openjdk23${secondaryArchSuffix}_default
+	openjdk24${secondaryArchSuffix}_default
+	"
+
+PROVIDES_jre="
+	openjdk25${secondaryArchSuffix}_jre = $portVersion compat >= 25
+	java:runtime = 25
+	"
+REQUIRES_jre="
+	haiku$secondaryArchSuffix
+	lib:libfreetype$secondaryArchSuffix
+	lib:libiconv$secondaryArchSuffix
+	lib:libjpeg$secondaryArchSuffix
+	lib:libz$secondaryArchSuffix
+	ca_root_certificates_java
+	dejavu
+	"
+
+SUMMARY_sources="JDK source files, demos and examples"
+PROVIDES_sources="
+	openjdk25${secondaryArchSuffix}_sources = $portVersion compat >= 25
+	"
+REQUIRES_sources="
+	openjdk25$secondaryArchSuffix
+	"
+
+BUILD_REQUIRES="
+	haiku${secondaryArchSuffix}_devel
+	java:environment == 24
+	ca_root_certificates
+	devel:libfontconfig$secondaryArchSuffix
+	devel:libfreetype$secondaryArchSuffix
+	devel:libiconv$secondaryArchSuffix
+	devel:libjpeg$secondaryArchSuffix
+	devel:libz$secondaryArchSuffix
+	"
+BUILD_PREREQUIRES="
+	cmd:cpio
+	cmd:make
+	cmd:gcc$secondaryArchSuffix
+	cmd:ld$secondaryArchSuffix
+	cmd:sed
+	cmd:tar
+	cmd:zip
+	cmd:gawk
+	cmd:hostname
+	cmd:find
+	cmd:unzip
+	cmd:unzipsfx
+	cmd:head
+	cmd:file
+	cmd:which
+	cmd:autoconf
+	cmd:pkg_config$secondaryArchSuffix
+	"
+
+TEST_REQUIRES="
+	cmd:true
+	"
+
+BUILD()
+{
+	source /system/data/profile.d/openjdk24.sh
+	export PATH=$JDK24_HOME/bin:$PATH
+	export COMPANY=HaikuPorts
+
+	ln -sfn $sourceDir2 jtreg
+
+	cp $portDir/additional-files/elf.h src/hotspot/share/utilities
+
+	# If ASLR is enabled, the JVM can fail to find a large enough area for
+	# the heap.
+	export DISABLE_ASLR=1
+
+	# Verify that we can allocate a large enough heap before starting.
+	java -XX:ThreadStackSize=1536 -Xmx1024M -version
+
+	freeTypeHeaders=$(finddir B_SYSTEM_HEADERS_DIRECTORY)$secondaryArchSubDir/freetype2
+	freeTypeLib=$(finddir B_SYSTEM_DEVELOP_DIRECTORY)/lib$secondaryArchSubDir
+
+	bash ./configure \
+					--with-freetype-include="${freeTypeHeaders}" \
+					--with-freetype-lib="${freeTypeLib}" \
+					--with-jtreg=./jtreg \
+					--with-version-build="${portVersion//*.}" \
+					--with-version-pre="" \
+					--with-version-opt="" \
+					--with-num-cores="${jobArgs#-j}" \
+					--enable-javac-server \
+					--disable-warnings-as-errors \
+					--with-extra-cflags="-w" \
+					--with-extra-cxxflags="-w"
+
+	make images LOG=info
+}
+
+INSTALL()
+{
+	# install the generated SDK image dir
+	jdkDir=$libDir/openjdk25
+
+	mkdir -p $jdkDir
+	cp -a build/haiku-*/images/jdk/* $jdkDir
+
+	# set up the cacerts link
+	ln -sf $dataDir/ssl/java/cacerts $jdkDir/conf/security/
+
+	# symlink the executables to binDir
+	mkdir -p $prefix/bin
+	bins="jar jarsigner javac javadoc javah javap jcmd jconsole jdb jinfo \
+		jmap jps jstack jstat jstatd serialver"
+	bins_runtime="java keytool rmiregistry"
+	man_runtime=""
+	for b in $bins $bins_runtime; do
+		symlinkRelative -s $jdkDir/bin/$b $prefix/bin
+	done
+
+	# TODO: Manpage is broken lol
+	# for b in $bins_runtime; do
+	# 	man_runtime+=" $jdkDir/man/man1/$b.1"
+	# done
+
+	mkdir -p $dataDir/profile.d
+
+	# create a profile.d file that sets up JAVA_HOME
+	jdkProfile=$dataDir/profile.d/openjdk.sh
+	echo "JAVA_HOME=$jdkDir" > $jdkProfile
+	echo "export JAVA_HOME" >> $jdkProfile
+
+	# create a profile.d file that sets up JDK25_HOME
+	jdkProfile=$dataDir/profile.d/openjdk25.sh
+	echo "JDK25_HOME=$jdkDir" > $jdkProfile
+	echo "export JDK25_HOME" >> $jdkProfile
+
+	# create a profile.d file that sets up JRE25_HOME
+	jreProfile=$dataDir/profile.d/openjre25.sh
+	echo "JRE25_HOME=$(getPackagePrefix jre)/$relativeLibDir/openjdk25" > $jreProfile
+	echo "export JRE25_HOME" >> $jreProfile
+
+	find $jdkDir -name '*.diz' -o -name '*.debuginfo' -delete
+	# not for jre
+	mv $jdkDir/lib/libattach.so $jdkDir/lib/ct.sym $prefix
+
+	packageEntries sources \
+		$jdkDir/lib/src.zip \
+		$jdkDir/demo
+
+	packageEntries jre \
+		$jdkDir/bin/java \
+		$jdkDir/bin/jrunscript \
+		$jdkDir/bin/keytool \
+		$jdkDir/bin/rmiregistry \
+		$jdkDir/conf \
+		$jdkDir/legal \
+		$jdkDir/lib \
+		$jdkDir/release \
+		$dataDir/profile.d/openjre25.sh \
+		$man_runtime
+
+	mkdir -p $jdkDir/lib
+	mv $prefix/libattach.so $prefix/ct.sym $jdkDir/lib/
+
+	packageEntries default \
+		$prefix/bin \
+		$dataDir/profile.d/openjdk.sh
+}
+
+TEST()
+{
+	export DISABLE_ASLR=1
+	make test-image
+	#make test-only TEST_JOBS=1 TEST=jdk_lang
+	#make test-only TEST_JOBS=1 TEST=jdk_util
+	make test-only JOBS=1 TEST=jdk_math
+	#make test-only JOBS=1 TEST=jdk_io
+	make test-only JOBS=1 TEST=jdk_nio
+	#make test-only JOBS=1 TEST=jdk_net
+	make test-only JOBS=1 TEST=jdk_time
+	#make test-only JOBS=1 TEST=jdk_rmi
+	#make test-only JOBS=1 TEST=jdk_security
+	make test-only JOBS=1 TEST=jdk_text
+	#make test-only TEST_JOBS=1 TEST=jdk_management
+	#make test-only JOBS=1 TEST=jdk_instrument
+	#make test-only JOBS=1 TEST=jdk_jmx
+	#make test-only JOBS=1 TEST=jdk_jdi
+}


### PR DESCRIPTION
When submitting changes to Haikuports, please check the following:

- [x] You are not a robot.
- [x] The modified recipe was confirmed to build on your Haiku machine.
- [x] The license and copyright information in modified recipes are correct.
- [x] The recipe follows one of the templates from https://github.com/haikuports/haikuporter/tree/master/generic (in particular, the fields are in the right [order](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines#ordering)).
- [x] The recipe is in the right category (matching Gentoo's overlays if the recipe is available there for example, use https://gpo.zugaina.org to search for existing recipes in Gentoo).

See the [guidelines](https://github.com/haikuports/haikuports/wiki/HaikuPorter-Guidelines) for more details.

The recipe is mostly copied from the openjdk24 recipe. The port of Java is based in part on korlis port of java 24, modified for java 25.